### PR TITLE
Clean up navigation drawer inheritance

### DIFF
--- a/res/layout/card_browser.xml
+++ b/res/layout/card_browser.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.v4.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/browser_drawer_layout"
+    android:id="@+id/drawer_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="?android:attr/colorBackground" >
@@ -41,13 +41,5 @@
 
     </LinearLayout>
     
-    <ListView
-        android:id="@+id/browser_left_drawer"
-        android:layout_width="250dp"
-        android:layout_height="match_parent"
-        android:layout_gravity="start"
-        android:background="?android:attr/colorBackground"
-        android:choiceMode="singleChoice"
-        android:divider="#d3d3d3"
-        android:dividerHeight="1dp" />
+    <include layout="@layout/navigation_drawer" />
 </android.support.v4.widget.DrawerLayout>   

--- a/res/layout/deck_picker.xml
+++ b/res/layout/deck_picker.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.v4.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/deckpicker_drawer_layout"
+    android:id="@+id/drawer_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="?android:attr/colorBackground" >
@@ -22,14 +22,6 @@
             android:focusable="true" />
     </RelativeLayout>    
 
-    <ListView
-        android:id="@+id/deckpicker_left_drawer"
-        android:layout_width="250dp"
-        android:layout_height="match_parent"
-        android:layout_gravity="start"
-        android:background="?android:attr/colorBackground"
-        android:choiceMode="singleChoice"
-        android:divider="#d3d3d3"
-        android:dividerHeight="1dp" />
+    <include layout="@layout/navigation_drawer" />
 </android.support.v4.widget.DrawerLayout>
 

--- a/res/layout/flashcard.xml
+++ b/res/layout/flashcard.xml
@@ -20,7 +20,7 @@
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <android.support.v4.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/reviewer_drawer_layout"
+    android:id="@+id/drawer_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="?android:attr/colorBackground" >
@@ -294,14 +294,6 @@
 
     </RelativeLayout>
     
-    <ListView
-        android:id="@+id/reviewer_left_drawer"
-        android:layout_width="250dp"
-        android:layout_height="match_parent"
-        android:layout_gravity="start"
-        android:background="?android:attr/colorBackground"
-        android:choiceMode="singleChoice"
-        android:divider="#d3d3d3"
-        android:dividerHeight="1dp" />
+    <include layout="@layout/navigation_drawer" />
 </android.support.v4.widget.DrawerLayout>
 

--- a/res/layout/navigation_drawer.xml
+++ b/res/layout/navigation_drawer.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>    
+<ListView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/left_drawer"
+    android:layout_width="250dp"
+    android:layout_height="match_parent"
+    android:layout_gravity="start"
+    android:background="?android:attr/colorBackground"
+    android:choiceMode="singleChoice"
+    android:divider="#d3d3d3"
+    android:dividerHeight="1dp" />

--- a/res/layout/studyoptions.xml
+++ b/res/layout/studyoptions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.v4.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/studyoptions_drawer_layout"
+    android:id="@+id/drawer_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="?android:attr/colorBackground" >
@@ -8,14 +8,6 @@
         android:id="@+id/studyoptions_frame"
         android:layout_width="fill_parent"
         android:layout_height="fill_parent" />
-    <ListView
-        android:id="@+id/studyoptions_left_drawer"
-        android:layout_width="250dp"
-        android:layout_height="match_parent"
-        android:layout_gravity="start"
-        android:background="?android:attr/colorBackground"
-        android:choiceMode="singleChoice"
-        android:divider="#d3d3d3"
-        android:dividerHeight="1dp" />
+    <include layout="@layout/navigation_drawer" />
 </android.support.v4.widget.DrawerLayout>
 

--- a/src/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/src/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -38,7 +38,6 @@ import android.os.Handler;
 import android.os.Message;
 import android.os.SystemClock;
 import android.os.Vibrator;
-import android.support.v4.widget.DrawerLayout;
 import android.text.ClipboardManager;
 import android.text.Editable;
 import android.text.Html;
@@ -913,10 +912,9 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
                 || Themes.getTheme() == Themes.THEME_ANDROID_DARK;
 
         // create inherited navigation drawer layout here so that it can be used by parent class
