### PR TITLE
Fix Issue 1922 - Allow image resizing when zooming

### DIFF
--- a/assets/card_template.html
+++ b/assets/card_template.html
@@ -15,6 +15,40 @@
         ::content::
         </div>
         <script type="text/javascript">
+            /*
+            Handle image resizing if the image exceeds the window dimensions.
+            
+            If we are using the Chrome engine, add the "chrome" class to the body and defer
+            image resizing to pure CSS. The Chrome engine can handle image resizing on its own,
+            but for older versions of WebView, we do it here.
+            */
+            window.onload = function() {
+                if (navigator.userAgent.indexOf("Chrome") > -1) {
+                    document.body.className = document.body.className + " chrome";
+                } else {
+                    var maxWidth = window.innerWidth * 0.90;
+                    var maxHeight = window.innerHeight * 0.90;
+                    var ratio = 0;
+                    var images = document.getElementsByTagName('img');
+                    for (var i = 0; i < images.length; i++) {
+                        var img = images[i];
+                        var width = img.width;
+                        var height = img.height;
+                        if (width > maxWidth) {
+                            ratio = maxWidth / width;
+                            img.style.width = maxWidth + "px";
+                            img.style.height = (height * ratio) + "px";
+                        }
+                        width = img.width;
+                        height = img.height;
+                        if (height > maxHeight) {
+                            ratio = maxHeight / height;
+                            img.style.width = (width * ratio) + "px";
+                            img.style.height = maxHeight + "px";
+                        }
+                    }
+                }
+            };
             window.location.href = "#answer";
         </script>
     </body>

--- a/assets/flashcard.css
+++ b/assets/flashcard.css
@@ -12,9 +12,14 @@ body.night_mode {
   margin: 0.5em;
 }
 
-img {
-  max-width: 100%;
-  max-height: 100%;
+/*
+Use hard-coded max dimensions if using Chrome back-end. Chrome is able to
+zoom into images correctly even with max dimensions specified, so this way is
+preferred over using JavaScript.
+*/
+.chrome img {
+  max-width: 90%;
+  max-height: 90%;
 }
 
 .vertically_centered {


### PR DESCRIPTION
Following up from @brunodea's initial work on this in https://github.com/ankidroid/Anki-Android/pull/300. Use javascript to constrain image dimensions or use CSS if we're on the newer Chrome engine.

Edit: I went back to 90%. 95% still seemed to generate scrolling vertically (it looks like the top padding is slightly larger than the bottom padding, but I don't understand why).
