### PR TITLE
Use ruby tags and styled spans for furigana instead of CSS tables.

### DIFF
--- a/assets/flashcard_css
+++ b/assets/flashcard_css
@@ -14,28 +14,22 @@ body {
   font-size: 250%;
 }
 
-ruby
-{
-	display: inline-table;
-	text-align: center;
-	white-space: nowrap;
-	text-indent: 0;
-	margin: 0;
-	vertical-align: -20%;
+.legacy_ruby_rb {
+  display: inline-block;
+  text-align: center;
+  line-height: 1;
+  white-space: nowrap;
+  vertical-align: baseline;
+  margin: 0;
+  padding: 0;
 }
 
-rb
-{
-	display: table-row-group;
-	line-height: 150%;
-}
-
-rt
-{
-	display: table-header-group;
-	font-size: 60%;
-	line-height: 40%;
-	letter-spacing: 0;
+.legacy_ruby_rt {
+  display: block;
+  text-decoration: none;
+  line-height: 1.2;
+  font-weight: normal;
+  font-size: 0.64em;
 }
 
 .chess_board

--- a/src/com/ichi2/libanki/hooks/FuriganaFilters.java
+++ b/src/com/ichi2/libanki/hooks/FuriganaFilters.java
@@ -16,12 +16,19 @@
 
 package com.ichi2.libanki.hooks;
 
+import com.ichi2.anki.AnkiDroidApp;
+
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class FuriganaFilters {
     private static final Pattern r = Pattern.compile(" ?([^ >]+?)\\[(.+?)\\]");
-    private static final String ruby = "<ruby><rb>$1</rb><rt>$2</rt></ruby>";
+
+    // Since there is no ruby tag support in Android before 3.0 (SDK version 11), we must use an alternative
+    // approach to align the elements. Anki does the same thing in aqt/qt.py for earlier versions of qt.
+    // The fallback approach relies on CSS in the file /assets/flashcard_css
+    private static final String RUBY = AnkiDroidApp.SDK_VERSION >= 11 ? "<ruby><rb>$1</rb><rt>$2</rt></ruby>"
+            : "<span class='legacy_ruby_rb'><span class='legacy_ruby_rt'>$2</span>$1</span>";
 
 
     public void install(Hooks h) {
@@ -72,7 +79,7 @@ public class FuriganaFilters {
             Matcher m = r.matcher((String) arg);
             StringBuffer sb = new StringBuffer();
             while (m.find()) {
-                m.appendReplacement(sb, noSound(m, ruby));
+                m.appendReplacement(sb, noSound(m, RUBY));
             }
             m.appendTail(sb);
             return sb.toString();


### PR DESCRIPTION
Instead of styling ruby tags as CSS tables (for furigana and such), we use the actual ruby element that is natively supported in newer versions of WebView. For older versions, we use the same approach used by Anki for earlier versions of qt that had no ruby support (and what I believe is the same approach for unsupported browsers in AnkiWeb).

According to [this website](http://caniuse.com/#search=ruby), ruby support was added in Android 3.0. I tested this code on Androids 2.3, 3.0, and 4.2, and it looks like it's correct (i.e., 2.3 used the spans version instead).

This fixes [Issue 1648](https://code.google.com/p/ankidroid/issues/detail?id=1648), but overall, it looks much better:
[-Before](https://f.cloud.github.com/assets/789082/376419/66d86948-a431-11e2-87dd-bb5362cf593c.png)
[-After](https://f.cloud.github.com/assets/789082/376418/66465fc6-a431-11e2-8195-8eda4789c325.png)
