### PR TITLE
Add a “replay” to the reviewer’s menu.

### DIFF
--- a/res/menu/reviewer.xml
+++ b/res/menu/reviewer.xml
@@ -47,6 +47,10 @@
 
 	</item>
 
+    <item android:id="@+id/action_replay"
+        android:icon="@android:drawable/ic_media_play"
+        android:title="@string/replay_audio" />
+
 	<item android:id="@+id/action_whiteboard"
 		android:title="@string/hide_whiteboard"
 		android:visible="false" />

--- a/res/values/02-strings.xml
+++ b/res/values/02-strings.xml
@@ -38,6 +38,7 @@
 <string name="show_whiteboard">Show Whiteboard</string>
 <string name="hide_whiteboard">Hide Whiteboard</string>
 <string name="clear_whiteboard">Clear Whiteboard</string>
+<string name="replay_audio">Replay audio</string>
 <string name="cram_edit_warning">Card editing not allowed while cramming</string>
 <string name="suspend_leeches">Suspend Leeches</string>
 <string name="leech_suspend_notification">Card marked as leech and suspended</string>
@@ -47,7 +48,7 @@
 <!--Browser-->
 <string-array name="browser_column1_headings">
     <item>Search Field</item>
-</string-array>   
+</string-array>
 <string-array name="browser_column2_headings">
 	<item>Answer</item>
 	<item>Card</item>
@@ -55,14 +56,14 @@
 	<item>Note</item>
 	<item>Question</item>
 	<item>Tags</item>
-	<item>Lapses</item>	
-	<item>Reviews</item>	
+	<item>Lapses</item>
+	<item>Reviews</item>
 	<!--<item>Changed</item>
 	<item>Created</item>
 	<item>Due</item>
 	<item>Ease</item>
 	<item>Edited</item>
-	<item>Interval</item>-->	
+	<item>Interval</item>-->
 </string-array>
 
 <!--Card Editor-->
@@ -73,7 +74,7 @@
 <string name="factadder_saving_error">Error saving note</string>
 
 <string name="pref_lang_support">Language</string>
-    
+
 <string name="saving_facts">Saving note</string>
 <string name="deck">Deck</string>
 <string name="add">Add</string>
@@ -82,7 +83,7 @@
 
 <string name="saving_changes">Saving changes...</string>
 <string name="reordering_cards">Reordering cards...</string>
-    
+
 <plurals name="timebox_reached">
   <item quantity="one">1 card studied in %2$s</item>
   <item quantity="other">%1$d cards studied in %2$s</item>
@@ -130,7 +131,7 @@
 
 <string name="check_db">Check database</string>
 <string name="check_db_message">Checking database.\nPlease wait...</string>
-    
+
 <string name="simple_interface_hint">Empty %s. Bear in mind that simple interface cannot show pictures/sounds etc.</string>
 
 <string name="delete_deck">Deleting deck...\nPlease wait.</string>

--- a/res/xml/deck_options.xml
+++ b/res/xml/deck_options.xml
@@ -139,8 +139,7 @@
             <CheckBoxPreference
                 android:key="replayQuestion"
                 android:summary="@string/deck_conf_replayq_summ"
-                android:title="@string/deck_conf_replayq"
-                android:dependency="autoPlayAudio" />
+                android:title="@string/deck_conf_replayq" />
         </PreferenceScreen>
         <PreferenceScreen android:title="@string/deck_conf_manage" >
             <Preference

--- a/src/com/ichi2/anki/Reviewer.java
+++ b/src/com/ichi2/anki/Reviewer.java
@@ -967,7 +967,7 @@ public class Reviewer extends AnkiActivity {
 
             // Get last whiteboard state
             long deckID = mSched.getCol().getDecks().current().optLong("id",-1);
-            if (mPrefWhiteboard && deckID!=-1 && MetaDB.getWhiteboardState(this, deckID) == 1) {            
+            if (mPrefWhiteboard && deckID!=-1 && MetaDB.getWhiteboardState(this, deckID) == 1) {
                 mShowWhiteboard = true;
                 mWhiteboard.setVisibility(View.VISIBLE);
             }
@@ -1330,6 +1330,10 @@ public class Reviewer extends AnkiActivity {
             case R.id.action_mark_card:
                 DeckTask.launchDeckTask(DeckTask.TASK_TYPE_MARK_CARD, mMarkCardHandler, new DeckTask.TaskData(mSched,
                         mCurrentCard, 0));
+                return true;
+
+            case R.id.action_replay:
+                playSounds(true);
                 return true;
 
             case R.id.action_edit:
@@ -2494,7 +2498,7 @@ public class Reviewer extends AnkiActivity {
         }
 
         if (!mConfigurationChanged) {
-            playSounds();
+            playSounds(false);  // Play sounds, but only if autoplay is true.
     	}
 	}
 
@@ -2515,13 +2519,16 @@ public class Reviewer extends AnkiActivity {
         return sb.toString();
     }
 
+
     /**
-     * Plays sounds (or TTS, if configured) for current shown side of card
+     * Plays sounds (or TTS, if configured) for currently shown side of card.
+     * @param play_always Switch whether to ignore the autoplay setting.
      */
-    private void playSounds() {
+    private void playSounds(boolean play_always) {
         try {
-            // first check, if sound is activated for the current deck
-            if (getConfigForCurrentCard().getBoolean("autoplay")) {
+            // First check whether sound is activated for the current deck, but only if this is not called as
+            // “replay”, through the menu or a play media gesture.
+            if (play_always || getConfigForCurrentCard().getBoolean("autoplay")) {
                 // We need to play the sounds from the proper side of the card
                 if (!mSpeakText) {
                     // when showing answer, repeat question audio if so configured
@@ -3097,7 +3104,7 @@ public class Reviewer extends AnkiActivity {
                 }
                 break;
             case GESTURE_PLAY_MEDIA:
-                playSounds();
+                playSounds(true);
                 break;
         }
     }


### PR DESCRIPTION
As @dae has noted in relation to PR #278:

> AnkiMobile provides a global replay button as an assignable action or from a menu, so by default users only see the embedded buttons

So here is a menu item that replays all files.

To do the replay i added a switch to Reviewer.playSounds() to ignore the autoplay setting at the right times. That should make "play sound' gestures work, too, when autoplay is off.

It  makes the "replay question, too" setting independent of the "autoplay". That seems like the Right Thing when there is a way to replay audio.

(And my emacs automatically nixes trailing whitespace.)
