### PR TITLE
Hide card_tmpl in card browser

### DIFF
--- a/res/layout/card_item.xml
+++ b/res/layout/card_item.xml
@@ -19,6 +19,7 @@
 		android:layout_height="fill_parent"
 		android:singleLine="true"
 		android:ellipsize="middle"
+		android:visibility="gone"
 		android:textColor="#000000"
 		android:layout_weight="1"
 		android:gravity="center_vertical"

--- a/src/com/ichi2/anki/CardEditor.java
+++ b/src/com/ichi2/anki/CardEditor.java
@@ -1184,6 +1184,8 @@ public class CardEditor extends Activity {
                 if (view.getId() == R.id.card_item) {
                     view.setBackgroundResource(mCardItemBackground);
                     return true;
+                } else if (view.getId() == R.id.card_tmpl) {
+                    view.setVisibility(View.VISIBLE);
                 }
                 return false;
             }


### PR DESCRIPTION
Hiding card_tmpl in the card browser gives some more space to display the search field. I hope this does not interfere with the saved data functionality, not sure how to test that.
