### PR TITLE
Lighter blue colour for filtered decks in deck list.

### DIFF
--- a/res/values/colors.xml
+++ b/res/values/colors.xml
@@ -103,7 +103,7 @@
 	
 	<color name="actionbar_background">#f5f5f5</color>
 
-	<color name="dyn_deck">#454545</color>
+	<color name="dyn_deck">#2222bb</color>
 	<color name="non_dyn_deck">#000000</color>
 		
 					


### PR DESCRIPTION
Filtered decks are blue on the desktop client. AnkiDroid already applies a colour, but it's almost impossible to discern from the normal deck colour. This makes it more blue.
![screenshot-1370780175378](https://f.cloud.github.com/assets/789082/628833/98c64a84-d0fe-11e2-9458-dda03e7bf67b.png)
