### PR TITLE
Restore Compat class for Nook Simple Touch

### DIFF
--- a/src/com/ichi2/anki/AnkiDroidApp.java
+++ b/src/com/ichi2/anki/AnkiDroidApp.java
@@ -34,12 +34,12 @@ import android.view.WindowManager;
 import com.ichi2.async.Connection;
 import com.ichi2.compat.Compat;
 import com.ichi2.compat.CompatV7;
+import com.ichi2.compat.CompatV7Nook;
 import com.ichi2.compat.CompatV8;
 import com.ichi2.compat.CompatV9;
 import com.ichi2.compat.CompatV15;
 import com.ichi2.compat.CompatV15NookHdPlus;
 import com.ichi2.compat.CompatV16;
-
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Storage;
 import com.ichi2.libanki.hooks.Hooks;
@@ -132,6 +132,8 @@ public class AnkiDroidApp extends Application {
             mCompat = new CompatV9();
         } else if (AnkiDroidApp.SDK_VERSION >= 8) {
             mCompat = new CompatV8();
+        } else if (isNook() && AnkiDroidApp.SDK_VERSION == 7) {
+            mCompat = new CompatV7Nook();
         } else {
             mCompat = new CompatV7();
         }
@@ -177,6 +179,13 @@ public class AnkiDroidApp extends Application {
                 && android.os.Build.PRODUCT.equals("HDplus")
                 && android.os.Build.DEVICE.equals("ovation");
     }
+
+
+    private boolean isNook() {
+        return android.os.Build.MODEL.equalsIgnoreCase("nook")
+                || android.os.Build.DEVICE.equalsIgnoreCase("nook");
+    }
+
 
     /**
      * Convenience method for accessing Shared preferences

--- a/src/com/ichi2/compat/CompatV7Nook.java
+++ b/src/com/ichi2/compat/CompatV7Nook.java
@@ -1,0 +1,17 @@
+package com.ichi2.compat;
+
+import android.annotation.TargetApi;
+import android.webkit.WebView;
+
+/** Implementation of {@link Compat} for SDK level 7 for Nooks, e.g. Simple Touch.
+ * 
+ * <p>This device does not support scrollbar fading.
+ **/
+@TargetApi(7)
+public class CompatV7Nook extends CompatV7 implements Compat {
+
+    @Override
+    public void setScrollbarFadingEnabled(WebView webview, boolean enable) {
+    }
+
+}


### PR DESCRIPTION
See discussion on the [mailing list](https://groups.google.com/forum/#!msg/anki-android/OSPCS_UjTVw/n3I24mpTSOEJ). A blank `setScrollbarFadingEnabled` was the only difference between `CompatV4` and `CompatV7`. Adding a dedicated `CompatV7NookSimpleTouch` class should better document the shortcoming of the device.
