### PR TITLE
Change the default to force quick WebView updates.

### DIFF
--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -344,7 +344,7 @@
             <CheckBoxPreference
                 android:title="@string/pref_force_quick_update_title"
                 android:summary="@string/pref_force_quick_update_summary"
-                android:defaultValue="false"
+                android:defaultValue="true"
                 android:key="forceQuickUpdate" />
             </PreferenceCategory>
         <PreferenceCategory android:title="@string/pref_cat_whiteboard" >

--- a/src/com/ichi2/anki/Reviewer.java
+++ b/src/com/ichi2/anki/Reviewer.java
@@ -2051,7 +2051,7 @@ public class Reviewer extends AnkiActivity {
         mRelativeButtonSize = preferences.getInt("answerButtonSize", 100);
         mInputWorkaround = preferences.getBoolean("inputWorkaround", false);
         mPrefFixArabic = preferences.getBoolean("fixArabicText", false);
-        mPrefForceQuickUpdate = preferences.getBoolean("forceQuickUpdate", false);
+        mPrefForceQuickUpdate = preferences.getBoolean("forceQuickUpdate", true);
         mSpeakText = preferences.getBoolean("tts", false);
         mShowProgressBars = preferences.getBoolean("progressBars", true);
         mPrefFadeScrollbars = preferences.getBoolean("fadeScrollbars", false);


### PR DESCRIPTION
Currently, the default is to not use quick WebView updates (updating the
content of the WebView when changing cards). This was done due to a bug
(first identified in Gingerbread during the development of AnkiDroid 0.7
and custom fonts support). The bug lead to the application crashing in
native code due to a probable memory leak in WebView that was trigged by
using custom fonts.

A setting for this was introduced in a previous versio as on more recent
devices, the WebView issue seemed to not be reproducible, and recreating
the WebView each time did introduce significant flickering on some
devices.

However, more recently we have found a bug related to text input that is
not reproducible when quick WebView updates are enabled. Since the
WebView bug is probably obsolete on recent versions of Android, make
quick WebView updates the default.

The idea is that we will have fewer people experiencing the former than
the latter issue, and therefore the new default is likely to affect
fewer users.
