### PR TITLE
Improve async dialog handling

### DIFF
--- a/res/values/10-preferences.xml
+++ b/res/values/10-preferences.xml
@@ -106,8 +106,10 @@
     <string name="language_summ">XXX</string>
     <string name="language_system">System language</string>
     <string name="notification_pref">Notifications</string>
-    <string name="notification_minimum_cards_due">Notify when more than</string>
-    <string name="notification_minimum_cards_due_summary">XXX cards due</string>
+    <string name="notification_pref_title">Notify when</string>
+    <string name="never_notify">Never notify</string>
+    <string name="notify_when_pending">Pending messages available</string>
+    <string name="notification_minimum_cards_due">More than %d cards due</string>
     <string name="notification_minimum_cards_due_vibrate">Vibrate</string>
     <string name="notification_minimum_cards_due_blink">Blink light</string>
     <string name="timeout_answer_text">Automatic display answer</string>

--- a/res/values/11-arrays.xml
+++ b/res/values/11-arrays.xml
@@ -34,16 +34,6 @@
         <item>Never report</item>
         <item>Ask me</item>
     </string-array>
-    <string-array name="notification_minimum_cards_due_labels">
-        <item>10</item>
-        <item>25</item>
-        <item>50</item>
-        <item>75</item>
-        <item>100</item>
-        <item>150</item>
-        <item>200</item>
-        <item>Never notify</item>
-    </string-array>
     <string-array name="cram_review_order_labels">
         <item>Show oldest modified first</item>
         <item>Show in order added</item>

--- a/res/values/constants.xml
+++ b/res/values/constants.xml
@@ -46,7 +46,21 @@
         <item>1</item>
         <item>2</item>
     </string-array>
+    <string-array name="notification_minimum_cards_due_labels">
+        <item>@string/never_notify</item>
+        <item>@string/notify_when_pending</item>
+        <item>@string/notification_minimum_cards_due</item>
+        <item>@string/notification_minimum_cards_due</item>
+        <item>@string/notification_minimum_cards_due</item>
+        <item>@string/notification_minimum_cards_due</item>
+        <item>@string/notification_minimum_cards_due</item>
+        <item>@string/notification_minimum_cards_due</item>
+        <item>@string/notification_minimum_cards_due</item>
+        <item>@string/notification_minimum_cards_due</item>
+    </string-array>
     <string-array name="notification_minimum_cards_due_values">
+        <item>2000000</item>
+        <item>1000000</item>
         <item>10</item>
         <item>25</item>
         <item>50</item>
@@ -54,7 +68,7 @@
         <item>100</item>
         <item>150</item>
         <item>200</item>
-        <item>1000000</item>
+        <item>500</item>
     </string-array>
     <string-array name="gestures_values">
         <item>0</item>

--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -69,8 +69,7 @@
                 android:entries="@array/notification_minimum_cards_due_labels"
                 android:entryValues="@array/notification_minimum_cards_due_values"
                 android:key="minimumCardsDueForNotification"
-                android:summary="@string/notification_minimum_cards_due_summary"
-                android:title="@string/notification_minimum_cards_due" />
+                android:title="@string/notification_pref_title" />
             <CheckBoxPreference
                 android:defaultValue="false"
                 android:key="widgetVibrate"

--- a/src/com/ichi2/anki/AnkiDroidApp.java
+++ b/src/com/ichi2/anki/AnkiDroidApp.java
@@ -1,6 +1,7 @@
 /****************************************************************************************
  * Copyright (c) 2009 Edu Zamora <edu.zasu@gmail.com>                                   *
  * Copyright (c) 2009 Casey Link <unnamedrambler@gmail.com>                             *
+ * Copyright (c) 2014 Timothy Rae <perceptualchaos2@gmail.com>                          *
  *                                                                                      *
  * This program is free software; you can redistribute it and/or modify it under        *
  * the terms of the GNU General Public License as published by the Free Software        *
@@ -26,6 +27,7 @@ import android.content.pm.PackageManager;
 import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.os.Environment;
+import android.os.Message;
 import android.util.Log;
 import android.view.Display;
 import android.view.WindowManager;
@@ -47,7 +49,6 @@ import com.ichi2.utils.LanguageUtil;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -78,7 +79,7 @@ public class AnkiDroidApp extends Application {
     private Collection mCurrentCollection;
     private int mAccessThreadCount = 0;
     private static final Lock mLock = new ReentrantLock();
-    private List<List<String>> mStoredData;
+    private static Message sStoredDialogHandlerMessage;
 
     /** Global hooks */
     private Hooks mHooks;
