### PR TITLE
Change failed color to learning color

### DIFF
--- a/res/values/colors.xml
+++ b/res/values/colors.xml
@@ -16,7 +16,7 @@
 	<color name="wb_fg_color">#B00000FF</color>
 	<color name="wb_fg_color_inv">#0099FF</color>
 	<color name="next_time_usual_color">#000000</color>
-	<color name="next_time_failed_color">#FF0000</color>
+	<color name="next_time_failed_color">#990000</color>
 	<color name="next_time_recommended_color">#007700</color>
 	<color name="next_time_usual_color_inv">#FFFFFF</color>
 	<color name="next_time_recommended_color_inv">#4AA02C</color>


### PR DESCRIPTION
Would it make sense to use the same color for both the text of the "Again" button in the reviewer and the number that represents the number of cards on the "Learning" pile? This could not only be instructive as in "click on the red-colored button and the red number will increase by 1", but I think it also looks better with only one shade of red.
