### PR TITLE
Do proper preference upgrade path

### DIFF
--- a/src/com/ichi2/anki/DeckPicker.java
+++ b/src/com/ichi2/anki/DeckPicker.java
@@ -1325,12 +1325,14 @@ public class DeckPicker extends ActionBarActivity {
     
     private void upgradePreferences(int previousVersionCode) {
         SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(getBaseContext());
+        if (previousVersionCode < 20100108) {
+            preferences.edit().putString("overrideFont", preferences.getString("defaultFont", "")).commit();
+            preferences.edit().putString("defaultFont", "").commit();            
+        }
         if (previousVersionCode < 20200170) {
         	boolean safeDisplayMode = preferences.getBoolean("eInkDisplay", false) || isNookDevice() || 
         			!preferences.getBoolean("forceQuickUpdate", false);
         	preferences.edit().putBoolean("safeDisplay", safeDisplayMode).commit();
-            preferences.edit().putString("overrideFont", preferences.getString("defaultFont", "")).commit();
-            preferences.edit().putString("defaultFont", "").commit();
         }
     }
 


### PR DESCRIPTION
The preference upgrade path should generally be list of changes to apply, only for the versions that need a particular update. Some well-formed variation is possible, but this change specifically address an introduced bug that would flip one user preference and clear another, for users who were already up-to-date.
