### PR TITLE
Fix vertical scrolling in card browser and widen column margins

### DIFF
--- a/res/layout/card_item_browser.xml
+++ b/res/layout/card_item_browser.xml
@@ -11,7 +11,7 @@
 		android:textColor="#000000"
 		android:layout_weight="1"
 		android:gravity="center_vertical"
-		android:layout_marginRight="0.5dip"/>
+		android:paddingRight="3dip"/>
   	<TextView 
   		android:id="@+id/card_column2"
 		android:layout_width="0dip"
@@ -19,5 +19,5 @@
 		android:layout_height="fill_parent"
 		android:layout_weight="1"
 		android:gravity="center_vertical"
-		android:layout_marginLeft="0.5dip"/>
+		android:paddingLeft="3dip"/>
 </LinearLayout>

--- a/src/com/ichi2/anki/CardBrowser.java
+++ b/src/com/ichi2/anki/CardBrowser.java
@@ -45,6 +45,7 @@ import android.support.v7.widget.SearchView;
 import android.util.Log;
 import android.util.TypedValue;
 import android.view.KeyEvent;
+import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -56,7 +57,7 @@ import android.widget.AdapterView.OnItemLongClickListener;
 import android.widget.AdapterView.OnItemSelectedListener;
 import android.widget.ArrayAdapter;
 import android.widget.ListView;
-import android.widget.SimpleAdapter;
+import android.widget.BaseAdapter;
 import android.widget.Spinner;
 import android.widget.TextView;
 
