### PR TITLE
Pre-select current deck in card editor

### DIFF
--- a/src/com/ichi2/anki/CardEditor.java
+++ b/src/com/ichi2/anki/CardEditor.java
@@ -379,7 +379,6 @@ public class CardEditor extends Activity {
                 mAddNote = false;
                 break;
 
-            case CALLER_STUDYOPTIONS:
             case CALLER_DECKPICKER:
                 mAddNote = true;
                 break;
@@ -408,8 +407,11 @@ public class CardEditor extends Activity {
                 mAddNote = false;
                 break;
 
+            case CALLER_STUDYOPTIONS:
             case CALLER_CARDBROWSER_ADD:
                 mAddNote = true;
+                // Pre-select current deck
+                mCurrentDid = AnkiDroidApp.getCol().getDecks().selected();
                 break;
 
             case CALLER_CARDEDITOR:


### PR DESCRIPTION
I'm so used to Anki pre-selecting the current deck when adding cards that a lot of cards added in AnkiDroid ended up in the Default deck by accident. This change pre-selects the current deck when adding cards from the study options or the card browser.
