### PR TITLE
Fixes to PR#458 on refactoring asynchronous loading of collection into Loader

### DIFF
--- a/res/layout-v14/styled_dialog.xml
+++ b/res/layout-v14/styled_dialog.xml
@@ -233,21 +233,21 @@
                 android:singleLine="true" />
 
             <Button
-                android:id="@+id/positive_button"
-                style="?android:attr/buttonBarButtonStyle"
-                android:layout_width="0dip"
-                android:layout_height="fill_parent"
-                android:layout_gravity="left"
-                android:layout_weight="1"
-                android:ellipsize="none"
-                android:singleLine="true" />
-
-            <Button
                 android:id="@+id/neutral_button"
                 style="?android:attr/buttonBarButtonStyle"
                 android:layout_width="0dip"
                 android:layout_height="fill_parent"
                 android:layout_gravity="center_horizontal"
+                android:layout_weight="1"
+                android:ellipsize="none"
+                android:singleLine="true" />
+
+            <Button
+                android:id="@+id/positive_button"
+                style="?android:attr/buttonBarButtonStyle"
+                android:layout_width="0dip"
+                android:layout_height="fill_parent"
+                android:layout_gravity="left"
                 android:layout_weight="1"
                 android:ellipsize="none"
                 android:singleLine="true" />

--- a/res/values/02-strings.xml
+++ b/res/values/02-strings.xml
@@ -146,6 +146,7 @@
     <string name="info_rate">Rate AnkiDroid</string>
     <string name="col_load_failed">Collection loading failed.\nPress back to close AnkiDroid.</string>
     <string name="import_title">Import cards</string>
+    <string name="import_select_title">Choose a file to import</string>
     <string name="import_message">Add content of file %s to your collection or replace your collection with it?</string>
     <string name="import_message_add">Add</string>
     <string name="import_message_replace">Replace</string>

--- a/src/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/src/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -912,7 +912,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
         // The hardware buttons should control the music volume while reviewing.
         setVolumeControlStream(AudioManager.STREAM_MUSIC);
         // Load the collection
-        loadCollection();
+        startLoadingCollection();
     }
 
 
@@ -974,7 +974,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
 
         deselectAllNavigationItems();
         supportInvalidateOptionsMenu();
-        dismissCollectionLoadingDialog();
+        dismissOpeningCollectionDialog();
     }
 
     @Override

--- a/src/com/ichi2/anki/CardBrowser.java
+++ b/src/com/ichi2/anki/CardBrowser.java
@@ -241,7 +241,7 @@ public class CardBrowser extends NavigationDrawerActivity implements ActionBar.O
         initNavigationDrawer(mainView);
         selectNavigationItem(DRAWER_BROWSER);
         
-        loadCollection();
+        startLoadingCollection();
     }
 
 
@@ -402,7 +402,7 @@ public class CardBrowser extends NavigationDrawerActivity implements ActionBar.O
                 }
             }
         }
-        dismissCollectionLoadingDialog();
+        dismissOpeningCollectionDialog();
     }
 
 

--- a/src/com/ichi2/anki/CardEditor.java
+++ b/src/com/ichi2/anki/CardEditor.java
@@ -306,7 +306,7 @@ public class CardEditor extends AnkiActivity {
             }
         }
 
-        loadCollection();
+        startLoadingCollection();
     }
 
 
@@ -512,7 +512,7 @@ public class CardEditor extends AnkiActivity {
             }
 
         });
-        dismissCollectionLoadingDialog();
+        dismissOpeningCollectionDialog();
     }
 
 

--- a/src/com/ichi2/anki/DeckPicker.java
+++ b/src/com/ichi2/anki/DeckPicker.java
@@ -21,8 +21,6 @@
 package com.ichi2.anki;
 
 import android.app.Activity;
-import android.app.AlertDialog;
-import android.app.Dialog;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -32,11 +30,13 @@ import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
 import android.content.res.Resources;
-import android.content.res.Resources.NotFoundException;
 import android.database.SQLException;
 import android.graphics.PixelFormat;
 import android.graphics.Rect;
 import android.os.Bundle;
+import android.os.Handler;
+import android.os.Message;
+import android.support.v4.app.DialogFragment;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentTransaction;
 import android.text.TextUtils;
@@ -51,6 +51,7 @@ import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewTreeObserver.OnGlobalLayoutListener;
 import android.view.Window;
+import android.widget.AbsListView;
 import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemLongClickListener;
 import android.widget.EditText;
@@ -59,6 +60,14 @@ import android.widget.SimpleAdapter;
 import android.widget.TextView;
 
 import com.ichi2.anim.ActivityTransitionAnimation;
+import com.ichi2.anki.dialogs.DatabaseErrorDialog;
+import com.ichi2.anki.dialogs.DeckPickerBackupNoSpaceLeftDialog;
+import com.ichi2.anki.dialogs.DeckPickerContextMenu;
+import com.ichi2.anki.dialogs.DeckPickerConfirmDeleteDeckDialog;
+import com.ichi2.anki.dialogs.DeckPickerNoSpaceLeftDialog;
+import com.ichi2.anki.dialogs.ImportDialog;
+import com.ichi2.anki.dialogs.DeckPickerDatabaseCheckResultDialog;
+import com.ichi2.anki.dialogs.SyncErrorDialog;
 import com.ichi2.anki.receiver.SdCardReceiver;
 import com.ichi2.anki.stats.AnkiStatsTaskHandler;
 import com.ichi2.async.Connection;
@@ -80,68 +89,19 @@ import org.json.JSONObject;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Locale;
 import java.util.TreeSet;
 
-public class DeckPicker extends NavigationDrawerActivity
-    implements StudyOptionsFragment.OnStudyOptionsReloadListener  {
+public class DeckPicker extends NavigationDrawerActivity implements StudyOptionsFragment.OnStudyOptionsReloadListener,
+        DatabaseErrorDialog.DatabaseErrorDialogListener, SyncErrorDialog.SyncErrorDialogListener,
+        ImportDialog.ImportDialogListener {
 
     public static final int CRAM_DECK_FRAGMENT = -1;
 
-    /**
-     * Dialogs
-     */
-    private static final int DIALOG_NO_SDCARD = 0;
-    private static final int DIALOG_USER_NOT_LOGGED_IN_SYNC = 1;
-    private static final int DIALOG_NO_CONNECTION = 3;
-    private static final int DIALOG_DELETE_DECK = 4;
-    private static final int DIALOG_CONTEXT_MENU = 9;
-    private static final int DIALOG_REPAIR_COLLECTION = 10;
-    private static final int DIALOG_NO_SPACE_LEFT = 11;
-    private static final int DIALOG_SYNC_CONFLICT_RESOLUTION = 12;
-    private static final int DIALOG_CONNECTION_ERROR = 13;
-    private static final int DIALOG_SYNC_LOG = 15;
-    private static final int DIALOG_BACKUP_NO_SPACE_LEFT = 17;
-    private static final int DIALOG_OK = 18;
-    private static final int DIALOG_DB_ERROR = 19;
-    private static final int DIALOG_ERROR_HANDLING = 20;
-    private static final int DIALOG_LOAD_FAILED = 21;
-    private static final int DIALOG_RESTORE_BACKUP = 22;
-    private static final int DIALOG_SD_CARD_NOT_MOUNTED = 23;
-    private static final int DIALOG_NEW_COLLECTION = 24;
-    private static final int DIALOG_FULL_SYNC_FROM_SERVER = 25;
-    private static final int DIALOG_SYNC_SANITY_ERROR = 26;
-    private static final int DIALOG_SYNC_UPGRADE_REQUIRED = 27;
-    private static final int DIALOG_IMPORT = 28;
-    private static final int DIALOG_IMPORT_LOG = 29;
-    private static final int DIALOG_IMPORT_HINT = 30;
-    private static final int DIALOG_IMPORT_SELECT = 31;
-    private static final int DIALOG_CONFIRM_DATABASE_CHECK = 32;
-    private static final int DIALOG_CONFIRM_RESTORE_BACKUP = 33;
     public static final String UPGRADE_OLD_COLLECTION_RENAME = "oldcollection.apkg";
     public static final String IMPORT_REPLACE_COLLECTION_NAME = "collection.apkg";
 
-    private static final int IMPORT_METHOD_ASK = 0;
-    private static final int IMPORT_METHOD_ADD = 1;
-    private static final int IMPORT_METHOD_REPLACE = 2;
-
-    private String mSyncMessage;
-    private String mDialogMessage;
-    private int[] mRepairValues;
-    private boolean mLoadFailed;
-
     private String mImportPath;
-    private String[] mImportValues;
-    private int mImportMethod = IMPORT_METHOD_ASK;
-
-    /**
-     * Context Menus
-     */
-    private static final int CONTEXT_MENU_COLLAPSE_DECK = 0;
-    private static final int CONTEXT_MENU_RENAME_DECK = 1;
-    private static final int CONTEXT_MENU_DECK_OPTIONS = 2;
-    private static final int CONTEXT_MENU_DELETE_DECK = 3;
 
     public static final String EXTRA_START = "start";
     public static final String EXTRA_DECK_ID = "deckId";
@@ -153,6 +113,11 @@ public class DeckPicker extends NavigationDrawerActivity
     public static final int RESULT_MEDIA_EJECTED = 202;
     public static final int RESULT_DB_ERROR = 203;
     public static final int RESULT_RESTART = 204;
+
+    /**
+     * Handler messages
+     */
+    private static final int MSG_SHOW_COLLECTION_LOADING_ERROR_DIALOG = 0;
 
     /**
      * Available options performed by other activities
@@ -177,23 +142,19 @@ public class DeckPicker extends NavigationDrawerActivity
     private static final int REQUEST_REVIEW = 19;
 
     private StyledProgressDialog mProgressDialog;
-    private StyledOpenCollectionDialog mOpenCollectionDialog;
     private StyledOpenCollectionDialog mNotMountedDialog;
 
-    private File[] mBackups;
+    private int mSyncMediaUsn = 0;
 
     private SimpleAdapter mDeckListAdapter;
     private ArrayList<HashMap<String, String>> mDeckList;
     private ListView mDeckListView;
 
-    private boolean mDontSaveOnStop = false;
-
     private BroadcastReceiver mUnmountReceiver = null;
 
     private String mPrefDeckPath = null;
     private long mLastTimeOpened;
-    private long mCurrentDid;
-    private int mSyncMediaUsn = 0;
+    private long mContextMenuDid;
 
     private EditText mDialogEditText;
 
@@ -201,11 +162,6 @@ public class DeckPicker extends NavigationDrawerActivity
 
     boolean mCompletionBarRestrictToActive = false; // set this to true in order to calculate completion bar only for
                                                     // active cards
-
-    private int[] mDictValues;
-
-    private int mContextMenuPosition;
-    
 
     /** Swipe Detection */
     private GestureDetector gestureDetector;
@@ -223,294 +179,9 @@ public class DeckPicker extends NavigationDrawerActivity
         }
     };
 
-    private DialogInterface.OnClickListener mContextMenuListener = new DialogInterface.OnClickListener() {
-        @Override
-        public void onClick(DialogInterface dialog, int item) {
-            Resources res = getResources();
-
-            @SuppressWarnings("unchecked")
-            HashMap<String, String> data = (HashMap<String, String>) mDeckListAdapter.getItem(mContextMenuPosition);
-            switch (item) {
-                case CONTEXT_MENU_COLLAPSE_DECK:
-                    try {
-                        JSONObject deck = getCol().getDecks().get(mCurrentDid);
-                        if (getCol().getDecks().children(mCurrentDid).size() > 0) {
-                            deck.put("collapsed", !deck.getBoolean("collapsed"));
-                            getCol().getDecks().save(deck);
-                            loadCounts();
-                        }
-                    } catch (JSONException e1) {
-                        // do nothing
-                    }
-                    return;
-                case CONTEXT_MENU_DELETE_DECK:
-                    showDialog(DIALOG_DELETE_DECK);
-                    return;
-                
-                case CONTEXT_MENU_DECK_OPTIONS:
-                    // set currently selected deck as clicked item
-                    mCurrentDid = Long.parseLong(mDeckList.get(mContextMenuPosition).get("did"));
-                    getCol().getDecks().select(mCurrentDid);
-                    if (mFragmented) {
-                        loadStudyOptionsFragment(mCurrentDid, null);
-                    }
-                    // open deck options
-                    if (getCol().getDecks().isDyn(mCurrentDid)){
-                        // open cram options if filtered deck
-                        Intent i = new Intent(DeckPicker.this, CramDeckOptions.class);
-                        i.putExtra("cramInitialConfig", (String) null);
-                        startActivityWithAnimation(i, ActivityTransitionAnimation.FADE);
-                    } else {
-                        // otherwise open regular options
-                        Intent i = new Intent(DeckPicker.this, DeckOptions.class);
-                        startActivityWithAnimation(i, ActivityTransitionAnimation.FADE);
-                    }
-                    return;
-                    
-                case CONTEXT_MENU_RENAME_DECK:
-                    StyledDialog.Builder builder2 = new StyledDialog.Builder(DeckPicker.this);
-                    builder2.setTitle(res.getString(R.string.contextmenu_deckpicker_rename_deck));
-
-                    mDialogEditText = new EditText(DeckPicker.this);
-                    mDialogEditText.setSingleLine();
-                    mDialogEditText.setText(getCol().getDecks().name(mCurrentDid));
-                    // mDialogEditText.setFilters(new InputFilter[] { mDeckNameFilter });
-                    builder2.setView(mDialogEditText, false, false);
-                    builder2.setPositiveButton(res.getString(R.string.rename), new DialogInterface.OnClickListener() {
-
-                        @Override
-                        public void onClick(DialogInterface dialog, int which) {
-                            String newName = mDialogEditText.getText().toString().replaceAll("['\"]", "");
-                            Collection col = getCol();
-                            if (col != null) {
-                                if (col.getDecks().rename(col.getDecks().get(mCurrentDid), newName)) {
-                                    for (HashMap<String, String> d : mDeckList) {
-                                        if (d.get("did").equals(Long.toString(mCurrentDid))) {
-                                            d.put("name", newName);
-                                        }
-                                    }
-                                    mDeckListAdapter.notifyDataSetChanged();
-                                    loadCounts();
-                                } else {
-                                    try {
-                                        Themes.showThemedToast(
-                                                DeckPicker.this,
-                                                getResources().getString(R.string.rename_error,
-                                                        col.getDecks().get(mCurrentDid).get("name")), false);
-                                    } catch (JSONException e) {
-                                        throw new RuntimeException(e);
-                                    }
-                                }
-                            }
-                        }
-                    });
-                    builder2.setNegativeButton(res.getString(R.string.dialog_cancel), null);
-                    builder2.create().show();
-                    return;
-
-            }
-        }
-    };
-
-    private Connection.TaskListener mSyncListener = new Connection.TaskListener() {
-
-        String currentMessage;
-        long countUp;
-        long countDown;
-
-
-        @Override
-        public void onDisconnected() {
-            showDialog(DIALOG_NO_CONNECTION);
-        }
-
-
-        @Override
-        public void onPreExecute() {
-            mDialogMessage = "";
-            mSyncMessage = "";
-            mDontSaveOnStop = true;
-            countUp = 0;
-            countDown = 0;
-            if (mProgressDialog == null || !mProgressDialog.isShowing()) {
-                mProgressDialog = StyledProgressDialog
-                        .show(DeckPicker.this, getResources().getString(R.string.sync_title),
-                                getResources().getString(R.string.sync_prepare_syncing) + "\n"
-                                        + getResources().getString(R.string.sync_up_down_size, countUp, countDown),
-                                true, false);
-            }
-        }
-
-
-        @Override
-        public void onProgressUpdate(Object... values) {
-            Resources res = getResources();
-            if (values[0] instanceof Boolean) {
-                // This is the part Download missing media of syncing
-                int total = (Integer) values[1];
-                int done = (Integer) values[2];
-                values[0] = ((String) values[3]);
-                values[1] = res.getString(R.string.sync_downloading_media, done, total);
-            } else if (values[0] instanceof Integer) {
-                int id = (Integer) values[0];
-                if (id != 0) {
-                    currentMessage = res.getString(id);
-                }
-                if (values.length >= 3) {
-                    countUp = (Long) values[1];
-                    countDown = (Long) values[2];
-                }
-            }
-            if (mProgressDialog != null && mProgressDialog.isShowing()) {
-                // mProgressDialog.setTitle((String) values[0]);
-                mProgressDialog.setMessage(currentMessage + "\n"
-                        + res.getString(R.string.sync_up_down_size, countUp / 1024, countDown / 1024));
-            }
-        }
-
-
-        @Override
-        public void onPostExecute(Payload data) {
-            Log.i(AnkiDroidApp.TAG, "onPostExecute");
-            Resources res = DeckPicker.this.getResources();
-            mDontSaveOnStop = false;
-            if (mProgressDialog != null) {
-                mProgressDialog.dismiss();
-            }
-            mSyncMessage = data.message;
-            if (!data.success) {
-                Object[] result = (Object[]) data.result;
-                if (result[0] instanceof String) {
-                    String resultType = (String) result[0];
-                    if (resultType.equals("badAuth")) {
-                        // delete old auth information
-                        SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(getBaseContext());
-                        Editor editor = preferences.edit();
-                        editor.putString("username", "");
-                        editor.putString("hkey", "");
-                        editor.commit();
-                        // then show
-                        showDialog(DIALOG_USER_NOT_LOGGED_IN_SYNC);
-                    } else if (resultType.equals("noChanges")) {
-                        mDialogMessage = res.getString(R.string.sync_no_changes_message);
-                        showDialog(DIALOG_SYNC_LOG);
-                    } else if (resultType.equals("clockOff")) {
-                        long diff = (Long) result[1];
-                        if (diff >= 86100) {
-                            // The difference if more than a day minus 5 minutes acceptable by ankiweb error
-                            mDialogMessage = res.getString(R.string.sync_log_clocks_unsynchronized, diff,
-                                    res.getString(R.string.sync_log_clocks_unsynchronized_date));
-                        } else if (Math.abs((diff % 3600.0) - 1800.0) >= 1500.0) {
-                            // The difference would be within limit if we adjusted the time by few hours
-                            // It doesn't work for all timezones, but it covers most and it's a guess anyway
-                            mDialogMessage = res.getString(R.string.sync_log_clocks_unsynchronized, diff,
-                                    res.getString(R.string.sync_log_clocks_unsynchronized_tz));
-                        } else {
-                            mDialogMessage = res.getString(R.string.sync_log_clocks_unsynchronized, diff, "");
-                        }
-                        showDialog(DIALOG_SYNC_LOG);
-                    } else if (resultType.equals("fullSync")) {
-                        if (data.data != null && data.data.length >= 1 && data.data[0] instanceof Integer) {
-                            mSyncMediaUsn = (Integer) data.data[0];
-                        }
-                        showDialog(DIALOG_SYNC_CONFLICT_RESOLUTION);
-                    } else if (resultType.equals("dbError")) {
-                        mDialogMessage = res.getString(R.string.sync_corrupt_database, R.string.repair_deck);
-                        showDialog(DIALOG_SYNC_LOG);
-                    } else if (resultType.equals("overwriteError")) {
-                        mDialogMessage = res.getString(R.string.sync_overwrite_error);
-                        showDialog(DIALOG_SYNC_LOG);
-                    } else if (resultType.equals("remoteDbError")) {
-                        mDialogMessage = res.getString(R.string.sync_remote_db_error);
-                        showDialog(DIALOG_SYNC_LOG);
-                    } else if (resultType.equals("sdAccessError")) {
-                        mDialogMessage = res.getString(R.string.sync_write_access_error);
-                        showDialog(DIALOG_SYNC_LOG);
-                    } else if (resultType.equals("finishError")) {
-                        mDialogMessage = res.getString(R.string.sync_log_finish_error);
-                        showDialog(DIALOG_SYNC_LOG);
-                    } else if (resultType.equals("IOException")) {
-                        handleDbError();
-                    } else if (resultType.equals("genericError")) {
-                        mDialogMessage = res.getString(R.string.sync_generic_error);
-                        showDialog(DIALOG_SYNC_LOG);
-                    } else if (resultType.equals("OutOfMemoryError")) {
-                        mDialogMessage = res.getString(R.string.error_insufficient_memory);
-                        showDialog(DIALOG_SYNC_LOG);
-                    } else if (resultType.equals("upgradeRequired")) {
-                        showDialog(DIALOG_SYNC_UPGRADE_REQUIRED);
-                    } else if (resultType.equals("sanityCheckError")) {
-                        Collection col = getCol();
-                        col.modSchema();
-                        col.save();
-                        mDialogMessage = res.getString(R.string.sync_sanity_failed);
-                        showDialog(DIALOG_SYNC_SANITY_ERROR);
-                    } else if (resultType.equals("serverAbort")) {
-                        // syncMsg has already been set above, no need to fetch it here.
-                        showDialog(DIALOG_SYNC_LOG);
-                    } else {
-                        if (result.length > 1 && result[1] instanceof Integer) {
-                            int type = (Integer) result[1];
-                            switch (type) {
-                                case 503:
-                                    mDialogMessage = res.getString(R.string.sync_too_busy);
-                                    break;
-                                default:
-                                    mDialogMessage = res.getString(R.string.sync_log_error_specific,
-                                            Integer.toString(type), (String) result[2]);
-                                    break;
-                            }
-                        } else if (result[0] instanceof String) {
-                            mDialogMessage = res.getString(R.string.sync_log_error_specific, -1, (String) result[0]);
-                        } else {
-                            mDialogMessage = res.getString(R.string.sync_generic_error);
-                        }
-                        showDialog(DIALOG_SYNC_LOG);
-                    }
-                }
-            } else {
-                updateDecksList((TreeSet<Object[]>) data.result, (Integer) data.data[2], (Integer) data.data[3]);
-                if (data.data[4] != null) {
-                    mDialogMessage = (String) data.data[4];
-                } else if (data.data.length > 0 && data.data[0] instanceof String
-                        && ((String) data.data[0]).length() > 0) {
-                    String dataString = (String) data.data[0];
-                    if (dataString.equals("upload")) {
-                        mDialogMessage = res.getString(R.string.sync_log_uploading_message);
-                    } else if (dataString.equals("download")) {
-                        mDialogMessage = res.getString(R.string.sync_log_downloading_message);
-                        // set downloaded collection as current one
-                    } else {
-                        mDialogMessage = res.getString(R.string.sync_database_acknowledge);
-                    }
-                } else {
-                    mDialogMessage = res.getString(R.string.sync_database_acknowledge);
-                }
-
-                showDialog(DIALOG_SYNC_LOG);
-
-                // close opening dialog in case it's open
-                if (mOpenCollectionDialog != null && mOpenCollectionDialog.isShowing()) {
-                    mOpenCollectionDialog.dismiss();
-                }
-
-                if (mFragmented) {
-                    try {
-                        // Pick the correct deck after sync. Updates the values in the fragment if same deck.
-                        long did = getCol().getDecks().current().getLong("id");
-                        selectDeck(did);
-                    } catch (JSONException e) {
-                        throw new RuntimeException();
-                    }
-                }
-                loadCounts();
-            }
-        }
-    };
-
-
     DeckTask.TaskListener mLoadCountsHandler = new DeckTask.TaskListener() {
 
+        @SuppressWarnings("unchecked")
         @Override
         public void onPostExecute(DeckTask.TaskData result) {
             if (result == null) {
@@ -518,7 +189,7 @@ public class DeckPicker extends NavigationDrawerActivity
             }
             Object[] res = result.getObjArray();
             updateDecksList((TreeSet<Object[]>) res[0], (Integer) res[1], (Integer) res[2]);
-            dismissCollectionLoadingDialog();
+            dismissOpeningCollectionDialog();
             try {
                 // Ensure we have the correct deck selected in the deck list after we have updated it. Check first
                 // if the collection is open since it might have been closed before this task completes.
@@ -543,123 +214,14 @@ public class DeckPicker extends NavigationDrawerActivity
 
         @Override
         public void onCancelled() {
-            // TODO Auto-generated method stub
-            
         }
-    };
-
-    DeckTask.TaskListener mCloseCollectionHandler = new DeckTask.TaskListener() {
-
-        @Override
-        public void onPostExecute(DeckTask.TaskData result) {
-        }
-
-
-        @Override
-        public void onPreExecute() {
-        }
-
-
-        @Override
-        public void onProgressUpdate(DeckTask.TaskData... values) {
-        }
-
-
-        @Override
-        public void onCancelled() {
-            // TODO Auto-generated method stub
-            
-        }
-    };
-
-
-    DeckTask.TaskListener mRepairDeckHandler = new DeckTask.TaskListener() {
-
-        @Override
-        public void onPreExecute() {
-            mProgressDialog = StyledProgressDialog.show(DeckPicker.this, "",
-                    getResources().getString(R.string.backup_repair_deck_progress), true);
-        }
-
-
-        @Override
-        public void onPostExecute(DeckTask.TaskData result) {
-            if (mProgressDialog != null && mProgressDialog.isShowing()) {
-                mProgressDialog.dismiss();
-            }
-            if (result.getBoolean()) {
-                loadCollection();
-            } else {
-                Themes.showThemedToast(DeckPicker.this, getResources().getString(R.string.deck_repair_error), true);
-                showDialog(DIALOG_ERROR_HANDLING);
-            }
-        }
-
-
-        @Override
-        public void onProgressUpdate(TaskData... values) {
-        }
-
-
-        @Override
-        public void onCancelled() {
-            // TODO Auto-generated method stub
-            
-        }
-
-    };
-
-    DeckTask.TaskListener mRestoreDeckHandler = new DeckTask.TaskListener() {
-
-        @Override
-        public void onPreExecute() {
-            mProgressDialog = StyledProgressDialog.show(DeckPicker.this, "",
-                    getResources().getString(R.string.backup_restore_deck), true);
-        }
-
-
-        @Override
-        public void onPostExecute(DeckTask.TaskData result) {
-            switch (result.getInt()) {
-                case BackupManager.RETURN_DECK_RESTORED:
-                    loadCollection();
-                    // Force full sync on next upload
-                    Collection col = getCol();
-                    if (col != null) {
-                        col.modSchema(false);
-                    }
-                    break;
-                case BackupManager.RETURN_ERROR:
-                    Themes.showThemedToast(DeckPicker.this, getResources().getString(R.string.backup_restore_error),
-                            true);
-                    showDialog(DIALOG_ERROR_HANDLING);
-                    break;
-                case BackupManager.RETURN_NOT_ENOUGH_SPACE:
-                    showDialog(DIALOG_NO_SPACE_LEFT);
-                    break;
-            }
-            if (mProgressDialog != null && mProgressDialog.isShowing()) {
-                mProgressDialog.dismiss();
-            }
-        }
-
-
-        @Override
-        public void onProgressUpdate(TaskData... values) {
-        }
-
-
-        @Override
-        public void onCancelled() {
-            // TODO Auto-generated method stub
-            
-        }
-
     };
 
     DeckTask.TaskListener mImportAddListener = new DeckTask.TaskListener() {
+        @SuppressWarnings("unchecked")
         @Override
         public void onPostExecute(DeckTask.TaskData result) {
+            String message = "";
             if (mProgressDialog != null && mProgressDialog.isShowing()) {
                 mProgressDialog.dismiss();
             }
@@ -668,14 +230,14 @@ public class DeckPicker extends NavigationDrawerActivity
                 int count = result.getInt();
                 if (count < 0) {
                     if (count == -2) {
-                        mDialogMessage = res.getString(R.string.import_log_no_apkg);
+                        message = res.getString(R.string.import_log_no_apkg);
                     } else {
-                        mDialogMessage = res.getString(R.string.import_log_error);
+                        message = res.getString(R.string.import_log_error);
                     }
-                    showDialog(DIALOG_IMPORT_LOG);
+                    showImportDialog(ImportDialog.DIALOG_IMPORT_LOG, message);
                 } else {
-                    mDialogMessage = res.getString(R.string.import_log_success, count);
-                    showDialog(DIALOG_IMPORT_LOG);
+                    message = res.getString(R.string.import_log_success, count);
+                    showImportDialog(ImportDialog.DIALOG_IMPORT_LOG, message);
                     Object[] info = result.getObjArray();
                     updateDecksList((TreeSet<Object[]>) info[0], (Integer) info[1], (Integer) info[2]);
                 }
@@ -703,31 +265,28 @@ public class DeckPicker extends NavigationDrawerActivity
 
         @Override
         public void onCancelled() {
-            // TODO Auto-generated method stub
-            
         }
     };
 
     DeckTask.TaskListener mImportReplaceListener = new DeckTask.TaskListener() {
+        @SuppressWarnings("unchecked")
         @Override
         public void onPostExecute(DeckTask.TaskData result) {
             if (mProgressDialog != null && mProgressDialog.isShowing()) {
                 mProgressDialog.dismiss();
             }
+            Resources res = getResources();
             if (result.getBoolean()) {
-                Resources res = getResources();
                 int code = result.getInt();
                 if (code == -2) {
-                    mDialogMessage = res.getString(R.string.import_log_no_apkg);
+                    // not a valid apkg file
+                    showImportDialog(ImportDialog.DIALOG_IMPORT_LOG, res.getString(R.string.import_log_no_apkg));
                 }
                 Object[] info = result.getObjArray();
                 updateDecksList((TreeSet<Object[]>) info[0], (Integer) info[1], (Integer) info[2]);
-                if (mOpenCollectionDialog != null && mOpenCollectionDialog.isShowing()) {
-                    mOpenCollectionDialog.dismiss();
-                }
+                dismissOpeningCollectionDialog();
             } else {
-                mDialogMessage = getResources().getString(R.string.import_log_no_apkg);
-                showDialog(DIALOG_IMPORT_LOG);
+                showImportDialog(ImportDialog.DIALOG_IMPORT_LOG, res.getString(R.string.import_log_no_apkg));
             }
         }
 
@@ -750,72 +309,12 @@ public class DeckPicker extends NavigationDrawerActivity
 
         @Override
         public void onCancelled() {
-            // TODO Auto-generated method stub
-            
-        }
-    };
-
-    DeckTask.TaskListener mUpgradeExportListener = new DeckTask.TaskListener() {
-        @Override
-        public void onPreExecute() {
-            if (mProgressDialog == null || !mProgressDialog.isShowing()) {
-                mProgressDialog = StyledProgressDialog.show(DeckPicker.this, getString(R.string.export_progress_title),
-                        getString(R.string.export_progress_exporting), true, false);
-            }
-        }
-
-
-        @Override
-        public void onPostExecute(DeckTask.TaskData result) {
-            if (mProgressDialog != null && mProgressDialog.isShowing()) {
-                mProgressDialog.dismiss();
-            }
-            StyledDialog.Builder builder = new StyledDialog.Builder(DeckPicker.this);
-            StyledDialog dialog;
-            if (result.getBoolean()) {
-                builder.setIcon(R.drawable.ic_dialog_info);
-                builder.setTitle(getString(R.string.export_progress_title));
-                builder.setMessage(getString(R.string.upgrade_deck_export_successful));
-            } else {
-                builder.setIcon(R.drawable.ic_dialog_alert);
-                builder.setTitle(R.string.export_progress_title);
-                builder.setMessage(getString(R.string.upgrade_deck_export_error));
-                builder.setNegativeButton(R.string.dialog_cancel, new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int which) {
-                        AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance().getBaseContext()).edit()
-                                .putInt("lastUpgradeVersion", AnkiDroidApp.getPkgVersionCode()).commit();
-                    }
-                });
-            }
-            builder.setPositiveButton(R.string.dialog_continue, new DialogInterface.OnClickListener() {
-                @Override
-                public void onClick(DialogInterface dialog, int which) {
-                    showUpgradeScreen(true, Info.UPGRADE_SCREEN_BASIC1);
-                    AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance().getBaseContext()).edit()
-                            .putInt("lastUpgradeVersion", AnkiDroidApp.getPkgVersionCode()).commit();
-                }
-            });
-            dialog = builder.create();
-            dialog.show();
-        }
-
-
-        @Override
-        public void onProgressUpdate(TaskData... values) {
-        }
-
-
-        @Override
-        public void onCancelled() {
-            // TODO Auto-generated method stub
-            
         }
     };
 
 
     // ----------------------------------------------------------------------------
