### PR TITLE
Issue 1821:Tags limited to numeric values

### DIFF
--- a/res/values/11-arrays.xml
+++ b/res/values/11-arrays.xml
@@ -109,14 +109,14 @@
 		<item>Latest added first</item>
 			</string-array>
 	<string-array name="custom_study_options_labels">
-		<item>Increase today\'s new card limit</item>
-				<item>Increase today\'s review card limit</item>
-			    		<item>Review forgotten cards</item>
-				<item>Review ahead</item>
-				<item>Study a random selection of cards</item>
-						<item>Preview new cards</item>
-						<item>Limit to particular tags</item>
-											</string-array>
+	    <item>Increase today\'s new card limit</item>
+	    <item>Increase today\'s review card limit</item>
+	    <item>Review forgotten cards</item>
+	    <item>Review ahead</item>
+	    <item>Study a random selection of cards</item>
+	    <item>Preview new cards</item>
+	    <item>Limit to particular tags</item>
+	</string-array>
 	
     <string-array name="add_to_cur_labels">
         <item>Use current deck</item>
@@ -126,5 +126,10 @@
         <item>Mix new cards and reviews</item>
         <item>New cards after reviews</item>
         <item>New cards before reviews</item>
+    </string-array>
+    <string-array name="cards_for_tag_filtered_deck_labels">
+        <item>All cards</item>
+        <item>New</item>
+        <item>Due</item>
     </string-array>
    	</resources>

--- a/src/com/ichi2/anki/StudyOptionsFragment.java
+++ b/src/com/ichi2/anki/StudyOptionsFragment.java
@@ -34,6 +34,7 @@ import android.text.Html;
 import android.util.Log;
 import android.view.GestureDetector;
 import android.view.GestureDetector.SimpleOnGestureListener;
+import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.MotionEvent;
 import android.view.View;
@@ -44,7 +45,10 @@ import android.widget.Button;
 import android.widget.EditText;
 import android.widget.ImageButton;
 import android.widget.LinearLayout;
+import android.widget.RadioButton;
+import android.widget.RadioGroup;
 import android.widget.TextView;
+import android.widget.RadioGroup.OnCheckedChangeListener;
 
 import com.ichi2.anim.ActivityTransitionAnimation;
 import com.ichi2.anim.ViewAnimation;
@@ -73,6 +77,7 @@ import org.json.JSONObject;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
 
@@ -104,6 +109,7 @@ public class StudyOptionsFragment extends Fragment {
     private static final int DIALOG_STATISTIC_TYPE = 0;
     private static final int DIALOG_CUSTOM_STUDY = 1;
     private static final int DIALOG_CUSTOM_STUDY_DETAILS = 2;
+    private static final int DIALOG_CUSTOM_STUDY_TAGS = 3;
 
     private int mCustomDialogChoice;
     
@@ -165,6 +171,13 @@ public class StudyOptionsFragment extends Fragment {
     private TextView mCustomStudyTextView1;
     private TextView mCustomStudyTextView2;
     private EditText mCustomStudyEditText;
+    
+    private String[] allTags;
+    private HashSet<String> mSelectedTags;
+    private String mSearchTerms;
+    private EditText mSearchEditText;
+    private RadioGroup mSelectWhichCards;
+    private int mSelectedOption = -1;
 
     /**
      * Swipe Detection
@@ -375,6 +388,7 @@ public class StudyOptionsFragment extends Fragment {
         // 4, getActivity().getResources().getDisplayMetrics());
         // text.setPadding(padding, padding, padding, padding);
         // scroller.addView();
+        mSelectedTags = new HashSet<String>();
         return createView(inflater, savedInstanceState);
     }
 
@@ -662,11 +676,18 @@ public class StudyOptionsFragment extends Fragment {
 
         // The view that shows the congratulations view.
         mCongratsView = inflater.inflate(R.layout.studyoptions_congrats, null);
+        
+        
         // The view that shows the learn more options
         mCustomStudyDetailsView = inflater.inflate(R.layout.styled_custom_study_details_dialog, null);
         mCustomStudyTextView1 = (TextView) mCustomStudyDetailsView.findViewById(R.id.custom_study_details_text1);
         mCustomStudyTextView2 = (TextView) mCustomStudyDetailsView.findViewById(R.id.custom_study_details_text2);
         mCustomStudyEditText = (EditText) mCustomStudyDetailsView.findViewById(R.id.custom_study_details_edittext2);
+        
+        /* When creating a new filtered deck after reviewing, there are several options.
+         * For selecting several tags, we need a new, different dialog, that allows to select
+         * a list of tags:
+         */
 
         Themes.setWallpaper(mCongratsView);
 
@@ -838,19 +859,6 @@ public class StudyOptionsFragment extends Fragment {
                     }
                 });
         		break;
