### PR TITLE
Fix 2088: Do not cut off drop-down deck names in landscape mode

### DIFF
--- a/res/layout/dropdown_deck_item.xml
+++ b/res/layout/dropdown_deck_item.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- Reference: appcompat's support_simple_spinner_dropdown_item -->
 <TextView xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/dropdown_deck_name"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent"
-    android:paddingBottom="10dp"
-    android:paddingLeft="6dp"
-    android:paddingRight="10dp"
-    android:paddingTop="10dp"
+    style="?attr/spinnerDropDownItemStyle"
+    android:layout_width="match_parent"
+    android:layout_height="?attr/dropdownListPreferredItemHeight"
     android:singleLine="true" />


### PR DESCRIPTION
I really don't understand how GitHub gets away with their simple [drop-down layout](https://github.com/github/android/blob/master/app/res/layout/org_dropdown_item.xml) for their Android app. Anyway, here's some magic to fix [2088](https://code.google.com/p/ankidroid/issues/detail?id=2088), basically taken from `support_simple_spinner_dropdown_item` found in the appcompat package.
