### PR TITLE
Grab all answer audio, even above answer horizonal rule

### DIFF
--- a/src/com/ichi2/libanki/Collection.java
+++ b/src/com/ichi2/libanki/Collection.java
@@ -956,7 +956,10 @@ public class Collection {
                     }
                 }
 
-                fields.put("FrontSide", d.get("q"));
+                // the following line differs from inherited libanki (original in comment)  
+                fields.put("FrontSide", d.get("q")); // fields.put("FrontSide", mMedia.stripAudio(d.get("q")));
+                
+                 
 
                 // runFilter mungeFields for type "a"
                 fparser = new Models.fieldParser(fields);


### PR DESCRIPTION
This change is complete.

This change might be replaced by #279, both of which address issue 2068 -- merge only one of the two, and close the other. The trade offs are: #279 holds libanki in the utmost of regard, working around that constraint by calling some code more than once, whereas this one would be less complex, but maintains a discrepancy from anki desktop libanki code. I very much recommend this code here -- look at the one line of libanki code that #279 returns to the original -- if you can find it in yourself to leave libanki one line out of sync, do that.

This request obviates request #277. If you merge this please close #277 if it has not yet been merged.

This change cleans several areas up, including using the content passed into the function as the source for the sounds instead of looking them up separately.
