### PR TITLE
Persist ints and force input type to integer in NumberRangePreference.

### DIFF
--- a/res/xml/deck_options.xml
+++ b/res/xml/deck_options.xml
@@ -39,27 +39,23 @@
                 android:title="@string/deck_conf_order" />
             <com.ichi2.preferences.NumberRangePreference
                 android:key="newPerDay"
-                android:numeric="integer"
                 android:title="@string/deck_conf_new_cards_day"
                 app:max="9999"
                 app:min="0" />
             <com.ichi2.preferences.NumberRangePreference
                 android:key="newGradIvl"
-                android:numeric="integer"
                 android:summary="@string/deck_conf_days"
                 android:title="@string/deck_conf_graduating_ivl"
                 app:max="99"
                 app:min="1" />
             <com.ichi2.preferences.NumberRangePreference
                 android:key="newEasy"
-                android:numeric="integer"
                 android:summary="@string/deck_conf_days"
                 android:title="@string/deck_conf_easy_ivl"
                 app:max="99"
                 app:min="1" />
             <com.ichi2.preferences.NumberRangePreference
                 android:key="newFactor"
-                android:numeric="integer"
                 android:summary="@string/deck_conf_percent"
                 android:title="@string/deck_conf_start_ease"
                 app:max="999"
@@ -73,33 +69,28 @@
         <PreferenceScreen android:title="@string/deck_conf_rev_cards" >
             <com.ichi2.preferences.NumberRangePreference
                 android:key="revPerDay"
-                android:numeric="integer"
                 android:title="@string/deck_conf_max_rev"
                 app:max="9999"
                 app:min="0" />
             <com.ichi2.preferences.NumberRangePreference
                 android:key="revSpaceMax"
-                android:numeric="integer"
                 android:summary="@string/deck_conf_percent"
                 android:title="@string/deck_conf_sibl_space"
                 app:max="100"
                 app:min="0" />
             <com.ichi2.preferences.NumberRangePreference
                 android:key="revSpaceMin"
-                android:numeric="integer"
                 android:summary="@string/deck_conf_days"
                 android:title="@string/deck_conf_min_range"
                 app:max="99"
                 app:min="0" />
             <com.ichi2.preferences.NumberRangePreference
                 android:key="easyBonus"
-                android:numeric="integer"
                 android:summary="@string/deck_conf_percent"
                 android:title="@string/deck_conf_easy_bonus"
                 app:max="1000"
                 app:min="100" />
             <com.ichi2.preferences.NumberRangePreference
-                android:inputType="numberDecimal"
                 android:key="revIvlFct"
                 android:summary="@string/deck_conf_percent"
                 android:title="@string/deck_conf_ivl_fct"
@@ -107,7 +98,6 @@
                 app:min="0" />
             <com.ichi2.preferences.NumberRangePreference
                 android:key="revMaxIvl"
-                android:numeric="integer"
                 android:summary="@string/deck_conf_days"
                 android:title="@string/deck_conf_max_ivl"
                 app:max="99999"
@@ -120,21 +110,18 @@
                 app:allowEmpty="true" />
             <com.ichi2.preferences.NumberRangePreference
                 android:key="lapNewIvl"
-                android:numeric="integer"
                 android:summary="@string/deck_conf_percent"
                 android:title="@string/deck_conf_new_lps_ivl"
                 app:max="100"
                 app:min="0" />
             <com.ichi2.preferences.NumberRangePreference
                 android:key="lapMinIvl"
-                android:numeric="integer"
                 android:summary="@string/deck_conf_days"
                 android:title="@string/deck_conf_min_ivl"
                 app:max="99"
                 app:min="1" />
             <com.ichi2.preferences.NumberRangePreference
                 android:key="lapLeechThres"
-                android:numeric="integer"
                 android:summary="@string/deck_conf_fails"
                 android:title="@string/deck_conf_leech_thres"
                 app:max="99"
@@ -146,7 +133,6 @@
         <PreferenceScreen android:title="@string/deck_conf_general" >
             <com.ichi2.preferences.NumberRangePreference
                 android:key="maxAnswerTime"
-                android:numeric="integer"
                 android:summary="@string/deck_conf_seconds"
                 android:title="@string/deck_conf_max_time"
                 app:max="3600"

