### PR TITLE
Fix crash due to unaccessible replayq

### DIFF
--- a/src/com/ichi2/anki/DeckOptions.java
+++ b/src/com/ichi2/anki/DeckOptions.java
@@ -141,6 +141,8 @@ public class DeckOptions extends PreferenceActivity implements OnSharedPreferenc
                 Log.d(AnkiDroidApp.TAG, "DeckOptions - commit() changes back to database");
 
                 try {
+                    mOptions.put("replayq", false); // set default to avoid no set value; true set in for loop
+                    
                     for (Entry<String, Object> entry : mUpdate.valueSet()) {
                         String key =  entry.getKey();
                         Object value = entry.getValue();


### PR DESCRIPTION
If you'll have this change, it simply makes sure some value is set for this preference at all times, to avoid a crash when attempting to read the value form a JSONObject that doesn't contain it. I still believe this is a better fix for this, like addressing why the value isn't passed through the commit() function's loop, but this is not a bad fix, and can be applied now.
