### PR TITLE
Proposed fix for Issue 1787: Duplicate can't save.

### DIFF
--- a/res/values/03-dialogs.xml
+++ b/res/values/03-dialogs.xml
@@ -63,6 +63,9 @@
 <string name="reset_card_dialog_message">This resets the learning progress for all cards of this note (they will look like new cards).\nReally continue?</string>
 <string name="reset_card_dialog_confirmation">All cards of this note reset</string>
 
+<string name="save_duplicate_dialog_title">Duplicate note</string>
+<string name="save_duplicate_dialog_message">This note shares its primary field with another note. Save anyway?</string>
+
 <string name="answering_error_title">Database error</string>
 <string name="answering_error_message">An error occurred while writing to the collection. This could be related to a corrupt database or to insufficient disc space.\n\nIf it happens more often, please try to check the database, repair the collection or restoring it from a backup. Click on \'options\' for that.\n\nNevertheless, it could be an AnkiDroid bug as well; please report the error that we can check this.</string>
 <string name="answering_error_report">Report error</string>


### PR DESCRIPTION
I'm proposing this fix for 1787. When users attempt to save a duplicate
note, they will be notified of the shared primary field and asked if they
wish to save it regardless. Initially I was worried this duplicate
prevention functionality was necessary for a reason unknown to me, but
after browsing through the note update code it looks as though there's
no entry collision issues when updating since it's using the unique
note ID anyway.

(As an aside: Thank you to all the contributors on this awesome project!)
