### PR TITLE
fix issue 2164 and issue 2182

### DIFF
--- a/src/com/ichi2/anki/DeckPicker.java
+++ b/src/com/ichi2/anki/DeckPicker.java
@@ -85,7 +85,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.TreeSet;
 
-public class DeckPicker extends NavigationDrawerActivity {
+public class DeckPicker extends NavigationDrawerActivity implements StudyOptionsFragment.OnStudyOptionsReloadListener {
 
     public static final int CRAM_DECK_FRAGMENT = -1;
 
@@ -252,7 +252,7 @@ public class DeckPicker extends NavigationDrawerActivity {
                     mCurrentDid = Long.parseLong(mDeckList.get(mContextMenuPosition).get("did"));
                     AnkiDroidApp.getCol().getDecks().select(mCurrentDid);
                     if (mFragmented) {
-                        setStudyContentView(mCurrentDid, null);
+                        loadStudyOptionsFragment(mCurrentDid, null);
                     }
                     // open deck options
                     if (AnkiDroidApp.getCol().getDecks().isDyn(mCurrentDid)){
@@ -2204,10 +2204,14 @@ public class DeckPicker extends NavigationDrawerActivity {
     // CUSTOM METHODS
     // ----------------------------------------------------------------------------
 
-    public void setStudyContentView(long deckId, Bundle cramConfig) {
-        StudyOptionsFragment details = StudyOptionsFragment.newInstance(deckId, false, cramConfig);
+    public void loadStudyOptionsFragment() {
+        loadStudyOptionsFragment(0, null);
+    }
+
+  
+    public void loadStudyOptionsFragment(long deckId, Bundle cramConfig) {
+        StudyOptionsFragment details = StudyOptionsFragment.newInstance(deckId, cramConfig);
         FragmentTransaction ft = getSupportFragmentManager().beginTransaction();
-        // ft.setCustomAnimations(R.anim.fade_in, R.anim.fade_out);
         ft.setTransition(FragmentTransaction.TRANSIT_FRAGMENT_CLOSE);
         ft.replace(R.id.studyoptions_fragment, details);
         ft.commit();
@@ -2738,7 +2742,7 @@ public class DeckPicker extends NavigationDrawerActivity {
 
     private void openStudyOptions(long deckId, Bundle cramInitialConfig) {
         if (mFragmented) {
-            setStudyContentView(deckId, cramInitialConfig);
+            loadStudyOptionsFragment(deckId, cramInitialConfig);
         } else {
             mDontSaveOnStop = true;
             Intent intent = new Intent();

--- a/src/com/ichi2/anki/StudyOptionsActivity.java
+++ b/src/com/ichi2/anki/StudyOptionsActivity.java
@@ -24,7 +24,6 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.Bundle;
 import android.support.v4.widget.DrawerLayout;
-import android.support.v7.app.ActionBarActivity;
 import android.util.Log;
 import android.view.KeyEvent;
 import android.view.Menu;
@@ -35,12 +34,11 @@ import android.widget.ListView;
 
 import com.ichi2.anim.ActivityTransitionAnimation;
 import com.ichi2.anki.receiver.SdCardReceiver;
-import com.ichi2.libanki.Utils;
 import com.ichi2.themes.StyledOpenCollectionDialog;
 import com.ichi2.themes.Themes;
 import com.ichi2.widget.WidgetStatus;
 
-public class StudyOptionsActivity extends NavigationDrawerActivity {
+public class StudyOptionsActivity extends NavigationDrawerActivity implements StudyOptionsFragment.OnStudyOptionsReloadListener {
 
     private StudyOptionsFragment mCurrentFragment;
 
@@ -62,7 +60,7 @@ public class StudyOptionsActivity extends NavigationDrawerActivity {
         mDrawerList = (ListView) findViewById(R.id.studyoptions_left_drawer);
         initNavigationDrawer();
         if (savedInstanceState == null) {
-            loadContent(getIntent().getBooleanExtra("onlyFnsMsg", false));
+            loadStudyOptionsFragment();
         }
         registerExternalStorageListener();
     }
@@ -77,22 +75,20 @@ public class StudyOptionsActivity extends NavigationDrawerActivity {
         return true;
     }
 
-    public void loadContent(boolean onlyFnsMsg) {
-        loadContent(onlyFnsMsg, null);
+    public void loadStudyOptionsFragment() {
+        loadStudyOptionsFragment(0, null);
     }
 
 
-    public void loadContent(boolean onlyFnsMsg, Bundle cramConfig) {
-        mCurrentFragment = StudyOptionsFragment.newInstance(0, false, null);
+    public void loadStudyOptionsFragment(long deckId, Bundle cramConfig) {
+        mCurrentFragment = StudyOptionsFragment.newInstance(deckId, null);
         Bundle args = getIntent().getExtras();
-        if (onlyFnsMsg) {
-            args.putBoolean("onlyFnsMsg", onlyFnsMsg);
-        }
+
         if (cramConfig != null) {
             args.putBundle("cramInitialConfig", cramConfig);
         }
         mCurrentFragment.setArguments(args);
-        getSupportFragmentManager().beginTransaction().add(R.id.studyoptions_frame, mCurrentFragment).commit();
+        getSupportFragmentManager().beginTransaction().replace(R.id.studyoptions_frame, mCurrentFragment).commit();
     }
     
     @Override


### PR DESCRIPTION
The old way of changing to study options for custom study session was buggy on small devices and broken on tablets. This uses the approach of reloading the fragment from scratch in both cases via a Listener interface, as per the Android guidelines for communicating between fragments.
