### PR TITLE
Scroll the deck list to the currently selected deck and center it

### DIFF
--- a/src/com/ichi2/anki/DeckPicker.java
+++ b/src/com/ichi2/anki/DeckPicker.java
@@ -2751,6 +2751,9 @@ public class DeckPicker extends ActionBarActivity {
                     public void onGlobalLayout() {
                         mDeckListView.getViewTreeObserver().removeGlobalOnLayoutListener(this);
                         mDeckListView.performItemClick(null, lastPosition, 0);
+                        // Scroll the listView to the currently selected row, then offset it by half the
+                        // listview's height so that it is centered.
+                        mDeckListView.setSelectionFromTop(lastPosition, mDeckListView.getHeight() / 2);
                     }
                 });
                 break;


### PR DESCRIPTION
Something that's been bothering me for a while.

On tablets, the currently selected deck is highlighted in the deck list. If there are many decks, then the selected deck may not be initially visible. This change will scroll the deck list to ensure AnkiDroid always opens up on tablets with the currently selected deck visible.
