### PR TITLE
Fix issue 2203

### DIFF
--- a/res/values/constants.xml
+++ b/res/values/constants.xml
@@ -39,6 +39,7 @@
         <item>4</item>
         <item>5</item>
         <item>6</item>
+        <item>7</item>
     </string-array>
     <string-array name="error_reporting_choice_values">
         <item>0</item>


### PR DESCRIPTION
Make sure AnkiDroid does not crash when you try to select the Nciku dictonary by making the "dictionary_values" as long as the "dictionary_labels".
Somehow we had eight values to chose from but only seven numbers assigned to those, which didn't [end well](https://code.google.com/p/ankidroid/issues/detail?id=2203).

eta a link
