### PR TITLE
Fix drag to select feature in Kitkat

### DIFF
--- a/src/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/src/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1101,14 +1101,6 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
     }
 
 
-
-    @Override
-    public boolean onMenuOpened(int feature, Menu menu) {
-        AnkiDroidApp.getCompat().invalidateOptionsMenu(this);
-        return super.onMenuOpened(feature, menu);
-    }
-
-
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);

--- a/src/com/ichi2/anki/DeckPicker.java
+++ b/src/com/ichi2/anki/DeckPicker.java
@@ -539,13 +539,6 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
 
 
     @Override
-    public boolean onMenuOpened(int feature, Menu menu) {
-        AnkiDroidApp.getCompat().invalidateOptionsMenu(this);
-        return super.onMenuOpened(feature, menu);
-    }
-
-
-    @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         // The action bar home/up action should open or close the drawer.
         // ActionBarDrawerToggle will take care of this.

--- a/src/com/ichi2/anki/NoteEditor.java
+++ b/src/com/ichi2/anki/NoteEditor.java
@@ -826,13 +826,6 @@ public class NoteEditor extends AnkiActivity {
 
 
     @Override
-    public boolean onMenuOpened(int feature, Menu menu) {
-        AnkiDroidApp.getCompat().invalidateOptionsMenu(this);
-        return super.onMenuOpened(feature, menu);
-    }
-
-
-    @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
 


### PR DESCRIPTION
Calling `invalidateOptionsMenu()` everytime the menu is opened causes a bug in Kitkat. We should only call `invalidateOptionsMenu()` when an event occurs which changes what should appear in the menus.
