### PR TITLE
Added option for relatively scaling images

### DIFF
--- a/res/values/10-preferences.xml
+++ b/res/values/10-preferences.xml
@@ -91,6 +91,8 @@
 <string name="use_ruby_support_summ">If the characters \'[\' and \']\' are found, then the enclosed text is handled as a ruby annotation</string>
 <string name="display_font_size">Relative font size</string>
 <string name="display_font_size_summ">The font size to use in the display relative to the definitions in the deck. At the moment: XXX %</string>
+<string name="image_size">Relative image size</string>
+<string name="image_size_summ">The size of images to use during review, relative to the size of the original media files. At the moment: XXX %</string>
 <string name="card_browser_font_size">Card Browser font size</string>
 <string name="card_browser_font_size_summ">The relative font size to use in the card browser. At the moment: XXX %</string>
 <string name="button_size">Relative button size</string>

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -313,6 +313,15 @@
                 android:title="@string/fade_scrollbars" />
             <com.hlidskialf.android.preference.SeekBarPreference
                 android:defaultValue="100"
+                android:key="relativeImageSize"
+                android:max="300"
+                android:summary="@string/image_size_summ"
+                android:text=" %"
+                android:title="@string/image_size"
+                app:interval="10"
+                app:min="50" />
+            <com.hlidskialf.android.preference.SeekBarPreference
+                android:defaultValue="100"
                 android:key="answerButtonSize"
                 android:max="170"
                 android:summary="@string/button_size_summ"

--- a/src/com/ichi2/anki/Preferences.java
+++ b/src/com/ichi2/anki/Preferences.java
@@ -100,7 +100,7 @@ public class Preferences extends PreferenceActivity implements OnSharedPreferenc
             "gestureSwipeRight", "gestureDoubleTap", "gestureTapTop", "gestureTapBottom", "gestureTapRight",
             "gestureLongclick", "gestureTapLeft", "newSpread", "useCurrent"};//, "theme" };
     private static String[] mShowValueInSummSeek = { "relativeDisplayFontSize", "relativeCardBrowserFontSize",
-            "answerButtonSize", "whiteBoardStrokeWidth", "minShakeIntensity", "swipeSensibility",
+            "relativeImageSize", "answerButtonSize", "whiteBoardStrokeWidth", "minShakeIntensity", "swipeSensibility",
             "timeoutAnswerSeconds", "timeoutQuestionSeconds", "animationDuration", "backupMax", "dayOffset" };
     private static String[] mShowValueInSummEditText = { "simpleInterfaceExcludeTags" };
     private static String[] mShowValueInSummNumRange = { "timeLimit", "learnCutoff" };

--- a/src/com/ichi2/anki/Reviewer.java
+++ b/src/com/ichi2/anki/Reviewer.java
@@ -193,6 +193,9 @@ public class Reviewer extends AnkiActivity {
     /** The percentage of the absolute font size specified in the deck. */
     private int mDisplayFontSize = 100;
 
+    /** The percentage of the original image size in the deck. */
+    private int mDisplayImageSize = 100;
+
     /** Pattern for font-size style declarations */
     private static final Pattern fFontSizePattern = Pattern.compile(
             "font-size\\s*:\\s*([0-9.]+)\\s*((?:px|pt|in|cm|mm|pc|%|em))\\s*;?", Pattern.CASE_INSENSITIVE);
@@ -223,6 +226,7 @@ public class Reviewer extends AnkiActivity {
     private boolean mPrefFullscreenReview;
     private boolean mZoomEnabled;
     private String mCollectionFilename;
+    private int mRelativeImageSize;
     private int mRelativeButtonSize;
     private boolean mDoubleScrolling;
     private boolean mScrollingButtons;
@@ -2030,6 +2034,7 @@ public class Reviewer extends AnkiActivity {
         mPrefFullscreenReview = preferences.getBoolean("fullscreenReview", false);
         mZoomEnabled = preferences.getBoolean("zoom", false);
         mDisplayFontSize = preferences.getInt("relativeDisplayFontSize", 100);// Card.DEFAULT_FONT_SIZE_RATIO);
+        mRelativeImageSize = preferences.getInt("relativeImageSize", 100);
         mRelativeButtonSize = preferences.getInt("answerButtonSize", 100);
         mInputWorkaround = preferences.getBoolean("inputWorkaround", false);
         mPrefFixArabic = preferences.getBoolean("fixArabicText", false);
@@ -2480,6 +2485,11 @@ public class Reviewer extends AnkiActivity {
             Log.i(AnkiDroidApp.TAG, "content card = \n" + content);
             StringBuilder style = new StringBuilder();
             style.append(mCustomFontStyle);
+            
+            // Scale images.
+            if (mRelativeImageSize != 100) {
+                style.append(String.format("img { zoom: %s }\n", mRelativeImageSize / 100.0));
+            }
             Log.i(AnkiDroidApp.TAG, "::style::" + style);
 
             if (mNightMode) {


### PR DESCRIPTION
This commit adds a simple option of scaling images through the almost-standard CSS zoom property.

Mobile devices have much higher pixel density than desktop displays; yet, the images in AnkiDroid are displayed in their original resolution.
