### PR TITLE
Remove jar.libs.dir from ant.properties

### DIFF
--- a/ant.properties
+++ b/ant.properties
@@ -15,7 +15,5 @@
 #  'key.alias' for the name of the key to use.
 # The password will be asked during the build when you use the 'release' target.
 
-jar.libs.dir=libs
-
 key.store=${user.home}/src/android-keystore
 key.alias=nrkeystorealias


### PR DESCRIPTION
See discussion in https://github.com/ankidroid/Anki-Android/commit/8bd2322dd6444acc3473b0ce8a9af6387e11dd88. `libs` is the default value.
