### PR TITLE
Support Nook HD and HD+ in journal_mode WAL

### DIFF
--- a/src/com/ichi2/async/Connection.java
+++ b/src/com/ichi2/async/Connection.java
@@ -359,7 +359,6 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
                 // set journal mode to delete
                 try {
                     AnkiDb d = AnkiDatabaseManager.getDatabase(deckPath);
-                    d.queryString("PRAGMA journal_mode = DELETE");
                 } catch (SQLiteDatabaseCorruptException e) {
                     // ignore invalid .anki files
                     corruptFiles.add(f.getName());

--- a/src/com/ichi2/async/DeckTask.java
+++ b/src/com/ichi2/async/DeckTask.java
@@ -1027,7 +1027,6 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
         try {
             try {
                 AnkiDb d = AnkiDatabaseManager.getDatabase(colPath);
-                d.queryString("PRAGMA journal_mode = DELETE");
             } catch (SQLiteDatabaseCorruptException e) {
                 // collection is invalid
                 return new TaskData(false);


### PR DESCRIPTION
Previous changes to support the Nook HD/HD+ switched to using a journal_mode of DELETE at all times, which works for new installs, but not for (the assumed low number of) users who had a collection being used on those devices already. This change, rather than working around the issue, addresses the issue: it corrects the inability to change the journal_mode to DELETE from WAL upon closing databases, which is done to ensure they are desktop Anki compatible. The change has been tested on my Nook HD+ and works, but I used trial and error to locate a functional codepath. I also tested the change on a samsung Galaxy Stellar (one of the rarer Stellar models, but always worked with AnkiDroid from google play) and it accepted the change without issue. Only one line of code will be new, and that's disableWriteAheadLogging() called on the underlying database. I addressed the one potential exception that documentation indicates it may throw as a safeguard (not by catch, but by handling the trigger of an outstanding transaction). Any unaddressed exceptions that occur will pass up the chain as it stood. I was told that 2.0.2 was coming to an end so I chose to put this in .3 -- let me know if I should submit a pull request to any other branch.
