### PR TITLE
Expose audio changes after card edit

### DIFF
--- a/src/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/src/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -638,6 +638,9 @@ public abstract class AbstractFlashcardViewer extends AnkiActivity {
             }
 
             if (sDisplayAnswer) {
+                Sound.resetSounds(); // load sounds from scratch, to expose any edit changes
+                mAnswerSoundsAdded = false; // causes answer sounds to be reloaded            
+                generateQuestionSoundList(); // questions must be intentionally regenerated
                 displayCardAnswer();
             } else {
                 displayCardQuestion();
@@ -1397,6 +1400,11 @@ public abstract class AbstractFlashcardViewer extends AnkiActivity {
         sEditorCard = mCurrentCard;
         startActivityForResultWithAnimation(editCard, EDIT_CURRENT_CARD, ActivityTransitionAnimation.LEFT);
         return true;
+    }
+
+
+    protected void generateQuestionSoundList() {
+        Sound.addSounds(mBaseUrl, mCurrentCard.qSimple(), Sound.SOUNDS_QUESTION);        
     }
 
 

--- a/src/com/ichi2/anki/CardEditor.java
+++ b/src/com/ichi2/anki/CardEditor.java
@@ -135,7 +135,7 @@ public class CardEditor extends ActionBarActivity {
 
     private static final int WAIT_TIME_UNTIL_UPDATE = 1000;
 
-    private static boolean mChanged = false;
+    private boolean mChanged = false;
 
     /**
      * Broadcast that informs us when the sd card is about to be unmounted


### PR DESCRIPTION
Before this change, is a card was edited during review, any changes to the sounds (such a removal) would not be exposed as changed. This addresses that.

This is one thing about this change I do not personally fully understand, but i expect no issues from this:

I reset the sounds after a desk task completes. My change has as an underlying assumption that this will not be run asynchronously, returning at an ~arbitrary~ time, but instead will be such that the changes will be present on the card as it is renders, after the editor is closed. This matches my experience on my device (edited text is always immediately available), and it matches how the code goes through the debugger (serially, completing the updates before rendering the card), but, it is after all an AsyncTask. I don't fully know the behavior of these things except that sometimes it's serial in nature, and I just don't know I am always guaranteed that, or why that would be. However, whether it returns serially or not, the audio flushing/reloading still happens in the right place (after changes saved), and the card is shown right after. So.
