### PR TITLE
Change "Note type" to "Type" as per Anki Desktop

### DIFF
--- a/res/values/02-strings.xml
+++ b/res/values/02-strings.xml
@@ -25,8 +25,8 @@
 
     <string name="CardEditorLaterMessage">Saved information for later</string>
     <string name="CardEditorCardDeck">Card deck:</string>
-    <string name="CardEditorNoteDeck">Note deck:</string>
-    <string name="CardEditorModel">Note type:</string>
+    <string name="CardEditorNoteDeck">Deck:</string>
+    <string name="CardEditorModel">Type:</string>
     <string name="CardEditorTags">Tags: %1$s</string>
     <string name="add_new_filter_tags">Add/filter tags</string>
     <string name="note_type">Note type</string>


### PR DESCRIPTION
In the note editor, "Type" is more easy to understand than "Note type". Since this string will have to be re-translated anyway after #500, we might as well change it now. I also changed "Note deck" to "Deck", unless we're editing an existing note, in which case it's only the currently selected card which is changed
