### PR TITLE
disableWriteAheadLogging() is not supported on API < 16

### DIFF
--- a/src/com/ichi2/anki/AnkiDb.java
+++ b/src/com/ichi2/anki/AnkiDb.java
@@ -313,8 +313,12 @@ public class AnkiDb {
             if (db.inTransaction()) {
                 db.endTransaction();
             }
-            db.disableWriteAheadLogging(); // call necessary on some Nook devices
-        } catch (Exception e) {
+            //This call is required on some with custom Android versiones
+            //for example on Nook, where it was backported from Jelly Bean.
+            //So, we can't rely here on API version, to check for availability.
+            //That's why we just catching the error if method is not available.
+            db.disableWriteAheadLogging();
+        } catch (Throwable e) {
             Log.e(AnkiDroidApp.TAG, "AnkiDb - setDeleteJournalMode, attempting to proceed after following exception: "
                     + e);
         }


### PR DESCRIPTION
This commit attempts to fix startup crash on API levels less than 16 as, according to documentation, SQLiteDatabase::disableWriteAheadLogging() was introduced in JELLY_BEAN. Probably, it should be rechecked on Nook as this code was added here for that device for the first place.
