### PR TITLE
Issue 1055: Anchor to answer when answer is shown.

### DIFF
--- a/assets/card_template.html
+++ b/assets/card_template.html
@@ -15,7 +15,7 @@
         ::content::
         </div>
         <script type="text/javascript">
-            window.location.href = "#question"
+            window.location.href = "#answer";
         </script>
     </body>
 </html>


### PR DESCRIPTION
[Issue 1055](https://code.google.com/p/ankidroid/issues/detail?id=1055)

Set the webview location to where the answer begins once the answer is revealed. The desktop client simply anchors to #answer, so we do the same here. Templates by default have a `<hr id=answer>`, so it relies on that.

The existing anchor to #question is actually not targeting anything. We don't have a `question` element id anywhere, so it was useless. (We do have a class, though).
