### PR TITLE
Change current deck on drop-down deck change

### DIFF
--- a/src/com/ichi2/anki/CardBrowser.java
+++ b/src/com/ichi2/anki/CardBrowser.java
@@ -766,11 +766,16 @@ public class CardBrowser extends ActionBarActivity implements ActionBar.OnNaviga
             mRestrictOnDeck = "";
         } else {
             JSONObject deck = mDropDownDecks.get(position - 1);
+            String deckName;
+            Long deckId;
             try {
-                mRestrictOnDeck = "deck:'" + deck.getString("name") + "' ";
+                deckName = deck.getString("name");
+                deckId = deck.getLong("id");
             } catch (JSONException e) {
                 throw new RuntimeException();
             }
+            mRestrictOnDeck = "deck:'" + deckName + "' ";
+            AnkiDroidApp.getCol().getDecks().select(deckId);
         }
         if (preferences.getBoolean("cardBrowserNoSearchOnOpen", false)) {
             mCards.clear();


### PR DESCRIPTION
After changing the deck in the drop-down menu of the card browser, the note editor would still be fixed on the old current deck. With this change the current deck changes when a deck is selected from the drop-down menu.

Maybe a question for the libanki people, why is there `id` and `did`? Is there a difference?
