### PR TITLE
Revert change to usn update flag on note/card flush

### DIFF
--- a/src/com/ichi2/libanki/Card.java
+++ b/src/com/ichi2/libanki/Card.java
@@ -166,9 +166,16 @@ public class Card implements Cloneable {
     }
 
 
+
     public void flush() {
-        mMod = Utils.intNow();
-        mUsn = mCol.usn();
+        flush(true);
+    }
+
+    public void flush(boolean changeModUsn) {
+        if (changeModUsn) {
+            mMod = Utils.intNow();
+            mUsn = mCol.usn();
+        }
         // bug check
         if ((mQueue == 2 && mODue != 0) && !mCol.getDecks().isDyn(mDid)) {
             // TODO: runHook("odueInvalid");

--- a/src/com/ichi2/libanki/Collection.java
+++ b/src/com/ichi2/libanki/Collection.java
@@ -1170,7 +1170,7 @@ public class Collection {
     	case UNDO_REVIEW:
             Card c = (Card) data[1];
             // write old data
-            c.flush();
+            c.flush(false);
             // and delete revlog entry
             long last = mDb.queryLongScalar("SELECT id FROM revlog WHERE cid = " + c.getId() + " ORDER BY id DESC LIMIT 1");
             mDb.execute("DELETE FROM revlog WHERE id = " + last);
@@ -1186,7 +1186,7 @@ public class Collection {
 
     	case UNDO_EDIT_NOTE:
     		Note note = (Note) data[1];
-    		note.flush(note.getMod());
+    		note.flush(note.getMod(), false);
     		long cid = (Long) data[2];
             Card card = null;
             if ((Boolean) data[3]) {
@@ -1210,28 +1210,28 @@ public class Collection {
 
     	case UNDO_BURY_NOTE:
     		for (Card cc : (ArrayList<Card>)data[2]) {
-    			cc.flush();
+    			cc.flush(false);
     		}
     		return (Long) data[3];
 
     	case UNDO_SUSPEND_CARD:
     		Card suspendedCard = (Card)data[1];
-    		suspendedCard.flush();
+    		suspendedCard.flush(false);
     		return suspendedCard.getId();
 
     	case UNDO_SUSPEND_NOTE:
     		for (Card ccc : (ArrayList<Card>) data[1]) {
-    			ccc.flush();
+    			ccc.flush(false);
     		}
     		return (Long) data[2];
 
     	case UNDO_DELETE_NOTE:
     		ArrayList<Long> ids = new ArrayList<Long>();
     		Note note2 = (Note)data[1];
-    		note2.flush(note2.getMod());
+    		note2.flush(note2.getMod(), false);
     		ids.add(note2.getId());
         		for (Card c4 : (ArrayList<Card>) data[2]) {
-        			c4.flush();
+        			c4.flush(false);
     			ids.add(c4.getId());
         		}
     		mDb.execute("DELETE FROM graves WHERE oid IN " + Utils.ids2str(Utils.arrayList2array(ids)));
@@ -1240,7 +1240,7 @@ public class Collection {
     	case UNDO_MARK_NOTE:
     		Note note3 = getNote((Long) data[1]);
     		note3.setTagsFromStr((String) data[2]);
-    		note3.flush(note3.getMod());
+    		note3.flush(note3.getMod(), false);
     		return (Long) data[3];
 
         default:

--- a/src/com/ichi2/libanki/Note.java
+++ b/src/com/ichi2/libanki/Note.java
@@ -123,10 +123,16 @@ public class Note implements Cloneable {
     	flush(null);
     }
 
-
     public void flush(Long mod) {
+        flush(mod, true);
+    }
+
+    public void flush(Long mod, boolean changeUsn) {
         assert mScm == mCol.getScm();
         _preFlush();
+        if (changeUsn) {
+            mUsn = mCol.usn();
+        }
         String sfld = Utils.stripHTMLMedia(mFields[mCol.getModels().sortIdx(mModel)]);
         String tags = stringTags();
         String fields = joinedFields();
@@ -137,7 +143,6 @@ public class Note implements Cloneable {
         }
         long csum = Utils.fieldChecksum(mFields[0]);
         mMod = mod != null ? mod : Utils.intNow();
-        mUsn = mCol.usn();
         mCol.getDb().execute("insert or replace into notes values (?,?,?,?,?,?,?,?,?,?,?)",
                 new Object[] { mId, mGuId, mMid, mMod, mUsn, tags, fields, sfld, csum, mFlags, mData });
         mCol.getTags().register(mTags);


### PR DESCRIPTION
This might be causing "inconsistent state" issues when syncing after frequent use of the "undo" feature.

I'll revisit this in the future when looking at the undo code since it needs a bit of attention.
