### PR TITLE
Fix stats not updating when switching between deck and collection

### DIFF
--- a/src/com/ichi2/anki/stats/AnkiStatsActivity.java
+++ b/src/com/ichi2/anki/stats/AnkiStatsActivity.java
@@ -297,8 +297,8 @@ public class AnkiStatsActivity extends NavigationDrawerActivity implements Actio
         //works best for updating all tabs
         @Override
         public int getItemPosition(Object object) {
-            if (object instanceof ChartFragment) {
-                ((ChartFragment) object).checkAndUpdate();
+            if (object instanceof StatisticFragment) {
+                ((StatisticFragment) object).checkAndUpdate();
             }
             //don't return POSITION_NONE, avoid fragment recreation.
             return super.getItemPosition(object);


### PR DESCRIPTION
How to reproduce:
- do some reviews here and there
- enter study options of a deck
- enter statistics
- notice that toggling between collection and deck doesn't have an effect on the `Today` tab
