### PR TITLE
Vertically align congrats dialog again

### DIFF
--- a/res/layout/studyoptions_congrats.xml
+++ b/res/layout/studyoptions_congrats.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:gravity="center"
-    android:orientation="vertical" >
+	android:layout_width="fill_parent"
+	android:layout_height="fill_parent"
+	android:fillViewport="true">
 	<LinearLayout
 		android:layout_height="wrap_content"
 		android:orientation="vertical"


### PR DESCRIPTION
6f2dc9c7cf19fdd095e66c44f8a484659dbf2954 (fix for [1332](https://code.google.com/p/ankidroid/issues/detail?id=1332)) broke the vertical alignment of the congrats dialog. This change brings it back while maintaining scrollability on lower resolutions.
