### PR TITLE
Skip media handling when deleting cram/filter deck

### DIFF
--- a/src/com/ichi2/async/DeckTask.java
+++ b/src/com/ichi2/async/DeckTask.java
@@ -817,8 +817,11 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
         Log.i(AnkiDroidApp.TAG, "doInBackgroundDeleteDeck");
         Collection col = params[0].getCollection();
         long did = params[0].getLong();
+        Boolean isDynamicDeck = col.getDecks().isDyn(did);
         col.getDecks().rem(did, true);
-        col.getMedia().removeUnusedImages();
+        if (!isDynamicDeck) {
+            col.getMedia().removeUnusedImages();
+        }
         return doInBackgroundLoadDeckCounts(new TaskData(col));
     }
 


### PR DESCRIPTION
This was part of pull request #208 but has been separated since it is less controversial and might be applied sooner alone. This change, upon deletion  of a dynamic deck, does not attempt to look for unused media that should be removed due to this deletion, as all cards of a dynamic deck continue to exist after the dynamic deck is deleted.

Beyond being a feature, this change bypasses a couple crash points for users, and does so in the most frequent source of deck deletions for many users.

For the record, I am not entirely sure of all possible decks that fall under the "dynamic" umbrella, but I do see in code where their cards are kept.
