### PR TITLE
Fixed issue 1461 - reset password

### DIFF
--- a/res/layout/my_account.xml
+++ b/res/layout/my_account.xml
@@ -63,6 +63,15 @@
 				android:singleLine="true"
 				android:text="@string/log_in"/>
 			
+			<Button android:id="@+id/reset_password_button"
+				android:layout_width="fill_parent"
+				android:layout_height="0dip"
+				android:layout_gravity="center"
+				android:gravity="center"
+				android:layout_weight="1"
+				android:singleLine="true"
+				android:text="@string/reset_password"/>
+			
 			<Button android:id="@+id/sign_up_button"
 				android:layout_width="fill_parent"
 				android:layout_height="0dip"

--- a/res/values/04-network.xml
+++ b/res/values/04-network.xml
@@ -67,6 +67,8 @@
 <string name="invalid_username_password">Invalid email address or password.</string>
 <string name="login_generic_error">Failed to log in.</string>
 
+<string name="reset_password">Reset password</string>
+
 <!-- DownloadManagerService.java -->
 <string name="download_finished">Download finished</string>
 

--- a/res/values/constants.xml
+++ b/res/values/constants.xml
@@ -100,6 +100,7 @@
     <string name="feedback_post_url">http://ankidroid-triage.appspot.com/feedback_receiver</string>
     <string name="shared_decks_url">https://ankiweb.net/shared/decks/</string>
     <string name="repair_deck">http://ankisrs.net/docs/DeckErrors.html</string>
+    <string name="resetpw_url">http://ankiweb.net/account/resetpw</string>
     <string-array name="tutorial_capitals_questions">
         <item>Cambodia</item>
         <item>Chile</item>

--- a/src/com/ichi2/anki/MyAccount.java
+++ b/src/com/ichi2/anki/MyAccount.java
@@ -20,6 +20,7 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
 import android.content.res.Resources;
+import android.net.Uri;
 import android.os.Bundle;
 import android.text.method.LinkMovementMethod;
 import android.util.Log;
@@ -154,6 +155,12 @@ public class MyAccount extends AnkiActivity {
 
         setContentView(mLoginToMyAccountView);
     }
+    
+    private void resetPassword() {
+        Intent intent = new Intent(Intent.ACTION_VIEW);
+        intent.setData(Uri.parse(getResources().getString(R.string.resetpw_url)));
+        startActivity(intent);
+    }
 
 
     private void initAllContentViews() {
@@ -173,6 +180,15 @@ public class MyAccount extends AnkiActivity {
             }
 
         });
+
+        Button resetPWButton = (Button) mLoginToMyAccountView.findViewById(R.id.reset_password_button);
+        resetPWButton.setOnClickListener(new OnClickListener() {
+
+			@Override
+			public void onClick(View v) {
+				resetPassword();		
+			}
+		});
 
         Button signUpButton = (Button) mLoginToMyAccountView.findViewById(R.id.sign_up_button);
         signUpButton.setOnClickListener(new OnClickListener() {
@@ -234,7 +250,6 @@ public class MyAccount extends AnkiActivity {
             }
 
         });
-
     }
 
 


### PR DESCRIPTION
I've tested the code in my LG G2 with android 4.2.2 and it worked.

Observations:
The code used to open the shared decks page was used to open the reset password page without change, I hope it's not confusing.

Also, I created the method ParseSharedDecks.parsePageHTML extracting code from ParseSharedDecks.doInBackground() because it seems more clear to me like this. What do you think?

EDIT: Please, ignore the observations, they were about an older version of the code.
