### PR TITLE
Do not populate new notes with model tags

### DIFF
--- a/src/com/ichi2/anki/CardEditor.java
+++ b/src/com/ichi2/anki/CardEditor.java
@@ -527,6 +527,18 @@ public class CardEditor extends Activity {
                     modified = modified | f.updateField();
                 }
                 if (mAddNote) {
+                    mEditorNote.setTags(mCurrentTags);
+                    // Save tags to model
+                    try {
+                        JSONArray ja = new JSONArray();
+                        for (String t : mCurrentTags) {
+                            ja.put(t);
+                        }
+                        mCol.getModels().current().put("tags", ja);
+                        mCol.getModels().setChanged();
+                    } catch (JSONException e) {
+                        throw new RuntimeException(e);
+                    }
                     DeckTask.launchDeckTask(DeckTask.TASK_TYPE_ADD_FACT, mSaveFactHandler, new DeckTask.TaskData(
                             mEditorNote));
                 } else {
@@ -958,19 +970,6 @@ public class CardEditor extends Activity {
                 builder.setPositiveButton(res.getString(R.string.select), new OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
-                        if (mAddNote) {
-                            try {
-                                JSONArray ja = new JSONArray();
-                                for (String t : selectedTags) {
-                                    ja.put(t);
-                                }
-                                mCol.getModels().current().put("tags", ja);
-                                mCol.getModels().setChanged();
-                            } catch (JSONException e) {
-                                throw new RuntimeException(e);
-                            }
-                            mEditorNote.setTags(selectedTags);
-                        }
                         mCurrentTags = selectedTags;
                         updateTags();
                     }
@@ -1462,18 +1461,18 @@ public class CardEditor extends Activity {
                 mEditorNote.model().put("did", mCurrentDid);
                 mModelButton.setText(getResources().getString(R.string.CardEditorModel,
                         model.getString("name")));
-                JSONArray tags = model.getJSONArray("tags");
-                for (int i = 0; i < tags.length(); i++) {
-                    mEditorNote.addTag(tags.getString(i));
+                // Re-use tags when adding multiple notes
+                if (mCurrentTags == null) {
+                    mCurrentTags = new ArrayList<String>();
                 }
             } else {
                 mEditorNote = note;
                 mCurrentDid = mCurrentEditedCard.getDid();
+                mCurrentTags = mEditorNote.getTags();
             }
         } catch (JSONException e) {
             throw new RuntimeException(e);
         }
-        mCurrentTags = mEditorNote.getTags();
         updateDeck();
         updateTags();
         populateEditFields();


### PR DESCRIPTION
I noticed that AnkiDroid populates new notes with tags from the model, something that I have never seen in Anki Desktop. In fact, Anki Desktop seems to store tags in the model, but I couldn't find a single occurrence where those tags are actually used. Maybe @dae can shed some light on this. This change will re-use tags from the previous note during a CardEditor session.
