### PR TITLE
Use long clicks instead of context menu to display dialogs (1911)

### DIFF
--- a/src/com/ichi2/anki/CardBrowser.java
+++ b/src/com/ichi2/anki/CardBrowser.java
@@ -43,6 +43,7 @@ import android.view.WindowManager;
 import android.view.inputmethod.EditorInfo;
 import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemClickListener;
+import android.widget.AdapterView.OnItemLongClickListener;
 import android.widget.EditText;
 import android.widget.ImageButton;
 import android.widget.ListView;
@@ -335,7 +336,14 @@ public class CardBrowser extends Activity {
                 }
             }
         });
-        registerForContextMenu(mCardsListView);
+        mCardsListView.setOnItemLongClickListener(new OnItemLongClickListener() {
+            @Override
+            public boolean onItemLongClick(AdapterView<?> adapterView, View view, int position, long id) {
+                mPositionInCardsList = position;
+                showDialog(DIALOG_CONTEXT_MENU);
+                return true;
+            }
+        });
 
         mSearchEditText = (EditText) findViewById(R.id.card_browser_search);
         mSearchEditText.setOnEditorActionListener(new TextView.OnEditorActionListener() {
@@ -396,13 +404,6 @@ public class CardBrowser extends Activity {
             unregisterReceiver(mUnmountReceiver);
         }
         Log.i(AnkiDroidApp.TAG, "CardBrowser - onDestroy()");
-    }
-
-
-    @Override
-    public void onCreateContextMenu(ContextMenu menu, View v, ContextMenuInfo menuInfo) {
-        mPositionInCardsList = ((AdapterView.AdapterContextMenuInfo) menuInfo).position;
-        showDialog(DIALOG_CONTEXT_MENU);
     }
 
 

--- a/src/com/ichi2/anki/DeckPicker.java
+++ b/src/com/ichi2/anki/DeckPicker.java
@@ -57,6 +57,7 @@ import android.view.View.OnClickListener;
 import android.view.ViewTreeObserver.OnGlobalLayoutListener;
 import android.view.Window;
 import android.widget.AdapterView;
+import android.widget.AdapterView.OnItemLongClickListener;
 import android.widget.EditText;
 import android.widget.ImageButton;
 import android.widget.ListView;
@@ -1057,13 +1058,19 @@ public class DeckPicker extends FragmentActivity {
             }
         });
         mDeckListView.setOnItemClickListener(mDeckSelHandler);
+        mDeckListView.setOnItemLongClickListener(new OnItemLongClickListener() {
+            @Override
+            public boolean onItemLongClick(AdapterView<?> adapterView, View view, int position, long id) {
+                mContextMenuPosition = position;
+                showDialog(DIALOG_CONTEXT_MENU);
+                return true;
+            }
+        });
         mDeckListView.setAdapter(mDeckListAdapter);
 
         if (mFragmented) {
             mDeckListView.setChoiceMode(ListView.CHOICE_MODE_SINGLE);
         }
-
-        registerForContextMenu(mDeckListView);
 
         showStartupScreensAndDialogs(preferences, 0);
 
@@ -2188,13 +2195,6 @@ public class DeckPicker extends FragmentActivity {
                 });
             	break;
         }
-    }
-
-
-    @Override
-    public void onCreateContextMenu(ContextMenu menu, View v, ContextMenuInfo menuInfo) {
-        mContextMenuPosition = ((AdapterView.AdapterContextMenuInfo) menuInfo).position;
-        showDialog(DIALOG_CONTEXT_MENU);
     }
 
 


### PR DESCRIPTION
I have a hard time using the context menu for list views. It seems that it does not consume the event, but passes it down to the click listener, resulting in the menu popping up, but then immediately redirecting to the next intent unless I move my finger out of the list view. This problem disappears using long clicks, and because we don't even use the actual context menu and roll out our own, not a lot of code has to be changed.
