### PR TITLE
Extend NookHD+ compat class to NookHD

### DIFF
--- a/src/com/ichi2/anki/AnkiDroidApp.java
+++ b/src/com/ichi2/anki/AnkiDroidApp.java
@@ -36,7 +36,7 @@ import com.ichi2.anki.exception.AnkiDroidErrorReportException;
 import com.ichi2.async.Connection;
 import com.ichi2.compat.Compat;
 import com.ichi2.compat.CompatV15;
-import com.ichi2.compat.CompatV15NookHdPlus;
+import com.ichi2.compat.CompatV15NookHdOrHdPlus;
 import com.ichi2.compat.CompatV16;
 import com.ichi2.compat.CompatV7;
 import com.ichi2.compat.CompatV7Nook;
@@ -123,8 +123,8 @@ public class AnkiDroidApp extends Application {
     public void onCreate() {
         super.onCreate();
 
-        if (isNookHdPlus() && AnkiDroidApp.SDK_VERSION == 15) {
-            mCompat = new CompatV15NookHdPlus();
+        if (isNookHdOrHdPlus() && AnkiDroidApp.SDK_VERSION == 15) {
+            mCompat = new CompatV15NookHdOrHdPlus();
         } else if (AnkiDroidApp.SDK_VERSION >= 16) {
             mCompat = new CompatV16();
         } else if (AnkiDroidApp.SDK_VERSION >= 15) {
@@ -175,9 +175,17 @@ public class AnkiDroidApp extends Application {
     }
 
 
+    private boolean isNookHdOrHdPlus() {
+        return isNookHd() || isNookHdPlus();
+    }
+    
     private boolean isNookHdPlus() {
         return android.os.Build.BRAND.equals("NOOK") && android.os.Build.PRODUCT.equals("HDplus")
                 && android.os.Build.DEVICE.equals("ovation");
+    }
+    
+    private boolean isNookHd () {
+        return android.os.Build.MODEL.equalsIgnoreCase("bntv400") && android.os.Build.BRAND.equals("NOOK");
     }
 
 

--- a/src/com/ichi2/compat/CompatV15NookHdOrHdPlus.java
+++ b/src/com/ichi2/compat/CompatV15NookHdOrHdPlus.java
@@ -11,7 +11,7 @@ import android.database.sqlite.SQLiteDatabase;
  * device.
  */
 @TargetApi(16)
-public class CompatV15NookHdPlus extends CompatV15 implements Compat {
+public class CompatV15NookHdOrHdPlus extends CompatV15 implements Compat {
 
     @Override
     public void disableDatabaseWriteAheadLogging(SQLiteDatabase db) {


### PR DESCRIPTION
We used to support both NookHD and NookHD+, but the code got factored out into these compat classes, and they only handled NookHD+'s. This change attempts to extend the same handling to NookHD's.

I'm not 1000% sure this will provide a fix, just that if were to break anyone, it would be the NookHD's I'm trying to help. Prior to this change the NookHD's (according to one user) could do local work/review, and just not sync.

More context to this change can be found here: https://groups.google.com/d/msg/anki-android/LGOG7OV_rWc/BGjVS0JaUNEJ  The errors pasted by the user fall in line with the original database journaling issues that all Nook HD(+)'s encountered.
