### PR TITLE
remove unused media check from delete deck routine

### DIFF
--- a/src/com/ichi2/async/DeckTask.java
+++ b/src/com/ichi2/async/DeckTask.java
@@ -817,11 +817,7 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
         Log.i(AnkiDroidApp.TAG, "doInBackgroundDeleteDeck");
         Collection col = params[0].getCollection();
         long did = params[0].getLong();
-        Boolean isDynamicDeck = col.getDecks().isDyn(did);
         col.getDecks().rem(did, true);
-        if (!isDynamicDeck) {
-            col.getMedia().removeUnusedImages();
-        }
         return doInBackgroundLoadDeckCounts(new TaskData(col));
     }
 


### PR DESCRIPTION
As per [issue 2009](https://code.google.com/p/ankidroid/issues/detail?id=2009), we realized that Anki Desktop doesn't do a check for unused media at all when deleting decks, so I've completely removed this functionality. This fixes the crashes when deleting decks in collections with very large number of media files.

In the future we should allow the user to call `col.getMedia().removeUnusedImages();` from the main menu entry, but I think it should first show a list of all unused media as the Desktop version does,
