### PR TITLE
Grab all answer audio, even above answer horizonal rule

### DIFF
--- a/src/com/ichi2/anki/Reviewer.java
+++ b/src/com/ichi2/anki/Reviewer.java
@@ -2389,6 +2389,7 @@ public class Reviewer extends AnkiActivity {
         setFlipCardAnimation();
 
         String answer = mCurrentCard.getAnswer(mCurrentSimpleInterface);
+        answer = IncludeAnyFrontSideAudio(answer);
         answer = typeAnsAnswerFilter(answer);
 
         if (mDisplayKanjiInfo) {
@@ -2461,8 +2462,78 @@ public class Reviewer extends AnkiActivity {
             mTimeoutHandler.postDelayed(mShowQuestionTask, mWaitQuestionSecond * 1000);
         }
     }
-
-
+    
+    
+    /**
+     * getAnswerFormat returns the answer part of this card's template as entered by user,
+     * without any parsing
+     */
+    public String getAnswerFormat() {
+        try {                    
+            JSONObject model = mCurrentCard.model();
+            JSONObject template;
+            if (model.getInt("type") == Sched.MODEL_STD) {
+                template = model.getJSONArray("tmpls").getJSONObject((Integer) mCurrentCard.getOrd());
+            } else {
+                template = model.getJSONArray("tmpls").getJSONObject(0);
+            }
+            
+            return template.getString("afmt");
+        } catch (JSONException e) {
+            throw new RuntimeException(e);
+        }            
+    }    
+    
+    
+    /**
+     * IncludeAnyFrontSideAudio is intended to take answerContent, as generated through libanki,
+     * and replace any audio that is stripped out when {{FrontSide}} is expanded. The motivation for
+     * this function was to allow Collection._renderQA() to more closely the core libanki code,
+     * which strips audio that ankidroid functionally exposes.
+     * @param answerContent the answer as rendered by  
+     */
+    private String IncludeAnyFrontSideAudio(String answerContent) {
+     // we need to re-inflate FrontSide audio if it appears in answer
+        String FullAudioContent = answerContent;
+        JSONObject t = mCurrentCard.template();
+        String afmt;
+        try {
+            afmt = t.getString("afmt");
+        } catch (JSONException e) {
+            throw new RuntimeException(e);
+        }
+        if (afmt.indexOf("{{FrontSide}}") != -1) {
+            // FrontSide is included on answer
+            String frontSideContentWithAudio = mCurrentCard._getQA(false).get("q");
+            String frontSideAudioless = AnkiDroidApp.getCol().getMedia().stripAudio(frontSideContentWithAudio);
+            if (!frontSideContentWithAudio.contentEquals(frontSideAudioless)) {
+                // FrontSide had audio that needs to be reinstated
+                afmt = afmt.replace("{{FrontSide}}", "[({FrontSide})]"); // put a placeholder
+                Note n = mCurrentCard.note(false);
+                JSONObject m = mCurrentCard.model();
+                Object[] data;
+                try {
+                    data = new Object[] { mCurrentCard.getId(), n.getId(), m.getLong("id"), mCurrentCard.getODid() != 0l ? mCurrentCard.getODid() : mCurrentCard.getDid(), mCurrentCard.getOrd(),
+                            n.stringTags(), n.joinedFields() };
+                } catch (JSONException e) {
+                    throw new RuntimeException(e);
+                }
+                // renderQA with our placeholder format
+                HashMap<String, String> QA = AnkiDroidApp.getCol()._renderQA(data, null, afmt);
+                String answerContentWithPlaceholder = QA.get("a");
+                // expand placeholder to FrontSide with embedded audio
+                FullAudioContent = answerContentWithPlaceholder.replace("[({FrontSide})]", frontSideContentWithAudio);
+                if (mCurrentSimpleInterface) {
+                    FullAudioContent = FullAudioContent.replaceAll("<hr[^>]*>", "<br>\u2500\u2500\u2500\u2500\u2500<br>");
+                } else {
+                    FullAudioContent = mCurrentCard.css() + FullAudioContent;
+                }                
+            }
+        }
+        return FullAudioContent;
+    }
+    
+    
     private void updateCard(String content) {
         Log.i(AnkiDroidApp.TAG, "updateCard");
 
@@ -2481,24 +2552,20 @@ public class Reviewer extends AnkiActivity {
                 mCard.getSettings().setDefaultFontSize(calculateDynamicFontSize(content));
             }
 
-            String question = "";
-            String answer = "";
-            int qa = -1; // prevent uninitialized variable errors
-
-            if (sDisplayAnswer) {
-                qa = MetaDB.LANGUAGES_QA_ANSWER;
-                answer = mCurrentCard.getPureAnswerForReading();
-                // don't add answer sounds multiple times, such as when reshowing card after exiting editor
-                if (!mAnswerSoundsAdded) {
-                    Sound.addSounds(mBaseUrl, answer, qa);
-                    mAnswerSoundsAdded = true;
-                }
-            } else {
-                Sound.resetSounds(); // reset sounds each time first side of card is displayed, even after leaving the editor
+            int qa = sDisplayAnswer ? MetaDB.LANGUAGES_QA_ANSWER : MetaDB.LANGUAGES_QA_QUESTION;
+            if (!sDisplayAnswer) {
+                Sound.resetSounds(); // whenever showing question, start audio list over
                 mAnswerSoundsAdded = false;
-                qa = MetaDB.LANGUAGES_QA_QUESTION;
-                question = mCurrentCard.getQuestion(mCurrentSimpleInterface);
-                Sound.addSounds(mBaseUrl, question, qa);
+                Sound.addSounds(mBaseUrl, content, qa);
+            } else { // sDisplayAnswer == true
+                String afmt = getAnswerFormat(); // to check for embedded {{FrontSide}}
+                String answerSoundSource = content;
+                if (afmt.indexOf("{{FrontSide}}") != -1) { // don't grab front side audio
+                    String fromFrontSide = mCurrentCard._getQA(false).get("q");
+                    answerSoundSource = content.replace(fromFrontSide, "");
+                }
+                Sound.addSounds(mBaseUrl, answerSoundSource, qa); 
+                mAnswerSoundsAdded = true;
             }
 
             content = Sound.expandSounds(mBaseUrl, content, mSpeakText, qa);

--- a/src/com/ichi2/libanki/Collection.java
+++ b/src/com/ichi2/libanki/Collection.java
@@ -956,7 +956,7 @@ public class Collection {
                     }
                 }
 
-                fields.put("FrontSide", d.get("q"));
+                fields.put("FrontSide", mMedia.stripAudio(d.get("q")));
 
                 // runFilter mungeFields for type "a"
                 fparser = new Models.fieldParser(fields);


### PR DESCRIPTION
This change is an alternative for #278, both of which address issue 2068 -- merge only one of the two, and close the other. The trade offs are: this one holds libanki in the utmost of regard, working around that constraint by calling some code more than once, whereas #278 would be less complex, but it maintains a discrepancy from anki desktop libanki code. I personally recommend #278 -- i don't think it's asking too much to have one slight libanki difference that suits us, rather than "fight to the death for identical libanki" at the price of all this extra code. Just my 2 cents.

This request obviates request #277. If you merge this please close #277 if it has not yet been merged.

We had issues in the past, where a call here involved regex calls that significantly slowed down users, so I address that topic of code speed here. When it comes to rendering questions, the code is slightly simplified, so there we are good. When it comes to rendering answers (where we had the issue before), this change certainly introduces a decent amount of code. The meat of that new code comes down to one call each to Reviewer.getAnswerFormat() and Reviewer.IncludeAnyFrontSideAudio(). That second call is highly repetitive in nature (necessarily so), in that in calls _renderQA a second time, and it also recalls a replaceAll regex operation a second time as well. I do not see any lag on my system, but I didn't see it before with the other issue either. I will be running some timing tests for 3 scenarios: 1) how it was after the last lag fix but before addressing issue 2068, 2) how it is after #278, and 3) how it is with this change. I will post those results in this conversation. However again, I did not encounter any lag with this last recent lag issue where other users did, so my system alone is likely not representative of the problem they encountered, for whatever reason (it's a somewhat dinky phone, but).

Both requests address the behavior, but this one not only makes no changes to libanki, but at the request of @timrae and suggestion of @dae goes out of its way to return a part of libanki that has differed for awhile back to a state that is closer to the core libanki we inherit.

A decent amount of effort is spent reproducing the expected ankidroid behavior of having all audio linked to media that a user can play by pressing the play buttons -- such that the user can independently play any one of the audio files present, including those expanded from inclusion of {{FrontSide}}

To that aim, the FrontSide audio which is now stripped in Collection._renderQA (from libanki) is then immediately reinserted. And then, that re-inserted audio from FrontSide is not added to the list of audio that is to be auto-played as part of the answer. If the question is to be repeated automatically, that question audio is already in the list designated as part of the question.

This request maintains the proper separation of question and answer audio that already existed, but the list of answer audio added for playing now strips the {{FrontSide}} expansion, rather than relying on the &lthr id=answer> as delineating the answer, which for some users I was told it did not.