-    // ANDROID METHODS
+    // ANDROID ACTIVITY METHODS
     // ----------------------------------------------------------------------------
 
     /** Called when the activity is first created. */
@@ -825,7 +324,8 @@ public class DeckPicker extends NavigationDrawerActivity
         Intent intent = getIntent();
         // What purpose does this serve?
         if (!intent.getBooleanExtra("viaNavigationDrawer", false) && !isTaskRoot()) {
-            Log.i(AnkiDroidApp.TAG, "DeckPicker - onCreate: Detected multiple instance of this activity, closing it and return to root activity");
+            Log.i(AnkiDroidApp.TAG,
+                    "DeckPicker - onCreate: Detected multiple instance of this activity, closing it and return to root activity");
             Intent reloadIntent = new Intent(DeckPicker.this, DeckPicker.class);
             reloadIntent.setAction(Intent.ACTION_MAIN);
             if (intent != null && intent.getExtras() != null) {
@@ -836,18 +336,23 @@ public class DeckPicker extends NavigationDrawerActivity
             }
             reloadIntent.addCategory(Intent.CATEGORY_LAUNCHER);
             reloadIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-            finish();
+            finishWithoutAnimation();
             startActivityIfNeeded(reloadIntent, 0);
         }
         if (intent.getData() != null) {
             mImportPath = getIntent().getData().getEncodedPath();
         }
 
+        // need to start this here in order to avoid showing deckpicker before splashscreen
+        if (!AnkiDroidApp.colIsOpen()) {
+            showOpeningCollectionDialog();
+        }
+
         Themes.applyTheme(this);
         super.onCreate(savedInstanceState);
-        
+
         setTitle(getResources().getString(R.string.app_name));
-        
+
         // mStartedByBigWidget = intent.getIntExtra(EXTRA_START, EXTRA_START_NOTHING);
 
         SharedPreferences preferences = restorePreferences();
@@ -878,14 +383,15 @@ public class DeckPicker extends NavigationDrawerActivity
                 Themes.CALLER_DECKPICKER);
 
         registerExternalStorageListener();
-        
+
         // create inherited navigation drawer layout here so that it can be used by parent class
         initNavigationDrawer(mainView);
         if (savedInstanceState == null) {
             selectNavigationItem(DRAWER_DECK_PICKER);
         }
-        //open the drawer on startup if it's never been opened voluntarily by the user (as per Android guidelines)
-        if (!intent.getBooleanExtra("viaNavigationDrawer", false) && !preferences.getBoolean("navDrawerHasBeenOpened", false)) {
+        // open the drawer on startup if it's never been opened voluntarily by the user (as per Android guidelines)
+        if (!intent.getBooleanExtra("viaNavigationDrawer", false)
+                && !preferences.getBoolean("navDrawerHasBeenOpened", false)) {
             getDrawerLayout().openDrawer(Gravity.LEFT);
         }
 
@@ -944,23 +450,27 @@ public class DeckPicker extends NavigationDrawerActivity
         mDeckListView.setOnItemLongClickListener(new OnItemLongClickListener() {
             @Override
             public boolean onItemLongClick(AdapterView<?> adapterView, View view, int position, long id) {
-                mContextMenuPosition = position;
-                showDialog(DIALOG_CONTEXT_MENU);
+                if (!AnkiDroidApp.colIsOpen() || mDeckList == null || mDeckList.size() == 0) {
+                    return true;
+                }
+                mContextMenuDid = Long.parseLong(mDeckList.get(position).get("did"));
+                String deckName = getCol().getDecks().name(mContextMenuDid);
+                boolean isCollapsed = getCol().getDecks().get(mContextMenuDid).optBoolean("collapsed", false);
+                showDialogFragment(DeckPickerContextMenu.newInstance(deckName, isCollapsed));
                 return true;
             }
         });
         mDeckListView.setAdapter(mDeckListAdapter);
 
         if (mFragmented) {
-            mDeckListView.setChoiceMode(ListView.CHOICE_MODE_SINGLE);
+            mDeckListView.setChoiceMode(AbsListView.CHOICE_MODE_SINGLE);
         }
-        
-        
-        if (getCol() == null){
-            // Show splash screen and load collection if it's null            
+
+        if (getCol() == null) {
+            // Show splash screen and load collection if it's null
             showStartupScreensAndDialogs(preferences, 0);
         } else {
-            // Otherwise just update the deck list            
+            // Otherwise just update the deck list
             loadCounts();
         }
 
@@ -974,1260 +484,6 @@ public class DeckPicker extends NavigationDrawerActivity
             });
         }
     }
