### PR TITLE
fix whiteboard state not loading

### DIFF
--- a/res/values/10-preferences.xml
+++ b/res/values/10-preferences.xml
@@ -55,6 +55,7 @@
 <string name="fade_scrollbars">Fade scrollbars</string>
 <string name="fade_scrollbars_summ">Automatically fade out flashcard scrollbars when not scrolling</string>
 <!-- show_whiteboard -> Reviewer.java -->
+<string name="enable_whiteboard">Enable Whiteboard</string>
 <string name="show_whiteboard_summ">Lets you write on the screen</string>
 <string name="whiteboard_stroke_width">Whiteboard stroke width</string>
 <string name="whiteboard_stroke_width_summ">Width of the stroke: XXX</string>

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -359,7 +359,7 @@
                 android:disableDependentsState="false"
                 android:key="whiteboard"
                 android:summary="@string/show_whiteboard_summ"
-                android:title="@string/show_whiteboard" />
+                android:title="@string/enable_whiteboard" />
             <com.hlidskialf.android.preference.SeekBarPreference
                 android:defaultValue="6"
                 android:dependency="whiteboard"

--- a/src/com/ichi2/anki/Reviewer.java
+++ b/src/com/ichi2/anki/Reviewer.java
@@ -982,7 +982,8 @@ public class Reviewer extends AnkiActivity {
             }
 
             // Get last whiteboard state
-            if (mPrefWhiteboard && mCurrentCard != null && MetaDB.getWhiteboardState(this, mCurrentCard.getDid()) == 1) {
+            long deckID = mSched.getCol().getDecks().current().optLong("id",-1);
+            if (mPrefWhiteboard && deckID!=-1 && MetaDB.getWhiteboardState(this, deckID) == 1) {            
                 mShowWhiteboard = true;
                 mWhiteboard.setVisibility(View.VISIBLE);
             }

--- a/tests/.classpath
+++ b/tests/.classpath
@@ -2,7 +2,7 @@
 <classpath>
 	<classpathentry kind="con" path="com.android.ide.eclipse.adt.ANDROID_FRAMEWORK"/>
 	<classpathentry exported="true" kind="con" path="com.android.ide.eclipse.adt.LIBRARIES"/>
-	<classpathentry kind="con" path="com.android.ide.eclipse.adt.DEPENDENCIES"/>
+	<classpathentry exported="true" kind="con" path="com.android.ide.eclipse.adt.DEPENDENCIES"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/AnkiDroid"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="gen"/>


### PR DESCRIPTION
The saved whiteboard state wasn't loading properly because we were trying to get the deckID from `mCurrentCard` before it was loaded. This fixes [issue 1447](https://code.google.com/p/ankidroid/issues/detail?id=1447).

Also renamed "Show Whiteboard" in user preferences to "Enable Whiteboard" as per [issue 676](https://code.google.com/p/ankidroid/issues/detail?id=676)
