### PR TITLE
Fix widget icon to only be 1x1 instead of 2x2 on most devices

### DIFF
--- a/res/xml/widget_provider_small.xml
+++ b/res/xml/widget_provider_small.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
 	android:initialLayout="@layout/widget_small"
-	android:minHeight="70dp"
-	android:minWidth="70dp"
+	android:minHeight="40dp"
+	android:minWidth="40dp"
 	android:updatePeriodMillis="3600000"/>


### PR DESCRIPTION
Fixes #1919 
