### PR TITLE
Fix link to Anki website

### DIFF
--- a/res/values/03-dialogs.xml
+++ b/res/values/03-dialogs.xml
@@ -38,7 +38,7 @@
     <string-array name="about_content">
         <item><![CDATA[<h2>%1$s:<br/>Flashcards for Android</h2>AnkiDroid is a flashcard application which is fully compatible with the desktop software <a href=\"%2$s\">Anki</a>. You can create, download and learn contents on both, AnkiDroid or Anki Desktop, and synchronize them very easily.]]></item>
         <item><![CDATA[To help us make AnkiDroid better, please report any bug <a href=\"%1$s\">here</a>; new feature ideas are very welcome too! Use the <a href=\"%2$s\">wiki</a> and say Hi on the <a href=\"%3$s\">forum</a>.]]></item>
-        <item><![CDATA[AnkiDroid is <a href=\"%1$s\">open source software<a/>, so everyone is encouraged to <a href=\"%2$s\">join</a> the <a href=\"%3$s\">contributors</a>:-)]]></item>
+        <item><![CDATA[AnkiDroid is <a href=\"%1$s\">open source software<a/>, so everyone is encouraged to <a href=\"%2$s\">join</a> the <a href=\"%3$s\">contributors</a> :-)]]></item>
         <item><![CDATA[Non-developers can also help, for instance by <a href=\"%1$s\">translating</a> AnkiDroid, updating the wiki and screenshots, <a href=\"%2$s\">donating</a> to Anki Desktop, or blogging about AnkiDroid!]]></item>
         <item><![CDATA[AnkiDroid is released under the <a href=\"%1$s\">GNU-GPL v3 license</a> and the source code is available <a href=\"%2$s\">here</a>.]]></item>
     </string-array>

--- a/res/values/constants.xml
+++ b/res/values/constants.xml
@@ -84,7 +84,8 @@
         <item>4</item>
     </string-array>
 
-    <string name="link_anki">https://ankiweb.net</string>
+    <string name="link_anki">http://ankisrs.net</string>
+    <string name="link_ankiweb">https://ankiweb.net</string>
     <string name="link_ankidroid">http://code.google.com/p/ankidroid</string>
     <string name="link_forum">http://groups.google.com/group/anki-android</string>
     <string name="link_wiki">http://code.google.com/p/ankidroid/wiki/Index</string>

--- a/src/com/ichi2/anki/Info.java
+++ b/src/com/ichi2/anki/Info.java
@@ -616,7 +616,7 @@ public class Info extends ActionBarActivity {
                 break;
 
             case DIALOG_SYNC_UPGRADE_REQUIRED:
-                builder.setMessage(res.getString(R.string.upgrade_required, res.getString(R.string.link_anki)));
+                builder.setMessage(res.getString(R.string.upgrade_required, res.getString(R.string.link_ankiweb)));
                 builder.setPositiveButton(R.string.retry, new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {


### PR DESCRIPTION
- Changed the link from ankiweb.net to ankisrs.net.
- Added `link_ankiweb` for the deck upgrade dialog.
