### PR TITLE
Style the typed and the correct texts.

### DIFF
--- a/src/com/ichi2/utils/DiffEngine.java
+++ b/src/com/ichi2/utils/DiffEngine.java
@@ -33,7 +33,7 @@ import java.util.regex.Pattern;
 /**
  * Functions for diff, match and patch. Computes the difference between two texts to create a patch. Applies the patch
  * onto another text, allowing for errors.
- * 
+ *
  * @author fraser@google.com (Neil Fraser) Class containing the diff, match and patch methods. Also contains the
  *         behaviour settings. TODO if possible, remove the merging code, unneeded.
  */
@@ -87,7 +87,7 @@ public class DiffEngine {
     /**
      * Find the differences between two texts. Run a faster slightly less optimal diff This method allows the
      * 'checklines' of diff_main() to be optional. Most of the time checklines is wanted, so default to true.
-     * 
+     *
      * @param text1 Old string to be diffed.
      * @param text2 New string to be diffed.
      * @return Linked List of Diff objects.
@@ -100,7 +100,7 @@ public class DiffEngine {
     /**
      * Find the differences between two texts. Simplifies the problem by stripping any common prefix or suffix off the
      * texts before diffing.
-     * 
+     *
      * @param text1 Old string to be diffed.
      * @param text2 New string to be diffed.
      * @param checklines Speedup flag. If false, then don't run a line-level diff first to identify the changed areas.
@@ -146,7 +146,7 @@ public class DiffEngine {
 
     /**
      * Find the differences between two texts. Assumes that the texts do not have any common prefix or suffix.
-     * 
+     *
      * @param text1 Old string to be diffed.
      * @param text2 New string to be diffed.
      * @param checklines Speedup flag. If false, then don't run a line-level diff first to identify the changed areas.
@@ -276,7 +276,7 @@ public class DiffEngine {
     /**
      * Split two texts into a list of strings. Reduce the texts to a string of hashes where each Unicode character
      * represents one line.
-     * 
+     *
      * @param text1 First string.
      * @param text2 Second string.
      * @return An object containing the encoded text1, the encoded text2 and the List of unique strings. The zeroth
@@ -301,7 +301,7 @@ public class DiffEngine {
     /**
      * Split a text into a list of strings. Reduce the texts to a string of hashes where each Unicode character
      * represents one line.
-     * 
+     *
      * @param text String to encode.
      * @param lineArray List of unique strings.
      * @param lineHash Map of strings to indices.
@@ -337,7 +337,7 @@ public class DiffEngine {
 
     /**
      * Rehydrate the text in a diff from a string of line hashes to real lines of text.
-     * 
+     *
      * @param diffs LinkedList of Diff objects.
      * @param lineArray List of unique strings.
      */
@@ -355,7 +355,7 @@ public class DiffEngine {
 
     /**
      * Explore the intersection points between the two texts.
-     * 
+     *
      * @param text1 Old string to be diffed.
      * @param text2 New string to be diffed.
      * @return LinkedList of Diff objects or null if no diff available.
@@ -481,7 +481,7 @@ public class DiffEngine {
 
     /**
      * Work from the middle back to the start to determine the path.
-     * 
+     *
      * @param v_map List of path sets.
      * @param text1 Old string fragment to be diffed.
      * @param text2 New string fragment to be diffed.
@@ -531,7 +531,7 @@ public class DiffEngine {
 
     /**
      * Work from the middle back to the end to determine the path.
-     * 
+     *
      * @param v_map List of path sets.
      * @param text1 Old string fragment to be diffed.
      * @param text2 New string fragment to be diffed.
@@ -584,7 +584,7 @@ public class DiffEngine {
 
     /**
      * Compute a good hash of two integers.
-     * 
+     *
      * @param x First int.
      * @param y Second int.
      * @return A long made up of both ints.
@@ -602,7 +602,7 @@ public class DiffEngine {
 
     /**
      * Determine the common prefix of two strings
-     * 
+     *
      * @param text1 First string.
      * @param text2 Second string.
      * @return The number of characters common to the start of each string.
@@ -621,7 +621,7 @@ public class DiffEngine {
 
     /**
      * Determine the common suffix of two strings
-     * 
+     *
      * @param text1 First string.
      * @param text2 Second string.
      * @return The number of characters common to the end of each string.
@@ -642,7 +642,7 @@ public class DiffEngine {
 
     /**
      * Do the two texts share a substring which is at least half the length of the longer text?
-     * 
+     *
      * @param text1 First string.
      * @param text2 Second string.
      * @return Five element String array, containing the prefix of text1, the suffix of text1, the prefix of text2, the
@@ -684,7 +684,7 @@ public class DiffEngine {
     /**
      * Does a substring of shorttext exist within longtext such that the substring is at least half the length of
      * longtext?
-     * 
+     *
      * @param longtext Longer string.
      * @param shorttext Shorter string.
      * @param i Start index of quarter length substring within longtext.
@@ -719,7 +719,7 @@ public class DiffEngine {
 
     /**
      * Reduce the number of edits by eliminating semantically trivial equalities.
-     * 
+     *
      * @param diffs LinkedList of Diff objects.
      */
     public void diff_cleanupSemantic(LinkedList<DiffAction> diffs) {
@@ -796,7 +796,7 @@ public class DiffEngine {
     /**
      * Look for single edits surrounded on both sides by equalities which can be shifted sideways to align the edit to a
      * word boundary. e.g: The c<ins>at c</ins>ame. -> The <ins>cat </ins>came.
-     * 
+     *
      * @param diffs LinkedList of Diff objects.
      */
     public void diff_cleanupSemanticLossless(LinkedList<DiffAction> diffs) {
@@ -878,7 +878,7 @@ public class DiffEngine {
     /**
      * Given two strings, compute a score representing whether the internal boundary falls on logical boundaries. Scores
      * range from 5 (best) to 0 (worst).
-     * 
+     *
      * @param one First string.
      * @param two Second string.
      * @return The score.
@@ -922,7 +922,7 @@ public class DiffEngine {
     /**
      * Reorder and merge like edit sections. Merge equalities. Any edit section can move as long as it doesn't cross an
      * equality.
-     * 
+     *
      * @param diffs LinkedList of Diff objects.
      */
     public void diff_cleanupMerge(LinkedList<DiffAction> diffs) {
@@ -1064,35 +1064,44 @@ public class DiffEngine {
 
 
     /**
-     * Convert a Diff list into a pretty HTML report.
-     * 
-     * @param diffs LinkedList of Diff objects.
-     * @return HTML representation.
+     * Return two strings to display as typed and correct text.
+     *
+     * @param typed (cleaned-up) text the user typed in,
+     * @param typed (cleaned-up) correct text
+     * @return Two-element String array with HTML representation of the diffs between the inputs.
      */
-    public String diff_prettyHtml(LinkedList<DiffAction> diffs, boolean mNightMode) {
-        StringBuilder html = new StringBuilder();
-        for (DiffAction aDiff : diffs) {
-            String text = aDiff.text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
-                    .replace("\n", "<br>");
+    public String[] diffedHtmlStrings(String typed, String correct) {
+        StringBuilder prettyTyped = new StringBuilder();
+        StringBuilder prettyCorrect = new StringBuilder();
+        for (DiffAction aDiff : diff_main(typed, correct)) {
             switch (aDiff.operation) {
                 case INSERT:
-                    String spaces = "";
-                    int l = text.length();
-                    for (int j = 0; j < l; j++) {
-                        spaces += "&nbsp;";
-                    }
-                    html.append("<span class=typeBad>").append(spaces).append("</span>");
+                    prettyTyped.append(wrapBad(aDiff.text));
                     break;
                 case DELETE:
-                    html.append("<span class=typeBad>").append(text).append("</span>");
+                    prettyCorrect.append(wrapMissing(aDiff.text));
                     break;
                 case EQUAL:
-                    html.append("<span class=typeGood>").append(text).append("</span>");
+                    prettyTyped.append(wrapGood(aDiff.text));
+                    prettyCorrect.append(wrapGood(aDiff.text));
                     break;
             }
         }
-        return html.toString();
+        return new String[] {prettyTyped.toString(), prettyCorrect.toString()};
     }
+
+    public static String wrapBad(String in) {
+        return "<span class=\"typeBad\">" + in + "</span>";
+    }
+
+    public static String wrapGood(String in) {
+        return "<span class=\"typeGood\">" + in + "</span>";
+    }
+
+    public static String wrapMissing(String in) {
+        return "<span class=\"typeMissed\">" + in + "</span>";
+    }
+
 
     /**
      * Class representing one diff operation.
@@ -1110,7 +1119,7 @@ public class DiffEngine {
 
         /**
          * Constructor. Initializes the diff with the provided values.
-         * 
+         *
          * @param operation One of INSERT, DELETE or EQUAL.
          * @param text The text being applied.
          */
@@ -1123,7 +1132,7 @@ public class DiffEngine {
 
         /**
          * Display a human-readable version of this Diff.
-         * 
+         *
          * @return text version.
          */
         @Override
@@ -1135,7 +1144,7 @@ public class DiffEngine {
 
         /**
          * Is this Diff equivalent to another Diff?
-         * 
+         *
          * @param d Another Diff to compare against.
          * @return true or false.
          */


### PR DESCRIPTION
When the answer is typed, use the INSERT/DELETE/EQUAL results that the diff engine supplied all the time to style the input _and_ the correct texts, similar to the way Anki desktop does now.
Clean up (trim trailing whitespace &c.) the typed and correct texts a bit.

Seems to run with Android 2.1 devices. :persevere: At least on the emulator. Just the unicode normalization that [Anki desktop does](https://github.com/dae/anki/blob/master/aqt/reviewer.py#L446-L447) is skipped. So this hopefully avoids  something like  [this](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/anki-android/luiSvDOrkZQ/_aW54vvAc2oJ) problem.

Demo: Anki desktop:
![barbados_desktop](https://cloud.githubusercontent.com/assets/1690429/2984296/a8b9b096-dc30-11e3-9d34-d7438aca2d49.png)

AnkiDroid before:
![barbados_before](https://cloud.githubusercontent.com/assets/1690429/2984382/bc829c9a-dc31-11e3-9681-897fe6d87f28.png)

AnkiDroid after:
![barbados_android](https://cloud.githubusercontent.com/assets/1690429/2984389/c5835172-dc31-11e3-9712-d5125513d945.png)

(Emacs removed some trailings spaces.)
