### PR TITLE
Remove "Reset as new" leech action

### DIFF
--- a/res/values/11-arrays.xml
+++ b/res/values/11-arrays.xml
@@ -92,7 +92,6 @@
 	<string-array name="leech_action_labels">
 		<item>Suspend card</item>
 		<item>Tag only</item>
-		<item>Reset as new</item>
 	</string-array>
    	<string-array name="new_order_labels">
 		<item>New cards in random order</item>

--- a/res/values/constants.xml
+++ b/res/values/constants.xml
@@ -123,7 +123,6 @@
     <string-array name="leech_action_values">
         <item>0</item>
         <item>1</item>
-        <item>2</item>
     </string-array>
     <string-array name="new_order_values">
         <item>0</item>


### PR DESCRIPTION
The _Reset as new_ leech action is not included in Anki Desktop anymore. It doesn't have an effect in AnkiDroid either. Is it necessary to update users of this option to a valid one?
