### PR TITLE
Issue 1501: Close media database after importing.

### DIFF
--- a/src/com/ichi2/libanki/importer/Anki2Importer.java
+++ b/src/com/ichi2/libanki/importer/Anki2Importer.java
@@ -90,9 +90,7 @@ public class Anki2Importer {
         publishProgress(false, 0, 0, false);
         try {
             // extract the deck from the zip file
-            // Issue 1501 workaround: we can't reuse the temp directory after it has been deleted,
-            // so any imports after the first one fail. Avoid this by appending a UUID.
-            String tempDir = AnkiDroidApp.getCurrentAnkiDroidDirectory() + "/tmpzip-" + UUID.randomUUID().toString();
+            String tempDir = AnkiDroidApp.getCurrentAnkiDroidDirectory() + "/tmpzip";
             // from anki2.py
             String colFile = tempDir + "/collection.anki2";
             if (!Utils.unzipFiles(mZip, tempDir, new String[]{"collection.anki2", "media"}, null) ||
@@ -125,6 +123,7 @@ public class Anki2Importer {
                 cnt = _import();
             } finally {
                 // do not close collection but close only db (in order not to confuse access counting in storage.java
+                // Note that the media database is still open and needs to be closed below.
                 AnkiDatabaseManager.closeDatabase(mSrc.getPath());
             }
             // import static media
@@ -143,6 +142,7 @@ public class Anki2Importer {
                 }
             }
             mZip.close();
+            mSrc.getMedia().close();
             // delete tmp dir
             File dir = new File(tempDir);
             BackupManager.removeDir(dir);


### PR DESCRIPTION
[Issue 1501](https://code.google.com/p/ankidroid/issues/detail?id=1501) again. It was going to haunt me until I figured it out.

`mSrc` is the collection we are importing. Notice, however, that the collection itself isn't closed in the normal way. We're directly closing its database. This, however, means that the media database in the collection is still left open.

To be honest, I don't understand why we aren't closing it with Collection.close. Why do we need to need to keep the "count" (which is actually in AnkiDatabaseManager, contrary to the comment) of this database? Haven't we finished using it? I'm not sure what the implications of changing this are, so I've left it as-in and just closed the media database as well later down when we've finished importing media.
