### PR TITLE
Dim zeros in deck picker

### DIFF
--- a/res/values/colors.xml
+++ b/res/values/colors.xml
@@ -105,6 +105,6 @@
 
     <color name="dyn_deck">#2222bb</color>
     <color name="non_dyn_deck">#000000</color>
-
+    <color name="zero_count">#e0e0e0</color>
 
 </resources>

--- a/src/com/ichi2/anki/DeckPicker.java
+++ b/src/com/ichi2/anki/DeckPicker.java
@@ -997,6 +997,9 @@ public class DeckPicker extends ActionBarActivity {
                         ((TextView) view).setTextColor(getResources().getColor(R.color.dyn_deck));
                         return true;
                     }
+                } else if ((view.getId() == R.id.deckpicker_new || view.getId() == R.id.deckpicker_lrn ||
+                            view.getId() == R.id.deckpicker_rev) && text.equals("0")) {
+                     ((TextView) view).setTextColor(getResources().getColor(R.color.zero_count));
                 }
                     // } else if (view.getId() == R.id.deckpicker_bar_mat || view.getId() == R.id.deckpicker_bar_all) {
                     // if (text.length() > 0 && !text.equals("-1.0")) {


### PR DESCRIPTION
This shows zeros in the deck picker in a rather light gray, the way Anki desktop does it. Like this decks where you actually should do some reviews stand out from the decks where you are through for the day.

As usual, i did some whitespace clean up and put that in an extra commit. Use [`?w=1`](https://github.com/ospalh/Anki-Android/compare/ankidroid:develop...feature-dim-zeros?w=1) for the whole pull request to not see those changes.
