### PR TITLE
Fix query to find siblings in order to bury them.

### DIFF
--- a/src/com/ichi2/libanki/Sched.java
+++ b/src/com/ichi2/libanki/Sched.java
@@ -2141,8 +2141,8 @@ public class Sched {
         Cursor cur = null;
         try {
             cur = mCol.getDb().getDatabase().rawQuery(String.format(Locale.US,
-                    "select id, queue from cards where nid=? and id!=? "+
-                    "and (queue=0 or (queue=2 and due<=?))", new Object[]{card.getNid(), card.getId(), mToday}), null);
+                    "select id, queue from cards where nid=%d and id!=%d "+
+                    "and (queue=0 or (queue=2 and due<=%d))", new Object[]{card.getNid(), card.getId(), mToday}), null);
             while (cur.moveToNext()) {
                 long cid = cur.getLong(0);
                 int queue = cur.getInt(1);


### PR DESCRIPTION
As reported on the forums, sibling spacing was broken. There was a bad String.format that never worked which I've fixed.

I stepped through a deck of siblings alongside the desktop client and the behaviour matches, so siblings should work correctly now.

We'll need another beta after merging this. Should really be the last one this time.