-        setContentView(R.layout.flashcard);
-        mDrawerLayout = (DrawerLayout) findViewById(R.id.reviewer_drawer_layout);
-        mDrawerList = (ListView) findViewById(R.id.reviewer_left_drawer);
-        initNavigationDrawer();
+        View mainView = getLayoutInflater().inflate(R.layout.flashcard, null);
+        setContentView(mainView);
+        initNavigationDrawer(mainView);
 
         // The hardware buttons should control the music volume while reviewing.
         setVolumeControlStream(AudioManager.STREAM_MUSIC);
@@ -990,12 +988,9 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
         Lookup.initialize(this);
     }
 
-
-    private void deselectAllNavigationItems() {
-        // Deselect all entries in navigation drawer since the Reviewer isn't included in ND
-        for (int i=0; i< mDrawerList.getCount(); i++) {
-            mDrawerList.setItemChecked(i, false);
-        }
+    @Override
+    protected void deselectAllNavigationItems() {
+        super.deselectAllNavigationItems();
         setTitle();
         updateScreenCounts();
     }
@@ -1249,7 +1244,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
     public boolean onOptionsItemSelected(MenuItem item) {
         // The action bar home/up action should open or close the drawer.
         // ActionBarDrawerToggle will take care of this.
-        if (mDrawerToggle.onOptionsItemSelected(item)) {
+        if (getDrawerToggle().onOptionsItemSelected(item)) {
             return true;
         }
 
@@ -1891,7 +1886,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
                 if (actionId == EditorInfo.IME_ACTION_DONE) {
                     mFlipCardLayout.performClick();
                 }
-                return false; // We don’t “handle” this. Let Android hide the input method.
+                return false; // We don't handle this. Let Android hide the input method.
             }
         });
     }

--- a/src/com/ichi2/anki/CardBrowser.java
+++ b/src/com/ichi2/anki/CardBrowser.java
@@ -32,7 +32,6 @@ import android.graphics.Typeface;
 import android.os.Bundle;
 import android.support.v4.app.DialogFragment;
 import android.support.v4.view.MenuItemCompat;
-import android.support.v4.widget.DrawerLayout;
 import android.support.v7.app.ActionBar;
 import android.support.v7.widget.SearchView;
 import android.util.Log;
@@ -249,10 +248,7 @@ public class CardBrowser extends NavigationDrawerActivity implements ActionBar.O
         setContentView(mainView);
         Themes.setContentStyle(mainView, Themes.CALLER_CARDBROWSER);
         
-        // Create inherited navigation drawer layout here so that it can be used by parent class
-        mDrawerLayout = (DrawerLayout) findViewById(R.id.browser_drawer_layout);
-        mDrawerList = (ListView) findViewById(R.id.browser_left_drawer);
-        initNavigationDrawer();
+        initNavigationDrawer(mainView);
         selectNavigationItem(DRAWER_BROWSER);
         
         // Try to load the collection
