### PR TITLE
Fix a fallthrough

### DIFF
--- a/src/com/ichi2/anki/StudyOptionsFragment.java
+++ b/src/com/ichi2/anki/StudyOptionsFragment.java
@@ -1125,6 +1125,7 @@ public class StudyOptionsFragment extends Fragment {
 
             case R.id.action_add_note_from_study_options:
                 addNote();
+                return true;
 
             default:
                 return super.onOptionsItemSelected(item);


### PR DESCRIPTION
Don't go on and call `super.onOptionsItemSelected(item);` when the user has touched the add note action.

That call to the parent function appears not do be doing much harm, so i think this is not strictly needed for the 2.2 hotfix.
