### PR TITLE
Pretty simple "fix" (more of a hack I guess) for Issue 2033 "MediaPlayer...

### DIFF
--- a/res/layout/flashcard.xml
+++ b/res/layout/flashcard.xml
@@ -151,6 +151,11 @@
 		<FrameLayout android:id="@+id/whiteboard"
 			android:layout_width="fill_parent"
 			android:layout_height="fill_parent"/>
+		<SurfaceView android:id="@+id/mp4surfaceview"
+			android:visibility="invisible"
+			android:layout_gravity="center"
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content" />
 		<ImageView android:id="@+id/lookup_button"
 			android:padding="5dip"
 			android:layout_gravity="right"

--- a/src/com/ichi2/anki/Reviewer.java
+++ b/src/com/ichi2/anki/Reviewer.java
@@ -465,7 +465,7 @@ public class Reviewer extends AnkiActivity {
         @Override
         public void handleMessage(Message msg) {
             Sound.stopSounds();
-            Sound.playSound((String) msg.obj, null);
+            Sound.playSound((String) msg.obj, null,null);
         }
     };
 
@@ -2644,9 +2644,9 @@ public class Reviewer extends AnkiActivity {
                 if (!mSpeakText) {
                     // when showing answer, repeat question audio if so configured
                 	if (sDisplayAnswer && getConfigForCurrentCard().optBoolean("replayq",true)) {
-                        Sound.playSounds(MetaDB.LANGUAGES_QA_QUESTION);
+                        Sound.playSounds(MetaDB.LANGUAGES_QA_QUESTION,this);
                     }
-                    Sound.playSounds(sDisplayAnswer ? MetaDB.LANGUAGES_QA_ANSWER : MetaDB.LANGUAGES_QA_QUESTION);
+                    Sound.playSounds(sDisplayAnswer ? MetaDB.LANGUAGES_QA_ANSWER : MetaDB.LANGUAGES_QA_QUESTION,this);
                 } else {
                     // If the question is displayed or if the question should be replayed, read the question
                 	if (!sDisplayAnswer || getConfigForCurrentCard().optBoolean("replayq",true)) {


### PR DESCRIPTION
... setup doesn't include mp4 support", basically uses the existing audio playing code in Sound.java and detects if an .mp4 is being played, if so, it connects the mediaplayer to a surfaceview so it can display the video.  Sets a timer to hide the surfaceview half a second longer that the duration of the video.  This code works on a Nexus 7 running Android 4.4.2, viewing the ASL Browser cards from the shared decks.
