### PR TITLE
Fix multilined LaTeX within card templates

### DIFF
--- a/src/com/ichi2/libanki/LaTeX.java
+++ b/src/com/ichi2/libanki/LaTeX.java
@@ -42,10 +42,12 @@ public class LaTeX {
     /**
      * Patterns used to identify LaTeX tags
      */
-    public static Pattern sStandardPattern = Pattern.compile("\\[latex\\](.+?)\\[/latex\\]");
-    public static Pattern sExpressionPattern = Pattern.compile("\\[\\$\\](.+?)\\[/\\$\\]");
-    public static Pattern sMathPattern = Pattern.compile("\\[\\$\\$\\](.+?)\\[/\\$\\$\\]");
-    public static Pattern sEntityPattern = Pattern.compile("(&[a-z]+;)");
+    public static Pattern sStandardPattern = Pattern.compile("\\[latex\\](.+?)\\[/latex\\]",
+            Pattern.DOTALL | Pattern.CASE_INSENSITIVE);
+    public static Pattern sExpressionPattern = Pattern.compile("\\[\\$\\](.+?)\\[/\\$\\]",
+            Pattern.DOTALL | Pattern.CASE_INSENSITIVE);
+    public static Pattern sMathPattern = Pattern.compile("\\[\\$\\$\\](.+?)\\[/\\$\\$\\]",
+            Pattern.DOTALL | Pattern.CASE_INSENSITIVE);
 
 
     /**


### PR DESCRIPTION
Fix issue 1935. The mungeQA method is passed a string that has been
stripped of newline characters in the "meat" of the card, but which can
still contain newlines in the templated part. Get mungeQA to handle this
properly; also, switch to case-insensitive matching for [latex] tags.
