### PR TITLE
Hide timer by default to avoid flicker

### DIFF
--- a/res/layout/flashcard.xml
+++ b/res/layout/flashcard.xml
@@ -112,7 +112,7 @@
 			android:layout_width="wrap_content"
 			android:layout_height="fill_parent"
 			android:textSize="14dip"
-			android:visibility="visible"
+			android:visibility="invisible"
 			android:gravity="center"
 			android:textColor="#000000" />
 	</LinearLayout>


### PR DESCRIPTION
The timer is shown by default, only to be hidden as part of `onCreate` later. On slower devices, this change in state is visible and distracting.
