### PR TITLE
Do not show top panel if timer is disabled.

### DIFF
--- a/src/com/ichi2/anki/Reviewer.java
+++ b/src/com/ichi2/anki/Reviewer.java
@@ -2670,7 +2670,7 @@ public class Reviewer extends AnkiActivity {
                         }
                 }
             }
-            if (!mShowAnimations && mCardTimer.getVisibility() == View.INVISIBLE) {
+            if (!mShowAnimations && mShowTimer && mCardTimer.getVisibility() == View.INVISIBLE) {
                 switchTopBarVisibility(View.VISIBLE);
             }
             if (!sDisplayAnswer) {


### PR DESCRIPTION
Fix error which made the top panel reload if show timer preference is disabled.
