### PR TITLE
Do not add font files with the wrong extension.

### DIFF
--- a/src/com/ichi2/libanki/Utils.java
+++ b/src/com/ichi2/libanki/Utils.java
@@ -1124,12 +1124,18 @@ public class Utils {
 		}
         List<AnkiFont> fonts = new ArrayList<AnkiFont>();
         for (int i = 0; i < fontsCount; i++) {
-            AnkiFont font = AnkiFont.createAnkiFont(context, fontsList[i].getAbsolutePath(), false);
+            String filePath = fontsList[i].getAbsolutePath();
+            if (!filePath.endsWith(".ttf") && !filePath.endsWith(".ttc")) {
+                // Ignore files that do not look like fonts.
+                continue;
+            }
+            AnkiFont font = AnkiFont.createAnkiFont(context, filePath, false);
             if (font != null) {
                 fonts.add(font);
             }
         }
         for (int i = 0; i < ankiDroidFonts.length; i++) {
+            // Assume all files in the assets directory are actually fonts.
             AnkiFont font = AnkiFont.createAnkiFont(context, ankiDroidFonts[i], true);
         	if (font != null) {
                 fonts.add(font);


### PR DESCRIPTION
Since the user can put any arbitrary files in the fonts directory on the
SD card, simply ignore anything that is not a .ttf or .ttc file.

If any extraneous files are added as fonts, a corresponding @font-face
directive will be added to the stylesheet, which will actually cause a
pop-up to show up during review.

This is a fix for:
https://code.google.com/p/ankidroid/issues/detail?id=1575
