### PR TITLE
Issue 1743: Use US locale when formatting DB queries.

### DIFF
--- a/src/com/ichi2/libanki/sync/Syncer.java
+++ b/src/com/ichi2/libanki/sync/Syncer.java
@@ -40,6 +40,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 public class Syncer {
@@ -453,7 +454,7 @@ public class Syncer {
                     .getDb()
                     .getDatabase()
                     .rawQuery(
-                            String.format(
+                            String.format(Locale.US,
                                     "SELECT id, cid, %d, ease, ivl, lastIvl, factor, time, type FROM revlog WHERE %s",
                                     mMaxUsn, lim), null);
         } else if (table.equals("cards")) {
@@ -461,7 +462,7 @@ public class Syncer {
                     .getDb()
                     .getDatabase()
                     .rawQuery(
-                            String.format(
+                            String.format(Locale.US,
                                     "SELECT id, nid, did, ord, mod, %d, type, queue, due, ivl, factor, reps, lapses, left, odue, odid, flags, data FROM cards WHERE %s",
                                     mMaxUsn, lim), null);
         } else {
@@ -469,7 +470,7 @@ public class Syncer {
                     .getDb()
                     .getDatabase()
                     .rawQuery(
-                            String.format(
+                            String.format(Locale.US,
                                     "SELECT id, guid, mid, mod, %d, tags, flds, '', '', flags, data FROM notes WHERE %s",
                                     mMaxUsn, lim), null);
         }


### PR DESCRIPTION
[Issue 1743](https://code.google.com/p/ankidroid/issues/detail?id=1743)

Syncing does not work when certain system languages like Arabic are in use. In the syncer code, there are three places where we use String.format without specifying a locale. [The documentation](http://developer.android.com/reference/java/util/Locale.html#default_locale) is pretty clear about not using the default locale for machine-readable text. We end up building a bad query like this:

<tt>android.database.sqlite.SQLiteException: no such column: ٢٧٩٢ (code 1): , while compiling: SELECT id, cid, ٢٧٩٢, ease, ivl, lastIvl, factor, time, type FROM revlog WHERE usn = -1</tt>

This change makes use of the US locale, as recommended by the API documentation.
