### PR TITLE
Allow user to email exported APKG

### DIFF
--- a/res/values/02-strings.xml
+++ b/res/values/02-strings.xml
@@ -165,7 +165,8 @@
     <string name="confirm_apkg_export">Export collection as apkg file?</string>
     <string name="confirm_apkg_export_deck">Export \"%s\" as apkg file?</string>
     <string name="export_in_progress">Exporting apkg file…</string>
-    <string name="export_successful">File \"%s\" was exported</string>
+    <string name="export_successful_title">Email apkg?</string>
+    <string name="export_successful">File \"%s\" was exported. Do you want to email it?</string>
     <string name="export_unsuccessful">Error exporting collection</string>
     <string name="import_hint">Place the apkg file in directory %s and press \"OK\" to import cards</string>
     <string name="upgrade_import_no_file_found">No importable %1$s file found</string>


### PR DESCRIPTION
It can be a bit of a pain to use USB to copy an exported APKG, so I got AnkiDroid to ask if the user wants to email the apkg at the end of the export. This was motivated by [this thread](https://groups.google.com/d/msg/anki-android/oAbdlNhiNyk/SyI7WSQN-0cJ) on the forum, but it should also be useful in many other places, and also for us when providing support.
