### PR TITLE
Issue 1309: Set language from Preferences on start of ankidroid

### DIFF
--- a/src/com/ichi2/anki/DeckPicker.java
+++ b/src/com/ichi2/anki/DeckPicker.java
@@ -2663,8 +2663,7 @@ public class DeckPicker extends FragmentActivity {
         	String oldPath = mPrefDeckPath;
             SharedPreferences pref = restorePreferences();
             String newLanguage = pref.getString("language", "");
-            if (!AnkiDroidApp.getLanguage().equals(newLanguage)) {
-                AnkiDroidApp.setLanguage(newLanguage);
+            if (AnkiDroidApp.setLanguage(newLanguage)) {
                 mInvalidateMenu = true;
             }
             if (mNotMountedDialog != null && mNotMountedDialog.isShowing() && pref.getBoolean("internalMemory", false)) {

--- a/src/com/ichi2/anki/StudyOptionsActivity.java
+++ b/src/com/ichi2/anki/StudyOptionsActivity.java
@@ -37,15 +37,12 @@ import android.widget.EditText;
 
 import com.ichi2.anim.ActivityTransitionAnimation;
 import com.ichi2.anki.receiver.SdCardReceiver;
-import com.ichi2.libanki.Collection;
 import com.ichi2.themes.StyledDialog;
 import com.ichi2.themes.StyledOpenCollectionDialog;
 import com.ichi2.themes.Themes;
 import com.ichi2.widget.WidgetStatus;
 
-import org.json.JSONArray;
 import org.json.JSONException;
-import org.json.JSONObject;
 
 import java.util.ArrayList;
 
@@ -217,8 +214,7 @@ public class StudyOptionsActivity extends FragmentActivity {
         Log.i(AnkiDroidApp.TAG, "StudyOptionsActivity: onActivityResult");
         
         String newLanguage = AnkiDroidApp.getSharedPrefs(this).getString("language", "");
-        if (!AnkiDroidApp.getLanguage().equals(newLanguage)) {
-            AnkiDroidApp.setLanguage(newLanguage);
+        if (AnkiDroidApp.setLanguage(newLanguage)) {
             mInvalidateMenu = true;
         }
         if (mCurrentFragment != null) {


### PR DESCRIPTION
The correct config.locale was not set when Ankidroid is started. Therefore the language set in the preferences was not applied after a restart.
Each time AnkiDroidApp is created, the locale from the settings is now applied.
