### PR TITLE
retain vertical scroll position when changing column

### DIFF
--- a/res/layout/card_item_browser.xml
+++ b/res/layout/card_item_browser.xml
@@ -11,7 +11,7 @@
 		android:textColor="#000000"
 		android:layout_weight="1"
 		android:gravity="center_vertical"
-		android:layout_marginRight="0.5dip"/>
+		android:layout_marginRight="3dip"/>
   	<TextView 
   		android:id="@+id/card_column2"
 		android:layout_width="0dip"
@@ -19,5 +19,5 @@
 		android:layout_height="fill_parent"
 		android:layout_weight="1"
 		android:gravity="center_vertical"
-		android:layout_marginLeft="0.5dip"/>
+		android:layout_marginLeft="3dip"/>
 </LinearLayout>


### PR DESCRIPTION
Before the vertical scroll position wasn't maintained when changing columns because I was creating a new adapter every time... Here I've extended the adapter class to be able to handle a change in the data mapping, so that the vertical scroll position is maintained.

I also increased the spacing between columns, as it was looking too cramped.
