### PR TITLE
Avoid answer sound chaining after editor exit

### DIFF
--- a/src/com/ichi2/anki/PreviewClass.java
+++ b/src/com/ichi2/anki/PreviewClass.java
@@ -175,6 +175,7 @@ public class PreviewClass extends Activity {
     private boolean mInputWorkaround;
     private boolean mRefreshWebview = true;
     private boolean mPrefFullscreenReview=true;
+    private boolean mAnswerSoundsAdded = false;    
     private Button mFlipCard;
     private static final Pattern sSpanPattern = Pattern.compile("</?span[^>]*>");
     private static final Pattern sBrPattern = Pattern.compile("<br\\s?/?>");
@@ -834,9 +835,14 @@ public class PreviewClass extends Activity {
 	            if (sDisplayAnswer) {
 	                qa = MetaDB.LANGUAGES_QA_ANSWER;
 	                answer = mCurrentCard.getPureAnswerForReading();
-	                Sound.addSounds(mBaseUrl, answer, qa);
+	                // don't add answer sounds multiple times, in cases where this codepath is encountered again
+	                if (!mAnswerSoundsAdded) {
+	                    Sound.addSounds(mBaseUrl, answer, qa);
+	                    mAnswerSoundsAdded = true;
+	                }
 	            } else {
-	                Sound.resetSounds(); // reset sounds on first side of card
+	                Sound.resetSounds(); // reset sounds each time first side of card is displayed
+	                mAnswerSoundsAdded = false;	                
 	                qa = MetaDB.LANGUAGES_QA_QUESTION;
 	                question = mCurrentCard.getQuestion(mCurrentSimpleInterface);
 	                Sound.addSounds(mBaseUrl, question, qa);                

--- a/src/com/ichi2/anki/Reviewer.java
+++ b/src/com/ichi2/anki/Reviewer.java
@@ -280,6 +280,7 @@ public class Reviewer extends AnkiActivity {
     private boolean mIsSelecting = false;
     private boolean mTouchStarted = false;
     private boolean mInAnswer = false;
+    private boolean mAnswerSoundsAdded = false;
 
     private String mCardTemplate;
 
@@ -2585,9 +2586,14 @@ public class Reviewer extends AnkiActivity {
             if (sDisplayAnswer) {
                 qa = MetaDB.LANGUAGES_QA_ANSWER;
                 answer = mCurrentCard.getPureAnswerForReading();
-                Sound.addSounds(mBaseUrl, answer, qa);
+                // don't add answer sounds multiple times, in cases where this codepath is encountered again 
+                if (!mAnswerSoundsAdded) {
+                    Sound.addSounds(mBaseUrl, answer, qa);
+                    mAnswerSoundsAdded = true;
+                }
             } else {
-                Sound.resetSounds(); // reset sounds on first side of card
+                Sound.resetSounds(); // reset sounds each time first side of card is displayed
+                mAnswerSoundsAdded = false;
                 qa = MetaDB.LANGUAGES_QA_QUESTION;
                 question = mCurrentCard.getQuestion(mCurrentSimpleInterface);
                 Sound.addSounds(mBaseUrl, question, qa);                

--- a/src/com/ichi2/libanki/Sound.java
+++ b/src/com/ichi2/libanki/Sound.java
@@ -76,7 +76,7 @@ public class Sound {
         Matcher matcher = sSoundPattern.matcher(content);
         // While there is matches of the pattern for sound markers
         while (matcher.find()) {
-            // Create appropiate list if needed; list must not be empty so long as code does no check
+            // Create appropriate list if needed; list must not be empty so long as code does no check
             if (!sSoundPaths.containsKey(qa)) {
                 sSoundPaths.put(qa, new ArrayList<String>());
             }


### PR DESCRIPTION
I introduced a non-critical bug after altering how the reviewer exposes its audio to the Sound class, such that after exiting the editor of a card which was currently showing an answer, answer audio would get re-listed, and at the point the audio would replay, and do so double. Subsequent edits and exits from there would chain additions to that card, and play more and more copies. I added a check that answers have already been added.

Also, I extended this to the previewer, only because the function affected has exited there as a full copy from reviewer before and after my last changes. However, I believe reviewer only shows and exits, so it would not add audio multiple times, just live fleetingly and die. I don't know the specs of previewer (didn't even realize it existed til recently, and just looked at it for the first time), but I do see that it doesn't play the audio it embeds, either automatically or when clicking the audio icons.
