### PR TITLE
fix issue 2063 - showing text in statistics dialog.

### DIFF
--- a/src/com/ichi2/charts/ChartBuilder.java
+++ b/src/com/ichi2/charts/ChartBuilder.java
@@ -306,7 +306,7 @@ public class ChartBuilder extends ActionBarActivity {
         for (int i = 0; i < statisticRadioButtons.length; i++) {
             statisticRadioButtons[i] = new RadioButton(context);
             statisticRadioButtons[i].setClickable(true);
-            statisticRadioButtons[i].setText("         " + text[i]);
+            statisticRadioButtons[i].setText(text[i]);
             statisticRadioButtons[i].setHeight(height * 2);
             statisticRadioButtons[i].setSingleLine();
             statisticRadioButtons[i].setBackgroundDrawable(null);


### PR DESCRIPTION
In the statistic dialog the text for the options "1 month", "1 year" and "all" weren't being completely shown.

The fix I made solved this issue, but I don't really understand why the spaces were added to the texts. I ran the code and tested and everything seems fine... so I think someone forgot to remove that.