--- a/src/com/ichi2/anki/CramDeckOptions.java
+++ b/src/com/ichi2/anki/CramDeckOptions.java
@@ -132,7 +132,7 @@ public class CramDeckOptions extends PreferenceActivity implements OnSharedPrefe
                             mDeck.put("terms", ar);
                         } else if (entry.getKey().equals("limit")) {
                             JSONArray ar = mDeck.getJSONArray("terms");
-                            ar.getJSONArray(0).put(1, Integer.parseInt((String) entry.getValue()));
+                            ar.getJSONArray(0).put(1, (Integer) entry.getValue());
                             mDeck.put("terms", ar);
                         } else if (entry.getKey().equals("order")) {
                             JSONArray ar = mDeck.getJSONArray("terms");

--- a/src/com/ichi2/anki/DeckOptions.java
+++ b/src/com/ichi2/anki/DeckOptions.java
@@ -148,9 +148,9 @@ public class DeckOptions extends PreferenceActivity implements OnSharedPreferenc
                         Log.i(AnkiDroidApp.TAG, "Change value for key '" + key + "': " + value);
                         
                         if (key.equals("maxAnswerTime")) {
-                            mOptions.put("maxTaken", Integer.parseInt((String) value));
+                            mOptions.put("maxTaken", (Integer) value);
                         } else if (key.equals("newFactor")) {
-                            mOptions.getJSONObject("new").put("initialFactor", Integer.parseInt((String) value) * 10);
+                            mOptions.getJSONObject("new").put("initialFactor", (Integer) value * 10);
                         } else if (key.equals("newOrder")) {
                             int newValue = Integer.parseInt((String) value);
                             // Sorting is slow, so only do it if we change order
@@ -162,37 +162,37 @@ public class DeckOptions extends PreferenceActivity implements OnSharedPreferenc
                             }
                             mOptions.getJSONObject("new").put("order", Integer.parseInt((String) value));
                         } else if (key.equals("newPerDay")) {
-                            mOptions.getJSONObject("new").put("perDay", Integer.parseInt((String) value));
+                            mOptions.getJSONObject("new").put("perDay", (Integer) value);
                         } else if (key.equals("newGradIvl")) {
                             JSONArray ja = new JSONArray(); //[graduating, easy]
-                            ja.put(Integer.parseInt((String) value));
+                            ja.put((Integer) value);
                             ja.put(mOptions.getJSONObject("new").getJSONArray("ints").get(1));
                             mOptions.getJSONObject("new").put("ints", ja);
                         } else if (key.equals("newEasy")) {
                             JSONArray ja = new JSONArray(); //[graduating, easy]
                             ja.put(mOptions.getJSONObject("new").getJSONArray("ints").get(0));
-                            ja.put(Integer.parseInt((String) value));
+                            ja.put((Integer) value);
                             mOptions.getJSONObject("new").put("ints", ja);
                         } else if (key.equals("revPerDay")) {
-                            mOptions.getJSONObject("rev").put("perDay", Integer.parseInt((String) value));
+                            mOptions.getJSONObject("rev").put("perDay", (Integer) value);
                         } else if (key.equals("revSpaceMax")) {
-                            mOptions.getJSONObject("rev").put("fuzz", Integer.parseInt((String) value) / 100.0f);
+                            mOptions.getJSONObject("rev").put("fuzz", (Integer) value / 100.0f);
                         } else if (key.equals("revSpaceMin")) {
-                            mOptions.getJSONObject("rev").put("minSpace", Integer.parseInt((String) value));
+                            mOptions.getJSONObject("rev").put("minSpace", (Integer) value);
                         } else if (key.equals("easyBonus")) {
-                            mOptions.getJSONObject("rev").put("ease4", Integer.parseInt((String) value) / 100.0f);
+                            mOptions.getJSONObject("rev").put("ease4", (Integer) value / 100.0f);
                         } else if (key.equals("revIvlFct")) {
-                            mOptions.getJSONObject("rev").put("ivlFct", Integer.parseInt((String) value) / 100.0f);
+                            mOptions.getJSONObject("rev").put("ivlFct", (Integer) value / 100.0f);
                         } else if (key.equals("revMaxIvl")) {
-                            mOptions.getJSONObject("rev").put("maxIvl", Integer.parseInt((String) value));
+                            mOptions.getJSONObject("rev").put("maxIvl", (Integer) value);
                         } else if (key.equals("lapMinIvl")) {
-                            mOptions.getJSONObject("lapse").put("minInt", Integer.parseInt((String) value));
+                            mOptions.getJSONObject("lapse").put("minInt", (Integer) value);
                         } else if (key.equals("lapLeechThres")) {
-                            mOptions.getJSONObject("lapse").put("leechFails", Integer.parseInt((String) value));
+                            mOptions.getJSONObject("lapse").put("leechFails", (Integer) value);
                         } else if (key.equals("lapLeechAct")) {
                             mOptions.getJSONObject("lapse").put("leechAction", Integer.parseInt((String) value));
                         } else if (key.equals("lapNewIvl")) {
-                            mOptions.getJSONObject("lapse").put("mult", Integer.parseInt((String) value) / 100.0f);
+                            mOptions.getJSONObject("lapse").put("mult", (Integer) value / 100.0f);
                         } else if (key.equals("showAnswerTimer")) {
                             mOptions.put("timer", (Boolean) value ? 1 : 0);
                         } else if (key.equals("autoPlayAudio")) {

--- a/src/com/ichi2/preferences/NumberRangePreference.java
+++ b/src/com/ichi2/preferences/NumberRangePreference.java
@@ -19,6 +19,7 @@ package com.ichi2.preferences;
 import android.content.Context;
 import android.preference.EditTextPreference;
 import android.text.InputFilter;
+import android.text.InputType;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 
@@ -34,7 +35,7 @@ public class NumberRangePreference extends EditTextPreference {
         super(context, attrs, defStyle);
         mMin = getMinFromAttributes(attrs);
         mMax = getMaxFromAttributes(attrs);
-        updateLengthLimit();
+        updateSettings();
     }
 
 
@@ -42,7 +43,7 @@ public class NumberRangePreference extends EditTextPreference {
         super(context, attrs);
         mMin = getMinFromAttributes(attrs);
         mMax = getMaxFromAttributes(attrs);
-        updateLengthLimit();
+        updateSettings();
     }
 
 
@@ -50,7 +51,7 @@ public class NumberRangePreference extends EditTextPreference {
         super(context);
         mMin = getMinFromAttributes(null);
         mMax = getMaxFromAttributes(null);
-        updateLengthLimit();
+        updateSettings();
     }
 
 
@@ -60,6 +61,25 @@ public class NumberRangePreference extends EditTextPreference {
             String validated = getValidatedRange(getEditText().getText().toString());
             setText(validated);
         }
+    }
+
+
+    /*
+     * Since this preference deals with integers only, it makes sense to only store and retrieve
+     * integers. However, since it is extending EditTextPreference, the persistence and retrieval
+     * methods that are called are for a String type. The two methods below intercept the persistence
+     * and retrieval methods for Strings and replaces them with their Integer equivalents.
+     */
+    
+    @Override
+    protected String getPersistedString(String defaultReturnValue) {
+        return String.valueOf(getPersistedInt(mMin));
+    }
+
+
+    @Override
+    protected boolean persistString(String value) {
+        return persistInt(Integer.valueOf(value));
     }
 
 
