### PR TITLE
Remove fullscreen from previewer and charts (issue 2070)

### DIFF
--- a/res/layout/statistics.xml
+++ b/res/layout/statistics.xml
@@ -1,19 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-	android:layout_width="fill_parent" android:orientation="vertical"
-	android:layout_height="fill_parent">
-	<TextView android:id="@+id/statistics_title"
-		android:layout_width="fill_parent" android:layout_height="wrap_content"
-		android:gravity="center" android:layout_marginTop="6dip"
-		android:textColor="#ffffff"
-		android:textSize="15dip" android:textStyle="bold" />
-	<LinearLayout
-		android:layout_width="fill_parent" 
-		android:layout_height="fill_parent">
-		<LinearLayout
-			android:id="@+id/chart"
-			android:layout_width="fill_parent" 
-			android:layout_height="fill_parent" />
-	</LinearLayout>
-</LinearLayout>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+	android:id="@+id/chart"
+	android:layout_width="fill_parent"
+	android:layout_height="fill_parent" />

--- a/src/com/ichi2/anki/PreviewClass.java
+++ b/src/com/ichi2/anki/PreviewClass.java
@@ -174,7 +174,6 @@ public class PreviewClass extends ActionBarActivity {
     private int mCurrentBackgroundColor;
     private boolean mInputWorkaround;
     private boolean mRefreshWebview = true;
-    private boolean mPrefFullscreenReview=true;
     private boolean mAnswerSoundsAdded = false;
     private Button mFlipCard;
     private static final Pattern sSpanPattern = Pattern.compile("</?span[^>]*>");
@@ -189,6 +188,7 @@ public class PreviewClass extends ActionBarActivity {
 	        // Log.i(AnkiDroidApp.TAG, "CardEditor: onCreate");
 
 	        super.onCreate(savedInstanceState);
+
 	        mCurrentCard =CardEditor.mCurrentEditedCard;
 	        mRefreshWebview = getRefreshWebviewAndInitializeWebviewVariables();
 	        initLayout(R.layout.flashcard);
@@ -198,9 +198,7 @@ public class PreviewClass extends ActionBarActivity {
 	            //reloadCollection(savedInstanceState);
 	            return;
 	        }
-	        mPrefFullscreenReview = AnkiDroidApp.getSharedPrefs(getBaseContext()).getBoolean("fullscreenReview", false);
 	        mGesturesEnabled = AnkiDroidApp.initiateGestures(this, AnkiDroidApp.getSharedPrefs(getBaseContext()));
-	        setFullScreen(true);
 	        mBaseUrl = Utils.getBaseUrl(col.getMedia().getDir());
 
 	        try {
@@ -212,15 +210,6 @@ public class PreviewClass extends ActionBarActivity {
 	        PreviewClass.this.displayCardAnswer();
 
 	 }
-	    private void setFullScreen(boolean fullScreen) {
-	        WindowManager.LayoutParams attrs = getWindow().getAttributes();
-	        if (fullScreen) {
-	            attrs.flags |= WindowManager.LayoutParams.FLAG_FULLSCREEN;
-	        } else {
-	            attrs.flags &= (~WindowManager.LayoutParams.FLAG_FULLSCREEN);
-	        }
-	        getWindow().setAttributes(attrs);
-	    }
 
 
 	    private boolean mGesturesEnabled;

--- a/src/com/ichi2/anki/Reviewer.java
+++ b/src/com/ichi2/anki/Reviewer.java
@@ -897,16 +897,6 @@ public class Reviewer extends AnkiActivity {
         return result;
     }
 
-    private void setFullScreen(boolean fullScreen) {
-        WindowManager.LayoutParams attrs = getWindow().getAttributes();
-        if (fullScreen) {
-            attrs.flags |= WindowManager.LayoutParams.FLAG_FULLSCREEN;
-        } else {
-            attrs.flags &= (~WindowManager.LayoutParams.FLAG_FULLSCREEN);
-        }
-        getWindow().setAttributes(attrs);
-    }
-
 
     private Handler mTimerHandler = new Handler();
 
@@ -934,16 +924,6 @@ public class Reviewer extends AnkiActivity {
         super.onCreate(savedInstanceState);
         Log.i(AnkiDroidApp.TAG, "Reviewer - onCreate");
 
-        // Remove the status bar and title bar
-        if (mPrefFullscreenReview) {
-            getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN,
-                    WindowManager.LayoutParams.FLAG_FULLSCREEN);
-            // Do not hide the title bar in Honeycomb, since it contains the action bar.
-            if (AnkiDroidApp.SDK_VERSION <= 11) {
-                requestWindowFeature(Window.FEATURE_NO_TITLE);
-            }
-        }
-
         mChangeBorderStyle = Themes.getTheme() == Themes.THEME_ANDROID_LIGHT
                 || Themes.getTheme() == Themes.THEME_ANDROID_DARK;
 
@@ -957,10 +937,13 @@ public class Reviewer extends AnkiActivity {
         } else {
             mSched = col.getSched();
             mCollectionFilename = col.getPath();
-
             mBaseUrl = Utils.getBaseUrl(col.getMedia().getDir());
+
             restorePreferences();
-            setFullScreen(mPrefFullscreenReview);
+
+            if (mPrefFullscreenReview) {
+                UIUtils.setFullScreen(this);
+            }
 
             registerExternalStorageListener();
 
@@ -1381,10 +1364,8 @@ public class Reviewer extends AnkiActivity {
             }
 
             // Restore fullscreen preference
-            getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN,
-                    WindowManager.LayoutParams.FLAG_FULLSCREEN);
+            UIUtils.setFullScreen(this);
         }
-        setFullScreen(mPrefFullscreenReview);
     }
 
 

--- a/src/com/ichi2/anki/UIUtils.java
+++ b/src/com/ichi2/anki/UIUtils.java
@@ -1,11 +1,14 @@
 
 package com.ichi2.anki;
 
+import android.app.Activity;
 import android.content.Context;
 import android.support.v4.view.MenuItemCompat;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
+import android.view.Window;
+import android.view.WindowManager;
 
 import com.ichi2.async.DeckTask;
 import com.ichi2.async.DeckTask.TaskData;
@@ -79,4 +82,10 @@ public class UIUtils {
             }, new DeckTask.TaskData(AnkiDroidApp.getCol()));
     	}
     }
