### PR TITLE
Fix IOException bug in media sync

### DIFF
--- a/src/com/ichi2/libanki/Media.java
+++ b/src/com/ichi2/libanki/Media.java
@@ -839,7 +839,10 @@ public class Media {
             z.close();
             return new Pair<File, List<String>>(f, fnames);
         } catch (IOException e) {
+            // Probably a file was manually deleted from the media folder
             Log.e(AnkiDroidApp.TAG, "Failed to create media changes zip", e);
+            // mark the media db as new so that next sync the media database is rebuilt
+            mCol.getMedia().getDb().execute("update meta set dirmod=0");
             throw new RuntimeException(e);
         } finally {
             if (cur != null) {


### PR DESCRIPTION
@dae, @hssm 
2.3 currently fails to complete media sync if a user has manually a deleted a media file... It doesn't crash, but an [unhandled exception dialog](https://lh5.googleusercontent.com/-oDS5_ebfpaM/VFFBHrQN8CI/AAAAAAAAEho/d_NCcr3Xf4o/s320/Screenshot_2014-10-29-19-16-05.png) is shown, and the user isn't given any clues on how to solve the problem.

I just set `dirmod` so that next media sync the database will be rebuilt, which will automatically resolve the problem. I know we are forced to do things a bit differently from Anki Desktop, so could you guys please confirm if this is the right thing to do?
