### PR TITLE
Classpath for updated SDK tools

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="con" path="com.android.ide.eclipse.adt.ANDROID_FRAMEWORK"/>
-	<classpathentry kind="con" path="com.android.ide.eclipse.adt.LIBRARIES"/>
+	<classpathentry exported="true" kind="con" path="com.android.ide.eclipse.adt.LIBRARIES"/>
 	<classpathentry kind="lib" path="libs/android-support-v4.jar"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="gen"/>
@@ -10,5 +10,6 @@
 			<attribute name="javadoc_location" value="jar:platform:/resource/AnkiAndroid/libs/google-gson-2.2.3/gson-2.2.3-javadoc.jar!/"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry exported="true" kind="con" path="com.android.ide.eclipse.adt.DEPENDENCIES"/>
 	<classpathentry kind="output" path="bin/classes"/>
 </classpath>


### PR DESCRIPTION
After updating my ADT plugin to the latest version, AnkiDroid started crashing on startup. This is a fix for that, [courtesy of StackOverflow](http://stackoverflow.com/questions/12243631/unable-to-resolve-superclass-of-activity/16607165#16607165). I'm not sure if this breaks older versions.
