### PR TITLE
Feature type answer fixes, issue 1508, v2

### DIFF
--- a/assets/flashcard.css
+++ b/assets/flashcard.css
@@ -13,6 +13,40 @@ body.night_mode {
 }
 
 /*
+  For the typed/correct answer comparison. The typePrompt class is
+  AnkiDroid specific. It is for a placeholder where Anki desktop shows
+  the input box.
+*/
+.typeGood {
+  background-color: #0f0;
+}
+
+.typeBad {
+  background-color: #f00;
+}
+
+.typeMissed {
+  background-color: #ccc;
+}
+
+#typeans {
+  width: 100%;
+}
+
+.typePrompt {
+  color: magenta;
+}
+
+.night_mode .typeGood {
+  background-color: #508040;
+}
+
+.night_mode .typeBad {
+  background-color: #905050;
+}
+
+
+/*
 Use hard-coded max dimensions if using Chrome back-end. Chrome is able to
 zoom into images correctly even with max dimensions specified, so this way is
 preferred over using JavaScript.

--- a/res/layout/flashcard.xml
+++ b/res/layout/flashcard.xml
@@ -5,6 +5,7 @@
 ~ Copyright (c) 2009 Edu Zamora <edu.zasu@gmail.com>
 ~ Copyright (c) 2009 Jordi Chacon <jordi.chacon@gmail.com>
 ~ Copyright (c) 2010 Norbert Nagold <norbert.nagold@gmail.com>
+~ Copyright (c) 2014 Roland Sieker <ospalh@gmail.com>
 ~
 ~ This program is free software; you can redistribute it and/or modify it under
 ~ the terms of the GNU General Public License as published by the Free Software
@@ -19,19 +20,19 @@
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-	android:id="@+id/main_layout"
-	android:layout_width="fill_parent"
-	android:layout_height="fill_parent"
-	android:background="?android:attr/colorBackground">
+    android:id="@+id/main_layout"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:background="?android:attr/colorBackground">
 
-	<!-- Top bar -->
-	<RelativeLayout android:id="@+id/top_bar"
-		android:layout_width="fill_parent"
-		android:layout_marginTop="4dp"
-		android:gravity="center_vertical"
-		android:layout_marginLeft="9dp"
-		android:layout_marginRight="10dp"
-		android:layout_height="wrap_content">
+    <!-- Top bar -->
+    <RelativeLayout android:id="@+id/top_bar"
+        android:layout_width="fill_parent"
+        android:layout_marginTop="4dp"
+        android:gravity="center_vertical"
+        android:layout_marginLeft="9dp"
+        android:layout_marginRight="10dp"
+        android:layout_height="wrap_content">
         <TextView android:id="@+id/new_number"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -54,165 +55,169 @@
             android:text=""
             android:textSize="14dip"
             android:textColor="@color/review_count" />
-		<TextView android:id="@+id/choosen_answer"
-			android:layout_centerHorizontal="true"
-			android:layout_width="wrap_content"
-			android:layout_height="wrap_content"
-			android:gravity="center"
-			android:text=""
-			android:textSize="14dip"/>
-		<Chronometer android:id="@+id/card_time"
-			android:layout_alignParentRight="true"
-			android:layout_width="wrap_content"
-			android:layout_height="wrap_content"
-			android:textSize="14dip"
-			android:visibility="invisible"
-			android:gravity="center"
-			android:textColor="#000000" />
-	</RelativeLayout>
-	<!-- Card and whiteboard -->
-	<FrameLayout android:id="@+id/flashcard_frame"
-		android:layout_margin="0dip"
-		android:layout_below="@+id/top_bar"
-		android:layout_above="@+id/bottom_area_layout"
-		android:layout_width="fill_parent"
-		android:layout_height="fill_parent">
-		<FrameLayout android:id="@+id/flashcard"
-			android:padding="4.6667dip"
-			android:layout_width="fill_parent"
-			android:layout_height="fill_parent"/>
-		<RelativeLayout
-			android:layout_width="fill_parent"
-			android:layout_height="fill_parent">
-			<FrameLayout android:id="@+id/touch_layer"
-				android:layout_marginTop="20dip"
-				android:layout_marginBottom="20dip"
-				android:longClickable="true"
-				android:layout_width="fill_parent"
-				android:layout_height="fill_parent"/>
-		    	<ProgressBar android:id="@+id/flashcard_progressbar"
-				android:layout_width="wrap_content"
-				android:layout_height="wrap_content"
-				android:layout_margin="9.3333dip"
-				android:layout_alignParentRight="true"
-	    			android:indeterminate="true"
-				android:focusable="false"
-				android:visibility="invisible"
-				style="@android:style/Widget.ProgressBar.Small"
-			    	android:clickable="false"/>
-		</RelativeLayout>
-		<FrameLayout android:id="@+id/whiteboard"
-			android:layout_width="fill_parent"
-			android:layout_height="fill_parent"/>
-		<ImageView android:id="@+id/lookup_button"
-			android:padding="5dip"
-			android:layout_gravity="right"
-			android:src="@drawable/ic_lookup"
-			android:visibility="gone"
-			android:clickable="true"
-			android:layout_width="wrap_content"
-			android:layout_height="wrap_content"/>
-		<FrameLayout android:id="@+id/flashcard_border"
-			android:visibility="gone"
-			android:layout_width="fill_parent"
-			android:layout_height="fill_parent"/>
-	</FrameLayout>
-	<LinearLayout android:id="@+id/bottom_area_layout"
-		android:layout_width="fill_parent"
-		android:layout_height="wrap_content"
-		android:orientation="vertical"
-		android:layout_alignParentBottom="true" >
+        <TextView android:id="@+id/choosen_answer"
+            android:layout_centerHorizontal="true"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:text=""
+            android:textSize="14dip"/>
+        <Chronometer android:id="@+id/card_time"
+            android:layout_alignParentRight="true"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="14dip"
+            android:visibility="invisible"
+            android:gravity="center"
+            android:textColor="#000000" />
+    </RelativeLayout>
+    <!-- Card and whiteboard -->
+    <FrameLayout android:id="@+id/flashcard_frame"
+        android:layout_margin="0dip"
+        android:layout_below="@+id/top_bar"
+        android:layout_above="@+id/bottom_area_layout"
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent">
+        <FrameLayout android:id="@+id/flashcard"
+            android:padding="4.6667dip"
+            android:layout_width="fill_parent"
+            android:layout_height="fill_parent"/>
+        <RelativeLayout
+            android:layout_width="fill_parent"
+            android:layout_height="fill_parent">
+            <FrameLayout android:id="@+id/touch_layer"
+                android:layout_marginTop="20dip"
+                android:layout_marginBottom="20dip"
+                android:longClickable="true"
+                android:layout_width="fill_parent"
+                android:layout_height="fill_parent"/>
+                <ProgressBar android:id="@+id/flashcard_progressbar"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_margin="9.3333dip"
+                android:layout_alignParentRight="true"
+                    android:indeterminate="true"
+                android:focusable="false"
+                android:visibility="invisible"
+                style="@android:style/Widget.ProgressBar.Small"
+                    android:clickable="false"/>
+        </RelativeLayout>
+        <FrameLayout android:id="@+id/whiteboard"
+            android:layout_width="fill_parent"
+            android:layout_height="fill_parent"/>
+        <ImageView android:id="@+id/lookup_button"
+            android:padding="5dip"
+            android:layout_gravity="right"
+            android:src="@drawable/ic_lookup"
+            android:visibility="gone"
+            android:clickable="true"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"/>
+        <FrameLayout android:id="@+id/flashcard_border"
+            android:visibility="gone"
+            android:layout_width="fill_parent"
+            android:layout_height="fill_parent"/>
+    </FrameLayout>
+    <LinearLayout android:id="@+id/bottom_area_layout"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:layout_alignParentBottom="true" >
 
-			<!-- Answer bar -->
-		<EditText android:id="@+id/answer_field"
-			android:layout_above="@+id/flip_card"
-			android:layout_width="fill_parent"
-			android:layout_height="wrap_content"
-			android:maxLines="2" />
+            <!-- Answer bar -->
+        <EditText android:id="@+id/answer_field"
+            android:layout_above="@+id/flip_card"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:inputType="text|textNoSuggestions"
+            android:imeOptions="actionDone"
+            android:hint="@string/type_answer_hint" />
+        <!-- Looks like setting android:imeActionLabel confuses the
+             original ASOP soft keyboard, so don't. -->
 
-		<LinearLayout android:id="@+id/answer_options_layout"
-			android:layout_width="fill_parent"
-			android:layout_height="fill_parent"
-			android:layout_alignParentBottom="true" >
+        <LinearLayout android:id="@+id/answer_options_layout"
+            android:layout_width="fill_parent"
+            android:layout_height="fill_parent"
+            android:layout_alignParentBottom="true" >
 
-   			<LinearLayout android:id="@+id/flashcard_layout_flip"
-		    	android:layout_height="fill_parent"
-		    	android:layout_width="fill_parent"
-		    	android:layout_weight="1"
-		    	android:orientation="vertical"
-		    	style="?android:attr/buttonStyleSmall">
-  				<Button android:id="@+id/flip_card"
-					android:gravity="center"
-					android:lines="1"
-					android:text="@string/show_answer"
-					android:background="@color/transparent"
-		    		style="?android:attr/buttonStyleSmall"
-					android:layout_width="fill_parent"
-					android:clickable="false"
-					android:layout_height="fill_parent" />
-				<LinearLayout
-				    android:layout_height="fill_parent"
-		    		android:layout_width="0dip"
-		    		android:orientation="horizontal">
-					<include android:id="@+id/nextTimeflip" layout="@layout/next_time_textview" />
-					<Button
-						android:layout_width="0dip"
-						android:layout_height="wrap_content"
-						android:background="@color/transparent"
-						android:lines="1"
-						android:textSize="14sp" />
-				</LinearLayout>
-			</LinearLayout>
-   			<LinearLayout android:id="@+id/flashcard_layout_ease1"
-		    	android:layout_height="fill_parent"
-		    	android:layout_width="0dip"
-		    	android:layout_weight="1"
-		    	android:orientation="vertical"
-		    	android:visibility="gone"
-		    	style="?android:attr/buttonStyleSmall">
-				<include
-				    android:id="@+id/nextTime1"
-				    layout="@layout/next_time_textview"/>
-				<include android:id="@+id/ease1" layout="@layout/bottom_button" />
-			</LinearLayout>
-   			<LinearLayout android:id="@+id/flashcard_layout_ease2"
-		    	android:layout_height="fill_parent"
-		    	android:layout_width="0dip"
-		    	android:layout_weight="1"
-		    	android:visibility="gone"
-		    	android:orientation="vertical"
-		    	style="?android:attr/buttonStyleSmall">
-				<include
-				    android:id="@+id/nextTime2"
-				    layout="@layout/next_time_textview"
-				    android:textColor="@color/next_time_usual_color" />
-				<include android:id="@+id/ease2" layout="@layout/bottom_button" />
-			</LinearLayout>
-   			<LinearLayout android:id="@+id/flashcard_layout_ease3"
-		    	android:layout_height="fill_parent"
-		    	android:visibility="gone"
-		    	android:layout_width="0dip"
-		    	android:layout_weight="1"
-		    	android:orientation="vertical"
-		    	style="?android:attr/buttonStyleSmall">
-				<include
-				    android:id="@+id/nextTime3"
-				    layout="@layout/next_time_textview"/>
-				<include android:id="@+id/ease3" layout="@layout/bottom_button" />
-			</LinearLayout>
-   			<LinearLayout android:id="@+id/flashcard_layout_ease4"
-		    	android:layout_height="fill_parent"
-		    	android:layout_width="0dip"
-		    	android:visibility="gone"
-		    	android:layout_weight="1"
-		    	android:orientation="vertical"
-		    	style="?android:attr/buttonStyleSmall">
-				<include
-				    android:id="@+id/nextTime4"
-				    layout="@layout/next_time_textview" />
-				<include android:id="@+id/ease4" layout="@layout/bottom_button" />
-			</LinearLayout>
-		</LinearLayout>
-	</LinearLayout>
+            <LinearLayout android:id="@+id/flashcard_layout_flip"
+                android:layout_height="fill_parent"
+                android:layout_width="fill_parent"
+                android:layout_weight="1"
+                android:orientation="vertical"
+                style="?android:attr/buttonStyleSmall">
+                <Button android:id="@+id/flip_card"
+                    android:gravity="center"
+                    android:lines="1"
+                    android:text="@string/show_answer"
+                    android:background="@color/transparent"
+                    style="?android:attr/buttonStyleSmall"
+                    android:layout_width="fill_parent"
+                    android:clickable="false"
+                    android:layout_height="fill_parent" />
+                <LinearLayout
+                    android:layout_height="fill_parent"
+                    android:layout_width="0dip"
+                    android:orientation="horizontal">
+                    <include android:id="@+id/nextTimeflip" layout="@layout/next_time_textview" />
+                    <Button
+                        android:layout_width="0dip"
+                        android:layout_height="wrap_content"
+                        android:background="@color/transparent"
+                        android:lines="1"
+                        android:textSize="14sp" />
+                </LinearLayout>
+            </LinearLayout>
+            <LinearLayout android:id="@+id/flashcard_layout_ease1"
+                android:layout_height="fill_parent"
+                android:layout_width="0dip"
+                android:layout_weight="1"
+                android:orientation="vertical"
+                android:visibility="gone"
+                style="?android:attr/buttonStyleSmall">
+                <include
+                    android:id="@+id/nextTime1"
+                    layout="@layout/next_time_textview"/>
+                <include android:id="@+id/ease1" layout="@layout/bottom_button" />
+            </LinearLayout>
+            <LinearLayout android:id="@+id/flashcard_layout_ease2"
+                android:layout_height="fill_parent"
+                android:layout_width="0dip"
+                android:layout_weight="1"
+                android:visibility="gone"
+                android:orientation="vertical"
+                style="?android:attr/buttonStyleSmall">
+                <include
+                    android:id="@+id/nextTime2"
+                    layout="@layout/next_time_textview"
+                    android:textColor="@color/next_time_usual_color" />
+                <include android:id="@+id/ease2" layout="@layout/bottom_button" />
+            </LinearLayout>
+            <LinearLayout android:id="@+id/flashcard_layout_ease3"
+                android:layout_height="fill_parent"
+                android:visibility="gone"
+                android:layout_width="0dip"
+                android:layout_weight="1"
+                android:orientation="vertical"
+                style="?android:attr/buttonStyleSmall">
+                <include
+                    android:id="@+id/nextTime3"
+                    layout="@layout/next_time_textview"/>
+                <include android:id="@+id/ease3" layout="@layout/bottom_button" />
+            </LinearLayout>
+            <LinearLayout android:id="@+id/flashcard_layout_ease4"
+                android:layout_height="fill_parent"
+                android:layout_width="0dip"
+                android:visibility="gone"
+                android:layout_weight="1"
+                android:orientation="vertical"
+                style="?android:attr/buttonStyleSmall">
+                <include
+                    android:id="@+id/nextTime4"
+                    layout="@layout/next_time_textview" />
+                <include android:id="@+id/ease4" layout="@layout/bottom_button" />
+            </LinearLayout>
+        </LinearLayout>
+    </LinearLayout>
 
 </RelativeLayout>

--- a/res/values/01-core.xml
+++ b/res/values/01-core.xml
@@ -24,7 +24,7 @@
 <string name="app_name">AnkiDroid</string>
 
 <string name="attention">Attention</string>
-    
+
 <string name="yes">Yes</string>
 <string name="no">No</string>
 <string name="ok">OK</string>
@@ -56,6 +56,7 @@
 </plurals>
 
 <!-- flashcard_portrait.xml -->
+<string name="type_answer_hint">Type answer</string>
 <string name="show_answer">Show Answer</string>
 <!--<string name="show_question">Re-display Question</string>
 <string name="card_hint">Flashcard</string>-->
@@ -112,7 +113,7 @@
 <string name="menu_suspend_note">Suspend Note</string>
 <string name="menu_delete_note">Delete Note</string>
 <string name="delete_note_message">Really delete this note and all its cards?\n%s</string>
-    
+
 <string name="menu_edit_card">Edit Card</string>
 <string name="menu_select">Select text</string>
 <string name="menu_search">Lookup in %1$s</string>
@@ -129,22 +130,22 @@
 <!--<string name="studyoptions_load_sample_deck">Load Sample Deck</string>-->
 <string name="night_mode">Night mode</string>
 
-	<string-array name="next_review_s">
-		<item>1 second</item>
-		<item>1 minute</item>
-		<item>1 hour</item>
-		<item>1 day</item>
-		<item>1 month</item>
-		<item>1 year</item>
-	</string-array>
-	<string-array name="next_review_p">
-		<item>%s seconds</item>
-		<item>%s minutes</item>
-		<item>%s hours</item>
-		<item>%s days</item>
-		<item>%s months</item>
-		<item>%s years</item>
-	</string-array>
+    <string-array name="next_review_s">
+        <item>1 second</item>
+        <item>1 minute</item>
+        <item>1 hour</item>
+        <item>1 day</item>
+        <item>1 month</item>
+        <item>1 year</item>
+    </string-array>
+    <string-array name="next_review_p">
+        <item>%s seconds</item>
+        <item>%s minutes</item>
+        <item>%s hours</item>
+        <item>%s days</item>
+        <item>%s months</item>
+        <item>%s years</item>
+    </string-array>
 
 <string name="visit">Visit</string>
 <string name="later">Later</string>

--- a/src/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/src/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1,6 +1,7 @@
 /****************************************************************************************
  * Copyright (c) 2011 Kostas Spyropoulos <inigo.aldana@gmail.com>                       *
  * Copyright (c) 2014 Bruno Romero de Azevedo <brunodea@inf.ufsm.br>                    *
+ * Copyright (c) 2014 Roland Sieker <ospalh@gmail.com>                                  *
  *                                                                                      *
  * This program is free software; you can redistribute it and/or modify it under        *
  * the terms of the GNU General Public License as published by the Free Software        *
@@ -65,7 +66,7 @@ import android.view.MotionEvent;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.WindowManager;
-import android.view.inputmethod.InputMethodManager;
+import android.view.inputmethod.EditorInfo;
 import android.webkit.JavascriptInterface;
 import android.webkit.JsResult;
 import android.webkit.WebChromeClient;
@@ -715,12 +716,7 @@ public abstract class AbstractFlashcardViewer extends AnkiActivity {
                         getResources().getString(R.string.saving_changes), true);
             } else {
                 // Start reviewing next card
-                if (mPrefWriteAnswers) {
-                    // only bother query deck if needed
-                    updateTypeAnswerInfo();
-                } else {
-                    mTypeCorrect = null;
-                }
+                updateTypeAnswerInfo();
                 mProgressBar.setVisibility(View.INVISIBLE);
                 AbstractFlashcardViewer.this.unblockControls();
                 AbstractFlashcardViewer.this.displayCardQuestion();
@@ -832,9 +828,9 @@ public abstract class AbstractFlashcardViewer extends AnkiActivity {
         if (mTypeWarning != null) {
             return m.replaceFirst(mTypeWarning);
         }
-        
-        return m.replaceFirst("<span style=\"color:magenta;\">........</span>");
+        return m.replaceFirst("<span id=typeans class=typePrompt>........</span>");
     }
+
 
     /**
      * Format answer field when it contains typeAnswer or clozes
@@ -844,15 +840,18 @@ public abstract class AbstractFlashcardViewer extends AnkiActivity {
      */
     private String typeAnsAnswerFilter(String buf, String userAnswer, String correctAnswer) {
         Matcher m = sTypeAnsPat.matcher(buf);
-        
+
         // Obtain the diff and send it to updateCard
         DiffEngine diff = new DiffEngine();
         String diffUserAnswer = diff.diff_prettyHtml(diff.diff_main(userAnswer, correctAnswer), mNightMode);
-        if(userAnswer.equals(correctAnswer))
-        	return m.replaceFirst(diffUserAnswer + "\u2714");
-        else
-        	return m.replaceFirst(diffUserAnswer + "\u21a6" + diff.diff_prettyHtml(diff.diff_main(correctAnswer, correctAnswer), mNightMode));
+        if (userAnswer.equals(correctAnswer)) {
+            return m.replaceFirst("<div><code id=typeans>" + diffUserAnswer + "\u2714</code></div>");
+        } else {
+            return m.replaceFirst("<div><code id=typeans>" + diffUserAnswer + "<br>&darr;<br>" +
+                    diff.diff_prettyHtml(diff.diff_main(correctAnswer, correctAnswer), mNightMode) + "</code></div>");
     }
+    }
+
 
     private String contentForCloze(String txt, int idx) {
         Pattern re = Pattern.compile("\\{\\{c" + idx + "::(.+?)\\}\\}");
@@ -1811,10 +1810,6 @@ public abstract class AbstractFlashcardViewer extends AnkiActivity {
             mFlipCardLayout.requestFocus();
         } else if (typeAnswer()) {
             mAnswerField.requestFocus();
-
-            // Show soft keyboard
-            //InputMethodManager inputMethodManager = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
-            //inputMethodManager.showSoftInput(mAnswerField, InputMethodManager.SHOW_FORCED);
         }
     }
 
