### PR TITLE
Options group management

### DIFF
--- a/res/values/02-strings.xml
+++ b/res/values/02-strings.xml
@@ -94,6 +94,7 @@
 
 <string name="rename">Rename</string>
 <string name="rename_error">Deck %s could not be renamed</string>
+<string name="default_conf_delete_error">The default options group can\'t be removed</string>
 
 <plurals name="factadder_cards_added">
   <item quantity="one">1 card added</item>

--- a/res/values/10-preferences.xml
+++ b/res/values/10-preferences.xml
@@ -250,13 +250,16 @@
 <!-- Deck configurations -->
 <string name="deck_conf_deck_name">Deck name</string>
 <string name="deck_conf_deck_description">Deck description</string>
-<string name="deck_conf_conf_set">Options group</string>
 <string name="deck_conf_pref_cat_options">Options</string>
+<string name="deck_conf_group">Group</string>
+<plurals name="deck_conf_group_summ">
+  <item quantity="one">%1$s\n1 deck uses this group</item>
+  <item quantity="other">%1$s\n%2$d decks use this group</item>
+</plurals>
 <string name="deck_conf_new_cards">New cards</string>
 <string name="deck_conf_rev_cards">Reviews</string>
 <string name="deck_conf_lps_cards">Lapses</string>
 <string name="deck_conf_general">General</string>
-<string name="deck_conf_add_conf">Add/delete options</string>
 <string name="deck_conf_steps">Steps (in minutes)</string>
 <string name="deck_conf_order">Order</string>
 <string name="deck_conf_new_cards_day">New cards/day</string>
@@ -283,9 +286,25 @@
 <string name="deck_conf_autoplay">Automatically play audio</string>
 <string name="deck_conf_replayq">Replay Question</string>
 <string name="deck_conf_replayq_summ">When answer shown, replay both question and answer audio</string>
-<string name="deck_conf_add">Add configuration</string>
-<string name="deck_conf_ren">Rename configuration</string>
-<string name="deck_conf_rem">Remove configuration</string>
+<string name="deck_conf_manage">Group management</string>
+<string name="deck_conf_current_group">Current group</string>
+<string name="deck_conf_rename">Rename</string>
+<string name="deck_conf_reset">Restore defaults</string>
+<string name="deck_conf_reset_title">Restore defaults</string>
+<string name="deck_conf_reset_message">Restore current options group to default values?</string>
+<string name="deck_conf_add">Add</string>
+<string name="deck_conf_add_summ">Create a copy of the current options group</string>
+<string name="deck_conf_remove">Remove</string>
+<string name="deck_conf_remove_title">Remove</string>
+<string name="deck_conf_remove_message">Remove current options group?</string>
+<string name="deck_conf_set_subdecks">Set for all subdecks</string>
+<plurals name="deck_conf_set_subdecks_summ">
+  <item quantity="one">1 subdeck will use this group</item>
+  <item quantity="other">%s subdecks will use this group</item>
+</plurals>
+<string name="deck_conf_set_subdecks_title">Set for all subdecks</string>
+<string name="deck_conf_set_subdecks_message">Set current options group for all of this deck\'s subdecks?</string>
+
 <string name="pref_cat_tibetan">Tibetan Support</string>
 <string name="pref_cat_languages_advanced">Advanced support for typefaces</string>
 <string name="pref_enable_tibetan">Enable Tibetan Support</string>

--- a/res/xml/deck_options.xml
+++ b/res/xml/deck_options.xml
@@ -24,8 +24,8 @@
 		android:key="desc" />
 	<PreferenceCategory android:title="@string/deck_conf_pref_cat_options">
 	<ListPreference
-            	android:title="@string/deck_conf_conf_set"
-		android:key="deckConf"/>
+           	android:title="@string/deck_conf_group"
+           	android:key="deckConf"/>
 	<PreferenceScreen android:title="@string/deck_conf_new_cards">
 		<EditTextPreference
         	    	android:title="@string/deck_conf_steps"
@@ -126,36 +126,60 @@
 			android:title="@string/deck_conf_leech_action"
 			android:key="lapLeechAct"/>
 	</PreferenceScreen>
