### PR TITLE
Fix broken help link

### DIFF
--- a/res/values/constants.xml
+++ b/res/values/constants.xml
@@ -91,7 +91,7 @@
     <string name="link_wikipedia_open_source">http://en.wikipedia.org/wiki/Open_source_software</string>
     <string name="link_contribution">http://code.google.com/p/ankidroid/wiki/Contribution</string>
     <string name="link_contribution_contributors">http://code.google.com/p/ankidroid/wiki/Contribution</string>
-    <string name="link_help">http://code.google.com/p/ankidroid/wiki/help</string>
+    <string name="link_help">http://code.google.com/p/ankidroid/wiki/Help</string>
     <string name="link_faq">https://code.google.com/p/ankidroid/wiki/FAQ</string>
     <string name="link_hebrew_font">http://code.google.com/p/ankidroid/downloads/detail?name=Tohu.ttf</string>
     <string name="error_email">ankidroid@gmail.com</string>

--- a/src/com/ichi2/anki/DeckPicker.java
+++ b/src/com/ichi2/anki/DeckPicker.java
@@ -1383,7 +1383,7 @@ public class DeckPicker extends FragmentActivity {
                                     if (Utils.isIntentAvailable(DeckPicker.this, "android.intent.action.VIEW")) {
                                         Intent intent = new Intent("android.intent.action.VIEW", Uri
                                                 .parse(getResources().getString(
-                                                        arg1 == 0 ? R.string.link_help : R.string.link_faq)));
+                                                        arg1 == 1 ? R.string.link_help : R.string.link_faq)));
                                         startActivity(intent);
                                     } else {
                                         startActivity(new Intent(DeckPicker.this, Info.class));


### PR DESCRIPTION
The in-app help link was pointing to FAQ... this makes it point to the correct URL.
No issue on the tracker AFAIK
