### PR TITLE
Improve Aedict integration

### DIFF
--- a/src/com/ichi2/anki/CardEditor.java
+++ b/src/com/ichi2/anki/CardEditor.java
@@ -430,7 +430,7 @@ public class CardEditor extends Activity {
             String contents = null;
             if (mSourceText != null) {
                 if (mAedictIntent && (mEditFields.size() == 3) && mSourceText[1].contains("[")) {
-                    contents = mSourceText[1].replaceFirst("\\[", "\u001f");
+                    contents = mSourceText[1].replaceFirst("\\[", "\u001f" + mSourceText[0] + "\u001f");
                     contents = contents.substring(0, contents.length() - 1);
                 } else {
                     mEditFields.get(0).setText(mSourceText[0]);


### PR DESCRIPTION
When Adding card via Aedict intent, automatically add meaning
information when avaliable. Before it was only adding the
reading(hiragana) and the word in kanji. With this new functionality, if
the user model has at least 3 fields, extra information will be added
(meaning/reading/kanji).
