### PR TITLE
Fix showing of welcome screen on first app startup

### DIFF
--- a/src/com/ichi2/anki/DeckPicker.java
+++ b/src/com/ichi2/anki/DeckPicker.java
@@ -928,11 +928,13 @@ public class DeckPicker extends NavigationDrawerActivity implements StudyOptions
 
         SharedPreferences preferences = restorePreferences();
 
-        // activate broadcast messages if first start of a day
-        if (mLastTimeOpened < UIUtils.getDayStart()) {
-            preferences.edit().putBoolean("showBroadcastMessageToday", true).commit();
+        // activate broadcast messages if first start of a day, and not fresh install
+        if (mLastTimeOpened > 0) {
+            if (mLastTimeOpened < UIUtils.getDayStart()) {
+                preferences.edit().putBoolean("showBroadcastMessageToday", true).commit();
+            }
+            preferences.edit().putLong("lastTimeOpened", System.currentTimeMillis()).commit();
         }
-        preferences.edit().putLong("lastTimeOpened", System.currentTimeMillis()).commit();
 
         // if (intent != null && intent.hasExtra(EXTRA_DECK_ID)) {
         // openStudyOptions(intent.getLongExtra(EXTRA_DECK_ID, 1));
@@ -959,10 +961,6 @@ public class DeckPicker extends NavigationDrawerActivity implements StudyOptions
         initNavigationDrawer();
         if (savedInstanceState == null) {
             selectNavigationItem(DRAWER_DECK_PICKER);
-        }
-        //open the drawer on startup if it's never been opened voluntarily by the user (as per Android guidelines)
-        if (!intent.getBooleanExtra("viaNavigationDrawer", false) && !preferences.getBoolean("navDrawerHasBeenOpened", false)) {
-            mDrawerLayout.openDrawer(Gravity.LEFT);
         }
 
 
@@ -2571,7 +2569,7 @@ public class DeckPicker extends NavigationDrawerActivity implements StudyOptions
         } else if (requestCode == SHOW_INFO_WELCOME || requestCode == SHOW_INFO_NEW_VERSION) {
             if (resultCode == RESULT_OK) {
                 showStartupScreensAndDialogs(AnkiDroidApp.getSharedPrefs(getBaseContext()),
-                        requestCode == SHOW_INFO_WELCOME ? 1 : 2);
+                        requestCode == SHOW_INFO_WELCOME ? 2 : 3);
             } else {
                 finishWithAnimation();
             }

--- a/src/com/ichi2/anki/Info.java
+++ b/src/com/ichi2/anki/Info.java
@@ -160,6 +160,8 @@ public class Info extends ActionBarActivity {
                     case TYPE_WELCOME:
                         AnkiDroidApp.getSharedPrefs(Info.this.getBaseContext()).edit()
                                 .putLong("lastTimeOpened", System.currentTimeMillis()).commit();
+                        AnkiDroidApp.getSharedPrefs(Info.this.getBaseContext()).edit()
+                                .putString("lastVersion", AnkiDroidApp.getPkgVersionName()).commit();
                         break;
                     case TYPE_NEW_VERSION:
                         AnkiDroidApp.getSharedPrefs(Info.this.getBaseContext()).edit()
@@ -219,6 +221,7 @@ public class Info extends ActionBarActivity {
                         setResult(RESULT_OK);
                         Editor edit = AnkiDroidApp.getSharedPrefs(Info.this.getBaseContext()).edit();
                         edit.putLong("lastTimeOpened", System.currentTimeMillis());
+                        edit.putString("lastVersion", AnkiDroidApp.getPkgVersionName()).commit();
                         edit.putBoolean("createTutorial", true);
                         edit.commit();
                         finishWithAnimation();

--- a/src/com/ichi2/anki/NavigationDrawerActivity.java
+++ b/src/com/ichi2/anki/NavigationDrawerActivity.java
@@ -98,8 +98,6 @@ public class NavigationDrawerActivity extends AnkiActivity {
             }
 
             public void onDrawerOpened(View drawerView) {
-                AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance().getBaseContext()).edit()
-                .putBoolean("navDrawerHasBeenOpened", true).commit();
                 getSupportActionBar().setTitle(mDrawerTitle);
                 supportInvalidateOptionsMenu(); // creates call to onPrepareOptionsMenu()
             }


### PR DESCRIPTION
Until now the welcome screen was never shown on first install as intended, and users were instead shown the upgrade screen, which is confusing. It could be nice for the tutorial video to start from a fresh install with just the tutorial deck, so this change will be useful for that.

Also removed some code which was supposed to open nav. drawer on first startup, but wasn't working and is more hassle than it's worth.
