### PR TITLE
Refactor async collection loading to a single loader class

### DIFF
--- a/src/com/ichi2/anki/NavigationDrawerActivity.java
+++ b/src/com/ichi2/anki/NavigationDrawerActivity.java
@@ -16,9 +16,7 @@
 package com.ichi2.anki;
 
 import android.app.Activity;
-import android.app.Dialog;
 import android.content.Context;
-import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.res.Configuration;
 import android.content.res.TypedArray;
@@ -28,7 +26,6 @@ import android.os.Bundle;
 import android.support.v4.app.ActionBarDrawerToggle;
 import android.support.v4.view.GravityCompat;
 import android.support.v4.widget.DrawerLayout;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -40,8 +37,6 @@ import android.widget.TextView;
 import com.ichi2.anim.ActivityTransitionAnimation;
 import com.ichi2.anki.stats.AnkiStatsActivity;
 import com.ichi2.anki.stats.AnkiStatsTaskHandler;
-import com.ichi2.async.DeckTask;
-import com.ichi2.themes.StyledProgressDialog;
 
 
 public class NavigationDrawerActivity extends AnkiActivity {
@@ -55,8 +50,6 @@ public class NavigationDrawerActivity extends AnkiActivity {
     private CharSequence mDrawerTitle;
     private String[] mNavigationTitles;
     private TypedArray mNavigationImages;
-    // Porgress dialog
-    private StyledProgressDialog mProgressDialog;
     // Navigation drawer list item entries
     protected static final int DRAWER_DECK_PICKER = 0;
     protected static final int DRAWER_BROWSER = 1;

--- a/src/com/ichi2/anki/Previewer.java
+++ b/src/com/ichi2/anki/Previewer.java
@@ -34,8 +34,8 @@ public class Previewer extends AbstractFlashcardViewer {
 
 
     @Override
-    protected void initActivity(Collection col) {
-        super.initActivity(col);
+    protected void onCollectionLoaded(Collection col) {
+        super.onCollectionLoaded(col);
         mCurrentCard = CardEditor.mCurrentEditedCard;
         displayCardQuestion();
     }

--- a/src/com/ichi2/anki/Reviewer.java
+++ b/src/com/ichi2/anki/Reviewer.java
@@ -39,8 +39,8 @@ public class Reviewer extends AbstractFlashcardViewer {
 
 
     @Override
-    protected void initActivity(Collection col) {
-        super.initActivity(col);
+    protected void onCollectionLoaded(Collection col) {
+        super.onCollectionLoaded(col);
         // Load the first card and start reviewing. Uses the answer card
         // task to load a card, but since we send null
         // as the card to answer, no card will be answered.

--- a/src/com/ichi2/anki/StudyOptionsActivity.java
+++ b/src/com/ichi2/anki/StudyOptionsActivity.java
@@ -29,8 +29,6 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.view.MotionEvent;
 import android.view.View;
-import android.widget.EditText;
-
 import com.ichi2.anim.ActivityTransitionAnimation;
 import com.ichi2.anki.receiver.SdCardReceiver;
 import com.ichi2.themes.StyledOpenCollectionDialog;
@@ -43,7 +41,6 @@ public class StudyOptionsActivity extends NavigationDrawerActivity implements St
 
     private BroadcastReceiver mUnmountReceiver = null;
     private StyledOpenCollectionDialog mNotMountedDialog;
-    private EditText mDialogEditText = null;
 
 
     @Override
@@ -62,6 +59,7 @@ public class StudyOptionsActivity extends NavigationDrawerActivity implements St
         }
         registerExternalStorageListener();
     }
+
 
     @Override
     public boolean onPrepareOptionsMenu(Menu menu){
@@ -200,14 +198,14 @@ public class StudyOptionsActivity extends NavigationDrawerActivity implements St
 
                             @Override
                             public void onCancel(DialogInterface arg0) {
-                                finish();
+                                finishWithoutAnimation();
                             }
                         });
                     } else if (intent.getAction().equals(SdCardReceiver.MEDIA_MOUNT)) {
                         if (mNotMountedDialog != null && mNotMountedDialog.isShowing()) {
                             mNotMountedDialog.dismiss();
                         }
-                        mCurrentFragment.reloadCollection();
+                        loadCollection();
                     }
                 }
             };

--- a/src/com/ichi2/async/CollectionLoader.java
+++ b/src/com/ichi2/async/CollectionLoader.java
@@ -1,0 +1,101 @@
+package com.ichi2.async;
+
+import android.content.Context;
+import android.content.res.Resources;
+import android.support.v4.content.AsyncTaskLoader;
+import android.util.Log;
+
+import com.ichi2.anki.AnkiActivity;
+import com.ichi2.anki.AnkiDroidApp;
+import com.ichi2.anki.BackupManager;
+import com.ichi2.anki.R;
+import com.ichi2.libanki.Collection;
+
+import java.lang.ref.WeakReference;
+
+public class CollectionLoader extends AsyncTaskLoader<Collection> {
+    static WeakReference<AnkiActivity> sActivity;
+    
+    public CollectionLoader(Context context) {
+        super(context);
+        try {
+            sActivity = new WeakReference<AnkiActivity>((AnkiActivity) context);    
+        } catch (ClassCastException e) {
+            sActivity = null;
+        }
+        
+    }
+
+    @Override
+    public Collection loadInBackground() {
+        // do a safety backup if last backup is too old --> addresses Android's delete db bug
+        Resources res = AnkiDroidApp.getInstance().getBaseContext().getResources();
+        String colPath = AnkiDroidApp.getCollectionPath();
+        if (BackupManager.safetyBackupNeeded(colPath)) {
+            setProgressMessage(res.getString(R.string.backup_collection));
+            BackupManager.performBackup(colPath);
+        }
+        setProgressMessage(res.getString(R.string.open_collection));
+
+        // load collection
+        try {
+            return AnkiDroidApp.openCollection(colPath);
+        } catch (RuntimeException e) {
+            BackupManager.restoreCollectionIfMissing(colPath);
+            Log.e(AnkiDroidApp.TAG, "doInBackgroundOpenCollection - RuntimeException on opening collection: " + e);
+            AnkiDroidApp.saveExceptionReportFile(e, "doInBackgroundOpenCollection");
+            return null;
+        }
+    }
+    
+    @Override
+    public void deliverResult(Collection col) {
+        // Loader has been reset so don't forward data to listener
+        if (isReset()) {
+            if (col != null) {
+                return;
+            }
+        }
+        // Loader is running so dismiss progress dialog and forward data to listener
+        if (isStarted()) {
+            super.deliverResult(col);
+        }
+    }
+    
+    @Override
+    protected void onStartLoading() {
+        String colPath = AnkiDroidApp.getCollectionPath();
+        
+        if (AnkiDroidApp.colIsOpen() && AnkiDroidApp.getCol() != null && AnkiDroidApp.getCol().getPath().equals(colPath)) {
+            // deliver current path if open and valid
+            deliverResult(AnkiDroidApp.getCol());
+        } else {
+            // otherwise reload the collection
+            forceLoad();
+        }        
+    }
+    
+    @Override
+    protected void onStopLoading() {
+        // The Loader has been put in a stopped state, so we should attempt to cancel the current load (if there is one).
+        cancelLoad();
+    }
+    
+    @Override
+    protected void onReset() {
+        // Ensure the loader is stopped.
+        onStopLoading();
+    }
+    
+    
+    private void setProgressMessage(final String message) {
+        // Update the text of the opening collection dialog
+        if (sActivity != null && sActivity.get() != null) {
+            sActivity.get().runOnUiThread(new Runnable() {
+                public void run() {
+                    sActivity.get().setProgressMessage(message);
+                }
+            });
+        }
+    }
+}


### PR DESCRIPTION
I've changed to a unified `AsyncTaskLoader` approach for loading the collection. This has the advantage that it is aware of the activity / fragment lifecycle, so it's easier to avoid bugs, not to mention reducing  code duplication. The main motivation for this was fixing [Issue 1632](https://code.google.com/p/ankidroid/issues/detail?id=1632) -- hopefully it hasn't introduced too many new issues.

There's a new class in `com.ichi2.async` called `CollectionLoader` which replaces the old `AsyncTask`code. `AnkiActivity` has been extended to take care of most of loading stuff -- and all activities which extend it just need to call `loadCollection()` in their `onCreate()` methods, and optionally implement a method `onCollectionLoaded()` which will be called back when the collection is loaded. The collection should be accessed via the new method `AnkiActivity.getCol()` instead of `AnkiDroidApp.getCol()`.

Since we currently only have one Fragment, that has it's own implementation which somewhat duplicates the one in `AnkiActivity` -- we can look at refactoring that further in the future.

I have also removed a bunch of unused stuff that was causing warnings, and fixed deprecated method warnings for the animations. Sorry that it's all in a single commit.
