### PR TITLE
Add drop-down menu in card browser

### DIFF
--- a/res/layout/spinner_item.xml
+++ b/res/layout/spinner_item.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+	android:layout_width="fill_parent"
+	android:layout_height="fill_parent"
+	android:paddingBottom="10dp"
+	android:paddingLeft="6dp"
+	android:paddingRight="10dp"
+	android:paddingTop="10dp"
+	android:singleLine="true"/>


### PR DESCRIPTION
As I'm implementing the navigation drawer I realized that our current card browser has to change a bit. We used to have two entry points into the card browser: one from the deck picker and one from the study options. Their behavior was different: one would show you all cards while the other is limited to the cards of the particular deck you selected. If the card browser moves into the navigation drawer, we will only have one point of entry and therefore we have to come up with a way to change the deck. I think a drop-down menu of decks in the action bar would be great for that.

![dropdown](https://cloud.githubusercontent.com/assets/527708/2742391/cb68644a-c702-11e3-9033-10ce7e4ccf14.png)

How do you all like this? I still have to add the number of search results back, and maybe use a dedicated adapter for the list (gosh, I hate writing those so much), so this is just a start.
