### PR TITLE
Issue 1501: Use unique temporary directory name when importing.

### DIFF
--- a/src/com/ichi2/libanki/importer/Anki2Importer.java
+++ b/src/com/ichi2/libanki/importer/Anki2Importer.java
@@ -90,7 +90,9 @@ public class Anki2Importer {
         publishProgress(false, 0, 0, false);
         try {
             // extract the deck from the zip file
-            String tempDir = AnkiDroidApp.getCurrentAnkiDroidDirectory() + "/tmpzip";
+            // Issue 1501 workaround: we can't reuse the temp directory after it has been deleted,
+            // so any imports after the first one fail. Avoid this by appending a UUID.
+            String tempDir = AnkiDroidApp.getCurrentAnkiDroidDirectory() + "/tmpzip-" + UUID.randomUUID().toString();
             // from anki2.py
             String colFile = tempDir + "/collection.anki2";
             if (!Utils.unzipFiles(mZip, tempDir, new String[]{"collection.anki2", "media"}, null) ||


### PR DESCRIPTION
[Issue 1501](https://code.google.com/p/ankidroid/issues/detail?id=1501)

While importing, a temporary directory is used to extract the apkg, then deleted when done. For some reason that I couldn't work out, it's not possible to recreate this directory again without terminating AnkiDroid. Thus, subsequent imports fail. 

This is a workaround to use a UUID suffix in the temporary directory name to guarantee it's unique every time.
