### PR TITLE
Implement default font as seperate from override font

### DIFF
--- a/res/values/10-preferences.xml
+++ b/res/values/10-preferences.xml
@@ -154,7 +154,9 @@
 <string name="fix_hebrew_instructions">This setting bypasses the RTL algorithm of Android to show Hebrew text with vowels correctly.\n\nFor this to work, you need to download font Tohu.ttf and copy it manually to:\n%s/fonts/\n\nYou won\'t have to modify your cards.</string>
 <string name="fix_hebrew_download_font">Download Font</string>
 <string name="default_font">Default font</string>
-<string name="default_font_summ">The font used for text that has no font formatting specified. Custom fonts should be installed on the SD card in a folder called \'fonts\' in your AnkiDroid folder.</string>
+<string name="default_font_summ">The font used for text that has no font formatting specified. Custom fonts should be installed in a folder called \'fonts\' in your AnkiDroid folder.</string>
+<string name="override_font">Override font</string>
+<string name="override_font_summ">A font that will be used instead of any fonts specified, including the default font. Custom fonts should be installed in a folder called \'fonts\' in your AnkiDroid folder.</string>
 <string name="language">Language</string>
 <string name="language_summ">Select the language AnkiDroid should use. At the moment: XXX</string>
 <string name="language_system">System Language</string>
@@ -313,7 +315,7 @@
 <string name="pref_enable_tibetan">Enable Tibetan Support</string>
 <string name="pref_enable_tibetan_summ">Enables tibetan typeface for card browser and card editor. Typeface should be provided in /mnt/sdard/fonts/DDC_Uchen.ttf.</string>
 <string name="pref_browser_editor_font">Browser and Editor font</string>
-<string name="pref_browser_editor_font_summ">Default font to be used in Card Browser and Card Editor. Custom fonts should be installed on the SD card in a folder called \'fonts\' in your AnkiDroid folder.</string>
+<string name="pref_browser_editor_font_summ">Default font to be used in Card Browser and Card Editor. Custom fonts should be installed in a folder called \'fonts\' in your AnkiDroid folder.</string>
 
 <string name="deck_conf_cram_filter">Filter</string>
 <string name="deck_conf_cram_options">Options</string>

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -194,7 +194,12 @@
                 android:defaultValue=""
                 android:key="defaultFont"
                 android:summary="@string/default_font_summ"
-                android:title="@string/default_font" />
+                android:title="@string/default_font" />            
+            <ListPreference
+                android:defaultValue=""
+                android:key="overrideFont"
+                android:summary="@string/override_font_summ"
+                android:title="@string/override_font" />
             <com.hlidskialf.android.preference.SeekBarPreference
                 android:defaultValue="100"
                 android:key="relativeDisplayFontSize"

--- a/src/com/ichi2/anki/AnkiFont.java
+++ b/src/com/ichi2/anki/AnkiFont.java
@@ -1,6 +1,7 @@
 package com.ichi2.anki;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.content.res.Resources;
 import android.graphics.Typeface;
 import android.util.Log;
