### PR TITLE
Fix inconsistent replayq behavior, by adding new menu entry to globally replay audio

### DIFF
--- a/res/menu/reviewer.xml
+++ b/res/menu/reviewer.xml
@@ -47,6 +47,10 @@
 
 	</item>
 
+    <item android:id="@+id/action_replay"
+        android:title="@string/replay_audio"
+        android:visible="false" />
+
 	<item android:id="@+id/action_whiteboard"
 		android:title="@string/hide_whiteboard"
 		android:visible="false" />

--- a/res/values/02-strings.xml
+++ b/res/values/02-strings.xml
@@ -38,6 +38,7 @@
 <string name="show_whiteboard">Show Whiteboard</string>
 <string name="hide_whiteboard">Hide Whiteboard</string>
 <string name="clear_whiteboard">Clear Whiteboard</string>
+<string name="replay_audio">Replay audio</string>
 <string name="cram_edit_warning">Card editing not allowed while cramming</string>
 <string name="suspend_leeches">Suspend Leeches</string>
 <string name="leech_suspend_notification">Card marked as leech and suspended</string>
@@ -47,7 +48,7 @@
 <!--Browser-->
 <string-array name="browser_column1_headings">
     <item>Search Field</item>
-</string-array>   
+</string-array>
 <string-array name="browser_column2_headings">
 	<item>Answer</item>
 	<item>Card</item>
@@ -55,14 +56,14 @@
 	<item>Note</item>
 	<item>Question</item>
 	<item>Tags</item>
-	<item>Lapses</item>	
-	<item>Reviews</item>	
+	<item>Lapses</item>
+	<item>Reviews</item>
 	<!--<item>Changed</item>
 	<item>Created</item>
 	<item>Due</item>
 	<item>Ease</item>
 	<item>Edited</item>
-	<item>Interval</item>-->	
+	<item>Interval</item>-->
 </string-array>
 
 <!--Card Editor-->
@@ -73,7 +74,7 @@
 <string name="factadder_saving_error">Error saving note</string>
 
 <string name="pref_lang_support">Language</string>
-    
+
 <string name="saving_facts">Saving note</string>
 <string name="deck">Deck</string>
 <string name="add">Add</string>
@@ -82,7 +83,7 @@
 
 <string name="saving_changes">Saving changes...</string>
 <string name="reordering_cards">Reordering cards...</string>
-    
+
 <plurals name="timebox_reached">
   <item quantity="one">1 card studied in %2$s</item>
   <item quantity="other">%1$d cards studied in %2$s</item>
@@ -130,7 +131,7 @@
 
 <string name="check_db">Check database</string>
 <string name="check_db_message">Checking database.\nPlease wait...</string>
-    
+
 <string name="simple_interface_hint">Empty %s. Bear in mind that simple interface cannot show pictures/sounds etc.</string>
 
 <string name="delete_deck">Deleting deck...\nPlease wait.</string>

--- a/res/xml/deck_options.xml
+++ b/res/xml/deck_options.xml
@@ -139,8 +139,7 @@
             <CheckBoxPreference
                 android:key="replayQuestion"
                 android:summary="@string/deck_conf_replayq_summ"
-                android:title="@string/deck_conf_replayq"
-                android:dependency="autoPlayAudio" />
+                android:title="@string/deck_conf_replayq" />
         </PreferenceScreen>
         <PreferenceScreen android:title="@string/deck_conf_manage" >
             <Preference

