### PR TITLE
Add `color:white` in night mode.

### DIFF
--- a/src/com/ichi2/anki/Reviewer.java
+++ b/src/com/ichi2/anki/Reviewer.java
@@ -1759,7 +1759,7 @@ public class Reviewer extends AnkiActivity {
             mTextBarBlack.setVisibility(View.GONE);
             mTextBarBlue.setVisibility(View.GONE);
         }
-        
+
         if (mShowProgressBars) {
             mSessionProgressTotalBar = (View) findViewById(R.id.daily_bar);
             mSessionProgressBar = (View) findViewById(R.id.session_progress);
@@ -2103,7 +2103,7 @@ public class Reviewer extends AnkiActivity {
         } catch (JSONException e) {
             throw new RuntimeException();
         }
-        
+
         return preferences;
     }
 
@@ -2478,6 +2478,10 @@ public class Reviewer extends AnkiActivity {
 
             Log.i(AnkiDroidApp.TAG, "content card = \n" + content);
             StringBuilder style = new StringBuilder();
+            if (mNightMode) {
+                // Fallback to avoid black-on-black cards when there is no color in the user’s style.
+                style.append("html {color: white;}\n");
+            }
             style.append(mCustomFontStyle);
             Log.i(AnkiDroidApp.TAG, "::style::" + style);
 


### PR DESCRIPTION
One way to fix [issue #1440](https://code.google.com/p/ankidroid/issues/detail?id=1440).
This seems to work. That is, when there is a color set in the card style or when night mode is off, nothing is changed in the display, and when there is no color set you get white-on-black in night mode, instead of black-on-black.
But i am not sure that this is the RIght Way. Maybe the `ForegroundColor` of the webview should be set, or something. I don’t really like that this only works because of the order of the different styles, nor that it sets a style for `html`, which seems a bit odd, but is the only way i can see to make this work when the user sets a color for `html` or `body`.
