### PR TITLE
Move import action to main menu next to export

### DIFF
--- a/res/menu/deck_picker.xml
+++ b/res/menu/deck_picker.xml
@@ -16,9 +16,6 @@
             <item
                 android:id="@+id/action_new_deck"
                 android:title="@string/new_deck"/>
-            <item
-                android:id="@+id/action_import"
-                android:title="@string/menu_import"/>
         </menu>
     </item>
     <item
@@ -50,6 +47,9 @@
         android:id="@+id/action_restore_backup"
         android:menuCategory="secondary"
         android:title="@string/backup_restore"/>
+    <item
+        android:id="@+id/action_import"
+        android:title="@string/menu_import"/>
     <item
         android:id="@+id/action_export"
         android:menuCategory="secondary"


### PR DESCRIPTION
Now that we have an export button, I thin it makes more sense to have import next to it rather than in the + button.
