### PR TITLE
Refresh to Travis CI configuration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: java
+branches:
+  only:
+    - /^v[0-9.]*-dev$/
+
+before_install:
+  # Needed to run Android SDK tools, which are 32-bit binaries.
+  - sudo apt-get update -qq
+  - if [ `uname -m` = x86_64 ]; then sudo apt-get install -qq --force-yes libgd2-xpm ia32-libs ia32-libs-multiarch > /dev/null; fi
+before_script:
+  # Configure Android SDK tools and platforms required to build.
+  - ./tools/travis/continuous-setup.sh ..
+script: "./tools/travis/continuous-build.sh"
+
+notifications:
+  email:
+    - flerda+ankidroid-continuous@gmail.com


### PR DESCRIPTION
This commit updates the Travis Continuous Integration configuration to
make it work again.

I chose a different approach to installing the SDK, that avoid depending
on the order in which things are returned by the tool and breaks each
time something changes (like a new release). Instead use static links to
the SDK components that we need.

Since the continuous build is not reliable enough (or at least I am not
sure it is), also only notify myself of failures.