-
-        	case CUSTOM_STUDY_TAGS:
-        		mCustomStudyTextView1.setText("");
-        		mCustomStudyTextView2.setText(res.getString(R.string.custom_study_tags));
-        		mCustomStudyEditText.setText(AnkiDroidApp.getSharedPrefs(getActivity()).getString("customTags", ""));
-        		styledDialog.setButtonOnClickListener(Dialog.BUTTON_POSITIVE, new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int which) {
-                    	String tags = ((EditText) mCustomStudyEditText).getText().toString();
-                    	createFilteredDeck(new JSONArray(), new Object[]{"(is:new or is:due) " + tags, 9999, Sched.DYN_RANDOM}, true);
-                    }
-                });
-        		break;
         	}
     	}
     }
@@ -879,6 +887,15 @@ public class StudyOptionsFragment extends Fragment {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
                     	mCustomDialogChoice = which;
+                    	if(which == CUSTOM_STUDY_TAGS-1){
+                    		/*
+                    		 * There is a special Dialog for CUSTOM STUDY, where instead of only collecting
+                    		 * a number, it is necessary to collect a list of tags. This case handles the
+                    		 * creation of that Dialog.
+                    		 */
+                    		showDialog(DIALOG_CUSTOM_STUDY_TAGS);
+                    		return;
+                    	}
                     	showDialog(DIALOG_CUSTOM_STUDY_DETAILS);
                     }
                 });
@@ -886,20 +903,173 @@ public class StudyOptionsFragment extends Fragment {
                 dialog = builder1.create();
                 break;
 
+            case DIALOG_CUSTOM_STUDY_TAGS:
+            	 /*
+            	  * This handles the case where we want to create a Custom Study Deck using tags.
+            	  * This dialog needs to be different from the normal Custom Study dialogs, because
+            	  * more information is required:
+            	  * --List of Tags to select.
+            	  * --Which cards to select 
+            	  * 	--(New cards, Due cards, or all cards, as in the desktop version)
+            	  */
+                if (!AnkiDroidApp.colIsOpen())
+                {
+                    //TODO how should this error be handled?
+                }
+
+                Context context = getActivity().getBaseContext();
+
+                /*
+                 * The following RadioButtons and RadioGroup are to select the category of cards
+                 * to select for the Custom Study Deck (New, Due or All cards).
+                 */
+                RadioGroup rg = formatRGCardType(context,res);
+                mSelectWhichCards = rg;
+
+                builder1.setView(rg, false, true);
+
+                //Here we add the list of tags for the whole collection.
+                Collection col;
+                col = AnkiDroidApp.getCol();
+                allTags = col.getTags().all();
+                builder1.setTitle(R.string.studyoptions_limit_select_tags);
+                builder1.setMultiChoiceItems(allTags, new boolean[allTags.length],
+                        new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        String tag = allTags[which];
+                        if (mSelectedTags.contains(tag)) {
+                            Log.i(AnkiDroidApp.TAG, "unchecked tag: " + tag);
+                            mSelectedTags.remove(tag);
+                        } else {
+                            Log.i(AnkiDroidApp.TAG, "checked tag: " + tag);
+                            mSelectedTags.add(tag);
+                        }
+                    }
+                });
+
+                /*
+                 * Here's the method that gathers the final selection of tags, type of cards
+                 * and generates the search screen for the custom study deck.
+                 */
+                builder1.setPositiveButton(res.getString(R.string.select), new OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        mCustomStudyEditText.setText("");
+                        String tags = mSelectedTags.toString();
+                        mCustomStudyEditText.setHint(getResources().getString(R.string.card_browser_tags_shown,
+                                tags.substring(1, tags.length() - 1)));
+                        StringBuilder sb = new StringBuilder();
+                        switch(mSelectedOption){
+                            case 1:
+                                sb.append("is:new ");
+                                break;
+                            case 2:
+                                sb.append("is:due ");
+                                break;
+                            default:
+                                // Logging here might be appropriate : )
+                                break;
+                        }
+                        int i = 0;
+                        for (String tag : mSelectedTags) {
+                            if(i != 0)
+                            {
+                                sb.append("or ");
+                            }
+                            else{
+                                sb.append("("); //Only if we really have selected tags
+                            }
+                            sb.append("tag:").append(tag).append(" ");
+                            i++;
+                        }
+                        if(i>0){
+                            sb.append(")");	//Only if we added anything to the tag list 
+                        }
+                        mSearchTerms = sb.toString();
+                        createFilteredDeck(new JSONArray(), new Object[]{mSearchTerms, 9999, Sched.DYN_RANDOM}, false);
+                    }
+                });
+                builder1.setNegativeButton(res.getString(R.string.cancel), new OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        mSelectedTags.clear();
+                    }
+                });
+                builder1.setOnCancelListener(new OnCancelListener() {
+
+                    @Override
+                    public void onCancel(DialogInterface dialog) {
+                        mSelectedTags.clear();
+                    }
+                });
+
+                dialog = builder1.create();
+                break;
             case DIALOG_CUSTOM_STUDY_DETAILS:
