### PR TITLE
Fix importing of apkg files from external intents and make shared decks download via browser

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -127,6 +127,12 @@
                     android:pathPattern=".*\\.apkg"
                     android:scheme="file" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="application/apkg"/>
+                <data android:mimeType="application/octet-stream"/>
+            </intent-filter>
         </activity>
         <activity
             android:name="com.ichi2.anki.DeckPicker"

--- a/src/com/ichi2/anki/DeckPicker.java
+++ b/src/com/ichi2/anki/DeckPicker.java
@@ -34,6 +34,7 @@ import android.content.SharedPreferences.Editor;
 import android.content.res.Resources;
 import android.database.SQLException;
 import android.graphics.PixelFormat;
+import android.net.Uri;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Message;
@@ -242,7 +243,10 @@ public class DeckPicker extends NavigationDrawerActivity implements StudyOptions
             } else {
                 handleDbError();
             }
-            // reset import path so that it's not incorrectly imported next time Activity starts
+            // delete temp file if necessary and reset import path so that it's not incorrectly imported next time Activity starts
+            if (getIntent().getBooleanExtra("deleteTempFile", false)) {
+                new File(mImportPath).delete();
+            }
             mImportPath = null;
         }
 
@@ -288,7 +292,10 @@ public class DeckPicker extends NavigationDrawerActivity implements StudyOptions
             } else {
                 showLogDialog(res.getString(R.string.import_log_no_apkg), true);
             }
-            // reset import path so that it's not incorrectly imported next time Activity starts
+            // delete temp file if necessary and reset import path so that it's not incorrectly imported next time Activity starts
+            if (getIntent().getBooleanExtra("deleteTempFile", false)) {
+                new File(mImportPath).delete();
+            }
             mImportPath = null;
         }
 
@@ -1662,10 +1669,7 @@ public class DeckPicker extends NavigationDrawerActivity implements StudyOptions
 
 
     private void addSharedDeck() {
-        Intent intent = new Intent(DeckPicker.this, Info.class);
-        intent.putExtra(Info.TYPE_EXTRA, Info.TYPE_SHARED_DECKS);
-        startActivityForResultWithAnimation(intent, ADD_SHARED_DECKS, ActivityTransitionAnimation.RIGHT);
-        // Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(res.getString(R.string.shared_decks_url)));
+        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(getResources().getString(R.string.shared_decks_url)));
         startActivityWithAnimation(intent, ActivityTransitionAnimation.RIGHT);
     }
 

--- a/src/com/ichi2/anki/IntentHandler.java
+++ b/src/com/ichi2/anki/IntentHandler.java
@@ -2,7 +2,19 @@ package com.ichi2.anki;
 
 import android.app.Activity;
 import android.content.Intent;
+import android.database.Cursor;
+import android.net.Uri;
 import android.os.Bundle;
+import android.provider.OpenableColumns;
+
+import com.ichi2.themes.Themes;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 
 /**
  * Class which handles how the application responds to different intents, forcing it to always be single task,
@@ -18,18 +30,60 @@ public class IntentHandler extends Activity {
         super.onCreate(savedInstanceState);
         Intent intent = getIntent();
         Intent reloadIntent = new Intent(this, DeckPicker.class);
-        if (intent.getExtras() != null) {
-            reloadIntent.putExtras(intent.getExtras());
-        }
-        if (intent.getData() != null) {
-            reloadIntent.setData(intent.getData());
-        }
+        reloadIntent.setDataAndType(getIntent().getData(), getIntent().getType());
         String action = intent.getAction();
         if (action.equals(Intent.ACTION_VIEW)) {
             // This intent is used for opening apkg package
             // We want to go immediately to DeckPicker, clearing any history in the process
             // TODO: Still one bug, where if AnkiDroid is launched via ACTION_VIEW,
             // then subsequent ACTION_VIEW events bypass IntentHandler. Prob need to do something onResume() of AnkiActivity
+
+            /* When a VIEW intent is sent with a content provider URI, we copy to a temporary file that we can read directly */
+            if (intent.getData().getScheme().equals("content")) {
+                // Get the original filename from the content provider URI and save to temporary cache dir
+                String filename = null;
+                Cursor cursor = null;
+                try {
+                    cursor = this.getContentResolver().query(intent.getData(), new String[]{OpenableColumns.DISPLAY_NAME}, null, null, null );
+                    if (cursor != null && cursor.moveToFirst()) {
+                        filename = cursor.getString(0);
+                    }
+                } finally {
+                    if (cursor != null)
+                        cursor.close();
+                }
+                // Copy to temp file
+                if (filename != null && filename.endsWith(".apkg")) {
+                    File tempImportPath = new File(getCacheDir(), filename);
+                    try {
+                        // Get an input stream to the data in ContentProvider
+                        InputStream in = getContentResolver().openInputStream(intent.getData());
+                        // Create new output stream in temporary path
+                        OutputStream out = new FileOutputStream(tempImportPath);
+                        // Copy the input stream to temporary file
+                        byte[] buf = new byte[1024];
+                        int len;
+                        while ((len = in.read(buf)) > 0) {
+                            out.write(buf, 0, len);
+                        }
+                        in.close();
+                        out.close();
+                    } catch (FileNotFoundException e) {
+                        e.printStackTrace();
+                    } catch (IOException e2) {
+                        e2.printStackTrace();
+                    }
+                    // Replace the intent URI with the URI to temporary file
+                    reloadIntent.setData(Uri.fromFile(tempImportPath));
+                    reloadIntent.putExtra("deleteTempFile", true);
+                } else {
+                    // Don't import the file if it didn't load properly or doesn't have apkg extension
+                    Themes.showThemedToast(this, getResources().getString(R.string.import_log_no_apkg), true);
+                    finish();
+                    return;
+                }
+            }
+
             reloadIntent.setAction(action);
             reloadIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
             startActivity(reloadIntent);


### PR DESCRIPTION
Opening apkg files from external apps like chrome and gmail was broken, since recently they use a content provider instead of passing files directly. That was preventing us from being able to change over to handling shared decks using the standard browser. This PR fixes both issues. 

In the case where the decks are downloaded from AnkiWeb, a new `application/apkg` MIME type is used in the manifest to catch the file. Unfortunately in other cases like gmail, there's no way to exclusively catch apkg files, so I had to set the manifest to catch the generic binary file type `application/octet-stream`, and then check the file extension from within AnkiDroid. This is not optimal, but [unfortunately that seems to be the only way](http://stackoverflow.com/questions/14256916/open-custom-file-type-gmail-attachment-in-app).
