### PR TITLE
Implementation of collection preferences.

### DIFF
--- a/res/values/10-preferences.xml
+++ b/res/values/10-preferences.xml
@@ -21,7 +21,7 @@
 <resources>
 
 <!-- preferences.xml -->
-<string name="pref_cat_decks">Decks</string>
+<string name="pref_cat_collection">Collection</string>
 <string name="pref_internal_memory">Use internal memory</string>
 <string name="pref_internal_memory_summ">Store collection in internal memory. This is not recommended, as you cannot access the collection file that easily</string>
 <string name="pref_cat_sync">Synchronization</string>
@@ -200,8 +200,6 @@
 <string name="new_card_spacing_summ">Where to distribute new cards during the review.</string>
 <string name="show_new_cards">Show new cards...</string>
 
-<string name="show_next_review_time">Next review time</string>
-<string name="show_next_review_time_summ">Shows the next review time depending on your choice</string>
 <string name="update_notification">Update notifications</string>
 <string name="update_notification_summ">Notify me when AnkiDroid is updated</string>
 
@@ -330,4 +328,16 @@
 <string name="pref_cat_intent_add">External data addition</string>
 
 
+<string name="show_estimates">Show button time</string>
+<string name="show_estimates_summ">Show next review time above answer buttons</string>
+<string name="show_progress">Show remaining</string>
+<string name="show_progress_summ">Show remaining card count during review</string>
+<string name="use_current">Deck for new cards</string>
+<string name="new_spread">New card position</string>
+<string name="learn_cutoff">Learn ahead limit</string>
+<string name="learn_cutoff_summ">XXX min(s)</string>
+<string name="time_limit">Timebox time limit</string>
+<string name="time_limit_summ">XXX min(s)</string>
+<string name="day_offset">Start of next day</string>
+<string name="day_offset_summ">Hours past midnight: XXX</string>
 </resources>

--- a/res/values/11-arrays.xml
+++ b/res/values/11-arrays.xml
@@ -118,4 +118,13 @@
 						<item>Limit to particular tags</item>
 											</string-array>
 	
+    <string-array name="add_to_cur_labels">
+        <item>Use current deck</item>
+        <item>Decide by note type</item>
+    </string-array>
+    <string-array name="new_spread_labels">
+        <item>Mix new cards and reviews</item>
+        <item>New cards after reviews</item>
+        <item>New cards before reviews</item>
+    </string-array>
    	</resources>

--- a/res/values/constants.xml
+++ b/res/values/constants.xml
@@ -174,5 +174,14 @@
         <item>7</item>
     </string-array>
 
+    <string-array name="add_to_cur_values">
+        <item>0</item>
+        <item>1</item>
+    </string-array>
+    <string-array name="new_spread_values">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+    </string-array>
 
 </resources>

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -22,20 +22,34 @@
     xmlns:app="http://schemas.android.com/apk/res/com.ichi2.anki" >
 
     <PreferenceScreen android:title="@string/pref_cat_general" >
-        <PreferenceCategory android:title="@string/pref_cat_decks" >
+        <PreferenceCategory android:title="@string/pref_cat_collection" >
             <EditTextPreference
                 android:defaultValue="/sdcard/AnkiDroid"
                 android:key="deckPath"
                 android:dependency="internalMemory"
                 android:summary="@string/col_path_summ"
                 android:title="@string/col_path" />
+            <com.hlidskialf.android.preference.SeekBarPreference
+                android:key="dayOffset"
+                android:summary="@string/day_offset_summ"
+                android:title="@string/day_offset"
+                app:interval="1"
+                app:min="0"
+                android:max="23" />
+            <ListPreference
+                android:key="useCurrent"
+                android:defaultValue=""
+                android:title="@string/use_current"
+                android:summary=""
+                android:entries="@array/add_to_cur_labels"
+                android:entryValues="@array/add_to_cur_values" />
             <CheckBoxPreference
                 android:defaultValue="false"
                 android:disableDependentsState="true"
                 android:key="internalMemory"
                 android:summary="@string/pref_internal_memory_summ"
                 android:title="@string/pref_internal_memory" />
