### PR TITLE
Fix saved data dialog

### DIFF
--- a/src/com/ichi2/anki/CardEditor.java
+++ b/src/com/ichi2/anki/CardEditor.java
@@ -1149,6 +1149,7 @@ public class CardEditor extends Activity {
 
             case DIALOG_INTENT_INFORMATION:
                 dialog = createDialogIntentInformation(builder, res);
+                break;
 
             case DIALOG_CONFIRM_DUPLICATE:
                 builder.setTitle(res.getString(R.string.save_duplicate_dialog_title));


### PR DESCRIPTION
Fix for [issue 2056](https://code.google.com/p/ankidroid/issues/detail?id=2056). It was just a missing `break` in https://github.com/ankidroid/Anki-Android/pull/238.
