### PR TITLE
Fix inconsistent headline in navigation drawer

### DIFF
--- a/src/com/ichi2/anki/NavigationDrawerActivity.java
+++ b/src/com/ichi2/anki/NavigationDrawerActivity.java
@@ -47,7 +47,6 @@ public class NavigationDrawerActivity extends AnkiActivity {
     private DrawerLayout mDrawerLayout;
     private ListView mDrawerList;
     private ActionBarDrawerToggle mDrawerToggle;
-    private CharSequence mDrawerTitle;
     private String[] mNavigationTitles;
     private TypedArray mNavigationImages;
     // Other members
@@ -69,7 +68,7 @@ public class NavigationDrawerActivity extends AnkiActivity {
         // Create inherited navigation drawer layout here so that it can be used by parent class
         mDrawerLayout = (DrawerLayout) mainView.findViewById(R.id.drawer_layout);
         mDrawerList = (ListView) mainView.findViewById(R.id.left_drawer);
-        mTitle = mDrawerTitle = getTitle();
+        mTitle = getTitle();
         mNavigationTitles = getResources().getStringArray(R.array.navigation_titles);
         mNavigationImages = getResources().obtainTypedArray(R.array.drawer_images);
         // set a custom shadow that overlays the main content when the drawer opens
@@ -97,7 +96,7 @@ public class NavigationDrawerActivity extends AnkiActivity {
             }
 
             public void onDrawerOpened(View drawerView) {
-                getSupportActionBar().setTitle(mDrawerTitle);
+                getSupportActionBar().setTitle(getResources().getString(R.string.app_name));
                 supportInvalidateOptionsMenu(); // creates call to onPrepareOptionsMenu()
             }
         };


### PR DESCRIPTION
I noticed that when opening the navigation drawer in different activities, it would sometimes show the app name, sometimes something else (see study options, statistics). This change consistently shows the app name.

Would be nice to hide the subtitle when the navigation drawer is open, will look into this later.