@@ -111,14 +131,18 @@ public class NumberRangePreference extends EditTextPreference {
 
 
     /**
-     * Updates the maximum length allowed in the text field based on the current value of the {@link #mMax} field.
+     * Update settings to only allow integer input and set the maximum number of digits allowed in the text
+     * field based on the current value of the {@link #mMax} field.
      * <p>
      * This method should only be called once from the constructor.
      */
-    private void updateLengthLimit() {
+    private void updateSettings() {
+        // Only allow integer input
+        getEditText().setInputType(InputType.TYPE_CLASS_NUMBER);
+        
+        // Set max number of digits
         int maxLength = String.valueOf(mMax).length();
-        // Clone the existing filters so we don't override them, then append our one
-        // at the end.
+        // Clone the existing filters so we don't override them, then append our one at the end.
         InputFilter[] filters = getEditText().getFilters();
         InputFilter[] newFilters = new InputFilter[filters.length + 1];
         System.arraycopy(filters, 0, newFilters, 0, filters.length);


### PR DESCRIPTION
@flerda
A little more work on NumberRangePreference. Two changes here:
1 - We shouldn't rely on setting the input type as integer-only in the XML definition. Do it programmatically instead..

2 - Persist and retrieve the values as ints instead of strings. At the moment, we aren't persisting the value (to a shared preference) so it won't have any effect, but we'll need it for other settings later. I'll add a getter and setter in a future commit since it'll help in the other preference work I'm doing now.
