### PR TITLE
Add missing indices to integrity check.

### DIFF
--- a/src/com/ichi2/libanki/Collection.java
+++ b/src/com/ichi2/libanki/Collection.java
@@ -1351,6 +1351,12 @@ public class Collection {
                             + " WHERE id IN " + Utils.ids2str(Utils.arrayList2array(ids)));
                 }
                 mDb.getDatabase().setTransactionSuccessful();
+                // DB must have indices. Older versions of AnkiDroid didn't create them for new collections.
+                int ixs = mDb.queryScalar("select count(name) from sqlite_master where type = 'index'");
+                if (ixs < 7) {
+                    problems.add("Indices were missing.");
+                    Storage.addIndices(mDb);
+                }
             } catch (JSONException e) {
                 throw new RuntimeException(e);
             } finally {

--- a/src/com/ichi2/libanki/Storage.java
+++ b/src/com/ichi2/libanki/Storage.java
@@ -347,6 +347,10 @@ public class Storage {
     }
 
 
+    public static void addIndices(AnkiDb db) {
+        _updateIndices(db);
+    }
+    
     /*
      * Upgrading ************************************************************
      */


### PR DESCRIPTION
@flerda

Continuing from this: https://github.com/ankidroid/Anki-Android/pull/43

I added a check for missing indices in the "Check database" function. This is still a manually triggered function though. Did you have some other automated method in mind?
