### PR TITLE
remove restart upgrade wizard menu entry

### DIFF
--- a/res/values/02-strings.xml
+++ b/res/values/02-strings.xml
@@ -146,7 +146,6 @@
 <string name="upgrade_import_no_file_found">No importable %1$s file found</string>
 <string name="custom_study">Custom Study</string>
   <string name="dyn_deck_desc">This is a special deck for studying outside of the normal schedule. Cards will be automatically returned to their original decks after you review them. Deleting this deck from the deck list will return all remaining cards to their original deck.</string>
-    <string name="restart_upgrade_process">Restart upgrade process</string>
     <string name="exit_wizard">Exit Wizard</string>
 
 <string name="steps_error">Steps must be numbers greater than 0</string>

--- a/src/com/ichi2/anki/DeckPicker.java
+++ b/src/com/ichi2/anki/DeckPicker.java
@@ -155,7 +155,6 @@ public class DeckPicker extends FragmentActivity {
     private static final int MENU_STATISTICS = 12;
     private static final int MENU_CARDBROWSER = 13;
     private static final int MENU_IMPORT = 14;
-    private static final int MENU_REUPGRADE = 15;
 
     /**
      * Context Menus
@@ -1189,44 +1188,6 @@ public class DeckPicker extends FragmentActivity {
             return true;
         }
         return false;
-    }
-
-    private void restartUpgradeProcess() {
-        StyledDialog.Builder builder = new StyledDialog.Builder(DeckPicker.this);
-        builder.setTitle(R.string.deck_upgrade_title);
-        builder.setIcon(R.drawable.ic_dialog_alert);
-        builder.setMessage(getString(R.string.deck_upgrade_rename_warning, UPGRADE_OLD_COLLECTION_RENAME));
-        builder.setPositiveButton(R.string.yes, new DialogInterface.OnClickListener() {
-            @Override
-            public void onClick(DialogInterface dialog, int which) {
-                AnkiDroidApp.closeCollection(true);
-
-                String path = AnkiDroidApp.getCurrentAnkiDroidDirectory();
-                File apkgExport = new File(path, UPGRADE_OLD_COLLECTION_RENAME);
-                if (apkgExport.exists()) {
-                    // rename any existing oldcollection.apkg files oldcollection.apkgi, i = 1, 2, 3,...
-                    int i = 0;
-                    File altname;
-                    do {
-                        altname = new File(path, UPGRADE_OLD_COLLECTION_RENAME + i);
-                        ++i;
-                    } while (altname.exists());
-                    apkgExport.renameTo(altname);
-                }
-                DeckTask.launchDeckTask(DeckTask.TASK_TYPE_EXPORT_APKG, mUpgradeExportListener,
-                        new DeckTask.TaskData(new Object[] {AnkiDroidApp.getCollectionPath(),
-                                apkgExport.getAbsolutePath(), false}));
-            }
-        });
-        builder.setCancelable(false);
-        builder.setNegativeButton(R.string.no, new DialogInterface.OnClickListener() {
-            @Override
-            public void onClick(DialogInterface dialog, int which) {
-                AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance().getBaseContext())
-                        .edit().putInt("lastUpgradeVersion", AnkiDroidApp.getPkgVersionCode()).commit();
-            }
-        });
-        builder.show();
     }
 
     private SharedPreferences restorePreferences() {
@@ -2477,7 +2438,6 @@ public class DeckPicker extends FragmentActivity {
         item.setIcon(R.drawable.ic_menu_send);
         item = menu.add(Menu.NONE, MENU_ABOUT, Menu.NONE, R.string.menu_about);
         item.setIcon(R.drawable.ic_menu_info_details);
-        item = menu.add(Menu.NONE, MENU_REUPGRADE, Menu.NONE, R.string.restart_upgrade_process);
         item.setIcon(R.drawable.ic_menu_preferences);
         
         return true;
@@ -2646,10 +2606,6 @@ public class DeckPicker extends FragmentActivity {
             		preferences.edit().putBoolean("invertedColors", true).commit();
             		item.setIcon(R.drawable.ic_menu_night_checked);
             	}
-                return true;
-
-            case MENU_REUPGRADE:
-                restartUpgradeProcess();
                 return true;
 
             default:


### PR DESCRIPTION
As per issue [1722](https://code.google.com/p/ankidroid/issues/detail?id=1722), this commit removes the "restart upgrade process menu" item. Suggest including in **version 2.1** since this item may confuse some users who think it will _upgrade the application_... it also clogs up the menu for 99% of users. 

The upgrade wizard itself is left intact, so the minority of users updating from 1.x can still upgrade their decks automatically, they just can't restart the upgrade wizard if it fails, meaning they have to either follow the manual upgrade instructions, or rollback to version 2.0.4.
