### PR TITLE
Update checkout command to not track remote branch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Fetch the latest version of the AnkiDroid repository:
 `git fetch ankidroid`
 
 Create a new feature branch for what you want to contribute:  
-`git checkout -b feature-name ankidroid/v2.1-dev`
+`git checkout --no-track ankidroid/v2.1-dev -b feature-name`
 
 ### Step 4: Make your changes
 


### PR DESCRIPTION
We want users to be tracking pushing to their own branch, not the
organization repository.

Also, move the name of the branch to the end of the command, so it is
easier for people to edit after copying and pasting.
