### PR TITLE
Select the correct deck after sync in fragmented mode.

### DIFF
--- a/src/com/ichi2/anki/DeckPicker.java
+++ b/src/com/ichi2/anki/DeckPicker.java
@@ -530,13 +530,15 @@ public class DeckPicker extends FragmentActivity {
             		mOpenCollectionDialog.dismiss();
             	}
 
-                // update StudyOptions too if open
-                if (mFragmented) {
-                	StudyOptionsFragment frag = getFragment();
-                	if (frag != null) {
-                		frag.resetAndUpdateValuesFromDeck();
-                	}
-                }
+            	if (mFragmented) {
+                    try {
+                        // Pick the correct deck after sync. Updates the values in the fragment if same deck.
+                        long did = AnkiDroidApp.getCol().getDecks().current().getLong("id");
+                        selectDeck(did);
+                    } catch (JSONException e) {
+                        throw new RuntimeException();
+                    }
+            	}
             }
         }
     };
@@ -557,19 +559,7 @@ public class DeckPicker extends FragmentActivity {
             // select last loaded deck if any
             if (mFragmented) {
             	long did = col.getDecks().selected();
-            	for (int i = 0; i < mDeckList.size(); i++) {
-            		if (Long.parseLong(mDeckList.get(i).get("did")) == did) {
-            			final int lastPosition = i;
-                        mDeckListView.getViewTreeObserver().addOnGlobalLayoutListener(new OnGlobalLayoutListener() {
-                            @Override
-                            public void onGlobalLayout() {
-                            	mDeckListView.getViewTreeObserver().removeGlobalOnLayoutListener(this);
-                            	mDeckListView.performItemClick(null, lastPosition, 0);
-                            }
-                        });
-                        break;
-            		}
-            	}
+            	selectDeck(did);
             }
             if (AnkiDroidApp.colIsOpen() && mImportPath != null) {
             	showDialog(DIALOG_IMPORT);
@@ -2836,6 +2826,27 @@ public class DeckPicker extends FragmentActivity {
         }
     }
 
+
+    /**
+     * Programmatically click on a deck in the deck list.
+     * @param did The deck ID of the deck to select.
+     */
+    private void selectDeck(long did) {
+        Log.i(AnkiDroidApp.TAG, "Selected deck with ID " + did);
+        for (int i = 0; i < mDeckList.size(); i++) {
+            if (Long.parseLong(mDeckList.get(i).get("did")) == did) {
+                final int lastPosition = i;
+                mDeckListView.getViewTreeObserver().addOnGlobalLayoutListener(new OnGlobalLayoutListener() {
+                    @Override
+                    public void onGlobalLayout() {
+                        mDeckListView.getViewTreeObserver().removeGlobalOnLayoutListener(this);
+                        mDeckListView.performItemClick(null, lastPosition, 0);
+                    }
+                });
+                break;
+            }
+        }
+    }
 
     private void handleDeckSelection(int id) {
     	if (!AnkiDroidApp.colIsOpen()) {


### PR DESCRIPTION
[Issue 1235](https://code.google.com/p/ankidroid/issues/detail?id=1235)

The currently selected deck might change after a sync. In fragmented mode, the selected deck is updated in the fragment but not in the deck list. This ensures both are updated after a sync ends.

I found a bit of code that programmatically selects the deck (and thus loads a new StudyOptionsFragment) and factored it out for use in other places.
