### PR TITLE
Styling for night_mode

### DIFF
--- a/assets/chess.css
+++ b/assets/chess.css
@@ -17,3 +17,13 @@
   background:-webkit-gradient(linear,0 0, 0 100%, from(#ccc), to(#eee));
   -webkit-box-shadow:inset 0 0 8px rgba(0,0,0,.4);
 }
+
+.night_mode .chess_board td {
+  background:-webkit-gradient(linear,0 0, 0 100%, from(#000), to(#333));
+  -webkit-box-shadow:inset 0 0 0 1px #000;
+}
+.night_mode .chess_board tr:nth-child(odd) td:nth-child(even),
+.night_mode .chess_board tr:nth-child(even) td:nth-child(odd) {
+  background:-webkit-gradient(linear,0 0, 0 100%, from(#555), to(#777));
+  -webkit-box-shadow:inset 0 0 8px rgba(128, 128, 128,.4);
+}

--- a/assets/flashcard.css
+++ b/assets/flashcard.css
@@ -3,6 +3,11 @@ body {
   padding: 0px;
 }
 
+body.night_mode {
+  color: white;
+  background-color: black;
+}
+
 #content {
   margin: 0.5em;
 }

--- a/src/com/ichi2/anki/Reviewer.java
+++ b/src/com/ichi2/anki/Reviewer.java
@@ -2483,6 +2483,7 @@ public class Reviewer extends AnkiActivity {
 
             if (mNightMode) {
                 content = HtmlColors.invertColors(content);
+                cardClass += " night_mode";
             }
 
             content = SmpToHtmlEntity(content);


### PR DESCRIPTION
This is another approach from #65  to fix [issue #1440](https://code.google.com/p/ankidroid/issues/detail?id=1440).

Add class `night_mode` to cards in night mode, and set that to white-on-black in the `flashcard.css`.

This also adds dark styling for the chess board in night_mode.