-	<PreferenceScreen android:title="@string/deck_conf_general">
-		<EditTextPreference
-        	    	android:title="@string/deck_conf_max_time"
-        	    	android:summary="@string/deck_conf_seconds"
-        	    	android:numeric="integer"
-        	    	android:maxLength="4"
-		    	android:key="maxAnswerTime" />
-		<CheckBoxPreference
-			android:title="@string/deck_conf_timer"
-			android:key="showAnswerTimer" />
-		<CheckBoxPreference
-			android:title="@string/deck_conf_autoplay"
-			android:key="autoPlayAudio" />
-		<CheckBoxPreference
-			android:title="@string/deck_conf_replayq"
-        	android:summary="@string/deck_conf_replayq_summ"
-			android:key="replayQuestion" />
-			</PreferenceScreen>
-<!--
-    	<PreferenceScreen android:title="@string/deck_conf_add_conf">
-		<PreferenceScreen android:title="@string/deck_conf_add"
-		    android:enabled="false"
-			android:key="confAdd"/>
-		<PreferenceScreen android:title="@string/deck_conf_ren"
-		    android:enabled="false"
-			android:key="confRen"/>
-		<PreferenceScreen android:title="@string/deck_conf_rem"
-		    android:enabled="false"
-			android:key="confRem"/>
-		</PreferenceScreen>
--->	
-	</PreferenceCategory>
+    <PreferenceScreen android:title="@string/deck_conf_general" >
+        <EditTextPreference
+            android:maxLength="4"
+            android:numeric="integer"
+            android:summary="@string/deck_conf_seconds"
+            android:title="@string/deck_conf_max_time"
+            android:key="maxAnswerTime" />
+        <CheckBoxPreference
+            android:title="@string/deck_conf_timer"
+            android:key="showAnswerTimer" />
+        <CheckBoxPreference
+            android:title="@string/deck_conf_autoplay"
+            android:key="autoPlayAudio" />
+        <CheckBoxPreference
+            android:summary="@string/deck_conf_replayq_summ"
+            android:title="@string/deck_conf_replayq"
+            android:key="replayQuestion" />
+    </PreferenceScreen>
+    <PreferenceScreen android:title="@string/deck_conf_manage" >
+        <Preference
+            android:enabled="false"
+            android:title="@string/deck_conf_current_group"
+            android:key="currentConf" />
+        <EditTextPreference
+            android:summary="@string/deck_conf_add_summ"
+            android:title="@string/deck_conf_add"
+            android:key="confAdd" />
+        <com.ichi2.preferences.CustomDialogPreference
+            android:dialogIcon="@android:drawable/ic_dialog_alert"
+            android:dialogMessage="@string/deck_conf_remove_message"
+            android:dialogTitle="@string/deck_conf_remove_title"
+            android:negativeButtonText="@string/no"
+            android:positiveButtonText="@string/yes"
+            android:title="@string/deck_conf_remove"
+            android:key="confRemove" />
+        <EditTextPreference
+            android:title="@string/deck_conf_rename"
+            android:key="confRename" />
+        <com.ichi2.preferences.CustomDialogPreference
+            android:dialogIcon="@android:drawable/ic_dialog_alert"
+            android:dialogMessage="@string/deck_conf_reset_message"
+            android:dialogTitle="@string/deck_conf_reset_title"
+            android:negativeButtonText="@string/no"
+            android:positiveButtonText="@string/yes"
+            android:title="@string/deck_conf_reset_title"
+            android:key="confRestore" />
+        <com.ichi2.preferences.CustomDialogPreference
+            android:dialogIcon="@android:drawable/ic_dialog_alert"
+            android:dialogMessage="@string/deck_conf_set_subdecks_message"
+            android:dialogTitle="@string/deck_conf_set_subdecks_title"
+            android:negativeButtonText="@string/no"
+            android:positiveButtonText="@string/yes"
+            android:title="@string/deck_conf_set_subdecks"
+            android:key="confSetSubdecks" />
+    </PreferenceScreen>
+    </PreferenceCategory>
 </PreferenceScreen>

