### PR TITLE
Issue 1852 - Using wildcards in field searches is not working properly

### DIFF
--- a/tests/.classpath
+++ b/tests/.classpath
@@ -2,7 +2,7 @@
 <classpath>
 	<classpathentry kind="con" path="com.android.ide.eclipse.adt.ANDROID_FRAMEWORK"/>
 	<classpathentry exported="true" kind="con" path="com.android.ide.eclipse.adt.LIBRARIES"/>
-	<classpathentry kind="con" path="com.android.ide.eclipse.adt.DEPENDENCIES"/>
+	<classpathentry exported="true" kind="con" path="com.android.ide.eclipse.adt.DEPENDENCIES"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/AnkiDroid"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="gen"/>


### PR DESCRIPTION
Corrected the code that is in charge of matching regular expressions of fields. The problem was that we needed to use different syntax for SQL Lite and the Java Pattern class, when matching the expressions.

Also, removed the line:

```
String regex = Pattern.quote(val).replace("\\Q_\\E", ".").replace("\\Q%\\E", ".*");
```

Because the regex matching already makes sure that the string matches exactly.

Also, created the pattern outside of the loop, to make sure only one is created:

```
Pattern thePattern = Pattern.compile(val, Pattern.CASE_INSENSITIVE);
while(...
```

Also made sure to test several cases of field search. Any comments are welcome!
