### PR TITLE
Guard against deck deletion crashes; speed up cram/filter deck deletion

### DIFF
--- a/src/com/ichi2/async/DeckTask.java
+++ b/src/com/ichi2/async/DeckTask.java
@@ -817,8 +817,11 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
         Log.i(AnkiDroidApp.TAG, "doInBackgroundDeleteDeck");
         Collection col = params[0].getCollection();
         long did = params[0].getLong();
+        Boolean isDyn = col.getDecks().isDyn(did);
         col.getDecks().rem(did, true);
-        col.getMedia().removeUnusedImages();
+        if (!isDyn) { // don't bother pruning media for cram/dynamic decks as all cards will still exist after delete
+            col.getMedia().removeUnusedImages();
+        }
         return doInBackgroundLoadDeckCounts(new TaskData(col));
     }
 


### PR DESCRIPTION
It turns out the the crash was caused when attempting to remove unused media. This does not apply to dynamic decks, and the attempt can be long-running, so now the attempting purging of unused media will be skipped for dynamic/filter/cram decks.

However, there was in fact an issue in the code path now skipped. It came down to trying to access a sql result that was null. In the exception handler, I added a specific check to see if a null was encountered, and if so attempt to simply move on. Potential concerns are:

1) it is possible to design a query where you expect to get nulls returned to you and handle them, as sometimes this is a meaningful thing to notice and make choices based off of, so skipping nulls we are crashing on is not an appropriate response when we should be able to instead return a null result in the results to the caller

2) call me paranoid, but with so many devices/configurations, I don't fully trust null crashes will always end up in the exception clause where I check for them, though on my system that's where it ends up. Ideally, queries that do not wish to work with null values would be designed to not return nulls. Note that I ~tried~ that approach in this case, but a query of "select flds from note where flds IS NOT NULL" was not functioning as I would expect, and as sqlite documentation claims to support (a very core syntax, mind you).
