### PR TITLE
Fix issue 2265

### DIFF
--- a/src/com/ichi2/anki/CardBrowser.java
+++ b/src/com/ichi2/anki/CardBrowser.java
@@ -59,7 +59,6 @@ import com.ichi2.anki.receiver.SdCardReceiver;
 import com.ichi2.async.DeckTask;
 import com.ichi2.async.DeckTask.TaskData;
 import com.ichi2.libanki.Card;
-import com.ichi2.libanki.CardStats;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Note;
 import com.ichi2.libanki.Utils;
@@ -732,15 +731,12 @@ public class CardBrowser extends NavigationDrawerActivity implements ActionBar.O
         } else {
             JSONObject deck = mDropDownDecks.get(position - 1);
             String deckName;
-            Long deckId;
             try {
                 deckName = deck.getString("name");
-                deckId = deck.getLong("id");
             } catch (JSONException e) {
                 throw new RuntimeException();
             }
             mRestrictOnDeck = "deck:'" + deckName + "' ";
-            getCol().getDecks().select(deckId);
         }
         searchCards();
         return true;


### PR DESCRIPTION
#339 introduced the bug reported in [issue 2265](https://code.google.com/p/ankidroid/issues/detail?id=2265).

I agree that it would be nice to allow adding cards to the currently selected deck in the browser (although Anki Desktop doesn't do this)... I considered passing an argument for selected did to the note editor via intent, but in that case we need to manually figure out the default model which is a bit messy, so for now just reverting #339.
