### PR TITLE
Fix crash when trying to load mini-stats with col closed

### DIFF
--- a/src/com/ichi2/anki/DeckPicker.java
+++ b/src/com/ichi2/anki/DeckPicker.java
@@ -909,9 +909,9 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
     private void loadCounts() {
         if (AnkiDroidApp.colIsOpen()) {
             DeckTask.launchDeckTask(DeckTask.TASK_TYPE_LOAD_DECK_COUNTS, mLoadCountsHandler, new TaskData(getCol()));
+            mTodayTextView.setVisibility(View.GONE);
+            AnkiStatsTaskHandler.createSmallTodayOverview(mTodayTextView);
         }
-        mTodayTextView.setVisibility(View.GONE);
-        AnkiStatsTaskHandler.createSmallTodayOverview(mTodayTextView);
     }
 
 


### PR DESCRIPTION
http://ankidroid-triage.appspot.com/view_crash?crash_id=4987543825154048
