### PR TITLE
Remove unused currDid variable

### DIFF
--- a/src/com/ichi2/anki/DeckPicker.java
+++ b/src/com/ichi2/anki/DeckPicker.java
@@ -1410,7 +1410,6 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
         String currentMessage;
         long countUp;
         long countDown;
-        long currDid;
         boolean colIsEmpty;
 
 
@@ -1440,12 +1439,6 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
                 col = getCol();
             }
             colIsEmpty = col.isEmpty();
-            // store current did so we can reselect deck properly after sync
-            try {
-                currDid = col.getDecks().current().getLong("id");
-            } catch (JSONException e) {
-                throw new RuntimeException();
-            }
         }
 
 


### PR DESCRIPTION
This is just a cleanup. `currDid` used to keep the deck the same after a sync. The logic was recently removed in #568 as part of a bug hunt, and I think it should stay removed to be in line with Anki Desktop.
