### PR TITLE
Iss1852 wildcards fields

### DIFF
--- a/src/com/ichi2/libanki/Finder.java
+++ b/src/com/ichi2/libanki/Finder.java
@@ -681,7 +681,27 @@ public class Finder {
 
 
     private String _findField(String field, String val) {
-        val = val.replace("*", "%");
+        /*
+         * We need two expressions to query the cards: One that will use JAVA REGEX syntax and another
+         * that should use SQLITE LIKE clause syntax.
+         */
+        String sqlVal = val
+                .replace("%","\\%") // For SQLITE, we escape all % signs
+                .replace("*","%"); // And then convert the * into non-escaped % signs
+
+        /*
+         * The following three lines make sure that only _ and * are valid wildcards. 
+         * Any other characters are enclosed inside the \Q \E markers, which force  
+         * all meta-characters in between them to lose their special meaning 
+         */
+        String javaVal = val
+                    .replace("_","\\E.\\Q") 
+                    .replace("*","\\E.*\\Q");
+        /*
+         * For the pattern, we use the javaVal expression that uses JAVA REGEX syntax
+         */
+        Pattern pattern = Pattern.compile("\\Q" + javaVal + "\\E", Pattern.CASE_INSENSITIVE);
+
         // find models that have that field
         Map<Long, Object[]> mods = new HashMap<Long, Object[]>();
         try {
@@ -703,21 +723,24 @@ public class Finder {
             // nothing has that field
             return "";
         }
-        // gather nids
-        // Pattern.quote escapes the meta characters with \Q \E
-        String regex = Pattern.quote(val).replace("\\Q_\\E", ".").replace("\\Q%\\E", ".*");
         LinkedList<Long> nids = new LinkedList<Long>();
         Cursor cur = null;
         try {
+            /*
+             * Here we use the sqlVal expression, that is required for LIKE syntax in sqllite.
+             * There is no problem with special characters, because only % and _ are special
+             * characters in this syntax.
+             */
             cur = mCol.getDb().getDatabase().rawQuery(
                     "select id, mid, flds from notes where mid in " +
-                    Utils.ids2str(new LinkedList<Long>(mods.keySet())) +
-                    " and flds like ? escape '\\'", new String[] { "%" + val + "%" });
+                            Utils.ids2str(new LinkedList<Long>(mods.keySet())) +
+                            " and flds like ? escape '\\'", new String[] { "%" + sqlVal + "%" });
+
             while (cur.moveToNext()) {
                 String[] flds = Utils.splitFields(cur.getString(2));
                 int ord = (Integer) mods.get(cur.getLong(1))[1];
                 String strg = flds[ord];
-                if (Pattern.compile(regex, Pattern.CASE_INSENSITIVE).matcher(strg).matches()) {
+                if (pattern.matcher(strg).matches()) {
                     nids.add(cur.getLong(0));
                 }
             }


### PR DESCRIPTION
Corrected the code that is in charge of matching regular expressions of fields.
The problem was that we needed to use different syntax for SQL Lite and the
Java Pattern class, when matching the expressions.