-
-
-    @Override
-    protected void onCollectionLoaded(Collection col) {
-        // keep reference to collection in parent
-        super.onCollectionLoaded(col);
-        // select last loaded deck if any
-        if (mFragmented) {
-            long did = col.getDecks().selected();
-            selectDeck(did);
-        }
-        // show import dialog if shared deck was opened
-        if (AnkiDroidApp.colIsOpen() && mImportPath != null) {
-            showDialog(DIALOG_IMPORT);
-        }
-        // prepare deck counts and mini-today-statistic
-        loadCounts();
-    }
-
-
-    @Override
-    protected void onResume() {
-        super.onResume();
-        if (getCol() != null) {
-            if (Utils.now() > getCol().getSched().getDayCutoff() && AnkiDroidApp.isSdCardMounted()) {
-                loadCounts();
-            }
-        }
-        selectNavigationItem(DRAWER_DECK_PICKER);
-    }
-
-
-    @Override
-    public void onSaveInstanceState(Bundle savedInstanceState) {
-        super.onSaveInstanceState(savedInstanceState);
-        savedInstanceState.putLong("mCurrentDid", mCurrentDid);
-        // savedInstanceState.putSerializable("mDeckList", mDeckList);
-    }
-
-
-    @Override
-    public void onRestoreInstanceState(Bundle savedInstanceState) {
-        super.onRestoreInstanceState(savedInstanceState);
-        mCurrentDid = savedInstanceState.getLong("mCurrentDid");
-        // mDeckList = (ArrayList<HashMap<String, String>>) savedInstanceState.getSerializable("mDeckList");
-    }
-
-
-
-    public void loadCounts() {
-        if (AnkiDroidApp.colIsOpen()) {
-            DeckTask.launchDeckTask(DeckTask.TASK_TYPE_LOAD_DECK_COUNTS, mLoadCountsHandler,
-                    new TaskData(getCol()));
-        }
-        TextView textView = (TextView) findViewById(R.id.today_stats_text_view);
-        textView.setVisibility(View.GONE);
-        AnkiStatsTaskHandler.createSmallTodayOverview(textView);
-    }
-
-
-    private void addNote() {
-        Preferences.COMING_FROM_ADD = true;
-        Intent intent = new Intent(DeckPicker.this, CardEditor.class);
-        intent.putExtra(CardEditor.EXTRA_CALLER, CardEditor.CALLER_DECKPICKER);
-        startActivityForResultWithAnimation(intent, ADD_NOTE, ActivityTransitionAnimation.LEFT);
-    }
-
-    private boolean hasErrorFiles() {
-        for (String file : this.fileList()) {
-            if (file.endsWith(".stacktrace")) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-
-    private void showUpgradeScreen(boolean animation, int stage) {
-        showUpgradeScreen(animation, stage, true);
-    }
-
-
-    private void showUpgradeScreen(boolean animation, int stage, boolean left) {
-        Intent upgradeIntent = new Intent(this, Info.class);
-        upgradeIntent.putExtra(Info.TYPE_EXTRA, Info.TYPE_UPGRADE_DECKS);
-        upgradeIntent.putExtra(Info.TYPE_UPGRADE_STAGE, stage);
-        startActivityForResultWithAnimation(upgradeIntent, SHOW_INFO_UPGRADE_DECKS, left ? ActivityTransitionAnimation.LEFT
-                : ActivityTransitionAnimation.RIGHT);
-    }
-
-
-    private boolean upgradeNeeded() {
-        if (!AnkiDroidApp.isSdCardMounted()) {
-            showDialog(DIALOG_SD_CARD_NOT_MOUNTED);
-            return false;
-        }
-        File dir = new File(AnkiDroidApp.getCurrentAnkiDroidDirectory());
-        if (!dir.isDirectory()) {
-            dir.mkdirs();
-        }
-        if ((new File(AnkiDroidApp.getCollectionPath())).exists()) {
-            // collection file exists
-            return false;
-        }
-        return dir.listFiles(new OldAnkiDeckFilter()).length > 0;
-    }
-
-
-    private SharedPreferences restorePreferences() {
-        SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(getBaseContext());
-        mPrefDeckPath = AnkiDroidApp.getCurrentAnkiDroidDirectory();
-        mLastTimeOpened = preferences.getLong("lastTimeOpened", 0);
-        mSwipeEnabled = AnkiDroidApp.initiateGestures(this, preferences);
-
-        // mInvertedColors = preferences.getBoolean("invertedColors", false);
-        // mSwap = preferences.getBoolean("swapqa", false);
-        // mLocale = preferences.getString(Preferences.LANGUAGE, "");
-        // setLanguage(mLocale);
-
-        return preferences;
-    }
-
-
-    private void showStartupScreensAndDialogs(SharedPreferences preferences, int skip) {
-        if (skip < 1 && preferences.getLong("lastTimeOpened", 0) == 0) {
-            Intent infoIntent = new Intent(this, Info.class);
-            infoIntent.putExtra(Info.TYPE_EXTRA, Info.TYPE_WELCOME);
-            if (skip != 0) {
-                startActivityForResultWithAnimation(infoIntent, SHOW_INFO_WELCOME, ActivityTransitionAnimation.LEFT);
-            } else {
-                startActivityForResultWithoutAnimation(infoIntent, SHOW_INFO_WELCOME);
-            }
-        } else if (skip < 2 && !preferences.getString("lastVersion", "").equals(AnkiDroidApp.getPkgVersionName())) {
-            preferences.edit().putBoolean("showBroadcastMessageToday", true).commit();
-            Intent infoIntent = new Intent(this, Info.class);
-            infoIntent.putExtra(Info.TYPE_EXTRA, Info.TYPE_NEW_VERSION);
-
-            if (skip != 0) {
-                startActivityForResultWithAnimation(infoIntent, SHOW_INFO_NEW_VERSION, ActivityTransitionAnimation.LEFT);
-            } else {
-                startActivityForResultWithoutAnimation(infoIntent, SHOW_INFO_NEW_VERSION);
-            }
-        } else if (skip < 3 && upgradeNeeded()) {
-            // Note that the "upgrade needed" refers to upgrading Anki 1.x decks, not to newer
-            // versions of AnkiDroid.
-            AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance().getBaseContext()).edit()
-                    .putInt("lastUpgradeVersion", AnkiDroidApp.getPkgVersionCode()).commit();
-            showUpgradeScreen(skip != 0, Info.UPGRADE_SCREEN_BASIC1);
-        } else if (skip < 4 && hasErrorFiles()) {
-            Intent i = new Intent(this, Feedback.class);
-            if (skip != 0) {
-                startActivityForResultWithAnimation(i, REPORT_ERROR, ActivityTransitionAnimation.LEFT);
-            } else {
-                startActivityForResultWithoutAnimation(i, REPORT_ERROR);
-            }
-        } else if (!AnkiDroidApp.isSdCardMounted()) {
-            showDialog(DIALOG_SD_CARD_NOT_MOUNTED);
-        } else if (!BackupManager.enoughDiscSpace(mPrefDeckPath)) {// && !preferences.getBoolean("dontShowLowMemory",
-                                                                   // false)) {
-            showDialog(DIALOG_NO_SPACE_LEFT);
-        } else if (preferences.getBoolean("noSpaceLeft", false)) {
-            showDialog(DIALOG_BACKUP_NO_SPACE_LEFT);
-            preferences.edit().putBoolean("noSpaceLeft", false).commit();
-        } else if (mImportPath != null && AnkiDroidApp.colIsOpen()) {
-            showDialog(DIALOG_IMPORT);
-        } else {
-            loadCollection();
-        }
-    }
-
-
-    /**
-     * @return true if the device is a Nook
-     */
-    private boolean isNookDevice() {
-        for (String s : new String[] { "nook" }) {
-            if (android.os.Build.DEVICE.toLowerCase(Locale.US).contains(s)
-                    || android.os.Build.MODEL.toLowerCase(Locale.US).contains(s)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-
-    private void upgradePreferences(int previousVersionCode) {
-        SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(getBaseContext());
-        // when upgrading from before 2.1alpha08
-        if (previousVersionCode < 20100108) {
-            preferences.edit().putString("overrideFont", preferences.getString("defaultFont", "")).commit();
-            preferences.edit().putString("defaultFont", "").commit();
-        }
-        // when upgrading from before 2.2alpha66
-        if (previousVersionCode < 20200166) {
-            // change name from swipe to gestures
-            preferences.edit().putInt("swipeSensitivity", preferences.getInt("swipeSensibility", 100)).commit();
-            preferences.edit().putBoolean("gestures", preferences.getBoolean("swipe", false)).commit();
-            // set new safeDisplayMode preference based on old behavior
-            boolean safeDisplayMode = preferences.getBoolean("eInkDisplay", false) || isNookDevice() ||
-                    !preferences.getBoolean("forceQuickUpdate", false);
-            preferences.edit().putBoolean("safeDisplay", safeDisplayMode).commit();
-            // set overrideFontBehavior based on old overrideFont settings
-            String overrideFont = preferences.getString("overrideFont", "");
-            if (!overrideFont.equals("")){
-                preferences.edit().putString("defaultFont", overrideFont ).commit();
-                preferences.edit().putString("overrideFontBehavior", "1" ).commit();
-            } else {
-                preferences.edit().putString("overrideFontBehavior", "0" ).commit();
-            }
-            // change typed answers setting from enable to disable
-            preferences.edit().putBoolean("writeAnswersDisable", !preferences.getBoolean("writeAnswers", true) ).commit();
-        }
-    }
-
-
-    protected void sendKey(int keycode) {
-        this.dispatchKeyEvent(new KeyEvent(KeyEvent.ACTION_DOWN, keycode));
-        this.dispatchKeyEvent(new KeyEvent(KeyEvent.ACTION_UP, keycode));
-    }
-
-
-    @Override
-    protected void onPause() {
-        Log.i(AnkiDroidApp.TAG, "DeckPicker - onPause");
-
-        super.onPause();
-    }
-
-
-    @Override
-    protected void onStop() {
-        Log.i(AnkiDroidApp.TAG, "DeckPicker - onStop");
-        super.onStop();
-        if (!mDontSaveOnStop) {
-            if (isFinishing()) {
-                DeckTask.launchDeckTask(DeckTask.TASK_TYPE_CLOSE_DECK, mCloseCollectionHandler, new TaskData(
-                        getCol()));
-            } else {
-                StudyOptionsFragment frag = getFragment();
-                if (!(frag != null && !frag.dbSaveNecessary())) {
-                    UIUtils.saveCollectionInBackground();
-                }
-            }
-        }
-    }
-
-
-    @Override
-    protected void onDestroy() {
-        super.onDestroy();
-        if (mUnmountReceiver != null) {
-            unregisterReceiver(mUnmountReceiver);
-        }
-        Log.i(AnkiDroidApp.TAG, "DeckPicker - onDestroy()");
-    }
-
-
-    @Override
-    protected Dialog onCreateDialog(int id) {
-        StyledDialog dialog;
-        Resources res = getResources();
-        StyledDialog.Builder builder = new StyledDialog.Builder(this);
-
-        switch (id) {
-            case DIALOG_OK:
-                builder.setPositiveButton(R.string.dialog_ok, null);
-                dialog = builder.create();
-                break;
-
-            case DIALOG_NO_SDCARD:
-                builder.setMessage(res.getString(R.string.sdcard_missing_message));
-                builder.setPositiveButton(R.string.dialog_ok, null);
-                dialog = builder.create();
-                break;
-
-            case DIALOG_CONNECTION_ERROR:
-                // From the Android style guide: ﾃ｢竄ｬﾅ溺ost alerts don't need titles.ﾃ｢竄ｬ�ｽ And "Attention" is quite unhelpful.
-                // builder.setTitle(res.getString(R.string.connection_error_title));
-                builder.setIcon(R.drawable.ic_dialog_alert);
-                builder.setMessage(res.getString(R.string.connection_error_message));
-                builder.setPositiveButton(res.getString(R.string.retry), new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int which) {
-                        sync();
-                    }
-                });
-                builder.setNegativeButton(res.getString(R.string.dialog_cancel), null);
-                dialog = builder.create();
-                break;
-
-            case DIALOG_SYNC_CONFLICT_RESOLUTION:
-                builder.setTitle(res.getString(R.string.sync_conflict_title));
-                builder.setIcon(android.R.drawable.ic_input_get);
-                builder.setMessage(res.getString(R.string.sync_conflict_message));
-                builder.setPositiveButton(res.getString(R.string.sync_conflict_local), mSyncConflictResolutionListener);
-                builder.setNeutralButton(res.getString(R.string.sync_conflict_remote), mSyncConflictResolutionListener);
-                builder.setNegativeButton(res.getString(R.string.dialog_cancel), mSyncConflictResolutionListener);
-                builder.setCancelable(true);
-                dialog = builder.create();
-                break;
-
-            case DIALOG_LOAD_FAILED:
-                builder.setMessage(res.getString(R.string.open_collection_failed_message,
-                        BackupManager.BROKEN_DECKS_SUFFIX, res.getString(R.string.repair_deck)));
-                builder.setTitle(R.string.open_collection_failed_title);
-                builder.setIcon(R.drawable.ic_dialog_alert);
-                builder.setPositiveButton(res.getString(R.string.error_handling_options),
-                        new DialogInterface.OnClickListener() {
-                            @Override
-                            public void onClick(DialogInterface dialog, int which) {
-                                showDialog(DIALOG_ERROR_HANDLING);
-                            }
-                        });
-                builder.setNegativeButton(res.getString(R.string.close), new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int which) {
-                        finishWithAnimation();
-                    }
-                });
-                builder.setOnCancelListener(new OnCancelListener() {
-                    @Override
-                    public void onCancel(DialogInterface dialog) {
-                        finishWithAnimation();
-                    }
-                });
-                dialog = builder.create();
-                break;
-
-            case DIALOG_DB_ERROR:
-                builder.setMessage(R.string.answering_error_message);
-                builder.setTitle(R.string.answering_error_title);
-                builder.setIcon(R.drawable.ic_dialog_alert);
-                builder.setPositiveButton(res.getString(R.string.error_handling_options),
-                        new DialogInterface.OnClickListener() {
-                            @Override
-                            public void onClick(DialogInterface dialog, int which) {
-                                showDialog(DIALOG_ERROR_HANDLING);
-                            }
-                        });
-                builder.setNeutralButton(res.getString(R.string.answering_error_report),
-                        new DialogInterface.OnClickListener() {
-                            @Override
-                            public void onClick(DialogInterface dialog, int which) {
-                                Intent i = new Intent(DeckPicker.this, Feedback.class);
-                                i.putExtra("request", RESULT_DB_ERROR);
-                                dialog.dismiss();
-                                startActivityForResultWithAnimation(i, REPORT_ERROR, ActivityTransitionAnimation.RIGHT);
-                            }
-                        });
-                builder.setNegativeButton(res.getString(R.string.close), new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int which) {
-                        if (!AnkiDroidApp.colIsOpen()) {
-                            finishWithAnimation();
-                        }
-                    }
-                });
-                builder.setCancelable(true);
-                dialog = builder.create();
-                break;
-
-            case DIALOG_ERROR_HANDLING:
-                builder.setTitle(res.getString(R.string.error_handling_title));
-                builder.setIcon(R.drawable.ic_dialog_alert);
-                builder.setSingleChoiceItems(new String[] { "1" }, 0, null);
-                builder.setOnCancelListener(new OnCancelListener() {
-                    @Override
-                    public void onCancel(DialogInterface dialog) {
-                        if (mLoadFailed) {
-                            // dialog has been called because collection could not be opened
-                            showDialog(DIALOG_LOAD_FAILED);
-                        } else {
-                            // dialog has been called because a db error happened
-                            showDialog(DIALOG_DB_ERROR);
-                        }
-                    }
-                });
-                builder.setNegativeButton(res.getString(R.string.dialog_cancel), new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int which) {
-                        if (mLoadFailed) {
-                            // dialog has been called because collection could not be opened
-                            showDialog(DIALOG_LOAD_FAILED);
-                        } else {
-                            // dialog has been called because a db error happened
-                            showDialog(DIALOG_DB_ERROR);
-                        }
-                    }
-                });
-                dialog = builder.create();
-                break;
-
-            case DIALOG_USER_NOT_LOGGED_IN_SYNC:
-                builder.setTitle(res.getString(R.string.not_logged_in_title));
-                builder.setIcon(R.drawable.ic_dialog_alert);
-                builder.setMessage(res.getString(R.string.login_create_account_message));
-                builder.setNegativeButton(res.getString(R.string.dialog_cancel), null);
-                builder.setPositiveButton(res.getString(R.string.log_in), new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int which) {
-                        Intent myAccount = new Intent(DeckPicker.this, MyAccount.class);
-                        myAccount.putExtra("notLoggedIn", true);
-                        startActivityForResultWithAnimation(myAccount, LOG_IN_FOR_SYNC, ActivityTransitionAnimation.FADE);
-                    }
-                });
-                dialog = builder.create();
-                break;
-
-
-            case DIALOG_NO_CONNECTION:
-                // builder.setTitle(res.getString(R.string.connection_error_title));
-                builder.setIcon(R.drawable.ic_dialog_alert);
-                builder.setMessage(res.getString(R.string.youre_offline));
-                builder.setPositiveButton(res.getString(R.string.dialog_ok), null);
-                dialog = builder.create();
-                break;
-
-            case DIALOG_DELETE_DECK:
-                if (!AnkiDroidApp.colIsOpen() || mDeckList == null) {
-                    return null;
-                }
-                // Message is set in onPrepareDialog
-                builder.setTitle(res.getString(R.string.delete_deck_title));
-                builder.setIcon(R.drawable.ic_dialog_alert);
-                builder.setPositiveButton(res.getString(R.string.dialog_positive_delete),
-                        new DialogInterface.OnClickListener() {
-                            @Override
-                            public void onClick(DialogInterface dialog, int which) {
-                                DeckTask.launchDeckTask(DeckTask.TASK_TYPE_DELETE_DECK, new DeckTask.TaskListener() {
-                                        @Override
-                                        public void onPreExecute() {
-                                            mProgressDialog = StyledProgressDialog.show(DeckPicker.this, "",
-                                                    getResources().getString(R.string.delete_deck), true);
-                                        }
-
-                                        @Override
-                                        public void onPostExecute(TaskData result) {
-                                            if (result == null) {
-                                                return;
-                                            }
-                                            Object[] res = result.getObjArray();
-                                            updateDecksList((TreeSet<Object[]>) res[0], (Integer) res[1],
-                                                    (Integer) res[2]);
-                                            if (mFragmented) {
-                                                selectDeck(getCol().getDecks().selected());
-                                            }
-                                            if (mProgressDialog.isShowing()) {
-                                                try {
-                                                    mProgressDialog.dismiss();
-                                                } catch (Exception e) {
-                                                    Log.e(AnkiDroidApp.TAG,
-                                                          "onPostExecute - Dialog dismiss Exception = " + e.getMessage());
-                                                }
-                                            }
-                                        }
-
-
-                                        @Override
-                                        public void onProgressUpdate(TaskData... values) {
-                                        }
-
-                                        @Override
-                                        public void onCancelled() {
-                                            // TODO Auto-generated method stub
-                                            
-                                        }
-                                    }, new TaskData(getCol(), mCurrentDid));
-                            }
-                        });
-                builder.setNegativeButton(res.getString(R.string.dialog_cancel), null);
-                dialog = builder.create();
-                break;
-
-            case DIALOG_CONTEXT_MENU:
-                String[] entries = new String[4];
-                entries[CONTEXT_MENU_COLLAPSE_DECK] = res.getString(R.string.contextmenu_deckpicker_collapse_deck);
-                entries[CONTEXT_MENU_RENAME_DECK] = res.getString(R.string.contextmenu_deckpicker_rename_deck);
-                entries[CONTEXT_MENU_DECK_OPTIONS] = res.getString(R.string.study_options);
-                entries[CONTEXT_MENU_DELETE_DECK] = res.getString(R.string.contextmenu_deckpicker_delete_deck);
-                builder.setTitle("Context Menu");
-                builder.setIcon(R.drawable.ic_menu_manage);
-                builder.setItems(entries, mContextMenuListener);
-                dialog = builder.create();
-                break;
-
-            case DIALOG_REPAIR_COLLECTION:
-                builder.setTitle(res.getString(R.string.backup_repair_deck));
-                builder.setMessage(res.getString(R.string.repair_deck_dialog, BackupManager.BROKEN_DECKS_SUFFIX));
-                builder.setIcon(R.drawable.ic_dialog_alert);
-                builder.setPositiveButton(res.getString(R.string.dialog_positive_repair),
-                        new DialogInterface.OnClickListener() {
-                            @Override
-                            public void onClick(DialogInterface dialog, int which) {
-                                DeckTask.launchDeckTask(DeckTask.TASK_TYPE_REPAIR_DECK, mRepairDeckHandler,
-                                        new DeckTask.TaskData(getCol(), AnkiDroidApp.getCollectionPath()));
-                            }
-                        });
-                builder.setNegativeButton(res.getString(R.string.dialog_cancel), new DialogInterface.OnClickListener() {
-                        @Override
-                        public void onClick(DialogInterface dialog, int which) {
-                            showDialog(DIALOG_ERROR_HANDLING);
-                        }
-                    });
-                builder.setOnCancelListener(new OnCancelListener() {
-
-                    @Override
-                    public void onCancel(DialogInterface arg0) {
-                        showDialog(DIALOG_ERROR_HANDLING);
-                    }
-
-                });
-                dialog = builder.create();
-                break;
-
-            case DIALOG_SYNC_SANITY_ERROR:
-                builder.setPositiveButton(getString(R.string.sync_sanity_local), mSyncSanityFailListener);
-                builder.setNeutralButton(getString(R.string.sync_sanity_remote), mSyncSanityFailListener);
-                builder.setNegativeButton(res.getString(R.string.dialog_cancel), mSyncSanityFailListener);
-                dialog = builder.create();
-                break;
-
-            case DIALOG_SYNC_UPGRADE_REQUIRED:
-                builder.setMessage(res.getString(R.string.upgrade_required, res.getString(R.string.link_anki)));
-                builder.setPositiveButton(res.getString(R.string.retry), new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int which) {
-                        sync("download", mSyncMediaUsn);
-                    }
-                });
-                builder.setNegativeButton(res.getString(R.string.dialog_cancel), new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int which) {
-                        if (mLoadFailed) {
-                            // dialog has been called because collection could not be opened
-                            showDialog(DIALOG_LOAD_FAILED);
-                        } else {
-                            // dialog has been called because a db error happened
-                            showDialog(DIALOG_DB_ERROR);
-                        }
-                    }
-                });
-                builder.setOnCancelListener(new OnCancelListener() {
-                    @Override
-                    public void onCancel(DialogInterface arg0) {
-                        if (mLoadFailed) {
-                            // dialog has been called because collection could not be opened
-                            showDialog(DIALOG_LOAD_FAILED);
-                        } else {
-                            // dialog has been called because a db error happened
-                            showDialog(DIALOG_DB_ERROR);
-                        }
-                    }
-                });
-                dialog = builder.create();
-                break;
-
-            case DIALOG_SYNC_LOG:
-                builder.setPositiveButton(res.getString(R.string.dialog_ok), null);
-                dialog = builder.create();
-                break;
-
-            case DIALOG_BACKUP_NO_SPACE_LEFT:
-                builder.setTitle(res.getString(R.string.sd_card_full_title));
-                builder.setMessage(res.getString(R.string.backup_deck_no_space_left));
-                builder.setPositiveButton(res.getString(R.string.dialog_ok), new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int which) {
-                        loadCollection();
-                    }
-                });
-                // builder.setNegativeButton(res.getString(R.string.dont_show_again), new
-                // DialogInterface.OnClickListener() {
-                // @Override
-                // public void onClick(DialogInterface arg0, int arg1) {
-                // PrefSettings.getSharedPrefs(getBaseContext()).edit().putBoolean("dontShowLowMemory", true).commit();
-                // }
-                // });
-                builder.setCancelable(true);
-                builder.setOnCancelListener(new OnCancelListener() {
-                    @Override
-                    public void onCancel(DialogInterface arg0) {
-                        loadCollection();
-                    }
-                });
-                dialog = builder.create();
-                break;
-
-            case DIALOG_SD_CARD_NOT_MOUNTED:
-                if (mNotMountedDialog == null || !mNotMountedDialog.isShowing()) {
-                    mNotMountedDialog = StyledOpenCollectionDialog.show(DeckPicker.this,
-                            getResources().getString(R.string.sd_card_not_mounted), new OnCancelListener() {
-
-                                @Override
-                                public void onCancel(DialogInterface arg0) {
-                                    finishWithAnimation();
-                                }
-                            }, new View.OnClickListener() {
-
-                                @Override
-                                public void onClick(View v) {
-                                    startActivityForResultWithoutAnimation(new Intent(DeckPicker.this, Preferences.class),
-                                            PREFERENCES_UPDATE);
-                                }
-                            });
-                }
-                dialog = null;
-                break;
-
-            case DIALOG_IMPORT:
-                builder.setTitle(res.getString(R.string.import_title));
-                builder.setMessage(res.getString(R.string.import_message, mImportPath));
-                builder.setPositiveButton(res.getString(R.string.import_message_add),
-                        new DialogInterface.OnClickListener() {
-                            @Override
-                            public void onClick(DialogInterface dialog, int which) {
-                                DeckTask.launchDeckTask(DeckTask.TASK_TYPE_IMPORT, mImportAddListener, new TaskData(
-                                        getCol(), mImportPath, false));
-                                mImportPath = null;
-                            }
-                        });
-                builder.setNeutralButton(res.getString(R.string.import_message_replace),
-                        new DialogInterface.OnClickListener() {
-                            @Override
-                            public void onClick(DialogInterface dialog, int which) {
-                                Resources res = getResources();
-                                StyledDialog.Builder builder = new StyledDialog.Builder(DeckPicker.this);
-                                builder.setTitle(res.getString(R.string.import_title));
-                                builder.setMessage(res.getString(R.string.import_message_replace_confirm, mImportPath));
-                                builder.setPositiveButton(res.getString(R.string.dialog_positive_replace),
-                                        new DialogInterface.OnClickListener() {
-
-                                            @Override
-                                            public void onClick(DialogInterface dialog, int which) {
-                                                DeckTask.launchDeckTask(DeckTask.TASK_TYPE_IMPORT_REPLACE,
-                                                        mImportReplaceListener, new TaskData(getCol(),
-                                                                mImportPath));
-                                                mImportPath = null;
-                                            }
-
-                                        });
-                                builder.setNegativeButton(res.getString(R.string.dialog_cancel), null);
-                                builder.show();
-                            }
-                        });
-                builder.setNegativeButton(res.getString(R.string.dialog_cancel), null);
-                builder.setCancelable(true);
-                dialog = builder.create();
-                break;
-
-            case DIALOG_IMPORT_SELECT:
-                builder.setTitle(res.getString(R.string.import_title));
-                dialog = builder.create();
-                break;
-
-            case DIALOG_IMPORT_HINT:
-                builder.setTitle(res.getString(R.string.import_title));
-                builder.setMessage(res.getString(R.string.import_hint, AnkiDroidApp.getCurrentAnkiDroidDirectory()));
-                builder.setPositiveButton(res.getString(R.string.dialog_ok), new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int which) {
-                        showDialog(DIALOG_IMPORT_SELECT);
-                    }
-                });
-                builder.setNegativeButton(res.getString(R.string.dialog_cancel), null);
-                dialog = builder.create();
-                break;
-
-            case DIALOG_IMPORT_LOG:
-                builder.setIcon(R.drawable.ic_dialog_alert);
-                builder.setTitle(res.getString(R.string.import_title));
-                builder.setPositiveButton(res.getString(R.string.dialog_ok), null);
-                dialog = builder.create();
-                break;
-
-            case DIALOG_NO_SPACE_LEFT:
-                builder.setTitle(res.getString(R.string.sd_card_almost_full_title));
-                builder.setMessage(res.getString(R.string.sd_space_warning, BackupManager.MIN_FREE_SPACE));
-                builder.setPositiveButton(res.getString(R.string.dialog_ok), new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int which) {
-                        finishWithAnimation();
-                    }
-                });
-                // builder.setNegativeButton(res.getString(R.string.dont_show_again), new
-                // DialogInterface.OnClickListener() {
-                // @Override
-                // public void onClick(DialogInterface arg0, int arg1) {
-                // PrefSettings.getSharedPrefs(getBaseContext()).edit().putBoolean("dontShowLowMemory", true).commit();
-                // }
-                // });
-                builder.setCancelable(true);
-                builder.setOnCancelListener(new OnCancelListener() {
-                    @Override
-                    public void onCancel(DialogInterface arg0) {
-                        finishWithAnimation();
-                    }
-                });
-                dialog = builder.create();
-                break;
-
-            case DIALOG_RESTORE_BACKUP:
-                File[] files = BackupManager.getBackups(new File(AnkiDroidApp.getCollectionPath()));
-                mBackups = new File[files.length];
-                for (int i = 0; i < files.length; i++) {
-                    mBackups[i] = files[files.length - 1 - i];
-                }
-                if (mBackups.length == 0) {
-                    builder.setTitle(getResources().getString(R.string.backup_restore));
-                    builder.setMessage(res.getString(R.string.backup_restore_no_backups));
-                    builder.setPositiveButton(res.getString(R.string.dialog_ok), new Dialog.OnClickListener() {
-                        @Override
-                        public void onClick(DialogInterface dialog, int which) {
-                            showDialog(DIALOG_ERROR_HANDLING);
-                        }
-                    });
-                    builder.setCancelable(true).setOnCancelListener(new OnCancelListener() {
-                        @Override
-                        public void onCancel(DialogInterface arg0) {
-                            showDialog(DIALOG_ERROR_HANDLING);
-                        }
-                    });
-                } else {
-                    String[] dates = new String[mBackups.length];
-                    for (int i = 0; i < mBackups.length; i++) {
-                        dates[i] = mBackups[i].getName().replaceAll(
-                                ".*-(\\d{4}-\\d{2}-\\d{2})-(\\d{2})-(\\d{2}).anki2", "$1 ($2:$3 h)");
-                    }
-                    builder.setTitle(res.getString(R.string.backup_restore_select_title));
-                    builder.setIcon(android.R.drawable.ic_input_get);
-                    builder.setSingleChoiceItems(dates, dates.length, new DialogInterface.OnClickListener() {
-
-                        @Override
-                        public void onClick(DialogInterface dialog, int which) {
-                            if (mBackups[which].length() > 0){
-                                // restore the backup if it's valid
-                                DeckTask.launchDeckTask(
-                                        DeckTask.TASK_TYPE_RESTORE_DECK,
-                                        mRestoreDeckHandler,
-                                        new DeckTask.TaskData(new Object[] { getCol(),
-                                                AnkiDroidApp.getCollectionPath(), mBackups[which].getPath() }));
-                            } else {
-                                // otherwise show an error dialog
-                                Dialog invalidFileDialog = new AlertDialog.Builder(DeckPicker.this)
-                                .setTitle(R.string.backup_error)
-                                .setMessage(R.string.backup_invalid_file_error)
-                                .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener()
-                                {
-                                    @Override
-                                    public void onClick(DialogInterface dialog, int which)
-                                    {                                      
-                                    }
-                                })
-                                .create();
-                                invalidFileDialog.show();
-                            }
-
-                        }
-                    });
-                    builder.setCancelable(true).setOnCancelListener(new OnCancelListener() {
-                        @Override
-                        public void onCancel(DialogInterface arg0) {
-                            showDialog(DIALOG_ERROR_HANDLING);
-                        }
-                    });
-                }
-                dialog = builder.create();
-                break;
-
-            case DIALOG_NEW_COLLECTION:
-                builder.setTitle(res.getString(R.string.backup_new_collection));
-                builder.setMessage(res.getString(R.string.backup_del_collection_question));
-                builder.setPositiveButton(res.getString(R.string.dialog_positive_create),
-                       new DialogInterface.OnClickListener() {
-                           @Override
-                           public void onClick(DialogInterface dialog, int which) {
-                               AnkiDroidApp.closeCollection(false);
-                               String path = AnkiDroidApp.getCollectionPath();
-                               AnkiDatabaseManager.closeDatabase(path);
-                               if (BackupManager.moveDatabaseToBrokenFolder(path, false)) {
-                                   loadCollection();
-                               } else {
-                            showDialog(DIALOG_ERROR_HANDLING);
-                               }
-                           }
-                       });
-                builder.setNegativeButton(res.getString(R.string.dialog_cancel), new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface arg0, int arg1) {
-                        showDialog(DIALOG_ERROR_HANDLING);
-                    }
-                });
-                builder.setCancelable(true);
-                builder.setOnCancelListener(new OnCancelListener() {
-                    @Override
-                    public void onCancel(DialogInterface arg0) {
-                        showDialog(DIALOG_ERROR_HANDLING);
-                    }
-                });
-                dialog = builder.create();
-                break;
-
-            case DIALOG_FULL_SYNC_FROM_SERVER:
-                builder.setTitle(res.getString(R.string.backup_full_sync_from_server));
-                builder.setMessage(res.getString(R.string.backup_full_sync_from_server_question));
-                builder.setPositiveButton(res.getString(R.string.dialog_positive_overwrite),
-                        new DialogInterface.OnClickListener() {
-                            @Override
-                            public void onClick(DialogInterface dialog, int which) {
-                                sync("download", mSyncMediaUsn);
-                            }
-                        });
-                builder.setNegativeButton(res.getString(R.string.dialog_cancel), new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface arg0, int arg1) {
-                        showDialog(DIALOG_ERROR_HANDLING);
-                    }
-                });
-                builder.setCancelable(true);
-                builder.setOnCancelListener(new OnCancelListener() {
-                    @Override
-                    public void onCancel(DialogInterface arg0) {
-                        showDialog(DIALOG_ERROR_HANDLING);
-                    }
-                });
-                dialog = builder.create();
-                break;
-
-            case DIALOG_CONFIRM_DATABASE_CHECK:
-                builder.setTitle(res.getString(R.string.check_db_title));
-                builder.setMessage(res.getString(R.string.check_db_warning));
-                builder.setPositiveButton(res.getString(R.string.dialog_ok),
-                        new DialogInterface.OnClickListener() {
-                            @Override
-                            public void onClick(DialogInterface dialog, int which) {
-                                integrityCheck();
-                            }
-                        });
-                builder.setNegativeButton(res.getString(R.string.dialog_cancel), null);
-                builder.setCancelable(true);
-                dialog = builder.create();
-                break;
-
-            case DIALOG_CONFIRM_RESTORE_BACKUP:
-                builder.setTitle(res.getString(R.string.restore_backup_title));
-                builder.setMessage(res.getString(R.string.restore_backup));
-                builder.setPositiveButton(res.getString(R.string.dialog_continue),
-                        new DialogInterface.OnClickListener() {
-                            @Override
-                            public void onClick(DialogInterface dialog, int which) {
-                                showDialog(DIALOG_RESTORE_BACKUP);
-                            }
-                        });
-                builder.setNegativeButton(res.getString(R.string.dialog_cancel), null);
-                builder.setCancelable(true);
-                dialog = builder.create();
-                break;
-            default:
-                return super.onCreateDialog(id);
-        }
-        if (dialog != null) {
-            dialog.setOwnerActivity(this);
-        }
-        return dialog;
-    }
-
-
-    @Override
-    protected void onPrepareDialog(int id, Dialog dialog) {
-        Resources res = getResources();
-        StyledDialog ad = (StyledDialog) dialog;
-        switch (id) {
-            case DIALOG_DELETE_DECK:
-                if (!AnkiDroidApp.colIsOpen() || mDeckList == null || mDeckList.size() == 0) {
-                    return;
-                }
-                boolean isDyn = getCol().getDecks().isDyn(mCurrentDid);
-                if (isDyn) {
-                    ad.setMessage(String.format(res.getString(R.string.delete_cram_deck_message), "\'"
-                            + getCol().getDecks().name(mCurrentDid) + "\'"));
-                } else {
-                    ad.setMessage(String.format(res.getString(R.string.delete_deck_message), "\'"
-                            + getCol().getDecks().name(mCurrentDid) + "\'"));
-                }
-                break;
-
-            case DIALOG_CONTEXT_MENU:
-                if (!AnkiDroidApp.colIsOpen() || mDeckList == null || mDeckList.size() == 0) {
-                    return;
-                }
-                mCurrentDid = Long.parseLong(mDeckList.get(mContextMenuPosition).get("did"));
-                try {
-                    ad.changeListItem(
-                            CONTEXT_MENU_COLLAPSE_DECK,
-                            getResources()
-                                    .getString(
-                                            getCol().getDecks().get(mCurrentDid).getBoolean("collapsed") ? R.string.contextmenu_deckpicker_inflate_deck
-                                                    : R.string.contextmenu_deckpicker_collapse_deck));
-                } catch (NotFoundException e) {
-                    // do nothing
-                } catch (JSONException e) {
-                    // do nothing
-                }
-                ad.setTitle(getCol().getDecks().name(mCurrentDid));
-                break;
-
-            case DIALOG_IMPORT_LOG:
-            case DIALOG_SYNC_LOG:
-            case DIALOG_SYNC_SANITY_ERROR:
-                // If both have text, separate them by a new line.
-                if (!TextUtils.isEmpty(mDialogMessage) && !TextUtils.isEmpty(mSyncMessage)) {
-                    ad.setMessage(mDialogMessage + "\n\n" + mSyncMessage);
-                } else if (!TextUtils.isEmpty(mDialogMessage)) {
-                    ad.setMessage(mDialogMessage);
-                } else {
-                    ad.setMessage(mSyncMessage);
-                }
-                break;
-
-            case DIALOG_DB_ERROR:
-                mLoadFailed = false;
-                ad.getButton(Dialog.BUTTON3).setEnabled(hasErrorFiles());
-                break;
-
-            case DIALOG_LOAD_FAILED:
-                mLoadFailed = true;
-                if (mOpenCollectionDialog != null && mOpenCollectionDialog.isShowing()) {
-                    mOpenCollectionDialog.setMessage(res.getString(R.string.col_load_failed));
-                }
-                break;
-
-            case DIALOG_ERROR_HANDLING:
-                ArrayList<String> options = new ArrayList<String>();
-                ArrayList<Integer> values = new ArrayList<Integer>();
-                if (getCol() == null) {
-                    // retry
-                    options.add(res.getString(R.string.backup_retry_opening));
-                    values.add(0);
-                } else {
-                    // fix integrity
-                    options.add(res.getString(R.string.check_db));
-                    values.add(1);
-                }
-                // repair db with sqlite
-                options.add(res.getString(R.string.backup_error_menu_repair));
-                values.add(2);
-                // // restore from backup
-                options.add(res.getString(R.string.backup_restore));
-                values.add(3);
-                // delete old collection and build new one
-                options.add(res.getString(R.string.backup_full_sync_from_server));
-                values.add(4);
-                // delete old collection and build new one
-                options.add(res.getString(R.string.backup_del_collection));
-                values.add(5);
-
-                String[] titles = new String[options.size()];
-                mRepairValues = new int[options.size()];
-                for (int i = 0; i < options.size(); i++) {
-                    titles[i] = options.get(i);
-                    mRepairValues[i] = values.get(i);
-                }
-                ad.setItems(titles, new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int which) {
-                        switch (mRepairValues[which]) {
-                            case 0:
-                                loadCollection();
-                                return;
-                            case 1:
-                                showDialog(DIALOG_CONFIRM_DATABASE_CHECK);
-                                return;
-                            case 2:
-                                showDialog(DIALOG_REPAIR_COLLECTION);
-                                return;
-                            case 3:
-                                showDialog(DIALOG_RESTORE_BACKUP);
-                                return;
-                            case 4:
-                                showDialog(DIALOG_FULL_SYNC_FROM_SERVER);
-                                return;
-                            case 5:
-                                showDialog(DIALOG_NEW_COLLECTION);
-                                return;
-                        }
-                    }
-                });
-                break;
-
-            case DIALOG_IMPORT_SELECT:
-                List<File> fileList = Utils.getImportableDecks();
-                if (fileList.size() == 0) {
-                    Themes.showThemedToast(DeckPicker.this,
-                            getResources().getString(R.string.upgrade_import_no_file_found), false);
-                }
-                ad.setEnabled(fileList.size() != 0);
-                String[] tts = new String[fileList.size()];
-                mImportValues = new String[fileList.size()];
-                for (int i = 0; i < tts.length; i++) {
-                    tts[i] = fileList.get(i).getName().replace(".apkg", "");
-                    mImportValues[i] = fileList.get(i).getAbsolutePath();
-                }
-                ad.setItems(tts, new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int which) {
-                        mImportPath = mImportValues[which];
-                        // If the apkg file is called "collection.apkg", we assume the collection will be replaced
-                        if (mImportPath.split("/")[mImportPath.split("/").length - 1].equals("collection.apkg")) {
-                            mImportMethod = IMPORT_METHOD_REPLACE;
-                        }
-                        switch (mImportMethod) {
-                            case IMPORT_METHOD_ADD:
-                                DeckTask.launchDeckTask(DeckTask.TASK_TYPE_IMPORT, mImportAddListener, new TaskData(
-                                        getCol(), mImportPath, false));
-                                mImportPath = null;
-                                break;
-                            case IMPORT_METHOD_REPLACE:
-                                DeckTask.launchDeckTask(DeckTask.TASK_TYPE_IMPORT_REPLACE, mImportReplaceListener,
-                                        new TaskData(getCol(), mImportPath));
-                                mImportPath = null;
-                                break;
-                            case IMPORT_METHOD_ASK:
-                            default:
-                                showDialog(DIALOG_IMPORT);
-                        }
-                        mImportMethod = IMPORT_METHOD_ASK;
-                    }
-                });
-                break;
-        }
-    }
-
-
-    @Override
-    public boolean onKeyDown(int keyCode, KeyEvent event) {
-        if (keyCode == KeyEvent.KEYCODE_BACK && event.getRepeatCount() == 0) {
-            Log.i(AnkiDroidApp.TAG, "DeckPicker - onBackPressed()");
-            finishWithAnimation();
-            return true;
-        }
-        return super.onKeyDown(keyCode, event);
-    }
-
-
-    private void finishWithAnimation() {
-        finish();
-        ActivityTransitionAnimation.slide(this, ActivityTransitionAnimation.DIALOG_EXIT);
-    }
-
-
-    // ----------------------------------------------------------------------------
-    // CUSTOM METHODS
-    // ----------------------------------------------------------------------------
-
-    public void loadStudyOptionsFragment() {
-        loadStudyOptionsFragment(0, null);
-    }
-
-  
-    public void loadStudyOptionsFragment(long deckId, Bundle cramConfig) {
-        StudyOptionsFragment details = StudyOptionsFragment.newInstance(deckId, cramConfig);
-        FragmentTransaction ft = getSupportFragmentManager().beginTransaction();
-        ft.setTransition(FragmentTransaction.TRANSIT_FRAGMENT_CLOSE);
-        ft.replace(R.id.studyoptions_fragment, details);
-        ft.commit();
-    }
-
-
-    public StudyOptionsFragment getFragment() {
-        Fragment frag = getSupportFragmentManager().findFragmentById(R.id.studyoptions_fragment);
-        if (frag != null && (frag instanceof StudyOptionsFragment)) {
-            return (StudyOptionsFragment) frag;
-        }
-        return null;
-    }
-
-
-    /**
-     * Show/dismiss dialog when sd card is ejected/remounted (collection is saved by SdCardReceiver)
-     */
-    private void registerExternalStorageListener() {
-        if (mUnmountReceiver == null) {
-            mUnmountReceiver = new BroadcastReceiver() {
-                @Override
-                public void onReceive(Context context, Intent intent) {
-                    if (intent.getAction().equals(SdCardReceiver.MEDIA_EJECT)) {
-                        showDialog(DIALOG_SD_CARD_NOT_MOUNTED);
-                    } else if (intent.getAction().equals(SdCardReceiver.MEDIA_MOUNT)) {
-                        if (mNotMountedDialog != null && mNotMountedDialog.isShowing()) {
-                            mNotMountedDialog.dismiss();
-                        }
-                        loadCollection();
-                    }
-                }
-            };
-            IntentFilter iFilter = new IntentFilter();
-            iFilter.addAction(SdCardReceiver.MEDIA_EJECT);
-            iFilter.addAction(SdCardReceiver.MEDIA_MOUNT);
-            registerReceiver(mUnmountReceiver, iFilter);
-        }
-    }
-
-
-    /**
-     * Creates an intent to load a deck given the full pathname of it. The constructed intent is equivalent (modulo the
-     * extras) to the open used by the launcher shortcut, which means it will not open a new study options window but
-     * bring the existing one to the front.
-     */
-    public static Intent getLoadDeckIntent(Context context, long deckId) {
-        Intent loadDeckIntent = new Intent(context, DeckPicker.class);
-        loadDeckIntent.setAction(Intent.ACTION_MAIN);
-        loadDeckIntent.addCategory(Intent.CATEGORY_LAUNCHER);
-        loadDeckIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
-        loadDeckIntent.putExtra(EXTRA_DECK_ID, deckId);
-        return loadDeckIntent;
-    }
-
-
-    // private void handleRestoreDecks(boolean reloadIfEmpty) {
-    // if (mBrokenDecks.size() != 0) {
-    // while (true) {
-    // mCurrentDeckPath = mBrokenDecks.remove(0);
-    // if (!mAlreadyDealtWith.contains(mCurrentDeckPath) || mBrokenDecks.size() == 0) {
-    // break;
-    // }
-    // }
-    // mDeckNotLoadedAlert.setMessage(getResources().getString(R.string.open_deck_failed, "\'" + new
-    // File(mCurrentDeckPath).getName() + "\'", BackupManager.BROKEN_DECKS_SUFFIX.replace("/", ""),
-    // getResources().getString(R.string.repair_deck)));
-    // mDeckNotLoadedAlert.show();
-    // } else if (reloadIfEmpty) {
-    // if (mRestoredOrDeleted) {
-    // mBrokenDecks = new ArrayList<String>();
-    // // populateDeckList(mPrefDeckPath);
-    // }
-    // }
-    // }
-
-    private void sync() {
-        sync(null, 0);
-    }
-
-
-    /**
-     * The mother of all syncing attempts. This might be called from sync() as first attempt to sync a collection OR
-     * from the mSyncConflictResolutionListener if the first attempt determines that a full-sync is required. In the
-     * second case, we have passed the mediaUsn that was obtained during the first attempt.
-     *
-     * @param syncConflictResolution Either "upload" or "download", depending on the user's choice.
-     * @param syncMediaUsn The media Usn, as determined during the prior sync() attempt that determined that full
-     *            syncing was required.
-     */
-    private void sync(String syncConflictResolution, int syncMediaUsn) {
-        SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(getBaseContext());
-        String hkey = preferences.getString("hkey", "");
-        if (hkey.length() == 0) {
-            showDialog(DIALOG_USER_NOT_LOGGED_IN_SYNC);
-        } else {
-            Connection.sync(mSyncListener,
-                    new Connection.Payload(new Object[] { hkey, preferences.getBoolean("syncFetchesMedia", true),
-                            syncConflictResolution, syncMediaUsn }));
-        }
-    }
-
-
-    private void addSharedDeck() {
-        Intent intent = new Intent(DeckPicker.this, Info.class);
-        intent.putExtra(Info.TYPE_EXTRA, Info.TYPE_SHARED_DECKS);
-        startActivityForResultWithAnimation(intent, ADD_SHARED_DECKS, ActivityTransitionAnimation.RIGHT);
-    }
-
-    private DialogInterface.OnClickListener mSyncSanityFailListener = new DialogInterface.OnClickListener() {
-        @Override
-        public void onClick(DialogInterface dialog, int which) {
-            Resources res = getResources();
-            StyledDialog.Builder builder;
-            switch (which) {
-                case DialogInterface.BUTTON_POSITIVE:
-                    builder = new StyledDialog.Builder(DeckPicker.this);
-                    builder.setPositiveButton(res.getString(R.string.dialog_positive_overwrite),
-                            new Dialog.OnClickListener() {
-                                @Override
-                                public void onClick(DialogInterface dialog, int which) {
-                                    Collection col = getCol();
-                                    if (col != null) {
-                                        col.modSchema(true);
-                                        col.setMod();
-                                        sync("upload", 0);
-                                    }
-                                }
-                            });
-                    builder.setNegativeButton(res.getString(R.string.dialog_cancel), null);
-                    builder.setMessage(res.getString(R.string.sync_conflict_local_confirm));
-                    builder.show();
-                    break;
-                case DialogInterface.BUTTON_NEUTRAL:
-                    builder = new StyledDialog.Builder(DeckPicker.this);
-                    builder.setPositiveButton(res.getString(R.string.dialog_positive_overwrite),
-                            new Dialog.OnClickListener() {
-                                @Override
-                                public void onClick(DialogInterface dialog, int which) {
-                                    Collection col = getCol();
-                                    if (col != null) {
-                                        col.modSchema(true);
-                                        col.setMod();
-                                        sync("download", 0);
-                                    }
-                                }
-                            });
-                    builder.setNegativeButton(res.getString(R.string.dialog_cancel), null);
-                    builder.setMessage(res.getString(R.string.sync_conflict_remote_confirm));
-                    builder.show();
-                    break;
-                case DialogInterface.BUTTON_NEGATIVE:
-                default:
-            }
-        }
-    };
-
-    private DialogInterface.OnClickListener mSyncConflictResolutionListener = new DialogInterface.OnClickListener() {
-        @Override
-        public void onClick(DialogInterface dialog, int which) {
-            Resources res = getResources();
-            StyledDialog.Builder builder;
-            switch (which) {
-                case DialogInterface.BUTTON_POSITIVE:
-                    builder = new StyledDialog.Builder(DeckPicker.this);
-                    builder.setPositiveButton(res.getString(R.string.dialog_positive_overwrite), new Dialog.OnClickListener() {
-                        @Override
-                        public void onClick(DialogInterface dialog, int which) {
-                            sync("upload", mSyncMediaUsn);
-                        }
-                    });
-                    builder.setNegativeButton(res.getString(R.string.dialog_cancel), null);
-                    builder.setMessage(res.getString(R.string.sync_conflict_local_confirm));
-                    builder.show();
-                    break;
-                case DialogInterface.BUTTON_NEUTRAL:
-                    builder = new StyledDialog.Builder(DeckPicker.this);
-                    builder.setPositiveButton(res.getString(R.string.dialog_positive_overwrite),
-                            new Dialog.OnClickListener() {
-                                @Override
-                                public void onClick(DialogInterface dialog, int which) {
-                                    sync("download", mSyncMediaUsn);
-                                }
-                            });
-                    builder.setNegativeButton(res.getString(R.string.dialog_cancel), null);
-                    builder.setMessage(res.getString(R.string.sync_conflict_remote_confirm));
-                    builder.show();
-                    break;
-                case DialogInterface.BUTTON_NEGATIVE:
-                default:
-            }
-        }
-    };
 
 
     @Override
