### PR TITLE
Remove `<rb>` element. Not in html5.

### DIFF
--- a/src/com/ichi2/libanki/hooks/FuriganaFilters.java
+++ b/src/com/ichi2/libanki/hooks/FuriganaFilters.java
@@ -26,8 +26,8 @@ public class FuriganaFilters {
 
     // Since there is no ruby tag support in Android before 3.0 (SDK version 11), we must use an alternative
     // approach to align the elements. Anki does the same thing in aqt/qt.py for earlier versions of qt.
-    // The fallback approach relies on CSS in the file /assets/flashcard_css
-    private static final String RUBY = AnkiDroidApp.SDK_VERSION >= 11 ? "<ruby><rb>$1</rb><rt>$2</rt></ruby>"
+    // The fallback approach relies on CSS in the file /assets/ruby.css
+    private static final String RUBY = AnkiDroidApp.SDK_VERSION >= 11 ? "<ruby>$1<rt>$2</rt></ruby>"
             : "<span class='legacy_ruby_rb'><span class='legacy_ruby_rt'>$2</span>$1</span>";
 
 


### PR DESCRIPTION
I already have one change that uses my latest change (#50, thx for that merge):
While some [old draft](http://www.w3.org/TR/1999/WD-ruby-19990322/) does mention `<rb>` elements, it is _not_ in the  html5 [`<ruby>` elements](http://www.w3.org/TR/html-markup/ruby.html) description.
(This commit also brings the comment in line with #50.)
