### PR TITLE
fix memory leak due to statically declared DeckTask variable

### DIFF
--- a/src/com/ichi2/async/DeckTask.java
+++ b/src/com/ichi2/async/DeckTask.java
@@ -197,7 +197,7 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
 
     private final int mType;
     private final Listener mListener;
-    private final DeckTask mPreviousTask;
+    private DeckTask mPreviousTask;
 
 
     public DeckTask(int type, Listener listener, DeckTask previousTask) {
@@ -235,7 +235,7 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
                 Log.e(AnkiDroidApp.TAG, "previously running task was cancelled: " + mPreviousTask.mType, e);
             }
         }
-
+        
         // Actually execute the task now that we are at the front of the queue.
         switch (mType) {
             case TASK_TYPE_OPEN_COLLECTION:
@@ -362,6 +362,8 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
     protected void onPostExecute(TaskData result) {
         super.onPostExecute(result);
         mListener.onPostExecute(this, result);
+        Log.i(AnkiDroidApp.TAG, "enabling garbage collection of mPreviousTask...");
+        mPreviousTask = null;
     }
 
 


### PR DESCRIPTION
`DeckTask sLatestInstance` in Async.DeckTask gets stored statically so that we can keep track of the previous task, however this was causing a memory leak, which became dramatically enhanced when the whiteboard is enabled, especially on devices with large screens -- [see issue 1907](https://code.google.com/p/ankidroid/issues/detail?id=1907).

This fixes the problem by destroying the reference to the old `DeckTask` object once the new `DeckTask` has finished.
