### PR TITLE
Fix 2090: Sort decks in drop-down menu

### DIFF
--- a/res/layout/dropdown_deck_item.xml
+++ b/res/layout/dropdown_deck_item.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/dropdown_deck_name"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:paddingBottom="10dp"
+    android:paddingLeft="6dp"
+    android:paddingRight="10dp"
+    android:paddingTop="10dp"
+    android:singleLine="true" />

--- a/res/layout/spinner_item.xml
+++ b/res/layout/spinner_item.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<TextView xmlns:android="http://schemas.android.com/apk/res/android"
-	android:layout_width="fill_parent"
-	android:layout_height="fill_parent"
-	android:paddingBottom="10dp"
-	android:paddingLeft="6dp"
-	android:paddingRight="10dp"
-	android:paddingTop="10dp"
-	android:singleLine="true"/>

--- a/src/com/ichi2/anki/CardBrowser.java
+++ b/src/com/ichi2/anki/CardBrowser.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.json.JSONException;
+import org.json.JSONObject;
 
 import android.app.Activity;
 import android.app.Dialog;
@@ -72,6 +73,7 @@ import com.ichi2.libanki.Card;
 import com.ichi2.libanki.CardStats;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Note;
+import com.ichi2.libanki.Sched;
 import com.ichi2.themes.StyledDialog;
 import com.ichi2.themes.StyledOpenCollectionDialog;
 import com.ichi2.themes.StyledProgressDialog;
@@ -85,7 +87,7 @@ public class CardBrowser extends ActionBarActivity implements ActionBar.OnNaviga
     private ArrayList<HashMap<String, String>> mCards;
     // private ArrayList<HashMap<String, String>> mAllCards;
     private HashMap<String, String> mDeckNames;
-    private ArrayList<String> mDropDownDecks;
+    private ArrayList<JSONObject> mDropDownDecks;
     private SearchView mSearchView;
     private ListView mCardsListView;
     private Spinner mCardsColumn1Spinner;
@@ -160,7 +162,7 @@ public class CardBrowser extends ActionBarActivity implements ActionBar.OnNaviga
     private boolean mWholeCollection;
 
     private ActionBar mActionBar;
-    private ArrayAdapter<String> mDropDownAdapter;
+    private DeckDropDownAdapter mDropDownAdapter;
 
     private String[] allTags;
     private String[] mColumn2Indexs;
@@ -263,12 +265,13 @@ public class CardBrowser extends ActionBarActivity implements ActionBar.OnNaviga
         SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(getBaseContext());
         Resources res = getResources();
 
-        String currentDeckName;
-        try {
-            currentDeckName = mCol.getDecks().current().getString("name");
-        } catch (JSONException e) {
-            throw new RuntimeException(e);
-        }
+        // Add drop-down menu to select deck to action bar.
+        mDropDownDecks = mCol.getDecks().allSorted();
+        mDropDownAdapter = new DeckDropDownAdapter(this, mDropDownDecks);
+        mActionBar = getSupportActionBar();
+        mActionBar.setDisplayShowTitleEnabled(false);
+        mActionBar.setNavigationMode(ActionBar.NAVIGATION_MODE_LIST);
+        mActionBar.setListNavigationCallbacks(mDropDownAdapter, this);
 
         mOrderByFields = res.getStringArray(R.array.card_browser_order_labels);
         try {
@@ -374,26 +377,29 @@ public class CardBrowser extends ActionBarActivity implements ActionBar.OnNaviga
 
         getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN);
 
-        mSearchTerms = "";
-        if (mWholeCollection) {
-            mRestrictOnDeck = "";
-        } else {
-            mRestrictOnDeck = "deck:'" + currentDeckName + "' ";
-        }
-
         mSelectedTags = new HashSet<String>();
 
-        // Add drop-down menu to select deck to action bar.
         // onNavigationItemSelected will be called automatically, replacing onSearch in onCreate.
-        mDropDownDecks = new ArrayList<String>(mDeckNames.values());
-        mDropDownDecks.add(0, res.getString(R.string.deck_summary_all_decks));
-        mDropDownAdapter = new ArrayAdapter<String>(this, R.layout.spinner_item, mDropDownDecks);
-        mActionBar = getSupportActionBar();
-        mActionBar.setDisplayShowTitleEnabled(false);
-        mActionBar.setNavigationMode(ActionBar.NAVIGATION_MODE_LIST);
-        mActionBar.setListNavigationCallbacks(mDropDownAdapter, this);
         if (!mWholeCollection) {
-            mActionBar.setSelectedNavigationItem(mDropDownDecks.indexOf(currentDeckName));
+            String currentDeckName;
+            try {
+                currentDeckName = mCol.getDecks().current().getString("name");
+            } catch (JSONException e) {
+                throw new RuntimeException(e);
+            }
+            for (int dropDownDeckIdx = 0; dropDownDeckIdx < mDropDownDecks.size(); dropDownDeckIdx++) {
+                JSONObject deck = mDropDownDecks.get(dropDownDeckIdx);
+                String deckName;
+                try {
+                    deckName = deck.getString("name");
+                } catch (JSONException e) {
+                    throw new RuntimeException();
+                }
+                if (deckName.equals(currentDeckName)) {
+                    mActionBar.setSelectedNavigationItem(dropDownDeckIdx + 1);
+                    break;
+                }
+            }
         }
     }
 
