### PR TITLE
Issue 1756 - preparation to open shared decks in browser

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -84,13 +84,11 @@
         android:theme="@style/Theme_White"
         android:windowSoftInputMode="adjustResize" >
         <activity
-            android:name="com.ichi2.anki.DeckPicker"
+            android:name="com.ichi2.anki.IntentHandler"
             android:configChanges="keyboardHidden|orientation|screenSize|locale"
-            android:label="@string/app_name"
-            android:theme="@style/Theme_Start" >
+            android:label="@string/app_name" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
                 <category android:name="android.intent.category.MULTIWINDOW_LAUNCHER" />
             </intent-filter>
@@ -129,6 +127,12 @@
                     android:pathPattern=".*\\.apkg"
                     android:scheme="file" />
             </intent-filter>
+        </activity>
+        <activity
+            android:name="com.ichi2.anki.DeckPicker"
+            android:configChanges="keyboardHidden|orientation|screenSize|locale"
+            android:label="@string/app_name"
+            android:theme="@style/Theme_Start" >"
         </activity>
         <activity
             android:name="com.ichi2.anki.StudyOptionsActivity"

--- a/src/com/ichi2/anki/IntentHandler.java
+++ b/src/com/ichi2/anki/IntentHandler.java
@@ -1,0 +1,50 @@
+package com.ichi2.anki;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
+
+/**
+ * Class which handles how the application responds to different intents, forcing it to always be single task,
+ * but allowing custom behavior depending on the intent
+ * 
+ * @author Tim
+ *
+ */
+
+public class IntentHandler extends Activity {
+    @Override 
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        Intent intent = getIntent();
+        Intent reloadIntent = new Intent(this, DeckPicker.class);
+        if (intent.getExtras() != null) {
+            reloadIntent.putExtras(intent.getExtras());
+        }
+        if (intent.getData() != null) {
+            reloadIntent.setData(intent.getData());
+        }
+        String action = intent.getAction();
+        switch (action) {
+            case Intent.ACTION_VIEW:
+                // This intent is used for opening apkg package
+                // We want to go immediately to DeckPicker, clearing any history in the process
+                // TODO: Still one bug, where if AnkiDroid is launched via ACTION_VIEW, 
+                // then subsequent ACTION_VIEW events bypass IntentHandler. Prob need to do something onResume() of AnkiActivity
+                reloadIntent.setAction(action);
+                reloadIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+                startActivity(reloadIntent);
+                finish();
+                break;
+            default :
+                // Launcher intents should start DeckPicker if no other task exists,
+                // otherwise go to previous task
+                reloadIntent.setAction(Intent.ACTION_MAIN);
+                reloadIntent.addCategory(Intent.CATEGORY_LAUNCHER);
+                reloadIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                startActivityIfNeeded(reloadIntent, 0);
+                finish();
+                break;
+        }
+    }  
+}


### PR DESCRIPTION
This is some preparation to get shared decks downloadable by browser.
There's an issue in newer versions of Android where the Android DownloadManager has [apparently stopped providing absolute links to its downloads](http://stackoverflow.com/questions/14364091/retrieve-file-path-from-caught-downloadmanager-intent). Instead it passes a link like "content://downloads/all_downloads/166". So we currently just get a message saying "can't open file".

So until we can resolve this issue, I'll keep the old method enabled, but this is an important step towards eventually getting there.
