### PR TITLE
Always replace fragment content on deck selection.

### DIFF
--- a/src/com/ichi2/anki/DeckPicker.java
+++ b/src/com/ichi2/anki/DeckPicker.java
@@ -2178,15 +2178,12 @@ public class DeckPicker extends FragmentActivity {
     // ----------------------------------------------------------------------------
 
     public void setStudyContentView(long deckId, Bundle cramConfig) {
-    	Fragment frag = (Fragment) getSupportFragmentManager().findFragmentById(R.id.studyoptions_fragment);
-    	if (frag == null || !(frag instanceof StudyOptionsFragment) || ((StudyOptionsFragment) frag).getShownIndex() != deckId) {
-            StudyOptionsFragment details = StudyOptionsFragment.newInstance(deckId, false, cramConfig);
-            FragmentTransaction ft = getSupportFragmentManager().beginTransaction();
-//            ft.setCustomAnimations(R.anim.fade_in, R.anim.fade_out);
-            ft.setTransition(FragmentTransaction.TRANSIT_FRAGMENT_CLOSE);
-            ft.replace(R.id.studyoptions_fragment, details);
-            ft.commit();
-    	}
+        StudyOptionsFragment details = StudyOptionsFragment.newInstance(deckId, false, cramConfig);
+        FragmentTransaction ft = getSupportFragmentManager().beginTransaction();
+//      ft.setCustomAnimations(R.anim.fade_in, R.anim.fade_out);
+        ft.setTransition(FragmentTransaction.TRANSIT_FRAGMENT_CLOSE);
+        ft.replace(R.id.studyoptions_fragment, details);
+        ft.commit();
     }
 
     public StudyOptionsFragment getFragment() {


### PR DESCRIPTION
Possible fix for [Issue 1634](https://code.google.com/p/ankidroid/issues/detail?id=1634)

This crash happens after syncing when there is no content loaded in the fragment on the right in the tablet view. AnkiDroid will try to update some objects inside the fragment after syncing but will crash since those objects are null.

The fragment is not loaded under certain conditions when opening AnkiDroid. I traced it to [this line](https://github.com/ankidroid/Anki-Android/blob/v2.1-dev/src/com/ichi2/anki/DeckPicker.java#L2182). For the fix, I removed this condition entirely. I don't think it is achieving anything. Here's my reasoning:

Below it, we are creating a new instance of `StudyOptionsFragment` and then [replacing everything in the container with the new instance](http://developer.android.com/reference/android/support/v4/app/FragmentTransaction.html#replace(int, android.support.v4.app.Fragment, java.lang.String)). So the state of the existing fragment is irrelevant and we don't need to check it.

The third condition seems to be trying to avoid updating the fragment if it's the same deck, but this bug shows we can't rely on this method. Perhaps there is a better way for this one (or it just may not be worth it).