-            </PreferenceCategory>
+        </PreferenceCategory>
         <PreferenceCategory android:title="@string/pref_cat_backup" >
             <CheckBoxPreference
                 android:defaultValue="true"
@@ -208,6 +222,25 @@
     </PreferenceScreen>
     <PreferenceScreen android:title="@string/pref_cat_reviewing" >
         <PreferenceCategory android:title="@string/pref_cat_reviewer_behaviour" >
+            <ListPreference
+                android:key="newSpread"
+                android:defaultValue=""
+                android:title="@string/new_spread"
+                android:summary=""
+                android:entries="@array/new_spread_labels"
+                android:entryValues="@array/new_spread_values" />
+            <com.ichi2.preferences.NumberRangePreference
+                android:key="learnCutoff"
+                android:title="@string/learn_cutoff"
+                android:summary="@string/learn_cutoff_summ"
+                app:min="0"
+                app:max="999" />
+            <com.ichi2.preferences.NumberRangePreference
+                android:key="timeLimit"
+                android:title="@string/time_limit"
+                android:summary="@string/time_limit_summ"
+                app:min="0"
+                app:max="9999" />
 	        <CheckBoxPreference
 	            android:defaultValue="true"
 	            android:key="writeAnswers"
@@ -256,10 +289,13 @@
                 android:summary="@string/fullscreen_review_summ"
                 android:title="@string/fullscreen_review" />
             <CheckBoxPreference
-                android:defaultValue="true"
-                android:key="showNextReviewTime"
-                android:summary="@string/show_next_review_time_summ"
-                android:title="@string/show_next_review_time" />
+                android:key="showEstimates"
+                android:title="@string/show_estimates"
+                android:summary="@string/show_estimates_summ" />
+            <CheckBoxPreference
+                android:key="showProgress"
+                android:title="@string/show_progress"
+                android:summary="@string/show_progress_summ" />
             <CheckBoxPreference
                 android:defaultValue="true"
                 android:key="progressBars"

--- a/src/com/hlidskialf/android/preference/SeekBarPreference.java
+++ b/src/com/hlidskialf/android/preference/SeekBarPreference.java
@@ -112,6 +112,10 @@ public class SeekBarPreference extends DialogPreference implements SeekBar.OnSee
         }
     }
 
+    public void setValue(int value) {
+        mValue = value;
+        persistInt(value);
+    }
 
     public void onStartTrackingTouch(SeekBar seek) {
     }