+
+    public static void setFullScreen(Activity activity) {
+        activity.getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN,
+                WindowManager.LayoutParams.FLAG_FULLSCREEN);
+    }
+
 }

--- a/src/com/ichi2/charts/ChartBuilder.java
+++ b/src/com/ichi2/charts/ChartBuilder.java
@@ -48,6 +48,7 @@ import android.view.Window;
 import android.view.WindowManager;
 import android.view.GestureDetector.SimpleOnGestureListener;
 import android.view.ViewGroup.LayoutParams;
+import android.widget.FrameLayout;
 import android.widget.LinearLayout;
 import android.widget.RadioButton;
 import android.widget.RadioGroup;
@@ -69,15 +70,10 @@ public class ChartBuilder extends ActionBarActivity {
     private XYMultipleSeriesRenderer mRenderer = new XYMultipleSeriesRenderer();
 
     private GraphicalView mChartView;
-    private TextView mTitle;
     private double[] mPan;
-
-    private boolean mFullScreen;
 
     private double[][] mSeriesList;
     private Object[] mMeta;
-
-    private static final int MENU_FULLSCREEN = 0;
 
     /**
      * Swipe Detection
@@ -107,42 +103,8 @@ public class ChartBuilder extends ActionBarActivity {
 
     private SharedPreferences restorePreferences() {
         SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(getBaseContext());
-        mFullScreen = preferences.getBoolean("fullScreen", false);
         mSwipeEnabled = preferences.getBoolean("swipe", false);
         return preferences;
-    }
-
-
-    @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
-        MenuItem item;
-        item = menu.add(Menu.NONE, MENU_FULLSCREEN, Menu.NONE, R.string.statistics_fullscreen);
-        item.setIcon(R.drawable.ic_menu_manage);
-        return true;
-    }
-
-
-    @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
-        switch (item.getItemId()) {
-            case MENU_FULLSCREEN:
-                SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(getBaseContext());
-                Editor editor = preferences.edit();
-                editor.putBoolean("fullScreen", !mFullScreen);
-                // Statistics.sZoom = zoom;
-                editor.commit();
-                finish();
-                Intent intent = new Intent(this, com.ichi2.charts.ChartBuilder.class);
-                startActivity(intent);
-                ActivityTransitionAnimation.slide(this, ActivityTransitionAnimation.FADE);
-                return true;
-            case android.R.id.home:
-                setResult(AnkiDroidApp.RESULT_TO_HOME);
-                closeChartBuilder();
-                return true;
-            default:
-                return super.onOptionsItemSelected(item);
-        }
     }
 
 
@@ -213,24 +175,13 @@ public class ChartBuilder extends ActionBarActivity {
             finish();
             return;
         }
-        if (mFullScreen) {
-            getWindow()
-                    .setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN, WindowManager.LayoutParams.FLAG_FULLSCREEN);
-            requestWindowFeature(Window.FEATURE_NO_TITLE);
-        }
+
         View mainView = getLayoutInflater().inflate(R.layout.statistics, null);
         setContentView(mainView);
         mainView.setBackgroundColor(Color.WHITE);
-        mTitle = (TextView) findViewById(R.id.statistics_title);
         if (mChartView == null) {
-            if (mFullScreen) {
-                mTitle.setText(title);
-                mTitle.setTextColor(Color.BLACK);
-            } else {
-                setTitle(title);
-                AnkiDroidApp.getCompat().setSubtitle(this, subTitle);
-                mTitle.setVisibility(View.GONE);
-            }
+            setTitle(title);
+            AnkiDroidApp.getCompat().setSubtitle(this, subTitle);
             for (int i = 1; i < mSeriesList.length; i++) {
                 XYSeries series = new XYSeries(res.getString(valueLabels[i - 1]));
                 for (int j = 0; j < mSeriesList[i].length; j++) {
@@ -276,8 +227,8 @@ public class ChartBuilder extends ActionBarActivity {
             mRenderer.setPanEnabled(true, false);
             mRenderer.setPanLimits(mPan);
             mChartView = ChartFactory.getBarChartView(this, mDataset, mRenderer, BarChart.Type.STACKED);
-            LinearLayout layout = (LinearLayout) findViewById(R.id.chart);
-            layout.addView(mChartView, new LayoutParams(LayoutParams.FILL_PARENT, LayoutParams.FILL_PARENT));
+            FrameLayout layout = (FrameLayout) findViewById(R.id.chart);
+            layout.addView(mChartView);
         } else {
             mChartView.repaint();
         }


### PR DESCRIPTION
Yet another tease :smile: This change removes the fullscreen mode from both previewer and charts.
While I fully support to keep the setting for the reviewer (for another reason than screen estate, though, it just allows for a more distraction-free review process), I don't see much value in it in the other activities. The previewer always switches into fullscreen, which is a bug identified in [2070](https://code.google.com/p/ankidroid/issues/detail?id=2070), and in the stats fullscreen is the only menu button...
