### PR TITLE
Don't show a custom study button in congrats view of filtered deck.

### DIFF
--- a/src/com/ichi2/anki/StudyOptionsFragment.java
+++ b/src/com/ichi2/anki/StudyOptionsFragment.java
@@ -1132,6 +1132,15 @@ public class StudyOptionsFragment extends Fragment {
                     AnkiDroidApp.getCol().undoName(res)));
         }
         mTextCongratsMessage.setText(AnkiDroidApp.getCol().getSched().finishedMsg(getActivity()));
+        // Filtered decks must not have a custom study button
+        try {
+            if (AnkiDroidApp.getCol().getDecks().current().getInt("dyn") == 1) {
+                mButtonCongratsCustomStudy.setEnabled(false);
+                mButtonCongratsCustomStudy.setVisibility(View.GONE);
+            }
+        } catch (JSONException e) {
+            throw new RuntimeException();
+        }
     }
 
 


### PR DESCRIPTION
It doesn't make sense to have a custom study button for a filtered deck, so hide it.
