### PR TITLE
Update to Android API Level 19

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -55,7 +55,7 @@
 
     <uses-sdk
         android:minSdkVersion="7"
-        android:targetSdkVersion="18" />
+        android:targetSdkVersion="19" />
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.VIBRATE" />

--- a/tools/travis/continuous-setup.sh
+++ b/tools/travis/continuous-setup.sh
@@ -34,24 +34,24 @@ function main() {
 
   # Download the Android SDK and necessary components.
   download_and_install \
-    $base_uri/tools_r22.0.5-linux.zip \
+    $base_uri/tools_r22.6.3-linux.zip \
     $root/android
 
   download_and_install \
-    $base_uri/platform-tools_r18.0.1-linux.zip \
+    $base_uri/platform-tools_r19.0.2-linux.zip \
     $root/android
 
   download_and_install \
-    $base_uri/build-tools_r18.0.1-linux.zip \
+    $base_uri/build-tools_r19.1-linux.zip \
     $root/android/build-tools
 
   download_and_install \
-    $base_uri/android-18_r01.zip \
+    $base_uri/android-19_r03.zip \
     $root/android/platforms
 
   download_and_install \
-    $base_uri/sysimg_armv7a-18_r01.zip \
-    $root/android/system-images/android-18
+    $base_uri/sysimg_armv7a-19_r02.zip \
+    $root/android/system-images/android-19
 }
 
 set -e

--- a/tools/travis/continuous-test.sh
+++ b/tools/travis/continuous-test.sh
@@ -4,7 +4,7 @@
 
 # It assumes it is being executed on a Linux machine.
 
-TARGET=android-18
+TARGET=android-19
 ABI=armeabi-v7a
 DELAY_SECONDS=10  # Wait as many seconds before checking again.
 NOT_RUNNING_TIMEOUT_SECONDS=60  # Fail if not running for that many seconds. 


### PR DESCRIPTION
Is there any particular reason for not targeting Android API Level 19? Seems like `android-19` crept into `project.properties` with the inclusion of the previewer. I also updated the Travis files, but I'm not sure how to test it, hope it works!
