### PR TITLE
Implement default font with override font

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -29,7 +29,7 @@
         The <build> is only present for alpha and beta releases (e.g., 2.0.4alpha2 or 2.0.4beta4), developer builds do
         not have a build number (e.g., 2.0.4dev) and official releases only have three components (e.g., 2.0.4).
 
-        The version code is deerived from the version name as follows:
+        The version code is derived from the version name as follows:
           AAbbCCtDD
         where AA is 2-digit decimal number (with leading zeros omitted) representing the major version; bb is a 2-digit
         decimal number representing the minor version; CC is a 2-digit decimal number representing the maintenance

--- a/res/values/10-preferences.xml
+++ b/res/values/10-preferences.xml
@@ -154,7 +154,9 @@
 <string name="fix_hebrew_instructions">This setting bypasses the RTL algorithm of Android to show Hebrew text with vowels correctly.\n\nFor this to work, you need to download font Tohu.ttf and copy it manually to:\n%s/fonts/\n\nYou won\'t have to modify your cards.</string>
 <string name="fix_hebrew_download_font">Download Font</string>
 <string name="default_font">Default font</string>
-<string name="default_font_summ">The font used for text that has no font formatting specified. Custom fonts should be installed on the SD card in a folder called \'fonts\' in your AnkiDroid folder.</string>
+<string name="default_font_summ">The font used for text that has no font formatting specified. Custom fonts should be installed in a folder called \'fonts\' in your AnkiDroid folder.</string>
+<string name="override_font">Override font</string>
+<string name="override_font_summ">A font that will be used instead of any fonts specified, including the default font. Custom fonts should be installed in a folder called \'fonts\' in your AnkiDroid folder.</string>
 <string name="language">Language</string>
 <string name="language_summ">Select the language AnkiDroid should use. At the moment: XXX</string>
 <string name="language_system">System Language</string>
@@ -313,7 +315,7 @@
 <string name="pref_enable_tibetan">Enable Tibetan Support</string>
 <string name="pref_enable_tibetan_summ">Enables tibetan typeface for card browser and card editor. Typeface should be provided in /mnt/sdard/fonts/DDC_Uchen.ttf.</string>
 <string name="pref_browser_editor_font">Browser and Editor font</string>
-<string name="pref_browser_editor_font_summ">Default font to be used in Card Browser and Card Editor. Custom fonts should be installed on the SD card in a folder called \'fonts\' in your AnkiDroid folder.</string>
+<string name="pref_browser_editor_font_summ">Default font to be used in Card Browser and Card Editor. Custom fonts should be installed in a folder called \'fonts\' in your AnkiDroid folder.</string>
 
 <string name="deck_conf_cram_filter">Filter</string>
 <string name="deck_conf_cram_options">Options</string>

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -194,7 +194,13 @@
                 android:defaultValue=""
                 android:key="defaultFont"
                 android:summary="@string/default_font_summ"
-                android:title="@string/default_font" />
+                android:title="@string/default_font"
+                android:shouldDisableView="true" />
+            <ListPreference
+                android:defaultValue=""
+                android:key="overrideFont"
+                android:summary="@string/override_font_summ"
+                android:title="@string/override_font" />
             <com.hlidskialf.android.preference.SeekBarPreference
                 android:defaultValue="100"
                 android:key="relativeDisplayFontSize"

