### PR TITLE
Fix for Issue 1840 - Handle thread cancellation

### DIFF
--- a/src/com/ichi2/async/DeckTask.java
+++ b/src/com/ichi2/async/DeckTask.java
@@ -64,6 +64,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
@@ -209,6 +210,9 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
             } catch (ExecutionException e) {
                 // Ignore failures in the previous task.
                 Log.e(AnkiDroidApp.TAG, "previously running task failed with exception: " + mPreviousTask.mType, e);
+            } catch (CancellationException e) {
+                // Ignore cancellation of previous task
+                Log.e(AnkiDroidApp.TAG, "previously running task was cancelled: " + mPreviousTask.mType, e);
             }
         }
 


### PR DESCRIPTION
Fix for [Issue 1840](https://code.google.com/p/ankidroid/issues/detail?id=1840)

[AsyncTask.get](http://developer.android.com/reference/android/os/AsyncTask.html#get%28%29) can throw a `CancellationException`, which wasn't being handled.
