### PR TITLE
Separate hide whiteboard and clear whiteboard buttons again

### DIFF
--- a/res/menu/reviewer.xml
+++ b/res/menu/reviewer.xml
@@ -2,22 +2,17 @@
     xmlns:ankidroid="http://schemas.android.com/apk/res-auto" >
 
     <item
-        android:id="@+id/action_whiteboard"
-        android:title="@string/pref_cat_whiteboard"
+        android:id="@+id/action_clear_whiteboard"
+        android:title="@string/clear_whiteboard"
+        android:icon="@drawable/ic_menu_clear_playlist"
+        android:visible="false"
+        ankidroid:showAsAction="always"/>
+    <item
+        android:id="@+id/action_hide_whiteboard"
+        android:title="@string/hide_whiteboard"
         android:icon="@drawable/whiteboard_show"
         android:visible="false"
-        ankidroid:showAsAction="always" >
-        <menu>
-            <group android:id="@+id/whiteboard_group">
-                <item
-                    android:id="@+id/action_hide_whiteboard"
-                    android:title="@string/hide_whiteboard"/>
-                <item
-                    android:id="@+id/action_clear_whiteboard"
-                    android:title="@string/clear_whiteboard" />
-            </group>
-        </menu>
-    </item>
+        ankidroid:showAsAction="always"/>
     <item
         android:id="@+id/action_undo"
         android:enabled="false"


### PR DESCRIPTION
Based on the discussion in #467, I've separated back out the hide whiteboard and clear whiteboard buttons again, which default to both show when the whiteboard is enabled, assuming it will fit without looking horrible. Both icons are hidden when whiteboard is disabled, which is a deck specific setting as per #467.

Small screens on older devices (i.e. with hardware menu button) work fine:
![qvga_2 1](https://cloud.githubusercontent.com/assets/2818274/4129176/e0ccbb04-331a-11e4-8b53-9bd3368a32cd.png)

However narrow screens on newer devices (i.e. with overflow menu) rollback to the 2.2 behavior:
![wvga800_4 1](https://cloud.githubusercontent.com/assets/2818274/4129183/f894166a-331a-11e4-90cb-2a9180a4f1ed.png)

On a Nexus 5 it could look better (unfortunately cuts off the time remaining), but it's not incredibly detrimental since it's only on decks which have the whiteboard enabled, which will only affect a small number of users a small amount of the time:

![nexus5_4 1](https://cloud.githubusercontent.com/assets/2818274/4129515/f9b6bac8-3321-11e4-9345-ca6a4318517a.png)
