### PR TITLE
Be sure that all dialogs have the itemlist sorted alphabetically

### DIFF
--- a/src/com/ichi2/anki/StudyOptionsFragment.java
+++ b/src/com/ichi2/anki/StudyOptionsFragment.java
@@ -77,11 +77,8 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Locale;
 
 public class StudyOptionsFragment extends Fragment {
@@ -920,14 +917,7 @@ public class StudyOptionsFragment extends Fragment {
                 // Here we add the list of tags for the whole collection.
                 Collection col;
                 col = AnkiDroidApp.getCol();
-                List<String> tags_list = col.getTags().all();
-                Collections.sort(tags_list, new Comparator<String>() {
-                    @Override
-                    public int compare(String lhs, String rhs) {
-                        return lhs.compareToIgnoreCase(rhs);
-                    }
-                });
-                allTags = tags_list.toArray(new String[tags_list.size()]);
+                allTags = col.getTags().all().toArray(new String[0]);
                 builder1.setTitle(R.string.studyoptions_limit_select_tags);
                 builder1.setMultiChoiceItems(allTags, new boolean[allTags.length],
                         new DialogInterface.OnClickListener() {

--- a/src/com/ichi2/themes/StyledDialog.java
+++ b/src/com/ichi2/themes/StyledDialog.java
@@ -46,7 +46,9 @@ import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.R;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 public class StyledDialog extends Dialog {
@@ -116,8 +118,14 @@ public class StyledDialog extends Dialog {
     private void setItems(int type, ListView listview, String[] values, int checkedItem, boolean[] checked,
             DialogInterface.OnClickListener listener) {
         mListView = listview;
-        mItemList = new ArrayList<String>();
-        Collections.addAll(mItemList, values);
+        mItemList = Arrays.asList(values);
+        Collections.sort(mItemList, new Comparator<String>() {
+            @Override
+            public int compare(String lhs, String rhs) {
+                return lhs.compareToIgnoreCase(rhs);
+            }
+        });
+
         mListener = listener;
         if (type == 3) {
             mListView.setOnItemClickListener(new OnItemClickListener() {


### PR DESCRIPTION
Be sure that all dialogs have the itemlist sorted alphabetically ignoring case.

I noticed that there was a dialog in the CardBrowser (filter by tag) with the tags sorted wrongly. So I added some code to the StyledDialog to force all dialogs to have their itemlists sorted correctly (ignoring case).
