### PR TITLE
Respect cardBrowserNoSearchOnOpen on deck change

### DIFF
--- a/res/values/10-preferences.xml
+++ b/res/values/10-preferences.xml
@@ -236,7 +236,7 @@
 <string name="write_answers_message">You should define for every deck a field to compare the written answer with. You can do this via Anki Desktop (deck properties -> edit model -> card layout).\n\nIf no compare field is set, your written answer will always be compared with the whole card answer.</string>
 
 <string name="pref_cardbrowser_skip_init_search">Fast Card Browser Open</string>
-<string name="pref_cardbrowser_skip_init_search_summ">Skips initial automatic search when the card browser opens.</string>
+<string name="pref_cardbrowser_skip_init_search_summ">Skips initial automatic search when the card browser opens or the deck is changed.</string>
 
 <string name="pref_keep_screen_on">Keep Screen On</string>
 <string name="pref_keep_screen_on_summ">Prevent screen from being turned off while reviewing</string>

--- a/src/com/ichi2/anki/CardBrowser.java
+++ b/src/com/ichi2/anki/CardBrowser.java
@@ -166,8 +166,6 @@ public class CardBrowser extends ActionBarActivity implements ActionBar.OnNaviga
     private String[] mColumn2Indexs;
     private HashSet<String> mSelectedTags;
 
-    private boolean mInitializing = true;
-
     /**
      * Broadcast that informs us when the sd card is about to be unmounted
      */
@@ -725,19 +723,15 @@ public class CardBrowser extends ActionBarActivity implements ActionBar.OnNaviga
 
     @Override
     public boolean onNavigationItemSelected(int position, long itemId) {
+        SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(getBaseContext());
         if (position == 0) {
             mRestrictOnDeck = "";
         } else {
             mRestrictOnDeck = "deck:'" + mDropDownDecks.get(position) + "' ";
         }
-        // onNavigationItemSelected is called when the activity is launched.
-        // mInitializing captures this step to support the cardBrowserNoSearchOnOpen option.
-        if (mInitializing) {
-            mInitializing = false;
-            SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(getBaseContext());
-            if (!preferences.getBoolean("cardBrowserNoSearchOnOpen", false)) {
-                searchCards();
-            }
+        if (preferences.getBoolean("cardBrowserNoSearchOnOpen", false)) {
+            mCards.clear();
+            updateList();
         } else {
             searchCards();
         }


### PR DESCRIPTION
A simpler fix for [2091](https://code.google.com/p/ankidroid/issues/detail?id=2091): respect the _Fast Card Browser Open_ not just when the card browser opens, but also when the deck is changed.
