### PR TITLE
Make deck description scrollable (issue 1974)

### DIFF
--- a/res/layout-xlarge/studyoptions.xml
+++ b/res/layout-xlarge/studyoptions.xml
@@ -25,18 +25,6 @@
 			android:layout_height="wrap_content"
 			android:layout_margin="5dp"
 			android:text=""/>
-		<TextView
-			android:id="@+id/studyoptions_deck_description"
-			android:ellipsize="end"
-			android:maxLines="3"
-			android:gravity="center" 
-			android:textColor="#000000"
-			android:layout_width="fill_parent" 
-			android:layout_height="wrap_content" 
-			android:layout_marginBottom="5dp" 
-			android:layout_marginLeft="5dp" 
-			android:layout_marginRight="5dp" 
-			android:text=""/>
 		<LinearLayout android:id="@+id/studyoptions_deckcounts"
 			android:visibility="invisible"
 			android:layout_marginLeft="5dip"
@@ -172,6 +160,28 @@
 				android:layout_width="0dip" 
 				android:layout_height="wrap_content" />
 		</LinearLayout>
+		<ScrollView 
+		    android:fillViewport="true"
+		    android:layout_width="fill_parent"
+		    android:layout_weight="1"
+		    android:layout_height="0dp"
+		    android:fadeScrollbars="false">		
+			<LinearLayout
+				android:orientation="vertical"
+				android:layout_width="fill_parent" 
+				android:layout_height="wrap_content"> 		
+				<TextView
+					android:id="@+id/studyoptions_deck_description"
+					android:gravity="center" 
+					android:textColor="#000000"
+					android:layout_width="fill_parent" 
+					android:layout_height="wrap_content" 
+					android:layout_marginBottom="5dp" 
+					android:layout_marginLeft="5dp" 
+					android:layout_marginRight="5dp" 
+					android:text=""/>
+			</LinearLayout>		
+		</ScrollView>
 	</LinearLayout>
 	<LinearLayout android:id="@+id/studyoptions_bottom_buttons" 
 		android:layout_alignParentBottom="true"

--- a/res/layout/studyoptions.xml
+++ b/res/layout/studyoptions.xml
@@ -35,16 +35,7 @@
 					android:layout_height="wrap_content"
 					android:layout_margin="5dp"
 					android:text=""/>
-		    	<TextView
-					android:id="@+id/studyoptions_deck_description"
-					android:gravity="center" 
-					android:textColor="#000000"
-					android:layout_width="fill_parent" 
-					android:layout_height="wrap_content" 
-					android:layout_marginBottom="5dp" 
-					android:layout_marginLeft="5dp" 
-					android:layout_marginRight="5dp" 
-					android:text=""/>
+			    	
 		    	<LinearLayout android:id="@+id/studyoptions_deckcounts"
 		    	    android:visibility="invisible"
 			    android:layout_marginLeft="5dip"
@@ -160,6 +151,21 @@
 	   			</TableRow>
 				</TableLayout>
 				</LinearLayout>
+				<LinearLayout
+					android:orientation="vertical"
+					android:layout_width="fill_parent" 
+					android:layout_height="wrap_content"> 					
+			    	<TextView
+						android:id="@+id/studyoptions_deck_description"
+						android:gravity="center" 
+						android:textColor="#000000"
+						android:layout_width="fill_parent" 
+						android:layout_height="wrap_content" 
+						android:layout_marginBottom="5dp" 
+						android:layout_marginLeft="5dp" 
+						android:layout_marginRight="5dp" 
+						android:text=""/>
+		    	</LinearLayout>			
 			</LinearLayout>
 		</ScrollView>
 		<LinearLayout

--- a/src/com/ichi2/anki/StudyOptionsFragment.java
+++ b/src/com/ichi2/anki/StudyOptionsFragment.java
@@ -1155,13 +1155,8 @@ public class StudyOptionsFragment extends Fragment {
         try {
 			if (deck.getInt("dyn") == 0) {
 			    desc = AnkiDroidApp.getCol().getDecks().getActualDescription();
-			    // Truncate the deck description... it can be seen in full from options
-			    mTextDeckDescription.setMaxLines(3);
-                mTextDeckDescription.setEllipsize(TextUtils.TruncateAt.END);
 			} else {
 				desc = getResources().getString(R.string.dyn_deck_desc);
-			    // we should show the full text of the dynamic deck description. Don't truncate with ellipsize
-                mTextDeckDescription.setMaxLines(10);
 			}
 		} catch (JSONException e) {
 			throw new RuntimeException(e);


### PR DESCRIPTION
_Squashed and rebased version of  #219_

It moves the deck description to the bottom of the deck info layout, and disables truncation of the deck description so that users can scroll to view the whole text. Solves [issue 1974](https://code.google.com/p/ankidroid/issues/detail?id=1974)

Unfortunately for very small screens, it may mean that scrolling is necessary to see _any_ of the deck description, but for most screen-sizes it should not be a problem. See the below screenshot for an example of what I mean on QVGA (smallest Android screen size)

![scrollable description](https://f.cloud.github.com/assets/2818274/2470456/ffbf93f0-b012-11e3-8e71-da0b36e0b991.png)
