### PR TITLE
Use the field name for the show hint link, like Anki desktop.

### DIFF
--- a/res/values/02-strings.xml
+++ b/res/values/02-strings.xml
@@ -140,7 +140,7 @@
     </string-array>
 
     <string name="menu_cardbrowser">Card browser</string>
-    <string name="show_hint">Show hint</string>
+    <string name="show_hint">Show %s</string>
     <string name="pref_lang_other">Language preferences</string>
     <string name="pref_font_UI">Custom UI font</string>
     <string name="info_rate">Rate AnkiDroid</string>

--- a/src/com/ichi2/libanki/hooks/HintFilter.java
+++ b/src/com/ichi2/libanki/hooks/HintFilter.java
@@ -37,8 +37,8 @@ public class HintFilter {
             String domid = "hint" + txt.hashCode();
             return "<a class=hint href=\"#\" onclick=\"this.style.display='none';document.getElementById('" +
                     domid + "').style.display='block';return false;\">" +
-                    res.getString(R.string.show_hint) + "</a><div id=\"" +
-            		domid + "\" class=hint style=\"display: none\">" + txt + "</div>";
+                    res.getString(R.string.show_hint, (String) args[2]) + "</a><div id=\"" +
+                    domid + "\" class=hint style=\"display: none\">" + txt + "</div>";
         }
     }
 }


### PR DESCRIPTION
Fix for [issue 1788](https://code.google.com/p/ankidroid/issues/detail?id=1788), although that report asks that the “Show ” in “Show NN” should be remov

It’s called [`tag`](https://github.com/dae/anki/blob/3ee193731007ca8df28cbe9534218a70d97599fa/anki/template/hint.py#L17) in the Anki desktop code and somewhere in the `args` in AnkiDroid.

I checked all calls to `runFilter` and we always put in a fourth argument.

The original issue report asks that the “Show ” in “Show NN” should be removed. This brings it in line with Anki desktop instead, which has the “Show” too.

P.S.: I untabified line 41.
