### PR TITLE
Fix for issue 2073.  Get rid of the swap button and swapText() function.

### DIFF
--- a/res/layout/card_editor.xml
+++ b/res/layout/card_editor.xml
@@ -88,16 +88,6 @@
                         android:gravity="left|center_vertical"
                         android:textColor="#000000" />
                 </LinearLayout>
-
-                <Button
-                    android:id="@+id/CardEditorSwapButton"
-                    style="?android:attr/buttonStyleSmall"
-                    android:layout_width="0dip"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center"
-                    android:layout_weight="1"
-                    android:gravity="center"
-                    android:text="@string/fact_adder_swap" />
             </LinearLayout>
 
             <LinearLayout

--- a/res/values/02-strings.xml
+++ b/res/values/02-strings.xml
@@ -96,7 +96,6 @@
     <string name="studyoptions_no_external_storage_title">No External Storage Available</string>
     <string name="studyoptions_no_external_storage_message">No external storage is currently available. AnkiDroid needs to have access to the SD card in order to read and load your Anki decks. Check that your SD card is mounted and try again.</string>
     <string name="fact_adder_intent_title">AnkiDroid Card</string>
-    <string name="fact_adder_swap">Swap</string>
     <string name="deckpicker_select_dictionary_title">Select Dictionary</string>
     <string name="deckpicker_select_dictionary_default">Default</string>
     <string name="card_editor_add_card">Add note</string>

--- a/src/com/ichi2/anki/CardEditor.java
+++ b/src/com/ichi2/anki/CardEditor.java
@@ -92,7 +92,7 @@ import java.util.TreeSet;
  * Allows the user to edit a fact, for instance if there is a typo. A card is a presentation of a fact, and has two
  * sides: a question and an answer. Any number of fields can appear on each side. When you add a fact to Anki, cards
  * which show that fact are generated. Some models generate one card, others generate more than one.
- * 
+ *
  * @see http://ichi2.net/anki/wiki/KeyTermsAndConcepts#Cards
  */
 public class CardEditor extends ActionBarActivity {
@@ -154,7 +154,6 @@ public class CardEditor extends ActionBarActivity {
     private TextView mTagsButton;
     private TextView mModelButton;
     private TextView mDeckButton;
-    private Button mSwapButton;
 
     private Note mEditorNote;
     public static Card mCurrentEditedCard;
@@ -191,8 +190,6 @@ public class CardEditor extends ActionBarActivity {
     // private String mSourceLanguage;
     // private String mTargetLanguage;
     private String[] mSourceText;
-    private int mSourcePosition = 0;
-    private int mTargetPosition = 1;
     private boolean mCancelled = false;
 
     private boolean mPrefFixArabic;
@@ -347,13 +344,6 @@ public class CardEditor extends ActionBarActivity {
         mDeckButton = (TextView) findViewById(R.id.CardEditorDeckText);
         mModelButton = (TextView) findViewById(R.id.CardEditorModelText);
         mTagsButton = (TextView) findViewById(R.id.CardEditorTagText);
-        mSwapButton = (Button) findViewById(R.id.CardEditorSwapButton);
-        mSwapButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                swapText(false);
-            }
-        });
 
         Preferences.COMING_FROM_ADD = false;
 
@@ -481,16 +471,6 @@ public class CardEditor extends ActionBarActivity {
             });
         } else {
             setTitle(R.string.cardeditor_title_edit_card);
-            mSwapButton.setVisibility(View.GONE);
-            mSwapButton = (Button) findViewById(R.id.CardEditorLaterButton);
-            mSwapButton.setVisibility(View.VISIBLE);
-            mSwapButton.setText(getResources().getString(R.string.fact_adder_swap));
-            mSwapButton.setOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View v) {
-                    swapText(false);
-                }
-            });
         }
 
         ((LinearLayout) findViewById(R.id.CardEditorDeckButton)).setOnClickListener(new View.OnClickListener() {
@@ -1304,53 +1284,6 @@ public class CardEditor extends ActionBarActivity {
     }
 
 
-    private void swapText(boolean reset) {
-        int len = mEditFields.size();
-        if (len < 2) {
-            return;
-        }
-        mSourcePosition = Math.min(mSourcePosition, len - 1);
-        mTargetPosition = Math.min(mTargetPosition, len - 1);
-
-        // get source text
-        FieldEditText field = mEditFields.get(mSourcePosition);
-        Editable sourceText = field.getText();
-
-        // get target text
-        field = mEditFields.get(mTargetPosition);
-        Editable targetText = field.getText();
-
-        if (len > mSourcePosition) {
-            mEditFields.get(mSourcePosition).setText("");
-        }
-        if (len > mTargetPosition) {
-            mEditFields.get(mTargetPosition).setText("");
-        }
-        if (reset) {
-            mSourcePosition = 0;
-            mTargetPosition = 1;
-        } else {
-            mTargetPosition++;
-            while (mTargetPosition == mSourcePosition || mTargetPosition >= mEditFields.size()) {
-                mTargetPosition++;
-                if (mTargetPosition >= mEditFields.size()) {
-                    mTargetPosition = 0;
-                    mSourcePosition++;
-                }
-                if (mSourcePosition >= mEditFields.size()) {
-                    mSourcePosition = 0;
-                }
-            }
-        }
-        if (sourceText != null) {
-            mEditFields.get(mSourcePosition).setText(sourceText);
-        }
-        if (targetText != null) {
-            mEditFields.get(mTargetPosition).setText(targetText);
-        }
-    }
-
-
     private void populateEditFields() {
         mFieldsLayoutContainer.removeAllViews();
         mEditFields = new LinkedList<FieldEditText>();
@@ -1479,7 +1412,6 @@ public class CardEditor extends ActionBarActivity {
         updateDeck();
         updateTags();
         populateEditFields();
-        swapText(true);
     }
 
 


### PR DESCRIPTION
With more than two fields, pressing the “swap” button in the editor oddly [cleared the second](https://code.google.com/p/ankidroid/issues/detail?id=2073) field.

As [nobody defended](https://groups.google.com/forum/#!topic/anki-android/4POz1Bu7Q8k) keeping the button for two-field models, just cut it out.
