### PR TITLE
This is a proposed fix for bug 1759

### DIFF
--- a/res/layout/my_account.xml
+++ b/res/layout/my_account.xml
@@ -73,5 +73,11 @@
 				android:gravity="center"/>
 		</LinearLayout>	
 	</LinearLayout>
-	
+	<TextView
+		    android:id="@+id/terms_conditions_link"
+		    android:layout_width="wrap_content"
+		    android:layout_height="wrap_content"
+		    android:lineSpacingExtra="8dp"
+		    android:layout_marginLeft="6dp"
+		    android:text="@string/terms_conditions" />
 </LinearLayout>

--- a/res/values/04-network.xml
+++ b/res/values/04-network.xml
@@ -59,6 +59,7 @@
 <string name="sign_up_description">Don\'t have an AnkiWeb account? It\'s free!</string>
 <string name="sign_up">Sign up</string>
 <string name="sign_up_terms">By tapping <i>Sign up</i>, you confirm that you have read and agree to our <a href='https://ankiweb.net/account/terms'>terms of use</a>.</string>
+<string name="terms_conditions"><a href='https://ankiweb.net/account/terms'>Terms and Conditions</a></string>
 
 <string name="logged_as">Logged in as</string>
 <string name="log_out">Log out</string>

--- a/src/com/ichi2/anki/MyAccount.java
+++ b/src/com/ichi2/anki/MyAccount.java
@@ -183,6 +183,9 @@ public class MyAccount extends AnkiActivity {
             }
 
         });
+        
+        TextView terms_conditions = (TextView) mLoginToMyAccountView.findViewById(R.id.terms_conditions_link);
+        terms_conditions.setMovementMethod(LinkMovementMethod.getInstance());
 
         mLoggedIntoMyAccountView = getLayoutInflater().inflate(R.layout.my_account_logged_in, null);
         Themes.setWallpaper(mLoggedIntoMyAccountView);


### PR DESCRIPTION
I have added a link "Terms and Conditions" in the "Sync account" screen. However, I think there is already one in the next screen for signing up. Moreover, I would propose the text "Don't have an account..." to be modified as now it looks like a button!

This is related to the following bug 1759:
https://code.google.com/p/ankidroid/issues/detail?id=1759&colspec=ID%20Type%20Priority%20Status%20Milestone%20Owner%20Summary
