### PR TITLE
Reorder buttons in study options congrats

### DIFF
--- a/res/layout/studyoptions_congrats.xml
+++ b/res/layout/studyoptions_congrats.xml
@@ -24,6 +24,12 @@
 			android:layout_height="wrap_content"
 			android:layout_width="fill_parent"
 			android:gravity="center"
+			android:id="@+id/studyoptions_congrats_customstudy"
+			android:text="@string/studyoptions_congrats_custom_study" />
+		<Button
+			android:layout_height="wrap_content"
+			android:layout_width="fill_parent"
+			android:gravity="center"
 			android:id="@+id/studyoptions_congrats_unbury"
 			android:text="@string/unbury" />
 		<Button
@@ -32,11 +38,5 @@
 			android:gravity="center"
 			android:id="@+id/studyoptions_congrats_open_other_deck"
 			android:text="@string/studyoptions_congrats_open_other_deck" />
-		<Button
-			android:layout_height="wrap_content"
-			android:layout_width="fill_parent"
-			android:gravity="center"
-			android:id="@+id/studyoptions_congrats_customstudy"
-			android:text="@string/studyoptions_congrats_custom_study" />
 	</LinearLayout>
 </ScrollView>


### PR DESCRIPTION
_Custom Study_ and _Unbury_ are related and shouldn't be separated by _Open other deck_.

_Open other deck_ is probably the most frequently used button, and after a review session, the finger is likely to be at the bottom of the screen. Having the button there as well improves the flow.

In Anki Desktop, _Custom Study_ comes before _Unbury_, so I changed that, too:
![congrats](https://cloud.githubusercontent.com/assets/527708/2651459/8f0a0e1c-bf8d-11e3-9bfa-31271cb5593a.png)