--- a/src/com/ichi2/anki/Reviewer.java
+++ b/src/com/ichi2/anki/Reviewer.java
@@ -220,7 +220,6 @@ public class Reviewer extends AnkiActivity {
     private boolean mInputWorkaround;
     private boolean mLongClickWorkaround;
     private boolean mPrefFullscreenReview;
-    private boolean mshowNextReviewTime;
     private boolean mZoomEnabled;
     private String mCollectionFilename;
     private int mRelativeButtonSize;
@@ -246,6 +245,10 @@ public class Reviewer extends AnkiActivity {
     private boolean mCurrentSimpleInterface = false;
     private ArrayList<String> mSimpleInterfaceExcludeTags;
     private int mAvailableInCardWidth;
+
+    // Preferences from the collection
+    private boolean mShowNextReviewTime;
+    private boolean mShowRemainingCardCount;
 
     // Answer card & cloze deletion variables
     /** The correct answer in the compare to field if answer should be given by learner.
@@ -1726,7 +1729,7 @@ public class Reviewer extends AnkiActivity {
         mNext1.setTextColor(res.getColor(R.color.next_time_failed_color));
         mNext2.setTextColor(res.getColor(R.color.next_time_usual_color));
 
-        if (!mshowNextReviewTime) {
+        if (!mShowNextReviewTime) {
             ((TextView) findViewById(R.id.nextTimeflip)).setVisibility(View.GONE);
             mNext1.setVisibility(View.GONE);
             mNext2.setVisibility(View.GONE);
@@ -1742,6 +1745,12 @@ public class Reviewer extends AnkiActivity {
         mTextBarBlack = (TextView) findViewById(R.id.black_number);
         mTextBarBlue = (TextView) findViewById(R.id.blue_number);
 
+        if (!mShowRemainingCardCount) {
+            mTextBarRed.setVisibility(View.GONE);
+            mTextBarBlack.setVisibility(View.GONE);
+            mTextBarBlue.setVisibility(View.GONE);
+        }
+        
         if (mShowProgressBars) {
             mSessionProgressTotalBar = (View) findViewById(R.id.daily_bar);
             mSessionProgressBar = (View) findViewById(R.id.session_progress);
@@ -1913,7 +1922,7 @@ public class Reviewer extends AnkiActivity {
         }
 
         // Show next review time
-        if (mshowNextReviewTime) {
+        if (mShowNextReviewTime) {
             mNext1.setText(mSched.nextIvlStr(mCurrentCard, 1));
             mNext2.setText(mSched.nextIvlStr(mCurrentCard, 2));
         if (buttonCount > 2) {
@@ -1971,18 +1980,22 @@ public class Reviewer extends AnkiActivity {
         if (mShowProgressBars) {
             switchVisibility(mProgressBars, visible, true);
         }
-        switchVisibility(mTextBarRed, visible, true);
-        switchVisibility(mTextBarBlack, visible, true);
-        switchVisibility(mTextBarBlue, visible, true);
+        if (mShowRemainingCardCount) {
+            switchVisibility(mTextBarRed, visible, true);
+            switchVisibility(mTextBarBlack, visible, true);
+            switchVisibility(mTextBarBlue, visible, true);
+        }
         switchVisibility(mChosenAnswer, visible, true);
     }
 
 
     private void initControls() {
         mCardFrame.setVisibility(View.VISIBLE);
-        mTextBarRed.setVisibility(View.VISIBLE);
-        mTextBarBlack.setVisibility(View.VISIBLE);
-        mTextBarBlue.setVisibility(View.VISIBLE);
+        if (mShowRemainingCardCount) {
+            mTextBarRed.setVisibility(View.VISIBLE);
+            mTextBarBlack.setVisibility(View.VISIBLE);
+            mTextBarBlue.setVisibility(View.VISIBLE);
+        }
         mChosenAnswer.setVisibility(View.VISIBLE);
         mFlipCardLayout.setVisibility(View.VISIBLE);
 
@@ -2005,7 +2018,6 @@ public class Reviewer extends AnkiActivity {
         mInvertedColors = mNightMode;
         mBlackWhiteboard = preferences.getBoolean("blackWhiteboard", true);
         mPrefFullscreenReview = preferences.getBoolean("fullscreenReview", false);
-        mshowNextReviewTime = preferences.getBoolean("showNextReviewTime", true);
         mZoomEnabled = preferences.getBoolean("zoom", false);
         mDisplayFontSize = preferences.getInt("relativeDisplayFontSize", 100);// Card.DEFAULT_FONT_SIZE_RATIO);
         mRelativeButtonSize = preferences.getInt("answerButtonSize", 100);
@@ -2074,6 +2086,14 @@ public class Reviewer extends AnkiActivity {
         	}
         }
 
+        // These are preferences we pull out of the collection instead of SharedPreferences
+        try {
+            mShowNextReviewTime = AnkiDroidApp.getCol().getConf().getBoolean("estTimes");
+            mShowRemainingCardCount = AnkiDroidApp.getCol().getConf().getBoolean("dueCounts");
+        } catch (JSONException e) {
+            throw new RuntimeException();
+        }
+        
         return preferences;
     }
 

--- a/src/com/ichi2/preferences/NumberRangePreference.java
+++ b/src/com/ichi2/preferences/NumberRangePreference.java
@@ -58,8 +58,8 @@ public class NumberRangePreference extends EditTextPreference {
     @Override
     protected void onDialogClosed(boolean positiveResult) {
         if (positiveResult) {
-            String validated = getValidatedRange(getEditText().getText().toString());
-            setText(validated);
+            int validated = getValidatedRangeFromString(getEditText().getText().toString());
+            setValue(validated);
         }
     }
 
@@ -84,30 +84,38 @@ public class NumberRangePreference extends EditTextPreference {
 
 
     /**
-     * Return the input number with the number rounded to the nearest bound if it is outside
+     * Return the string as an int with the number rounded to the nearest bound if it is outside
      * of the acceptable range.
      * @param input User input in text editor.
      * @return The input value within acceptable range.
      */
-    private String getValidatedRange(String input) {
-        int valueInt;
+    private int getValidatedRangeFromString(String input) {
         if (TextUtils.isEmpty(input)) {
-            valueInt = mMin;
+            return mMin;
         } else {
             try {
-                valueInt = Integer.parseInt(input);
+                return getValidatedRangeFromInt(Integer.parseInt(input));
             } catch (NumberFormatException e) {
-                valueInt = mMin;
+                return mMin;
             }
         }
-        if (valueInt < mMin) {
-            valueInt = mMin;
-        } else if (valueInt > mMax) {
-            valueInt = mMax;
-        }
-        return String.valueOf(valueInt);
     }
 
+
+    /**
+     * Return the integer rounded to the nearest bound if it is outside of the acceptable
+     * range.
+     * @param input Integer to validate.
+     * @return The input value within acceptable range.
+     */
+    private int getValidatedRangeFromInt(int input) {
+        if (input < mMin) {
+            input = mMin;
+        } else if (input > mMax) {
+            input = mMax;
+        }
+        return input;
+    }
 
     /**
      * Returns the value of the min attribute, or its default value if not specified
@@ -148,5 +156,24 @@ public class NumberRangePreference extends EditTextPreference {
         System.arraycopy(filters, 0, newFilters, 0, filters.length);
         newFilters[newFilters.length - 1] = new InputFilter.LengthFilter(maxLength);
         getEditText().setFilters(newFilters);
+    }
+    
+    /**
+     * Get the persisted value held by this preference.
+     * @return the persisted value.
+     */
+    public int getValue() {
+        return getPersistedInt(mMin);
+    }
+
+    
+    /**
+     * Set this preference's value. The value is validated and persisted as an Integer.
+     * @param value to set.
+     */
+    public void setValue(int value) {
+        int validated = getValidatedRangeFromInt(value);
+        setText(Integer.toString(validated));
+        persistInt(validated);
     }
 }


### PR DESCRIPTION
[Issue 1687](https://code.google.com/p/ankidroid/issues/detail?id=1687)

Here's an implementation of the collection preferences. See [preferences.py](https://github.com/dae/anki/blob/master/aqt/preferences.py) for reference. I used the same keys in our version.

I also made some small changes in Reviewer.java to actually use some of those preferences correctly. The card adder needs to implement the "When adding, default to..." option, but I left that alone since there's still work being done in that part of the code.

The approach here differs from DeckOptions.java and CramDeckOptions.java where I think the `DeckPreferenceHack` class was used to avoid persisting values as Shared Preferences (I could be wrong). In the code here, we're storing and retrieving the values in the collection, but they are also stored as Shared Preferences, even though those values are never used. I couldn't find a way to keep getting the callbacks without leaving persistence on, and to me this seemed much simpler than the DeckPreferenceHack approach, especially with the existing code already there. Hopefully this won't cause problems.
