### PR TITLE
MM Editor: Only delete temporary media when new path is different from old path

### DIFF
--- a/src/com/ichi2/anki/servicelayer/NoteService.java
+++ b/src/com/ichi2/anki/servicelayer/NoteService.java
@@ -177,7 +177,7 @@ public class NoteService {
                     Collection col = AnkiDroidApp.getCol();
                     String fname = col.getMedia().addFile(inFile);
                     File outFile = new File(col.getMedia().dir(), fname);
-                    if (field.hasTemporaryMedia()) {
+                    if (field.hasTemporaryMedia() && !outFile.getAbsolutePath().equals(tmpMediaPath)) {
                         // Delete original
                         inFile.delete();
                     }


### PR DESCRIPTION
Fix adding images from Google in multimedia editor
