### PR TITLE
Add reset and reschedule options to cards in editor

### DIFF
--- a/res/menu/card_editor.xml
+++ b/res/menu/card_editor.xml
@@ -20,6 +20,10 @@
         android:title="@string/card_editor_reset_card"
         android:visible="false"/>
     <item
+        android:id="@+id/action_reschedule_card"
+        android:title="@string/card_editor_reschedule_card"
+        android:visible="false"/>
+    <item
         android:id="@+id/action_saved_notes"
         android:enabled="false"
         android:title="@string/intent_add_saved_information"/>

--- a/res/values/02-strings.xml
+++ b/res/values/02-strings.xml
@@ -103,6 +103,7 @@
     <string name="card_editor_reset">Reset</string>
     <string name="card_editor_copy_card">Copy card</string>
     <string name="card_editor_reset_card">Reset progress</string>
+    <string name="card_editor_reschedule_card">Reschedule card</string>
     <string name="card_editor_preview_card">Preview</string>
     <string name="error_insufficient_memory">Operation not possible due to insufficient memory on your device</string>
     <string name="tutorial_load">Creating tutorial deck…</string>

--- a/res/values/03-dialogs.xml
+++ b/res/values/03-dialogs.xml
@@ -54,8 +54,11 @@
     <string name="notification_message">A new version of AnkiDroid is available at Google Play.\n\nWould you like to install it?</string>
     <string name="notification_stop">Don\'t notify me of this update again</string>
     <string name="reset_card_dialog_title">Reset card progress</string>
-    <string name="reset_card_dialog_message">All cards of this note will look like new cards.</string>
-    <string name="reset_card_dialog_acknowledge">Cards reset</string>
+    <string name="reset_card_dialog_message">This card will be placed at the end of the new card queue.</string>
+    <string name="reset_card_dialog_acknowledge">Card reset</string>
+    <string name="reschedule_card_dialog_title">Reschedule card</string>
+    <string name="reschedule_card_dialog_message">Reschedule for review in x days:</string>
+    <string name="reschedule_card_dialog_acknowledge">Card rescheduled</string>
     <string name="answering_error_title">Database error</string>
     <string name="answering_error_message">Writing to the collection failed. The databese could be corrupt or there may not to be enough empty space on disk.\n\nIf this happens more often, try checking the database, repairing the collection or restoring it from a backup. Touch \'options\' for that.\n\Or it could be an AnkiDroid bug as well; please report the error so that we can check this.</string>
     <string name="answering_error_report">Report error</string>

--- a/src/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/src/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1273,6 +1273,14 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
             finishNoStorageAvailable();
         }
         if (requestCode == EDIT_CURRENT_CARD) {
+            // If the card was rescheduled, we need to remove it from the top of the queue as it is
+            // no longer positioned there. Use a "fake" answer for this by passing a null card.
+            if (data.hasExtra("rescheduled")) {
+                DeckTask.launchDeckTask(DeckTask.TASK_TYPE_ANSWER_CARD, mAnswerCardHandler, new DeckTask.TaskData(
+                        mSched, null, 0));
+            }
+            // Modification of the note is independent of rescheduling, so we still need to save it if it
+            // happened.
             if (resultCode != RESULT_CANCELED) {
                 Log.i(AnkiDroidApp.TAG, "Saving card...");
                 DeckTask.launchDeckTask(DeckTask.TASK_TYPE_UPDATE_FACT, mUpdateCardHandler, new DeckTask.TaskData(

--- a/src/com/ichi2/libanki/Sched.java
+++ b/src/com/ichi2/libanki/Sched.java
@@ -2201,7 +2201,7 @@ public class Sched {
         }
         remFromDyn(ids);
         mCol.getDb().executeMany(
-                "update cards set type=2,queue=2,ivl=?,due=?,odue=0 " +
+                "update cards set type=2,queue=2,ivl=?,due=?,odue=0, " +
                 "usn=?,mod=?,factor=? where id=?", d);
         mCol.log(ids);
     }


### PR DESCRIPTION
Based on @eginhard's work from https://github.com/ankidroid/Anki-Android/pull/270

This commit allows individual cards to be reset to new or rescheduled from the note editor.
