### PR TITLE
Do not use onCancelled with result.

### DIFF
--- a/src/com/ichi2/async/BaseAsyncTask.java
+++ b/src/com/ichi2/async/BaseAsyncTask.java
@@ -16,7 +16,6 @@
 
 package com.ichi2.async;
 
-import android.annotation.TargetApi;
 import android.os.AsyncTask;
 
 import com.ichi2.utils.MethodLogger;
@@ -79,17 +78,6 @@ public class BaseAsyncTask<Params, Progress, Result> extends AsyncTask<Params, P
         }
         Threads.checkMainThread();
         super.onProgressUpdate(values);
-    }
-
-
-    @TargetApi(11)
-    @Override
-    protected void onCancelled(Result result) {
-        if (DEBUG) {
-            MethodLogger.log();
-        }
-        Threads.checkMainThread();
-        super.onCancelled(result);
     }
 
 


### PR DESCRIPTION
The overloading that takes a result has been introduced in API Level 11
and therefore this causes a crash on previous version.

The default implementation is to simply call the version that does not
have a result, so we can use that instead. None of our code should
depend on the former version anyway, since we cannot guarantee it will
be called.

Issue: https://code.google.com/p/ankidroid/issues/detail?id=1769
