### PR TITLE
Remove total card count from subtitles

### DIFF
--- a/res/values/01-core.xml
+++ b/res/values/01-core.xml
@@ -34,8 +34,8 @@
 
     <!-- DeckPicker.java -->
     <plurals name="deckpicker_title">
-        <item quantity="one">1 of %2$d due (%3$s)</item>
-        <item quantity="other">%1$d of %2$d due (%3$s)</item>
+        <item quantity="one">1 card due (%2$s)</item>
+        <item quantity="other">%1$d cards due (%2$s)</item>
     </plurals>
     <plurals name="deckpicker_title_minutes">
         <item quantity="one">1 min.</item>

--- a/res/values/07-cardbrowser.xml
+++ b/res/values/07-cardbrowser.xml
@@ -22,8 +22,8 @@
 
     <!-- CardBrowser -->
     <plurals name="card_browser_subtitle">
-        <item quantity="one">1 of %2$d cards shown</item>
-        <item quantity="other">%1$d of %2$d cards shown</item>
+        <item quantity="one">1 card shown</item>
+        <item quantity="other">%d cards shown</item>
     </plurals>
 
     <string name="card_browser_all_decks">All decks</string>

--- a/src/com/ichi2/anki/CardBrowser.java
+++ b/src/com/ichi2/anki/CardBrowser.java
@@ -842,7 +842,7 @@ public class CardBrowser extends NavigationDrawerActivity implements ActionBar.O
     private void updateList() {
         mCardsAdapter.notifyDataSetChanged();
         int count = mCards.size();
-        mDropDownAdapter.setCounts(count, mTotalCount);
+        mDropDownAdapter.setCardCount(count);
         mDropDownAdapter.notifyDataSetChanged();
     }
 
@@ -1358,7 +1358,6 @@ public class CardBrowser extends NavigationDrawerActivity implements ActionBar.O
         private Context context;
         private ArrayList<JSONObject> decks;
         private int count;
-        private int totalCount;
 
 
         public DeckDropDownAdapter(Context context, ArrayList<JSONObject> decks) {
@@ -1418,7 +1417,7 @@ public class CardBrowser extends NavigationDrawerActivity implements ActionBar.O
                     new RuntimeException();
                 }
             }
-            deckCountsView.setText(getResources().getQuantityString(R.plurals.card_browser_subtitle, count, count, totalCount));
+            deckCountsView.setText(getResources().getQuantityString(R.plurals.card_browser_subtitle, count, count));
             return convertView;
         }
 
@@ -1448,9 +1447,8 @@ public class CardBrowser extends NavigationDrawerActivity implements ActionBar.O
         }
 
 
-        public void setCounts(int count, int totalCount) {
+        public void setCardCount(int count) {
             this.count = count;
-            this.totalCount = totalCount;
         }
 
     }

--- a/src/com/ichi2/anki/DeckPicker.java
+++ b/src/com/ichi2/anki/DeckPicker.java
@@ -2917,7 +2917,7 @@ public class DeckPicker extends NavigationDrawerActivity {
                 time = res.getQuantityString(R.plurals.deckpicker_title_minutes, eta, eta);
             }
             AnkiDroidApp.getCompat().setSubtitle(this,
-                    res.getQuantityString(R.plurals.deckpicker_title, due, due, count, time));
+                    res.getQuantityString(R.plurals.deckpicker_title, due, due, time));
         }
 
         // update widget


### PR DESCRIPTION
As discussed in #409. I did the same in the deck picker, and added the word _card_ or _cards_ as in _100 cards due_ to make it clearer. Tell me if you think it's too long, I only have my Nexus 4 as a reference right now (package update broke emulators).
