### PR TITLE
Fix for issue1834

### DIFF
--- a/src/com/ichi2/anki/DeckPicker.java
+++ b/src/com/ichi2/anki/DeckPicker.java
@@ -619,8 +619,11 @@ public class DeckPicker extends FragmentActivity {
             	mOpenCollectionDialog.dismiss();
         	}
             try {
-                // Ensure we have the correct deck selected in the deck list after we have updated it
-                setSelectedDeck(AnkiDroidApp.getCol().getDecks().current().getLong("id"));
+                // Ensure we have the correct deck selected in the deck list after we have updated it. Check first
+                // if the collection is open since it might have been closed before this task completes.
+                if (AnkiDroidApp.getCol() != null) {
+                    setSelectedDeck(AnkiDroidApp.getCol().getDecks().current().getLong("id"));
+                }
             } catch (JSONException e) {
                 throw  new RuntimeException();
             }


### PR DESCRIPTION
[Issue 1834](https://code.google.com/p/ankidroid/issues/detail?id=1834)

In the post-execute of the task that builds the deck list and counts, the collection can be null and we get a crash when we try to access it to set the deck in the deck list. I mentioned on the issue tracker at least one way it could end up with a null collection, but it's possible there are others. This adds an additional check to skip the call if it's null. The next time the collection is opened, this handler will run again, so the correct deck will be selected eventually, even if we skip it here.
