### PR TITLE
Do not show deck name in card browser

### DIFF
--- a/src/com/ichi2/anki/CardBrowser.java
+++ b/src/com/ichi2/anki/CardBrowser.java
@@ -312,7 +312,7 @@ public class CardBrowser extends Activity {
                     }
                     view.setBackgroundResource(mBackground[which]);
                     return true;
-                } else if (view.getId() == R.id.card_deck && text.length() > 0) {
+                } else if (view.getId() == R.id.card_deck && mWholeCollection && text.length() > 0) {
                     view.setVisibility(View.VISIBLE);
                 }
                 return false;


### PR DESCRIPTION
Unless the card browser is used to browse all decks, the deck name is already given in the title and therefore redundant.
