### PR TITLE
Show card counts in card browser

### DIFF
--- a/res/layout/dropdown_deck_selected_item.xml
+++ b/res/layout/dropdown_deck_selected_item.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+    <TextView
+        android:id="@+id/dropdown_deck_name"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:singleLine="true"
+        android:textSize="@dimen/action_bar_title_text_size" />
+    <TextView
+        android:id="@+id/dropdown_deck_counts"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/action_bar_subtitle_top_margin"
+        android:singleLine="true"
+        android:textSize="@dimen/action_bar_subtitle_text_size" />
+</LinearLayout>

--- a/res/values/dimens.xml
+++ b/res/values/dimens.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+~ Copyright (c) 2014 Alexander Grüneberg <alexander.grueneberg@googlemail.com>
+~
+~ This program is free software; you can redistribute it and/or modify it under
+~ the terms of the GNU General Public License as published by the Free Software
+~ Foundation; either version 3 of the License, or (at your option) any later
+~ version.
+~
+~ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+~ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+~ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+~
+~ You should have received a copy of the GNU General Public License along with
+~ this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+<resources>
+    <dimen name="action_bar_title_text_size">18dp</dimen>
+    <dimen name="action_bar_subtitle_text_size">14dp</dimen>
+    <dimen name="action_bar_subtitle_top_margin">-3dp</dimen>
+</resources>

--- a/src/com/ichi2/anki/CardBrowser.java
+++ b/src/com/ichi2/anki/CardBrowser.java
@@ -841,6 +841,9 @@ public class CardBrowser extends NavigationDrawerActivity implements ActionBar.O
 
     private void updateList() {
         mCardsAdapter.notifyDataSetChanged();
+        int count = mCards.size();
+        mDropDownAdapter.setCounts(count, mTotalCount);
+        mDropDownAdapter.notifyDataSetChanged();
     }
 
 
@@ -1343,10 +1346,19 @@ public class CardBrowser extends NavigationDrawerActivity implements ActionBar.O
         }
     }
 
+
+    private static class DeckDropDownViewHolder {
+        public TextView deckNameView;
+        public TextView deckCountsView;
+    }
+
+
     private final class DeckDropDownAdapter extends BaseAdapter {
 
         private Context context;
         private ArrayList<JSONObject> decks;
+        private int count;
+        private int totalCount;
 
 
         public DeckDropDownAdapter(Context context, ArrayList<JSONObject> decks) {
@@ -1379,6 +1391,40 @@ public class CardBrowser extends NavigationDrawerActivity implements ActionBar.O
 
         @Override
         public View getView(int position, View convertView, ViewGroup parent) {
+            DeckDropDownViewHolder viewHolder;
+            TextView deckNameView;
+            TextView deckCountsView;
+            if (convertView == null) {
+                convertView = LayoutInflater.from(context).inflate(R.layout.dropdown_deck_selected_item, parent, false);
+                deckNameView = (TextView) convertView.findViewById(R.id.dropdown_deck_name);
+                deckCountsView = (TextView) convertView.findViewById(R.id.dropdown_deck_counts);
+                viewHolder = new DeckDropDownViewHolder();
+                viewHolder.deckNameView = deckNameView;
+                viewHolder.deckCountsView = deckCountsView;
+                convertView.setTag(viewHolder);
+            } else {
+                viewHolder = (DeckDropDownViewHolder) convertView.getTag();
+                deckNameView = (TextView) viewHolder.deckNameView;
+                deckCountsView = (TextView) viewHolder.deckCountsView;
+            }
+            if (position == 0) {
+                deckNameView.setText(context.getResources().getString(R.string.deck_summary_all_decks));
+            } else {
+                JSONObject deck = decks.get(position - 1);
+                try {
+                    String deckName = deck.getString("name");
+                    deckNameView.setText(deckName);
+                } catch (JSONException ex) {
+                    new RuntimeException();
+                }
+            }
+            deckCountsView.setText(getResources().getQuantityString(R.plurals.card_browser_subtitle, count, count, totalCount));
+            return convertView;
+        }
+
+
+        @Override
+        public View getDropDownView(int position, View convertView, ViewGroup parent) {
             TextView deckNameView;
             if (convertView == null) {
                 convertView = LayoutInflater.from(context).inflate(R.layout.dropdown_deck_item, parent, false);
@@ -1399,6 +1445,12 @@ public class CardBrowser extends NavigationDrawerActivity implements ActionBar.O
                 }
             }
             return convertView;
+        }
+
+
+        public void setCounts(int count, int totalCount) {
+            this.count = count;
+            this.totalCount = totalCount;
         }
 
     }


### PR DESCRIPTION
I know I'm a bit late to the party, but I was hoping to still get the card counts in the card browser into the 2.2 release. I think it's a feature that people will miss otherwise.

![screenshot_2014-06-29-17-30-46](https://cloud.githubusercontent.com/assets/527708/3424688/bb59f9e6-ffde-11e3-851e-d41fd79f388e.png)