--- a/src/com/ichi2/libanki/Decks.java
+++ b/src/com/ichi2/libanki/Decks.java
@@ -509,10 +509,10 @@ public class Decks {
         JSONObject c;
         long id;
         try {
-            c = new JSONObject(defaultConf);
+            c = new JSONObject(cloneFrom);
             while (true) {
                 id = Utils.intNow(1000);
-                if (!mDconf.containsKey(new Long(id))) {
+                if (!mDconf.containsKey(Long.valueOf(id))) {
                     break;
                 }
             }
@@ -521,13 +521,32 @@ public class Decks {
         } catch (JSONException e) {
             throw new RuntimeException(e);
         }
-        mDconf.put(new Long(id), c);
+        mDconf.put(Long.valueOf(id), c);
         save(c);
         return id;
     }
 
-
-    // remConf
+    /**
+     * Remove a configuration and update all decks using it.
+     */
+    public void remConf(long id) {
+        mCol.modSchema();
+        mDconf.remove(Long.valueOf(id));
+        for (JSONObject g : all()) {
+            // ignore cram decks
+            if (!g.has("conf")) {
+                continue;
+            }
+            try {
+                if (g.getString("conf").equals(Long.toString(id))) {
+                    g.put("conf", 1);
+                    save(g);
+                }
+            } catch (JSONException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
 
     public void setConf(JSONObject deck, long id) {
         try {
@@ -555,7 +574,22 @@ public class Decks {
         }
     }
     
-    // restoretodefault
+    public void restoreToDefault(JSONObject conf) {
+        try {
+            int oldOrder = conf.getJSONObject("new").getInt("order");
+            JSONObject newConf = new JSONObject(defaultConf);
+            newConf.put("id", conf.getLong("id"));
+            newConf.put("name", conf.getString("name"));
+            mDconf.put(conf.getLong("id"), newConf);
+            save(newConf);
+            // if it was previously randomized, resort
+            if (oldOrder == 0) {
+                mCol.getSched().resortConf(newConf);
+            }
+        } catch (JSONException e) {
+            throw new RuntimeException(e);
+        }
+    }
 
     /**
      * Deck utils *************************************************************** ********************************

--- a/src/com/ichi2/preferences/CustomDialogPreference.java
+++ b/src/com/ichi2/preferences/CustomDialogPreference.java
@@ -54,6 +54,18 @@ public class CustomDialogPreference extends DialogPreference implements DialogIn
                             AnkiDroidApp.getAppResources().getString(R.string.reset_confirmation), Toast.LENGTH_SHORT);
                     successReport.show();
                 }
+            } else if (this.getTitle().equals(mContext.getResources().getString(R.string.deck_conf_reset))) {
+                Editor editor = AnkiDroidApp.getSharedPrefs(mContext).edit();
+                editor.putBoolean("confReset", true);
+                editor.commit();
+            } else if (this.getTitle().equals(mContext.getResources().getString(R.string.deck_conf_remove))) {
+                Editor editor = AnkiDroidApp.getSharedPrefs(mContext).edit();
+                editor.putBoolean("confRemove", true);
+                editor.commit();
+            } else if (this.getTitle().equals(mContext.getResources().getString(R.string.deck_conf_set_subdecks))) {
+                Editor editor = AnkiDroidApp.getSharedPrefs(mContext).edit();
+                editor.putBoolean("confSetSubdecks", true);
+                editor.commit();
             } else {
                 if (MetaDB.resetLanguages(mContext)) {
                     Toast successReport = Toast.makeText(this.getContext(),


### PR DESCRIPTION
[Issue 1591](http://code.google.com/p/ankidroid/issues/detail?id=1591)

This will add options group management, including:
- Add
- Remove
- Rename
- Reset to default
- Apply group to all subdecks

Most options group management operations can trigger a card reordering, which takes time, so I've added new DeckTasks for the ones that do. Note that desktop Anki [doesn't reorder cards yet](https://anki.lighthouseapp.com/projects/100923-ankidesktop/tickets/675) for these operations (except for reset), so the reorder logic is kept out of libanki.