@@ -2256,7 +512,7 @@ public class DeckPicker extends NavigationDrawerActivity
         if (getDrawerToggle().onOptionsItemSelected(item)) {
             return true;
         }
-        
+
         Resources res = getResources();
         switch (item.getItemId()) {
 
@@ -2295,7 +551,7 @@ public class DeckPicker extends NavigationDrawerActivity
                 return true;
 
             case R.id.action_import:
-                showDialog(DIALOG_IMPORT_HINT);
+                showImportDialog(ImportDialog.DIALOG_IMPORT_HINT);
                 return true;
 
             case R.id.action_new_filtered_deck:
@@ -2324,8 +580,7 @@ public class DeckPicker extends NavigationDrawerActivity
                 return true;
 
             case R.id.action_check_database:
-                StyledDialog dialog = (StyledDialog) onCreateDialog(this.DIALOG_CONFIRM_DATABASE_CHECK);
-                dialog.show();
+                showDatabaseErrorDialog(DatabaseErrorDialog.DIALOG_CONFIRM_DATABASE_CHECK);
                 return true;
 
             case R.id.action_tutorial:
@@ -2333,10 +588,9 @@ public class DeckPicker extends NavigationDrawerActivity
                 return true;
 
             case R.id.action_restore_backup:
-                StyledDialog dialog2 = (StyledDialog) onCreateDialog(this.DIALOG_CONFIRM_RESTORE_BACKUP);
-                dialog2.show();
+                showDatabaseErrorDialog(DatabaseErrorDialog.DIALOG_CONFIRM_RESTORE_BACKUP);
                 return true;
-                
+
             default:
                 return super.onOptionsItemSelected(item);
 
@@ -2348,9 +602,8 @@ public class DeckPicker extends NavigationDrawerActivity
     protected void onActivityResult(int requestCode, int resultCode, Intent intent) {
         super.onActivityResult(requestCode, resultCode, intent);
 
-        mDontSaveOnStop = false;
         if (resultCode == RESULT_MEDIA_EJECTED) {
-            showDialog(DIALOG_SD_CARD_NOT_MOUNTED);
+            showSdCardNotMountedDialog();
             return;
         } else if (resultCode == RESULT_DB_ERROR) {
             handleDbError();
@@ -2378,9 +631,7 @@ public class DeckPicker extends NavigationDrawerActivity
                 }
             } else {
                 if (resultCode == RESULT_OK) {
-                    if (mOpenCollectionDialog != null && mOpenCollectionDialog.isShowing()) {
-                        mOpenCollectionDialog.dismiss();
-                    }
+                    dismissOpeningCollectionDialog();
                     if (AnkiDroidApp.colIsOpen()) {
                         AnkiDroidApp.closeCollection(true);
                     }
@@ -2406,19 +657,9 @@ public class DeckPicker extends NavigationDrawerActivity
             }
             // reload the collection if the path has changed
             if (!mPrefDeckPath.equals(oldPath)) {
-                loadCollection();
+                startLoadingCollection();
             }
-            // if (resultCode == StudyOptions.RESULT_RESTART) {
-            // setResult(StudyOptions.RESULT_RESTART);
-            // finishWithAnimation();
-            // } else {
-            // SharedPreferences preferences = PrefSettings.getSharedPrefs(getBaseContext());
-            // BackupManager.initBackup();
-            // if (!mPrefDeckPath.equals(preferences.getString("deckPath", AnkiDroidApp.getStorageDirectory())) ||
-            // mPrefDeckOrder != Integer.parseInt(preferences.getString("deckOrder", "0"))) {
-            // // populateDeckList(preferences.getString("deckPath", AnkiDroidApp.getStorageDirectory()));
-            // }
-            // }
+
         } else if (requestCode == REPORT_FEEDBACK && resultCode == RESULT_OK) {
         } else if (requestCode == LOG_IN_FOR_SYNC && resultCode == RESULT_OK) {
             sync();
@@ -2429,8 +670,8 @@ public class DeckPicker extends NavigationDrawerActivity
                 mImportPath = intent.getStringExtra("importPath");
             }
             if (AnkiDroidApp.colIsOpen() && mImportPath != null) {
-                DeckTask.launchDeckTask(DeckTask.TASK_TYPE_IMPORT, mImportAddListener,
-                        new TaskData(getCol(), mImportPath, true));
+                DeckTask.launchDeckTask(DeckTask.TASK_TYPE_IMPORT, mImportAddListener, new TaskData(getCol(),
+                        mImportPath, true));
                 mImportPath = null;
             }
         } else if (requestCode == REQUEST_REVIEW) {
@@ -2440,8 +681,7 @@ public class DeckPicker extends NavigationDrawerActivity
                     // do not reload counts, if activity is created anew because it has been before destroyed by android
                     loadCounts();
                     break;
-                case Reviewer.RESULT_NO_MORE_CARDS:
-                    mDontSaveOnStop = true;
+                case AbstractFlashcardViewer.RESULT_NO_MORE_CARDS:
                     Intent i = new Intent();
                     i.setClass(this, StudyOptionsActivity.class);
                     startActivityForResultWithAnimation(i, SHOW_STUDYOPTIONS, ActivityTransitionAnimation.RIGHT);
@@ -2455,11 +695,445 @@ public class DeckPicker extends NavigationDrawerActivity
     }
 
 
