### PR TITLE
Use placeholder instead of “1” for “quantity="one"”.

### DIFF
--- a/res/values/01-core.xml
+++ b/res/values/01-core.xml
@@ -34,19 +34,19 @@
 
     <!-- DeckPicker.java -->
     <plurals name="deckpicker_title">
-        <item quantity="one">1 card due (%2$s)</item>
+        <item quantity="one">%1$d card due (%2$s)</item>
         <item quantity="other">%1$d cards due (%2$s)</item>
     </plurals>
     <plurals name="deckpicker_title_minutes">
-        <item quantity="one">1 min.</item>
+        <item quantity="one">%d min.</item>
         <item quantity="other">%d min.</item>
     </plurals>
     <plurals name="deckpicker_due">
-        <item quantity="one">1 of %2$d due</item>
+        <item quantity="one">%1$d of %2$d due</item>
         <item quantity="other">%1$d of %2$d due</item>
     </plurals>
     <plurals name="reviewer_window_title">
-        <item quantity="one">1 minute left</item>
+        <item quantity="one">%d minute left</item>
         <item quantity="other">%d minutes left</item>
     </plurals>
 
@@ -147,15 +147,15 @@
     <string name="studyoptions_congrats_custom">To study outside of the normal schedule, touch the \"Custom study\" button below</string>
 
     <plurals name="studyoptions_congrats_message">
-        <item quantity="one">Tomorrow there will be: 1 card to review and %2$s.\n Estimated time: %3$s</item>
+        <item quantity="one">Tomorrow there will be: %1$d card to review and %2$s.\n Estimated time: %3$s</item>
         <item quantity="other">Tomorrow there will be: %1$d cards to review and %2$s.\n Estimated time: %3$s</item>
     </plurals>
     <plurals name="studyoptions_congrats_new_cards">
-        <item quantity="one">1 new card</item>
+        <item quantity="one">%1$d new card</item>
         <item quantity="other">%1$d new cards</item>
     </plurals>
     <plurals name="studyoptions_congrats_eta">
-        <item quantity="one">Estimated time: 1 min.</item>
+        <item quantity="one">Estimated time: %1$d min.</item>
         <item quantity="other">Estimated time: %1$d min.</item>
     </plurals>
 

--- a/res/values/02-strings.xml
+++ b/res/values/02-strings.xml
@@ -22,7 +22,7 @@
     <!-- Navigation Drawer Strings -->
     <string name="drawer_open">Open Drawer</string>
     <string name="drawer_close">Close Drawer</string>
-    
+
     <string name="CardEditorLaterMessage">Saved information for later</string>
     <string name="CardEditorCardDeck">Card deck: %s</string>
     <string name="CardEditorNoteDeck">Note deck: %s</string>
@@ -83,11 +83,11 @@
     <string name="reordering_cards">Reordering cards…</string>
 
     <plurals name="timebox_reached">
-        <item quantity="one">1 card studied in %2$s</item>
+        <item quantity="one">%1$d card studied in %2$s</item>
         <item quantity="other">%1$d cards studied in %2$s</item>
     </plurals>
     <plurals name="timebox_reached_minutes">
-        <item quantity="one">1 minute</item>
+        <item quantity="one">%1$d minute</item>
         <item quantity="other">%1$d minutes</item>
     </plurals>
 
@@ -110,7 +110,7 @@
     <string name="default_conf_delete_error">The default options group can\'t be removed</string>
 
     <plurals name="factadder_cards_added">
-        <item quantity="one">1 card added</item>
+        <item quantity="one">%d card added</item>
         <item quantity="other">%d cards added</item>
     </plurals>
 

--- a/res/values/05-feedback.xml
+++ b/res/values/05-feedback.xml
@@ -23,7 +23,7 @@
     <!-- Feedback.java -->
     <!--
 <plurals name="error_message">
-  <item quantity="one">There is one error to report</item>
+  <item quantity="one">There is %d error to report</item>
   <item quantity="other">There are %d errors to report</item>
 </plurals>
     -->

--- a/res/values/07-cardbrowser.xml
+++ b/res/values/07-cardbrowser.xml
@@ -22,7 +22,7 @@
 
     <!-- CardBrowser -->
     <plurals name="card_browser_subtitle">
-        <item quantity="one">1 card shown</item>
+        <item quantity="one">%d card shown</item>
         <item quantity="other">%d cards shown</item>
     </plurals>
 

--- a/res/values/08-widget.xml
+++ b/res/values/08-widget.xml
@@ -27,11 +27,11 @@
     <string name="widget_loading">Widget loading…</string>
 
     <plurals name="widget_cards_in_decks_due">
-        <item quantity="one">1 card due in %2$s</item>
+        <item quantity="one">%1$d card due in %2$s</item>
         <item quantity="other">%1$d cards due in %2$s</item>
     </plurals>
     <plurals name="widget_decks">
-        <item quantity="one">1 deck</item>
+        <item quantity="one">%1$d deck</item>
         <item quantity="other">%1$d decks</item>
     </plurals>
 
@@ -42,7 +42,7 @@
     <string name="open_in_reviewer">Open deck in AnkiDroid</string>
 
     <plurals name="widget_big_eta">
-        <item quantity="one">Estimated time: 1 min.</item>
+        <item quantity="one">Estimated time: %d min.</item>
         <item quantity="other">Estimated time: %d min.</item>
     </plurals>
 

--- a/res/values/10-preferences.xml
+++ b/res/values/10-preferences.xml
@@ -178,7 +178,7 @@
     <string name="deck_conf_deck_description">Deck description</string>
     <string name="deck_conf_group">Options group</string>
     <plurals name="deck_conf_group_summ">
-        <item quantity="one">%1$s\n1 deck uses this group</item>
+        <item quantity="one">%1$s\n%2$d deck uses this group</item>
         <item quantity="other">%1$s\n%2$d decks use this group</item>
     </plurals>
     <string name="deck_conf_new_cards">New cards</string>
@@ -224,7 +224,7 @@
     <string name="deck_conf_remove_message">Remove current options group?</string>
     <string name="deck_conf_set_subdecks">Set for all subdecks</string>
     <plurals name="deck_conf_set_subdecks_summ">
-        <item quantity="one">1 subdeck will use this group</item>
+        <item quantity="one">%s subdeck will use this group</item>
         <item quantity="other">%s subdecks will use this group</item>
     </plurals>
     <string name="deck_conf_set_subdecks_title">Set for all subdecks</string>


### PR DESCRIPTION
This one requires a bit of explanation.

Checking the code with lint reported a number of errors, for example

```
res/values-fr/01-core.xml:56: Error: The quantity 'one' matches more than one specific number in this locale, but the message did not include a formatting argument (such as %d). This is usually an internationalization error. See full issue explanation for more. [ImpliedQuantity]
    <item quantity="one">1 minute.</item>
```

(Looks like “this locale” applies to fa, fr, hi, lt, ru, sl, sr and uk.)

Apparently, in those languages you use something like a singular form for e.g. “101 minute” instead of “101 minutes”. At the moment, when there are 101 minutes or 201 cards left, in these languages there would appear localized text like “1 minute left” or “1 card left” instead.

This does not fix the problem, but only gives a hint to the translators. They are presented with e.g. “%d card left” instead of “1 card left” as the text to translate and told to please make sure the `%d` is there in the translation at crowdin.
