### PR TITLE
Don't use an inlined style for the audio playback image.

### DIFF
--- a/src/com/ichi2/libanki/Sound.java
+++ b/src/com/ichi2/libanki/Sound.java
@@ -98,7 +98,7 @@ public class Sound {
             stringBuilder
                     .append("<a onclick=\"window.ankidroid.playSound(this.title);\" title=\""
                             + soundPath
-                            + "\"><span style=\"padding:5px;display:inline-block;vertical-align:middle\"><img src=\"file:///android_asset/media_playback_start2.png\" /></span></a>");
+                            + "\"><span style=\"padding:5px;\"><img src=\"file:///android_asset/media_playback_start2.png\" /></span></a>");
             contentLeft = contentLeft.substring(markerStart + soundMarker.length());
             Log.i(AnkiDroidApp.TAG, "Content left = " + contentLeft);
         }


### PR DESCRIPTION
All right, first bug for 2.0.2.

[Issue 1917](https://code.google.com/p/ankidroid/issues/detail?id=1917)

There are some unneeded style rules applied to the audio playback image. It's possible they were useful back when we had the table layout, but they serve no purpose now. The rules also result in Issue 1917 on Android 2.3.
