### PR TITLE
Fix string comparison in tag deletion

### DIFF
--- a/src/com/ichi2/libanki/Note.java
+++ b/src/com/ichi2/libanki/Note.java
@@ -243,7 +243,7 @@ public class Note implements Cloneable {
     public void delTag(String tag) {
         List<String> rem = new LinkedList<String>();
         for (String t : mTags) {
-            if (t.toLowerCase(Locale.getDefault()) == tag.toLowerCase(Locale.getDefault())) {
+            if (t.equalsIgnoreCase(tag)) {
                 rem.add(t);
             }
         }


### PR DESCRIPTION
Classic string comparison fail :\

You'd think I'd have learned not to do this by now.
