### PR TITLE
Don't scan media on every sync and expose media checking to UI

### DIFF
--- a/res/menu/deck_picker.xml
+++ b/res/menu/deck_picker.xml
@@ -42,6 +42,11 @@
         android:menuCategory="secondary"
         android:title="@string/check_db"/>
     <item
+        android:id="@+id/action_check_media"
+        android:enabled="false"
+        android:menuCategory="secondary"
+        android:title="@string/check_media"/>
+    <item
         android:id="@+id/action_restore_backup"
         android:menuCategory="secondary"
         android:title="@string/backup_restore"/>

--- a/res/values/02-strings.xml
+++ b/res/values/02-strings.xml
@@ -122,6 +122,7 @@
     <string name="help_tutorial">Create tutorial deck</string>
     <string name="tutorial_deck_name">Tutorial deck</string>
     <string name="check_db">Check database</string>
+    <string name="check_media">Check media</string>
     <string name="check_db_message">Checking database…</string>
     <string
         name="empty_card_warning"

--- a/res/values/03-dialogs.xml
+++ b/res/values/03-dialogs.xml
@@ -132,9 +132,24 @@
     <string name="card_browser_button_content">Card browser</string>
     <string name="lookup_button_content">Look up</string>
     <string name="statistics_button_content">Statistics</string>
-    
-    
+
+
     <string name="dialog_collection_path_title">Folder does not exit</string>
     <string name="dialog_collection_path_text">The folder you specified does not exist, would you like to create it?</string>
     <string name="dialog_collection_path_not_dir">The path specified was not a valid directory</string>
+
+    <!-- Media checking -->
+    <string name="check_media_title">Check media?</string>
+    <string name="check_media_warning">This may take a long time with large media collections</string>
+    <string name="check_media_message">Checking media…</string>
+    <string name="check_media_acknowledge">Media checked</string>
+    <string name="check_media_failed">Media checked failed</string>
+    <string name="check_media_invalid">Files with invalid encoding: %d</string>
+    <string name="check_media_unused">Files in media folder but not used by any cards: %d</string>
+    <string name="check_media_nohave">Files used on cards but not in media folder: %d</string>
+    <string name="check_media_no_unused_missing">No unused or missing files found.</string>
+    <string name="check_media_db_updated">Media database rebuilt.</string>
+    <string name="check_media_delete_unused">Delete unused</string>
+    <string name="check_media_deleted">Files deleted: %d</string>
+
 </resources>

--- a/res/values/04-network.xml
+++ b/res/values/04-network.xml
@@ -121,6 +121,8 @@
     <string name="sync_media_sanity_check">Checking media counts…</string>
     <string name="sync_media_no_changes">No changes to media files</string>
     <string name="sync_media_success">Media synced</string>
+    <string name="sync_media_changes_count">%d media changes to upload</string>
+    <string name="sync_media_downloaded_count">%d media files downloaded</string>
     <string name="sync_sanity_failed">After syncing, the collection was in an inconsistent state. To fix this problem, AnkiDroid will force a full sync. Choose which side you would like to keep.</string>
     <string name="sync_media_sanity_failed">Media sync completed, but the media count doesn\'t agree with the server. The next media sync will be full to correct any error.</string>
     <string name="sync_media_error">Error syncing media data</string>

--- a/src/com/ichi2/anki/DeckPicker.java
+++ b/src/com/ichi2/anki/DeckPicker.java
@@ -65,6 +65,7 @@ import com.ichi2.anki.dialogs.DeckPickerConfirmDeleteDeckDialog;
 import com.ichi2.anki.dialogs.DeckPickerContextMenu;
 import com.ichi2.anki.dialogs.DeckPickerNoSpaceLeftDialog;
 import com.ichi2.anki.dialogs.ImportDialog;
+import com.ichi2.anki.dialogs.MediaCheckDialog;
 import com.ichi2.anki.dialogs.SyncErrorDialog;
 import com.ichi2.anki.receiver.SdCardReceiver;
 import com.ichi2.anki.stats.AnkiStatsTaskHandler;
