### PR TITLE
Issue 635 - Don't center-align cards in global style rule

### DIFF
--- a/assets/flashcard_css
+++ b/assets/flashcard_css
@@ -11,7 +11,6 @@ body {
   display: table-cell;
   vertical-align: middle;
   width: 100%;
-  text-align: center;
   font-size: 250%;
 }
 


### PR DESCRIPTION
[Issue 635](http://code.google.com/p/ankidroid/issues/detail?id=635)

Anki creates new note type style sheets using the `text-align: center;` rule by default. A user who wishes not to center-align cards can either change that to `text-align: left;` or simply remove the rule. In the latter case, AnkiDroid will still center-align cards because we have it defined as centered in flashcard_css. 
