### PR TITLE
Top align QA in card browser

### DIFF
--- a/res/layout/card_item_browser.xml
+++ b/res/layout/card_item_browser.xml
@@ -1,23 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
-  	xmlns:android="http://schemas.android.com/apk/res/android"
-  	android:id="@+id/card_item_browser"
-  	android:layout_width="fill_parent"
-  	android:layout_height="wrap_content">
-  	<TextView 
-  		android:id="@+id/card_sfld"
+	xmlns:android="http://schemas.android.com/apk/res/android"
+	android:id="@+id/card_item_browser"
+	android:layout_width="fill_parent"
+	android:layout_height="wrap_content">
+	<TextView
+		android:id="@+id/card_sfld"
 		android:layout_width="0dip"
 		android:layout_height="fill_parent"
-		android:textColor="#000000"
 		android:layout_weight="1"
-		android:gravity="center_vertical"
+		android:textColor="#000000"
 		android:paddingRight="3dip"/>
-  	<TextView 
-  		android:id="@+id/card_column2"
+	<TextView
+		android:id="@+id/card_column2"
 		android:layout_width="0dip"
-		android:textColor="#000000"
 		android:layout_height="fill_parent"
 		android:layout_weight="1"
-		android:gravity="center_vertical"
+		android:textColor="#000000"
 		android:paddingLeft="3dip"/>
 </LinearLayout>


### PR DESCRIPTION
I know this is Tim's territory :wink:, but it was much quicker to fix it than starting a discussion: I think the card browser is more readable if the text is not center aligned.

Before:
![align-top](https://cloud.githubusercontent.com/assets/527708/2688803/cee565b8-c2cb-11e3-89cd-2988a991fe25.png)

After:
![align-center](https://cloud.githubusercontent.com/assets/527708/2688802/c9e0e7b8-c2cb-11e3-9311-592eb4d9e418.png)

What do y'all think?