-    private void integrityCheck() {
-        if (!AnkiDroidApp.colIsOpen()) {
-            loadCollection();
-            return;
+    @Override
+    protected void onResume() {
+        super.onResume();
+        if (getCol() != null) {
+            if (Utils.now() > getCol().getSched().getDayCutoff() && AnkiDroidApp.isSdCardMounted()) {
+                loadCounts();
+            }
         }
+        selectNavigationItem(DRAWER_DECK_PICKER);
+    }
+
+
+    @Override
+    public void onSaveInstanceState(Bundle savedInstanceState) {
+        super.onSaveInstanceState(savedInstanceState);
+        savedInstanceState.putLong("mContextMenuDid", mContextMenuDid);
+    }
+
+
+    @Override
+    public void onRestoreInstanceState(Bundle savedInstanceState) {
+        super.onRestoreInstanceState(savedInstanceState);
+        mContextMenuDid = savedInstanceState.getLong("mContextMenuDid");
+    }
+
+
+    protected void sendKey(int keycode) {
+        this.dispatchKeyEvent(new KeyEvent(KeyEvent.ACTION_DOWN, keycode));
+        this.dispatchKeyEvent(new KeyEvent(KeyEvent.ACTION_UP, keycode));
+    }
+
+
+    @Override
+    protected void onPause() {
+        Log.i(AnkiDroidApp.TAG, "DeckPicker - onPause");
+
+        super.onPause();
+    }
+
+
+    @Override
+    protected void onStop() {
+        Log.i(AnkiDroidApp.TAG, "DeckPicker - onStop");
+        super.onStop();
+        UIUtils.saveCollectionInBackground();
+    }
+
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        if (mUnmountReceiver != null) {
+            unregisterReceiver(mUnmountReceiver);
+        }
+        Log.i(AnkiDroidApp.TAG, "DeckPicker - onDestroy()");
+    }
+
+
+    @Override
+    public boolean onKeyDown(int keyCode, KeyEvent event) {
+        if (keyCode == KeyEvent.KEYCODE_BACK && event.getRepeatCount() == 0) {
+            Log.i(AnkiDroidApp.TAG, "DeckPicker - onBackPressed()");
+            finishWithAnimation();
+            return true;
+        }
+        return super.onKeyDown(keyCode, event);
+    }
+
+
+    private void finishWithAnimation() {
+        super.finishWithAnimation(ActivityTransitionAnimation.DIALOG_EXIT);
+    }
+
+
+    // ----------------------------------------------------------------------------
+    // CUSTOM METHODS
+    // ----------------------------------------------------------------------------
+
+    @Override
+    protected void onCollectionLoaded(Collection col) {
+        // keep reference to collection in parent
+        super.onCollectionLoaded(col);
+        // select last loaded deck if any
+        if (mFragmented) {
+            long did = col.getDecks().selected();
+            selectDeck(did);
+        }
+        // show import dialog if shared deck was opened
+        // TODO: This should default to ADD instead of asking the user to choose between ADD and REPLACE
+        if (AnkiDroidApp.colIsOpen() && mImportPath != null) {
+            showImportDialog(ImportDialog.DIALOG_IMPORT);
+        }
+        // prepare deck counts and mini-today-statistic
+        loadCounts();
+    }
+
+
+    @Override
+    protected void onCollectionLoadError() {
+        // Show dialogs for handling collection load error
+        setOpeningCollectionDialogMessage(getResources().getString(R.string.col_load_failed));
+        // We're not allowed to commit fragment transactions from this method so need to show error dialog via handler:
+        // http://stackoverflow.com/questions/7746140/android-problems-using-fragmentactivity-loader-to-update-fragmentstatepagera
+        handler.sendEmptyMessage(MSG_SHOW_COLLECTION_LOADING_ERROR_DIALOG);
+    }
+
+    private Handler handler = new Handler() {
+        @Override
+        public void handleMessage(Message msg) {
+            if (msg.what == MSG_SHOW_COLLECTION_LOADING_ERROR_DIALOG) {
+                showDatabaseErrorDialog(DatabaseErrorDialog.DIALOG_LOAD_FAILED);
+            }
+        }
+    };
+
+
+    // Load deck counts, and update the today overview
+    public void loadCounts() {
+        if (AnkiDroidApp.colIsOpen()) {
+            DeckTask.launchDeckTask(DeckTask.TASK_TYPE_LOAD_DECK_COUNTS, mLoadCountsHandler, new TaskData(getCol()));
+        }
+        TextView textView = (TextView) findViewById(R.id.today_stats_text_view);
+        textView.setVisibility(View.GONE);
+        AnkiStatsTaskHandler.createSmallTodayOverview(textView);
+    }
+
+
+    private void addNote() {
+        Preferences.COMING_FROM_ADD = true;
+        Intent intent = new Intent(DeckPicker.this, CardEditor.class);
+        intent.putExtra(CardEditor.EXTRA_CALLER, CardEditor.CALLER_DECKPICKER);
+        startActivityForResultWithAnimation(intent, ADD_NOTE, ActivityTransitionAnimation.LEFT);
+    }
+
+
+    private void showUpgradeScreen(boolean animation, int stage) {
+        showUpgradeScreen(animation, stage, true);
+    }
+
+
+    private void showUpgradeScreen(boolean animation, int stage, boolean left) {
+        Intent upgradeIntent = new Intent(this, Info.class);
+        upgradeIntent.putExtra(Info.TYPE_EXTRA, Info.TYPE_UPGRADE_DECKS);
+        upgradeIntent.putExtra(Info.TYPE_UPGRADE_STAGE, stage);
+        startActivityForResultWithAnimation(upgradeIntent, SHOW_INFO_UPGRADE_DECKS,
+                left ? ActivityTransitionAnimation.LEFT : ActivityTransitionAnimation.RIGHT);
+    }
+
+
+    private boolean upgradeNeeded() {
+        if (!AnkiDroidApp.isSdCardMounted()) {
+            showSdCardNotMountedDialog();
+            return false;
+        }
+        File dir = new File(AnkiDroidApp.getCurrentAnkiDroidDirectory());
+        if (!dir.isDirectory()) {
+            dir.mkdirs();
+        }
+        if ((new File(AnkiDroidApp.getCollectionPath())).exists()) {
+            // collection file exists
+            return false;
+        }
+        return dir.listFiles(new OldAnkiDeckFilter()).length > 0;
+    }
+
+
+    private SharedPreferences restorePreferences() {
+        SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(getBaseContext());
+        mPrefDeckPath = AnkiDroidApp.getCurrentAnkiDroidDirectory();
+        mLastTimeOpened = preferences.getLong("lastTimeOpened", 0);
+        mSwipeEnabled = AnkiDroidApp.initiateGestures(this, preferences);
+
+        return preferences;
+    }
+
+
+    private void showStartupScreensAndDialogs(SharedPreferences preferences, int skip) {
+        if (skip < 1 && preferences.getLong("lastTimeOpened", 0) == 0) {
+            // First time to install the app
+            Intent infoIntent = new Intent(this, Info.class);
+            infoIntent.putExtra(Info.TYPE_EXTRA, Info.TYPE_WELCOME);
+            if (skip != 0) {
+                startActivityForResultWithAnimation(infoIntent, SHOW_INFO_WELCOME, ActivityTransitionAnimation.LEFT);
+            } else {
+                startActivityForResultWithoutAnimation(infoIntent, SHOW_INFO_WELCOME);
+            }
+        } else if (!AnkiDroidApp.isSdCardMounted()) {
+            // SD Card mounted
+            showSdCardNotMountedDialog();
+        } else if (!BackupManager.enoughDiscSpace(mPrefDeckPath)) {
+            // Not enough space to do backup
+            showDialogFragment(DeckPickerNoSpaceLeftDialog.newInstance());
+        } else if (preferences.getBoolean("noSpaceLeft", false)) {
+            // No space left
+            showDialogFragment(DeckPickerBackupNoSpaceLeftDialog.newInstance());
+            preferences.edit().putBoolean("noSpaceLeft", false).commit();
+        } else if (skip < 2 && !preferences.getString("lastVersion", "").equals(AnkiDroidApp.getPkgVersionName())) {
+            // AnkiDroid is being updated and a collection already exists. We check if we are upgrading
+            // to a version that contains additions to the database integrity check routine that we would
+            // like to run on all collections. A missing version number is assumed to be a fresh
+            // installation of AnkiDroid and we don't run the check.
+            int current = AnkiDroidApp.getPkgVersionCode();
+            int previous;
+            if (!preferences.contains("lastUpgradeVersion")) {
+                // Fresh install
+                previous = current;
+            } else {
+                try {
+                    previous = preferences.getInt("lastUpgradeVersion", current);
+                } catch (ClassCastException e) {
+                    // Previous versions stored this as a string.
+                    String s = preferences.getString("lastUpgradeVersion", "");
+                    // The last version of AnkiDroid that stored this as a string was 2.0.2.
+                    // We manually set the version here, but anything older will force a DB
+                    // check.
+                    if (s.equals("2.0.2")) {
+                        previous = 40;
+                    } else {
+                        previous = 0;
+                    }
+                }
+            }
+            preferences.edit().putInt("lastUpgradeVersion", current).commit();
+            // Check if preference upgrade or database check required, otherwise go to new feature screen
+            if (previous < AnkiDroidApp.CHECK_DB_AT_VERSION || previous < AnkiDroidApp.CHECK_PREFERENCES_AT_VERSION) {
+                if (previous < AnkiDroidApp.CHECK_PREFERENCES_AT_VERSION) {
+                    upgradePreferences(previous);
+                }
+                // Integrity check loads asynchronously and then restart deckpicker when finished
+                if (previous < AnkiDroidApp.CHECK_DB_AT_VERSION) {
+                    integrityCheck();
+                } else if (previous < AnkiDroidApp.CHECK_PREFERENCES_AT_VERSION) {
+                    // If integrityCheck() doesn't occur, but we did update preferences we should restart DeckPicker to proceed
+                    Intent deckPicker = new Intent(this, DeckPicker.class);
+                    deckPicker.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
+                    startActivityWithoutAnimation(deckPicker);
+                }
+            } else {
+                // If no changes are required we go to the new features activity
+                // There the "lastVersion" is set, so that this code is not reached again
+                preferences.edit().putBoolean("showBroadcastMessageToday", true).commit();
+                Intent infoIntent = new Intent(this, Info.class);
+                infoIntent.putExtra(Info.TYPE_EXTRA, Info.TYPE_NEW_VERSION);
+
+                if (skip != 0) {
+                    startActivityForResultWithAnimation(infoIntent, SHOW_INFO_NEW_VERSION, ActivityTransitionAnimation.LEFT);
+                } else {
+                    startActivityForResultWithoutAnimation(infoIntent, SHOW_INFO_NEW_VERSION);
+                }
+            }
+        } else if (skip < 3 && upgradeNeeded()) {
+            // Note that the "upgrade needed" refers to upgrading Anki 1.x decks, not to newer
+            // versions of AnkiDroid.
+            AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance().getBaseContext()).edit()
+                    .putInt("lastUpgradeVersion", AnkiDroidApp.getPkgVersionCode()).commit();
+            showUpgradeScreen(skip != 0, Info.UPGRADE_SCREEN_BASIC1);
+        } else if (skip < 4 && hasErrorFiles()) {
+            // Need to submit error reports
+            Intent i = new Intent(this, Feedback.class);
+            if (skip != 0) {
+                startActivityForResultWithAnimation(i, REPORT_ERROR, ActivityTransitionAnimation.LEFT);
+            } else {
+                startActivityForResultWithoutAnimation(i, REPORT_ERROR);
+            }
+        } else if (mImportPath != null && AnkiDroidApp.colIsOpen()) {
+            showImportDialog(ImportDialog.DIALOG_IMPORT);
+        } else {
+            // This is the main call when there is nothing special required
+            startLoadingCollection();
+        }
+    }
+
+
+    /**
+     * @return true if the device is a Nook
+     */
+    private boolean isNookDevice() {
+        for (String s : new String[] { "nook" }) {
+            if (android.os.Build.DEVICE.toLowerCase(Locale.US).contains(s)
+                    || android.os.Build.MODEL.toLowerCase(Locale.US).contains(s)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+
+    private void upgradePreferences(int previousVersionCode) {
+        SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(getBaseContext());
+        // when upgrading from before 2.1alpha08
+        if (previousVersionCode < 20100108) {
+            preferences.edit().putString("overrideFont", preferences.getString("defaultFont", "")).commit();
+            preferences.edit().putString("defaultFont", "").commit();
+        }
+        // when upgrading from before 2.2alpha66
+        if (previousVersionCode < 20200166) {
+            // change name from swipe to gestures
+            preferences.edit().putInt("swipeSensitivity", preferences.getInt("swipeSensibility", 100)).commit();
+            preferences.edit().putBoolean("gestures", preferences.getBoolean("swipe", false)).commit();
+            // set new safeDisplayMode preference based on old behavior
+            boolean safeDisplayMode = preferences.getBoolean("eInkDisplay", false) || isNookDevice()
+                    || !preferences.getBoolean("forceQuickUpdate", false);
+            preferences.edit().putBoolean("safeDisplay", safeDisplayMode).commit();
+            // set overrideFontBehavior based on old overrideFont settings
+            String overrideFont = preferences.getString("overrideFont", "");
+            if (!overrideFont.equals("")) {
+                preferences.edit().putString("defaultFont", overrideFont).commit();
+                preferences.edit().putString("overrideFontBehavior", "1").commit();
+            } else {
+                preferences.edit().putString("overrideFontBehavior", "0").commit();
+            }
+            // change typed answers setting from enable to disable
+            preferences.edit().putBoolean("writeAnswersDisable", !preferences.getBoolean("writeAnswers", true))
+                    .commit();
+        }
+    }
+
+
+    public void showDialogFragment(DialogFragment newFragment) {
+        // DialogFragment.show() will take care of adding the fragment
+        // in a transaction. We also want to remove any currently showing
+        // dialog, so make our own transaction and take care of that here.
+        FragmentTransaction ft = getSupportFragmentManager().beginTransaction();
+        Fragment prev = getSupportFragmentManager().findFragmentByTag("dialog");
+        if (prev != null) {
+            ft.remove(prev);
+        }
+        // save transaction to the back stack
+        ft.addToBackStack("dialog");
+        newFragment.show(ft, "dialog");
+    }
+
+
+    // Show dialogs to deal with database loading issues etc
+    @Override
+    public void showDatabaseErrorDialog(int id) {
+        DialogFragment newFragment = DatabaseErrorDialog.newInstance(id);
+        showDialogFragment(newFragment);
+    }
+
+
+    // Show dialogs to deal with database loading issues etc
+    @Override
+    public void showSyncErrorDialog(int id) {
+        showSyncErrorDialog(id, "");
+    }
+
+
+    @Override
+    public void showSyncErrorDialog(int id, String message) {
+        DialogFragment newFragment = SyncErrorDialog.newInstance(id, message);
+        showDialogFragment(newFragment);
+    }
+
+
+    @Override
+    public void showImportDialog(int id) {
+        showImportDialog(id, "");
+    }
+
+
+    @Override
+    public void showImportDialog(int id, String message) {
+        DialogFragment newFragment = ImportDialog.newInstance(id, message);
+        showDialogFragment(newFragment);
+    }
+
+
+    public void showSdCardNotMountedDialog() {
+        if (mNotMountedDialog == null || !mNotMountedDialog.isShowing()) {
+            mNotMountedDialog = StyledOpenCollectionDialog.show(DeckPicker.this,
+                    getResources().getString(R.string.sd_card_not_mounted), new OnCancelListener() {
+
+                        @Override
+                        public void onCancel(DialogInterface arg0) {
+                            finishWithAnimation();
+                        }
+                    }, new View.OnClickListener() {
+
+                        @Override
+                        public void onClick(View v) {
+                            startActivityForResultWithoutAnimation(new Intent(DeckPicker.this, Preferences.class),
+                                    PREFERENCES_UPDATE);
+                        }
+                    });
+        }
+    }
+
+
+    // Callback method to submit error report
+    @Override
+    public void sendErrorReport() {
+        Intent i = new Intent(this, Feedback.class);
+        i.putExtra("request", DeckPicker.RESULT_DB_ERROR);
+        startActivityForResultWithAnimation(i, DeckPicker.REPORT_ERROR, ActivityTransitionAnimation.RIGHT);
+    }
+
+
+    // Callback method to handle repairing deck
+    @Override
+    public void repairDeck() {
+        DeckTask.launchDeckTask(DeckTask.TASK_TYPE_REPAIR_DECK, new DeckTask.TaskListener() {
+
+            @Override
+            public void onPreExecute() {
+                mProgressDialog = StyledProgressDialog.show(DeckPicker.this, "",
+                        getResources().getString(R.string.backup_repair_deck_progress), true);
+            }
+
+
+            @Override
+            public void onPostExecute(DeckTask.TaskData result) {
+                if (mProgressDialog != null && mProgressDialog.isShowing()) {
+                    mProgressDialog.dismiss();
+                }
+                if (result.getBoolean()) {
+                    startLoadingCollection();
+                } else {
+                    Themes.showThemedToast(DeckPicker.this, getResources().getString(R.string.deck_repair_error), true);
+                    showDatabaseErrorDialog(DatabaseErrorDialog.DIALOG_ERROR_HANDLING);
+                }
+            }
+
+
+            @Override
+            public void onProgressUpdate(TaskData... values) {
+            }
+
+
+            @Override
+            public void onCancelled() {
+            }
+        }, new DeckTask.TaskData(AnkiDroidApp.getCol(), AnkiDroidApp.getCollectionPath()));
+    }
+
+
+    // Callback method to handle database integrity check
+    @Override
+    public void integrityCheck() {
         DeckTask.launchDeckTask(DeckTask.TASK_TYPE_CHECK_DATABASE, new DeckTask.TaskListener() {
             @Override
             public void onPreExecute() {
@@ -2474,15 +1148,16 @@ public class DeckPicker extends NavigationDrawerActivity
                     mProgressDialog.dismiss();
                 }
                 if (result.getBoolean()) {
-                    StyledDialog dialog = (StyledDialog) onCreateDialog(DIALOG_OK);
+                    String msg = "";
                     double shrunk = Math.round(result.getLong() / 1024.0);
                     if (shrunk > 0.0) {
-                        dialog.setMessage(String.format(Locale.getDefault(),
-                                getResources().getString(R.string.check_db_acknowledge_shrunk), shrunk));
+                        msg = String.format(Locale.getDefault(),
+                                getResources().getString(R.string.check_db_acknowledge_shrunk), shrunk);
                     } else {
-                        dialog.setMessage(getResources().getString(R.string.check_db_acknowledge));
+                        msg = getResources().getString(R.string.check_db_acknowledge);
                     }
-                    dialog.show();
+                    // Show result of database check and restart the app
+                    showDialogFragment(DeckPickerDatabaseCheckResultDialog.newInstance(msg));
                 } else {
                     handleDbError();
                 }
@@ -2496,28 +1171,16 @@ public class DeckPicker extends NavigationDrawerActivity
 
             @Override
             public void onCancelled() {
-                // TODO Auto-generated method stub
-                
             }
         }, new DeckTask.TaskData(getCol()));
     }
 
 
-    // private void resetDeckLanguages(String deckPath) {
-    // if (MetaDB.resetDeckLanguages(this, deckPath)) {
-    // Themes.showThemedToast(this, getResources().getString(R.string.contextmenu_deckpicker_reset_reset_message),
-    // true);
-    // }
-    // }
-    //
-    //
-    // public void openSharedDeckPicker() {
-    // // deckLoaded = false;
-    // startActivityForResultWithAnimation(new Intent(this, SharedDeckPicker.class), DOWNLOAD_SHARED_DECK);
-    // if (UIUtils.getApiLevel() > 4) {
-    // ActivityTransitionAnimation.slide(this, ActivityTransitionAnimation.RIGHT);
-    // }
-    // }
+    @Override
+    public void exit() {
+        finishWithoutAnimation();
+    }
+
 
     public void handleDbError() {
         DeckTask.launchDeckTask(DeckTask.TASK_TYPE_RESTORE_IF_MISSING, new DeckTask.TaskListener() {
@@ -2537,7 +1200,7 @@ public class DeckPicker extends NavigationDrawerActivity
                         Log.e(AnkiDroidApp.TAG, "onPostExecute - Dialog dismiss Exception = " + e.getMessage());
                     }
                 }
-                showDialog(DIALOG_DB_ERROR);
+                showDatabaseErrorDialog(DatabaseErrorDialog.DIALOG_DB_ERROR);
             }
 
 
@@ -2548,10 +1211,416 @@ public class DeckPicker extends NavigationDrawerActivity
 
             @Override
             public void onCancelled() {
-                // TODO Auto-generated method stub
-                
             }
         }, new DeckTask.TaskData(AnkiDroidApp.getCollectionPath()));
+    }
+
+
+    @Override
+    public void restoreFromBackup(String path) {
+        DeckTask.launchDeckTask(DeckTask.TASK_TYPE_RESTORE_DECK, new DeckTask.TaskListener() {
+
+            @Override
+            public void onPreExecute() {
+                mProgressDialog = StyledProgressDialog.show(DeckPicker.this, "",
+                        getResources().getString(R.string.backup_restore_deck), true);
+            }
+
+
+            @Override
+            public void onPostExecute(DeckTask.TaskData result) {
+                switch (result.getInt()) {
+                    case BackupManager.RETURN_DECK_RESTORED:
+                        // Force full sync on next upload
+                        if (AnkiDroidApp.colIsOpen()) {
+                            AnkiDroidApp.getCol().modSchema(false);
+                        }
+                        startLoadingCollection();
+                        break;
+                    case BackupManager.RETURN_ERROR:
+                        Themes.showThemedToast(DeckPicker.this,
+                                getResources().getString(R.string.backup_restore_error), true);
+                        showDatabaseErrorDialog(DatabaseErrorDialog.DIALOG_ERROR_HANDLING);
+                        break;
+                    case BackupManager.RETURN_NOT_ENOUGH_SPACE:
+                        showDialogFragment(DeckPickerNoSpaceLeftDialog.newInstance());
+                        break;
+                }
+                if (mProgressDialog != null && mProgressDialog.isShowing()) {
+                    mProgressDialog.dismiss();
+                }
+            }
+
+
+            @Override
+            public void onProgressUpdate(TaskData... values) {
+            }
+
+
+            @Override
+            public void onCancelled() {
+            }
+        }, new DeckTask.TaskData(new Object[] { AnkiDroidApp.getCol(), AnkiDroidApp.getCollectionPath(), path }));
+    }
+
+
+    // Helper function to check if there are any saved stacktraces
+    @Override
+    public boolean hasErrorFiles() {
+        for (String file : this.fileList()) {
+            if (file.endsWith(".stacktrace")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+
+    // Sync with Anki Web
+    @Override
+    public void sync() {
+        sync(null, 0);
+    }
+
+
+    /**
+     * The mother of all syncing attempts. This might be called from sync() as first attempt to sync a collection OR
+     * from the mSyncConflictResolutionListener if the first attempt determines that a full-sync is required. In the
+     * second case, we have passed the mediaUsn that was obtained during the first attempt.
+     * 
+     * @param syncConflictResolution Either "upload" or "download", depending on the user's choice.
+     * @param syncMediaUsn The media Usn, as determined during the prior sync() attempt that determined that full
+     *            syncing was required.
+     */
+    @Override
+    public void sync(String syncConflictResolution, int syncMediaUsn) {
+        SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(getBaseContext());
+        String hkey = preferences.getString("hkey", "");
+        if (hkey.length() == 0) {
+            showSyncErrorDialog(SyncErrorDialog.DIALOG_USER_NOT_LOGGED_IN_SYNC);
+        } else {
+            Connection.sync(mSyncListener,
+                    new Connection.Payload(new Object[] { hkey, preferences.getBoolean("syncFetchesMedia", true),
+                            syncConflictResolution, syncMediaUsn }));
+        }
+    }
+
+
+    @Override
+    public int getSyncMediaUsn() {
+        return mSyncMediaUsn;
+    }
+
+    private Connection.TaskListener mSyncListener = new Connection.TaskListener() {
+
+        String currentMessage;
+        long countUp;
+        long countDown;
+
+
+        @Override
+        public void onDisconnected() {
+            showSyncErrorDialog(SyncErrorDialog.DIALOG_NO_CONNECTION);
+        }
+
+
+        @Override
+        public void onPreExecute() {
+            countUp = 0;
+            countDown = 0;
+            if (mProgressDialog == null || !mProgressDialog.isShowing()) {
+                mProgressDialog = StyledProgressDialog
+                        .show(DeckPicker.this, getResources().getString(R.string.sync_title),
+                                getResources().getString(R.string.sync_prepare_syncing) + "\n"
+                                        + getResources().getString(R.string.sync_up_down_size, countUp, countDown),
+                                true, false);
+            }
+        }
+
+
+        @Override
+        public void onProgressUpdate(Object... values) {
+            Resources res = getResources();
+            if (values[0] instanceof Boolean) {
+                // This is the part Download missing media of syncing
+                int total = (Integer) values[1];
+                int done = (Integer) values[2];
+                values[0] = (values[3]);
+                values[1] = res.getString(R.string.sync_downloading_media, done, total);
+            } else if (values[0] instanceof Integer) {
+                int id = (Integer) values[0];
+                if (id != 0) {
+                    currentMessage = res.getString(id);
+                }
+                if (values.length >= 3) {
+                    countUp = (Long) values[1];
+                    countDown = (Long) values[2];
+                }
+            }
+            if (mProgressDialog != null && mProgressDialog.isShowing()) {
+                // mProgressDialog.setTitle((String) values[0]);
+                mProgressDialog.setMessage(currentMessage + "\n"
+                        + res.getString(R.string.sync_up_down_size, countUp / 1024, countDown / 1024));
+            }
+        }
+
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public void onPostExecute(Payload data) {
+            String dialogMessage = "";
+            String syncMessage = "";
+            Log.i(AnkiDroidApp.TAG, "onPostExecute");
+            Resources res = getResources();
+            if (mProgressDialog != null) {
+                mProgressDialog.dismiss();
+            }
+            syncMessage = data.message;
+            if (!data.success) {
+                Object[] result = (Object[]) data.result;
+                if (result[0] instanceof String) {
+                    String resultType = (String) result[0];
+                    if (resultType.equals("badAuth")) {
+                        // delete old auth information
+                        SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(getBaseContext());
+                        Editor editor = preferences.edit();
+                        editor.putString("username", "");
+                        editor.putString("hkey", "");
+                        editor.commit();
+                        // then show
+                        showSyncErrorDialog(SyncErrorDialog.DIALOG_USER_NOT_LOGGED_IN_SYNC);
+                    } else if (resultType.equals("noChanges")) {
+                        dialogMessage = res.getString(R.string.sync_no_changes_message);
+                        showSyncErrorDialog(SyncErrorDialog.DIALOG_SYNC_LOG,
+                                joinSyncMessages(dialogMessage, syncMessage));
+                    } else if (resultType.equals("clockOff")) {
+                        long diff = (Long) result[1];
+                        if (diff >= 86100) {
+                            // The difference if more than a day minus 5 minutes acceptable by ankiweb error
+                            dialogMessage = res.getString(R.string.sync_log_clocks_unsynchronized, diff,
+                                    res.getString(R.string.sync_log_clocks_unsynchronized_date));
+                        } else if (Math.abs((diff % 3600.0) - 1800.0) >= 1500.0) {
+                            // The difference would be within limit if we adjusted the time by few hours
+                            // It doesn't work for all timezones, but it covers most and it's a guess anyway
+                            dialogMessage = res.getString(R.string.sync_log_clocks_unsynchronized, diff,
+                                    res.getString(R.string.sync_log_clocks_unsynchronized_tz));
+                        } else {
+                            dialogMessage = res.getString(R.string.sync_log_clocks_unsynchronized, diff, "");
+                        }
+                        showSyncErrorDialog(SyncErrorDialog.DIALOG_SYNC_LOG,
+                                joinSyncMessages(dialogMessage, syncMessage));
+                    } else if (resultType.equals("fullSync")) {
+                        if (data.data != null && data.data.length >= 1 && data.data[0] instanceof Integer) {
+                            mSyncMediaUsn = (Integer) data.data[0];
+                        }
+                        showSyncErrorDialog(SyncErrorDialog.DIALOG_SYNC_CONFLICT_RESOLUTION);
+                    } else if (resultType.equals("dbError")) {
+                        dialogMessage = res.getString(R.string.sync_corrupt_database, R.string.repair_deck);
+                        showSyncErrorDialog(SyncErrorDialog.DIALOG_SYNC_LOG,
+                                joinSyncMessages(dialogMessage, syncMessage));
+                    } else if (resultType.equals("overwriteError")) {
+                        dialogMessage = res.getString(R.string.sync_overwrite_error);
+                        showSyncErrorDialog(SyncErrorDialog.DIALOG_SYNC_LOG,
+                                joinSyncMessages(dialogMessage, syncMessage));
+                    } else if (resultType.equals("remoteDbError")) {
+                        dialogMessage = res.getString(R.string.sync_remote_db_error);
+                        showSyncErrorDialog(SyncErrorDialog.DIALOG_SYNC_LOG,
+                                joinSyncMessages(dialogMessage, syncMessage));
+                    } else if (resultType.equals("sdAccessError")) {
+                        dialogMessage = res.getString(R.string.sync_write_access_error);
+                        showSyncErrorDialog(SyncErrorDialog.DIALOG_SYNC_LOG,
+                                joinSyncMessages(dialogMessage, syncMessage));
+                    } else if (resultType.equals("finishError")) {
+                        dialogMessage = res.getString(R.string.sync_log_finish_error);
+                        showSyncErrorDialog(SyncErrorDialog.DIALOG_SYNC_LOG,
+                                joinSyncMessages(dialogMessage, syncMessage));
+                    } else if (resultType.equals("IOException")) {
+                        handleDbError();
+                    } else if (resultType.equals("genericError")) {
+                        dialogMessage = res.getString(R.string.sync_generic_error);
+                        showSyncErrorDialog(SyncErrorDialog.DIALOG_SYNC_LOG,
+                                joinSyncMessages(dialogMessage, syncMessage));
+                    } else if (resultType.equals("OutOfMemoryError")) {
+                        dialogMessage = res.getString(R.string.error_insufficient_memory);
+                        showSyncErrorDialog(SyncErrorDialog.DIALOG_SYNC_LOG,
+                                joinSyncMessages(dialogMessage, syncMessage));
+                    } else if (resultType.equals("sanityCheckError")) {
+                        Collection col = getCol();
+                        col.modSchema();
+                        col.save();
+                        dialogMessage = res.getString(R.string.sync_sanity_failed);
+                        showSyncErrorDialog(SyncErrorDialog.DIALOG_SYNC_SANITY_ERROR,
+                                joinSyncMessages(dialogMessage, syncMessage));
+                    } else if (resultType.equals("serverAbort")) {
+                        // syncMsg has already been set above, no need to fetch it here.
+                        showSyncErrorDialog(SyncErrorDialog.DIALOG_SYNC_LOG,
+                                joinSyncMessages(dialogMessage, syncMessage));
+                    } else {
+                        if (result.length > 1 && result[1] instanceof Integer) {
+                            int type = (Integer) result[1];
+                            switch (type) {
+                                case 503:
+                                    dialogMessage = res.getString(R.string.sync_too_busy);
+                                    break;
+                                default:
+                                    dialogMessage = res.getString(R.string.sync_log_error_specific,
+                                            Integer.toString(type), result[2]);
+                                    break;
+                            }
+                        } else if (result[0] instanceof String) {
+                            dialogMessage = res.getString(R.string.sync_log_error_specific, -1, result[0]);
+                        } else {
+                            dialogMessage = res.getString(R.string.sync_generic_error);
+                        }
+                        showSyncErrorDialog(SyncErrorDialog.DIALOG_SYNC_LOG,
+                                joinSyncMessages(dialogMessage, syncMessage));
+                    }
+                }
+            } else {
+                updateDecksList((TreeSet<Object[]>) data.result, (Integer) data.data[2], (Integer) data.data[3]);
+
+                if (data.data[4] != null) {
+                    dialogMessage = (String) data.data[4];
+                } else if (data.data.length > 0 && data.data[0] instanceof String
+                        && ((String) data.data[0]).length() > 0) {
+                    String dataString = (String) data.data[0];
+                    if (dataString.equals("upload")) {
+                        dialogMessage = res.getString(R.string.sync_log_uploading_message);
+                    } else if (dataString.equals("download")) {
+                        dialogMessage = res.getString(R.string.sync_log_downloading_message);
+                        // set downloaded collection as current one
+                    } else {
+                        dialogMessage = res.getString(R.string.sync_database_acknowledge);
+                    }
+                } else {
+                    dialogMessage = res.getString(R.string.sync_database_acknowledge);
+                }
+
+                showSyncErrorDialog(SyncErrorDialog.DIALOG_SYNC_LOG, joinSyncMessages(dialogMessage, syncMessage));
+                dismissOpeningCollectionDialog();
+
+                if (mFragmented) {
+                    try {
+                        // Pick the correct deck after sync. Updates the values in the fragment if same deck.
+                        long did = getCol().getDecks().current().getLong("id");
+                        selectDeck(did);
+                    } catch (JSONException e) {
+                        throw new RuntimeException();
+                    }
+                }
+                loadCounts();
+
+            }
+        }
+    };
+
+
+    private String joinSyncMessages(String dialogMessage, String syncMessage) {
+        // If both strings have text, separate them by a new line, otherwise return whichever has text
+        if (!TextUtils.isEmpty(dialogMessage) && !TextUtils.isEmpty(syncMessage)) {
+            return dialogMessage + "\n\n" + syncMessage;
+        } else if (!TextUtils.isEmpty(dialogMessage)) {
+            return dialogMessage;
+        } else {
+            return syncMessage;
+        }
+    }
+
+
+    @Override
+    public void loginToSyncServer() {
+        Intent myAccount = new Intent(this, MyAccount.class);
+        myAccount.putExtra("notLoggedIn", true);
+        startActivityForResultWithAnimation(myAccount, LOG_IN_FOR_SYNC, ActivityTransitionAnimation.FADE);
+    }
+
+
+    // Callback to import a file -- adding it to existing collection
+    @Override
+    public void importAdd(String importPath) {
+        DeckTask.launchDeckTask(DeckTask.TASK_TYPE_IMPORT, mImportAddListener,
+                new TaskData(getCol(), importPath, false));
+    }
+
+
+    // Callback to import a file -- replacing the existing collection
+    @Override
+    public void importReplace(String importPath) {
+        DeckTask.launchDeckTask(DeckTask.TASK_TYPE_IMPORT_REPLACE, mImportReplaceListener, new TaskData(getCol(),
+                mImportPath));
+    }
+
+
+    @Override
+    public void loadStudyOptionsFragment() {
+        loadStudyOptionsFragment(0, null);
+    }
+
+
+    @Override
+    public void loadStudyOptionsFragment(long deckId, Bundle cramConfig) {
+        StudyOptionsFragment details = StudyOptionsFragment.newInstance(deckId, cramConfig);
+        FragmentTransaction ft = getSupportFragmentManager().beginTransaction();
+        ft.setTransition(FragmentTransaction.TRANSIT_FRAGMENT_CLOSE);
+        ft.replace(R.id.studyoptions_fragment, details);
+        ft.commit();
+    }
+
+
+    public StudyOptionsFragment getFragment() {
+        Fragment frag = getSupportFragmentManager().findFragmentById(R.id.studyoptions_fragment);
+        if (frag != null && (frag instanceof StudyOptionsFragment)) {
+            return (StudyOptionsFragment) frag;
+        }
+        return null;
+    }
+
+
+    /**
+     * Show/dismiss dialog when sd card is ejected/remounted (collection is saved by SdCardReceiver)
+     */
+    private void registerExternalStorageListener() {
+        if (mUnmountReceiver == null) {
+            mUnmountReceiver = new BroadcastReceiver() {
+                @Override
+                public void onReceive(Context context, Intent intent) {
+                    if (intent.getAction().equals(SdCardReceiver.MEDIA_EJECT)) {
+                        showSdCardNotMountedDialog();
+                    } else if (intent.getAction().equals(SdCardReceiver.MEDIA_MOUNT)) {
+                        if (mNotMountedDialog != null && mNotMountedDialog.isShowing()) {
+                            mNotMountedDialog.dismiss();
+                        }
+                        startLoadingCollection();
+                    }
+                }
+            };
+            IntentFilter iFilter = new IntentFilter();
+            iFilter.addAction(SdCardReceiver.MEDIA_EJECT);
+            iFilter.addAction(SdCardReceiver.MEDIA_MOUNT);
+            registerReceiver(mUnmountReceiver, iFilter);
+        }
+    }
+
+
+    /**
+     * Creates an intent to load a deck given the full pathname of it. The constructed intent is equivalent (modulo the
+     * extras) to the open used by the launcher shortcut, which means it will not open a new study options window but
+     * bring the existing one to the front.
+     */
+    public static Intent getLoadDeckIntent(Context context, long deckId) {
+        Intent loadDeckIntent = new Intent(context, DeckPicker.class);
+        loadDeckIntent.setAction(Intent.ACTION_MAIN);
+        loadDeckIntent.addCategory(Intent.CATEGORY_LAUNCHER);
+        loadDeckIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        loadDeckIntent.putExtra(EXTRA_DECK_ID, deckId);
+        return loadDeckIntent;
+    }
+
+
+    private void addSharedDeck() {
+        Intent intent = new Intent(DeckPicker.this, Info.class);
+        intent.putExtra(Info.TYPE_EXTRA, Info.TYPE_SHARED_DECKS);
+        startActivityForResultWithAnimation(intent, ADD_SHARED_DECKS, ActivityTransitionAnimation.RIGHT);
     }
 
 
@@ -2564,7 +1633,6 @@ public class DeckPicker extends NavigationDrawerActivity
         if (mFragmented) {
             loadStudyOptionsFragment(deckId, cramInitialConfig);
         } else {
-            mDontSaveOnStop = true;
             Intent intent = new Intent();
             intent.putExtra("index", deckId);
             intent.putExtra("cramInitialConfig", cramInitialConfig);
@@ -2576,7 +1644,7 @@ public class DeckPicker extends NavigationDrawerActivity
 
     /**
      * Programmatically click on a deck in the deck list.
-     *
+     * 
      * @param did The deck ID of the deck to select.
      */
     private void selectDeck(long did) {
@@ -2605,7 +1673,7 @@ public class DeckPicker extends NavigationDrawerActivity
      * <p>
      * Note that this method does not change the currently selected deck in the collection, only the highlighted deck in
      * the deck list. To select a deck, see {@link #selectDeck(long)}.
-     *
+     * 
      * @param did The deck ID of the deck to select.
      */
     public void setSelectedDeck(long did) {
@@ -2620,7 +1688,7 @@ public class DeckPicker extends NavigationDrawerActivity
 
     private void handleDeckSelection(int id) {
         if (!AnkiDroidApp.colIsOpen()) {
-            loadCollection();
+            startLoadingCollection();
         }
 
         String deckFilename = null;
@@ -2669,8 +1737,6 @@ public class DeckPicker extends NavigationDrawerActivity
 
             @Override
             public void onCancelled() {
-                // TODO Auto-generated method stub
-                
             }
         }, new DeckTask.TaskData(getCol()));
     }
@@ -2738,15 +1804,147 @@ public class DeckPicker extends NavigationDrawerActivity
         WidgetStatus.update(this, decks);
     }
 
-    // private void restartApp() {
-    // // restarts application in order to apply new themes or localisations
-    // Intent i = getBaseContext().getPackageManager()
-    // .getLaunchIntentForPackage(getBaseContext().getPackageName());
-    // mCompat.invalidateOptionsMenu(this);
-    // MetaDB.closeDB();
-    // StudyOptions.this.finishWithAnimation();
-    // startActivity(i);
-    // }
+
+    // Callback to collapse currently selected deck
+    public void collapseContextMenuDeck() {
+        try {
+            JSONObject deck = getCol().getDecks().get(mContextMenuDid);
+            if (getCol().getDecks().children(mContextMenuDid).size() > 0) {
+                deck.put("collapsed", !deck.getBoolean("collapsed"));
+                getCol().getDecks().save(deck);
+                loadCounts();
+            }
+        } catch (JSONException e1) {
+            // do nothing
+        }
+    }
+
+
+    // Callback to show study options for currently selected deck
+    public void showContextMenuDeckOptions() {
+        getCol().getDecks().select(mContextMenuDid);
+        if (mFragmented) {
+            loadStudyOptionsFragment(mContextMenuDid, null);
+        }
+        // open deck options
+        if (getCol().getDecks().isDyn(mContextMenuDid)) {
+            // open cram options if filtered deck
+            Intent i = new Intent(DeckPicker.this, CramDeckOptions.class);
+            i.putExtra("cramInitialConfig", (String) null);
+            startActivityWithAnimation(i, ActivityTransitionAnimation.FADE);
+        } else {
+            // otherwise open regular options
+            Intent i = new Intent(DeckPicker.this, DeckOptions.class);
+            startActivityWithAnimation(i, ActivityTransitionAnimation.FADE);
+        }
+    }
+
+
+    // Callback to show dialog to rename the current deck
+    public void renameContextMenuDeckDialog() {
+        Resources res = getResources();
+        StyledDialog.Builder builder2 = new StyledDialog.Builder(DeckPicker.this);
+        builder2.setTitle(res.getString(R.string.contextmenu_deckpicker_rename_deck));
+
+        mDialogEditText = new EditText(DeckPicker.this);
+        mDialogEditText.setSingleLine();
+        mDialogEditText.setText(getCol().getDecks().name(mContextMenuDid));
+        // mDialogEditText.setFilters(new InputFilter[] { mDeckNameFilter });
+        builder2.setView(mDialogEditText, false, false);
+        builder2.setPositiveButton(res.getString(R.string.rename), new DialogInterface.OnClickListener() {
+
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                String newName = mDialogEditText.getText().toString().replaceAll("['\"]", "");
+                Collection col = getCol();
+                if (col != null) {
+                    if (col.getDecks().rename(col.getDecks().get(mContextMenuDid), newName)) {
+                        for (HashMap<String, String> d : mDeckList) {
+                            if (d.get("did").equals(Long.toString(mContextMenuDid))) {
+                                d.put("name", newName);
+                            }
+                        }
+                        mDeckListAdapter.notifyDataSetChanged();
+                        loadCounts();
+                    } else {
+                        try {
+                            Themes.showThemedToast(
+                                    DeckPicker.this,
+                                    getResources().getString(R.string.rename_error,
+                                            col.getDecks().get(mContextMenuDid).get("name")), false);
+                        } catch (JSONException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+                }
+            }
+        });
+        builder2.setNegativeButton(res.getString(R.string.dialog_cancel), null);
+        builder2.create().show();
+        return;
+    }
+
+
+    // Callback to show confirm deck deletion dialog before deleting currently selected deck
+    public void confirmDeckDeletion() {
+        Resources res = getResources();
+        if (!AnkiDroidApp.colIsOpen() || mDeckList == null || mDeckList.size() == 0) {
+            return;
+        }
+        String msg = "";
+        boolean isDyn = getCol().getDecks().isDyn(mContextMenuDid);
+        if (isDyn) {
+            msg = String.format(res.getString(R.string.delete_cram_deck_message),
+                    "\'" + getCol().getDecks().name(mContextMenuDid) + "\'");
+        } else {
+            msg = String.format(res.getString(R.string.delete_deck_message),
+                    "\'" + getCol().getDecks().name(mContextMenuDid) + "\'");
+        }
+        showDialogFragment(DeckPickerConfirmDeleteDeckDialog.newInstance(msg));
+    }
+
+
+    // Callback to delete currently selected deck
+    public void deleteContextMenuDeck() {
+        DeckTask.launchDeckTask(DeckTask.TASK_TYPE_DELETE_DECK, new DeckTask.TaskListener() {
+            @Override
+            public void onPreExecute() {
+                mProgressDialog = StyledProgressDialog.show(DeckPicker.this, "",
+                        getResources().getString(R.string.delete_deck), true);
+            }
+
+
+            @SuppressWarnings("unchecked")
+            @Override
+            public void onPostExecute(TaskData result) {
+                if (result == null) {
+                    return;
+                }
+                Object[] res = result.getObjArray();
+                updateDecksList((TreeSet<Object[]>) res[0], (Integer) res[1], (Integer) res[2]);
+                if (mFragmented) {
+                    selectDeck(getCol().getDecks().selected());
+                }
+                if (mProgressDialog.isShowing()) {
+                    try {
+                        mProgressDialog.dismiss();
+                    } catch (Exception e) {
+                        Log.e(AnkiDroidApp.TAG, "onPostExecute - Dialog dismiss Exception = " + e.getMessage());
+                    }
+                }
+            }
+
+
+            @Override
+            public void onProgressUpdate(TaskData... values) {
+            }
+
+
+            @Override
+            public void onCancelled() {
+            }
+        }, new TaskData(getCol(), mContextMenuDid));
+    }
 
     // ----------------------------------------------------------------------------
     // INNER CLASSES
@@ -2760,13 +1958,13 @@ public class DeckPicker extends NavigationDrawerActivity
                     if (e1.getX() - e2.getX() > AnkiDroidApp.sSwipeMinDistance
                             && Math.abs(velocityX) > AnkiDroidApp.sSwipeThresholdVelocity
                             && Math.abs(e1.getY() - e2.getY()) < AnkiDroidApp.sSwipeMaxOffPath) {
-                        mDontSaveOnStop = true;
                         float pos = e1.getY();
                         for (int j = 0; j < mDeckListView.getChildCount(); j++) {
                             View v = mDeckListView.getChildAt(j);
                             Rect rect = new Rect();
                             v.getHitRect(rect);
                             if (rect.top < pos && rect.bottom > pos) {
+                                @SuppressWarnings("unchecked")
                                 HashMap<String, String> data = (HashMap<String, String>) mDeckListAdapter
                                         .getItem(mDeckListView.getPositionForView(v));
                                 Collection col = getCol();
@@ -2774,7 +1972,8 @@ public class DeckPicker extends NavigationDrawerActivity
                                     col.getDecks().select(Long.parseLong(data.get("did")));
                                     col.reset();
                                     Intent reviewer = new Intent(DeckPicker.this, Reviewer.class);
-                                    startActivityForResultWithAnimation(reviewer, REQUEST_REVIEW, ActivityTransitionAnimation.LEFT);
+                                    startActivityForResultWithAnimation(reviewer, REQUEST_REVIEW,
+                                            ActivityTransitionAnimation.LEFT);
                                     return true;
                                 }
                             }
@@ -2788,18 +1987,6 @@ public class DeckPicker extends NavigationDrawerActivity
         }
     }
 
-
-    // @Override
-    // protected void onNewIntent(Intent intent) {
-    // super.onNewIntent(intent);
-    // String deck = intent.getStringExtra(EXTRA_DECK);
-    // Log.d(AnkiDroidApp.TAG, "StudyOptions.onNewIntent: " + intent
-    // + ", deck=" + deck);
-    // // if (deck != null && !deck.equals(mDeckFilename)) {
-    // // mDeckFilename = deck;
-    // // // loadPreviousDeck();
-    // // }
-    // }
 
     public static String readableDeckName(String[] name) {
         int len = name.length;

--- a/src/com/ichi2/anki/StudyOptionsActivity.java
+++ b/src/com/ichi2/anki/StudyOptionsActivity.java
@@ -205,7 +205,7 @@ public class StudyOptionsActivity extends NavigationDrawerActivity implements St
                         if (mNotMountedDialog != null && mNotMountedDialog.isShowing()) {
                             mNotMountedDialog.dismiss();
                         }
-                        loadCollection();
+                        startLoadingCollection();
                     }
                 }
             };

--- a/src/com/ichi2/anki/StudyOptionsFragment.java
+++ b/src/com/ichi2/anki/StudyOptionsFragment.java
@@ -277,6 +277,8 @@ public class StudyOptionsFragment extends Fragment implements LoaderManager.Load
         return mStudyOptionsView;
     }
     
+    // Called when the collection loader has finished
+    // NOTE: Fragment transactions are NOT allowed to be called from here on
     private void onCollectionLoaded(Collection col) {
         mCollection = col;
         initAllContentViews();
@@ -1092,7 +1094,7 @@ public class StudyOptionsFragment extends Fragment implements LoaderManager.Load
             closeStudyOptions(DeckPicker.RESULT_MEDIA_EJECTED);
         } else {
             if (!AnkiDroidApp.colIsOpen()) {
-                ((AnkiActivity) getActivity()).loadCollection();
+                ((AnkiActivity) getActivity()).startLoadingCollection();
                 mDontSaveOnStop = false;
                 return;
             }

--- a/src/com/ichi2/anki/UIUtils.java
+++ b/src/com/ichi2/anki/UIUtils.java
@@ -10,7 +10,6 @@ import com.ichi2.async.DeckTask;
 import com.ichi2.async.DeckTask.TaskData;
 
 import java.util.Calendar;
-import java.util.GregorianCalendar;
 
 public class UIUtils {
 
@@ -20,7 +19,7 @@ public class UIUtils {
 
 
     public static long getDayStart() {
-        Calendar cal = GregorianCalendar.getInstance();
+        Calendar cal = Calendar.getInstance();
         if (cal.get(Calendar.HOUR_OF_DAY) < 4) {
             cal.roll(Calendar.DAY_OF_YEAR, -1);
         }
@@ -29,6 +28,38 @@ public class UIUtils {
         cal.set(Calendar.SECOND, 0);
         cal.set(Calendar.MILLISECOND, 0);
         return cal.getTimeInMillis();
+    }
+
+
+    public static void closeCollectionInBackground() {
+        // note: this code used to be called in the onStop() method of DeckPicker
+        // https://github.com/ankidroid/Anki-Android/blob/d7023159b3599d07e18c308fdaa4bb8f8935fd1d/src/com/ichi2/anki/DeckPicker.java#L1206
+        // it's currently not being used anywhere, in favor of letting the Android kernel automatically close the
+        // collection when it kills the process
+        if (AnkiDroidApp.colIsOpen()) {
+            DeckTask.launchDeckTask(DeckTask.TASK_TYPE_CLOSE_DECK, new DeckTask.TaskListener() {
+                @Override
+                public void onPreExecute() {
+                    Log.i(AnkiDroidApp.TAG, "closeCollectionInBackground: start");
+                }
+
+
+                @Override
+                public void onPostExecute(TaskData result) {
+                    Log.i(AnkiDroidApp.TAG, "closesCollectionInBackground: finished");
+                }
+
+
+                @Override
+                public void onProgressUpdate(TaskData... values) {
+                }
+
+
+                @Override
+                public void onCancelled() {
+                }
+            }, new DeckTask.TaskData(AnkiDroidApp.getCol()));
+        }
     }
 
 
@@ -54,8 +85,6 @@ public class UIUtils {
 
                 @Override
                 public void onCancelled() {
-                    // TODO Auto-generated method stub
-                    
                 }
             }, new DeckTask.TaskData(AnkiDroidApp.getCol()));
         }

--- a/src/com/ichi2/anki/dialogs/DatabaseErrorDialog.java
+++ b/src/com/ichi2/anki/dialogs/DatabaseErrorDialog.java
@@ -1,0 +1,365 @@
+
+package com.ichi2.anki.dialogs;
+
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.content.DialogInterface;
+import android.content.res.Resources;
+import android.os.Bundle;
+import android.support.v4.app.DialogFragment;
+
+import com.ichi2.anki.AnkiDatabaseManager;
+import com.ichi2.anki.AnkiDroidApp;
+import com.ichi2.anki.BackupManager;
+import com.ichi2.anki.R;
+import com.ichi2.themes.StyledDialog;
+
+import java.io.File;
+import java.util.ArrayList;
+
+public class DatabaseErrorDialog extends DialogFragment {
+    private int mType = 0;
+    private int[] mRepairValues;
+    private File[] mBackups;
+
+    public static final int DIALOG_LOAD_FAILED = 0;
+    public static final int DIALOG_DB_ERROR = 1;
+    public static final int DIALOG_ERROR_HANDLING = 2;
+    public static final int DIALOG_REPAIR_COLLECTION = 3;
+    public static final int DIALOG_RESTORE_BACKUP = 4;
+    public static final int DIALOG_NEW_COLLECTION = 5;
+    public static final int DIALOG_CONFIRM_DATABASE_CHECK = 6;
+    public static final int DIALOG_CONFIRM_RESTORE_BACKUP = 7;
+    public static final int DIALOG_FULL_SYNC_FROM_SERVER = 8;
+
+    public interface DatabaseErrorDialogListener {
+        public void showDatabaseErrorDialog(int dialogType);
+
+
+        public void sendErrorReport();
+
+
+        public boolean hasErrorFiles();
+
+
+        public void startLoadingCollection();
+
+
+        public void repairDeck();
+
+
+        public void restoreFromBackup(String backupPath);
+
+
+        public void integrityCheck();
+
+
+        public int getSyncMediaUsn();
+
+
+        public void sync(String conflict, int mediaUsn);
+
+
+        public void exit();
+
+
+        public void dismissAllDialogFragments();
+    }
+
+
+    /**
+     * A set of dialogs which deal with problems with the database when it can't load
+     * 
+     * @param dialogType An integer which specifies which of the sub-dialogs to show
+     */
+    public static DatabaseErrorDialog newInstance(int dialogType) {
+        DatabaseErrorDialog f = new DatabaseErrorDialog();
+        Bundle args = new Bundle();
+        args.putInt("dialogType", dialogType);
+        f.setArguments(args);
+        return f;
+    }
+
+
+    @Override
+    public StyledDialog onCreateDialog(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        mType = getArguments().getInt("dialogType");
+        Resources res = getResources();
+        StyledDialog.Builder builder = new StyledDialog.Builder(getActivity());
+        setCancelable(true);
+
+        switch (mType) {
+            case DIALOG_LOAD_FAILED:
+                // Collection failed to load; give user the option of either choosing from repair options, or closing
+                // the activity
+                setCancelable(false);
+                builder.setMessage(res.getString(R.string.open_collection_failed_message,
+                        BackupManager.BROKEN_DECKS_SUFFIX, res.getString(R.string.repair_deck)));
+                builder.setTitle(R.string.open_collection_failed_title);
+                builder.setIcon(R.drawable.ic_dialog_alert);
+                builder.setPositiveButton(res.getString(R.string.error_handling_options),
+                        new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialog, int which) {
+                                ((DatabaseErrorDialogListener) getActivity())
+                                        .showDatabaseErrorDialog(DIALOG_ERROR_HANDLING);
+                            }
+                        });
+                builder.setNegativeButton(res.getString(R.string.close), new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        ((DatabaseErrorDialogListener) getActivity()).exit();
+                    }
+                });
+                return builder.create();
+
+            case DIALOG_DB_ERROR:
+                // Database Check failed to execute successfully; give user the option of either choosing from repair
+                // options, submitting an error report, or closing the activity
+                setCancelable(false);
+                builder.setMessage(R.string.answering_error_message);
+                builder.setTitle(R.string.answering_error_title);
+                builder.setIcon(R.drawable.ic_dialog_alert);
+                builder.setPositiveButton(res.getString(R.string.error_handling_options),
+                        new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialog, int which) {
+                                ((DatabaseErrorDialogListener) getActivity())
+                                        .showDatabaseErrorDialog(DIALOG_ERROR_HANDLING);
+                            }
+                        });
+                builder.setNeutralButton(res.getString(R.string.answering_error_report),
+                        new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialog, int which) {
+                                ((DatabaseErrorDialogListener) getActivity()).sendErrorReport();
+                                dismissAllDialogFragments();
+                            }
+                        });
+                builder.setNegativeButton(res.getString(R.string.close), new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        ((DatabaseErrorDialogListener) getActivity()).exit();
+                    }
+                });
+                StyledDialog d = builder.create();
+                // Disable the error report button if there are already unsent error reports
+                d.getButton(DialogInterface.BUTTON_NEUTRAL).setEnabled(
+                        ((DatabaseErrorDialogListener) getActivity()).hasErrorFiles());
+                return d;
+
+            case DIALOG_ERROR_HANDLING:
+                // The user has asked to see repair options; allow them to choose one of the repair options or go back
+                // to the previous dialog
+                builder.setTitle(res.getString(R.string.error_handling_title));
+                builder.setIcon(R.drawable.ic_dialog_alert);
+                builder.setSingleChoiceItems(new String[] { "1" }, 0, null);
+                builder.setNegativeButton(res.getString(R.string.dialog_cancel), null);
+
+                StyledDialog dialog = builder.create();
+                ArrayList<String> options = new ArrayList<String>();
+                ArrayList<Integer> values = new ArrayList<Integer>();
+                if (AnkiDroidApp.getCol() == null) {
+                    // retry
+                    options.add(res.getString(R.string.backup_retry_opening));
+                    values.add(0);
+                } else {
+                    // fix integrity
+                    options.add(res.getString(R.string.check_db));
+                    values.add(1);
+                }
+                // repair db with sqlite
+                options.add(res.getString(R.string.backup_error_menu_repair));
+                values.add(2);
+                // // restore from backup
+                options.add(res.getString(R.string.backup_restore));
+                values.add(3);
+                // delete old collection and build new one
+                options.add(res.getString(R.string.backup_full_sync_from_server));
+                values.add(4);
+                // delete old collection and build new one
+                options.add(res.getString(R.string.backup_del_collection));
+                values.add(5);
+
+                String[] titles = new String[options.size()];
+                mRepairValues = new int[options.size()];
+                for (int i = 0; i < options.size(); i++) {
+                    titles[i] = options.get(i);
+                    mRepairValues[i] = values.get(i);
+                }
+                dialog.setItems(titles, new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        switch (mRepairValues[which]) {
+                            case 0:
+                                ((DatabaseErrorDialogListener) getActivity()).startLoadingCollection();
+                                return;
+                            case 1:
+                                ((DatabaseErrorDialogListener) getActivity())
+                                        .showDatabaseErrorDialog(DIALOG_CONFIRM_DATABASE_CHECK);
+                                return;
+                            case 2:
+                                ((DatabaseErrorDialogListener) getActivity())
+                                        .showDatabaseErrorDialog(DIALOG_REPAIR_COLLECTION);
+                                return;
+                            case 3:
+                                ((DatabaseErrorDialogListener) getActivity())
+                                        .showDatabaseErrorDialog(DIALOG_RESTORE_BACKUP);
+                                return;
+                            case 4:
+                                ((DatabaseErrorDialogListener) getActivity())
+                                        .showDatabaseErrorDialog(DIALOG_FULL_SYNC_FROM_SERVER);
+                                return;
+                            case 5:
+                                ((DatabaseErrorDialogListener) getActivity())
+                                        .showDatabaseErrorDialog(DIALOG_NEW_COLLECTION);
+                                return;
+                        }
+                    }
+                });
+                return dialog;
+
+            case DIALOG_REPAIR_COLLECTION:
+                // Allow user to run BackupManager.repairDeck()
+                builder.setTitle(res.getString(R.string.backup_repair_deck));
+                builder.setMessage(res.getString(R.string.repair_deck_dialog, BackupManager.BROKEN_DECKS_SUFFIX));
+                builder.setIcon(R.drawable.ic_dialog_alert);
+                builder.setPositiveButton(res.getString(R.string.dialog_positive_repair),
+                        new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialog, int which) {
+                                ((DatabaseErrorDialogListener) getActivity()).repairDeck();
+                                dismissAllDialogFragments();
+                            }
+                        });
+                builder.setNegativeButton(res.getString(R.string.dialog_cancel), null);
+                return builder.create();
+
+            case DIALOG_RESTORE_BACKUP:
+                // Allow user to restore one of the backups
+                File[] files = BackupManager.getBackups(new File(AnkiDroidApp.getCollectionPath()));
+                mBackups = new File[files.length];
+                for (int i = 0; i < files.length; i++) {
+                    mBackups[i] = files[files.length - 1 - i];
+                }
+                if (mBackups.length == 0) {
+                    builder.setTitle(getResources().getString(R.string.backup_restore));
+                    builder.setMessage(res.getString(R.string.backup_restore_no_backups));
+                    builder.setPositiveButton(res.getString(R.string.dialog_ok), new Dialog.OnClickListener() {
+                        @Override
+                        public void onClick(DialogInterface dialog, int which) {
+                            ((DatabaseErrorDialogListener) getActivity())
+                                    .showDatabaseErrorDialog(DIALOG_ERROR_HANDLING);
+                        }
+                    });
+                } else {
+                    String[] dates = new String[mBackups.length];
+                    for (int i = 0; i < mBackups.length; i++) {
+                        dates[i] = mBackups[i].getName().replaceAll(
+                                ".*-(\\d{4}-\\d{2}-\\d{2})-(\\d{2})-(\\d{2}).anki2", "$1 ($2:$3 h)");
+                    }
+                    builder.setTitle(res.getString(R.string.backup_restore_select_title));
+                    builder.setIcon(android.R.drawable.ic_input_get);
+                    builder.setSingleChoiceItems(dates, dates.length, new DialogInterface.OnClickListener() {
+
+                        @Override
+                        public void onClick(DialogInterface dialog, int which) {
+                            if (mBackups[which].length() > 0) {
+                                // restore the backup if it's valid
+                                ((DatabaseErrorDialogListener) getActivity()).restoreFromBackup(mBackups[which]
+                                        .getPath());
+                                dismissAllDialogFragments();
+                            } else {
+                                // otherwise show an error dialog
+                                Dialog invalidFileDialog = new AlertDialog.Builder(getActivity())
+                                        .setTitle(R.string.backup_error).setMessage(R.string.backup_invalid_file_error)
+                                        .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
+                                            @Override
+                                            public void onClick(DialogInterface dialog, int which) {
+                                            }
+                                        }).create();
+                                invalidFileDialog.show();
+                            }
+                        }
+                    });
+                }
+                return builder.create();
+
+            case DIALOG_NEW_COLLECTION:
+                // Allow user to create a new empty collection
+                builder.setTitle(res.getString(R.string.backup_new_collection));
+                builder.setMessage(res.getString(R.string.backup_del_collection_question));
+                builder.setPositiveButton(res.getString(R.string.dialog_positive_create),
+                        new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialog, int which) {
+                                AnkiDroidApp.closeCollection(false);
+                                String path = AnkiDroidApp.getCollectionPath();
+                                AnkiDatabaseManager.closeDatabase(path);
+                                if (BackupManager.moveDatabaseToBrokenFolder(path, false)) {
+                                    ((DatabaseErrorDialogListener) getActivity()).startLoadingCollection();
+                                } else {
+                                    ((DatabaseErrorDialogListener) getActivity())
+                                            .showDatabaseErrorDialog(DIALOG_ERROR_HANDLING);
+                                }
+                            }
+                        });
+                builder.setNegativeButton(res.getString(R.string.dialog_cancel), null);
+                return builder.create();
+
+            case DIALOG_CONFIRM_DATABASE_CHECK:
+                // Confirmation dialog for database check
+                builder.setTitle(res.getString(R.string.check_db_title));
+                builder.setMessage(res.getString(R.string.check_db_warning));
+                builder.setPositiveButton(res.getString(R.string.dialog_ok), new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        ((DatabaseErrorDialogListener) getActivity()).integrityCheck();
+                        dismissAllDialogFragments();
+                    }
+                });
+                builder.setNegativeButton(res.getString(R.string.dialog_cancel), null);
+                return builder.create();
+
+            case DIALOG_CONFIRM_RESTORE_BACKUP:
+                // Confirmation dialog for backup restore
+                builder.setTitle(res.getString(R.string.restore_backup_title));
+                builder.setMessage(res.getString(R.string.restore_backup));
+                builder.setPositiveButton(res.getString(R.string.dialog_continue),
+                        new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialog, int which) {
+                                ((DatabaseErrorDialogListener) getActivity())
+                                        .showDatabaseErrorDialog(DIALOG_RESTORE_BACKUP);
+                            }
+                        });
+                builder.setNegativeButton(res.getString(R.string.dialog_cancel), null);
+                return builder.create();
+
+            case DIALOG_FULL_SYNC_FROM_SERVER:
+                // Allow user to do a full-sync from the server
+                builder.setTitle(res.getString(R.string.backup_full_sync_from_server));
+                builder.setMessage(res.getString(R.string.backup_full_sync_from_server_question));
+                builder.setPositiveButton(res.getString(R.string.dialog_positive_overwrite),
+                        new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialog, int which) {                                
+                                DatabaseErrorDialogListener activity = (DatabaseErrorDialogListener) getActivity();
+                                activity.sync("download", activity.getSyncMediaUsn());
+                                dismissAllDialogFragments();
+                            }
+                        });
+                builder.setNegativeButton(res.getString(R.string.dialog_cancel), null);
+                return builder.create();
+
+            default:
+                return null;
+        }
+    }
+
+
+    public void dismissAllDialogFragments() {
+        ((DatabaseErrorDialogListener) getActivity()).dismissAllDialogFragments();
+    }
+}

