### PR TITLE
Fixed width of congrats message

### DIFF
--- a/res/layout/studyoptions_congrats.xml
+++ b/res/layout/studyoptions_congrats.xml
@@ -7,7 +7,7 @@
 		android:layout_height="wrap_content"
 		android:orientation="vertical"
 		android:gravity="center"
-		android:layout_width="wrap_content">
+		android:layout_width="fill_parent">
 		<TextView
 			android:layout_height="wrap_content"
 			android:layout_width="fill_parent"


### PR DESCRIPTION
Before, the congratulations message when done reviewing would sometimes be wrapped on the left side like this:

![before](https://cloud.githubusercontent.com/assets/5547518/2750465/215b8046-c87d-11e3-9119-0cc3904d5297.png)

I changed the layout_width to be consistent with the other stuff that is displayed there.

![after](https://cloud.githubusercontent.com/assets/5547518/2750468/3afc5926-c87d-11e3-84c6-d001caf930c6.png)
