### PR TITLE
Issue 1400- Removing the line that was resetting the Current deck: field in the

### DIFF
--- a/src/com/ichi2/anki/CardEditor.java
+++ b/src/com/ichi2/anki/CardEditor.java
@@ -1421,8 +1421,12 @@ public class CardEditor extends Activity {
     private void setNote(Note note) {
         try {
             if (note == null) {
-                mCurrentDid = mCol.getDecks().current().getLong("id");
                 if (mCol.getDecks().isDyn(mCurrentDid)) {
+                    /*
+                     * If the deck in mCurrentDid is a filtered (dynamic) deck, then we can't create
+                     * cards in it, and we set mCurrentDid to the Default deck. Otherwise, we keep
+                     * the number that had been selected previously in the activity.
+                     */
                     mCurrentDid = 1;
                 }
 


### PR DESCRIPTION
The problem lies in the fact that the local variable `mCurrentDid` and the global context `mCol.getDecks.current()` are not synchronized. Whenever a card was inserted or any change was made in the activity, the deck in the activity was refreshed to `mCol.getDecks.current()`. This was weird at least, and annoying at worst : )
After verifying with the desktop application, the behavior after applying this change is the appropriate one.

Also added a comment, just 'cause I feel it's more clear that way!

Regards
Pablo
Here's the bug report
https://code.google.com/p/ankidroid/issues/detail?can=2&start=0&num=100&q=&colspec=ID%20Type%20Priority%20Status%20Milestone%20Owner%20Summary&groupby=&sort=&id=1400
