### PR TITLE
Remove suppressed warning.

### DIFF
--- a/src/com/ichi2/anki/AnkiDb.java
+++ b/src/com/ichi2/anki/AnkiDb.java
@@ -19,7 +19,6 @@
 
 package com.ichi2.anki;
 
-import android.annotation.SuppressLint;
 import android.content.ContentValues;
 import android.database.Cursor;
 import android.database.SQLException;
@@ -329,7 +328,6 @@ public class AnkiDb {
      * <p>The method might not exist (it is only included in API level 16) but we attempt anyway since it is part of
      * present in a number of implementations.
      */
-    @SuppressLint("NewApi")
     private void disableWriteAheadLogging() {
         SQLiteDatabase db = getDatabase();
         // The call to disableWriteAheadLogging() below requires no transaction is in progress.


### PR DESCRIPTION
We were suppressing the warning here because we were calling a function
available only in API 16. However, that causes crashes on some versions
of Android and using the Compat interface turned out to be a better
solution.

Now, we can remove the suppressed warning since there is no longer a
warning.
