### PR TITLE
Disable text selection setting if we get a NPE when using clipboard.

### DIFF
--- a/src/com/ichi2/anki/Reviewer.java
+++ b/src/com/ichi2/anki/Reviewer.java
@@ -1317,7 +1317,15 @@ public class Reviewer extends AnkiActivity {
 
     private void clipboardSetText(CharSequence text) {
         if (mClipboard != null) {
-        	mClipboard.setText(text);
+            try {
+                mClipboard.setText(text);
+            } catch (NullPointerException e) {
+                // Workaround for https://code.google.com/p/ankidroid/issues/detail?id=1746
+                // Some devices end up with an unusable clipboard. If so, we must disable it or AnkiDroid will
+                // crash if it tries to use it.
+                Log.e(AnkiDroidApp.TAG, "Clipboard error. Disabling text selection setting.");
+                AnkiDroidApp.getSharedPrefs(getBaseContext()).edit().putBoolean("textSelection", false).commit();
+            }
         }
     }
 


### PR DESCRIPTION
Fix for [Issue 1746](https://code.google.com/p/ankidroid/issues/detail?id=1746).

A Samsung bug leaves devices unable to use the clipboard. AnkiDroid
will crash while using the clipboard on those devices (i.e., every time
the reviewer opens). Here, we disable the text selection setting so
the clipboard isn't used and AnkiDroid can continue to review cards.
