### PR TITLE
Highlight the currently selected deck when the deck list is updated.

### DIFF
--- a/src/com/ichi2/anki/DeckPicker.java
+++ b/src/com/ichi2/anki/DeckPicker.java
@@ -616,8 +616,14 @@ public class DeckPicker extends FragmentActivity {
             Object[] res = result.getObjArray();
             updateDecksList((TreeSet<Object[]>) res[0], (Integer) res[1], (Integer) res[2]);
         	if (mOpenCollectionDialog != null && mOpenCollectionDialog.isShowing()) {
-            	mOpenCollectionDialog.dismiss();        		
+            	mOpenCollectionDialog.dismiss();
         	}
+            try {
+                // Ensure we have the correct deck selected in the deck list after we have updated it
+                setSelectedDeck(AnkiDroidApp.getCol().getDecks().current().getLong("id"));
+            } catch (JSONException e) {
+                throw  new RuntimeException();
+            }
         }
 
 
@@ -2843,6 +2849,22 @@ public class DeckPicker extends FragmentActivity {
                         mDeckListView.performItemClick(null, lastPosition, 0);
                     }
                 });
+                break;
+            }
+        }
+    }
+
+    /**
+     * Set which deck is selected (highlighted) in the deck list.
+     * <p>
+     * Note that this method does not change the currently selected deck in the collection, only the highlighted
+     * deck in the deck list. To select a deck, see {@link #selectDeck(long)}.
+     * @param did The deck ID of the deck to select.
+     */
+    public void setSelectedDeck(long did) {
+        for (int i = 0; i < mDeckList.size(); i++) {
+            if (Long.parseLong(mDeckList.get(i).get("did")) == did) {
+                mDeckListView.setItemChecked(i, true);
                 break;
             }
         }


### PR DESCRIPTION
There still remains cases where the deck list is updated and the StudyOptionsFragment is replaced (e.g., new filtered deck) but the currently selected deck isn't correctly highlighted in the deck list in fragmented mode. So the highlighted deck and the StudyOptionsFragment deck differ.

This change will ensure that any time the deck list is updated, the correct deck in the list is also highlighted. The assumption is made that the deck visible in the StudyOptionsFragment is internally set as the currently selected deck.
