### PR TITLE
Issue1449 workaround: don't return negative times for time taken.

### DIFF
--- a/src/com/ichi2/libanki/Card.java
+++ b/src/com/ichi2/libanki/Card.java
@@ -325,11 +325,6 @@ public class Card implements Cloneable {
     }
 
 
-    public void setTimer(double time) {
-        mTimerStarted = time;
-    }
-
-
      public void stopTimer() {
     	 mTimerStopped = Utils.now();
      }
@@ -358,6 +353,10 @@ public class Card implements Cloneable {
 
     public long timeTaken() {
         long total = (long) ((Utils.now() - mTimerStarted) * 1000);
+        // Workaround for 1449. Ensure we don't return negative times.
+        if (total < 0) {
+            total = timeLimit();
+        }
         return Math.min(total, timeLimit());
     }
 


### PR DESCRIPTION
This is a workaround for [Issue 1449](https://code.google.com/p/ankidroid/issues/detail?id=1449).

I couldn't figure out how it was possible to end up with a negative number besides the actual time of the device being set back (e.g., daylight saving time). But that idea doesn't entirely agree with the comments on the issue tracker. Even fiddling with the time on the device didn't seem to trigger it.

So for now, here is this workaround. I hope it conceals the problem well enough for now.