--- a/src/com/ichi2/anki/dialogs/DeckPickerBackupNoSpaceLeftDialog.java
+++ b/src/com/ichi2/anki/dialogs/DeckPickerBackupNoSpaceLeftDialog.java
@@ -1,0 +1,42 @@
+package com.ichi2.anki.dialogs;
+
+import android.content.DialogInterface;
+import android.content.DialogInterface.OnCancelListener;
+import android.content.res.Resources;
+import android.os.Bundle;
+import android.support.v4.app.DialogFragment;
+
+import com.ichi2.anki.BackupManager;
+import com.ichi2.anki.DeckPicker;
+import com.ichi2.anki.R;
+import com.ichi2.themes.StyledDialog;
+
+public class DeckPickerBackupNoSpaceLeftDialog extends DialogFragment {
+    public static DeckPickerBackupNoSpaceLeftDialog newInstance() {
+        DeckPickerBackupNoSpaceLeftDialog f = new DeckPickerBackupNoSpaceLeftDialog();
+        return f;        
+    }
+    
+    @Override
+    public StyledDialog onCreateDialog(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        StyledDialog.Builder builder = new StyledDialog.Builder(getActivity());
+        Resources res = getResources();
+        builder.setTitle(res.getString(R.string.sd_card_almost_full_title));
+        builder.setMessage(res.getString(R.string.sd_space_warning, BackupManager.MIN_FREE_SPACE));
+        builder.setPositiveButton(res.getString(R.string.dialog_ok), new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                ((DeckPicker)getActivity()).finishWithoutAnimation();
+            }
+        });
+        builder.setCancelable(true);
+        builder.setOnCancelListener(new OnCancelListener() {
+            @Override
+            public void onCancel(DialogInterface arg0) {
+                ((DeckPicker)getActivity()).finishWithoutAnimation();
+            }
+        });
+        return builder.create();
+    }
+}