@@ -518,7 +514,7 @@ public class CardBrowser extends NavigationDrawerActivity implements ActionBar.O
     public boolean onOptionsItemSelected(MenuItem item) {
         // The action bar home/up action should open or close the drawer.
         // ActionBarDrawerToggle will take care of this.
-        if (mDrawerToggle.onOptionsItemSelected(item)) {
+        if (getDrawerToggle().onOptionsItemSelected(item)) {
             return true;
         }    	
     	

--- a/src/com/ichi2/anki/DeckPicker.java
+++ b/src/com/ichi2/anki/DeckPicker.java
@@ -2,7 +2,7 @@
  * Copyright (c) 2009 Andrew Dubya <andrewdubya@gmail.com>                              *
  * Copyright (c) 2009 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
  * Copyright (c) 2009 Edu Zamora <edu.zasu@gmail.com>                                   *
- * Copyright (c) 2009 Daniel SvÃ¤rd <daniel.svard@gmail.com>                             *
+ * Copyright (c) 2009 Daniel Svﾃδ､rd <daniel.svard@gmail.com>                             *
  * Copyright (c) 2010 Norbert Nagold <norbert.nagold@gmail.com>                         *
  *                                                                                      *
  * This program is free software; you can redistribute it and/or modify it under        *
@@ -39,7 +39,6 @@ import android.graphics.Rect;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentTransaction;
-import android.support.v4.widget.DrawerLayout;
 import android.text.TextUtils;
 import android.util.Log;
 import android.view.GestureDetector;
@@ -954,15 +953,13 @@ public class DeckPicker extends NavigationDrawerActivity {
         registerExternalStorageListener();
         
         // create inherited navigation drawer layout here so that it can be used by parent class
-        mDrawerLayout = (DrawerLayout) findViewById(R.id.deckpicker_drawer_layout);
-        mDrawerList = (ListView) findViewById(R.id.deckpicker_left_drawer);
-        initNavigationDrawer();
+        initNavigationDrawer(mainView);
         if (savedInstanceState == null) {
             selectNavigationItem(DRAWER_DECK_PICKER);
         }
         //open the drawer on startup if it's never been opened voluntarily by the user (as per Android guidelines)
         if (!intent.getBooleanExtra("viaNavigationDrawer", false) && !preferences.getBoolean("navDrawerHasBeenOpened", false)) {
-            mDrawerLayout.openDrawer(Gravity.LEFT);
+            getDrawerLayout().openDrawer(Gravity.LEFT);
         }
 
 
@@ -1404,7 +1401,7 @@ public class DeckPicker extends NavigationDrawerActivity {
                 break;
 
             case DIALOG_CONNECTION_ERROR:
-                // From the Android style guide: â€œMost alerts don't need titles.â€� And "Attention" is quite unhelpful.
+                // From the Android style guide: ﾃ｢竄ｬﾅ溺ost alerts don't need titles.ﾃ｢竄ｬ�ｽ And "Attention" is quite unhelpful.
                 // builder.setTitle(res.getString(R.string.connection_error_title));
                 builder.setIcon(R.drawable.ic_dialog_alert);
                 builder.setMessage(res.getString(R.string.connection_error_message));
@@ -2427,7 +2424,7 @@ public class DeckPicker extends NavigationDrawerActivity {
     public boolean onOptionsItemSelected(MenuItem item) {
         // The action bar home/up action should open or close the drawer.
         // ActionBarDrawerToggle will take care of this.
-        if (mDrawerToggle.onOptionsItemSelected(item)) {
+        if (getDrawerToggle().onOptionsItemSelected(item)) {
             return true;
         }
         

--- a/src/com/ichi2/anki/NavigationDrawerActivity.java
+++ b/src/com/ichi2/anki/NavigationDrawerActivity.java
@@ -46,11 +46,11 @@ import com.ichi2.themes.StyledProgressDialog;
 public class NavigationDrawerActivity extends AnkiActivity {
     
     /** Navigation Drawer */
-    protected DrawerLayout mDrawerLayout;
-    protected ListView mDrawerList;
-    protected ActionBarDrawerToggle mDrawerToggle;
     protected CharSequence mTitle;
     protected Boolean mFragmented = false;
+    private DrawerLayout mDrawerLayout;
+    private ListView mDrawerList;
+    private ActionBarDrawerToggle mDrawerToggle;
     private CharSequence mDrawerTitle;
     private String[] mNavigationTitles;
     private TypedArray mNavigationImages;
@@ -69,7 +69,10 @@ public class NavigationDrawerActivity extends AnkiActivity {
     
     
     // navigation drawer stuff
-    protected void initNavigationDrawer(){
+    protected void initNavigationDrawer(View mainView){
+        // Create inherited navigation drawer layout here so that it can be used by parent class
+        mDrawerLayout = (DrawerLayout) mainView.findViewById(R.id.drawer_layout);
+        mDrawerList = (ListView) mainView.findViewById(R.id.left_drawer);
         mTitle = mDrawerTitle = getTitle();
         mNavigationTitles = getResources().getStringArray(R.array.navigation_titles);
         mNavigationImages = getResources().obtainTypedArray(R.array.drawer_images);
@@ -175,6 +178,13 @@ public class NavigationDrawerActivity extends AnkiActivity {
         mDrawerList.setItemChecked(position, true);
         setTitle(mNavigationTitles[position]);
         mDrawerLayout.closeDrawer(mDrawerList);
+    }
+    
+    protected void deselectAllNavigationItems() {
+        // Deselect all entries in navigation drawer
+        for (int i=0; i< mDrawerList.getCount(); i++) {
+            mDrawerList.setItemChecked(i, false);
+        }
     }
 
     @Override
@@ -307,4 +317,16 @@ public class NavigationDrawerActivity extends AnkiActivity {
         super.onDestroy();
         mNavigationImages.recycle();
     }
+    
+    public DrawerLayout getDrawerLayout() {
+        return mDrawerLayout;
+    }
+    
+    public ListView getDrawerList() {
+        return mDrawerList;
+    }
+    
+    public ActionBarDrawerToggle getDrawerToggle() {
+        return mDrawerToggle;
+    }    
 }

--- a/src/com/ichi2/anki/Previewer.java
+++ b/src/com/ichi2/anki/Previewer.java
@@ -62,7 +62,7 @@ public class Previewer extends AbstractFlashcardViewer {
     @Override
     protected void initLayout() {
         super.initLayout();
-        mDrawerToggle.setDrawerIndicatorEnabled(false);
+        getDrawerToggle().setDrawerIndicatorEnabled(false);
         findViewById(R.id.answer_options_layout).setVisibility(View.GONE);
         mTopBarLayout.setVisibility(View.GONE);
         mFlipCardLayout.setVisibility(View.GONE);

--- a/src/com/ichi2/anki/StudyOptionsActivity.java
+++ b/src/com/ichi2/anki/StudyOptionsActivity.java
@@ -23,19 +23,16 @@ import android.content.DialogInterface.OnCancelListener;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.Bundle;
-import android.support.v4.widget.DrawerLayout;
-import android.support.v7.app.ActionBarActivity;
 import android.util.Log;
 import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.MotionEvent;
+import android.view.View;
 import android.widget.EditText;
-import android.widget.ListView;
 
 import com.ichi2.anim.ActivityTransitionAnimation;
 import com.ichi2.anki.receiver.SdCardReceiver;
-import com.ichi2.libanki.Utils;
 import com.ichi2.themes.StyledOpenCollectionDialog;
 import com.ichi2.themes.Themes;
 import com.ichi2.widget.WidgetStatus;
@@ -56,11 +53,10 @@ public class StudyOptionsActivity extends NavigationDrawerActivity {
         // The empty frame layout is a workaround for fragments not showing when they are added
         // to android.R.id.content when an action bar is used in Android 2.1 (and potentially
         // higher) with the appcompat package.
-        setContentView(R.layout.studyoptions);
+        View mainView = getLayoutInflater().inflate(R.layout.studyoptions, null);
+        setContentView(mainView);
         // create inherited navigation drawer layout here so that it can be used by parent class
-        mDrawerLayout = (DrawerLayout) findViewById(R.id.studyoptions_drawer_layout);
-        mDrawerList = (ListView) findViewById(R.id.studyoptions_left_drawer);
-        initNavigationDrawer();
+        initNavigationDrawer(mainView);
         if (savedInstanceState == null) {
             loadContent(getIntent().getBooleanExtra("onlyFnsMsg", false));
         }
@@ -98,9 +94,7 @@ public class StudyOptionsActivity extends NavigationDrawerActivity {
     @Override
     protected void onResume() {
         super.onResume();
-        for (int i=0; i< mDrawerList.getCount(); i++) {
-            mDrawerList.setItemChecked(i, false);
-        }
+        deselectAllNavigationItems();
     }    
 
 
@@ -110,7 +104,7 @@ public class StudyOptionsActivity extends NavigationDrawerActivity {
     public boolean onOptionsItemSelected(MenuItem item) {
         // The action bar home/up action should open or close the drawer.
         // ActionBarDrawerToggle will take care of this.
-        if (mDrawerToggle.onOptionsItemSelected(item)) {
+        if (getDrawerToggle().onOptionsItemSelected(item)) {
             return true;
         }
         


### PR DESCRIPTION
Cleaned up the way that the navigation drawer is created so that we no longer have to implement mysterious inherited variables in the activity `onCreate()` method.
