### PR TITLE
Issue 1710: Check if sound collection contains item before using it.

### DIFF
--- a/src/com/ichi2/libanki/Sound.java
+++ b/src/com/ichi2/libanki/Sound.java
@@ -188,7 +188,7 @@ public class Sound {
         @Override
         public void onCompletion(MediaPlayer mp) {
             // If there is still more sounds to play for the current card, play the next one
-            if (mNextToPlay < sSoundPaths.get(mQa).size())
+            if (sSoundPaths.containsKey(mQa) && mNextToPlay < sSoundPaths.get(mQa).size())
                 playSound(sSoundPaths.get(mQa).get(mNextToPlay++), this);
             else
                 releaseSound();


### PR DESCRIPTION
[Issue 1710](http://code.google.com/p/ankidroid/issues/detail?id=1710)

Sounds are played through in sequence on their own thread. Another thread could clear the collection of sounds, resulting in a crash after .get()ing a null object. Here, we check if the collection contains items before trying to use it, so the sequence terminates if the collection has been cleared elsewhere.