--- a/src/com/ichi2/anki/dialogs/DeckPickerConfirmDeleteDeckDialog.java
+++ b/src/com/ichi2/anki/dialogs/DeckPickerConfirmDeleteDeckDialog.java
@@ -1,0 +1,49 @@
+
+package com.ichi2.anki.dialogs;
+
+import android.content.DialogInterface;
+import android.content.res.Resources;
+import android.os.Bundle;
+import android.support.v4.app.DialogFragment;
+
+import com.ichi2.anki.DeckPicker;
+import com.ichi2.anki.R;
+import com.ichi2.themes.StyledDialog;
+
+public class DeckPickerConfirmDeleteDeckDialog extends DialogFragment {
+    public static DeckPickerConfirmDeleteDeckDialog newInstance(String dialogMessage) {
+        DeckPickerConfirmDeleteDeckDialog f = new DeckPickerConfirmDeleteDeckDialog();
+        Bundle args = new Bundle();
+        args.putString("dialogMessage", dialogMessage);
+        f.setArguments(args);
+        return f;
+    }
+
+
+    @Override
+    public StyledDialog onCreateDialog(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        StyledDialog.Builder builder = new StyledDialog.Builder(getActivity());
+        Resources res = getResources();
+        builder.setTitle(res.getString(R.string.delete_deck_title));
+        builder.setMessage(getArguments().getString("dialogMessage"));
+        builder.setIcon(R.drawable.ic_dialog_alert);
+        builder.setPositiveButton(res.getString(R.string.dialog_positive_delete), new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        ((DeckPicker) getActivity()).deleteContextMenuDeck();
+                        ((DeckPicker) getActivity()).dismissAllDialogFragments();
+                    }
+                });
+        builder.setNegativeButton(res.getString(R.string.dialog_cancel), new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                ((DeckPicker) getActivity()).dismissAllDialogFragments();
+            }
+        });
+        
+        setCancelable(true);
+        return builder.create();
+
+    }
+}

--- a/src/com/ichi2/anki/dialogs/DeckPickerContextMenu.java
+++ b/src/com/ichi2/anki/dialogs/DeckPickerContextMenu.java
@@ -1,0 +1,82 @@
+
+package com.ichi2.anki.dialogs;
+
+import android.content.DialogInterface;
+import android.content.res.Resources;
+import android.os.Bundle;
+import android.support.v4.app.DialogFragment;
+
+import com.ichi2.anki.DeckPicker;
+import com.ichi2.anki.R;
+import com.ichi2.themes.StyledDialog;
+
+public class DeckPickerContextMenu extends DialogFragment {
+    /**
+     * Context Menus
+     */
+    private static final int CONTEXT_MENU_COLLAPSE_DECK = 0;
+    private static final int CONTEXT_MENU_RENAME_DECK = 1;
+    private static final int CONTEXT_MENU_DECK_OPTIONS = 2;
+    private static final int CONTEXT_MENU_DELETE_DECK = 3;
+
+
+    public static DeckPickerContextMenu newInstance(String dialogTitle, boolean isCollapsed) {
+        DeckPickerContextMenu f = new DeckPickerContextMenu();
+        Bundle args = new Bundle();
+        args.putString("dialogTitle", dialogTitle);
+        args.putBoolean("isCollapsed", isCollapsed);
+        f.setArguments(args);
+        return f;
+    }
+
+
+    @Override
+    public StyledDialog onCreateDialog(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        StyledDialog.Builder builder = new StyledDialog.Builder(getActivity());
+        String[] entries = new String[4];
+        Resources res = getResources();
+        entries[CONTEXT_MENU_COLLAPSE_DECK] = res.getString(R.string.contextmenu_deckpicker_collapse_deck);
+        entries[CONTEXT_MENU_RENAME_DECK] = res.getString(R.string.contextmenu_deckpicker_rename_deck);
+        entries[CONTEXT_MENU_DECK_OPTIONS] = res.getString(R.string.study_options);
+        entries[CONTEXT_MENU_DELETE_DECK] = res.getString(R.string.contextmenu_deckpicker_delete_deck);
+        builder.setTitle("Context Menu");
+        builder.setIcon(R.drawable.ic_menu_manage);
+        builder.setItems(entries, mContextMenuListener);
+        builder.setTitle(getArguments().getString("dialogTitle"));
+        StyledDialog dialog = builder.create();
+        // Toggle the collapse / inflate deck item based on actual collapsed state
+        dialog.changeListItem(
+                CONTEXT_MENU_COLLAPSE_DECK,
+                getResources().getString(
+                        getArguments().getBoolean("isCollapsed") ? R.string.contextmenu_deckpicker_inflate_deck
+                                : R.string.contextmenu_deckpicker_collapse_deck));
+
+        setCancelable(true);
+        return dialog;
+    }
+
+    // Handle item selection on context menu which is shown when the user long-clicks on a deck
+    private DialogInterface.OnClickListener mContextMenuListener = new DialogInterface.OnClickListener() {
+        @Override
+        public void onClick(DialogInterface dialog, int item) {
+            switch (item) {
+                case CONTEXT_MENU_COLLAPSE_DECK:
+                    ((DeckPicker) getActivity()).collapseContextMenuDeck();
+                    return;
+                case CONTEXT_MENU_DELETE_DECK:
+                    ((DeckPicker) getActivity()).confirmDeckDeletion();
+                    return;
+
+                case CONTEXT_MENU_DECK_OPTIONS:
+                    ((DeckPicker) getActivity()).showContextMenuDeckOptions();
+                    return;
+
+                case CONTEXT_MENU_RENAME_DECK:
+                    ((DeckPicker) getActivity()).renameContextMenuDeckDialog();
+
+            }
+        }
+    };
+
+}

