### PR TITLE
Fix duplicate check in note editor

### DIFF
--- a/res/values/03-dialogs.xml
+++ b/res/values/03-dialogs.xml
@@ -55,8 +55,6 @@
     <string name="reset_card_dialog_title">Reset card progress</string>
     <string name="reset_card_dialog_message">This resets the learning progress for all cards of this note (they will look like new cards).\nReally continue?</string>
     <string name="reset_card_dialog_confirmation">All cards of this note reset</string>
-    <string name="save_duplicate_dialog_title">Duplicate note</string>
-    <string name="save_duplicate_dialog_message">This note shares its primary field with another note. Save anyway?</string>
     <string name="answering_error_title">Database error</string>
     <string name="answering_error_message">An error occurred while writing to the collection. This could be related to a corrupt database or to insufficient disc space.\n\nIf it happens more often, please try to check the database, repair the collection or restoring it from a backup. Click on \'options\' for that.\n\nNevertheless, it could be an AnkiDroid bug as well; please report the error that we can check this.</string>
     <string name="answering_error_report">Report error</string>


### PR DESCRIPTION
Duplicate checking was broken. The content of the Note was never being updated to reflect the content in the text boxes in the editor, so the dupe check was only ever running on old values. I made it update the relevant (first) field before a dupe check (but then put the old value back since there is a modification check later on).

I also removed the confirmation dialog on dupes. There have been a few complains about it, and it just adds an extra step to modifying notes when the highlighting should already be enough to signal a duplicate.
