### PR TITLE
Quick fix: throw non-file URLs into an Intent. Fix for 2189

### DIFF
--- a/src/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/src/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -33,6 +33,7 @@ import android.graphics.Color;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
 import android.media.AudioManager;
+import android.net.Uri;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Message;
@@ -108,6 +109,8 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -1733,7 +1736,20 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
                     sHandler.sendMessage(msg);
                     return true;
                 }
-                return false;
+                try {
+                    new URL(url);  // dummy variable to check if the string looks like an url
+                } catch (MalformedURLException mue) {
+                    // Ignore malformed urls by handling them and then doing nothing.
+                    return true;
+                }
+                if (url.startsWith("file"))
+                {
+                    return false;  // Let the webview load files, i.e. local images.
+                }
+                Log.d(AnkiDroidApp.TAG, "Opening external link \"" + url + "\" with an Intent");
+                Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+                startActivity(intent);
+                return true;
             }
         });
 


### PR DESCRIPTION
From the Android docs [how to launch a browser](https://developer.android.com/reference/android/webkit/WebView.html), see Basic usage.
With an extra step added to check if the `url` actually looks like an URL

Should fix [issue 2189](https://code.google.com/p/ankidroid/issues/detail?id=2189)
