### PR TITLE
Detect invalid ease for current card

### DIFF
--- a/src/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/src/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1328,6 +1328,10 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
         }
         mIsSelecting = false;
         hideLookupButton();
+        // Detect invalid ease for current card (e.g. by using keyboard shortcut or gesture).
+        if (getCol().getSched().answerButtons(mCurrentCard) < ease) {
+            return;
+        }
         switch (ease) {
             case EASE_FAILED:
                 mChosenAnswer.setText("\u2022");


### PR DESCRIPTION
How to reproduce:
- set gesture for `Answer button 4`
- find a relearning card during review
- trigger gesture
- card will be answered with ease 4, even though that's not an option

This test is also in Anki: https://github.com/dae/anki/blob/master/aqt/reviewer.py#L265
