### PR TITLE
Reorder cards according to default group order when deleting options group

### DIFF
--- a/src/com/ichi2/async/DeckTask.java
+++ b/src/com/ichi2/async/DeckTask.java
@@ -1222,11 +1222,12 @@ public class DeckTask extends
             Collection col = (Collection) data[0];
             JSONObject conf = (JSONObject) data[1];
             try {
-                int oldOrder = conf.getJSONObject("new").getInt("order");
-                // If cards are randomized in this group, they need to be reordered
-                // to the default ordering first, then we can delete the conf.
-                if (oldOrder == 0) {
-                    conf.getJSONObject("new").put("order", 1);
+                // When a conf is deleted, all decks using it revert to the default conf.
+                // Cards must be reordered according to the default conf.
+                int order = conf.getJSONObject("new").getInt("order");
+                int defaultOrder = col.getDecks().getConf(1).getJSONObject("new").getInt("order");
+                if (order != defaultOrder) {
+                    conf.getJSONObject("new").put("order", defaultOrder);
                     col.getSched().resortConf(conf);
                 }
                 col.getDecks().remConf(conf.getLong("id"));


### PR DESCRIPTION
Use the correct ordering of the default options group when deleting a group.

On another note, deleting an options group calls modSchema. Right now, there's no warning that a full sync is needed when doing so. I could easily add another line in the dialog saying so, but I wonder if there is a better way that can get triggered every time modSchema is called from anywhere in the application, much like the desktop client.
