### PR TITLE
Extract custom fonts into an extension.

### DIFF
--- a/src/com/ichi2/anki/reviewer/CustomFontsReviewerExt.java
+++ b/src/com/ichi2/anki/reviewer/CustomFontsReviewerExt.java
@@ -1,0 +1,110 @@
+/****************************************************************************************
+ * Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+
+package com.ichi2.anki.reviewer;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.text.TextUtils;
+
+import com.ichi2.anki.AnkiDroidApp;
+import com.ichi2.anki.AnkiFont;
+import com.ichi2.libanki.Utils;
+import com.ichi2.themes.Themes;
+
+public class CustomFontsReviewerExt implements ReviewerExt {
+
+    private final String mCustomStyle;
+    private final boolean mSupportsQuickUpdate;
+
+    public CustomFontsReviewerExt(Context context) {
+        Map<String, AnkiFont> customFontsMap = getCustomFontsMap(context);
+        mCustomStyle = getCustomDefaultFontStyle(context, customFontsMap) + getCustomFontsStyle(customFontsMap);
+        mSupportsQuickUpdate = customFontsMap.size() == 0;
+    }
+
+
+    @Override
+    public void updateCssStyle(StringBuilder cssStyle) {
+        cssStyle.append(mCustomStyle);
+    }
+
+    @Override
+    public boolean supportsQuickUpdate() {
+        return mSupportsQuickUpdate;
+    }
+
+
+    /**
+     * Returns the CSS used to handle custom fonts.
+     * <p>
+     * Custom fonts live in fonts directory in the directory used to store decks.
+     * <p>
+     * Each font is mapped to the font family by the same name as the name of the font without the extension.
+     */
+    private static String getCustomFontsStyle(Map<String, AnkiFont> customFontsMap) {
+        StringBuilder builder = new StringBuilder();
+        for (AnkiFont font : customFontsMap.values()) {
+            builder.append(font.getDeclaration());
+            builder.append('\n');
+        }
+        return builder.toString();
+    }
+
+
+    /** Returns the CSS used to set the default font. */
+    private static String getCustomDefaultFontStyle(Context context, Map<String, AnkiFont> customFontsMap) {
+        SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(context);
+        AnkiFont defaultFont = customFontsMap.get(preferences.getString("defaultFont", null));
+        if (defaultFont != null) {
+            return "BODY { " + defaultFont.getCSS() + " }\n";
+        } else {
+            String defaultFontName = Themes.getReviewerFontName();
+            if (TextUtils.isEmpty(defaultFontName)) {
+                return "";
+            } else {
+                return String.format(
+                        "BODY {"
+                        + "font-family: '%s';"
+                        + "font-weight: normal;"
+                        + "font-style: normal;"
+                        + "font-stretch: normal;"
+                        + "}\n", defaultFontName);
+            }
+        }
+    }
+
+
+    /**
+     * Returns a map from custom fonts names to the corresponding {@link AnkiFont} object.
+     *
+     * <p>The list of constructed lazily the first time is needed.
+     */
+    private static Map<String, AnkiFont> getCustomFontsMap(Context context) {
+        List<AnkiFont> fonts = Utils.getCustomFonts(context);
+        Map<String, AnkiFont> customFontsMap = new HashMap<String, AnkiFont>();
+        for (AnkiFont f : fonts) {
+            customFontsMap.put(f.getName(), f);
+        }
+        return customFontsMap;
+    }
+
+
+}

--- a/src/com/ichi2/anki/reviewer/ReviewerExt.java
+++ b/src/com/ichi2/anki/reviewer/ReviewerExt.java
@@ -1,0 +1,44 @@
+/****************************************************************************************
+ * Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+
+package com.ichi2.anki.reviewer;
+
+import android.webkit.WebView;
+
+/**
+ * An extension to the reviewer class.
+ *
+ * <p>This allows splitting parts of the code that offer a specific feature outside the activity itself.
+ */
+public interface ReviewerExt {
+
+    /**
+     * Hook for updating the CSS style used by a card.
+     *
+     * <p>It should modify the content of the {@link StringBuilder} to reflect the new style.
+     *
+     * @param cssStyle containing current style
+     */
+    void updateCssStyle(StringBuilder cssStyle);
+
+
+    /**
+     * Returns true if the extensions supports updating the content of a single {@link WebView} (called quick update)
+     * instead of switch between two instances.
+     */
+    boolean supportsQuickUpdate();
+
+}

--- a/src/com/ichi2/anki/reviewer/ReviewerExtRegistry.java
+++ b/src/com/ichi2/anki/reviewer/ReviewerExtRegistry.java
@@ -1,0 +1,62 @@
+/****************************************************************************************
+ * Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+
+package com.ichi2.anki.reviewer;
+
+import android.content.Context;
+
+/**
+ * Keeps track of all the {@link ReviewerExt} implementations and delegates to them.
+ */
+public class ReviewerExtRegistry implements ReviewerExt {
+
+    /**
+     * The registered extensions.
+     */
+    private final ReviewerExt[] mReviewerExts;
+
+
+    /**
+     * Creates the list of extensions.
+     *
+     * <p>Must be called at the beginning of onCreate().
+     */
+    public ReviewerExtRegistry(Context context) {
+        mReviewerExts = new ReviewerExt[]{
+            new CustomFontsReviewerExt(context),
+        };
+    }
+
+
+    @Override
+    public void updateCssStyle(StringBuilder cssStyle) {
+        for (ReviewerExt ext : mReviewerExts) {
+            ext.updateCssStyle(cssStyle);
+        }
+    }
+
+
+    @Override
+    public boolean supportsQuickUpdate() {
+        for (ReviewerExt ext : mReviewerExts) {
+            if (!ext.supportsQuickUpdate()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+}


### PR DESCRIPTION
Currently, a lot of our classes have a very large amount of code,
implementing many different features, all mixed together. This is quite
hard to manage and makes the code overly complex.

What I am aiming to do is separate out some of the code that does
related things, offering a better paradigm for implementing new features
that does not clutter the existing code.

As a proof of concept, I am aiming to extract the Custom Fonts support
(which I wrote and therefore know reasonably well) into a set of classes
that separate classes that define anything relating to that particular
feature, so that the rest of the code does not need to know about it.

This is a work in progress: it will take a bit of time to get to the
perfect solution; but it is a step forward in that direction. Probably
things will change as I go along, so nothing is really final yet.
