### PR TITLE
Issue 1401: Text color for white-theme buttons.

### DIFF
--- a/res/values/colors.xml
+++ b/res/values/colors.xml
@@ -91,6 +91,7 @@
 	<!-- colors for white theme -->
 	<color name="white_background">#f5f5f5</color>
 	<color name="white_background_night">#3d3d3d</color>
+	<color name="white_buttontext">#10171d</color>
 
 	<!-- top bar colors in reviewer -->
 	<color name="blue">#000099</color>

--- a/res/values/styles.xml
+++ b/res/values/styles.xml
@@ -126,6 +126,7 @@
     </style>
     <style name="White.Button" parent="@android:style/Widget.Button">
         <item name="android:background">@drawable/white_btn_default</item>
+        <item name="android:textColor">@color/white_buttontext</item>
     </style>
     <style name="White.Button.Small" parent="@android:style/Widget.Button.Small">
         <item name="android:background">@drawable/white_btn_small</item>


### PR DESCRIPTION
Currently the buttons do not have an explicit text color. This works if
the device default theme has a proper color for the text by default, but
fails if the default color is not readable.

This commit makes the color explicit and therefore makes it the same on
all devices.
