### PR TITLE
Add preview to the long click menu of the browser

### DIFF
--- a/res/values/07-cardbrowser.xml
+++ b/res/values/07-cardbrowser.xml
@@ -46,7 +46,6 @@
     <string name="card_browser_change_display_order_title">Choose display order</string>
     <string name="card_browser_change_display_order_reverse">Select a field twice to reverse</string>
     <string name="card_browser_order_reverse">(reverse)</string>
-    <string name="card_browser_card_details">Card details</string>
     <string name="card_details_question">Question</string>
     <string name="card_details_answer">Answer</string>
     <string name="card_details_due">Due</string>

--- a/src/com/ichi2/anki/CardBrowser.java
+++ b/src/com/ichi2/anki/CardBrowser.java
@@ -207,11 +207,10 @@ public class CardBrowser extends NavigationDrawerActivity implements ActionBar.O
                     return;
 
                 case CONTEXT_MENU_DETAILS:
-                    Card tempCard = getCol().getCard(Long.parseLong(mCards.get(mPositionInCardsList).get("id")));
-                    Themes.htmlOkDialog(
-                            CardBrowser.this,
-                            getResources().getString(R.string.card_browser_card_details),
-                            CardStats.report(CardBrowser.this, tempCard, getCol())).show();
+                    Long cardId = Long.parseLong(mCards.get(mPositionInCardsList).get("id"));
+                    Intent previewer = new Intent(CardBrowser.this, Previewer.class);
+                    previewer.putExtra("currentCardId", cardId);
+                    startActivityWithoutAnimation(previewer);
                     return;
             }
         }
@@ -673,7 +672,7 @@ public class CardBrowser extends NavigationDrawerActivity implements ActionBar.O
                 entries[CONTEXT_MENU_MARK] = res.getString(R.string.card_browser_mark_card);
                 entries[CONTEXT_MENU_SUSPEND] = res.getString(R.string.card_browser_suspend_card);
                 entries[CONTEXT_MENU_DELETE] = res.getString(R.string.card_browser_delete_card);
-                entries[CONTEXT_MENU_DETAILS] = res.getString(R.string.card_browser_card_details);
+                entries[CONTEXT_MENU_DETAILS] = res.getString(R.string.card_editor_preview_card);
                 builder.setTitle("contextmenu");
                 builder.setIcon(R.drawable.ic_menu_manage);
                 builder.setItems(entries, mContextMenuListener);

--- a/src/com/ichi2/anki/CardEditor.java
+++ b/src/com/ichi2/anki/CardEditor.java
@@ -561,6 +561,7 @@ public class CardEditor extends AnkiActivity {
 
     private void openReviewer() {
         Intent reviewer = new Intent(CardEditor.this, Previewer.class);
+        reviewer.putExtra("currentCardId", mCurrentEditedCard.getId());
         startActivityWithoutAnimation(reviewer);
     }
 

--- a/src/com/ichi2/anki/Previewer.java
+++ b/src/com/ichi2/anki/Previewer.java
@@ -25,18 +25,20 @@ import android.view.View;
 import com.ichi2.libanki.Collection;
 
 public class Previewer extends AbstractFlashcardViewer {
+    Long mCurrentCardId;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         Log.i(AnkiDroidApp.TAG, "PreviewClass - onCreate");
+        mCurrentCardId=getIntent().getLongExtra("currentCardId", -1);
     }
 
 
     @Override
     protected void onCollectionLoaded(Collection col) {
         super.onCollectionLoaded(col);
-        mCurrentCard = CardEditor.mCurrentEditedCard;
+        mCurrentCard = col.getCard(mCurrentCardId);
         displayCardQuestion();
     }
 


### PR DESCRIPTION
It was pointed out in [Issue 478](https://code.google.com/p/ankidroid/issues/detail?id=478) that the browser is still showing the old "card details" view, whereas it should be showing the new preview.
