### PR TITLE
Fix up clipboard

### DIFF
--- a/res/values/02-strings.xml
+++ b/res/values/02-strings.xml
@@ -171,5 +171,5 @@
     <string name="sched_has_buried">Some related or buried cards were delayed until tomorrow.</string>
     <string name="tag_editor_add_hint">Use tick mark on the right to add new tag</string>
     <string name="tag_editor_add_feedback">Press \"%2$s\" button to confirm adding \"%1$s\"</string>
-
+    <string name="lookup_hint">After copying the text, tap anywhere on the flashcard to show the search icon</string>
 </resources>

--- a/src/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/src/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -72,11 +72,9 @@ import android.widget.Chronometer;
 import android.widget.EditText;
 import android.widget.FrameLayout;
 import android.widget.LinearLayout;
-import android.widget.ListView;
 import android.widget.ProgressBar;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
-
 import com.ichi2.anim.ActivityTransitionAnimation;
 import com.ichi2.anim.ViewAnimation;
 import com.ichi2.anki.receiver.SdCardReceiver;
@@ -383,6 +381,11 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
         @Override
         public void run() {
             Log.i(AnkiDroidApp.TAG, "onEmulatedLongClick");
+            // Show hint about lookup function if dictionary available and Webview version supports text selection
+            if (!mDisableClipboard && Lookup.isAvailable() && AnkiDroidApp.SDK_VERSION >= 11) {
+                String lookupHint = getResources().getString(R.string.lookup_hint);
+                Themes.showThemedToast(AbstractFlashcardViewer.this, lookupHint, false);
+            }
             Vibrator vibratorManager = (Vibrator) getSystemService(Context.VIBRATOR_SERVICE);
             vibratorManager.vibrate(50);
             longClickHandler.postDelayed(startLongClickAction, 300);
@@ -1897,6 +1900,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
         mPrefHideDueCount = preferences.getBoolean("hideDueCount", false);
         mPrefWhiteboard = preferences.getBoolean("whiteboard", false);
         mPrefWriteAnswers = !preferences.getBoolean("writeAnswersDisable", false);
+        mDisableClipboard = preferences.getString("dictionary","0").equals("0");
         mLongClickWorkaround = preferences.getBoolean("textSelectionLongclickWorkaround", false);
         // mDeckFilename = preferences.getString("deckFilename", "");
         mNightMode = preferences.getBoolean("invertedColors", false);


### PR DESCRIPTION
Disable messing with cliboard when no lookup dictionary selected, and show hint when user long-clicks while dictionary lookup enabled. As per [this thread](https://groups.google.com/forum/#!topic/anki-android/s6I5pevwxRo) on the forum.
