### PR TITLE
Preselect deck for new cards in the same way as Anki Desktop

### DIFF
--- a/src/com/ichi2/anki/CardEditor.java
+++ b/src/com/ichi2/anki/CardEditor.java
@@ -527,6 +527,12 @@ public class CardEditor extends Activity {
                     modified = modified | f.updateField();
                 }
                 if (mAddNote) {
+                    try {
+                        mEditorNote.model().put("did", mCurrentDid);
+                        mCol.getModels().setChanged();
+                    } catch (JSONException e) {
+                        throw new RuntimeException(e);
+                    }
                     DeckTask.launchDeckTask(DeckTask.TASK_TYPE_ADD_FACT, mSaveFactHandler, new DeckTask.TaskData(
                             mEditorNote));
                 } else {
@@ -1051,15 +1057,6 @@ public class CardEditor extends Activity {
                     public void onClick(DialogInterface dialog, int item) {
                         long newId = dialogDeckIds.get(item);
                         if (mCurrentDid != newId) {
-                            if (mAddNote) {
-                                try {
-                                    // TODO: mEditorNote.setDid(newId);
-                                    mEditorNote.model().put("did", newId);
-                                    mCol.getModels().setChanged();
-                                } catch (JSONException e) {
-                                    throw new RuntimeException(e);
-                                }
-                            }
                             mCurrentDid = newId;
                             updateDeck();
                         }
@@ -1101,7 +1098,8 @@ public class CardEditor extends Activity {
                         }
                         long newId = dialogIds.get(item);
                         if (oldModelId != newId) {
-                            mCol.getModels().setCurrent(mCol.getModels().get(newId));
+                            JSONObject model = mCol.getModels().get(newId);
+                            mCol.getModels().setCurrent(model);
                             JSONObject cdeck = mCol.getDecks().current();
                             try {
                                 cdeck.put("mid", newId);
@@ -1109,6 +1107,16 @@ public class CardEditor extends Activity {
                                 throw new RuntimeException(e);
                             }
                             mCol.getDecks().save(cdeck);
+                            // Update deck
+                            if (!mCol.getConf().optBoolean("addToCur", true)) {
+                                try {
+                                    mCurrentDid = model.getLong("did");
+                                    updateDeck();
+                                } catch (JSONException e) {
+                                    throw new RuntimeException(e);
+                                }
+                            }
+                            // Reset edit fields
                             int size = mEditFields.size();
                             String[] oldValues = new String[size];
                             for (int i = 0; i < size; i++) {
@@ -1448,16 +1456,21 @@ public class CardEditor extends Activity {
     private void setNote(Note note) {
         try {
             if (note == null) {
-                if (mCol.getDecks().isDyn(mCurrentDid)) {
-                    /*
-                     * If the deck in mCurrentDid is a filtered (dynamic) deck, then we can't create
-                     * cards in it, and we set mCurrentDid to the Default deck. Otherwise, we keep
-                     * the number that had been selected previously in the activity.
-                     */
-                    mCurrentDid = 1;
-                }
-
+                JSONObject conf = mCol.getConf();
                 JSONObject model = mCol.getModels().current();
+                if (conf.optBoolean("addToCur", true)) {
+                    mCurrentDid = conf.getLong("curDeck");
+                    if (mCol.getDecks().isDyn(mCurrentDid)) {
+                        /*
+                         * If the deck in mCurrentDid is a filtered (dynamic) deck, then we can't create
+                         * cards in it, and we set mCurrentDid to the Default deck. Otherwise, we keep
+                         * the number that had been selected previously in the activity.
+                         */
+                        mCurrentDid = 1;
+                    }
+                } else {
+                    mCurrentDid = model.getLong("did");
+                }
                 mEditorNote = new Note(mCol, model);
                 mEditorNote.model().put("did", mCurrentDid);
                 mModelButton.setText(getResources().getString(R.string.CardEditorModel,


### PR DESCRIPTION
This is a much better fix for preselecting decks for new cards than #195. It implements both the "When adding, default to current deck" as well as the "Change deck depending on note type" behavior found in Anki Desktop. AnkiDroid already had a setting for it, but didn't make use of it yet.
