### PR TITLE
Fix for Issue 2068: Missing autoplay in answer.

### DIFF
--- a/src/com/ichi2/anki/PreviewClass.java
+++ b/src/com/ichi2/anki/PreviewClass.java
@@ -834,8 +834,8 @@ public class PreviewClass extends Activity {
 
 	            if (sDisplayAnswer) {
 	                qa = MetaDB.LANGUAGES_QA_ANSWER;
-	                answer = mCurrentCard.getPureAnswerForReading();
 	                if (!mAnswerSoundsAdded) {
+	                    answer = mCurrentCard.getAnswer(mCurrentSimpleInterface);
 	                    Sound.addSounds(mBaseUrl, answer, qa);
 	                    mAnswerSoundsAdded = true;
 	                }

--- a/src/com/ichi2/anki/Reviewer.java
+++ b/src/com/ichi2/anki/Reviewer.java
@@ -2549,9 +2549,9 @@ public class Reviewer extends AnkiActivity {
 
             if (sDisplayAnswer) {
                 qa = MetaDB.LANGUAGES_QA_ANSWER;
-                answer = mCurrentCard.getPureAnswerForReading();
                 // don't add answer sounds multiple times, such as when reshowing card after exiting editor
                 if (!mAnswerSoundsAdded) {
+                    answer = mCurrentCard.getAnswer(mCurrentSimpleInterface);
                     Sound.addSounds(mBaseUrl, answer, qa);
                     mAnswerSoundsAdded = true;
                 }


### PR DESCRIPTION
This is my proposed fix for issue 2068, where audio before the &lt;hr
id="answer"&gt; would not autoplay when the card answer is shown. This was
caused by fix 18fdb7b, which used mCurrentCard.getPureAnswerForReading()
to grab the text after the &lt;hr&gt; to parse for audio. I've changed this to
parse the whole answer card to match Anki Desktop.