@@ -88,12 +89,13 @@ import java.io.File;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.TreeSet;
 
 public class DeckPicker extends NavigationDrawerActivity implements StudyOptionsFragment.OnStudyOptionsReloadListener,
         DatabaseErrorDialog.DatabaseErrorDialogListener, SyncErrorDialog.SyncErrorDialogListener,
-        ImportDialog.ImportDialogListener {
+        ImportDialog.ImportDialogListener, MediaCheckDialog.MediaCheckDialogListener {
 
     public static final int CRAM_DECK_FRAGMENT = -1;
 
@@ -483,6 +485,7 @@ public class DeckPicker extends NavigationDrawerActivity implements StudyOptions
         menu.findItem(R.id.action_new_deck).setEnabled(sdCardAvailable);
         menu.findItem(R.id.action_new_filtered_deck).setEnabled(sdCardAvailable);
         menu.findItem(R.id.action_check_database).setEnabled(sdCardAvailable);
+        menu.findItem(R.id.action_check_media).setEnabled(sdCardAvailable);
         return super.onCreateOptionsMenu(menu);
     }
 
@@ -570,6 +573,10 @@ public class DeckPicker extends NavigationDrawerActivity implements StudyOptions
 
             case R.id.action_check_database:
                 showDatabaseErrorDialog(DatabaseErrorDialog.DIALOG_CONFIRM_DATABASE_CHECK);
+                return true;
+
+            case R.id.action_check_media:
+                showMediaCheckDialog(MediaCheckDialog.DIALOG_CONFIRM_MEDIA_CHECK);
                 return true;
 
             case R.id.action_tutorial:
@@ -1047,8 +1054,21 @@ public class DeckPicker extends NavigationDrawerActivity implements StudyOptions
         showDialogFragment(newFragment);
     }
 
+    @Override
+    public void showMediaCheckDialog(int id) {
+        DialogFragment newFragment = MediaCheckDialog.newInstance(id);
+        showDialogFragment(newFragment);
+    }
 
-    // Show dialogs to deal with database loading issues etc
+
+    @Override
+    public void showMediaCheckDialog(int id, List<List<String>> checkList) {
+        DialogFragment newFragment = MediaCheckDialog.newInstance(id, checkList);
+        showDialogFragment(newFragment);
+    }
+
+
+    // Show dialogs to deal with sync issues etc
     @Override
     public void showSyncErrorDialog(int id) {
         showSyncErrorDialog(id, "");
@@ -1212,6 +1232,51 @@ public class DeckPicker extends NavigationDrawerActivity implements StudyOptions
         }, new DeckTask.TaskData(getCol()));
     }
 