--- a/src/com/ichi2/anki/Reviewer.java
+++ b/src/com/ichi2/anki/Reviewer.java
@@ -639,14 +639,14 @@ public class Reviewer extends AnkiActivity {
 
         @Override
         public void onProgressUpdate(DeckTask.TaskData... values) {
-        	if(mCurrentCard != values[0].getCard()){
-            	/*
-            	 * Before updating mCurrentCard, we check whether it is changing
-            	 * or not. If the current card changes, then we need to display it
-            	 * as a new card, without showing the answer.
-            	 */
-        		sDisplayAnswer = false;
-        	}
+            if(mCurrentCard != values[0].getCard()){
+                /*
+                 * Before updating mCurrentCard, we check whether it is changing
+                 * or not. If the current card changes, then we need to display it
+                 * as a new card, without showing the answer.
+                 */
+                sDisplayAnswer = false;
+            }
             mCurrentCard = values[0].getCard();
             if (mCurrentCard == null) {
                 // If the card is null means that there are no more cards scheduled for review.
@@ -1060,9 +1060,9 @@ public class Reviewer extends AnkiActivity {
 
         if (!isFinishing()) {
             // try {
-        	if (AnkiDroidApp.colIsOpen()) {
+            if (AnkiDroidApp.colIsOpen()) {
                 WidgetStatus.update(this, mSched.progressToday(null, mCurrentCard, true));
-        	}
+            }
 
             // } catch (JSONException e) {
             // throw new RuntimeException(e);
@@ -1211,7 +1211,7 @@ public class Reviewer extends AnkiActivity {
                     public void onPostExecute(DeckTask.TaskData result) {
                         if (mOpenCollectionDialog.isShowing()) {
                             try {
-                            	mOpenCollectionDialog.dismiss();
+                                mOpenCollectionDialog.dismiss();
                             } catch (Exception e) {
                                 Log.e(AnkiDroidApp.TAG, "onPostExecute - Dialog dismiss Exception = " + e.getMessage());
                             }
@@ -1226,7 +1226,7 @@ public class Reviewer extends AnkiActivity {
 
                     @Override
                     public void onPreExecute() {
-                    	mOpenCollectionDialog = StyledOpenCollectionDialog.show(Reviewer.this, getResources().getString(R.string.open_collection), new OnCancelListener() {
+                        mOpenCollectionDialog = StyledOpenCollectionDialog.show(Reviewer.this, getResources().getString(R.string.open_collection), new OnCancelListener() {
                                     @Override
                                     public void onCancel(DialogInterface arg0) {
                                         finish();
@@ -1335,6 +1335,10 @@ public class Reviewer extends AnkiActivity {
             case R.id.action_mark_card:
                 DeckTask.launchDeckTask(DeckTask.TASK_TYPE_MARK_CARD, mMarkCardHandler, new DeckTask.TaskData(mSched,
                         mCurrentCard, 0));
+                return true;
+
+            case R.id.action_replay:
+                playSounds(true);
                 return true;
 
             case R.id.action_edit:
@@ -1451,9 +1455,9 @@ public class Reviewer extends AnkiActivity {
 
     private void stopTimer() {
         // Stop visible timer and card timer
-    	if (mCardTimer != null) {
+        if (mCardTimer != null) {
             mCardTimer.stop();
-    	}
+        }
         if (mCurrentCard != null) {
              mCurrentCard.stopTimer();
         }
@@ -1471,7 +1475,7 @@ public class Reviewer extends AnkiActivity {
 
 
      private void undo() {
-    	if (mSched.getCol().undoAvailable()) {
+        if (mSched.getCol().undoAvailable()) {
             setNextCardAnimation(true);
             if (mProgressDialog != null && mProgressDialog.isShowing()) {
                 mProgressDialog.setMessage(getResources().getString(R.string.saving_changes));
@@ -1480,7 +1484,7 @@ public class Reviewer extends AnkiActivity {
                         getResources().getString(R.string.saving_changes), true);
             }
             DeckTask.launchDeckTask(DeckTask.TASK_TYPE_UNDO, mAnswerCardHandler, new DeckTask.TaskData(mSched));
-    	}
+        }
     }
 
 
@@ -1562,7 +1566,7 @@ public class Reviewer extends AnkiActivity {
 
 
     private int getRecommendedEase(boolean easy) {
-    	try {
+        try {
             switch (mSched.answerButtons(mCurrentCard)) {
             case 2:
                 return EASE_HARD;
@@ -1573,11 +1577,11 @@ public class Reviewer extends AnkiActivity {
             default:
                 return 0;
             }
-    	} catch (RuntimeException e) {
-			AnkiDroidApp.saveExceptionReportFile(e, "Reviewer-getRecommendedEase");
+        } catch (RuntimeException e) {
+            AnkiDroidApp.saveExceptionReportFile(e, "Reviewer-getRecommendedEase");
             closeReviewer(DeckPicker.RESULT_DB_ERROR, true);
-    		return 0;
-    	}
+            return 0;
+        }
     }
 
     private void answerCard(int ease) {
@@ -1823,12 +1827,12 @@ public class Reviewer extends AnkiActivity {
 
         int buttonCount;
         try {
-        	buttonCount = mSched.answerButtons(mCurrentCard);
-    	} catch (RuntimeException e) {
-    		AnkiDroidApp.saveExceptionReportFile(e, "Reviewer-showEaseButtons");
+            buttonCount = mSched.answerButtons(mCurrentCard);
+        } catch (RuntimeException e) {
+            AnkiDroidApp.saveExceptionReportFile(e, "Reviewer-showEaseButtons");
             closeReviewer(DeckPicker.RESULT_DB_ERROR, true);
             return;
-    	}
+        }
 
         // Set correct label for each button
         switch (buttonCount) {
@@ -2027,13 +2031,13 @@ public class Reviewer extends AnkiActivity {
 
         mSimpleInterface = preferences.getBoolean("simpleInterface", false);
         if (mSimpleInterface) {
-        	String tags = preferences.getString("simpleInterfaceExcludeTags", "").replace(",", " ");
-        	mSimpleInterfaceExcludeTags = new ArrayList<String>();
-        	for (String t : tags.split(" ")) {
-        		if (t.length() > 0) {
-        			mSimpleInterfaceExcludeTags.add(t);
-        		}
-        	}
+            String tags = preferences.getString("simpleInterfaceExcludeTags", "").replace(",", " ");
+            mSimpleInterfaceExcludeTags = new ArrayList<String>();
+            for (String t : tags.split(" ")) {
+                if (t.length() > 0) {
+                    mSimpleInterfaceExcludeTags.add(t);
+                }
+            }
         }
 
         // These are preferences we pull out of the collection instead of SharedPreferences
@@ -2048,64 +2052,64 @@ public class Reviewer extends AnkiActivity {
     }
 
     private void setInterface() {
-    	if (mCurrentCard == null) {
-    		return;
-    	}
-    	if (mSimpleInterface) {
-        	Note note = mCurrentCard.note();
-        	mCurrentSimpleInterface = true;
-        	for (String s : mSimpleInterfaceExcludeTags) {
-        		if (note.hasTag(s)) {
-        			mCurrentSimpleInterface = false;
-        			break;
-        		}
-        	}
-    	}
-		if (mCurrentSimpleInterface) {
-			if (mSimpleCard == null) {
-	            mSimpleCard = new ScrollTextView(this);
-	            Themes.setRegularFont(mSimpleCard);
-	            mSimpleCard.setTextSize(TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 10, getResources().getDisplayMetrics()) * mDisplayFontSize / 100);
-	            mSimpleCard.setGravity(Gravity.CENTER);
-	            try {
-	                mSetTextIsSelectable = TextView.class.getMethod("setTextIsSelectable", boolean.class);
-	            } catch (Throwable e) {
-	                Log.i(AnkiDroidApp.TAG, "mSetTextIsSelectable could not be found due to a too low Android version (< 3.0)");
-	                mSetTextIsSelectable = null;
-	            }
-	            if (mSetTextIsSelectable != null) {
-	                try {
-	                    mSetTextIsSelectable.invoke(mSimpleCard, true);
-	                } catch (Exception e) {
-	                    Log.e(AnkiDroidApp.TAG, e.toString());
-	                }
-	            }
-	            mSimpleCard.setClickable(true);
-	            mCardFrame.addView(mSimpleCard);
+        if (mCurrentCard == null) {
+            return;
+        }
+        if (mSimpleInterface) {
+            Note note = mCurrentCard.note();
+            mCurrentSimpleInterface = true;
+            for (String s : mSimpleInterfaceExcludeTags) {
+                if (note.hasTag(s)) {
+                    mCurrentSimpleInterface = false;
+                    break;
+                }
+            }
+        }
+        if (mCurrentSimpleInterface) {
+            if (mSimpleCard == null) {
+                mSimpleCard = new ScrollTextView(this);
+                Themes.setRegularFont(mSimpleCard);
+                mSimpleCard.setTextSize(TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 10, getResources().getDisplayMetrics()) * mDisplayFontSize / 100);
+                mSimpleCard.setGravity(Gravity.CENTER);
+                try {
+                    mSetTextIsSelectable = TextView.class.getMethod("setTextIsSelectable", boolean.class);
+                } catch (Throwable e) {
+                    Log.i(AnkiDroidApp.TAG, "mSetTextIsSelectable could not be found due to a too low Android version (< 3.0)");
+                    mSetTextIsSelectable = null;
+                }
+                if (mSetTextIsSelectable != null) {
+                    try {
+                        mSetTextIsSelectable.invoke(mSimpleCard, true);
+                    } catch (Exception e) {
+                        Log.e(AnkiDroidApp.TAG, e.toString());
+                    }
+                }
+                mSimpleCard.setClickable(true);
+                mCardFrame.addView(mSimpleCard);
 
-	            mSimpleCard.setBackgroundColor(mCurrentBackgroundColor);
-	            mSimpleCard.setTextColor(mForegroundColor);
-			}
-			if (mSimpleCard.getVisibility() != View.VISIBLE || (mCard != null && mCard.getVisibility() == View .VISIBLE)) {
-				mSimpleCard.setVisibility(View.VISIBLE);
-				mCard.setVisibility(View.GONE);
-			}
-		} else {
-			if (mCard == null) {
-	            mCard = createWebView();
+                mSimpleCard.setBackgroundColor(mCurrentBackgroundColor);
+                mSimpleCard.setTextColor(mForegroundColor);
+            }
+            if (mSimpleCard.getVisibility() != View.VISIBLE || (mCard != null && mCard.getVisibility() == View .VISIBLE)) {
+                mSimpleCard.setVisibility(View.VISIBLE);
+                mCard.setVisibility(View.GONE);
+            }
+        } else {
+            if (mCard == null) {
+                mCard = createWebView();
                 mCardFrame.addView(mCard);
-	            if (!mUseQuickUpdate) {
-	                mNextCard = createWebView();
-	                mNextCard.setVisibility(View.GONE);
-	                mCardFrame.addView(mNextCard, 0);
-		            mCard.setBackgroundColor(mCurrentBackgroundColor);
-	            }
-			}
-			if (mCard.getVisibility() != View.VISIBLE || (mSimpleCard != null && mSimpleCard.getVisibility() == View .VISIBLE)) {
-				mSimpleCard.setVisibility(View.GONE);
-				mCard.setVisibility(View.VISIBLE);
-			}
-		}
+                if (!mUseQuickUpdate) {
+                    mNextCard = createWebView();
+                    mNextCard.setVisibility(View.GONE);
+                    mCardFrame.addView(mNextCard, 0);
+                    mCard.setBackgroundColor(mCurrentBackgroundColor);
+                }
+            }
+            if (mCard.getVisibility() != View.VISIBLE || (mSimpleCard != null && mSimpleCard.getVisibility() == View .VISIBLE)) {
+                mSimpleCard.setVisibility(View.GONE);
+                mCard.setVisibility(View.VISIBLE);
+            }
+        }
     }
 
     private void setDueMessage() {
@@ -2199,17 +2203,17 @@ public class Reviewer extends AnkiActivity {
     private void initTimer() {
         mShowTimer = mCurrentCard.showTimer();
         if (mShowTimer && mCardTimer.getVisibility() == View.INVISIBLE) {
-        	switchVisibility(mCardTimer, View.VISIBLE);
+            switchVisibility(mCardTimer, View.VISIBLE);
         } else if (!mShowTimer && mCardTimer.getVisibility() != View.INVISIBLE) {
-        	switchVisibility(mCardTimer, View.INVISIBLE);
+            switchVisibility(mCardTimer, View.INVISIBLE);
         }
         mCardTimer.setBase(SystemClock.elapsedRealtime());
         mCardTimer.start();
     }
 
     private void displayCardQuestion() {
-    	// show timer, if activated in the deck's preferences
-    	initTimer();
+        // show timer, if activated in the deck's preferences
+        initTimer();
 
         sDisplayAnswer = false;
 
@@ -2522,9 +2526,9 @@ public class Reviewer extends AnkiActivity {
         }
 
         if (!mConfigurationChanged) {
-            playSounds();
-    	}
-	}
+            playSounds(false);  // Play sounds, but only if autoplay is true.
+        }
+    }
 
     /**
      * Converts characters in Unicode Supplementary Multilingual Plane (SMP) to their equivalent Html Entities.
@@ -2543,33 +2547,38 @@ public class Reviewer extends AnkiActivity {
         return sb.toString();
     }
 
+
     /**
-     * Plays sounds (or TTS, if configured) for current shown side of card
+     * Plays sounds (or TTS, if configured) for currently shown side of card.
+     * @param play_always Switch whether to ignore the autoplay setting.
      */
-    private void playSounds() {
+    private void playSounds(boolean fromMenuButton) {
+        boolean replayQuestion = getConfigForCurrentCard().optBoolean("replayq",true);
+        boolean autoPlayEnabled;
         try {
-            // first check, if sound is activated for the current deck
-            if (getConfigForCurrentCard().getBoolean("autoplay")) {
-                // We need to play the sounds from the proper side of the card
-                if (!mSpeakText) {
-                    // when showing answer, repeat question audio if so configured
-                	if (sDisplayAnswer && getConfigForCurrentCard().optBoolean("replayq",true)) {
-                        Sound.playSounds(MetaDB.LANGUAGES_QA_QUESTION);
-                    }
-                    Sound.playSounds(sDisplayAnswer ? MetaDB.LANGUAGES_QA_ANSWER : MetaDB.LANGUAGES_QA_QUESTION);
-                } else {
-                    // If the question is displayed or if the question should be replayed, read the question
-                	if (!sDisplayAnswer || getConfigForCurrentCard().optBoolean("replayq",true)) {
-                        readCardText(mCurrentCard, MetaDB.LANGUAGES_QA_QUESTION);
-                    }
-                    if (sDisplayAnswer) {
-                        readCardText(mCurrentCard, MetaDB.LANGUAGES_QA_ANSWER);
-                    }
-                }
-            }
+            autoPlayEnabled = getConfigForCurrentCard().getBoolean("autoplay");                 
         } catch (JSONException e) {
             throw new RuntimeException(e);
-        }
+        }        
+        
+        if (fromMenuButton || autoPlayEnabled) {
+            // We need to play the sounds from the proper side of the card
+            if (!mSpeakText) {
+                // when showing answer, repeat question audio if so configured
+                if (sDisplayAnswer && fromMenuButton && replayQuestion) {
+                    Sound.playSounds(MetaDB.LANGUAGES_QA_QUESTION);
+                }
+                Sound.playSounds(sDisplayAnswer ? MetaDB.LANGUAGES_QA_ANSWER : MetaDB.LANGUAGES_QA_QUESTION);
+            } else {
+                // If the question is displayed or if the question should be replayed, read the question
+                if (!sDisplayAnswer || fromMenuButton && replayQuestion) {
+                    readCardText(mCurrentCard, MetaDB.LANGUAGES_QA_QUESTION);
+                }
+                if (sDisplayAnswer) {
+                    readCardText(mCurrentCard, MetaDB.LANGUAGES_QA_ANSWER);
+                }
+            }
+        }        
     }
 
 
@@ -3093,25 +3102,25 @@ public class Reviewer extends AnkiActivity {
                 closeReviewer(RESULT_DEFAULT, false);
                 break;
             case GESTURE_UNDO:
-            	if(mSched.getCol().undoAvailable()) {
-                	undo();
-            	}
-            	break;
+                if(mSched.getCol().undoAvailable()) {
+                    undo();
+                }
+                break;
             case GESTURE_EDIT:
                 editCard();
                 break;
-     		case GESTURE_MARK:
-     			DeckTask.launchDeckTask(DeckTask.TASK_TYPE_MARK_CARD, mMarkCardHandler, new DeckTask.TaskData(mSched, mCurrentCard, 0));
-     			break;
+            case GESTURE_MARK:
+                DeckTask.launchDeckTask(DeckTask.TASK_TYPE_MARK_CARD, mMarkCardHandler, new DeckTask.TaskData(mSched, mCurrentCard, 0));
+                break;
             case GESTURE_LOOKUP:
                 lookUpOrSelectText();
                 break;
-         	case GESTURE_BURY:
+            case GESTURE_BURY:
                 setNextCardAnimation(false);
                 DeckTask.launchDeckTask(DeckTask.TASK_TYPE_DISMISS_NOTE, mDismissCardHandler, new DeckTask.TaskData(
                         mSched, mCurrentCard, 0));
                 break;
-         	case GESTURE_SUSPEND:
+            case GESTURE_SUSPEND:
                 setNextCardAnimation(false);
                 DeckTask.launchDeckTask(DeckTask.TASK_TYPE_DISMISS_NOTE, mDismissCardHandler, new DeckTask.TaskData(
                         mSched, mCurrentCard, 1));
@@ -3125,7 +3134,7 @@ public class Reviewer extends AnkiActivity {
                 }
                 break;
             case GESTURE_PLAY_MEDIA:
-                playSounds();
+                playSounds(true);
                 break;
         }
     }
@@ -3222,31 +3231,31 @@ public class Reviewer extends AnkiActivity {
             }
         }
 
-		@Override
-		protected void onScrollChanged (int horiz, int vert, int oldHoriz, int oldVert) {
-			super.onScrollChanged(horiz, vert, oldHoriz, oldVert);
-			if (Math.abs(horiz - oldHoriz) > Math.abs(vert - oldVert)) {
-	        	mIsXScrolling = true;
-				scrollHandler.removeCallbacks(scrollXRunnable);
-				scrollHandler.postDelayed(scrollXRunnable, 300);
-			} else {
-	        	mIsYScrolling = true;
-				scrollHandler.removeCallbacks(scrollYRunnable);
-				scrollHandler.postDelayed(scrollYRunnable, 300);
-			}
-		}
+        @Override
+        protected void onScrollChanged (int horiz, int vert, int oldHoriz, int oldVert) {
+            super.onScrollChanged(horiz, vert, oldHoriz, oldVert);
+            if (Math.abs(horiz - oldHoriz) > Math.abs(vert - oldVert)) {
+                mIsXScrolling = true;
+                scrollHandler.removeCallbacks(scrollXRunnable);
+                scrollHandler.postDelayed(scrollXRunnable, 300);
+            } else {
+                mIsYScrolling = true;
+                scrollHandler.removeCallbacks(scrollYRunnable);
+                scrollHandler.postDelayed(scrollYRunnable, 300);
+            }
+        }
 
-	    private final Handler scrollHandler = new Handler();
-	    private final Runnable scrollXRunnable = new Runnable() {
-	        public void run() {
-	        	mIsXScrolling = false;
-	        }
-	    };
-	    private final Runnable scrollYRunnable = new Runnable() {
-	        public void run() {
-	        	mIsYScrolling = false;
-	        }
-	    };
+        private final Handler scrollHandler = new Handler();
+        private final Runnable scrollXRunnable = new Runnable() {
+            public void run() {
+                mIsXScrolling = false;
+            }
+        };
+        private final Runnable scrollYRunnable = new Runnable() {
+            public void run() {
+                mIsYScrolling = false;
+            }
+        };
 
     }
 
@@ -3344,35 +3353,35 @@ public class Reviewer extends AnkiActivity {
 
     class ScrollTextView extends TextView {
 
-		public ScrollTextView(Context context) {
-			super(context);
-		}
+        public ScrollTextView(Context context) {
+            super(context);
+        }
 
-		@Override
-		protected void onScrollChanged (int horiz, int vert, int oldHoriz, int oldVert) {
-			super.onScrollChanged(horiz, vert, oldHoriz, oldVert);
-			if (Math.abs(horiz - oldHoriz) > Math.abs(vert - oldVert)) {
-	        	mIsXScrolling = true;
-				scrollHandler.removeCallbacks(scrollXRunnable);
-				scrollHandler.postDelayed(scrollXRunnable, 300);
-			} else {
-	        	mIsYScrolling = true;
-				scrollHandler.removeCallbacks(scrollYRunnable);
-				scrollHandler.postDelayed(scrollYRunnable, 300);
-			}
-		}
+        @Override
+        protected void onScrollChanged (int horiz, int vert, int oldHoriz, int oldVert) {
+            super.onScrollChanged(horiz, vert, oldHoriz, oldVert);
+            if (Math.abs(horiz - oldHoriz) > Math.abs(vert - oldVert)) {
+                mIsXScrolling = true;
+                scrollHandler.removeCallbacks(scrollXRunnable);
+                scrollHandler.postDelayed(scrollXRunnable, 300);
+            } else {
+                mIsYScrolling = true;
+                scrollHandler.removeCallbacks(scrollYRunnable);
+                scrollHandler.postDelayed(scrollYRunnable, 300);
+            }
+        }
 
-	    private final Handler scrollHandler = new Handler();
-	    private final Runnable scrollXRunnable = new Runnable() {
-	        public void run() {
-	        	mIsXScrolling = false;
-	        }
-	    };
-	    private final Runnable scrollYRunnable = new Runnable() {
-	        public void run() {
-	        	mIsYScrolling = false;
-	        }
-	    };
+        private final Handler scrollHandler = new Handler();
+        private final Runnable scrollXRunnable = new Runnable() {
+            public void run() {
+                mIsXScrolling = false;
+            }
+        };
+        private final Runnable scrollYRunnable = new Runnable() {
+            public void run() {
+                mIsYScrolling = false;
+            }
+        };
 
     }
 
@@ -3381,9 +3390,9 @@ public class Reviewer extends AnkiActivity {
         public void handleTag(boolean opening, String tag, Editable output,
                 XMLReader xmlReader) {
 //            if(tag.equalsIgnoreCase("div")) {
-//            	output.append("\n");
+//              output.append("\n");
 //            } else
-        	if(tag.equalsIgnoreCase("strike") || tag.equals("s")) {
+            if(tag.equalsIgnoreCase("strike") || tag.equals("s")) {
                 int len = output.length();
                 if(opening) {
                     output.setSpan(new StrikethroughSpan(), len, len, Spannable.SPAN_MARK_MARK);
@@ -3425,12 +3434,12 @@ public class Reviewer extends AnkiActivity {
                 d.setBounds(0,0,d.getIntrinsicWidth(),d.getIntrinsicHeight());
                 return d;
             } else {
-            	return null;
+                return null;
             }
         }
     };
 
     private Spanned convertToSimple(String text) {
-    	return Html.fromHtml(text, mSimpleInterfaceImagegetter, mSimpleInterfaceTagHandler);
+        return Html.fromHtml(text, mSimpleInterfaceImagegetter, mSimpleInterfaceTagHandler);
     }
 }


### PR DESCRIPTION
This fixes an inconsistency in the autoplay behavior between Anki Desktop and AnkiDroid, where the question was automatically replayed when `replayq` was set. A "replay audio" entry is added to the menu in the reviewer using the code from @ospalh, which does respect this `replayq` setting, but for now we keep the new menu item hidden due to a bug where cascading audio like this fails. I've created a [new issue 2084](https://code.google.com/p/ankidroid/issues/detail?id=2084) for this cascading audio bug. 

@chajadan I think this is one of your areas of expertise; would you mind taking a look at issue 2084? Once 2084 is fixed, we can re-enable the replay audio menu entry, and maybe add some preferences to remove the embedded play buttons, and/or promote replay to the action bar.

see #284 for more details
