### PR TITLE
Remove FrontSide audio from answer without requiring entire FrontSide by located.

### DIFF
--- a/src/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/src/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -2154,12 +2154,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
                 // don't add answer sounds multiple times, such as when reshowing card after exiting editor
                 // additionally, this condition reduces computation time
                 if (!mAnswerSoundsAdded) {
-                    String afmt = getAnswerFormat();
-                    String answerSoundSource = content;
-                    if (afmt.contains("{{FrontSide}}")) { // don't grab front side audio
-                        String fromFrontSide = mCurrentCard._getQA(false).get("q");
-                        answerSoundSource = content.replace(fromFrontSide, "");
-                    }
+                    String answerSoundSource = removeFrontSideAudio(content);
                     Sound.addSounds(mBaseUrl, answerSoundSource, Sound.SOUNDS_ANSWER);
                     mAnswerSoundsAdded = true;
                 }
@@ -3002,5 +2997,24 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
 
     private Spanned convertToSimple(String text) {
         return Html.fromHtml(text, mSimpleInterfaceImagegetter, mSimpleInterfaceTagHandler);
+    }
+
+
+    /**
+     * Removes first occurrence in answerContent of any audio that is present due to use of
+     * {{FrontSide}} on the answer. 
+     * @param answerContent     The content from which to remove front side audio.
+     * @return                  The content stripped of audio due to {{FrontSide}} inclusion.
+     */
+    private String removeFrontSideAudio(String answerContent) {
+        String answerFormat = getAnswerFormat();
+        if (answerFormat.contains("{{FrontSide}}")) { // possible audio removal necessary
+            String frontSideFormat = mCurrentCard._getQA(false).get("q");
+            Matcher audioReferences = Sound.sSoundPattern.matcher(frontSideFormat);
+            while (audioReferences.find()) {
+                answerContent = answerContent.replace(audioReferences.group(), "");
+            }
+        }
+        return answerContent;
     }
 }


### PR DESCRIPTION
This is a rather benign code change. Previously, code attempted to strip the entire part introduced by {{FrontSide}} from the answer, in an attempt to not play audio from the question, but as pointed out by Xiao, type answer prompts broke this. The break was due to the fact that the prompts from FrontSide content are transformed, so as not be literally found at the point we try to strip audio. This changes the code to only look for exactly the embedded sounds from FrontSide. It has been tested to work with type answer prompts.