@@ -1845,6 +1840,15 @@ public abstract class AbstractFlashcardViewer extends AnkiActivity {
             mWhiteboard.setVisibility(mShowWhiteboard ? View.VISIBLE : View.GONE);
         }
         mAnswerField.setVisibility(typeAnswer() ? View.VISIBLE : View.GONE);
+        mAnswerField.setOnEditorActionListener(new EditText.OnEditorActionListener() {
+                @Override
+                public boolean onEditorAction(TextView v, int actionId, KeyEvent event) {
+                    if (actionId == EditorInfo.IME_ACTION_DONE) {
+                        mFlipCardLayout.performClick();
+                    }
+                    return false;  // We don’t “handle” this. Let Android hide the input method.
+                }
+            });
     }
 
 
@@ -2140,10 +2144,6 @@ public abstract class AbstractFlashcardViewer extends AnkiActivity {
             // If the user wants to write the answer
             if (typeAnswer()) {
                 mAnswerField.setVisibility(View.VISIBLE);
-
-                // Show soft keyboard
-                //InputMethodManager inputMethodManager = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
-                //inputMethodManager.showSoftInput(mAnswerField, InputMethodManager.SHOW_FORCED);
             }
 
             displayString = enrichWithQADiv(question, false);
@@ -2218,10 +2218,11 @@ public abstract class AbstractFlashcardViewer extends AnkiActivity {
 
     protected String getAnswerText(String answer)
     {
-    	if(answer == null || answer.equals(""))
-    		return "";
-    	
-    	 Matcher matcher = sSpanPattern.matcher(Utils.stripHTMLMedia(answer));
+        if (answer == null || answer.equals("")) {
+            return "";
+        }
+
+         Matcher matcher = sSpanPattern.matcher(Utils.stripHTMLMedia(answer));
          String answerText = matcher.replaceAll("");
          matcher = sBrPattern.matcher(answerText);
          answerText = matcher.replaceAll("\n");
@@ -2246,7 +2247,6 @@ public abstract class AbstractFlashcardViewer extends AnkiActivity {
         } else {
             answer = mCurrentCard.a();
         }
-        answer = typeAnsAnswerFilter(answer);
 
         if (mDisplayKanjiInfo) {
             answer = answer + addKanjiInfo(mCurrentCard.q(mCurrentSimpleInterface));
@@ -2270,8 +2270,6 @@ public abstract class AbstractFlashcardViewer extends AnkiActivity {
                 answer = ArabicUtilities.reshapeSentence(answer, true);
             }
 
-            // If the user wrote an answer
-            if (typeAnswer()) {
                 mAnswerField.setVisibility(View.GONE);
                 if (mCurrentCard != null) {
                     if (mPrefFixArabic) {
@@ -2283,20 +2281,7 @@ public abstract class AbstractFlashcardViewer extends AnkiActivity {
                     String correctAnswer = getAnswerText(mTypeCorrect);
                     Log.i(AnkiDroidApp.TAG, "correct answer = " + correctAnswer);
 
-                    StringBuffer span = new StringBuffer();
-                    span.append("<span style=\"font-family: '").append(mTypeFont).append("'; font-size: ")
-                            .append(mTypeSize).append("px\">");
-                    
-                    span.append("</span>");
                     answer = typeAnsAnswerFilter(answer, userAnswer, correctAnswer);
-                    span.append("<br/>").append(answer);
-                    displayString = enrichWithQADiv(span.toString(), true);
-                }
-
-                // Hide soft keyboard
-                InputMethodManager inputMethodManager = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
-                inputMethodManager.hideSoftInputFromWindow(mAnswerField.getWindowToken(), 0);
-            } else {
                 displayString = enrichWithQADiv(answer, true);
             }
         }
@@ -3207,7 +3192,7 @@ public abstract class AbstractFlashcardViewer extends AnkiActivity {
 
         @Override
         public void handleTag(boolean opening, String tag, Editable output, XMLReader xmlReader) {
-            // if(tag.equalsIgnoreCase("div")) {
+            // if (tag.equalsIgnoreCase("div")) {
             // output.append("\n");
             // } else
             if (tag.equalsIgnoreCase("strike") || tag.equals("s")) {

--- a/src/com/ichi2/utils/DiffEngine.java
+++ b/src/com/ichi2/utils/DiffEngine.java
@@ -56,16 +56,6 @@ public class DiffEngine {
     public short Diff_DualThreshold = 32;
 
     /**
-     * Colors for right and wrong answer
-     */
-    private static final String RIGHT_COLOR = "#c0ffc0";
-    private static final String WRONG_COLOR = "#ffc0c0";
-    // Colours for night mode, they are going to be inverted, so we're just aiming for darker versions (#508040 and #905050)
-    // of the normal colours eventually, since the mapping green = right, red = wrong is quite universal.
-    private static final String RIGHT_COLOR_NIGHT = "#af7fbf";
-    private static final String WRONG_COLOR_NIGHT = "#6fafaf";
-
-    /**
      * Internal class for returning results from diff_linesToChars(). Other less paranoid languages just use a
      * three-element array.
      */
@@ -1081,12 +1071,6 @@ public class DiffEngine {
      */
     public String diff_prettyHtml(LinkedList<DiffAction> diffs, boolean mNightMode) {
         StringBuilder html = new StringBuilder();
-        String rightColor = RIGHT_COLOR;
-        String wrongColor = WRONG_COLOR;
-        if (mNightMode) {
-            rightColor = RIGHT_COLOR_NIGHT;
-            wrongColor = WRONG_COLOR_NIGHT;
-        }
         for (DiffAction aDiff : diffs) {
             String text = aDiff.text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
                     .replace("\n", "<br>");
@@ -1097,13 +1081,13 @@ public class DiffEngine {
                     for (int j = 0; j < l; j++) {
                         spaces += "&nbsp;";
                     }
-                    html.append("<span class=\"\" style=\"background:" + wrongColor + ";\">").append(spaces).append("</span>");
+                    html.append("<span class=typeBad>").append(spaces).append("</span>");
                     break;
                 case DELETE:
-                    html.append("<span style=\"background:" + wrongColor + ";\">").append(text).append("</span>");
+                    html.append("<span class=typeBad>").append(text).append("</span>");
                     break;
                 case EQUAL:
-                    html.append("<span style=\"background:" + rightColor + ";\">").append(text).append("</span>");
+                    html.append("<span class=typeGood>").append(text).append("</span>");
                     break;
             }
         }


### PR DESCRIPTION
This extends PR #304.
The extra changes:
- Use the `android:imeOptions="actionDone"` to hide the soft keyboard on enter/return presses. Also use that to show the answer. This is similar to the behavior of Anki desktop.
- Also, get rid of the visible `[[type:NN]]` by doing the comparison even when the type answer is switched off.

I may or may not write some code to bring the actual comparison in line with Anki desktop, but no guarantee. So maybe people want to wait a bit for that.

Extra notes:
- Unfortunately, i can't test this with old Android versions, as my Java seems to be broken
- You may want to look at the diffs wit [`?w=1`](https://github.com/ospalh/Anki-Android/compare/ankidroid:develop...feature-type-answer-fixes?w=1) to hide the whitespace changes.
