### PR TITLE
Support sticky fields

### DIFF
--- a/src/com/ichi2/anki/CardEditor.java
+++ b/src/com/ichi2/anki/CardEditor.java
@@ -218,7 +218,22 @@ public class CardEditor extends ActionBarActivity {
             } else if (count > 0) {
                 mChanged = true;
                 mSourceText = null;
+                Note oldNote = mEditorNote.clone();
                 setNote();
+                // Respect "Remember last input when adding" field option.
+                JSONArray flds;
+                try {
+                    flds = mEditorNote.model().getJSONArray("flds");
+                    if (oldNote != null) {
+                        for (int fldIdx = 0; fldIdx < flds.length(); fldIdx++) {
+                            if (flds.getJSONObject(fldIdx).getBoolean("sticky")) {
+                                mEditFields.get(fldIdx).setText(oldNote.getFields()[fldIdx]);
+                            }
+                        }
+                    }
+                } catch (JSONException e) {
+                    throw new RuntimeException();
+                }
                 Themes.showThemedToast(CardEditor.this,
                         getResources().getQuantityString(R.plurals.factadder_cards_added, count, count), true);
             } else {


### PR DESCRIPTION
I'm adding more cards on my phone than usual these days. I noticed that sticky fields are not supported, i.e. fields get emptied out after a card was added even though the _Remember last input when adding_ field option is set.

Background: I track references for almost all my cards. When I'm adding cards while reading a book the reference will stay mostly the same with exception of the page number. This feature saves a lot of typing / copy-pasting.

PS: I'm not too happy with the location of the code.
