### PR TITLE
Refresh to Travis CI configuration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,17 @@
 language: java
+branches:
+  only:
+    - /^v[0-9.]*-dev$/
+
 before_install:
-  # download the latest android sdk and unzip
-  - wget http://dl.google.com/android/android-sdk_r20-linux.tgz
-  - tar -zxf android-sdk_r20-linux.tgz
-  # setup your ANDROID_HOME and PATH environment variables
-  - export ANDROID_HOME=~/builds/ankidroid-continuous/Anki-Android/android-sdk-linux
-  - export PATH=${PATH}:${ANDROID_HOME}/tools:${ANDROID_HOME}/platform-tools
-  # Only update the SDK for the tools and platform-tools and whatever API level
-  # you are building for android.
-  - android update sdk --filter 1,2 --no-ui --force
-  - android list sdk
-  - android update sdk --filter 7 --no-ui --force
-  - android update project --path ~/builds/ankidroid-continuous/Anki-Android
-script: "ant clean debug"
+  # Needed to run Android SDK tools, which are 32-bit binaries.
+  - sudo apt-get update -qq
+  - if [ `uname -m` = x86_64 ]; then sudo apt-get install -qq --force-yes libgd2-xpm ia32-libs ia32-libs-multiarch > /dev/null; fi
+before_script:
+  # Configure Android SDK tools and platforms required to build.
+  - ./tools/travis/continuous-setup.sh ..
+script: "./tools/travis/continuous-build.sh"
+
+notifications:
+  email:
+    - flerda+ankidroid-continuous@gmail.com

--- a/tools/travis/continuous-build.sh
+++ b/tools/travis/continuous-build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# It assumes Android SDK is installed in ../android.
+
+# It assumes it is being executed on a Linux machine.
+
+function main() {
+  if [ ! -d ../android ]; then
+    echo "Could not find Android SDK: ../android"
+    return 1
+  fi
+  export ANDROID_HOME="$(cd ../android; /bin/pwd)"
+  export PATH="$ANDROID_HOME/tools:$ANDROID_HOME/platform-tools:$PATH"
+  ./create-build-files.sh
+  ant clean debug
+}
+
+main "$@"

--- a/tools/travis/continuous-setup.sh
+++ b/tools/travis/continuous-setup.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# This scripts downloads all the necessary components for making a full build
+# from scratch.
+
+# It assumes it is being executed on a Linux machine.
+
+function download_and_install() {
+  local uri="$1"; shift
+  local dst="$1"; shift
+  test $# = 0
+
+  local filename="$(basename $uri)"
+  wget $uri
+  unzip -d $dst $filename
+  rm $filename
+}
+
+function main() {
+  set -e
+  local root="."
+  if [ $# -gt 0 ]; then
+    root="$1"; shift
+  fi
+  test $# = 0
+
+  # Download the Android SDK and necessary components.
+  download_and_install \
+    http://dl-ssl.google.com/android/repository/tools_r21.1-linux.zip \
+    $root/android
+
+  download_and_install \
+    http://dl-ssl.google.com/android/repository/platform-tools_r16.0.2-linux.zip \
+    $root/android
+
+  download_and_install \
+    http://dl-ssl.google.com/android/repository/android-15_r03.zip \
+    $root/android/platforms
+}
+
+main "$@"


### PR DESCRIPTION
This commit updates the Travis Continuous Integration configuration to
make it work again.

I chose a different approach to installing the SDK, that avoid depending
on the order in which things are returned by the tool and breaks each
time something changes (like a new release). Instead use static links to
the SDK components that we need.

Since the continuous build is not reliable enough (or at least I am not
sure it is), also only notify myself of failures.
