### PR TITLE
Issue 1858 - annotate javascript interface methods.

### DIFF
--- a/src/com/ichi2/anki/Reviewer.java
+++ b/src/com/ichi2/anki/Reviewer.java
@@ -71,6 +71,7 @@ import android.view.animation.AccelerateDecelerateInterpolator;
 import android.view.animation.AccelerateInterpolator;
 import android.view.animation.DecelerateInterpolator;
 import android.view.inputmethod.InputMethodManager;
+import android.webkit.JavascriptInterface;
 import android.webkit.JsResult;
 import android.webkit.WebChromeClient;
 import android.webkit.WebView;
@@ -3210,11 +3211,13 @@ public class Reviewer extends AnkiActivity {
         /**
          * This is not called on the UI thread. Send a message that will be handled on the UI thread.
          */
+        @JavascriptInterface
         public void playSound(String soundPath) {
             Message msg = Message.obtain();
             msg.obj = soundPath;
             mHandler.sendMessage(msg);
         }
+        @JavascriptInterface
         public int getAvailableWidth() {
             if (mCtx.mAvailableInCardWidth == 0) {
                 mCtx.mAvailableInCardWidth = mCtx.calcAvailableInCardWidth();


### PR DESCRIPTION
The audio playback button doesn't work in Android 4.2+. SDK 17+ [added a new requirement](http://stackoverflow.com/a/13941284/1655084) to annotate Javascript interface methods or they simply wouldn't be exposed, so the sound playing function was never being called.

This commit annotates all the methods in the interface.
