### PR TITLE
Remove deck upgrade wizard on AnkiDroid upgrade

### DIFF
--- a/res/values/03-dialogs.xml
+++ b/res/values/03-dialogs.xml
@@ -90,7 +90,6 @@
 <string name="rebuild_custom_study_deck">Rebuilding custom study deck.\nPlease wait...</string>
     <string name="deck_upgrade_title">Deck Upgrade</string>
     <string name="deck_upgrade_rename_warning">Be aware that this will export your current collection to a file called \'%1$s\' and will create a new one from your old anki 1.x files. If desired, you can manually re-import the above apkg file after completing the wizard. Do you really want to continue?</string>
-    <string name="deck_upgrade_already_upgraded">Version 2 of AnkiDroid uses a new format for decks.\nIf you did not successfully upgrade your decks, you can restart the upgrade now to upgrade your decks.</string>
     <string name="deck_upgrade_major_warning"><![CDATA[This is a major update to Ankidroid and the upgrade process will take at least 10-20 minutes.<br><br>Do you want to proceed now or later?<br><br><a href=\"http://code.google.com/p/ankidroid/wiki/Upgrading?wl=en\">More info</a>]]></string>
     <string name="deck_upgrade_start_again_to_upgrade_toast">Please start Ankidroid again when you have time to upgrade!</string>
     <string name="deck_upgrade_recommended_method"><![CDATA[The recommended upgrade method is to sync with a PC and upgrade with the desktop version of Anki.<br><br>There is also an alternative method where you can upgrade over the internet if you do not have access to a PC, and your collection is not too big.]]></string>

--- a/src/com/ichi2/anki/DeckPicker.java
+++ b/src/com/ichi2/anki/DeckPicker.java
@@ -1268,29 +1268,10 @@ public class DeckPicker extends FragmentActivity {
         } else if (mImportPath != null && AnkiDroidApp.colIsOpen()) {
             showDialog(DIALOG_IMPORT);
         } else {
-            // if the collection is empty, user has already upgraded the app but maybe did not successfully upgrade the decks
-            if (!preferences.getString("lastUpgradeVersion", "").equals(AnkiDroidApp.getPkgVersion()) &&
-                    (new File(AnkiDroidApp.getCurrentAnkiDroidDirectory()).listFiles(new OldAnkiDeckFilter()).length) > 0) {
-                StyledDialog.Builder builder = new StyledDialog.Builder(DeckPicker.this);
-                builder.setTitle(R.string.deck_upgrade_title);
-                builder.setIcon(R.drawable.ic_dialog_alert);
-                builder.setMessage(R.string.deck_upgrade_already_upgraded);
-                builder.setPositiveButton(R.string.yes, new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int which) {
-                        restartUpgradeProcess();
-                    }
-                });
-                builder.setCancelable(false);
-                builder.setNegativeButton(R.string.no, new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int which) {
-                        AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance().getBaseContext())
-                                .edit().putString("lastUpgradeVersion", AnkiDroidApp.getPkgVersion()).commit();
-                        loadCollection();
-                    }
-                });
-                builder.show();
+            // AnkiDroid is being updated and a collection already exists. Do any upgrade logic here.
+            if (!preferences.getString("lastUpgradeVersion", "").equals(AnkiDroidApp.getPkgVersion())) {
+                preferences.edit().putString("lastUpgradeVersion", AnkiDroidApp.getPkgVersion()).commit();
+                loadCollection();
             } else {
                 loadCollection();
             }


### PR DESCRIPTION
As discussed earlier, ensure the deck upgrade wizard doesn't show up when AnkiDroid is upgraded and you still have .anki files in the AnkiDroid directory.