@@ -482,13 +483,12 @@ public class AnkiDroidApp extends Application {
         // Log.i(AnkiDroidApp.TAG, "Access has been reset to 0");
     }
 
-
-    public void setStoredData(List<List<String>> data) {
-        mStoredData = data;
+    public static void setStoredDialogHandlerMessage(Message msg) {
+        sStoredDialogHandlerMessage = msg;
     }
 
-    public List<List<String>> getStoredData() {
-        return mStoredData;
+    public static Message getStoredDialogHandlerMessage() {
+        return sStoredDialogHandlerMessage;
     }
 
     public static void setSyncInProgress(boolean value) {

--- a/src/com/ichi2/anki/DeckPicker.java
+++ b/src/com/ichi2/anki/DeckPicker.java
@@ -38,8 +38,6 @@ import android.graphics.PixelFormat;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
-import android.os.Handler;
-import android.os.Message;
 import android.support.v4.app.DialogFragment;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentTransaction;
@@ -72,6 +70,7 @@ import com.ichi2.anki.dialogs.DeckPickerConfirmDeleteDeckDialog;
 import com.ichi2.anki.dialogs.DeckPickerContextMenu;
 import com.ichi2.anki.dialogs.DeckPickerExportCompleteDialog;
 import com.ichi2.anki.dialogs.DeckPickerNoSpaceLeftDialog;
+import com.ichi2.anki.dialogs.DialogHandler;
 import com.ichi2.anki.dialogs.ExportDialog;
 import com.ichi2.anki.dialogs.ImportDialog;
 import com.ichi2.anki.dialogs.MediaCheckDialog;
@@ -94,7 +93,6 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.File;
-import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -112,7 +110,6 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
     public static final String IMPORT_REPLACE_COLLECTION_NAME = "collection.apkg";
 
     private String mImportPath;
-    private DialogHandler mHandler;
 
     public static final String EXTRA_START = "start";
     public static final String EXTRA_DECK_ID = "deckId";
@@ -125,13 +122,6 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
     public static final int RESULT_DB_ERROR = 203;
     public static final int RESULT_RESTART = 204;
 
-    /**
-     * Handler messages
-     */
-    private static final int MSG_SHOW_COLLECTION_LOADING_ERROR_DIALOG = 0;
-    private static final int MSG_SHOW_COLLECTION_IMPORT_REPLACE_DIALOG = 1;
-    private static final int MSG_SHOW_COLLECTION_IMPORT_ADD_DIALOG = 2;
-    private static final int MSG_SHOW_ASYNC_DIALOG = 3;
 
     /**
      * Available options performed by other activities
@@ -391,11 +381,6 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
         if (intent.getCategories()!= null || !AnkiDroidApp.colIsOpen()) {
             showOpeningCollectionDialog();
         }
-        // Get the path to the apkg file if started via VIEW intent
-        if (intent.getData() != null) {
-            mImportPath = getIntent().getData().getEncodedPath();
-        }
-        mHandler = new DialogHandler(this);
 
         Themes.applyTheme(this);
         super.onCreate(savedInstanceState);
@@ -816,31 +801,8 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
             long did = col.getDecks().selected();
             selectDeck(did);
         }
-        // Start import process if apkg file was opened via another app
-        Intent intent = getIntent();
-        if (AnkiDroidApp.colIsOpen() && mImportPath != null) {
-            if ((new File(mImportPath)).exists()) {
-                if (mHandler == null) {
-                    mHandler = new DialogHandler(this);
-                }
-                if (mImportPath.split("/")[mImportPath.split("/").length - 1].equals("collection.apkg")) {
-                    // Show confirmation dialog asking to confirm import with replace when file called "collection.apkg"
-                    mHandler.sendEmptyMessage(MSG_SHOW_COLLECTION_IMPORT_REPLACE_DIALOG);
-                } else {
-                    // Otherwise show confirmation dialog asking to confirm import with add
-                    mHandler.sendEmptyMessage(MSG_SHOW_COLLECTION_IMPORT_ADD_DIALOG);
-                }
-            } else {
-                Themes.showThemedToast(this, getResources().getString(R.string.import_log_no_apkg), true);
-            }
-        } else if (intent!= null && intent.getExtras()!= null && intent.getExtras().getBoolean("showAsyncDialogFragment")) {
-            Message m = Message.obtain();
-            m.what = MSG_SHOW_ASYNC_DIALOG;
-            m.setData(getIntent().getExtras());
-            mHandler.sendMessage(m);
-        }
+        // Set flag to show the showcase view if no fragments need to finish adding items to action bar
         if (!mFragmented) {
-            // Show the showcase view here if normal view, otherwise wait for  fragment to finish loading first
             mShowShowcaseView = true;
         }
         AnkiDroidApp.getCompat().invalidateOptionsMenu(this);
@@ -853,64 +815,7 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
     protected void onCollectionLoadError() {
         // Show dialogs for handling collection load error
         setOpeningCollectionDialogMessage(getResources().getString(R.string.col_load_failed));
-        if (mHandler == null) {
-            mHandler = new DialogHandler(this);
-        }
-        mHandler.sendEmptyMessage(MSG_SHOW_COLLECTION_LOADING_ERROR_DIALOG);
-    }
-
-    /**
-     * We're not allowed to commit fragment transactions from Loader.onLoadCompleted() so we work around this by using a
-     * handler to show the error dialog:
-     * http://stackoverflow.com/questions/7746140/android-problems-using-fragmentactivity
-     * -loader-to-update-fragmentstatepagera
-     * 
-     * @param DeckPicker activity the main activity
-     */
-    static class DialogHandler extends Handler {
-        private final WeakReference<DeckPicker> mActivity;
-
-
-        DialogHandler(DeckPicker activity) {
-            // Use weak reference to main activity to prevent leaking the activity when it's closed
-            mActivity = new WeakReference<DeckPicker>(activity);
-        }
-
-
-        @Override
-        public void handleMessage(Message msg) {
-            if (msg.what == MSG_SHOW_COLLECTION_LOADING_ERROR_DIALOG) {
-                // Collection could not be opened
-                mActivity.get().showDatabaseErrorDialog(DatabaseErrorDialog.DIALOG_LOAD_FAILED);
-            } else if (msg.what == MSG_SHOW_COLLECTION_IMPORT_REPLACE_DIALOG) {
-                // Handle import of collection package APKG
-                mActivity.get().showImportDialog(ImportDialog.DIALOG_IMPORT_REPLACE_CONFIRM,
-                        mActivity.get().mImportPath);
-            } else if (msg.what == MSG_SHOW_COLLECTION_IMPORT_ADD_DIALOG) {
-                // Handle import of deck package APKG
-                mActivity.get().showImportDialog(ImportDialog.DIALOG_IMPORT_ADD_CONFIRM, mActivity.get().mImportPath);
-            } else if (msg.what == MSG_SHOW_ASYNC_DIALOG) {
-                // Handle showing of AsyncDialogFragment which was not shown initially due to stopped activity
-                Bundle e = msg.getData();
-                String dialogClass = e.getString("dialogClass");
-                if (dialogClass.equals(SyncErrorDialog.CLASS_NAME_TAG)) {
-                    // Sync error
-                    int id = e.getInt("dialogType");
-                    String message = e.getString("dialogMessage");
-                    mActivity.get().showSyncErrorDialog(id, message);
-                } else if (dialogClass.equals(DeckPickerExportCompleteDialog.CLASS_NAME_TAG)) {
-                    // Export complete
-                    AsyncDialogFragment f = DeckPickerExportCompleteDialog.newInstance(e.getString("exportPath"));
-                    mActivity.get().showAsyncDialogFragment(f);
-                } else if (dialogClass.equals(MediaCheckDialog.CLASS_NAME_TAG)) {
-                    int id = e.getInt("dialogType");
-                    List<List<String>> checkList = AnkiDroidApp.getInstance().getStoredData();
-                    if (checkList != null || id==MediaCheckDialog.DIALOG_CONFIRM_MEDIA_CHECK) {
-                        mActivity.get().showMediaCheckDialog(id, checkList);
-                    }
-                }
-            }
-        }
+        getDialogHandler().sendEmptyMessage(DialogHandler.MSG_SHOW_COLLECTION_LOADING_ERROR_DIALOG);
     }
 
 
@@ -1116,8 +1021,8 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
     // Show dialogs to deal with database loading issues etc
     @Override
     public void showDatabaseErrorDialog(int id) {
-        DialogFragment newFragment = DatabaseErrorDialog.newInstance(id);
-        showDialogFragment(newFragment);
+        AsyncDialogFragment newFragment = DatabaseErrorDialog.newInstance(id);
+        showAsyncDialogFragment(newFragment);
     }
 
 
@@ -1129,7 +1034,6 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
 
     @Override
     public void showMediaCheckDialog(int id, List<List<String>> checkList) {
-        AnkiDroidApp.getInstance().setStoredData(checkList);
         showAsyncDialogFragment(MediaCheckDialog.newInstance(id, checkList));
     }
 

--- a/src/com/ichi2/anki/IntentHandler.java
+++ b/src/com/ichi2/anki/IntentHandler.java
@@ -5,10 +5,12 @@ import android.content.Intent;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.Bundle;
+import android.os.Message;
 import android.provider.OpenableColumns;
 import android.support.v4.content.IntentCompat;
 
 import com.ichi2.anim.ActivityTransitionAnimation;
+import com.ichi2.anki.dialogs.DialogHandler;
 import com.ichi2.themes.Themes;
 
 import java.io.File;
@@ -76,9 +78,20 @@ public class IntentHandler extends Activity {
                     } catch (IOException e2) {
                         e2.printStackTrace();
                     }
-                    // Replace the intent URI with the URI to temporary file
-                    reloadIntent.setData(importUri);
-                    reloadIntent.putExtra("deleteTempFile", true);
+                    // Create a new message for DialogHandler so that we see the appropriate import dialog in DeckPicker
+                    Message handlerMessage = Message.obtain();
+                    Bundle msgData = new Bundle();
+                    msgData.putString("importPath", importUri.getEncodedPath());
+                    handlerMessage.setData(msgData);
+                    if (filename.equals("collection.apkg")) {
+                        // Show confirmation dialog asking to confirm import with replace when file called "collection.apkg"
+                        handlerMessage.what = DialogHandler.MSG_SHOW_COLLECTION_IMPORT_REPLACE_DIALOG;
+                    } else {
+                        // Otherwise show confirmation dialog asking to confirm import with add
+                        handlerMessage.what = DialogHandler.MSG_SHOW_COLLECTION_IMPORT_ADD_DIALOG;
+                    }
+                    // Store the message in AnkiDroidApp message holder
+                    AnkiDroidApp.setStoredDialogHandlerMessage(handlerMessage);
                 } else {
                     // Don't import the file if it didn't load properly or doesn't have apkg extension
                     Themes.showThemedToast(this, getResources().getString(R.string.import_log_no_apkg), true);

--- a/src/com/ichi2/anki/Preferences.java
+++ b/src/com/ichi2/anki/Preferences.java
@@ -96,7 +96,7 @@ public class Preferences extends PreferenceActivity implements OnSharedPreferenc
     private EditTextPreference collectionPathPreference;
     private Preference syncAccount;
     private static String[] sShowValueInSummList = { LANGUAGE, "dictionary", "reportErrorMode",
-            "minimumCardsDueForNotification", "gestureSwipeUp", "gestureSwipeDown", "gestureSwipeLeft",
+            "gestureSwipeUp", "gestureSwipeDown", "gestureSwipeLeft",
             "gestureSwipeRight", "gestureDoubleTap", "gestureTapTop", "gestureTapBottom", "gestureTapRight",
             "gestureLongclick", "gestureTapLeft", "newSpread", "useCurrent", "defaultFont", "overrideFontBehavior", "browserEditorFont" };
     private static String[] sListNumericCheck = {"minimumCardsDueForNotification"};
@@ -291,10 +291,25 @@ public class Preferences extends PreferenceActivity implements OnSharedPreferenc
         for (String key : sShowValueInSummNumRange) {
             updateNumberRangePreference(key);
         }
-
+        // Handle notification preference separately
+        updateNotificationPreference();
     }
 
 
+    private void updateNotificationPreference() {
+        ListPreference listpref = (ListPreference) getPreferenceScreen().findPreference("minimumCardsDueForNotification");
+        CharSequence [] entries = listpref.getEntries();
+        CharSequence [] values = listpref.getEntryValues();
+        for (int i=0; i < entries.length; i++) {
+            int value = Integer.parseInt(values[i].toString());
+            if (entries[i].toString().contains("%d")) {
+                entries[i]=String.format(entries[i].toString(), value);
+            }
+        }
+        listpref.setEntries(entries);
+        listpref.setSummary(listpref.getEntry().toString());
+    }
+    
     private void updateListPreference(String key, final boolean numericCheck) {
         ListPreference listpref = (ListPreference) getPreferenceScreen().findPreference(key);
         String entry;
@@ -530,7 +545,10 @@ public class Preferences extends PreferenceActivity implements OnSharedPreferenc
                 date.set(Calendar.HOUR_OF_DAY, hours);
                 mCol.setCrt(date.getTimeInMillis() / 1000);
                 mCol.setMod();
+            } else if (key.equals("minimumCardsDueForNotification")) {
+                updateNotificationPreference();
             }
+            
             if (Arrays.asList(sShowValueInSummList).contains(key)) {
                 if (Arrays.asList(sListNumericCheck).contains(key)) {
                     updateListPreference(key, true);

--- a/src/com/ichi2/anki/dialogs/AsyncDialogFragment.java
+++ b/src/com/ichi2/anki/dialogs/AsyncDialogFragment.java
@@ -1,6 +1,6 @@
 package com.ichi2.anki.dialogs;
 import android.content.res.Resources;
-import android.os.Bundle;
+import android.os.Message;
 import android.support.v4.app.DialogFragment;
 
 import com.ichi2.anki.AnkiDroidApp;
@@ -14,8 +14,8 @@ public abstract class AsyncDialogFragment extends DialogFragment {
     public abstract String getNotificationMessage();
     public abstract String getNotificationTitle();
 
-    public Bundle getNotificationIntentExtras() {
-        return new Bundle();
+    public Message getDialogHandlerMessage() {
+        return null;
     }
 
     protected Resources res() {

--- a/src/com/ichi2/anki/dialogs/DeckPickerExportCompleteDialog.java
+++ b/src/com/ichi2/anki/dialogs/DeckPickerExportCompleteDialog.java
@@ -4,12 +4,13 @@ package com.ichi2.anki.dialogs;
 import android.content.DialogInterface;
 import android.content.res.Resources;
 import android.os.Bundle;
+import android.os.Message;
+
 import com.ichi2.anki.DeckPicker;
 import com.ichi2.anki.R;
 import com.ichi2.themes.StyledDialog;
 
 public class DeckPickerExportCompleteDialog extends AsyncDialogFragment {
-    public static String CLASS_NAME_TAG = "ExportCompleteDialog";
     
     public static DeckPickerExportCompleteDialog newInstance(String exportPath) {
         DeckPickerExportCompleteDialog f = new DeckPickerExportCompleteDialog();
@@ -56,11 +57,12 @@ public class DeckPickerExportCompleteDialog extends AsyncDialogFragment {
 
 
     @Override
-    public Bundle getNotificationIntentExtras() {
+    public Message getDialogHandlerMessage() {
+        Message msg = Message.obtain();
+        msg.what = DialogHandler.MSG_SHOW_EXPORT_COMPLETE_DIALOG;
         Bundle b = new Bundle();
-        b.putBoolean("showAsyncDialogFragment", true);
-        b.putString("dialogClass", CLASS_NAME_TAG);
         b.putString("exportPath", getArguments().getString("exportPath"));
-        return b;
+        msg.setData(b);
+        return msg;
     } 
 }

--- a/src/com/ichi2/anki/dialogs/DialogHandler.java
+++ b/src/com/ichi2/anki/dialogs/DialogHandler.java
@@ -1,0 +1,78 @@
+package com.ichi2.anki.dialogs;
+
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.Message;
+
+import com.ichi2.anki.AnkiActivity;
+import com.ichi2.anki.DeckPicker;
+
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.List;
+
+
+/**
+ * We're not allowed to commit fragment transactions from Loader.onLoadCompleted(),
+ * and it's unsafe to commit them from an AsyncTask onComplete event, so we work 
+ * around this by using a message handler.
+ * 
+ * @param DeckPicker activity the main activity
+ */
+public class DialogHandler extends Handler {
+
+    /**
+     * Handler messages
+     */
+    public static final int MSG_SHOW_COLLECTION_LOADING_ERROR_DIALOG = 0;
+    public static final int MSG_SHOW_COLLECTION_IMPORT_REPLACE_DIALOG = 1;
+    public static final int MSG_SHOW_COLLECTION_IMPORT_ADD_DIALOG = 2;
+    public static final int MSG_SHOW_SYNC_ERROR_DIALOG = 3;
+    public static final int MSG_SHOW_EXPORT_COMPLETE_DIALOG = 4;
+    public static final int MSG_SHOW_MEDIA_CHECK_COMPLETE_DIALOG = 5;
+    public static final int MSG_SHOW_DATABASE_ERROR_DIALOG = 6;
+
+
+    WeakReference<AnkiActivity> mActivity;
+    
+    public DialogHandler(AnkiActivity activity) {
+        // Use weak reference to main activity to prevent leaking the activity when it's closed
+        mActivity = new WeakReference<AnkiActivity>(activity);
+    }
+
+
+    @Override
+    public void handleMessage(Message msg) {
+        Bundle msgData = msg.getData();
+        if (msg.what == MSG_SHOW_COLLECTION_LOADING_ERROR_DIALOG) {
+            // Collection could not be opened
+            ((DeckPicker) mActivity.get()).showDatabaseErrorDialog(DatabaseErrorDialog.DIALOG_LOAD_FAILED);
+        } else if (msg.what == MSG_SHOW_COLLECTION_IMPORT_REPLACE_DIALOG) {
+            // Handle import of collection package APKG
+            ((DeckPicker) mActivity.get()).showImportDialog(ImportDialog.DIALOG_IMPORT_REPLACE_CONFIRM, msgData.getString("importPath"));
+        } else if (msg.what == MSG_SHOW_COLLECTION_IMPORT_ADD_DIALOG) {
+            // Handle import of deck package APKG
+            ((DeckPicker) mActivity.get()).showImportDialog(ImportDialog.DIALOG_IMPORT_ADD_CONFIRM, msgData.getString("importPath"));
+        } else if (msg.what == MSG_SHOW_SYNC_ERROR_DIALOG) {
+            int id = msgData.getInt("dialogType");
+            String message = msgData.getString("dialogMessage");
+            ((DeckPicker) mActivity.get()).showSyncErrorDialog(id, message);
+        } else if (msg.what == MSG_SHOW_EXPORT_COMPLETE_DIALOG) {
+            // Export complete
+            AsyncDialogFragment f = DeckPickerExportCompleteDialog.newInstance(msgData.getString("exportPath"));
+            mActivity.get().showAsyncDialogFragment(f);
+        } else if (msg.what == MSG_SHOW_MEDIA_CHECK_COMPLETE_DIALOG) {            
+            // Media check results
+            int id = msgData.getInt("dialogType");
+            if (id!=MediaCheckDialog.DIALOG_CONFIRM_MEDIA_CHECK) {
+                List<List<String>> checkList = new ArrayList<List<String>>();
+                checkList.add(msgData.getStringArrayList("nohave"));
+                checkList.add(msgData.getStringArrayList("unused"));
+                checkList.add(msgData.getStringArrayList("invalid"));
+                ((DeckPicker) mActivity.get()).showMediaCheckDialog(id, checkList);
+            }
+        } else if (msg.what == MSG_SHOW_DATABASE_ERROR_DIALOG) {
+            ((DeckPicker) mActivity.get()).showDatabaseErrorDialog(msgData.getInt("dialogType"));
+        }
+    }
+}

--- a/src/com/ichi2/anki/dialogs/MediaCheckDialog.java
+++ b/src/com/ichi2/anki/dialogs/MediaCheckDialog.java
@@ -3,6 +3,7 @@ package com.ichi2.anki.dialogs;
 
 import android.content.DialogInterface;
 import android.os.Bundle;
+import android.os.Message;
 
 import com.ichi2.anki.R;
 import com.ichi2.themes.StyledDialog;
@@ -13,7 +14,6 @@ import java.util.List;
 public class MediaCheckDialog extends AsyncDialogFragment {
     public static final int DIALOG_CONFIRM_MEDIA_CHECK = 0;
     public static final int DIALOG_MEDIA_CHECK_RESULTS = 1;
-    public static String CLASS_NAME_TAG = "MediaCheckDialog";
 
     public interface MediaCheckDialogListener {
         public void showMediaCheckDialog(int dialogType);
@@ -173,16 +173,15 @@ public class MediaCheckDialog extends AsyncDialogFragment {
 
 
     @Override
-    public Bundle getNotificationIntentExtras() {
+    public Message getDialogHandlerMessage() {
+        Message msg = Message.obtain();
+        msg.what = DialogHandler.MSG_SHOW_MEDIA_CHECK_COMPLETE_DIALOG;
         Bundle b = new Bundle();
-        /* Avoid putting too much data into the notification extras bundle. 
-         * Store large data in the ApplicationContext instead
-         * b.putStringArrayList("nohave", getArguments().getStringArrayList("nohave"));
-         * b.putStringArrayList("unused", getArguments().getStringArrayList("unused"));
-         * b.putStringArrayList("invalid", getArguments().getStringArrayList("invalid")); */
+        b.putStringArrayList("nohave", getArguments().getStringArrayList("nohave"));
+        b.putStringArrayList("unused", getArguments().getStringArrayList("unused"));
+        b.putStringArrayList("invalid", getArguments().getStringArrayList("invalid"));
         b.putInt("dialogType", getArguments().getInt("dialogType"));
-        b.putBoolean("showAsyncDialogFragment", true);
-        b.putString("dialogClass", CLASS_NAME_TAG);
-        return b;
+        msg.setData(b);
+        return msg;
     }
 }

--- a/src/com/ichi2/anki/dialogs/SyncErrorDialog.java
+++ b/src/com/ichi2/anki/dialogs/SyncErrorDialog.java
@@ -4,6 +4,7 @@ package com.ichi2.anki.dialogs;
 import android.app.Dialog;
 import android.content.DialogInterface;
 import android.os.Bundle;
+import android.os.Message;
 
 import com.ichi2.anki.R;
 import com.ichi2.libanki.Collection;
@@ -18,7 +19,6 @@ public class SyncErrorDialog extends AsyncDialogFragment {
     public static final int DIALOG_SYNC_SANITY_ERROR = 6;
     public static final int DIALOG_SYNC_SANITY_ERROR_CONFIRM_KEEP_LOCAL = 7;
     public static final int DIALOG_SYNC_SANITY_ERROR_CONFIRM_KEEP_REMOTE = 8;
-    public static String CLASS_NAME_TAG = "SyncErrorDialog";
 
     public interface SyncErrorDialogListener {
         public void showSyncErrorDialog(int dialogType);
@@ -264,16 +264,17 @@ public class SyncErrorDialog extends AsyncDialogFragment {
         }
     }
 
-
     @Override
-    public Bundle getNotificationIntentExtras() {
+    public Message getDialogHandlerMessage() {
+        Message msg = Message.obtain();
+        msg.what = DialogHandler.MSG_SHOW_SYNC_ERROR_DIALOG;
         Bundle b = new Bundle();
-        b.putBoolean("showAsyncDialogFragment", true);
-        b.putString("dialogClass", CLASS_NAME_TAG);
         b.putInt("dialogType", getArguments().getInt("dialogType"));
         b.putString("dialogMessage", getArguments().getString("dialogMessage"));
-        return b;
+        msg.setData(b);
+        return msg;
     }
+
 
     // Listener for cancel button which clears ALL previous dialogs on the back stack
     // Supply null instead of this listener in cases where we prefer to go back to last dialog


### PR DESCRIPTION
Some further changes to the new "AsyncDialogFragment" system which I created (see e.g. #543) so that AnkiDroid doesn't crash when trying to show a `DialogFragment` after an `AsyncTask` finishes.
- Make arguments to async dialogs not tied to notification system. Previously it was required that the user open the app via the notification, or else the dialog would not be shown to the user when they resume the app.
- Add preference to disable notification system as per the Android guidelines
- Make DatabaseErrorDialog async to prevent crash on basicCheck failure during sync (fix [issue 2355](https://code.google.com/p/ankidroid/issues/detail?id=2355))
