### PR TITLE
Solve codepage problems with explicit dash character

### DIFF
--- a/src/com/ichi2/libanki/Card.java
+++ b/src/com/ichi2/libanki/Card.java
@@ -236,7 +236,7 @@ public class Card implements Cloneable {
 
     public String getAnswer(boolean simple) {
         if (simple) {
-			return _getQA(false).get("a").replaceAll("<hr[^>]*>", "<br>─────<br>");
+        	return _getQA(false).get("a").replaceAll("<hr[^>]*>", "<br>\u2500\u2500\u2500\u2500\u2500<br>");
         } else {
             return css() + _getQA(false).get("a");
         }


### PR DESCRIPTION
There is a character set problem with the straight line separator
explicitly defined as a string in the simple interface. On my EN-GB Nook
ST, I was seeing a unicode translation problem like "àE"" instead of the
string. 

\u2500 seems to be a safe alternative across character sets and looks a little better than html mdash
