### PR TITLE
Rename Default font to Override font to describe functionality

### DIFF
--- a/res/values/10-preferences.xml
+++ b/res/values/10-preferences.xml
@@ -155,6 +155,8 @@
 <string name="fix_hebrew_download_font">Download Font</string>
 <string name="default_font">Default font</string>
 <string name="default_font_summ">The font used for text that has no font formatting specified. Custom fonts should be installed on the SD card in a folder called \'fonts\' in your AnkiDroid folder.</string>
+<string name="override_font">Override font</string>
+<string name="override_font_summ">A font that will be used instead of any fonts specified by a deck. Custom fonts should be installed on the SD card in a folder called \'fonts\' in your AnkiDroid folder.</string>
 <string name="language">Language</string>
 <string name="language_summ">Select the language AnkiDroid should use. At the moment: XXX</string>
 <string name="language_system">System Language</string>

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -192,9 +192,9 @@
         <PreferenceCategory android:title="@string/pref_cat_fonts" >
             <ListPreference
                 android:defaultValue=""
-                android:key="defaultFont"
-                android:summary="@string/default_font_summ"
-                android:title="@string/default_font" />
+                android:key="overrideFont"
+                android:summary="@string/override_font_summ"
+                android:title="@string/override_font" />
             <com.hlidskialf.android.preference.SeekBarPreference
                 android:defaultValue="100"
                 android:key="relativeDisplayFontSize"

--- a/src/com/ichi2/anki/Preferences.java
+++ b/src/com/ichi2/anki/Preferences.java
@@ -339,7 +339,7 @@ public class Preferences extends PreferenceActivity implements OnSharedPreferenc
 
     /** Initializes the list of custom fonts shown in the preferences. */
     private void initializeCustomFontsDialog() {
-        ListPreference customFontsPreference = (ListPreference) getPreferenceScreen().findPreference("defaultFont");
+        ListPreference customFontsPreference = (ListPreference) getPreferenceScreen().findPreference("overrideFont");
         customFontsPreference.setEntries(getCustomFonts("System default"));
         customFontsPreference.setEntryValues(getCustomFonts(""));
         ListPreference browserEditorCustomFontsPreference = (ListPreference) getPreferenceScreen().findPreference("browserEditorFont");
@@ -393,13 +393,13 @@ public class Preferences extends PreferenceActivity implements OnSharedPreferenc
                     case Themes.THEME_ANDROID_DARK:
                     case Themes.THEME_ANDROID_LIGHT:
                     case Themes.THEME_BLUE:
-                        sharedPreferences.edit().putString("defaultFont", "").commit();
+                        sharedPreferences.edit().putString("overrideFont", "").commit();
                         break;
                     case Themes.THEME_FLAT:
-                        sharedPreferences.edit().putString("defaultFont", "OpenSans").commit();
+                        sharedPreferences.edit().putString("overrideFont", "OpenSans").commit();
                         break;
                     case Themes.THEME_WHITE:
-                        sharedPreferences.edit().putString("defaultFont", "OpenSans").commit();
+                        sharedPreferences.edit().putString("overrideFont", "OpenSans").commit();
                         break;
                 }
                 Intent intent = this.getIntent();

--- a/src/com/ichi2/anki/Reviewer.java
+++ b/src/com/ichi2/anki/Reviewer.java
@@ -349,7 +349,7 @@ public class Reviewer extends AnkiActivity {
      * <p>Should not be accessed directly but via {@link #getCustomFontsMap()}, as it is lazily initialized.
      */
     private Map<String, AnkiFont> mCustomFontsMap;
-    private String mCustomDefaultFontCss;
+    private String mCustomOverrideFontCss;
     private String mCustomFontStyle;
 
     /**
@@ -2179,7 +2179,7 @@ public class Reviewer extends AnkiActivity {
 	                mCardFrame.addView(mNextCard, 0);
 		            mCard.setBackgroundColor(mCurrentBackgroundColor);
 
-	                mCustomFontStyle = getCustomFontsStyle() + getDefaultFontStyle();
+	                mCustomFontStyle = getCustomFontsStyle() + getOverrideFontStyle();
 	            }
 			}
 			if (mCard.getVisibility() != View.VISIBLE || (mSimpleCard != null && mSimpleCard.getVisibility() == View .VISIBLE)) {
@@ -2779,28 +2779,28 @@ public class Reviewer extends AnkiActivity {
 
 
     /** Returns the CSS used to set the default font. */
-    private String getDefaultFontStyle() {
-        if (mCustomDefaultFontCss == null) {
+    private String getOverrideFontStyle() {
+        if (mCustomOverrideFontCss == null) {
             SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(getBaseContext());
-            AnkiFont defaultFont = getCustomFontsMap().get(preferences.getString("defaultFont", null));
-            if (defaultFont != null) {
-                mCustomDefaultFontCss = "BODY, .card { " + defaultFont.getCSS() + " }\n";
+            AnkiFont overrideFont = getCustomFontsMap().get(preferences.getString("overrideFont", null));
+            if (overrideFont != null) {
+                mCustomOverrideFontCss = "BODY, .card { " + overrideFont.getCSS() + " }\n";
             } else {
-                String defaultFontName = Themes.getReviewerFontName();
-                if (TextUtils.isEmpty(defaultFontName)) {
-                    mCustomDefaultFontCss = "";
+                String overrideFontName = Themes.getReviewerFontName();
+                if (TextUtils.isEmpty(overrideFontName)) {
+                    mCustomOverrideFontCss = "";
                 } else {
-                    mCustomDefaultFontCss = String.format(
+                    mCustomOverrideFontCss = String.format(
                             "BODY {"
                             + "font-family: '%s';"
                             + "font-weight: normal;"
                             + "font-style: normal;"
                             + "font-stretch: normal;"
-                            + "}\n", defaultFontName);
+                            + "}\n", overrideFontName);
                 }
             }
         }
-        return mCustomDefaultFontCss;
+        return mCustomOverrideFontCss;
     }
 
 


### PR DESCRIPTION
The pull request #161 fully incorporates this change. Please consider that request's suitability, and only accept this change the other cannot be accepted.

I added res strings to a res/values file, but inserted nothing into the res/values-XX files for foreign language translations. I assume a process exists so that those are somehow generated from that master, and translated along the way through crowdIn, so if I actually need to do something else to complete this change, please let me know.

No functionality has been changed. New res strings have been added to describe the current functionality, and the old res strings have been left for the implementation that is worded (that of default font which we had be reverted to an override font). All variables and functions have been renamed to reference override in place of default.

I chose to say that an override font replaces any fonts specified "by a deck", knowing that fonts are not at all deck specific (living in the note/card instead), but I felt the description given lends itself more intuitively to an average user, which is fitting since this override functionality is expected to be used by those who rarely if ever work with cards or CSS but want a general feel even across shared decks.

This is a follow up to a change by @hssm (#144) that returned from a default implementation back to a user desired override implementation that had been around.
