### PR TITLE
Make message reported to users submitting bugs more clear

### DIFF
--- a/res/values/05-feedback.xml
+++ b/res/values/05-feedback.xml
@@ -41,7 +41,7 @@
 <string name="feedback_clear_all">Clear all errors</string>
 <string name="feedback_default_text">Please enter your feedback, or information about the nature of any errors you\'re reporting.</string>
 <string name="feedback_error_reply_new">Unknown issue, filed new bug</string>
-<string name="feedback_error_reply_known">Repeat issue, please post more details to AnkiDroid forum</string>
+<string name="feedback_error_reply_known">Issue previously detected. Details welcome on AnkiDroid issue tracker.</string>
 <string name="feedback_error_reply_issue_unknown">Issue %1$d, unknown status</string>
 <string name="feedback_error_reply_issue_status">Issue %1$d, status: %2$s</string>
 <string name="feedback_error_reply_issue_fixed_dev">Issue %1$d, fixed but not released yet</string>


### PR DESCRIPTION
Issue 1646: Crash report text "known issue, pending investigation" may be misleading