@@ -85,7 +86,7 @@ public class CardBrowser extends ActionBarActivity {
     private ListView mCardsListView;
     private Spinner mCardsColumn1Spinner;
     private Spinner mCardsColumn2Spinner;
-    private SimpleAdapter mCardsAdapter;
+    private MultiColumnListAdapter mCardsAdapter;
     private String mSearchTerms;
     private String mRestrictOnDeck;
 
@@ -134,6 +135,21 @@ public class CardBrowser extends ActionBarActivity {
         "cardReps",
         "cardLapses"};
     String[] mOrderByFields;
+    // list of available keys in mCards corresponding to the column names in R.array.browser_column2_headings. Note: the last 6 are currently hidden
+    private static final String[] COLUMN_KEYS = {"answer",
+        "card",
+        "deck",
+        "note",
+        "question",
+        "tags",
+        "lapses",
+        "reviews",
+        "changed",
+        "created",
+        "due",
+        "ease",
+        "edited",
+        "interval"};    
 
     private int[] mBackground;
 
@@ -283,12 +299,14 @@ public class CardBrowser extends ActionBarActivity {
         mCardsColumn2Spinner.setOnItemSelectedListener(new OnItemSelectedListener() {
             @Override
             public void onItemSelected(AdapterView<?> parent, View view, int pos, long id) {
-                // If a new column was selected then create a new list adapter with the mapping to new column
+                // If a new column was selected then change the key used to map from mCards to the column TextView
                 if (pos != mColumn2Index) {
                         mColumn2Index = pos;
                         AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance().getBaseContext()).edit()
                             .putInt("cardBrowserColumn2", mColumn2Index).commit();
-                        setBrowserListAdapter(mColumn2Index);
+                        String[] fromMap = mCardsAdapter.getFromMapping();
+                        fromMap[1] = COLUMN_KEYS[mColumn2Index];
+                        mCardsAdapter.setFromMapping(fromMap);
                 }
             }
             @Override
@@ -296,8 +314,22 @@ public class CardBrowser extends ActionBarActivity {
                 // Do Nothing
             }
         });
-        // Setup the list adapter for the cards
-        setBrowserListAdapter(mColumn2Index);
+        // get the font and font size from the preferences
+        int sflRelativeFontSize = preferences.getInt("relativeCardBrowserFontSize", DEFAULT_FONT_SIZE_RATIO);
+        String sflCustomFont = preferences.getString("browserEditorFont", ""); 
+        // make a new list adapter mapping the data in mCards to column1 and column2 of R.layout.card_item_browser
+        mCardsAdapter = new MultiColumnListAdapter(
+                this,
+                mCards,
+                R.layout.card_item_browser,
+                new String[] {"sfld", COLUMN_KEYS[mColumn2Index]},
+                new int[] {R.id.card_sfld, R.id.card_column2},
+                "flags",
+                sflRelativeFontSize,
+                sflCustomFont);
+        // link the adapter to the main mCardsListView
+        mCardsListView.setAdapter(mCardsAdapter);   
+        // set the spinner index
         mCardsColumn2Spinner.setSelection(mColumn2Index);
 
 
@@ -930,8 +962,7 @@ public class CardBrowser extends ActionBarActivity {
     private DeckTask.TaskListener mRenderQAHandler = new DeckTask.TaskListener() {
         @Override
         public void onProgressUpdate(TaskData... values) {
-            mCards  = values[0].getCards();
-            updateList();
+            mCardsAdapter.notifyDataSetChanged();
         }
 
         @Override
@@ -1019,93 +1050,120 @@ public class CardBrowser extends ActionBarActivity {
     }
 
 
-    // Helper method to setup the list adapter for the main mCardsListView, taking the index for column2 as an argument
-    private void setBrowserListAdapter(int column2){
-        // list of available keys in mCards corresponding to the column names in R.array.browser_column2_headings. Note: the last 6 are currently hidden
-        final String[] KEYS = {"answer","card","deck","note","question","tags","lapses","reviews","changed","created","due","ease","edited","interval"};
-        // load the preferences
-        SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(getBaseContext());
-        // get the font and font size from the preferences
-        int sflRelativeFontSize = preferences.getInt("relativeCardBrowserFontSize", DEFAULT_FONT_SIZE_RATIO);
-        String sflCustomFont = preferences.getString("browserEditorFont", "");
-        // make a new list adapter mapping the data in mCards to column1 and column2 of R.layout.card_item_browser
-        mCardsAdapter = new SizeControlledListAdapter(
-                this,
-                mCards,
-                R.layout.card_item_browser,
-                new String[] {"flags", "sfld", KEYS[column2]},
-                new int[] {R.id.card_item_browser, R.id.card_sfld, R.id.card_column2},
-                sflRelativeFontSize,
-                sflCustomFont);
-        /* Set the background color of each row based on the state of the card
-        using the flags string associated with the card_item_browser layout in mCardsAdapter */
-        mCardsAdapter.setViewBinder(new SimpleAdapter.ViewBinder() {
-            @Override
-            public boolean setViewValue(View view, Object arg1, String text) {
-                if (view.getId() == R.id.card_item_browser) {
-                    int which = BACKGROUND_NORMAL;
-                    if (text.equals("1")) {
-                        which = BACKGROUND_SUSPENDED;
-                    } else if (text.equals("2")) {
-                        which = BACKGROUND_MARKED;
-                    } else if (text.equals("3")) {
-                        which = BACKGROUND_MARKED_SUSPENDED;
-                    }
-                    view.setBackgroundResource(mBackground[which]);
-                    return true;
-                }
-                return false;
-            }
-        });
-        // link the adapter we just made to the main mCardsListView
-        mCardsListView.setAdapter(mCardsAdapter);
-    }
 
-    public class SizeControlledListAdapter extends SimpleAdapter {
-
-        private int fontSizeScalePcent;
-        private float originalTextSize = -1.0f;
+    private final class MultiColumnListAdapter extends BaseAdapter {
+        private ArrayList<HashMap<String, String>> mData;
+        private final int mResource;
+        private String[] mFromKeys;
+        private final int[] mToIds;
+        private final String mColorFlagKey;
+        private float mOriginalTextSize = -1.0f;
+        private final int mFontSizeScalePcent;
         private Typeface mCustomTypeface = null;
+        private LayoutInflater mInflater;
 
 
-        public SizeControlledListAdapter(Context context, List<? extends Map<String, ?>> data, int resource,
-                String[] from, int[] to, int fontSizeScalePcent, String customFont) {
-            super(context, data, resource, from, to);
-            this.fontSizeScalePcent = fontSizeScalePcent;
+        public MultiColumnListAdapter(Context context, ArrayList<HashMap<String, String>> data, int resource,
+                String[] from, int[] to, String colorFlagKey, int fontSizeScalePcent, String customFont) {            
+            mData = data;
+            mResource = resource;
+            mFromKeys = from;
+            mToIds = to;
+            mColorFlagKey = colorFlagKey;
+            mFontSizeScalePcent = fontSizeScalePcent;
             if (!customFont.equals("")) {
                 mCustomTypeface = AnkiFont.getTypeface(context, customFont);
             }
+            mInflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
         }
 
 
         public View getView(int position, View convertView, ViewGroup parent) {
-            View view = super.getView(position, convertView, parent);
-
-            // Iterate on all first level children
-            if (view instanceof ViewGroup) {
-                ViewGroup group = ((ViewGroup) view);
-                View child;
-                for (int i = 0; i < group.getChildCount(); i++) {
-                    child = group.getChildAt(i);
-                    // and set text size and custom font on the sfld view only
-                    if (child instanceof TextView && child.getId() == R.id.card_sfld) {
-                        float currentSize = ((TextView) child).getTextSize();
-                        if (originalTextSize < 0) {
-                            originalTextSize = ((TextView) child).getTextSize();
-                        }
-                        // do nothing when pref is 100% and apply scaling only once
-                        if (fontSizeScalePcent != 100 && Math.abs(originalTextSize - currentSize) < 0.1) {
-                            ((TextView) child).setTextSize(TypedValue.COMPLEX_UNIT_SP, originalTextSize
-                                    * (fontSizeScalePcent / 100.0f));
-                        }
-
-                        if (mCustomTypeface != null) {
-                            ((TextView) child).setTypeface(mCustomTypeface);
-                        }
-                    }
+            // Get the main container view if it doesn't already exist, and call bindView
+            View v;            
+            if (convertView == null){
+                v = mInflater.inflate(mResource, parent, false);
+                final int count = mToIds.length;
+                final View[] columns = new View[count];
+                for (int i = 0; i < count; i++) {
+                    columns[i] = v.findViewById(mToIds[i]);
                 }
+                v.setTag(columns);                
+            } else {
+                v = convertView;
             }
-            return view;
+            bindView(position, v);
+            return v;
+        }
+        
+        private void bindView(int position, View v) {
+            // Draw the content in the columns
+            View[] columns = (View[]) v.getTag();
+            final Map<String, String> dataSet = mData.get(position);
+            final int color = getColor(dataSet.get(mColorFlagKey));
+            for (int i = 0; i < mToIds.length; i++) {
+                TextView col = (TextView) columns[i];
+                // set font for column
+                setFont(col);
+                // set background color for column
+                col.setBackgroundResource(mBackground[color]);
+                // set text for column
+                col.setText(dataSet.get(mFromKeys[i]));
+            }           
+        }
+
+        private void setFont(TextView v) {
+            // Set the font and font size for a TextView v
+            float currentSize = v.getTextSize();
+            if (mOriginalTextSize < 0) {
+                mOriginalTextSize = v.getTextSize();
+            }
+            // do nothing when pref is 100% and apply scaling only once
+            if (mFontSizeScalePcent != 100 && Math.abs(mOriginalTextSize - currentSize) < 0.1) {
+                v.setTextSize(TypedValue.COMPLEX_UNIT_SP, mOriginalTextSize * (mFontSizeScalePcent / 100.0f));
+            }
+
+            if (mCustomTypeface != null) {
+                v.setTypeface(mCustomTypeface);
+            }
+        }
+        
+        private int getColor(String flag){
+            int which = BACKGROUND_NORMAL;
+            if (flag.equals("1")) {
+                which = BACKGROUND_SUSPENDED;
+            } else if (flag.equals("2")) {
+                which = BACKGROUND_MARKED;
+            } else if (flag.equals("3")) {
+                which = BACKGROUND_MARKED_SUSPENDED;
+            }            
+            return which;
+        }
+        
+        public void setFromMapping(String[] from){
+            mFromKeys = from;
+            notifyDataSetChanged();
+        }
+        
+        public String[] getFromMapping(){
+            return mFromKeys;
+        }        
+        
+        @Override
+        public int getCount() {
+            return mData.size();
+        }
+
+
+        @Override
+        public Object getItem(int position) {
+            return mData.get(position);
+        }
+
+
+        @Override
+        public long getItemId(int position) {
+            return position;
         }
     }
 


### PR DESCRIPTION
Before the vertical scroll position wasn't maintained when changing columns because I was creating a new adapter every time... Here I've extended the adapter class to be able to handle a change in the data mapping, so that the vertical scroll position is maintained.

I also increased the spacing between columns, as it was looking too cramped.
