### PR TITLE
Escape images to fix issue 2345

### DIFF
--- a/src/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/src/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1955,6 +1955,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
         } else {
             question = mCurrentCard.q();
         }
+        question = getCol().getMedia().escapeImages(question);
         question = typeAnsQuestionFilter(question);
 
         if (mPrefFixArabic) {
@@ -2057,7 +2058,6 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
         } else {
             answer = mCurrentCard.a();
         }
-
         String displayString = "";
 
         if (mCurrentSimpleInterface) {
@@ -2070,7 +2070,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
             }
         } else {
             Sound.stopSounds();
-
+            answer = getCol().getMedia().escapeImages(answer);
             if (mPrefFixArabic) {
                 // reshape
                 answer = ArabicUtilities.reshapeSentence(answer, true);

--- a/src/com/ichi2/libanki/Media.java
+++ b/src/com/ichi2/libanki/Media.java
@@ -385,9 +385,9 @@ public class Media {
                     string = tag;
                 } else {
                     if (unescape) {
-                        string = tag.replace(fname, Uri.decode(fname));
+                        string = string.replace(tag,tag.replace(fname, Uri.decode(fname)));
                     } else {
-                        string = tag.replace(fname, Uri.encode(fname));
+                        string = string.replace(tag,tag.replace(fname, Uri.encode(fname)));
                     }
                 }
             }


### PR DESCRIPTION
Fix a libanki bug where image escaping was stripping out all the surrounding html, and use escapeImages() when showing cards to fix [issue 2345](https://code.google.com/p/ankidroid/issues/detail?id=2345)
