### PR TITLE
make error reporting layout fill properly on small screns

### DIFF
--- a/res/layout/feedback.xml
+++ b/res/layout/feedback.xml
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
 	android:layout_width="fill_parent"
-	android:layout_height="fill_parent"
+	android:layout_height="wrap_content"
 	android:orientation="vertical"
 	android:paddingLeft="5dp"
 	android:paddingTop="10dp"
 	android:paddingRight="5dp"
-	android:paddingBottom="5dp" android:gravity="center_vertical">
+	android:paddingBottom="5dp" 
+	android:gravity="center_vertical">
 	<LinearLayout android:id="@+id/llFeedbackTopLine"
 		android:layout_width="fill_parent"
 		android:layout_height="wrap_content"
-		android:layout_alignParentTop="true"
-		android:orientation="horizontal" android:gravity="center_vertical|center_horizontal">
+		android:orientation="horizontal" 
+		android:gravity="center_vertical|center_horizontal">
 		<Button android:id="@+id/btnFeedbackSend"
 			android:text="@+id/feedback_send_feedback_and_errors"
 			android:layout_width="fill_parent"
 			android:layout_height="fill_parent"
 			android:layout_gravity="center"
-			android:gravity="center"
-			android:layout_weight="1"/>
+			android:gravity="center"/>
 		<ProgressBar android:id="@+id/pbFeedbackSpinner"
 			android:layout_width="wrap_content"
 			android:layout_height="wrap_content"
@@ -28,44 +28,48 @@
 			android:visibility="gone"/>
 	</LinearLayout>
 	<ScrollView android:id="@+id/scrollView1"
-		android:layout_below="@+id/llFeedbackTopLine"
 		android:layout_width="fill_parent"
 		android:layout_height="wrap_content">
 		<EditText android:id="@+id/etFeedbackText"
 			android:layout_width="fill_parent"
-			android:layout_height="fill_parent"
+			android:layout_height="wrap_content"
 			android:gravity="top"
-			android:minLines="4"
+			android:minLines="2"
 			android:hint="@string/feedback_default_text"/>
 	</ScrollView>
 	<LinearLayout android:id="@+id/lvButtons" 
 		android:layout_width="fill_parent"
-		android:layout_below="@+id/scrollView1"
 		android:layout_height="wrap_content"
 		android:orientation="horizontal">
 		<Button android:id="@+id/btnFeedbackKeepLatest"
 			android:text="@string/feedback_keep_latest"
 			android:layout_width="0dip"
+			android:layout_weight="1"
 			android:layout_height="fill_parent"
 			android:gravity="center"
-			android:layout_weight="1" android:layout_gravity="center|center_vertical"/>
+			android:layout_gravity="center|center_vertical"/>
 		<Button android:id="@+id/btnFeedbackClearAll" 
 			android:text="@string/feedback_clear_all"
 			android:layout_width="0dip"
+			android:layout_weight="1"
 			android:layout_height="fill_parent"
 			android:layout_gravity="center"
-			android:gravity="center"
-			android:layout_weight="1"/>
+			android:gravity="center"/>
 	</LinearLayout>
 	<ListView android:id="@+id/lvFeedbackErrorList"
-		android:layout_below="@+id/lvButtons"
 		android:layout_width="fill_parent"
 		android:layout_height="wrap_content"
 		android:fastScrollEnabled="true"/>
-	<TextView android:id="@+id/tvFeedbackDisclaimer"
-		android:layout_width="fill_parent"
-		android:layout_height="wrap_content"
-		android:textColor="#000000"
-		android:layout_alignParentBottom="true"
-		android:text="@+string/feedback_disclaimer"/>
-</RelativeLayout>
+	<ScrollView
+		    android:fillViewport="true"
+		    android:layout_width="fill_parent"
+		    android:layout_weight="1"
+		    android:layout_height="0dp"
+		    android:fadeScrollbars="false">	    
+		<TextView android:id="@+id/tvFeedbackDisclaimer"
+			android:layout_width="fill_parent"
+			android:layout_height="wrap_content"
+			android:textColor="#000000"
+			android:text="@+string/feedback_disclaimer"/>
+	</ScrollView>
+</LinearLayout>


### PR DESCRIPTION
_Could go in either 2.1 or 2.2 I guess since it's a bug not a feature._

Fix [Issue 2027](https://code.google.com/p/ankidroid/issues/detail?id=2027):    Issues with crash reporter screen on 320x240:

I embedded the Disclaimer text in the error reporter in a ScrollView, so that the disclaimer shrinks if the screen is too small... I couldn't get it to behave as expected using the existing RelativeLayout, so I changed to a LinearLayout.
