### PR TITLE
Iss1504 card answer revealed early

### DIFF
--- a/src/com/ichi2/anki/Reviewer.java
+++ b/src/com/ichi2/anki/Reviewer.java
@@ -659,6 +659,14 @@ public class Reviewer extends AnkiActivity {
 
         @Override
         public void onProgressUpdate(DeckTask.TaskData... values) {
+        	if(mCurrentCard != values[0].getCard()){
+            	/*
+            	 * Before updating mCurrentCard, we check whether it is changing
+            	 * or not. If the current card changes, then we need to display it
+            	 * as a new card, without showing the answer.
+            	 */
+        		sDisplayAnswer = false;
+        	}
             mCurrentCard = values[0].getCard();
             if (mCurrentCard == null) {
                 // If the card is null means that there are no more cards scheduled for review.


### PR DESCRIPTION
When in review, if we edit a card in such a way that when we go back to the review activity the displayed card should change (e.g. changing the deck of the card), we need to make sure that the new card's answer is not shown.

So when checking
`if(mCurrentCard != values[0].getCard())`
I am checking whether the card has changed or not, and if it has, then the answer to the new card should not be displayed.
Here's the bug report:

https://code.google.com/p/ankidroid/issues/detail?can=2&start=0&num=100&q=&colspec=ID%20Type%20Priority%20Status%20Milestone%20Owner%20Summary&groupby=&sort=&id=1504#makechanges
