### PR TITLE
Issue 1784: Catch template parsing errors and show useful message.

### DIFF
--- a/res/values/02-strings.xml
+++ b/res/values/02-strings.xml
@@ -30,6 +30,7 @@
 <string name="CardEditorTags">Tags: %1$s</string>
 <string name="add_new_tag">Add new tag</string>
 <string name="note_type">Note type</string>
+<string name="card_type">Card type</string>
 
 <string name="sdcard_missing_message">SD card is unavailable because it is being used as USB storage. Disconnect USB to access your decks.</string>
 
@@ -150,4 +151,9 @@
 <string name="steps_error">Steps must be numbers greater than 0</string>
 <string name="steps_min_error">At least one step is required</string>
 <string name="custom_study_invalid_number">Invalid number</string>
+
+<string name="template_error">Template error:</string>
+<string name="template_error_detail">There is an error in the template of this card.</string>
+<string name="template_error_fix">Please use the card editor on the desktop client to fix the error.</string>
+
 </resources>


### PR DESCRIPTION
[Issue 1784](http://code.google.com/p/ankidroid/issues/detail?id=1784)

Show a useful error message with some instructions when the template cannot be parsed. It ends up looking like this:
![screenshot-1371997727225](https://f.cloud.github.com/assets/789082/692261/26040174-dc13-11e2-8637-140c808ad2ed.png)

Since it isn't always obvious what the error might be, even on the desktop client, I thought it would be useful to also include the error in the output.

Edit: and you might want to use the ?w=1 at the end of the URL trick for a better diff on this one.