+
+    @Override
+    public void mediaCheck() {
+        DeckTask.launchDeckTask(DeckTask.TASK_TYPE_CHECK_MEDIA, new DeckTask.TaskListener() {
+            @Override
+            public void onPreExecute() {
+                mProgressDialog = StyledProgressDialog.show(DeckPicker.this, "",
+                        getResources().getString(R.string.check_media_message), true);
+            }
+
+
+            @Override
+            public void onPostExecute(TaskData result) {
+                if (mProgressDialog.isShowing()) {
+                    mProgressDialog.dismiss();
+                }
+                if (result.getBoolean()) {
+                    @SuppressWarnings("unchecked")
+                    List<List<String>> checkList = (List<List<String>>) result.getObjArray()[0];
+                    showMediaCheckDialog(MediaCheckDialog.DIALOG_MEDIA_CHECK_RESULTS, checkList);
+                } else {
+                    showLogDialog(getResources().getString(R.string.check_media_failed));
+                }
+            }
+
+
+            @Override
+            public void onProgressUpdate(TaskData... values) {
+            }
+
+
+            @Override
+            public void onCancelled() {
+            }
+        }, new DeckTask.TaskData(getCol()));
+    }
+
+    @Override
+    public void deleteUnused(List<String> unused) {
+        com.ichi2.libanki.Media m = getCol().getMedia();
+        for (String fname : unused) {
+            m.deleteFile(fname);
+        }
+        showLogDialog(String.format(getResources().getString(R.string.check_media_deleted), unused.size()));
+    }
 
     @Override
     public void exit() {
@@ -1389,6 +1454,12 @@ public class DeckPicker extends NavigationDrawerActivity implements StudyOptions
                 if (id != 0) {
                     currentMessage = res.getString(id);
                 }
+                if (values.length >= 3) {
+                    countUp = (Long) values[1];
+                    countDown = (Long) values[2];
+                }
+            } else if (values[0] instanceof String) {
+                currentMessage = (String) values[0];
                 if (values.length >= 3) {
                     countUp = (Long) values[1];
                     countDown = (Long) values[2];

--- a/src/com/ichi2/anki/dialogs/MediaCheckDialog.java
+++ b/src/com/ichi2/anki/dialogs/MediaCheckDialog.java
@@ -1,0 +1,154 @@
+
+package com.ichi2.anki.dialogs;
+
+import android.content.DialogInterface;
+import android.content.res.Resources;
+import android.os.Bundle;
+import android.support.v4.app.DialogFragment;
+
+import com.ichi2.anki.R;
+import com.ichi2.themes.StyledDialog;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MediaCheckDialog extends DialogFragment {
+    private int mType = 0;
+
+    public static final int DIALOG_CONFIRM_MEDIA_CHECK = 0;
+    public static final int DIALOG_MEDIA_CHECK_RESULTS = 1;
+
+    public interface MediaCheckDialogListener {
+        public void showMediaCheckDialog(int dialogType);
+
+
+        public void showMediaCheckDialog(int dialogType, List<List<String>> checkList);
+
+
+        public void mediaCheck();
+
+
+        public void deleteUnused(List<String> unused);
+
+
+        public void dismissAllDialogFragments();
+    }
+
+
+    public static MediaCheckDialog newInstance(int dialogType) {
+        MediaCheckDialog f = new MediaCheckDialog();
+        Bundle args = new Bundle();
+        args.putInt("dialogType", dialogType);
+        f.setArguments(args);
+        return f;
+    }
+
+
+    public static MediaCheckDialog newInstance(int dialogType, List<List<String>> checkList) {
+        MediaCheckDialog f = new MediaCheckDialog();
+        Bundle args = new Bundle();
+        args.putInt("dialogType", dialogType);
+        args.putStringArrayList("nohave", new ArrayList<String>(checkList.get(0)));
+        args.putStringArrayList("unused", new ArrayList<String>(checkList.get(1)));
+        args.putStringArrayList("invalid", new ArrayList<String>(checkList.get(2)));
+        f.setArguments(args);
+        return f;
+    }
+
+
+    @Override
+    public StyledDialog onCreateDialog(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        mType = getArguments().getInt("dialogType");
+        StyledDialog.Builder builder = new StyledDialog.Builder(getActivity());
+        Resources res = getResources();
+
+        switch (mType) {
+            case DIALOG_CONFIRM_MEDIA_CHECK:
+                builder.setTitle(res.getString(R.string.check_media_title));
+                builder.setMessage(res.getString(R.string.check_media_warning));
+                builder.setPositiveButton(res.getString(R.string.dialog_ok), new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        ((MediaCheckDialogListener) getActivity()).mediaCheck();
+                        ((MediaCheckDialogListener) getActivity()).dismissAllDialogFragments();
+                    }
+                });
+                builder.setNegativeButton(res.getString(R.string.dialog_cancel), new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        ((MediaCheckDialogListener) getActivity()).dismissAllDialogFragments();
+                    }
+                });
+                setCancelable(true);
+                return builder.create();
+            case DIALOG_MEDIA_CHECK_RESULTS:
+                builder.setTitle(res.getString(R.string.check_media_acknowledge));
+                final ArrayList<String> nohave = getArguments().getStringArrayList("nohave");
+                final ArrayList<String> unused = getArguments().getStringArrayList("unused");
+                final ArrayList<String> invalid = getArguments().getStringArrayList("invalid");
+                // Generate report
+                String report = "";
+                if (invalid.size() > 0) {
+                    report += String.format(res.getString(R.string.check_media_invalid), invalid.size());
+                }
+                if (unused.size() > 0) {
+                    if (report.length() > 0) {
+                        report += "\n";
+                    }
+                    report += String.format(res.getString(R.string.check_media_unused), unused.size());
+                }
+                if (nohave.size() > 0) {
+                    if (report.length() > 0) {
+                        report += "\n";
+                    }
+                    report += String.format(res.getString(R.string.check_media_nohave), nohave.size());
+                }
+
+                if (report.length() == 0) {
+                    report = res.getString(R.string.check_media_no_unused_missing);
+                }
+
+                // We also prefix the report with a message about the media db being rebuilt, since
+                // we do a full media scan and update the db on each media check on AnkiDroid.
+                report = res.getString(R.string.check_media_db_updated) + "\n\n" + report;
+
+                // If we have unused files, show a dialog with a "delete" button. Otherwise, the user only
+                // needs to acknowledge the results, so show only an OK dialog.
+                if (unused.size() > 0) {
+                    builder.setMessage(report);
+                    builder.setPositiveButton(res.getString(R.string.dialog_ok), new DialogInterface.OnClickListener() {
+                        @Override
+                        public void onClick(DialogInterface dialog, int which) {
+                            ((MediaCheckDialogListener) getActivity()).dismissAllDialogFragments();
+                        }
+                    });
+                    builder.setNegativeButton(res.getString(R.string.check_media_delete_unused),
+                            new DialogInterface.OnClickListener() {
+                                @Override
+                                public void onClick(DialogInterface dialog, int which) {
+                                    ((MediaCheckDialogListener) getActivity()).deleteUnused(unused);
+                                    dismissAllDialogFragments();
+                                }
+                            });
+                } else {
+                    builder.setMessage(report);
+                    builder.setPositiveButton(res.getString(R.string.dialog_ok), new DialogInterface.OnClickListener() {
+                        @Override
+                        public void onClick(DialogInterface dialog, int which) {
+                            ((MediaCheckDialogListener) getActivity()).dismissAllDialogFragments();
+                        }
+                    });
+                }
+                setCancelable(true);
+                return builder.create();
+            default:
+                return null;
+        }
+    }
+
+
+    public void dismissAllDialogFragments() {
+        ((MediaCheckDialogListener) getActivity()).dismissAllDialogFragments();
+    }
+}

