### PR TITLE
More robust image resizing (Issue 2207)

### DIFF
--- a/assets/card_template.html
+++ b/assets/card_template.html
@@ -9,12 +9,9 @@
         <style>
         ::style::
         </style>
-    </head>
-    <body class="::class::">
-        <div id="content">
-        ::content::
-        </div>
         <script type="text/javascript">
+            var resizeDone = false;
+            
             /*
             Handle image resizing if the image exceeds the window dimensions.
             
@@ -27,11 +24,19 @@
             browser will not be scaled accordingly, giving us only the original dimensions. We
             have to fetch the zoom value and scale the dimensions with it before checking if the
             image exceeds the window bounds.
+            
+            If the WebView loads too early on Android <= 2.3 (which happens on the first card or
+            regularly with WebView switching enabled), then the window dimensions returned to us
+            are 0x0. In this case, we skip image resizing and try again after we know the window
+            has fully loaded with a method call initiated from Java (onPageFinished).
             */
-            window.onload = function() {
+            var resizeImages = function() {
                 if (navigator.userAgent.indexOf("Chrome") > -1) {
                     document.body.className = document.body.className + " chrome";
                 } else {
+                    if (window.innerWidth === 0 || window.innerHeight === 0) {
+                        return;
+                    }
                     var maxWidth = window.innerWidth * 0.90;
                     var maxHeight = window.innerHeight * 0.90;
                     var ratio = 0;
@@ -59,8 +64,32 @@
                         }
                     }
                 }
+                resizeDone = true;
             };
-            window.location.href = "#answer";
+            
+            window.onload = function() {
+                /* If the WebView loads too early on Android <= 4.3 (which happens on the first card or
+                   regularly with WebView switching enabled), the window dimensions returned to us
+                   will be default built-in values. In this case, issuing a scroll event will force
+                   the browser to recalculate the dimensions and give us the correct values, so we
+                   do this every time. This lets us resize images correctly. */
+                window.scrollTo(0,0);
+                resizeImages();
+                window.location.href = "#answer";
+            };
+            
+            var onPageFinished = function() {
+                if (!resizeDone) {
+                    resizeImages();
+                    /* Re-anchor to answer after image resize since the point changes */
+                    window.location.href = "#answer";
+                }
+            }
         </script>
+    </head>
+    <body class="::class::">
+        <div id="content">
+        ::content::
+        </div>
     </body>
 </html>

--- a/src/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/src/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1707,9 +1707,10 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
         Log.i(AnkiDroidApp.TAG,
                 "Focusable = " + webView.isFocusable() + ", Focusable in touch mode = " + webView.isFocusableInTouchMode());
 
-        // Filter any links using the custom "playsound" protocol defined in Sound.java.
-        // We play sounds through these links when a user taps the sound icon.
+
         webView.setWebViewClient(new WebViewClient() {
+            // Filter any links using the custom "playsound" protocol defined in Sound.java.
+            // We play sounds through these links when a user taps the sound icon.
             @Override
             public boolean shouldOverrideUrlLoading(WebView view, String url) {
                 if (url.startsWith("playsound:")) {
@@ -1734,6 +1735,12 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
                 Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
                 startActivity(intent);
                 return true;
+            }
+            // Run any post-load events in javascript that rely on the window being completely loaded.
+            @Override
+            public void onPageFinished(WebView view, String url) {
+                Log.d(AnkiDroidApp.TAG, "onPageFinished triggered");
+                view.loadUrl("javascript:onPageFinished();");
             }
         });
 


### PR DESCRIPTION
[Issue 2207](https://code.google.com/p/ankidroid/issues/detail?id=2207)

This should resolve the issues relating to image resizing introduced in the last release. The underlying issue appears to be the javascript executing before the webview is fully loaded, which ends up reporting incorrect window dimensions.

The behaviour is different on older platoforms so there are two workaround in there. An interesting thing to note: when webview switching is enabled ("safe display mode"), the problem can appear on any card. When it isn't enabled, the behaviour is only observed in the first card. I think we are doing the webview switching thing on the first card still even with the option turned off (something to look into one day).