-            	builder1.setContentView(mCustomStudyDetailsView);
-            	builder1.setCancelable(true);
-            	builder1.setNegativeButton(R.string.cancel, null);
-            	builder1.setPositiveButton(R.string.ok, null);
+                /*
+                 * This is the normal case for creating a custom study deck, where the dialog
+                 * requires only a numeric input.
+                 */
+                builder1.setContentView(mCustomStudyDetailsView);
+                builder1.setCancelable(true);
+                builder1.setNegativeButton(R.string.cancel, null);
+                builder1.setPositiveButton(R.string.ok, null);
                 dialog = builder1.create();
                 break;	
 
             default:
                 dialog = null;
+                break;
         }
 
         dialog.setOwnerActivity(getActivity());
         return dialog;
+    }
+    
+    /**
+     * formatRGCardType
+     * Returns: RadioGroup - A radio group that contains the options of All Cards, New, and Due cards,
+     * 			for the selection of cards when creating a CUSTOM_STUDY_DECKS based on TAGS.
+     * Takes: context, and resources of the App.
+     * 
+     * This method just creates the RadioGroup required for the dialog to select tags for a new 
+     * custom study deck.
+     */
+    private RadioGroup formatRGCardType(Context context, Resources res){
+        RadioGroup rg = new RadioGroup(context);
+        final RadioButton[] radioButtonCards = new RadioButton[3];
+        rg.setOrientation(RadioGroup.HORIZONTAL);
+        RadioGroup.LayoutParams lp = new RadioGroup.LayoutParams(0, LayoutParams.MATCH_PARENT, 1);
+        int height = context.getResources().getDrawable(R.drawable.white_btn_radio).getIntrinsicHeight();
+        
+        //This array contains "All Cards", "New", and "Due", in that order. 
+        String[] text = res.getStringArray(R.array.cards_for_tag_filtered_deck_labels);
+        for(int i=0; i < radioButtonCards.length; i++){
+        	radioButtonCards[i] = new RadioButton(context);
+        	radioButtonCards[i].setClickable(true);
+        	radioButtonCards[i].setText(text[i]);
+        	radioButtonCards[i].setHeight(height*2);
+        	radioButtonCards[i].setSingleLine();
+        	radioButtonCards[i].setGravity(Gravity.CENTER_VERTICAL);
+        	rg.addView(radioButtonCards[i], lp);
+        }
+        rg.check(0);
+        
+        rg.setOnCheckedChangeListener(new OnCheckedChangeListener() {
+            @Override
+            public void onCheckedChanged(RadioGroup arg0, int arg1) {
+                int checked = arg0.getCheckedRadioButtonId();
+                for (int i = 0; i < 3; i++) {
+                    if (arg0.getChildAt(i).getId() == checked) {
+                        mSelectedOption = i;
+                        break;
+                    }
+                }
+            }
+        });
+        rg.setLayoutParams(new LinearLayout.LayoutParams(LayoutParams.FILL_PARENT, height));
+    	return rg;
     }
 
     private void createFilteredDeck(JSONArray delays, Object[] terms, Boolean resched) {


### PR DESCRIPTION
Fixing the bug in the custom study details section where selecting to create a custom study deck by tags would show a dialog requesting a number, rather than a list of tags.

Here's the bug report:
https://code.google.com/p/ankidroid/issues/detail?id=1821&q=tag&colspec=ID%20Type%20Priority%20Status%20Milestone%20Owner%20Summary
