### PR TITLE
Start app more gracefully

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -86,7 +86,8 @@
         <activity
             android:name="com.ichi2.anki.IntentHandler"
             android:configChanges="keyboardHidden|orientation|screenSize|locale"
-            android:label="@string/app_name" >
+            android:label="@string/app_name"
+            android:theme="@android:style/Theme.NoTitleBar.Fullscreen" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/src/com/ichi2/anki/DeckPicker.java
+++ b/src/com/ichi2/anki/DeckPicker.java
@@ -386,16 +386,16 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
     @Override
     protected void onCreate(Bundle savedInstanceState) throws SQLException {
         Log.i(AnkiDroidApp.TAG, "DeckPicker - onCreate");
-        // Get the path to the apkg file if started via VIEW intent
         Intent intent = getIntent();
+        // Show splashscreen if app first starting
+        if (intent.getCategories()!= null || !AnkiDroidApp.colIsOpen()) {
+            showOpeningCollectionDialog();
+        }
+        // Get the path to the apkg file if started via VIEW intent
         if (intent.getData() != null) {
             mImportPath = getIntent().getData().getEncodedPath();
         }
         mHandler = new DialogHandler(this);
-        // need to start this here in order to avoid showing deckpicker before splashscreen
-        if (!AnkiDroidApp.colIsOpen()) {
-            showOpeningCollectionDialog();
-        }
 
         Themes.applyTheme(this);
         super.onCreate(savedInstanceState);

--- a/src/com/ichi2/anki/IntentHandler.java
+++ b/src/com/ichi2/anki/IntentHandler.java
@@ -8,6 +8,7 @@ import android.os.Bundle;
 import android.provider.OpenableColumns;
 import android.support.v4.content.IntentCompat;
 
+import com.ichi2.anim.ActivityTransitionAnimation;
 import com.ichi2.themes.Themes;
 
 import java.io.File;
@@ -29,6 +30,7 @@ public class IntentHandler extends Activity {
     @Override 
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        setContentView(R.layout.styled_open_collection_dialog);
         Intent intent = getIntent();
         Intent reloadIntent = new Intent(this, DeckPicker.class);
         reloadIntent.setDataAndType(getIntent().getData(), getIntent().getType());
@@ -80,7 +82,7 @@ public class IntentHandler extends Activity {
                 } else {
                     // Don't import the file if it didn't load properly or doesn't have apkg extension
                     Themes.showThemedToast(this, getResources().getString(R.string.import_log_no_apkg), true);
-                    finish();
+                    finishWithFade();
                     return;
                 }
             }
@@ -88,7 +90,7 @@ public class IntentHandler extends Activity {
             reloadIntent.setAction(action);
             reloadIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
             startActivity(reloadIntent);
-            finish();
+            finishWithFade();
         } else {
             // Launcher intents should start DeckPicker if no other task exists,
             // otherwise go to previous task
@@ -96,7 +98,13 @@ public class IntentHandler extends Activity {
             reloadIntent.addCategory(Intent.CATEGORY_LAUNCHER);
             reloadIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | IntentCompat.FLAG_ACTIVITY_CLEAR_TASK);
             startActivityIfNeeded(reloadIntent, 0);
-            finish();
+            finishWithFade();
         }
+    }
+
+    /** Finish Activity using FADE animation **/
+    private void finishWithFade() {
+    	finish();
+    	ActivityTransitionAnimation.slide(this, ActivityTransitionAnimation.FADE);
     }
 }

--- a/src/com/ichi2/anki/NavigationDrawerActivity.java
+++ b/src/com/ichi2/anki/NavigationDrawerActivity.java
@@ -142,7 +142,7 @@ public class NavigationDrawerActivity extends AnkiActivity {
                     }
                     AnkiStatsTaskHandler.setIsWholeCollection(selectAllDecksButton);
                     Intent intent = new Intent(this, Statistics.class);
-                    startActivityWithAnimation(intent, ActivityTransitionAnimation.DOWN);
+                    startActivityWithAnimation(intent, ActivityTransitionAnimation.LEFT);
                 }
 
                 break;


### PR DESCRIPTION
Currently there is a brief period where a blank Activity and a jarring transition are shown to the user when they start the app. This PR makes the app start up more gracefully by showing the splashcreen inside the `IntentHandler` activity and then making a smooth fade transition to the `DeckPicker`.

I also made the animation when showing stats consistent with the other animations from the navigation drawer