--- a/src/com/ichi2/anki/AnkiDroidApp.java
+++ b/src/com/ichi2/anki/AnkiDroidApp.java
@@ -109,6 +109,13 @@ public class AnkiDroidApp extends Application {
     public static final int CHECK_DB_AT_VERSION = 40;
     
     /**
+     * The latest package version number that included changes to the preferences
+     * that requires handling. All collections being upgraded to (or after) this version
+     * must update preferences.
+     */
+    public static final int CHECK_PREFERENCES_AT_VERSION = 20100108;      
+    
+    /**
      * On application creation.
      */
     @Override

--- a/src/com/ichi2/anki/AnkiFont.java
+++ b/src/com/ichi2/anki/AnkiFont.java
@@ -1,6 +1,7 @@
 package com.ichi2.anki;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.content.res.Resources;
 import android.graphics.Typeface;
 import android.util.Log;
@@ -19,6 +20,8 @@ public class AnkiFont {
     private String mFamily;
     private List<String> mAttributes;
     private String mPath;
+    private Boolean mIsDefault;
+    private Boolean mIsOverride;
     private static final String fAssetPathPrefix = "/android_asset/fonts/";
     private static Set<String> corruptFonts = new HashSet<String>();
 
@@ -27,7 +30,10 @@ public class AnkiFont {
         mFamily = family;
         mAttributes = attributes;
         mPath = path;
-    }
+        mIsDefault = false;
+        mIsOverride = false;
+    } 
+    
     
     /**
      * Factory for AnkiFont creation.
@@ -51,6 +57,7 @@ public class AnkiFont {
             // unable to create typeface
             return null;
         }
+
         if (tf.isBold() || name.toLowerCase().contains("bold")) {
             attributes.add("font-weight: bolder;");
             family = family.replaceFirst("(?i)-?Bold", "");
@@ -77,11 +84,22 @@ public class AnkiFont {
             attributes.add("font-stretch: expanded;");
             family = family.replaceFirst("(?i)-?Expanded", "");
             family = family.replaceFirst("(?i)-?Wide(r)?", "");
-        } else {
-            attributes.add("font-stretch: normal;");
         }
-        family = family.replaceFirst("(?i)-?Regular", "");
-        return new AnkiFont(name, family, attributes, path);
+        
+        AnkiFont createdFont = new AnkiFont(name, family, attributes, path);
+        
+        // determine if override font or default font
+        SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(ctx);
+        String overrideFont = preferences.getString("overrideFont", "");        
+        if (overrideFont.equalsIgnoreCase(name)) {
+            createdFont.setAsOverride();
+        } else {
+            String defaultFont = preferences.getString("defaultFont", "");
+            if (defaultFont.equalsIgnoreCase(name)) {
+                createdFont.setAsDefault();
+            }
+        }
+        return createdFont;
     }
     
     public String getDeclaration() {
@@ -89,10 +107,23 @@ public class AnkiFont {
         sb.append(getCSS()).append(" src: url(\"file://").append(mPath).append("\");}");
         return sb.toString();
     }
-    public String getCSS() {
-        StringBuilder sb = new StringBuilder("font-family: \"").append(mFamily).append("\" !important;");
+    public String getCSS() {        
+        StringBuilder sb = new StringBuilder("font-family: \"").append(mFamily);
+        if (mIsOverride) {
+            sb.append("\" !important;");
+        } else {
+            sb.append("\";");
+        }
         for (String attr : mAttributes) {
             sb.append(" ").append(attr);
+            if (mIsOverride) {
+                if (sb.charAt(sb.length() - 1) == ';') {
+                    sb.deleteCharAt(sb.length() - 1);
+                    sb.append(" !important;");
+                } else {
+                    Log.d(AnkiDroidApp.TAG, "AnkiFont.getCSS() - unable to set a font attribute important while override is set.");
+                }
+            }
         }
         return sb.toString();
     }
@@ -123,4 +154,12 @@ public class AnkiFont {
             return null;
         }
     }
+    private void setAsDefault() {
+        mIsDefault = true;
+        mIsOverride = false;
+    }
+    private void setAsOverride() {
+        mIsOverride = true;
+        mIsDefault = false;
+    }    
 }

--- a/src/com/ichi2/anki/Info.java
+++ b/src/com/ichi2/anki/Info.java
@@ -186,9 +186,6 @@ public class Info extends Activity {
                 sb.append(
                         String.format(content[4], res.getString(R.string.licence_wiki),
                                 res.getString(R.string.link_source))).append("<br/><br/>");
-                sb.append(
-                        String.format(content[5])).append("<br/><br/>");
-
                 sb.append("</body></html>");
                 mWebView.loadDataWithBaseURL("", sb.toString(), "text/html", "utf-8", null);
                 ((Button) findViewById(R.id.info_continue)).setText(res.getString(R.string.info_rate));

--- a/src/com/ichi2/anki/Preferences.java
+++ b/src/com/ichi2/anki/Preferences.java
@@ -340,15 +340,30 @@ public class Preferences extends PreferenceActivity implements OnSharedPreferenc
 
     /** Initializes the list of custom fonts shown in the preferences. */
     private void initializeCustomFontsDialog() {
-        ListPreference customFontsPreference = (ListPreference) getPreferenceScreen().findPreference("defaultFont");
-        customFontsPreference.setEntries(getCustomFonts("System default"));
-        customFontsPreference.setEntryValues(getCustomFonts(""));
+        ListPreference defaultFontPreference = (ListPreference) getPreferenceScreen().findPreference("defaultFont");
+        ListPreference overrideFontPreference = (ListPreference) getPreferenceScreen().findPreference("overrideFont");        
+        if (defaultFontPreference != null) {
+            defaultFontPreference.setEntries(getCustomFonts("System default"));
+            defaultFontPreference.setEntryValues(getCustomFonts(""));
+        }
+        if (overrideFontPreference != null) {
+            overrideFontPreference.setEntries(getCustomFonts("None"));
+            overrideFontPreference.setEntryValues(getCustomFonts(""));
+        }
+        onOverrideFontChange(overrideFontPreference, defaultFontPreference);
+
         ListPreference browserEditorCustomFontsPreference = (ListPreference) getPreferenceScreen().findPreference("browserEditorFont");
         browserEditorCustomFontsPreference.setEntries(getCustomFonts("System default"));
         browserEditorCustomFontsPreference.setEntryValues(getCustomFonts("", true));
     }
 
 
+    private void onOverrideFontChange(ListPreference overrideFontPreference, ListPreference defaultFontPreference) {
+        if (overrideFontPreference != null && defaultFontPreference != null) {
+            Boolean overrideIsSet = !overrideFontPreference.getValue().isEmpty();
+            defaultFontPreference.setEnabled(!overrideIsSet);
+        }
+    }
     @Override
     protected void onPause() {
         super.onPause();
@@ -471,6 +486,12 @@ public class Preferences extends PreferenceActivity implements OnSharedPreferenc
                 date.set(Calendar.HOUR_OF_DAY, hours);
                 mCol.setCrt(date.getTimeInMillis() / 1000);
                 mCol.setMod();
+            } else if (key.equals("overrideFont")) {
+                ListPreference overrideFontPreference = 
+                        (ListPreference) getPreferenceScreen().findPreference("overrideFont");
+                ListPreference defaultFontPreference =
+                        (ListPreference) getPreferenceScreen().findPreference("defaultFont"); 
+                onOverrideFontChange(overrideFontPreference, defaultFontPreference);
             }
             if (Arrays.asList(mShowValueInSummList).contains(key)) {
                 updateListPreference(key);


### PR DESCRIPTION
This change is on top of an as of yet uncommitted change #132, as I expect that change will be committed. This change fully contains the changes in #132 -- I recommend committing #132 explicitly, then this one if it is to be incorporated.

The design is as follows: default font will be set on any element that has no font otherwise specified for it, override font will override any font settings that have been specified, including default font. Override font is a simplistic way for a user to control the appearance of decks they did not author, without having to get into anki workings. Override functionality is now more deserving of its name, being applied to all html elements that may have had a font specified for them in cases where it wasn't being applied before. You want a hammer, you have a hammer.

One area of this change deserves a review, as it removes a section of code which was apparently considered important. Namely, it is the section where, upon creating the AnkiFont of a custom font, a list of attributes (bold, italic, etc.) where added to it. These are superfluous when one considers that the fonts being added, such as OpenSans-Bold.ttf, have these features built into the very font itself without a need to specify css styles about it. However, I believe this is because all of the OpenSans-***.ttf files were being passed in as a font-face of "OpenSans", which is generic. Thus, a list of imported files were all sharing the same reference, making it hard to distinguish individual entries by font-family alone.

The thing is, these @font-face declarations allow you to create a random id of your choice for the font. It seems the original code in this area wanted to preserve a generic family name across the OpenSans fonts, to be somehow representative. The result with override fonts was then that the font-family of OpenSans was being used, but font-style, such as italic, might very well be ignored. It doesn't make sense to ignore Italic-ness when the user specifically set up "OpenSans-Italic" as their override font. I had two choices: the change as I'm proposing it, or, to add !important after each attribute when a font is an override.

What was:
@font-face { font-family: "OpenSans"; font-weight: bolder; src: url('OpenSans-Bold.ttf'); }
@font-face { font-family: "OpenSans"; font-style: italic; src: url('OpenSans-Italic.ttf'); }

Is now:
@font-face { font-family: "OpenSans-BoldFontId"; src: url('OpenSans-Bold.ttf'); }
@font-face { font-family: "OpenSans-ItalicFontId"; src: url('OpenSans-Italic.ttf'); }

Notice that the font-family is made unique, going out of its way to avoid any association with any system font that may exist.

The concern is that somewhere somehow this "font css attributizing" is necessary of used in a way that necessitates the code that has been here sotofar.
