### PR TITLE
Select correct deck after delete in fragmented mode.

### DIFF
--- a/src/com/ichi2/anki/DeckPicker.java
+++ b/src/com/ichi2/anki/DeckPicker.java
@@ -1579,16 +1579,6 @@ public class DeckPicker extends FragmentActivity {
 
                             @Override
                             public void onClick(DialogInterface dialog, int which) {
-                                if (AnkiDroidApp.getCol().getDecks().selected() == mCurrentDid) {
-                                    Fragment frag = (Fragment) getSupportFragmentManager().findFragmentById(
-                                            R.id.studyoptions_fragment);
-                                    if (frag != null && frag instanceof StudyOptionsFragment) {
-                                        FragmentTransaction ft = getSupportFragmentManager().beginTransaction();
-                                        ft.remove(frag);
-                                        ft.setTransition(FragmentTransaction.TRANSIT_FRAGMENT_FADE);
-                                        ft.commit();
-                                    }
-                                }
                                 DeckTask.launchDeckTask(DeckTask.TASK_TYPE_DELETE_DECK, new DeckTask.TaskListener() {
                                     @Override
                                     public void onPreExecute() {
@@ -1604,6 +1594,9 @@ public class DeckPicker extends FragmentActivity {
                                         }
                                         Object[] res = result.getObjArray();
                                         updateDecksList((TreeSet<Object[]>) res[0], (Integer) res[1], (Integer) res[2]);
+                                        if (mFragmented) {
+                                            selectDeck(AnkiDroidApp.getCol().getDecks().selected());
+                                        }
                                         if (mProgressDialog.isShowing()) {
                                             try {
                                                 mProgressDialog.dismiss();


### PR DESCRIPTION
Deleting a deck in fragmented mode will simply remove the fragment if the deck that was removed was the currently selected deck. This leaves us with an empty fragment, and a crash also happens if you tap the back button (I didn't bother finding out why).

This change solves two issues:
1 - If the currently selected deck is deleted, we ensure we don't leave an empty fragment after we are done deleting it. The next active deck is selected (libanki ensures there is always a selected deck internally). This also seems to fix the crash.

2 - If the deck we deleted was a sub-deck of the currently selected deck, the new fragment we end up loading will have updated counts, which are likely to have changed if we delete a subdeck.
