### PR TITLE
Make default font override card font.

### DIFF
--- a/src/com/ichi2/anki/AnkiFont.java
+++ b/src/com/ichi2/anki/AnkiFont.java
@@ -90,7 +90,7 @@ public class AnkiFont {
         return sb.toString();
     }
     public String getCSS() {
-        StringBuilder sb = new StringBuilder("font-family: \"").append(mFamily).append("\";");
+        StringBuilder sb = new StringBuilder("font-family: \"").append(mFamily).append("\" !important;");
         for (String attr : mAttributes) {
             sb.append(" ").append(attr);
         }

--- a/src/com/ichi2/anki/Reviewer.java
+++ b/src/com/ichi2/anki/Reviewer.java
@@ -2784,7 +2784,7 @@ public class Reviewer extends AnkiActivity {
             SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(getBaseContext());
             AnkiFont defaultFont = getCustomFontsMap().get(preferences.getString("defaultFont", null));
             if (defaultFont != null) {
-                mCustomDefaultFontCss = "BODY { " + defaultFont.getCSS() + " }\n";
+                mCustomDefaultFontCss = "BODY, .card { " + defaultFont.getCSS() + " }\n";
             } else {
                 String defaultFontName = Themes.getReviewerFontName();
                 if (TextUtils.isEmpty(defaultFontName)) {


### PR DESCRIPTION
@flerda, our recent changes to the default font handling haven't been well received. What we've done is made the feature "correct" in that if no font is specified, the default font is used. Unfortunately that's not what most users expect; they want something more like a "font override", which is mostly how the old way worked (even though it was sort of unintentional). I say we should bring that back.

This commit continues to provide a default font when none are specified but also overrides any font specified in .card. It will cover most cases that people expect. More elaborate templates will need to resort to the desktop client as before.
