### PR TITLE
Disable the AnkiWeb sections from the Upgrade Wizard

### DIFF
--- a/src/com/ichi2/anki/Info.java
+++ b/src/com/ichi2/anki/Info.java
@@ -313,7 +313,8 @@ public class Info extends Activity {
                                 finishWithAnimation(false);
                             }
                         });
-                        syncButton.setText(getString(R.string.internet));
+                        syncButton.setEnabled(false);
+                        syncButton.setText("N/A");
                         syncButton.setOnClickListener(new OnClickListener() {
                             @Override
                             public void onClick(View arg0) {
@@ -442,7 +443,8 @@ public class Info extends Activity {
                                 finishWithAnimation();
                             }
                         });
-                        continueButton.setText(R.string.ankiweb);
+                        continueButton.setEnabled(false);
+                        continueButton.setText("N/A");
                         continueButton.setOnClickListener(new OnClickListener() {
                             @Override
                             public void onClick(View arg0) {


### PR DESCRIPTION
_Please merge into 2.1_

Solves [Issue 1722](https://code.google.com/p/ankidroid/issues/detail?id=1722):
Disable the AnkiWeb sections from the Upgrade Wizard as they are no longer available.

I simply disabled the AnkiWeb buttons in the wizard and set the strings to "N/A". I have updated the Wiki page to make a note that the AnkiWeb mediated options are no longer available.
