### PR TITLE
Show terms and conditions with shared decks.

### DIFF
--- a/res/layout/info.xml
+++ b/res/layout/info.xml
@@ -15,65 +15,84 @@
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-	android:orientation="vertical"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="fill_parent"
-	android:layout_height="fill_parent"
-	android:layout_centerVertical="true"
-	android:layout_centerHorizontal="true">
-    	<RelativeLayout
-        android:layout_width="fill_parent"
-		android:layout_height="fill_parent"
-		android:layout_alignParentTop="true"
-		android:layout_marginBottom="4dip"
-		android:fadingEdge="vertical"
-		android:gravity="center"
-		android:layout_above="@+id/info_buttons">
-    	<FrameLayout
-        android:layout_width="wrap_content"
-		android:layout_height="wrap_content"
-		android:fadingEdge="vertical">
-    	    	<WebView
-        android:id="@+id/info"
-        android:gravity="center_vertical"
-        android:layout_width="wrap_content"
-		android:layout_height="wrap_content"/>
-	<RelativeLayout
-        android:id="@+id/info_loading_layer"
-	    android:background="@color/white"
-	    android:visibility="invisible"
-        android:layout_width="fill_parent"
-		android:layout_height="fill_parent"
-		android:gravity="center">
-	    <TextView 
-	        android:layout_gravity="center"
-	        android:text="@string/loading_shared_decks"
-        android:layout_width="wrap_content"
-		android:layout_height="wrap_content"/>
-	</RelativeLayout>
+    android:layout_height="fill_parent"
+    android:layout_centerHorizontal="true"
+    android:layout_centerVertical="true"
+    android:orientation="vertical" >
 
-	</FrameLayout>
-		 </RelativeLayout>
-	<LinearLayout  android:id="@+id/info_buttons"
-	    android:layout_width="fill_parent"
-	    android:layout_height="wrap_content"
-		android:layout_alignParentBottom="true">
-   	<Button android:id="@+id/info_tutorial"
-		android:text="@string/studyoptions_load_tutorial_deck"
-        android:layout_width="0dip"
+    <RelativeLayout
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="4dip"
         android:layout_weight="1"
-		android:layout_height="fill_parent"
-		android:visibility="gone"/>		
-   	<Button android:id="@+id/info_sync"
-		android:text="@string/button_sync"
-        android:layout_width="0dip"
-        android:layout_weight="1"
-		android:layout_height="fill_parent"
-		android:visibility="gone"/>		
-   		<Button android:id="@+id/info_continue"
-		android:text="@string/btn_continue"
-        android:layout_width="0dip"
-        android:layout_weight="1"
-		android:layout_height="fill_parent"/>		
-	</LinearLayout>
-</RelativeLayout>
+        android:fadingEdge="vertical"
+        android:gravity="center" >
+
+        <FrameLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:fadingEdge="vertical" >
+
+            <WebView
+                android:id="@+id/info"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:gravity="center_vertical" />
+
+            <RelativeLayout
+                android:id="@+id/info_loading_layer"
+                android:layout_width="fill_parent"
+                android:layout_height="fill_parent"
+                android:background="@color/white"
+                android:gravity="center"
+                android:visibility="invisible" >
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:text="@string/loading_shared_decks" />
+            </RelativeLayout>
+        </FrameLayout>
+    </RelativeLayout>
+
+    <TextView
+        android:id="@+id/info_terms_and_conditions"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:text="@string/terms_and_conditions"
+        android:visibility="gone" />
+
+    <LinearLayout
+        android:id="@+id/info_buttons"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content" >
+
+        <Button
+            android:id="@+id/info_tutorial"
+            android:layout_width="0dip"
+            android:layout_height="fill_parent"
+            android:layout_weight="1"
+            android:text="@string/studyoptions_load_tutorial_deck"
+            android:visibility="gone" />
+
+        <Button
+            android:id="@+id/info_sync"
+            android:layout_width="0dip"
+            android:layout_height="fill_parent"
+            android:layout_weight="1"
+            android:text="@string/button_sync"
+            android:visibility="gone" />
+
+        <Button
+            android:id="@+id/info_continue"
+            android:layout_width="0dip"
+            android:layout_height="fill_parent"
+            android:layout_weight="1"
+            android:text="@string/btn_continue" />
+    </LinearLayout>
+
+</LinearLayout>

--- a/res/values/04-network.xml
+++ b/res/values/04-network.xml
@@ -39,6 +39,7 @@
 <!-- SharedDeckPicker.java -->
 <string name="shared_decks">Shared Decks</string>
 <string name="loading_shared_decks">Loading available shared decks...</string>
+<string name="terms_and_conditions"><a href='https://ankiweb.net/account/terms'>Terms and Conditions</a></string>
 <string name="cancel_download">Cancel Download</string>
 <string name="resume_download">Resume Download</string>
 <string name="pause_download">Pause Download</string>

--- a/src/com/ichi2/anki/Info.java
+++ b/src/com/ichi2/anki/Info.java
@@ -30,6 +30,7 @@ import android.graphics.Bitmap;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
+import android.text.method.LinkMovementMethod;
 import android.util.Log;
 import android.view.KeyEvent;
 import android.view.View;
@@ -38,6 +39,8 @@ import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import android.widget.Button;
 import android.widget.RelativeLayout;
+import android.widget.TextView;
+
 import com.ichi2.anim.ActivityTransitionAnimation;
 import com.ichi2.async.BaseAsyncTask;
 import com.ichi2.async.Connection;
@@ -134,6 +137,8 @@ public class Info extends Activity {
         mWebView.setBackgroundColor(res.getColor(Themes.getBackgroundColor()));
         Themes.setWallpaper((View) mWebView.getParent().getParent().getParent());
 
+        TextView termsAndConditionsView = (TextView) findViewById(R.id.info_terms_and_conditions);
+        termsAndConditionsView.setMovementMethod(LinkMovementMethod.getInstance());
         Button continueButton = (Button) findViewById(R.id.info_continue);
         continueButton.setOnClickListener(new OnClickListener() {
             @Override
@@ -245,6 +250,7 @@ public class Info extends Activity {
                 mWebView.setWebViewClient(new MobileAnkiWebview());
                 mWebView.loadUrl(res.getString(R.string.shared_decks_url));
                 mWebView.getSettings().setJavaScriptEnabled(true);
+                termsAndConditionsView.setVisibility(View.VISIBLE);
                 continueButton.setText(res.getString(R.string.download_button_return));
                 break;
 


### PR DESCRIPTION
Currently the shared deck screen does not include the terms and
conditions, which are actually useful on that screen, as they cover the
use of shared decks.

Add them at the bottom of the screen so that they are always visible.
Clicking on them will open the default browser and to show the terms.
