### PR TITLE
Showing text in statistics dialog depending on API Level

### DIFF
--- a/src/com/ichi2/charts/ChartBuilder.java
+++ b/src/com/ichi2/charts/ChartBuilder.java
@@ -303,10 +303,18 @@ public class ChartBuilder extends ActionBarActivity {
         Resources res = context.getResources();
         String[] text = res.getStringArray(R.array.stats_period);
         int height = context.getResources().getDrawable(R.drawable.white_btn_radio).getIntrinsicHeight();
+        
+        //workaround for text overlapping radiobutton. 
+        //It appears that when API Level is <= 16, the text would overlap the radio button, hence the
+        //addition of spaces.
+        String spaces = "";
+        if (android.os.Build.VERSION.SDK_INT <= android.os.Build.VERSION_CODES.JELLY_BEAN) {
+            spaces = "         ";
+        }
         for (int i = 0; i < statisticRadioButtons.length; i++) {
             statisticRadioButtons[i] = new RadioButton(context);
             statisticRadioButtons[i].setClickable(true);
-            statisticRadioButtons[i].setText(text[i]);
+            statisticRadioButtons[i].setText(spaces + text[i]);
             statisticRadioButtons[i].setHeight(height * 2);
             statisticRadioButtons[i].setSingleLine();
             statisticRadioButtons[i].setBackgroundDrawable(null);


### PR DESCRIPTION
As noted by @chajadan in https://github.com/ankidroid/Anki-Android/pull/317#issuecomment-42143775, there was a problem with the text of the radio buttons in the statistics dialog.

@timrae suggested (https://github.com/ankidroid/Anki-Android/pull/317#issuecomment-42144778) checking for the API level in the code in order to add or not the spaces to the texts.
So, that's what I did.
From API Level 17 and up the text would be too far to the right if the spaces were added. In API Level 16, with spaces, the text would be just right.
