### PR TITLE
Issue 2307 -- escape % sign in Deck Options Name

### DIFF
--- a/src/com/ichi2/anki/DeckOptions.java
+++ b/src/com/ichi2/anki/DeckOptions.java
@@ -529,6 +529,8 @@ public class DeckOptions extends PreferenceActivity implements OnSharedPreferenc
             if (key.equals("deckConf")) {
                 String groupName = getOptionsGroupName();
                 int count = getOptionsGroupCount();
+                // Escape "%" in groupName as it's treated as a token
+                groupName = groupName.replaceAll("%", "%%");
                 pref.setSummary(res.getQuantityString(R.plurals.deck_conf_group_summ, count, groupName, count));
                 continue;
             }


### PR DESCRIPTION
Fix [issue 2307](https://code.google.com/p/ankidroid/issues/detail?id=2307)
