### PR TITLE
Prepare error report when null encountered in queryColumn

### DIFF
--- a/src/com/ichi2/anki/AnkiDroidApp.java
+++ b/src/com/ichi2/anki/AnkiDroidApp.java
@@ -31,6 +31,7 @@ import android.util.Log;
 import android.view.Display;
 import android.view.WindowManager;
 
+import com.ichi2.anki.exception.AnkiDroidErrorReportException;
 import com.ichi2.async.Connection;
 import com.ichi2.compat.Compat;
 import com.ichi2.compat.CompatV15;
@@ -349,8 +350,22 @@ public class AnkiDroidApp extends Application {
     }
 
 
+    public static void saveExceptionReportFile(String origin, String additionalInfo) {
+        try {
+            throw new AnkiDroidErrorReportException();
+        } catch (AnkiDroidErrorReportException e) {
+            saveExceptionReportFile(e, origin, additionalInfo);
+        }
+    }
+    
+    
     public static void saveExceptionReportFile(Throwable e, String origin) {
-        CustomExceptionHandler.getInstance().uncaughtException(null, e, origin);
+        saveExceptionReportFile(e, origin, null);
+    }
+    
+    
+    public static void saveExceptionReportFile(Throwable e, String origin, String additionalInfo) {
+        CustomExceptionHandler.getInstance().uncaughtException(null, e, origin, additionalInfo);
     }
 
 

--- a/src/com/ichi2/anki/CustomExceptionHandler.java
+++ b/src/com/ichi2/anki/CustomExceptionHandler.java
@@ -19,6 +19,7 @@ import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.os.Environment;
 import android.os.StatFs;
+import android.text.TextUtils;
 import android.util.Log;
 
 import java.io.File;
@@ -123,6 +124,11 @@ public class CustomExceptionHandler implements Thread.UncaughtExceptionHandler {
 
 
     public void uncaughtException(Thread t, Throwable e, String origin) {
+        uncaughtException(t, e, origin, null);
+    }
+    
+    
+    public void uncaughtException(Thread t, Throwable e, String origin, String additionalInfo) {
         Log.i(AnkiDroidApp.TAG, "uncaughtException");
 
         collectInformation();
@@ -154,7 +160,11 @@ public class CustomExceptionHandler implements Thread.UncaughtExceptionHandler {
 
             reportInformation.append(String.format("%s=%s\n", key.toLowerCase(), value));
         }
-
+        
+        if (additionalInfo != null && !TextUtils.isEmpty(additionalInfo)) {
+            reportInformation.append(String.format("additionalinformation=%s\n", additionalInfo));
+        }
+        
         reportInformation.append("stacktrace=\nBegin Stacktrace\n");
 
         // Stack trace

--- a/src/com/ichi2/anki/exception/AnkiDroidErrorReportException.java
+++ b/src/com/ichi2/anki/exception/AnkiDroidErrorReportException.java
@@ -1,0 +1,10 @@
+package com.ichi2.anki.exception;
+
+public class AnkiDroidErrorReportException extends Exception {
+    // auto-generated serialization id
+    private static final long serialVersionUID = -550830607597085764L;
+
+    public AnkiDroidErrorReportException() {
+        super("AnkiDroidErrorReportException: A custom exception generated only to save an error report, for instances when needed outside of a catch clause.");
+    }
+}


### PR DESCRIPTION
Nulls have been encountered in the results of queries in the queryColumn function, and they are not supported there. This change prepares an error report that the user can send when they next start Anki - which keeps them from getting prompted multiple times. Thanks to @timrae for info on generating the report.
