### PR TITLE
Add indices to new collections.

### DIFF
--- a/src/com/ichi2/libanki/Storage.java
+++ b/src/com/ichi2/libanki/Storage.java
@@ -261,6 +261,7 @@ public class Storage {
         db.execute("PRAGMA legacy_file_format = 0");
         db.execute("VACUUM");
         _addSchema(db);
+        _updateIndices(db);
         db.execute("ANALYZE");
         return Collection.SCHEMA_VERSION;
     }


### PR DESCRIPTION
Fix for [Issue 1470](https://code.google.com/p/ankidroid/issues/detail?id=1470). We were simply not calling the function that adds the indices when creating a new database.

This will fix new collections only. Do we need to add an extra check somewhere else for this condition to fix broken collections?
