### PR TITLE
Add basic keyboard shortcuts for reviewing

### DIFF
--- a/src/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/src/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1067,6 +1067,18 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
     }
 
 
+    @Override
+    public boolean onKeyUp(int keyCode, KeyEvent event) {
+        if (!sDisplayAnswer) {
+            if (keyCode == KeyEvent.KEYCODE_SPACE || keyCode == KeyEvent.KEYCODE_ENTER || keyCode == KeyEvent.KEYCODE_NUMPAD_ENTER) {
+                displayCardAnswer();
+                return true;
+            }
+        }
+        return super.onKeyUp(keyCode, event);
+    }
+
+
     // These three methods use a deprecated API - they should be updated to possibly use its more modern version.
     protected boolean clipboardHasText() {
         return mClipboard != null && mClipboard.hasText();
@@ -1322,7 +1334,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
     }
 
 
-    private void answerCard(int ease) {
+    protected void answerCard(int ease) {
         if (mInAnswer) {
             return;
         }

--- a/src/com/ichi2/anki/Reviewer.java
+++ b/src/com/ichi2/anki/Reviewer.java
@@ -23,6 +23,7 @@ import android.content.SharedPreferences;
 import android.content.res.Resources;
 import android.util.DisplayMetrics;
 import android.view.Display;
+import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.MotionEvent;
@@ -250,6 +251,58 @@ public class Reviewer extends AbstractFlashcardViewer {
         }
 
         return super.onPrepareOptionsMenu(menu);
+    }
+
+
+    @Override
+    public boolean onKeyUp(int keyCode, KeyEvent event) {
+        char keyPressed = (char) event.getUnicodeChar();
+        if (keyPressed == '1') {
+            answerCard(EASE_FAILED);
+            return true;
+        }
+        if (keyPressed == '2') {
+            answerCard(EASE_HARD);
+            return true;
+        }
+        if (keyPressed == '3') {
+            answerCard(EASE_MID);
+            return true;
+        }
+        if (keyPressed == '4') {
+            answerCard(EASE_EASY);
+            return true;
+        }
+        if (keyPressed == 'e') {
+            editCard();
+            return true;
+        }
+        if (keyPressed == '*') {
+            DeckTask.launchDeckTask(DeckTask.TASK_TYPE_MARK_CARD, mMarkCardHandler, new DeckTask.TaskData(mSched,
+                    mCurrentCard, 0));
+            return true;
+        }
+        if (keyPressed == '-') {
+            DeckTask.launchDeckTask(DeckTask.TASK_TYPE_DISMISS_NOTE, mDismissCardHandler, new DeckTask.TaskData(
+                    mSched, mCurrentCard, 4));
+            return true;
+        }
+        if (keyPressed == '=') {
+            DeckTask.launchDeckTask(DeckTask.TASK_TYPE_DISMISS_NOTE, mDismissCardHandler, new DeckTask.TaskData(
+                    mSched, mCurrentCard, 0));
+            return true;
+        }
+        if (keyPressed == '@') {
+            DeckTask.launchDeckTask(DeckTask.TASK_TYPE_DISMISS_NOTE, mDismissCardHandler, new DeckTask.TaskData(
+                    mSched, mCurrentCard, 1));
+            return true;
+        }
+        if (keyPressed == '!') {
+            DeckTask.launchDeckTask(DeckTask.TASK_TYPE_DISMISS_NOTE, mDismissCardHandler, new DeckTask.TaskData(
+                    mSched, mCurrentCard, 2));
+            return true;
+        }
+        return super.onKeyUp(keyCode, event);
     }
     
 


### PR DESCRIPTION
To make reviewing on a Chromebook / Android device with physical keyboard easier.

Had to make `answerCard` protected. Ideally we would move the whole card answering logic into the reviewer. Any opinions, @timrae?
