### PR TITLE
Do database checks on upgrade only for versions that contain new fixes

### DIFF
--- a/src/com/ichi2/anki/AnkiDroidApp.java
+++ b/src/com/ichi2/anki/AnkiDroidApp.java
@@ -101,6 +101,14 @@ public class AnkiDroidApp extends Application {
     private static final int SWIPE_THRESHOLD_VELOCITY_DIP = 120;
 
     /**
+     * The latest package version number that included important changes to the database
+     * integrity check routine. All collections being upgraded to (or after) this version
+     * must run an integrity check as it will contain fixes that all collections should
+     * have.
+     */
+    public static final int CHECK_DB_AT_VERSION = 40;
+    
+    /**
      * On application creation.
      */
     @Override
@@ -293,11 +301,11 @@ public class AnkiDroidApp extends Application {
 
 
     /**
-     * Get the package version as defined in the manifest.
+     * Get the package versionName as defined in the manifest.
      * 
      * @return the package version.
      */
-    public static String getPkgVersion() {
+    public static String getPkgVersionName() {
         String pkgVersion = "?";
         Context context = sInstance.getApplicationContext();
 
@@ -309,6 +317,22 @@ public class AnkiDroidApp extends Application {
         }
 
         return pkgVersion;
+    }
+
+
+    /**
+     * Get the package versionCode as defined in the manifest.
+     * @return
+     */
+    public static int getPkgVersionCode() {
+        Context context = sInstance.getApplicationContext();
+        try {
+            PackageInfo pInfo = context.getPackageManager().getPackageInfo(context.getPackageName(), 0);
+            return pInfo.versionCode;
+        } catch (PackageManager.NameNotFoundException e) {
+            Log.e(TAG, "Couldn't find package named " + context.getPackageName(), e);
+        }
+        return 0;
     }
 
 

--- a/src/com/ichi2/anki/BroadcastMessages.java
+++ b/src/com/ichi2/anki/BroadcastMessages.java
@@ -178,7 +178,7 @@ public class BroadcastMessages {
                 Document dom = db.parse(conn.getInputStream());
                 Element docEle = dom.getDocumentElement();
                 NodeList nl = docEle.getElementsByTagName("Message");
-                String currentVersion = AnkiDroidApp.getPkgVersion();
+                String currentVersion = AnkiDroidApp.getPkgVersionName();
                 if (nl != null && nl.getLength() > 0) {
                     for (int i = 0; i < nl.getLength(); i++) {
                         Element el = (Element) nl.item(i);

--- a/src/com/ichi2/anki/Info.java
+++ b/src/com/ichi2/anki/Info.java
@@ -150,7 +150,7 @@ public class Info extends Activity {
                         break;
                     case TYPE_NEW_VERSION:
                         AnkiDroidApp.getSharedPrefs(Info.this.getBaseContext()).edit()
-                                .putString("lastVersion", AnkiDroidApp.getPkgVersion()).commit();
+                                .putString("lastVersion", AnkiDroidApp.getPkgVersionName()).commit();
                         break;
                     case TYPE_UPGRADE_DECKS:
                         break;
@@ -691,7 +691,7 @@ public class Info extends Activity {
         StringBuilder appName = new StringBuilder();
         appName.append(AnkiDroidApp.getAppName());
         appName.append(" v");
-        appName.append(AnkiDroidApp.getPkgVersion());
+        appName.append(AnkiDroidApp.getPkgVersionName());
         return appName.toString();
     }
 
@@ -735,7 +735,7 @@ public class Info extends Activity {
                 httpParams.setParameter(ConnManagerPNames.MAX_TOTAL_CONNECTIONS, 30);
                 httpParams.setParameter(ConnManagerPNames.MAX_CONNECTIONS_PER_ROUTE, new ConnPerRouteBean(30));
                 httpParams.setParameter(CoreProtocolPNames.USE_EXPECT_CONTINUE, false);
-                httpParams.setParameter(CoreProtocolPNames.USER_AGENT, "AnkiDroid-" + AnkiDroidApp.getPkgVersion());
+                httpParams.setParameter(CoreProtocolPNames.USER_AGENT, "AnkiDroid-" + AnkiDroidApp.getPkgVersionName());
                 HttpProtocolParams.setVersion(httpParams, HttpVersion.HTTP_1_1);
                 HttpConnectionParams.setSoTimeout(httpParams, Connection.CONN_TIMEOUT);
 

--- a/src/com/ichi2/libanki/sync/BasicHttpSyncer.java
+++ b/src/com/ichi2/libanki/sync/BasicHttpSyncer.java
@@ -175,7 +175,7 @@ public class BasicHttpSyncer implements HttpSyncer {
             params.setParameter(ConnManagerPNames.MAX_TOTAL_CONNECTIONS, 30);
             params.setParameter(ConnManagerPNames.MAX_CONNECTIONS_PER_ROUTE, new ConnPerRouteBean(30));
             params.setParameter(CoreProtocolPNames.USE_EXPECT_CONTINUE, false);
-            params.setParameter(CoreProtocolPNames.USER_AGENT, "AnkiDroid-" + AnkiDroidApp.getPkgVersion());
+            params.setParameter(CoreProtocolPNames.USER_AGENT, "AnkiDroid-" + AnkiDroidApp.getPkgVersionName());
             HttpProtocolParams.setVersion(params, HttpVersion.HTTP_1_1);
             HttpConnectionParams.setSoTimeout(params, Connection.CONN_TIMEOUT);
 

--- a/src/com/ichi2/libanki/sync/RemoteServer.java
+++ b/src/com/ichi2/libanki/sync/RemoteServer.java
@@ -70,7 +70,7 @@ public class RemoteServer extends BasicHttpSyncer {
         try {
             JSONObject jo = new JSONObject();
             jo.put("v", Collection.SYNC_VER);
-            jo.put("cv", String.format(Locale.US, "ankidroid,%s,%s", AnkiDroidApp.getPkgVersion(), Utils.platDesc()));
+            jo.put("cv", String.format(Locale.US, "ankidroid,%s,%s", AnkiDroidApp.getPkgVersionName(), Utils.platDesc()));
             return super.req("meta", super.getInputStream(Utils.jsonToString(jo)));
         } catch (JSONException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
Here's a change that will allow us to trigger DB checks on upgrade only if we have actually added something  to the integrity checking routine that we must run on upgrade. It also fixes a bug where the DB check would always run on a fresh install of AnkiDroid.

Currently, the `lastUpgradeVersion` value that we are storing in the application preferences is actually storing the version name like "2.0.2", which makes it difficult to compare to see if it's a newer version. This commit replaces that value with the int value of the version code. I've changed all places where this value is initially written so future versions will not introduce a string value for this any more.
