### PR TITLE
Fix CSS in Reviewer for the default font.

### DIFF
--- a/src/com/ichi2/anki/Reviewer.java
+++ b/src/com/ichi2/anki/Reviewer.java
@@ -2709,8 +2709,13 @@ public class Reviewer extends AnkiActivity {
                 if (TextUtils.isEmpty(defaultFontName)) {
                     mCustomDefaultFontCss = "";
                 } else {
-                    mCustomDefaultFontCss = "BODY .question BODY .answer { font-family: '" + defaultFont
-                            + "' font-weight: normal; font-style: normal; font-stretch: normal; }\n";
+                    mCustomDefaultFontCss = String.format(
+                            "BODY .question, BODY .answer {"
+                            + "font-family: '%s';"
+                            + "font-weight: normal;"
+                            + "font-style: normal;"
+                            + "font-stretch: normal;"
+                            + "}\n", defaultFontName);
                 }
             }
         }


### PR DESCRIPTION
The CSS used for the default font was actually invalid because a number
of things were missing or incorrect.

This should reformat and fix the CSS.
