### PR TITLE
Address serial calls to playSounds not playing all sounds

### DIFF
--- a/res/menu/reviewer.xml
+++ b/res/menu/reviewer.xml
@@ -48,8 +48,7 @@
     </item>
 
     <item android:id="@+id/action_replay"
-        android:title="@string/replay_audio"
-        android:visible="false" />
+        android:title="@string/replay_audio" />
 
     <item android:id="@+id/action_whiteboard"
         android:title="@string/hide_whiteboard"


### PR DESCRIPTION
It has been seen in some cases that attempts to call playSounds multiple times in a row would result in only the first call being successful, so this change adds a list of sounds that can be played that is a combination of both question and answer, such that serial calls are now a single call. This additional list is only created on an as needed basis, so execution time should remain the same in all cases where the replay functionality is not instigated.

On that topic, there ~is~ no replay menu option in current develop, but I did test this feature as though such an option was exposed. However, this change, will necessary, will not come into play until users can emulate the replay behavior of the anki desktop client through a "replay audio" button that plays all audio as configured (question too, or not).

This change is in response to observations made by @timrae
