### PR TITLE
Correct question audio repeat, by deck options.

### DIFF
--- a/res/xml/deck_options.xml
+++ b/res/xml/deck_options.xml
@@ -139,7 +139,8 @@
             <CheckBoxPreference
                 android:key="replayQuestion"
                 android:summary="@string/deck_conf_replayq_summ"
-                android:title="@string/deck_conf_replayq" />
+                android:title="@string/deck_conf_replayq"
+                android:dependency="autoPlayAudio" />
         </PreferenceScreen>
         <PreferenceScreen android:title="@string/deck_conf_manage" >
             <Preference

--- a/src/com/ichi2/anki/PreviewClass.java
+++ b/src/com/ichi2/anki/PreviewClass.java
@@ -827,19 +827,22 @@ public class PreviewClass extends Activity {
 	                mCard.getSettings().setDefaultFontSize(calculateDynamicFontSize(content));
 	            }
 
-	            // don't play question sound again when displaying answer
 	            String question = "";
 	            String answer = "";
-
-	            Sound.resetSounds();
-
-	            int qa = MetaDB.LANGUAGES_QA_QUESTION;
+	            int qa = -1; // prevent uninitialized variable errors
+	            
 	            if (sDisplayAnswer) {
 	                qa = MetaDB.LANGUAGES_QA_ANSWER;
+	                answer = mCurrentCard.getPureAnswerForReading();
+	                Sound.addSounds(mBaseUrl, answer, qa);
+	            } else {
+	                Sound.resetSounds(); // reset sounds on first side of card
+	                qa = MetaDB.LANGUAGES_QA_QUESTION;
+	                question = mCurrentCard.getQuestion(mCurrentSimpleInterface);
+	                Sound.addSounds(mBaseUrl, question, qa);                
 	            }
-	            answer = Sound.parseSounds(mBaseUrl, content, mSpeakText, qa);
-
-	            content = question + answer;
+	            
+	            content = Sound.expandSounds(mBaseUrl, content, mSpeakText, qa);
 
 	            // In order to display the bold style correctly, we have to change
 	            // font-weight to 700

--- a/src/com/ichi2/anki/Reviewer.java
+++ b/src/com/ichi2/anki/Reviewer.java
@@ -2541,19 +2541,22 @@ public class Reviewer extends AnkiActivity {
                 mCard.getSettings().setDefaultFontSize(calculateDynamicFontSize(content));
             }
 
-            // don't play question sound again when displaying answer
             String question = "";
             String answer = "";
-
-            Sound.resetSounds();
-
-            int qa = MetaDB.LANGUAGES_QA_QUESTION;
+            int qa = -1; // prevent uninitialized variable errors
+            
             if (sDisplayAnswer) {
                 qa = MetaDB.LANGUAGES_QA_ANSWER;
+                answer = mCurrentCard.getPureAnswerForReading();
+                Sound.addSounds(mBaseUrl, answer, qa);
+            } else {
+                Sound.resetSounds(); // reset sounds on first side of card
+                qa = MetaDB.LANGUAGES_QA_QUESTION;
+                question = mCurrentCard.getQuestion(mCurrentSimpleInterface);
+                Sound.addSounds(mBaseUrl, question, qa);                
             }
-            answer = Sound.parseSounds(mBaseUrl, content, mSpeakText, qa);
-
-            content = question + answer;
+            
+            content = Sound.expandSounds(mBaseUrl, content, mSpeakText, qa);
 
             // In order to display the bold style correctly, we have to change
             // font-weight to 700
@@ -2633,6 +2636,10 @@ public class Reviewer extends AnkiActivity {
             if (getConfigForCurrentCard().getBoolean("autoplay")) {
                 // We need to play the sounds from the proper side of the card
                 if (!mSpeakText) {
+                    // when showing answer, repeat question audio if so configured
+                    if (sDisplayAnswer && getConfigForCurrentCard().getBoolean("replayq")) {
+                        Sound.playSounds(MetaDB.LANGUAGES_QA_QUESTION);
+                    }
                     Sound.playSounds(sDisplayAnswer ? MetaDB.LANGUAGES_QA_ANSWER : MetaDB.LANGUAGES_QA_QUESTION);
                 } else {
                     // If the question is displayed or if the question should be replayed, read the question

--- a/src/com/ichi2/libanki/Collection.java
+++ b/src/com/ichi2/libanki/Collection.java
@@ -956,7 +956,7 @@ public class Collection {
                     }
                 }
                 
-                fields.put("FrontSide", mMedia.stripAudio(d.get("q")));
+                fields.put("FrontSide", d.get("q"));
     
                 // runFilter mungeFields for type "a"
                 fparser = new Models.fieldParser(fields);

--- a/src/com/ichi2/libanki/Sound.java
+++ b/src/com/ichi2/libanki/Sound.java
@@ -64,13 +64,38 @@ public class Sound {
         sSoundPaths.clear();
     }
 
+    /**
+     * The function addSounds() parses content for sound files, and stores entries to the filepaths for them, categorized as
+     * belonging to the front (question) or back (answer) of cards. Note that all sounds embedded in the content will be given
+     * the same categorization.
+     * @param soundDir -- base path to the media files
+     * @param content -- parsed for sound entries
+     * @param qa -- the categorization of the sounds in the conent
+     */
+    public static void addSounds(String soundDir, String content, int qa) {
+        Matcher matcher = sSoundPattern.matcher(content);
+        // While there is matches of the pattern for sound markers
+        while (matcher.find()) {
+            // Create appropiate list if needed; list must not be empty so long as code does no check
+            if (!sSoundPaths.containsKey(qa)) {
+                sSoundPaths.put(qa, new ArrayList<String>());
+            }
+            
+            // Get the sound file name
+            String sound = matcher.group(1);
 
-    public static String parseSounds(String soundDir, String content, boolean ttsEnabled, int qa) {
+            // Construct the sound path and store it
+            String soundPath = soundDir + Uri.encode(sound);            
+            sSoundPaths.get(qa).add(soundPath);
+        }
+    }
+    
+    public static String expandSounds(String soundDir, String content, boolean ttsEnabled, int qa) {
         boolean soundAvailable = false;
         StringBuilder stringBuilder = new StringBuilder();
         String contentLeft = content;
 
-        Log.i(AnkiDroidApp.TAG, "parseSounds");
+        Log.i(AnkiDroidApp.TAG, "expandSounds");
 
         Matcher matcher = sSoundPattern.matcher(content);
         // While there is matches of the pattern for sound markers
@@ -79,15 +104,8 @@ public class Sound {
             // Get the sound file name
             String sound = matcher.group(1);
 
-            // Construct the sound path and store it
+            // Construct the sound path
             String soundPath = soundDir + Uri.encode(sound);
-
-            // Create appropiate list if needed
-            if (!sSoundPaths.containsKey(qa)) {
-                sSoundPaths.put(qa, new ArrayList<String>());
-            }
-
-            sSoundPaths.get(qa).add(soundPath);
 
             // Construct the new content, appending the substring from the beginning of the content left until the
             // beginning of the sound marker


### PR DESCRIPTION
Audio no longer stripped from {{FrontSide}} expansion, to allow user to replay at will. The previous attempt at this exposed an issue where audio from the front side would be repeated regardless of how the deck options were set. This change repeats the front side audio only if the deck options say to.

The code was refactored in the Sound class, to separate expansion of embedded sounds files (which accept data from both sides of a card at once sometimes) and the list of sounds to be played.