@@ -727,7 +733,12 @@ public class CardBrowser extends ActionBarActivity implements ActionBar.OnNaviga
         if (position == 0) {
             mRestrictOnDeck = "";
         } else {
-            mRestrictOnDeck = "deck:'" + mDropDownDecks.get(position) + "' ";
+            JSONObject deck = mDropDownDecks.get(position - 1);
+            try {
+                mRestrictOnDeck = "deck:'" + deck.getString("name") + "' ";
+            } catch (JSONException e) {
+                throw new RuntimeException();
+            }
         }
         if (preferences.getBoolean("cardBrowserNoSearchOnOpen", false)) {
             mCards.clear();
@@ -1186,6 +1197,62 @@ public class CardBrowser extends ActionBarActivity implements ActionBar.OnNaviga
         public long getItemId(int position) {
             return position;
         }
+    }
+
+
+    private final class DeckDropDownAdapter extends BaseAdapter {
+
+        private Context context;
+        private ArrayList<JSONObject> decks;
+
+        public DeckDropDownAdapter(Context context, ArrayList<JSONObject> decks) {
+            this.context = context;
+            this.decks = decks;
+        }
+
+        @Override
+        public int getCount() {
+            return decks.size() + 1;
+        }
+
+        @Override
+        public Object getItem(int position) {
+            if (position == 0) {
+                return null;
+            } else {
+                return decks.get(position + 1);
+            }
+        }
+
+        @Override
+        public long getItemId(int position) {
+            return position;
+        }
+
+        @Override
+        public View getView(int position, View convertView, ViewGroup parent) {
+            TextView deckNameView;
+            if (convertView == null) {
+                convertView = LayoutInflater.from(context).inflate(R.layout.dropdown_deck_item, parent, false);
+                deckNameView = (TextView) convertView.findViewById(R.id.dropdown_deck_name);
+                convertView.setTag(deckNameView);
+            } else {
+                deckNameView = (TextView) convertView.getTag();
+            }
+            if (position == 0) {
+                deckNameView.setText(context.getResources().getString(R.string.deck_summary_all_decks));
+            } else {
+                JSONObject deck = decks.get(position - 1);
+                try {
+                    String deckName = deck.getString("name");
+                    deckNameView.setText(deckName);
+                } catch (JSONException ex) {
+                    new RuntimeException();
+                }
+            }
+            return convertView;
+        }
+
     }
 
 

--- a/src/com/ichi2/libanki/Decks.java
+++ b/src/com/ichi2/libanki/Decks.java
@@ -26,6 +26,8 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -74,6 +76,16 @@ public class Decks {
             + "'rev': { " + "'perDay': 100, " + "'ease4': 1.3, " + "'fuzz': 0.05, " + "'minSpace': 1, "
             + "'ivlFct': 1, " + "'maxIvl': 36500 }, " + "'maxTaken': 60, " + "'timer': 0, " + "'autoplay': True, 'replayq': True, "
             + "'mod': 0, " + "'usn': 0 }";
+
+    public static final class DeckListComparator implements Comparator<JSONObject> {
+        public int compare(JSONObject o1, JSONObject o2) {
+            try {
+                return o1.getString("name").compareTo(o2.getString("name"));
+            } catch (JSONException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
 
     private Collection mCol;
     private HashMap<Long, JSONObject> mDecks;
@@ -313,6 +325,14 @@ public class Decks {
         while (it.hasNext()) {
             decks.add(it.next());
         }
+        return decks;
+    }
+
+
+    // LIBANKI: not in libanki
+    public ArrayList<JSONObject> allSorted() {
+        ArrayList<JSONObject> decks = all();
+        Collections.sort(decks, new DeckListComparator());
         return decks;
     }
 

--- a/src/com/ichi2/libanki/Sched.java
+++ b/src/com/ichi2/libanki/Sched.java
@@ -381,8 +381,8 @@ public class Sched {
     public ArrayList<Object[]> deckDueList() {
         _checkDay();
         mCol.getDecks().recoverOrphans();
-        ArrayList<JSONObject> decks = mCol.getDecks().all();
-        Collections.sort(decks, new DeckDueListComparator());
+        // LIBANKI: uses all() instead of sorted() and then sorts the decks
+        ArrayList<JSONObject> decks = mCol.getDecks().allSorted();
         HashMap<String, Integer[]> lims = new HashMap<String, Integer[]>();
         ArrayList<Object[]> data = new ArrayList<Object[]>();
         try {
@@ -2643,16 +2643,6 @@ public class Sched {
 
     public void setSpreadRev(boolean mSpreadRev) {
         this.mSpreadRev = mSpreadRev;
-    }
-
-    public class DeckDueListComparator implements Comparator<JSONObject> {
-        public int compare(JSONObject o1, JSONObject o2) {
-            try {
-                return o1.getString("name").compareTo(o2.getString("name"));
-            } catch (JSONException e) {
-                throw new RuntimeException(e);
-            }
-        }
     }
 
     /**


### PR DESCRIPTION
To solve [2090](https://code.google.com/p/ankidroid/issues/detail?id=2090) I need advice from someone familiar with the Anki internals. What would be the best way to get a sorted list of decks? The logic in `DeckPicker` is dependent on the broader task: opening the collection, deleting a deck, syncing. How about `deckDueList`?