@@ -19,6 +20,8 @@ public class AnkiFont {
     private String mFamily;
     private List<String> mAttributes;
     private String mPath;
+    private Boolean mIsDefault;
+    private Boolean mIsOverride;
     private static final String fAssetPathPrefix = "/android_asset/fonts/";
     private static Set<String> corruptFonts = new HashSet<String>();
 
@@ -27,7 +30,9 @@ public class AnkiFont {
         mFamily = family;
         mAttributes = attributes;
         mPath = path;
-    }
+        mIsDefault = false;
+        mIsOverride = false;
+    } 
     
     /**
      * Factory for AnkiFont creation.
@@ -42,7 +47,7 @@ public class AnkiFont {
         String name = Utils.removeExtension(fontfile.getName());
         String family = name;
         List<String> attributes = new ArrayList<String>();
-
+ 
         if (fromAssets) {
             path = fAssetPathPrefix.concat(fontfile.getName());
         }
@@ -81,7 +86,20 @@ public class AnkiFont {
             attributes.add("font-stretch: normal;");
         }
         family = family.replaceFirst("(?i)-?Regular", "");
-        return new AnkiFont(name, family, attributes, path);
+        
+        AnkiFont createdFont = new AnkiFont(name, family, attributes, path);
+        // determine if override font or default font
+        SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(ctx);
+        String overrideFont = preferences.getString("overrideFont", "");
+        if (overrideFont.equalsIgnoreCase(name)) {
+            createdFont.setAsOverride();
+        } else {
+            String defaultFont = preferences.getString("defaultFont", "");
+            if (defaultFont.equalsIgnoreCase(name)) {
+                createdFont.setAsDefault();
+            }
+        }
+        return createdFont;
     }
     
     public String getDeclaration() {
@@ -89,8 +107,13 @@ public class AnkiFont {
         sb.append(getCSS()).append(" src: url(\"file://").append(mPath).append("\");}");
         return sb.toString();
     }
-    public String getCSS() {
-        StringBuilder sb = new StringBuilder("font-family: \"").append(mFamily).append("\" !important;");
+    public String getCSS() {        
+        StringBuilder sb = new StringBuilder("font-family: \"").append(mFamily);
+        if (mIsOverride) {
+            sb.append("\" !important;");
+        } else {
+            sb.append("\";");
+        }
         for (String attr : mAttributes) {
             sb.append(" ").append(attr);
         }
@@ -123,4 +146,12 @@ public class AnkiFont {
             return null;
         }
     }
+    private void setAsDefault() {
+        mIsDefault = true;
+        mIsOverride = false;
+    }
+    private void setAsOverride() {
+        mIsOverride = true;
+        mIsDefault = false;
+    }    
 }

--- a/src/com/ichi2/anki/Reviewer.java
+++ b/src/com/ichi2/anki/Reviewer.java
@@ -187,7 +187,7 @@ public class Reviewer extends AnkiActivity {
     // Type answer pattern
     private static final Pattern sTypeAnsPat = Pattern.compile("\\[\\[type:(.+?)\\]\\]");
 
-    /** to be sento to and from the card editor */
+    /** to be sent to and from the card editor */
     private static Card sEditorCard;
 
     private static boolean sDisplayAnswer = false;
