### PR TITLE
Add null check to addExtras when reloading activity

### DIFF
--- a/src/com/ichi2/anki/AnkiActivity.java
+++ b/src/com/ichi2/anki/AnkiActivity.java
@@ -403,7 +403,10 @@ public class AnkiActivity extends ActionBarActivity implements LoaderManager.Loa
         AnkiDroidApp.setLanguage(AnkiDroidApp.getSharedPrefs(getBaseContext()).getString(Preferences.LANGUAGE, ""));
         Intent intent = new Intent();
         intent.setClass(this, this.getClass());
-        intent.putExtras(this.getIntent().getExtras());
+        Bundle extras = this.getIntent().getExtras();
+        if (extras != null) {
+            intent.putExtras(extras);
+        }
         this.startActivityWithoutAnimation(intent);
         this.finishWithoutAnimation();
     }


### PR DESCRIPTION
Add null check to ed0f703 to fix this:
http://ankidroid-triage.appspot.com/view_crash?crash_id=6362745108692992
