### PR TITLE
Move launch of renderQA task to onPostExecute() task of searchCards

### DIFF
--- a/res/layout/card_item_browser.xml
+++ b/res/layout/card_item_browser.xml
@@ -8,7 +8,6 @@
   		android:id="@+id/card_sfld"
 		android:layout_width="0dip"
 		android:layout_height="fill_parent"
-		android:maxLines="3"
 		android:textColor="#000000"
 		android:layout_weight="1"
 		android:gravity="center_vertical"

--- a/src/com/ichi2/anki/CardBrowser.java
+++ b/src/com/ichi2/anki/CardBrowser.java
@@ -721,9 +721,6 @@ public class CardBrowser extends ActionBarActivity {
             // Perform database query to get all card ids / sfld. Shows "filtering cards..." progress message
             DeckTask.launchDeckTask(DeckTask.TASK_TYPE_SEARCH_CARDS, mSearchCardsHandler, new DeckTask.TaskData(
                     new Object[] { mCol, mDeckNames, searchText, ((mOrder == CARD_ORDER_NONE) ? "" : "true") }));
-            // After this initial query, start rendering the question and answer in the background
-            DeckTask.launchDeckTask(DeckTask.TASK_TYPE_RENDER_BROWSER_QA, mRenderQAHandler, new DeckTask.TaskData(
-                    new Object[] { mCol, mCards}));
         }
     }
 
@@ -950,11 +947,15 @@ public class CardBrowser extends ActionBarActivity {
 
         @Override
         public void onPostExecute(TaskData result) {
+            Log.i(AnkiDroidApp.TAG, "Completed doInBackgroundSearchCards Successfuly");
             mTotalCount = result.getInt();
             updateList();
             if (mProgressDialog != null && mProgressDialog.isShowing()) {
                 mProgressDialog.dismiss();
             }
+            // After the initial searchCards query, start rendering the question and answer in the background
+            DeckTask.launchDeckTask(DeckTask.TASK_TYPE_RENDER_BROWSER_QA, mRenderQAHandler, new DeckTask.TaskData(
+                    new Object[] { mCol, mCards}));            
         }
     };
 

--- a/src/com/ichi2/async/DeckTask.java
+++ b/src/com/ichi2/async/DeckTask.java
@@ -132,6 +132,7 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
      */
     public static DeckTask launchDeckTask(int type, Listener listener, TaskData... params) {
         // Before starting a new task, cancel rendering of Q&A for browser
+        Log.i(AnkiDroidApp.TAG, "launchDeckTask("+type+")");
         if (sLatestInstance!=null && sLatestInstance.mType==TASK_TYPE_RENDER_BROWSER_QA && !sLatestInstance.isCancelled()){
             Log.i(AnkiDroidApp.TAG, "DeckTask: cancelling render browser QA...");
             sLatestInstance.cancel(true);
@@ -220,6 +221,7 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
             }
             try {
                 mPreviousTask.get();
+                Log.i(AnkiDroidApp.TAG, "Finished waiting for " + mPreviousTask.mType + " to finish. Status= " + mPreviousTask.getStatus());
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 // We have been interrupted, return immediately.


### PR DESCRIPTION
This fixes some problems where the answer etc weren't getting rendered, thanks to @agrueneberg for the investigation. See the discussion in #244 for more details.
