### PR TITLE
'Add new media' action wipes existing field content. [Issue #2224]

### DIFF
--- a/src/com/ichi2/anki/CardEditor.java
+++ b/src/com/ichi2/anki/CardEditor.java
@@ -176,6 +176,7 @@ public class CardEditor extends ActionBarActivity {
     private long mDeckId;
 
     private LinkedList<FieldEditText> mEditFields;
+    private Pair<Integer, Integer> fieldSelectors = new Pair<Integer, Integer>(0, 0);
 
     private int mCardItemBackground;
     private final List<Map<String, String>> mIntentInformation = new ArrayList<Map<String, String>>();
@@ -1143,7 +1144,15 @@ public class CardEditor extends ActionBarActivity {
                     IMultimediaEditableNote mNote = NoteService.createEmptyNote(mEditorNote.model());
                     NoteService.updateMultimediaNoteFromJsonNote(mEditorNote, mNote);
                     mNote.setField(index, field);
-                    mEditFields.get(index).setText(field.getFormattedValue());
+
+                    // Fix for issue #2224;
+                    // start/end handling will also deal with start > end cases, allegedly possible on older Androids
+                    FieldEditText textField = mEditFields.get(index);
+                    int start = Math.max(fieldSelectors.first, 0);
+                    int end = Math.max(fieldSelectors.second, 0);
+                    String textToInsert = field.getFormattedValue();
+                    textField.getText().replace(Math.min(start, end), Math.max(start, end), textToInsert, 0, textToInsert.length());
+
                     NoteService.saveMedia((MultimediaEditableNote) mNote);
                     mChanged = true;
                 }
@@ -1220,6 +1229,8 @@ public class CardEditor extends ActionBarActivity {
                             IMultimediaEditableNote mNote = NoteService.createEmptyNote(mEditorNote.model());
                             NoteService.updateMultimediaNoteFromJsonNote(mEditorNote, mNote);
                             IField field = mNote.getField(index);
+                            FieldEditText textField = mEditFields.get(index);
+                            fieldSelectors = new Pair<Integer, Integer>(textField.getSelectionStart(), textField.getSelectionEnd());
                             switch (item.getItemId()) {
                                 case R.id.menu_multimedia_audio:
                                     field = new AudioField();


### PR DESCRIPTION
Patch for issue #2224: https://code.google.com/p/ankidroid/issues/detail?id=2224

Fix should also deal with selections in the text field prior to hitting the 'Add new media' button.

Tested on real device running API 17 and on emulator running API 7.