@@ -350,7 +350,10 @@ public class Reviewer extends AnkiActivity {
      */
     private Map<String, AnkiFont> mCustomFontsMap;
     private String mCustomDefaultFontCss;
+    private String mCustomOverrideFontCss;
+    private String mThemeFontCss; 
     private String mCustomFontStyle;
+    private String mSystemicFontStyle;
 
     /**
      * Shake Detection
@@ -2179,7 +2182,7 @@ public class Reviewer extends AnkiActivity {
 	                mCardFrame.addView(mNextCard, 0);
 		            mCard.setBackgroundColor(mCurrentBackgroundColor);
 
-	                mCustomFontStyle = getCustomFontsStyle() + getDefaultFontStyle();
+	                mCustomFontStyle = getCustomFontsStyle() + getSystemicFontStyle();
 	            }
 			}
 			if (mCard.getVisibility() != View.VISIBLE || (mSimpleCard != null && mSimpleCard.getVisibility() == View .VISIBLE)) {
@@ -2766,7 +2769,7 @@ public class Reviewer extends AnkiActivity {
      * <p>
      * Custom fonts live in fonts directory in the directory used to store decks.
      * <p>
-     * Each font is mapped to the font family by the same name as the name of the font fint without the extension.
+     * Each font is mapped to the font family by the same name as the name of the font file without the extension.
      */
     private String getCustomFontsStyle() {
         StringBuilder builder = new StringBuilder();
@@ -2777,30 +2780,76 @@ public class Reviewer extends AnkiActivity {
         return builder.toString();
     }
 
+    
+    /** Returns the CSS used to set the theme font.
+     *  @return the font style, or the empty string if no font is set 
+     */
+    private String getThemeFontStyle() {
+        if (mThemeFontCss == null) {
+            String themeFontName = Themes.getReviewerFontName();
+            if (TextUtils.isEmpty(themeFontName)) {
+                mThemeFontCss = "";
+            } else {
+                mThemeFontCss = String.format(
+                        "BODY {"
+                        + "font-family: '%s';"
+                        + "font-weight: normal;"
+                        + "font-style: normal;"
+                        + "font-stretch: normal;"
+                        + "}\n", themeFontName);
+            }
+        }
+        return mThemeFontCss;
+    }    
 
-    /** Returns the CSS used to set the default font. */
+    
+    /** Returns the CSS used to set the default font.
+     *  @return the default font style, or the empty string if no default font is set 
+     */    
     private String getDefaultFontStyle() {
         if (mCustomDefaultFontCss == null) {
             SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(getBaseContext());
             AnkiFont defaultFont = getCustomFontsMap().get(preferences.getString("defaultFont", null));
             if (defaultFont != null) {
-                mCustomDefaultFontCss = "BODY, .card { " + defaultFont.getCSS() + " }\n";
+                mCustomDefaultFontCss = "BODY { " + defaultFont.getCSS() + " }\n";
             } else {
-                String defaultFontName = Themes.getReviewerFontName();
-                if (TextUtils.isEmpty(defaultFontName)) {
-                    mCustomDefaultFontCss = "";
-                } else {
-                    mCustomDefaultFontCss = String.format(
-                            "BODY {"
-                            + "font-family: '%s';"
-                            + "font-weight: normal;"
-                            + "font-style: normal;"
-                            + "font-stretch: normal;"
-                            + "}\n", defaultFontName);
-                }
+                mCustomDefaultFontCss = "";
             }
         }
         return mCustomDefaultFontCss;
+    }
+    
+    
+    /** Returns the CSS that determines font choice in a global fashion.
+     *  @return the font style, or the empty string if none applies 
+     */
+    private String getSystemicFontStyle() {
+        if (mSystemicFontStyle == null) {
+            mSystemicFontStyle = getOverrideFontStyle();
+            if (mSystemicFontStyle.isEmpty()) {
+                mSystemicFontStyle = getDefaultFontStyle();
+                if (mSystemicFontStyle.isEmpty()) {
+                    mSystemicFontStyle = getThemeFontStyle();
+                }
+            }
+        }
+        return mSystemicFontStyle;
+    }
+    
+    /** Returns the CSS used to set the override font.
+     *  @return the override font style, or the empty string if no override font is set 
+     */
+    private String getOverrideFontStyle() {
+        if (mCustomOverrideFontCss == null) {
+            SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(getBaseContext());
+            AnkiFont overrideFont = getCustomFontsMap().get(preferences.getString("overrideFont", null));
+            if (overrideFont != null) {
+                mCustomOverrideFontCss = "BODY, .card, * { " + overrideFont.getCSS() + " }\n";
+            } else {
+                mCustomOverrideFontCss = "";
+            }
+        }
+        return mCustomOverrideFontCss;
     }
 
 


### PR DESCRIPTION
First we had override font functionality named default font, then we matched its function to its name, people complained about a lost ability the want so we reinstated its override behavior back at square one. Pull request #160 (which is superceded by (i.e. fully incorporated into) this pull request) made the name match the behavior, and now this finishes it all off by having both functionalities present, and aptly named ;)

The design is as follows: default font will be set on any element that has no font otherwise specified for it, override font will override any font settings that have been specified, including default font. Override font is a simplistic way for a user to control the appearance of decks they did not author, without having to get into anki workings. Override functionality is now more deserving of its name, being applied to all html elements that may have had a font specified for them in cases where it wasn't being applied before. You want a hammer, you have a hammer.

If for some reason this change is ultimately rejected, then #160 is a much smaller change that may be easily incorporated.