--- a/src/com/ichi2/anki/dialogs/DeckPickerDatabaseCheckResultDialog.java
+++ b/src/com/ichi2/anki/dialogs/DeckPickerDatabaseCheckResultDialog.java
@@ -1,0 +1,40 @@
+
+package com.ichi2.anki.dialogs;
+
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.v4.app.DialogFragment;
+
+import com.ichi2.anim.ActivityTransitionAnimation;
+import com.ichi2.anki.DeckPicker;
+import com.ichi2.anki.R;
+import com.ichi2.themes.StyledDialog;
+
+public class DeckPickerDatabaseCheckResultDialog extends DialogFragment {
+    public static DeckPickerDatabaseCheckResultDialog newInstance(String dialogMessage) {
+        DeckPickerDatabaseCheckResultDialog f = new DeckPickerDatabaseCheckResultDialog();
+        Bundle args = new Bundle();
+        args.putString("dialogMessage", dialogMessage);
+        f.setArguments(args);
+        return f;
+    }
+
+
+    @Override
+    public StyledDialog onCreateDialog(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        StyledDialog.Builder builder = new StyledDialog.Builder(getActivity());
+        builder.setPositiveButton(R.string.dialog_ok, new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                Intent deckPicker = new Intent(getActivity(), DeckPicker.class);
+                deckPicker.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
+                ((DeckPicker) getActivity()).startActivityWithAnimation(deckPicker, ActivityTransitionAnimation.LEFT);                
+            }
+        });
+        builder.setMessage(getArguments().getString("dialogMessage"));
+        setCancelable(true);
+        return builder.create();
+    }
+}

--- a/src/com/ichi2/anki/dialogs/DeckPickerNoSpaceLeftDialog.java
+++ b/src/com/ichi2/anki/dialogs/DeckPickerNoSpaceLeftDialog.java
@@ -1,0 +1,41 @@
+package com.ichi2.anki.dialogs;
+
+import android.content.DialogInterface;
+import android.content.DialogInterface.OnCancelListener;
+import android.content.res.Resources;
+import android.os.Bundle;
+import android.support.v4.app.DialogFragment;
+
+import com.ichi2.anki.DeckPicker;
+import com.ichi2.anki.R;
+import com.ichi2.themes.StyledDialog;
+
+public class DeckPickerNoSpaceLeftDialog extends DialogFragment {
+    public static DeckPickerNoSpaceLeftDialog newInstance() {
+        DeckPickerNoSpaceLeftDialog f = new DeckPickerNoSpaceLeftDialog();
+        return f;
+    }
+    
+    @Override
+    public StyledDialog onCreateDialog(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        StyledDialog.Builder builder = new StyledDialog.Builder(getActivity());
+        Resources res = getResources();
+        builder.setTitle(res.getString(R.string.sd_card_full_title));
+        builder.setMessage(res.getString(R.string.backup_deck_no_space_left));
+        builder.setPositiveButton(res.getString(R.string.dialog_ok), new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                ((DeckPicker) getActivity()).startLoadingCollection();
+            }
+        });
+        builder.setCancelable(true);
+        builder.setOnCancelListener(new OnCancelListener() {
+            @Override
+            public void onCancel(DialogInterface arg0) {
+                ((DeckPicker) getActivity()).startLoadingCollection();
+            }
+        });
+        return builder.create();
+    }
+}

--- a/src/com/ichi2/anki/dialogs/ImportDialog.java
+++ b/src/com/ichi2/anki/dialogs/ImportDialog.java
@@ -1,0 +1,175 @@
+
+package com.ichi2.anki.dialogs;
+
+import android.content.DialogInterface;
+import android.content.res.Resources;
+import android.os.Bundle;
+import android.support.v4.app.DialogFragment;
+import com.ichi2.anki.AnkiDroidApp;
+import com.ichi2.anki.R;
+import com.ichi2.libanki.Utils;
+import com.ichi2.themes.StyledDialog;
+import com.ichi2.themes.Themes;
+
+import java.io.File;
+import java.util.List;
+
+public class ImportDialog extends DialogFragment {
+    private int mType = 0;
+    
+    public static final int DIALOG_IMPORT_HINT = 0;
+    public static final int DIALOG_IMPORT_SELECT = 1;
+    public static final int DIALOG_IMPORT = 2;
+    public static final int DIALOG_IMPORT_REPLACE_CONFIRM = 3;
+    public static final int DIALOG_IMPORT_LOG = 4;
+
+    public interface ImportDialogListener {
+        public void showImportDialog(int id, String message);
+        
+        public void showImportDialog(int id);
+
+        public void importAdd(String importPath);
+
+        public void importReplace(String importPath);
+        
+        public void dismissAllDialogFragments();
+    }
+
+
+    /**
+     * A set of dialogs which deal with importing a file
+     * 
+     * @param dialogType An integer which specifies which of the sub-dialogs to show
+     * @param dialogMessage An optional string which can be used to show a custom message
+     * or specify import path
+     */
+    public static ImportDialog newInstance(int dialogType, String dialogMessage) {
+        ImportDialog f = new ImportDialog();
+        Bundle args = new Bundle();
+        args.putInt("dialogType", dialogType);
+        args.putString("dialogMessage", dialogMessage);
+        f.setArguments(args);
+        return f;
+    }
+
+
+    @Override
+    public StyledDialog onCreateDialog(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        mType = getArguments().getInt("dialogType");
+        Resources res = getResources();
+        StyledDialog.Builder builder = new StyledDialog.Builder(getActivity());
+        setCancelable(true);
+
+        switch (mType) {
+            case DIALOG_IMPORT_HINT:
+                // Instruct the user that they need to put their APKG files into the AnkiDroid directory
+                builder.setTitle(res.getString(R.string.import_title));
+                builder.setMessage(res.getString(R.string.import_hint, AnkiDroidApp.getCurrentAnkiDroidDirectory()));
+                builder.setPositiveButton(res.getString(R.string.dialog_ok), new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        ((ImportDialogListener) getActivity()).showImportDialog(DIALOG_IMPORT_SELECT);
+                    }
+                });
+                builder.setNegativeButton(res.getString(R.string.dialog_cancel), clearAllDialogsClickListener);
+                return builder.create();
+
+            case DIALOG_IMPORT_SELECT:
+                // Allow user to choose from the list of available APKG files
+                builder.setTitle(res.getString(R.string.import_select_title));
+                StyledDialog dialog = builder.create();
+                List<File> fileList = Utils.getImportableDecks();
+                if (fileList.size() == 0) {
+                    Themes.showThemedToast(getActivity(),
+                            getResources().getString(R.string.upgrade_import_no_file_found), false);
+                }
+                dialog.setEnabled(fileList.size() != 0);
+                // Make arrays for the filenames and the full absolute paths of all importable APKGs
+                String[] tts = new String[fileList.size()];
+                final String[] importValues = new String[fileList.size()];
+                for (int i = 0; i < tts.length; i++) {
+                    tts[i] = fileList.get(i).getName().replace(".apkg", "");
+                    importValues[i] = fileList.get(i).getAbsolutePath();
+                }
+                dialog.setItems(tts, new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        String importPath = importValues[which];
+                        // If the apkg file is called "collection.apkg", we assume the collection will be replaced
+                        if (importPath.split("/")[importPath.split("/").length - 1].equals("collection.apkg")) {
+                            ((ImportDialogListener) getActivity()).importReplace(importPath);
+                            dismissAllDialogFragments();
+                            // Otherwise we ask the user to choose
+                        } else {
+                            ((ImportDialogListener) getActivity()).showImportDialog(DIALOG_IMPORT, importPath);
+                        }
+                    }
+                });
+                return dialog;
+
+            case DIALOG_IMPORT:
+                // Ask the user whether they want to perform add or replace operation with imported file
+                builder.setTitle(res.getString(R.string.import_title));
+                builder.setMessage(res.getString(R.string.import_message, getArguments().getString("dialogMessage")));
+                builder.setPositiveButton(res.getString(R.string.import_message_add),
+                        new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialog, int which) {
+                                ((ImportDialogListener) getActivity()).importAdd(getArguments().getString("dialogMessage"));
+                                dismissAllDialogFragments();
+                            }
+                        });
+                builder.setNeutralButton(res.getString(R.string.import_message_replace),
+                        new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialog, int which) {
+                                ((ImportDialogListener) getActivity()).showImportDialog(DIALOG_IMPORT_REPLACE_CONFIRM);
+                            }
+                        });
+                builder.setNegativeButton(res.getString(R.string.dialog_cancel), clearAllDialogsClickListener);
+                builder.setCancelable(true);
+                return builder.create();
+                
+            case DIALOG_IMPORT_REPLACE_CONFIRM:
+                builder.setTitle(res.getString(R.string.import_title));
+                builder.setMessage(res.getString(R.string.import_message_replace_confirm, getArguments().getString("dialogMessage")));
+                builder.setPositiveButton(res.getString(R.string.dialog_positive_replace),
+                        new DialogInterface.OnClickListener() {
+
+                            @Override
+                            public void onClick(DialogInterface dialog, int which) {
+                                ((ImportDialogListener) getActivity()).importReplace(getArguments().getString("dialogMessage"));
+                                dismissAllDialogFragments();
+                            }
+
+                        });
+                builder.setNegativeButton(res.getString(R.string.dialog_cancel), null);
+                return builder.create();                
+                
+            case DIALOG_IMPORT_LOG:
+                // Show log from import process
+                builder.setIcon(R.drawable.ic_dialog_alert);
+                builder.setTitle(res.getString(R.string.import_title));
+                builder.setPositiveButton(res.getString(R.string.dialog_ok), null);
+                builder.setMessage(getArguments().getString("dialogMessage"));
+                return builder.create();
+
+            default:
+                return null;
+        }
+    }
+    
+    // Listener for cancel button which clears ALL previous dialogs on the back stack
+    // Supply null instead of this listener in cases where we prefer to go back to last dialog
+    private DialogInterface.OnClickListener clearAllDialogsClickListener = new DialogInterface.OnClickListener() {
+        @Override
+        public void onClick(DialogInterface dialog, int which) {
+            dismissAllDialogFragments();
+        }
+    };
+    
+    public void dismissAllDialogFragments() {
+        ((ImportDialogListener) getActivity()).dismissAllDialogFragments();        
+    }
+}

--- a/src/com/ichi2/anki/dialogs/SyncErrorDialog.java
+++ b/src/com/ichi2/anki/dialogs/SyncErrorDialog.java
@@ -1,0 +1,253 @@
+
+package com.ichi2.anki.dialogs;
+
+import android.app.Dialog;
+import android.content.DialogInterface;
+import android.content.res.Resources;
+import android.os.Bundle;
+import android.support.v4.app.DialogFragment;
+
+import com.ichi2.anki.R;
+import com.ichi2.libanki.Collection;
+import com.ichi2.themes.StyledDialog;
+
+public class SyncErrorDialog extends DialogFragment {
+    private int mType = 0;
+
+    public static final int DIALOG_USER_NOT_LOGGED_IN_SYNC = 0;
+    public static final int DIALOG_CONNECTION_ERROR = 1;
+    public static final int DIALOG_SYNC_CONFLICT_RESOLUTION = 2;
+    public static final int DIALOG_SYNC_CONFLICT_CONFIRM_KEEP_LOCAL = 3;
+    public static final int DIALOG_SYNC_CONFLICT_CONFIRM_KEEP_REMOTE = 4;
+    public static final int DIALOG_NO_CONNECTION = 5;
+    public static final int DIALOG_SYNC_SANITY_ERROR = 6;
+    public static final int DIALOG_SYNC_SANITY_ERROR_CONFIRM_KEEP_LOCAL = 7;
+    public static final int DIALOG_SYNC_SANITY_ERROR_CONFIRM_KEEP_REMOTE = 8;
+    public static final int DIALOG_SYNC_LOG = 9;
+
+    public interface SyncErrorDialogListener {
+        public void showSyncErrorDialog(int dialogType);
+
+
+        public void showSyncErrorDialog(int dialogType, String message);
+
+
+        public void loginToSyncServer();
+
+
+        public void sync();
+
+
+        public void sync(String conflict, int syncMediaUsn);
+
+
+        public int getSyncMediaUsn();
+
+
+        public Collection getCol();
+
+
+        public void dismissAllDialogFragments();
+    }
+
+
+    /**
+     * A set of dialogs belonging to AnkiActivity which deal with sync problems
+     * 
+     * @param dialogType An integer which specifies which of the sub-dialogs to show
+     * @param dialogMessage A string which can be optionally used to set the dialog message
+     */
+    public static SyncErrorDialog newInstance(int dialogType, String dialogMessage) {
+        SyncErrorDialog f = new SyncErrorDialog();
+        Bundle args = new Bundle();
+        args.putInt("dialogType", dialogType);
+        args.putString("dialogMessage", dialogMessage);
+        f.setArguments(args);
+        return f;
+    }
+
+
+    @Override
+    public StyledDialog onCreateDialog(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        mType = getArguments().getInt("dialogType");
+        Resources res = getResources();
+        StyledDialog.Builder builder = new StyledDialog.Builder(getActivity());
+        setCancelable(true);
+
+        switch (mType) {
+            case DIALOG_USER_NOT_LOGGED_IN_SYNC:
+                // User not logged in; take them to login screen
+                builder.setTitle(res.getString(R.string.not_logged_in_title));
+                builder.setIcon(R.drawable.ic_dialog_alert);
+                builder.setMessage(res.getString(R.string.login_create_account_message));
+                builder.setNegativeButton(res.getString(R.string.dialog_cancel), null);
+                builder.setPositiveButton(res.getString(R.string.log_in), new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        ((SyncErrorDialogListener) getActivity()).loginToSyncServer();
+                    }
+                });
+                return builder.create();
+
+            case DIALOG_CONNECTION_ERROR:
+                // Connection error; allow user to retry or cancel
+                builder.setIcon(R.drawable.ic_dialog_alert);
+                builder.setMessage(res.getString(R.string.connection_error_message));
+                builder.setPositiveButton(res.getString(R.string.retry), new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        ((SyncErrorDialogListener) getActivity()).sync();
+                        dismissAllDialogFragments();
+                    }
+                });
+                builder.setNegativeButton(res.getString(R.string.dialog_cancel), clearAllDialogsClickListener);
+                return builder.create();
+
+            case DIALOG_SYNC_CONFLICT_RESOLUTION:
+                // Sync conflict; allow user to cancel, or choose between local and remote versions
+                builder.setTitle(res.getString(R.string.sync_conflict_title));
+                builder.setIcon(android.R.drawable.ic_input_get);
+                builder.setMessage(res.getString(R.string.sync_conflict_message));
+                builder.setPositiveButton(res.getString(R.string.sync_conflict_local),
+                        new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialog, int which) {
+                                ((SyncErrorDialogListener) getActivity())
+                                        .showSyncErrorDialog(DIALOG_SYNC_CONFLICT_CONFIRM_KEEP_LOCAL);
+                            }
+                        });
+                builder.setNeutralButton(res.getString(R.string.sync_conflict_remote),
+                        new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialog, int which) {
+                                ((SyncErrorDialogListener) getActivity())
+                                        .showSyncErrorDialog(DIALOG_SYNC_CONFLICT_CONFIRM_KEEP_REMOTE);
+                            }
+                        });
+                builder.setNegativeButton(res.getString(R.string.dialog_cancel), clearAllDialogsClickListener);
+                builder.setCancelable(true);
+                return builder.create();
+
+            case DIALOG_SYNC_CONFLICT_CONFIRM_KEEP_LOCAL:
+                // Confirmation before pushing local collection to server after sync conflict
+                builder.setPositiveButton(res.getString(R.string.dialog_positive_overwrite),
+                        new Dialog.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialog, int which) {
+                                SyncErrorDialogListener activity = (SyncErrorDialogListener) getActivity();
+                                activity.sync("upload", activity.getSyncMediaUsn());
+                                dismissAllDialogFragments();
+                            }
+                        });
+                builder.setNegativeButton(res.getString(R.string.dialog_cancel), null);
+                builder.setMessage(res.getString(R.string.sync_conflict_local_confirm));
+                return builder.create();
+
+            case DIALOG_SYNC_CONFLICT_CONFIRM_KEEP_REMOTE:
+                // Confirmation before overwriting local collection with server collection after sync conflict
+                builder.setPositiveButton(res.getString(R.string.dialog_positive_overwrite),
+                        new Dialog.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialog, int which) {
+                                SyncErrorDialogListener activity = (SyncErrorDialogListener) getActivity();
+                                activity.sync("download", activity.getSyncMediaUsn());
+                                dismissAllDialogFragments();
+                            }
+                        });
+                builder.setNegativeButton(res.getString(R.string.dialog_cancel), null);
+                builder.setMessage(res.getString(R.string.sync_conflict_remote_confirm));
+                return builder.create();
+
+            case DIALOG_NO_CONNECTION:
+                // No sync connection -- cancel sync
+                builder.setIcon(R.drawable.ic_dialog_alert);
+                builder.setMessage(res.getString(R.string.youre_offline));
+                builder.setPositiveButton(res.getString(R.string.dialog_ok), null);
+                return builder.create();
+
+            case DIALOG_SYNC_SANITY_ERROR:
+                // Sync sanity check error; allow user to cancel, or choose between local and remote versions
+                builder.setMessage(getArguments().getString("dialogMessage"));
+                builder.setPositiveButton(getString(R.string.sync_sanity_local), new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        ((SyncErrorDialogListener) getActivity())
+                                .showSyncErrorDialog(DIALOG_SYNC_SANITY_ERROR_CONFIRM_KEEP_LOCAL);
+                    }
+                });
+                builder.setNeutralButton(getString(R.string.sync_sanity_remote), new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        ((SyncErrorDialogListener) getActivity())
+                                .showSyncErrorDialog(DIALOG_SYNC_SANITY_ERROR_CONFIRM_KEEP_REMOTE);
+                    }
+                });
+                builder.setNegativeButton(res.getString(R.string.dialog_cancel), null);
+                return builder.create();
+
+            case DIALOG_SYNC_SANITY_ERROR_CONFIRM_KEEP_LOCAL:
+                // Confirmation before pushing local collection to server after sanity check error
+                builder.setPositiveButton(res.getString(R.string.dialog_positive_overwrite),
+                        new Dialog.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialog, int which) {
+                                SyncErrorDialogListener activity = (SyncErrorDialogListener) getActivity();
+                                Collection col = activity.getCol();
+                                if (col != null) {
+                                    col.modSchema(true);
+                                    col.setMod();
+                                    activity.sync("upload", 0);
+                                    dismissAllDialogFragments();
+                                }
+                            }
+                        });
+                builder.setNegativeButton(res.getString(R.string.dialog_cancel), null);
+                builder.setMessage(res.getString(R.string.sync_conflict_local_confirm));
+                return builder.create();
+
+            case DIALOG_SYNC_SANITY_ERROR_CONFIRM_KEEP_REMOTE:
+                // Confirmation before overwriting local collection with server collection after sanity check error
+                builder.setPositiveButton(res.getString(R.string.dialog_positive_overwrite),
+                        new Dialog.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialog, int which) {
+                                SyncErrorDialogListener activity = (SyncErrorDialogListener) getActivity();
+                                Collection col = activity.getCol();
+                                if (col != null) {
+                                    col.modSchema(true);
+                                    col.setMod();
+                                    activity.sync("download", 0);
+                                    dismissAllDialogFragments();
+                                }
+                            }
+                        });
+                builder.setNegativeButton(res.getString(R.string.dialog_cancel), null);
+                builder.setMessage(res.getString(R.string.sync_conflict_remote_confirm));
+                return builder.create();
+
+            case DIALOG_SYNC_LOG:
+                // Show log file
+                builder.setMessage(getArguments().getString("dialogMessage"));
+                builder.setPositiveButton(res.getString(R.string.dialog_ok), clearAllDialogsClickListener);
+                return builder.create();
+
+            default:
+                return null;
+        }
+    }
+
+    // Listener for cancel button which clears ALL previous dialogs on the back stack
+    // Supply null instead of this listener in cases where we prefer to go back to last dialog
+    private DialogInterface.OnClickListener clearAllDialogsClickListener = new DialogInterface.OnClickListener() {
+        @Override
+        public void onClick(DialogInterface dialog, int which) {
+            dismissAllDialogFragments();
+        }
+    };
+
+
+    public void dismissAllDialogFragments() {
+        ((SyncErrorDialogListener) getActivity()).dismissAllDialogFragments();
+    }
+}

--- a/src/com/ichi2/async/CollectionLoader.java
+++ b/src/com/ichi2/async/CollectionLoader.java
@@ -56,7 +56,7 @@ public class CollectionLoader extends AsyncTaskLoader<Collection> {
                 return;
             }
         }
-        // Loader is running so dismiss progress dialog and forward data to listener
+        // Loader is running so forward data to listener
         if (isStarted()) {
             super.deliverResult(col);
         }
@@ -93,7 +93,7 @@ public class CollectionLoader extends AsyncTaskLoader<Collection> {
         if (sActivity != null && sActivity.get() != null) {
             sActivity.get().runOnUiThread(new Runnable() {
                 public void run() {
-                    sActivity.get().setProgressMessage(message);
+                    sActivity.get().setOpeningCollectionDialogMessage(message);
                 }
             });
         }


### PR DESCRIPTION
PR#458 was incomplete as I had forgotten to get the error dialogs working for when there is an error loading the collection. I was planning on refactoring all of this code into `AnkiActivity`, which required us to refactor all the dialogs (something we've been wanting to do for a long time), but in the end I abandoned this because it would lead to an unclean inheritance structure, where we have to implement `onActivityResult()` in both `AnkiActivity` and its children.

Finally I came to a compromise where most of the functionality is retained in DeckPicker, but the Dialogs are properly refactored into several `DialogFragment` classes, and when `Activity`s which aren't `DeckPicker` have Collection load failures, they simply kick the user back to the DeckPicker which can deal with errors properly.

This was actually a huge amount of work, much more than I had even expected, but the error dialogs are now working properly when the collection fails to load properly, and I have reduced the number of warning in DeckPicker _signficantly_.

There were some other bugs that I fixed in the process, for example the "Neutral" button in `StyledDialog` for Android 4.x was on the right, whereas it's supposed to be in the middle.
