### PR TITLE
Use a numeric keyboard for steps preference.

### DIFF
--- a/src/com/ichi2/preferences/StepsPreference.java
+++ b/src/com/ichi2/preferences/StepsPreference.java
@@ -19,6 +19,7 @@ package com.ichi2.preferences;
 
 import android.content.Context;
 import android.preference.EditTextPreference;
+import android.text.InputType;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 
@@ -37,20 +38,32 @@ public class StepsPreference extends EditTextPreference {
     public StepsPreference(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
         mAllowEmpty = getAllowEmptyFromAttributes(attrs);
+        updateSettings();
     }
 
 
     public StepsPreference(Context context, AttributeSet attrs) {
         super(context, attrs);
         mAllowEmpty = getAllowEmptyFromAttributes(attrs);
+        updateSettings();
     }
 
 
     public StepsPreference(Context context) {
         super(context);
         mAllowEmpty = getAllowEmptyFromAttributes(null);
+        updateSettings();
     }
 
+    /**
+     * Update settings to show a numeric keyboard instead of the default keyboard.
+     * <p>
+     * This method should only be called once from the constructor.
+     */
+    private void updateSettings() {
+        // Use the number pad but still allow normal text for spaces and decimals.
+        getEditText().setInputType(InputType.TYPE_CLASS_NUMBER | InputType.TYPE_CLASS_TEXT);
+    }
 
     @Override
     protected void onDialogClosed(boolean positiveResult) {


### PR DESCRIPTION
Just a minor usability enhancement. Editing steps should show a numeric keyboard, since we're only interested in putting in numbers.
