### PR TITLE
Disable navigation drawer swipe open while reviewing

### DIFF
--- a/src/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/src/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -80,6 +80,7 @@ import com.ichi2.anim.ViewAnimation;
 import com.ichi2.anki.exception.APIVersionException;
 import com.ichi2.anki.receiver.SdCardReceiver;
 import com.ichi2.anki.reviewer.ReviewerExtRegistry;
+import com.ichi2.anki.reviewer.WhiteboardListener;
 import com.ichi2.async.DeckTask;
 import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
@@ -271,6 +272,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
     private int mCurrentEase;
 
     private boolean mShowWhiteboard = false;
+    private WhiteboardListener mWhiteboardListener;
 
     private int mNextTimeTextColor;
     private int mNextTimeTextRecomColor;
@@ -967,6 +969,9 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
         if (mPrefWhiteboard && deckID != -1 && MetaDB.getWhiteboardState(this, deckID) == 1) {
             mShowWhiteboard = true;
             mWhiteboard.setVisibility(View.VISIBLE);
+            if (mWhiteboardListener != null) {
+                mWhiteboardListener.onShowWhiteboard();
+            }
         }
 
         // Initialize dictionary lookup feature
@@ -1210,11 +1215,17 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
                     mWhiteboard.setVisibility(View.VISIBLE);
                     item.setTitle(R.string.hide_whiteboard);
                     MetaDB.storeWhiteboardState(this, deckID, 1);
+                    if (mWhiteboardListener != null) {
+                        mWhiteboardListener.onShowWhiteboard();
+                    }
                 } else {
                     // Hide whiteboard
                     mWhiteboard.setVisibility(View.GONE);
                     item.setTitle(R.string.show_whiteboard);
                     MetaDB.storeWhiteboardState(this, deckID, 0);
+                    if (mWhiteboardListener != null) {
+                        mWhiteboardListener.onHideWhiteboard();
+                    }                    
                 }
                 refreshActionBar();
                 return true;
@@ -3106,5 +3117,11 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
 
     private Spanned convertToSimple(String text) {
         return Html.fromHtml(text, mSimpleInterfaceImagegetter, mSimpleInterfaceTagHandler);
+    }
+    
+    protected void setWhiteboardListener(WhiteboardListener listener) {
+        if (listener != null) {
+            mWhiteboardListener = listener;
+        }
     }
 }

--- a/src/com/ichi2/anki/NavigationDrawerActivity.java
+++ b/src/com/ichi2/anki/NavigationDrawerActivity.java
@@ -270,5 +270,26 @@ public class NavigationDrawerActivity extends AnkiActivity {
     
     public ActionBarDrawerToggle getDrawerToggle() {
         return mDrawerToggle;
+    }
+    
+    /**
+     * This function locks the navigation drawer closed in regards to swipes,
+     * but continues to allowed it to be opened via it's indicator button. This
+     * function in a noop if the drawer hasn't been initialized.
+     */
+    protected void disableDrawerSwipe() {
+        if (mDrawerLayout != null) {
+            mDrawerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_LOCKED_CLOSED);
+        }
+    }
+    
+    /**
+     * This function allows swipes to open the navigation drawer. This
+     * function in a noop if the drawer hasn't been initialized.
+     */    
+    protected void enableDrawerSwipe() {
+        if (mDrawerLayout != null) {
+            mDrawerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_UNLOCKED);
+        }
     }    
 }

--- a/src/com/ichi2/anki/reviewer/WhiteboardListener.java
+++ b/src/com/ichi2/anki/reviewer/WhiteboardListener.java
@@ -1,0 +1,8 @@
+package com.ichi2.anki.reviewer;
+
+import java.util.EventListener;
+
+public interface WhiteboardListener extends EventListener {
+    abstract void onShowWhiteboard();
+    abstract void onHideWhiteboard();
+}


### PR DESCRIPTION
Users where having to put up with repeated unintentional navigation drawer openings due to swiping, such as when review gestures are enabled, and when the whiteboard is enabled. This change disables swipe open of the navigation drawer in the reviewer for all users, assuming that any user who tries to swipe open the navdrawer without success will resort to pressing the navdrawer indicator. Swipe close of the opened drawer continues to be enabled.
