### PR TITLE
Move SDK specific methods into Compat.

### DIFF
--- a/src/com/ichi2/anki/AnkiDb.java
+++ b/src/com/ichi2/anki/AnkiDb.java
@@ -337,7 +337,7 @@ public class AnkiDb {
             db.endTransaction();
         }
         try {
-            db.disableWriteAheadLogging();
+            AnkiDroidApp.getCompat().disableDatabaseWriteAheadLogging(db);
         } catch (NoSuchMethodError e) {
             // Ignore this error, since it is expected on devices below API level 16.
         }

--- a/src/com/ichi2/anki/AnkiDroidApp.java
+++ b/src/com/ichi2/anki/AnkiDroidApp.java
@@ -35,6 +35,7 @@ import com.ichi2.async.Connection;
 import com.ichi2.compat.Compat;
 import com.ichi2.compat.CompatV11;
 import com.ichi2.compat.CompatV15;
+import com.ichi2.compat.CompatV16;
 import com.ichi2.compat.CompatV4;
 import com.ichi2.compat.CompatV5;
 import com.ichi2.compat.CompatV9;
@@ -108,6 +109,8 @@ public class AnkiDroidApp extends Application {
         if (android.os.Build.MODEL.toLowerCase(Locale.US).equals("nook")
                 || android.os.Build.DEVICE.toLowerCase(Locale.US).equals("nook")) {
             mCompat = new CompatV4();
+        } else if (AnkiDroidApp.SDK_VERSION >= 16) {
+            mCompat = new CompatV16();
         } else if (AnkiDroidApp.SDK_VERSION >= 15) {
             mCompat = new CompatV15();
         } else if (AnkiDroidApp.SDK_VERSION >= 11) {

--- a/src/com/ichi2/compat/Compat.java
+++ b/src/com/ichi2/compat/Compat.java
@@ -16,10 +16,8 @@
 
 package com.ichi2.compat;
 
-import java.lang.reflect.Method;
-import java.util.ArrayList;
-
 import android.app.Activity;
+import android.database.sqlite.SQLiteDatabase;
 import android.speech.tts.TextToSpeech;
 import android.view.View;
 import android.webkit.WebView;
@@ -54,4 +52,5 @@ public interface Compat {
     public abstract void setSubtitle(Activity activity, String title);
     public abstract void setSubtitle(Activity activity, String title, boolean inverted);
     public abstract void setTtsOnUtteranceProgressListener(TextToSpeech tts);
+    public abstract void disableDatabaseWriteAheadLogging(SQLiteDatabase db);
 }

--- a/src/com/ichi2/compat/CompatV15.java
+++ b/src/com/ichi2/compat/CompatV15.java
@@ -1,8 +1,5 @@
 package com.ichi2.compat;
 
-import java.lang.reflect.Method;
-import java.util.ArrayList;
-
 import com.ichi2.anki.ReadText;
 
 import android.annotation.TargetApi;
@@ -10,7 +7,7 @@ import android.speech.tts.TextToSpeech;
 import android.speech.tts.UtteranceProgressListener;
 
 /** Implementation of {@link Compat} for SDK level 15 */
-@TargetApi(11)
+@TargetApi(15)
 public class CompatV15 extends CompatV11 implements Compat {
     @Override
     public void setTtsOnUtteranceProgressListener(TextToSpeech tts) {

--- a/src/com/ichi2/compat/CompatV16.java
+++ b/src/com/ichi2/compat/CompatV16.java
@@ -1,0 +1,15 @@
+package com.ichi2.compat;
+
+import android.annotation.TargetApi;
+import android.database.sqlite.SQLiteDatabase;
+
+/** Implementation of {@link Compat} for SDK level 16 */
+@TargetApi(16)
+public class CompatV16 extends CompatV15 implements Compat {
+
+    @Override
+    public void disableDatabaseWriteAheadLogging(SQLiteDatabase db) {
+        db.disableWriteAheadLogging();
+    }
+
+}

--- a/src/com/ichi2/compat/CompatV4.java
+++ b/src/com/ichi2/compat/CompatV4.java
@@ -16,15 +16,12 @@
 
 package com.ichi2.compat;
 
-import java.lang.reflect.Method;
-import java.util.ArrayList;
-
 import com.ichi2.anki.ReadText;
 
 import android.app.Activity;
+import android.database.sqlite.SQLiteDatabase;
 import android.speech.tts.TextToSpeech;
 import android.speech.tts.TextToSpeech.OnUtteranceCompletedListener;
-import android.speech.tts.UtteranceProgressListener;
 import android.view.View;
 import android.webkit.WebView;
 
@@ -59,4 +56,8 @@ public class CompatV4 implements Compat {
 
     }
 
+
+    @Override
+    public void disableDatabaseWriteAheadLogging(SQLiteDatabase db) {
+    }
 }


### PR DESCRIPTION
On certain devices (e.g., Donut), the application crashes if a class is
using a method that does not exist with a VerifyError even before any
methods on the class can be invoked.

To avoid this, we introduced a Compat interface, which hides all the
platform specific method calls. However, the disableWriteAheadLogging()
method was being called on SQLiteDatabase without following this
pattern, leading to a crash on start-up.

This commit moves those calls behind the interface.
