### PR TITLE
Use the compat mechanism for the Unicode normalization of typed text.

### DIFF
--- a/src/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/src/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -105,7 +105,6 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.lang.reflect.Method;
-import java.text.Normalizer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -804,10 +803,9 @@ public abstract class AbstractFlashcardViewer extends AnkiActivity {
         // A bit of clean-up.
         userAnswer = Utils.stripHTMLMedia(userAnswer).trim();
         correctAnswer = Utils.stripHTMLMedia(correctAnswer).trim();
-        if (AnkiDroidApp.SDK_VERSION > 8) {
-            userAnswer = Normalizer.normalize(userAnswer, Normalizer.Form.NFC);
-            correctAnswer = Normalizer.normalize(correctAnswer, Normalizer.Form.NFC);
-        }
+        userAnswer = AnkiDroidApp.getCompat().nfcNormalized(userAnswer);
+        correctAnswer = AnkiDroidApp.getCompat().nfcNormalized(correctAnswer);
+        // N.B. For API level <9 the NFC normalization is skipped. See also compat/CompatV[79].java.
         sb.append("<div");
         if (!mPrefWriteAnswers) {
             sb.append(" class=\"typeOff\"");

--- a/src/com/ichi2/compat/Compat.java
+++ b/src/com/ichi2/compat/Compat.java
@@ -29,22 +29,23 @@ import android.webkit.WebView;
  * A set of implementations for the supported platforms are available.
  * <p>
  * Each implementation ends with a {@code V<n>} prefix, identifying the minimum API version on which this implementation
- * can be used. For example, see {@link CompatV5}.
+ * can be used. For example, see {@link CompatV8}.
  * <p>
  * Each implementation should extend the previous implementation and implement this interface.
  * <p>
  * Each implementation should only override the methods that first become available in its own version, use @Override.
  * <p>
- * Methods not supported by its api, will default to the empty implementations of CompatV4.
- * Methods first supported by lower APIs, will default to those implementations since we extended them.
+ * Methods not supported by its API will default to the empty implementations of CompatV7.  Methods first supported
+ * by lower APIs will default to those implementations since we extended them.
  * <p>
- * Example: CompatV9 extends CompatV5 as of the time of writing. This means that the normalizeUnicode method
- * that uses classes only available in API 9, should be implemented properly in CompatV9 with @Override annotatin.
- * On the other hand the method onAttachedToWindow that first becomes available in API 5 need not be implemented
- * again in CompatV9, unless the behaviour is supposed to be different there.
+ * Example: CompatV9 extends CompatV8. This means that the nfdNormalized function that uses classes only available
+ * in API 9, should be implemented properly in CompatV9 with @Override annotatin. On the other hand a method
+ * like requestAudioFocus that first becomes available in API 8 need not be implemented again in CompatV9, unless the
+ * behaviour is supposed to be different there.
  */
 public interface Compat {
-    public abstract String normalizeUnicode(String txt);
+    public abstract String nfdNormalized(String txt);
+    public abstract String nfcNormalized(String txt);
     public abstract void setScrollbarFadingEnabled(WebView webview, boolean enable);
     public abstract void setOverScrollModeNever(View v);
     public abstract void invalidateOptionsMenu(Activity activity);

--- a/src/com/ichi2/compat/CompatV7.java
+++ b/src/com/ichi2/compat/CompatV7.java
@@ -23,31 +23,47 @@ import com.ichi2.anki.ReadText;
 @TargetApi(7)
 public class CompatV7 implements Compat {
 
-    @Override
-    public String normalizeUnicode(String txt) {
+
+    /*
+     *  Return the input string. Not doing the NFD normalization may cause problems with syncing media to Macs
+     *  where the file name contains diacritics, as file names are decomposed on HFS file systems.
+     *
+     * @param txt Text to be normalized
+     * @return The input text, not NFD normalized.
+    */
+    public String nfdNormalized(String txt) {
         return txt;
     }
 
 
-    @Override
+    /*
+     *  Return the input string. Not doing the NFC normalization may cause a typed answer to be displayed as
+     *  incorrect when it was correct, but stored in a differnt but equivalent form in the card. (E.g. umlauts
+     *  stored decomposed but typed as single characters.)
+     *
+     * @param txt Text to be normalized
+     * @return The input text not NFC normalized.
+    */
+    public String nfcNormalized(String txt) {
+        return txt;
+    }
+
+
     public void setScrollbarFadingEnabled(WebView webview, boolean enable) {
         webview.setScrollbarFadingEnabled(enable);
     }
 
 
-    @Override
     public void setOverScrollModeNever(View v) {
     }
 
 
-    @Override
     public void invalidateOptionsMenu(Activity activity) {
         ActionBarActivity actionBarActivity = (ActionBarActivity) activity;
         actionBarActivity.supportInvalidateOptionsMenu();
     }
 
 
-    @Override
     public void setActionBarBackground(Activity activity, int color) {
         ActionBarActivity actionBarActivity = (ActionBarActivity) activity;
         ActionBar actionBar = actionBarActivity.getSupportActionBar();
@@ -57,7 +73,6 @@ public class CompatV7 implements Compat {
     }
 
 
-    @Override
     public void setTitle(Activity activity, String title, boolean inverted) {
         ActionBarActivity actionBarActivity = (ActionBarActivity) activity;
         ActionBar actionBar = actionBarActivity.getSupportActionBar();
@@ -71,13 +86,11 @@ public class CompatV7 implements Compat {
     }
 
 
-    @Override
     public void setSubtitle(Activity activity, String title) {
         setSubtitle(activity, title, false);
     }
 
 
-    @Override
     public void setSubtitle(Activity activity, String title, boolean inverted) {
         ActionBarActivity actionBarActivity = (ActionBarActivity) activity;
         ActionBar actionBar = actionBarActivity.getSupportActionBar();
@@ -95,7 +108,6 @@ public class CompatV7 implements Compat {
     }
 
 
-    @Override
     public void setTtsOnUtteranceProgressListener(TextToSpeech tts) {
         tts.setOnUtteranceCompletedListener(new OnUtteranceCompletedListener() {
             @Override
@@ -109,17 +121,14 @@ public class CompatV7 implements Compat {
     }
 
 
-    @Override
     public void disableDatabaseWriteAheadLogging(SQLiteDatabase db) {
     }
 
 
-    @Override
     public void requestAudioFocus(AudioManager audioManager) {
     }
 
 
-    @Override
     public void abandonAudioFocus(AudioManager audioManager) {
     }
 

--- a/src/com/ichi2/compat/CompatV9.java
+++ b/src/com/ichi2/compat/CompatV9.java
@@ -10,10 +10,35 @@ import java.text.Normalizer;
 @TargetApi(9)
 public class CompatV9 extends CompatV8 implements Compat {
 
+
+    /*
+     *  Return the input string in its Unicode Canonical Decomposed form. For example umlauts such as ü are
+     *  decomposed into u plus the dots as an extra character. This decomposed form is how Apples’s HFS+ stores file
+     *  names. Decomposing media file names ensures these media will sync correctly.
+     *
+     * @param txt Text to be normalized
+     * @return The input text in its canonical decomposed form.
+    */
     @Override
-    public String normalizeUnicode(String txt) {
+    public String nfdNormalized(String txt) {
         if (!Normalizer.isNormalized(txt, Normalizer.Form.NFD)) {
             return Normalizer.normalize(txt, Normalizer.Form.NFD);
+        }
+        return txt;
+    }
+
+
+    /*
+     *  Return the input string in the Unicode normalized form. This helps with text comparisons, for example a ü
+     *  stored as u plus the dots but typed as a single character compare as the same.
+     *
+     * @param txt Text to be normalized
+     * @return The input text in its NFC normalized form form.
+    */
+    @Override
+    public String nfcNormalized(String txt) {
+        if (!Normalizer.isNormalized(txt, Normalizer.Form.NFC)) {
+            return Normalizer.normalize(txt, Normalizer.Form.NFC);
         }
         return txt;
     }

--- a/src/com/ichi2/libanki/Media.java
+++ b/src/com/ichi2/libanki/Media.java
@@ -294,9 +294,8 @@ public class Media {
 
         Set<String> normrefs = new HashSet<String>();
         for (String f : allMedia()) {
-            if (AnkiDroidApp.SDK_VERSION > 9) {
-                f = AnkiDroidApp.getCompat().normalizeUnicode(f);
-            }
+            f = AnkiDroidApp.getCompat().nfdNormalized(f);
+            // N.B.: for API version <9 the normalization does not work.
             normrefs.add(f);
         }
         for (File file : mdir.listFiles()) {
@@ -308,9 +307,7 @@ public class Media {
                 continue;
             }
             String nfile = file.getName();
-            if (AnkiDroidApp.SDK_VERSION > 9) {
-                nfile = AnkiDroidApp.getCompat().normalizeUnicode(nfile);
-            }
+            nfile = AnkiDroidApp.getCompat().nfdNormalized(nfile);
             if (!normrefs.contains(nfile)) {
                 unused.add(file.getName());
             } else {


### PR DESCRIPTION
The clean-up requested in a [comment](https://github.com/ankidroid/Anki-Android/commit/1fbdcbbf30ea73d8e40cfd26c95a499ddb96ab93#commitcomment-6364292).

Apart from cleaning up the AbstractFlashardViewer, this also cleans up the compat classes:
- Since CompatV7.java is now the base, the methods/functions there don’t `@Override` anything any more.
- Changed the name of `normalizeUnicode`. There are two types of Unicode normalization that we use.
- Added explanations for those normalization.
- Also updated the explanations in Compat.java.
