### PR TITLE
Add a settings to disable WebView switching.

### DIFF
--- a/res/values/10-preferences.xml
+++ b/res/values/10-preferences.xml
@@ -245,7 +245,8 @@
 <string name="pref_simple_interface_summ">Speeds up card showing but does not support all html features</string>
 <string name="pref_simple_interface_exclude_tags">Normal interface by tag</string>
 <string name="pref_simple_interface_exclude_tags_summ">Do not use simple interface for these tags: XXX</string>
-
+<string name="pref_force_quick_update_title">Force quick update of Webview</string>
+<string name="pref_force_quick_update_summary">Enabling this reduces flickering when flipping cards, but might cause the application to crash on some devices.</string>
 
 <!-- Deck configurations -->
 <string name="deck_conf_deck_name">Deck name</string>

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -291,6 +291,11 @@
                 android:summary="@string/pref_simple_interface_exclude_tags_summ"
                 android:dependency="simpleInterface"
                 android:key="simpleInterfaceExcludeTags" />
+            <CheckBoxPreference
+                android:title="@string/pref_force_quick_update_title"
+                android:summary="@string/pref_force_quick_update_summary"
+                android:defaultValue="false"
+                android:key="forceQuickUpdate" />
             </PreferenceCategory>
         <PreferenceCategory android:title="@string/pref_cat_whiteboard" >
             <CheckBoxPreference


### PR DESCRIPTION
WebView switching was added in Android 0.7 to fix a bug with custom
fonts on some versions of Android. However, recent versions of Android
seem to have fixed this issue.

This commit adds a setting to force quick updating of WebViews, so that
we can ask users to test this on a number of devices with the next
release and see if this is still an issue on any device.

Hopefully, we can identify which versions of Android we can disable the
workaround by default and possibly remove the setting in future
versions.
