### PR TITLE
Fix the HTML escaping of typed text.

### DIFF
--- a/src/com/ichi2/compat/Compat.java
+++ b/src/com/ichi2/compat/Compat.java
@@ -46,6 +46,7 @@ import android.webkit.WebView;
 public interface Compat {
     public abstract String nfdNormalized(String txt);
     public abstract String nfcNormalized(String txt);
+    public abstract String detagged(String txt);
     public abstract void setScrollbarFadingEnabled(WebView webview, boolean enable);
     public abstract void setOverScrollModeNever(View v);
     public abstract void invalidateOptionsMenu(Activity activity);

--- a/src/com/ichi2/compat/CompatV16.java
+++ b/src/com/ichi2/compat/CompatV16.java
@@ -3,6 +3,7 @@ package com.ichi2.compat;
 
 import android.annotation.TargetApi;
 import android.database.sqlite.SQLiteDatabase;
+import android.text.Html;
 
 /** Implementation of {@link Compat} for SDK level 16 */
 @TargetApi(16)
@@ -12,5 +13,17 @@ public class CompatV16 extends CompatV15 implements Compat {
     public void disableDatabaseWriteAheadLogging(SQLiteDatabase db) {
         db.disableWriteAheadLogging();
     }
+
+    /*
+     *  Return the input string in a form suitable for display on a HTML page.
+     *
+     * @param txt Text to be cleaned.
+     * @return The input text, HTML-escpaped
+    */
+    @Override
+    public String detagged(String txt) {
+        return Html.escapeHtml(txt);
+    }
+
 
 }

--- a/src/com/ichi2/compat/CompatV7.java
+++ b/src/com/ichi2/compat/CompatV7.java
@@ -50,6 +50,23 @@ public class CompatV7 implements Compat {
     }
 
 
+    /*
+     *  Return the input string in a form suitable for display on a HTML page. Replace “<”, “>”, “&”, “"” and “'” with
+     *  HTML entities.
+     *
+     * @param txt Text to be cleaned.
+     * @return The input text, with HTML tags and entities escaped.
+    */
+    public String detagged(String txt) {
+        if (txt == null)
+        {
+            return "";
+        }
+        return txt.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace("\"", "&quot;").replace(
+                "'", "&#39;");
+    }
+
+
     public void setScrollbarFadingEnabled(WebView webview, boolean enable) {
         webview.setScrollbarFadingEnabled(enable);
     }

--- a/src/com/ichi2/utils/DiffEngine.java
+++ b/src/com/ichi2/utils/DiffEngine.java
@@ -19,7 +19,8 @@
 
 package com.ichi2.utils;
 
-import android.text.Html;
+import com.ichi2.anki.AnkiDroidApp;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -30,6 +31,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.Stack;
 import java.util.regex.Pattern;
+
 
 /**
  * Functions for diff, match and patch. Computes the difference between two texts to create a patch. Applies the patch
@@ -1095,15 +1097,15 @@ public class DiffEngine {
         // We do the comparison with “<”s &c. in the strings, but should of course not just put those in the HTML
         // output. Also, it looks like the Android WebView swallows single “\”s, so replace those with the entity by
         // hand.
-        return "<span class=\"typeBad\">" + Html.escapeHtml(in).replace("\\", "&#x5c;") + "</span>";
+        return "<span class=\"typeBad\">" + AnkiDroidApp.getCompat().detagged(in).replace("\\", "&#x5c;") + "</span>";
     }
 
     public static String wrapGood(String in) {
-        return "<span class=\"typeGood\">" + Html.escapeHtml(in).replace("\\", "&#x5c;") + "</span>";
+        return "<span class=\"typeGood\">" + AnkiDroidApp.getCompat().detagged(in).replace("\\", "&#x5c;") + "</span>";
     }
 
     public static String wrapMissing(String in) {
-        return "<span class=\"typeMissed\">" + Html.escapeHtml(in).replace("\\", "&#x5c;") + "</span>";
+        return "<span class=\"typeMissed\">" + AnkiDroidApp.getCompat().detagged(in).replace("\\", "&#x5c;") + "</span>";
     }
 
 


### PR DESCRIPTION
Replace “`<`”, “`>`”, “`&`”, “`"`” and “`'`” with HTML entities by hand for API < 16, where there is no `Html.escapeHtml()`
 (Those five characters are the “htmlspecialchars” in PHP. That list should be good enough.)

Seems to fix the [recent crashes](https://groups.google.com/forum/#!topic/anki-android/ajy_5TWacVM).
