### PR TITLE
Option to enable/disable sw keyboard auto pop up

### DIFF
--- a/res/values/10-preferences.xml
+++ b/res/values/10-preferences.xml
@@ -50,7 +50,9 @@
     <string name="whiteboard_black">Black strokes</string>
     <string name="whiteboard_black_summ">Uses less memory, unless in night mode</string>
     <string name="write_answers_disable">Disable typing in answer</string>
-    <string name="write_answers_disable_summ">Prevents keyboard from appearing on cards containing \'type in the answer\' fields</string>
+    <string name="write_answers_disable_summ">Forces \'type in the answer\' fields to be disabled</string>
+    <string name="auto_keyboard_disable">Disable keyboard auto pop up</string>
+    <string name="auto_keyboard_disable_summ">Disables keyboard auto pop up for \'type in the answer\' fields</string>
     <string name="text_selection_click">Long press workaround</string>
     <string name="text_selection_click_summ">Enable this if you are not able to select text with a long press</string>
     <string name="dictionary">Lookup dictionary</string>

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -117,6 +117,11 @@
                 android:key="writeAnswersDisable"
                 android:summary="@string/write_answers_disable_summ"
                 android:title="@string/write_answers_disable" />
+            <CheckBoxPreference
+                android:defaultValue="false"
+                android:key="autoKeyboardDisable"
+                android:summary="@string/auto_keyboard_disable_summ"
+                android:title="@string/auto_keyboard_disable" />
         </PreferenceCategory>
         <PreferenceCategory android:title="@string/pref_cat_flashcard" >
             <CheckBoxPreference

--- a/src/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/src/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -195,6 +195,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
     private boolean mShowTimer;
     protected boolean mPrefWhiteboard;
     private boolean mPrefWriteAnswers;
+    private boolean mShowKeyboard;
     private boolean mInputWorkaround;
     private boolean mLongClickWorkaround;
     private boolean mPrefFullscreenReview;
@@ -1873,8 +1874,14 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
         if (mFlipCardLayout.getVisibility() != View.VISIBLE) {
             mFlipCardLayout.setVisibility(View.VISIBLE);
             mFlipCardLayout.requestFocus();
-        } else if (typeAnswer()) {
-            mAnswerField.requestFocus();
+        }
+
+        if (typeAnswer() && mShowKeyboard) {
+                mAnswerField.requestFocus();
+
+                // Show soft keyboard
+                InputMethodManager inputMethodManager = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
+                inputMethodManager.showSoftInput(mAnswerField, InputMethodManager.SHOW_FORCED);
         }
     }
 
@@ -1923,6 +1930,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
         mPrefHideDueCount = preferences.getBoolean("hideDueCount", false);
         mPrefWhiteboard = preferences.getBoolean("whiteboard", false);
         mPrefWriteAnswers = !preferences.getBoolean("writeAnswersDisable", false);
+        mShowKeyboard = !preferences.getBoolean("autoKeyboardDisable", false);
         mDisableClipboard = preferences.getString("dictionary","0").equals("0");
         mLongClickWorkaround = preferences.getBoolean("textSelectionLongclickWorkaround", false);
         // mDeckFilename = preferences.getString("deckFilename", "");


### PR DESCRIPTION
I have recently updated to 2.3alpha3 and saw that a lot have been changed in past months. Unfortunately, not all of the changes made me a happy camper. For example, now keyboard is not popping up automatically when I'm reviewing my cards with type in fields. And this adds substantial lag to a slow by nature process for reviewing on a touchscreen. From [this thread](https://github.com/ankidroid/Anki-Android/pull/304), I've learned that software keyboard auto pop up was disabled due to it's significant reduction of a view port on a cellphones. I feel your pain, people, but on a tablet it's not the case for the most time, so I think we should have an option to suit the best for both worlds. So, with this commit I propose a compromise: new preference. I know, that we should reduce the number of preferences, so an average user should not be puzzled with a slew of strange options. But personally, I would prefer having this, than having to do an extra tap each time. What is your opinions on this?

@ray-pixar and @ospalh would probably have some thoughts on this.
