### PR TITLE
shared random number between question and answer sides

### DIFF
--- a/src/com/ichi2/libanki/Collection.java
+++ b/src/com/ichi2/libanki/Collection.java
@@ -931,6 +931,11 @@ public class Collection {
             fields.put("Card", template.getString("name"));
             fields.put("c" + (((Integer) data[4]) + 1), "1");
 
+            Random r = new Random();
+            fields.put("Rand",  String.format("%.15f",r.nextDouble()));
+            fields.put("Rand2", String.format("%.15f",r.nextDouble()));
+            fields.put("Rand3", String.format("%.15f",r.nextDouble()));
+
             // render q & a
             HashMap<String, String> d = new HashMap<String, String>();
             try {


### PR DESCRIPTION
_(Related to pull request https://github.com/dae/anki/pull/74 for Anki.)_

It's unfeasible (and pretty useless) to generate cards for numbers individually. Having a shared random value between the question and the answer (which is impossible otherwise) would make it possible to create cards like "Numbers between 1 and 10" or "Tens: 10, 20, ..., 100" or "Factors of ten: 10, 100, 1000, ..."

A card, with javascript, can generate the number and the corresponding answer in the foreign language. Consider how fun it would be to be able to write something like this:

```
<script src="http://100.bryanesmith.com/js/knumbers.js"></script>
<script>
  // get a number and the number of zeroes between the set limits
  var number = Math.floor({{Rand}} * ({{Max}} - {{Min}} + 1) ) + {{Min}};
  var zeroes = Math.floor({{Rand2}} * ({{Zeroes Max}} - {{Zeroes Min}} + 1)) + {{Zeroes Min}};

  // compute the final number
  number = (number+{{Increment By}})*{{Multiplier}}*Math.pow(10,zeroes);

  document.getElementById("question").innerHTML = number;

  // set answer to the corresponding Sino-Korean number
  document.getElementById("answer").innerHTML = getSino(number);
</script>
```
