### PR TITLE
Use less specific CSS selectors for the default font.

### DIFF
--- a/src/com/ichi2/anki/Reviewer.java
+++ b/src/com/ichi2/anki/Reviewer.java
@@ -2725,14 +2725,14 @@ public class Reviewer extends AnkiActivity {
             SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(getBaseContext());
             AnkiFont defaultFont = getCustomFontsMap().get(preferences.getString("defaultFont", null));
             if (defaultFont != null) {
-                mCustomDefaultFontCss = "BODY .question, BODY .answer { " + defaultFont.getCSS() + " }\n";
+                mCustomDefaultFontCss = "BODY { " + defaultFont.getCSS() + " }\n";
             } else {
                 String defaultFontName = Themes.getReviewerFontName();
                 if (TextUtils.isEmpty(defaultFontName)) {
                     mCustomDefaultFontCss = "";
                 } else {
                     mCustomDefaultFontCss = String.format(
-                            "BODY .question, BODY .answer {"
+                            "BODY {"
                             + "font-family: '%s';"
                             + "font-weight: normal;"
                             + "font-style: normal;"


### PR DESCRIPTION
Now that we've fixed the CSS selectors for the default font, a new problem with their specificity has emerged in [Issue 1739](https://code.google.com/p/ankidroid/issues/detail?id=1739). Since .question and .answer appear inside .card, we are overriding any font specified by users using .card (a common case).

This changes the selector to simply target the body element. 
