### PR TITLE
move clear whiteboard to front of action bar

### DIFF
--- a/res/menu/reviewer.xml
+++ b/res/menu/reviewer.xml
@@ -1,62 +1,62 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
-	xmlns:ankidroid="http://schemas.android.com/apk/res-auto">
+    xmlns:ankidroid="http://schemas.android.com/apk/res-auto">
 
-	<item android:id="@+id/action_undo"
-		android:icon="@drawable/ic_menu_revert_disabled"
-		android:title="@string/undo"
-		android:enabled="false"
-		ankidroid:showAsAction="always" />
+    <item android:id="@+id/action_clear_whiteboard"
+        android:icon="@drawable/ic_menu_clear_playlist"
+        android:title="@string/clear_whiteboard"
+        android:visible="false"
+        ankidroid:showAsAction="always" />
+    
+    <item android:id="@+id/action_undo"
+        android:icon="@drawable/ic_menu_revert_disabled"
+        android:title="@string/undo"
+        android:enabled="false"
+        ankidroid:showAsAction="always" />
 
-	<item android:id="@+id/action_clear_whiteboard"
-		android:icon="@drawable/ic_menu_clear_playlist"
-		android:title="@string/clear_whiteboard"
-		android:visible="false"
-		ankidroid:showAsAction="always" />
+    <item android:id="@+id/action_mark_card"
+        android:icon="@drawable/ic_menu_mark"
+        android:title="@string/menu_mark_card"
+        ankidroid:showAsAction="ifRoom" />
 
-	<item android:id="@+id/action_mark_card"
-		android:icon="@drawable/ic_menu_mark"
-		android:title="@string/menu_mark_card"
-		ankidroid:showAsAction="ifRoom" />
+    <item android:id="@+id/action_edit"
+        android:icon="@drawable/ic_menu_edit"
+        android:title="@string/menu_edit_card"
+        ankidroid:showAsAction="ifRoom" />
 
-	<item android:id="@+id/action_edit"
-		android:icon="@drawable/ic_menu_edit"
-		android:title="@string/menu_edit_card"
-		ankidroid:showAsAction="ifRoom" />
+    <item android:id="@+id/action_dismiss"
+        android:title="@string/menu_dismiss_note">
 
-	<item android:id="@+id/action_dismiss"
-		android:title="@string/menu_dismiss_note">
+        <menu>
 
-		<menu>
+            <item android:id="@+id/action_bury_card"
+                android:title="@string/menu_bury_card" />
 
-			<item android:id="@+id/action_bury_card"
-				android:title="@string/menu_bury_card" />
+            <item android:id="@+id/action_bury_note"
+                android:title="@string/menu_bury_note" />
 
-			<item android:id="@+id/action_bury_note"
-				android:title="@string/menu_bury_note" />
+            <item android:id="@+id/action_suspend_card"
+                android:title="@string/menu_suspend_card" />
 
-			<item android:id="@+id/action_suspend_card"
-				android:title="@string/menu_suspend_card" />
+            <item android:id="@+id/action_suspend_note"
+                android:title="@string/menu_suspend_note" />
 
-			<item android:id="@+id/action_suspend_note"
-				android:title="@string/menu_suspend_note" />
+            <item android:id="@+id/action_delete"
+                android:title="@string/menu_delete_note" />
 
-			<item android:id="@+id/action_delete"
-				android:title="@string/menu_delete_note" />
+        </menu>
 
-		</menu>
-
-	</item>
+    </item>
 
     <item android:id="@+id/action_replay"
         android:title="@string/replay_audio"
         android:visible="false" />
 
-	<item android:id="@+id/action_whiteboard"
-		android:title="@string/hide_whiteboard"
-		android:visible="false" />
+    <item android:id="@+id/action_whiteboard"
+        android:title="@string/hide_whiteboard"
+        android:visible="false" />
 
-	<item android:id="@+id/action_search_dictionary"
-		android:title="@string/menu_select"
-		android:visible="false" />
+    <item android:id="@+id/action_search_dictionary"
+        android:title="@string/menu_select"
+        android:visible="false" />
 
 </menu>


### PR DESCRIPTION
As pointed out by Xiao, it can be distracting having the order of the actions change when reviewing... this moves the clear whiteboard action to the far left, so that the order is not changed (assuming the screen is big enough to show all actions).

I also converted tabs to spaces
