### PR TITLE
fix long-standing bug in syncer.chunk()

### DIFF
--- a/src/com/ichi2/libanki/sync/Syncer.java
+++ b/src/com/ichi2/libanki/sync/Syncer.java
@@ -503,11 +503,12 @@ public class Syncer {
                 String curTable = mTablesLeft.getFirst();
                 if (mCursor == null) {
                     mCursor = cursorForTable(curTable);
-                    colTypes = columnTypesForQuery(curTable);
                 }
+                colTypes = columnTypesForQuery(curTable);
                 JSONArray rows = new JSONArray();
                 int count = mCursor.getColumnCount();
-                while (mCursor.moveToNext() && mCursor.getPosition() <= lim) {
+                int fetched = 0;
+                while (mCursor.moveToNext()) {
                     JSONArray r = new JSONArray();
                     for (int i = 0; i < count; i++) {
                         switch (colTypes.get(i)) {
@@ -523,8 +524,10 @@ public class Syncer {
                         }
                     }
                     rows.put(r);
+                    if (++fetched == lim) {
+                        break;
+                    }
                 }
-                int fetched = rows.length();
                 if (fetched != lim) {
                     // table is empty
                     mTablesLeft.removeFirst();


### PR DESCRIPTION
chunk() was failing to gather anything but the first batch
of changes as the logic to determine whether there were
more changes was wrong.

with the recent change to a 250 chunk size, any users
who changed more than 250 cards on AD and synced may have
collections that don't match what's on AnkiWeb, so
for the 2.3.1 release I recommend you advise  users to force
a full sync to correct any possible problems
