### PR TITLE
Back button on tablet congrats screen should return to overview

### DIFF
--- a/src/com/ichi2/anki/DeckPicker.java
+++ b/src/com/ichi2/anki/DeckPicker.java
@@ -2155,6 +2155,10 @@ public class DeckPicker extends FragmentActivity {
     public boolean onKeyDown(int keyCode, KeyEvent event) {
         if (keyCode == KeyEvent.KEYCODE_BACK && event.getRepeatCount() == 0) {
             Log.i(AnkiDroidApp.TAG, "DeckPicker - onBackPressed()");
+            if (mFragmented && getFragment().congratsShowing()) {
+                getFragment().finishCongrats();
+                return true;
+            }
             finishWithAnimation();
             return true;
         }

--- a/src/com/ichi2/anki/StudyOptionsActivity.java
+++ b/src/com/ichi2/anki/StudyOptionsActivity.java
@@ -247,9 +247,11 @@ public class StudyOptionsActivity extends FragmentActivity {
     public boolean onKeyDown(int keyCode, KeyEvent event) {
         if (keyCode == KeyEvent.KEYCODE_BACK && event.getRepeatCount() == 0) {
             Log.i(AnkiDroidApp.TAG, "StudyOptions - onBackPressed()");
-            if (mCurrentFragment == null || !mCurrentFragment.congratsShowing()) {
-                closeStudyOptions();
+            if (mCurrentFragment != null && mCurrentFragment.congratsShowing()) {
+                mCurrentFragment.finishCongrats();
+                return true;
             }
+            closeStudyOptions();
             return true;
         }
         return super.onKeyDown(keyCode, event);

--- a/src/com/ichi2/anki/StudyOptionsFragment.java
+++ b/src/com/ichi2/anki/StudyOptionsFragment.java
@@ -1083,16 +1083,15 @@ public class StudyOptionsFragment extends Fragment {
     }
 
     public boolean congratsShowing() {
-    	if (mCurrentContentView == CONTENT_CONGRATS) {
+        if (mCurrentContentView == CONTENT_CONGRATS) {
             updateValuesFromDeck();
-        	finishCongrats();
-        	return true;
-    	} else {
-    		return false;
-    	}
+            return true;
+        } else {
+            return false;
+        }
     }
 
-    private void finishCongrats() {
+    public void finishCongrats() {
     	mCurrentContentView = CONTENT_STUDY_OPTIONS;
         mStudyOptionsView.setVisibility(View.INVISIBLE);
         mCongratsView.setVisibility(View.INVISIBLE);


### PR DESCRIPTION
In the current tablet view, if the study options fragment is showing the congrats screen, tapping back will close AnkiDroid. This change will instead return the fragment to the overview screen, which is likely what most users would expect.

This was an attempt at fixing [Issue1488](https://code.google.com/p/ankidroid/issues/detail?id=1488), but the problem is still there.
