### PR TITLE
Cause Card.getQuestion to reload the note. 

### DIFF
--- a/src/com/ichi2/libanki/Collection.java
+++ b/src/com/ichi2/libanki/Collection.java
@@ -1192,8 +1192,10 @@ public class Collection {
                 if (getDecks().active().contains(newCard.getDid())) {
                     card = newCard;
                     card.load();
-                    // reload qa-cache
-                    card.getQuestion(true);
+                    // Reloads the QA-cache.
+                    // Requests the simple interface version, since the only difference
+                    // is whether the CSS is added and that's not cached.
+                    card.getQuestion(true, true);
                 }
             }
             if (card == null) {


### PR DESCRIPTION
I‘m not totally sure, but it looks the point of calling `Card.getQuestion()` in this spot is to get the updated note data. Don’t we have to do the `mNote = mCol.getNote(mNid);` which gets triggered through a few more function calls only when we call a  `Card.getQuestion` with `reload=true`. 
