### PR TITLE
Fix bug in new note editor

### DIFF
--- a/src/com/ichi2/anki/CardEditor.java
+++ b/src/com/ichi2/anki/CardEditor.java
@@ -536,7 +536,8 @@ public class CardEditor extends AnkiActivity {
         } catch (JSONException e) {
             throw new RuntimeException(e);
         }
-        mNoteTypeSpinner.setSelection(position);
+        // set selection without firing selectionChanged event
+        mNoteTypeSpinner.setSelection(position, false);
 
         if (mAddNote) {
             mNoteTypeSpinner.setEnabled(true);


### PR DESCRIPTION
Fix bug introduced in #500 where setting the position of the note type spinner caused the deck to change
