### PR TITLE
Fix navigation drawer onCreate

### DIFF
--- a/src/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/src/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -911,6 +911,11 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
 
         mChangeBorderStyle = Themes.getTheme() == Themes.THEME_ANDROID_LIGHT
                 || Themes.getTheme() == Themes.THEME_ANDROID_DARK;
+        
+        // create inherited navigation drawer layout here so that it can be used by parent class
+        mDrawerLayout = (DrawerLayout) findViewById(R.id.reviewer_drawer_layout);
+        mDrawerList = (ListView) findViewById(R.id.reviewer_left_drawer);
+        initNavigationDrawer();
 
         // The hardware buttons should control the music volume while reviewing.
         setVolumeControlStream(AudioManager.STREAM_MUSIC);
@@ -1549,11 +1554,6 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
     protected void initLayout(Integer layout) {
         setContentView(layout);
         
-        // create inherited navigation drawer layout here so that it can be used by parent class
-        mDrawerLayout = (DrawerLayout) findViewById(R.id.reviewer_drawer_layout);
-        mDrawerList = (ListView) findViewById(R.id.reviewer_left_drawer);
-        initNavigationDrawer();
-
         mMainLayout = findViewById(R.id.main_layout);
         Themes.setContentStyle(mMainLayout, Themes.CALLER_REVIEWER);
 

--- a/src/com/ichi2/anki/CardBrowser.java
+++ b/src/com/ichi2/anki/CardBrowser.java
@@ -248,6 +248,13 @@ public class CardBrowser extends NavigationDrawerActivity implements ActionBar.O
         View mainView = getLayoutInflater().inflate(R.layout.card_browser, null);
         setContentView(mainView);
         Themes.setContentStyle(mainView, Themes.CALLER_CARDBROWSER);
+        
+        // Create inherited navigation drawer layout here so that it can be used by parent class
+        mDrawerLayout = (DrawerLayout) findViewById(R.id.browser_drawer_layout);
+        mDrawerList = (ListView) findViewById(R.id.browser_left_drawer);
+        initNavigationDrawer();
+        selectNavigationItem(DRAWER_BROWSER);
+        
         // Try to load the collection
         mCol = AnkiDroidApp.getCol();
         if (mCol == null) {
@@ -308,12 +315,6 @@ public class CardBrowser extends NavigationDrawerActivity implements ActionBar.O
             throw new RuntimeException(e);
         }
         
-        // create inherited navigation drawer layout here so that it can be used by parent class
-        mDrawerLayout = (DrawerLayout) findViewById(R.id.browser_drawer_layout);
-        mDrawerList = (ListView) findViewById(R.id.browser_left_drawer);
-        initNavigationDrawer();
-        selectNavigationItem(DRAWER_BROWSER);
-
         mCards = new ArrayList<HashMap<String, String>>();
         mCardsListView = (ListView) findViewById(R.id.card_browser_list);
         // Create a spinner for column1, but without letting the user change column

--- a/src/com/ichi2/anki/NavigationDrawerActivity.java
+++ b/src/com/ichi2/anki/NavigationDrawerActivity.java
@@ -192,9 +192,6 @@ public class NavigationDrawerActivity extends AnkiActivity {
     protected void onPostCreate(Bundle savedInstanceState) {
         super.onPostCreate(savedInstanceState);
         // Sync the toggle state after onRestoreInstanceState has occurred.
-        if (mDrawerToggle == null) {
-            initNavigationDrawer();
-        }
         mDrawerToggle.syncState();
     }
 


### PR DESCRIPTION
Move initialization of navigation drawer into the `onCreate()` methods, before the collection is loaded. This prevents `onPostCreate()` of `NavigationDrawerActivity` being called before the navigation drawer layout has been created, which I believe is the cause of [issue 2160](https://code.google.com/p/ankidroid/issues/detail?id=2160).
