### PR TITLE
Clear focus on SearchView on submitting search

### DIFF
--- a/src/com/ichi2/anki/CardBrowser.java
+++ b/src/com/ichi2/anki/CardBrowser.java
@@ -477,6 +477,7 @@ public class CardBrowser extends NavigationDrawerActivity implements ActionBar.O
             @Override
             public boolean onQueryTextSubmit(String query) {
                 onSearch();
+                mSearchView.clearFocus();
                 return true;
             }
         });


### PR DESCRIPTION
Fix [issue 2263](https://code.google.com/p/ankidroid/issues/detail?id=2263), reducing the number of back presses to close the browser after a search from 3 to 2 (one to hide the SearchView, another to close the activity)
