### PR TITLE
Remove unnecessary modSchema() from sanity check dialogs

### DIFF
--- a/src/com/ichi2/anki/dialogs/SyncErrorDialog.java
+++ b/src/com/ichi2/anki/dialogs/SyncErrorDialog.java
@@ -173,14 +173,8 @@ public class SyncErrorDialog extends AsyncDialogFragment {
                         new Dialog.OnClickListener() {
                             @Override
                             public void onClick(DialogInterface dialog, int which) {
-                                SyncErrorDialogListener activity = (SyncErrorDialogListener) getActivity();
-                                Collection col = activity.getCol();
-                                if (col != null) {
-                                    col.modSchema(true);
-                                    col.setMod();
-                                    activity.sync("upload", 0);
-                                    dismissAllDialogFragments();
-                                }
+                                ((SyncErrorDialogListener) getActivity()).sync("upload", 0);
+                                dismissAllDialogFragments();
                             }
                         });
                 builder.setNegativeButton(res().getString(R.string.dialog_cancel), null);
@@ -192,14 +186,8 @@ public class SyncErrorDialog extends AsyncDialogFragment {
                         new Dialog.OnClickListener() {
                             @Override
                             public void onClick(DialogInterface dialog, int which) {
-                                SyncErrorDialogListener activity = (SyncErrorDialogListener) getActivity();
-                                Collection col = activity.getCol();
-                                if (col != null) {
-                                    col.modSchema(true);
-                                    col.setMod();
-                                    activity.sync("download", 0);
-                                    dismissAllDialogFragments();
-                                }
+                                ((SyncErrorDialogListener) getActivity()).sync("download", 0);
+                                dismissAllDialogFragments();
                             }
                         });
                 builder.setNegativeButton(res().getString(R.string.dialog_cancel), null);


### PR DESCRIPTION
This is already taken care of by libanki and was causing a crash since the collection has been closed at this point:

http://ankidroid-triage.appspot.com/view_crash?crash_id=5155872183418880
