### PR TITLE
Check for null logger before trying to close it.

### DIFF
--- a/src/com/ichi2/anki/DeckPicker.java
+++ b/src/com/ichi2/anki/DeckPicker.java
@@ -1542,7 +1542,7 @@ public class DeckPicker extends NavigationDrawerActivity implements StudyOptions
     @Override
     public void importReplace(String importPath) {
         DeckTask.launchDeckTask(DeckTask.TASK_TYPE_IMPORT_REPLACE, mImportReplaceListener, new TaskData(getCol(),
-                mImportPath));
+                importPath));
     }
 
 

--- a/src/com/ichi2/libanki/Collection.java
+++ b/src/com/ichi2/libanki/Collection.java
@@ -1545,8 +1545,10 @@ public class Collection {
 
 
     private void _closeLog() {
-        mLogHnd.close();
-        mLogHnd = null;
+        if (mLogHnd != null) {
+            mLogHnd.close();
+            mLogHnd = null;
+        }
     }
 
     /**


### PR DESCRIPTION
@timrae 

Should fix bug 2 from [Issue 2271](https://code.google.com/p/ankidroid/issues/detail?id=2271). First problem was passing the wrong path from the dialog, second problem was trying to close a logger that we never created.
