### PR TITLE
Move sync button into action bar

### DIFF
--- a/res/layout/deck_picker.xml
+++ b/res/layout/deck_picker.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout
-	xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
 	android:layout_width="fill_parent"
 	android:layout_height="fill_parent"
 	android:orientation="vertical"
@@ -17,8 +16,7 @@
 		android:layout_above="@+id/deckpicker_buttons"
 		android:focusable="true"/>
 
-	<LinearLayout
-		android:id="@+id/deckpicker_buttons"
+	<LinearLayout android:id="@+id/deckpicker_buttons"
 		android:layout_width="fill_parent"
 		android:layout_alignParentBottom="true"
 		android:layout_height="wrap_content"
@@ -44,11 +42,6 @@
 			style="?android:attr/buttonStyleSmall"
 			android:layout_width="0dip"
 			android:layout_weight="1"/>
-		<ImageButton android:id="@+id/sync_all_button"
-			android:layout_height="fill_parent"
-			android:src="@drawable/deckpicker_sync"
-			style="?android:attr/buttonStyleSmall"
-			android:layout_width="0dip"
-			android:layout_weight="1"/>
-			</LinearLayout>
+	</LinearLayout>
+
 </RelativeLayout>

--- a/src/com/ichi2/anki/DeckPicker.java
+++ b/src/com/ichi2/anki/DeckPicker.java
@@ -205,7 +205,6 @@ public class DeckPicker extends ActionBarActivity {
     private ImageButton mAddButton;
     private ImageButton mCardsButton;
     private ImageButton mStatsButton;
-    private ImageButton mSyncButton;
 
     private File[] mBackups;
 
@@ -979,14 +978,6 @@ public class DeckPicker extends ActionBarActivity {
                 @Override
                 public void onClick(View v) {
                     showDialog(DIALOG_SELECT_STATISTICS_TYPE);
-                }
-            });
-
-            mSyncButton = (ImageButton) findViewById(R.id.sync_all_button);
-            mSyncButton.setOnClickListener(new OnClickListener() {
-                @Override
-                public void onClick(View v) {
-                    sync();
                 }
             });
         }
@@ -2358,9 +2349,10 @@ public class DeckPicker extends ActionBarActivity {
     public boolean onCreateOptionsMenu(Menu menu) {
         MenuItem item;
 
+        UIUtils.addMenuItemInActionBar(menu, Menu.NONE, MENU_SYNC, Menu.NONE, R.string.sync_title,
+                R.drawable.ic_menu_refresh);
+
         if (mFragmented) {
-            UIUtils.addMenuItemInActionBar(menu, Menu.NONE, MENU_SYNC, Menu.NONE, R.string.sync_title,
-                    R.drawable.ic_menu_refresh);
 
             UIUtils.addMenuItemInActionBar(menu, Menu.NONE, MENU_ADD_NOTE, Menu.NONE, R.string.add,
                     R.drawable.ic_menu_add);


### PR DESCRIPTION
Just want to collect some feedback on this one as I'm not sure if it's a good thing yet. It's basically prep work aimed to make replacing the current bottom bar with a [split bar](https://developer.android.com/guide/topics/ui/actionbar.html#SplitBar) easier. Deck picker and study options would then have the same layout.