--- a/src/com/ichi2/async/Connection.java
+++ b/src/com/ichi2/async/Connection.java
@@ -36,8 +36,8 @@ import com.ichi2.anki.exception.UnsupportedSyncException;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Decks;
 import com.ichi2.libanki.Utils;
-import com.ichi2.libanki.sync.HttpSyncer;
 import com.ichi2.libanki.sync.FullSyncer;
+import com.ichi2.libanki.sync.HttpSyncer;
 import com.ichi2.libanki.sync.MediaSyncer;
 import com.ichi2.libanki.sync.RemoteMediaServer;
 import com.ichi2.libanki.sync.RemoteServer;
@@ -704,10 +704,10 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
         String mediaError = null;
         if (media) {
             server = new RemoteMediaServer(col, hkey, this);
-            MediaSyncer mediaClient = new MediaSyncer(col, (RemoteMediaServer) server);
+            MediaSyncer mediaClient = new MediaSyncer(col, (RemoteMediaServer) server, this);
             String ret;
             try {
-                ret = mediaClient.sync(this);
+                ret = mediaClient.sync();
                 if (ret == null) {
                     mediaError = AnkiDroidApp.getAppResources().getString(R.string.sync_media_error);
                 } else {
@@ -746,6 +746,11 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
 
     public void publishProgress(int id) {
         super.publishProgress(id);
+    }
+
+
+    public void publishProgress(String message) {
+        super.publishProgress(message);
     }
 
 

--- a/src/com/ichi2/async/DeckTask.java
+++ b/src/com/ichi2/async/DeckTask.java
@@ -32,6 +32,7 @@ import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.BackupManager;
 import com.ichi2.anki.CardBrowser;
 import com.ichi2.anki.R;
+import com.ichi2.anki.exception.APIVersionException;
 import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Note;
@@ -108,6 +109,7 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
     public static final int TASK_TYPE_CONF_REMOVE = 35;
     public static final int TASK_TYPE_CONF_SET_SUBDECKS = 36;
     public static final int TASK_TYPE_RENDER_BROWSER_QA = 37;
+    public static final int TASK_TYPE_CHECK_MEDIA = 38;
 
     /**
      * The most recently started {@link DeckTask} instance.
@@ -330,6 +332,9 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
 
             case TASK_TYPE_RENDER_BROWSER_QA:
                 return doInBackgroundRenderBrowserQA(params);
+
+            case TASK_TYPE_CHECK_MEDIA:
+                return doInBackgroundCheckMedia(params);
 
             default:
                 Log.e(AnkiDroidApp.TAG, "unknown task type: " + mType);
@@ -1289,6 +1294,24 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
             return new TaskData(false);
         }
     }
+
+
+    /**
+     * @return The results list from the check, or false if any errors.
+     */
+    private TaskData doInBackgroundCheckMedia(TaskData... params) {
+        Log.i(AnkiDroidApp.TAG, "doInBackgroundCheckMedia");
+        try {
+            // A media check on AnkiDroid will also update the media db
+            AnkiDroidApp.getCol().getMedia().findChanges(true);
+            // Then do the actual check
+            List<List<String>> result = AnkiDroidApp.getCol().getMedia().check();
+            return new TaskData(0, new Object[]{result}, true);
+        } catch (APIVersionException e) {
+            return new TaskData(false);
+        }
+    }
+
 
     /**
      * Listener for the status and result of a {@link DeckTask}.

--- a/src/com/ichi2/libanki/importer/Anki2Importer.java
+++ b/src/com/ichi2/libanki/importer/Anki2Importer.java
@@ -710,6 +710,8 @@ public class Anki2Importer {
     private void _writeDstMedia(String fname, BufferedInputStream is) {
         try {
             Utils.writeToFile(is, mDstMediaDir + fname);
+            // Also mark file addition to media db
+            mDst.getMedia().markFileAdd(fname);
         } catch (IOException e) {
             // the user likely used subdirectories
             Log.e(AnkiDroidApp.TAG, String.format(Locale.US,

--- a/tests/src/com/ichi2/utils/MediaTest.java
+++ b/tests/src/com/ichi2/utils/MediaTest.java
@@ -190,12 +190,12 @@ public class MediaTest extends AndroidTestCase {
         os = new FileOutputStream(path, true);
         os.write("yo".getBytes());
         os.close();
-        d.getMedia().findChanges();
+        d.getMedia().findChanges(true);
         assertTrue(added(d).size() == 2);
         assertTrue(removed(d).size() == 0);
         // deletions should get noticed too
         path.delete();
-        d.getMedia().findChanges();
+        d.getMedia().findChanges(true);
         assertTrue(added(d).size() == 1);
         assertTrue(removed(d).size() == 1);
     }


### PR DESCRIPTION
Two main changes in this commit:
1 - Resolves the issue with really long sync times due to the scan for media changes
2 - Exposes a "check media" option in the menu

The gist of this commit:
The media scan is removed from the sync step (except on the first sync) but can be triggered manually with a media check which is now an option in the menu. Changes to media made through AnkiDroid (e.g., adding image through multimedia editor) are immediately recorded in the media database, so a scan for changes is not necessary unless the media collection is modified externally. In that case, the user will need to do a media check.
