### PR TITLE
Make new ConfirmationDialog class abstract

### DIFF
--- a/src/com/ichi2/anki/DeckPicker.java
+++ b/src/com/ichi2/anki/DeckPicker.java
@@ -66,8 +66,6 @@ import com.github.amlcurran.showcaseview.targets.ActionItemTarget;
 import com.ichi2.anim.ActivityTransitionAnimation;
 import com.ichi2.anki.StudyOptionsFragment.StudyOptionsListener;
 import com.ichi2.anki.dialogs.AsyncDialogFragment;
-import com.ichi2.anki.dialogs.ConfirmationDialog;
-import com.ichi2.anki.dialogs.ConfirmationDialog.ConfirmationDialogListener;
 import com.ichi2.anki.dialogs.DatabaseErrorDialog;
 import com.ichi2.anki.dialogs.DeckPickerBackupNoSpaceLeftDialog;
 import com.ichi2.anki.dialogs.DeckPickerConfirmDeleteDeckDialog;

--- a/src/com/ichi2/anki/NoteEditor.java
+++ b/src/com/ichi2/anki/NoteEditor.java
@@ -30,7 +30,6 @@ import android.content.res.Resources;
 import android.graphics.Color;
 import android.graphics.Typeface;
 import android.os.Bundle;
-import android.support.v4.app.DialogFragment;
 import android.support.v7.widget.PopupMenu;
 import android.support.v7.widget.PopupMenu.OnMenuItemClickListener;
 import android.text.Editable;
@@ -61,7 +60,6 @@ import android.widget.TextView;
 
 import com.ichi2.anim.ActivityTransitionAnimation;
 import com.ichi2.anki.dialogs.ConfirmationDialog;
-import com.ichi2.anki.dialogs.ConfirmationDialog.ConfirmationDialogListener;
 import com.ichi2.anki.dialogs.TagsDialog;
 import com.ichi2.anki.dialogs.TagsDialog.TagsDialogListener;
 import com.ichi2.anki.exception.ConfirmModSchemaException;
@@ -710,17 +708,14 @@ public class NoteEditor extends AnkiActivity {
             if (!newModel.equals(oldModel)) {
                 if (mModelChangeCardMap.size() < mEditorNote.cards().size() || mModelChangeCardMap.containsKey(null)) {
                     // If cards will be lost via the new mapping then show a confirmation dialog before proceeding with the change
-                    ConfirmationDialog dialog = ConfirmationDialog.newInstance(res.getString(R.string.confirm_map_cards_to_nothing));
-                    dialog.setListener(new ConfirmationDialogListener() {
+                    ConfirmationDialog dialog = new ConfirmationDialog () {
                         @Override
                         public void confirm() {
+                            // Bypass the check once the user confirms
                             changeNoteTypeWithErrorHandling(oldModel, newModel);
                         }
-                        @Override
-                        public void cancel() {
-                            // Take no action
-                        }
-                    });
+                    };
+                    dialog.setArgs(res.getString(R.string.confirm_map_cards_to_nothing));
                     showDialogFragment(dialog);                    
                 } else {
                     // Otherwise go straight to changing note type
@@ -773,8 +768,7 @@ public class NoteEditor extends AnkiActivity {
             changeNoteType(oldModel, newModel);
         } catch (ConfirmModSchemaException e) {
             // Libanki has determined we should ask the user to confirm first
-            ConfirmationDialog dialog = ConfirmationDialog.newInstance(res.getString(R.string.full_sync_confirmation));
-            dialog.setListener(new ConfirmationDialogListener() {
+            ConfirmationDialog dialog = new ConfirmationDialog() {
                 @Override
                 public void confirm() {
                     // Bypass the check once the user confirms
@@ -786,11 +780,8 @@ public class NoteEditor extends AnkiActivity {
                         throw new RuntimeException(e2);
                     }
                 }
-                @Override
-                public void cancel() {
-                    // Take no action
-                }
-            });
+            };
+            dialog.setArgs(res.getString(R.string.full_sync_confirmation));
             showDialogFragment(dialog);
         }
     }

--- a/src/com/ichi2/anki/dialogs/ConfirmationDialog.java
+++ b/src/com/ichi2/anki/dialogs/ConfirmationDialog.java
@@ -6,41 +6,32 @@ import android.content.res.Resources;
 import android.os.Bundle;
 import android.support.v4.app.DialogFragment;
 
-import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.R;
 import com.ichi2.themes.StyledDialog;
 
-public class ConfirmationDialog extends DialogFragment {
-    /**
-     * Listener interface for confirmation and cancel
-     */
-    public interface ConfirmationDialogListener {
-        public void confirm();
-        public void cancel();
-    }
-    /**
-     * Set default listeners to null
-     */
-    private ConfirmationDialogListener mConfirmListener;
+/**
+ * This is a reusable convenience class which makes it easy to show a confirmation dialog as a DialogFragment.
+ * To use, create a new instance which overrides the confirm() method, call setArgs(...), and then show
+ * the DialogFragment via the fragment manager as usual.
+ */
+public abstract class ConfirmationDialog extends DialogFragment {
 
-    public static ConfirmationDialog newInstance(String message) {
-        return newInstance("" , message);
+    public void setArgs(String message) {
+        setArgs("" , message);
     }
 
-    public static ConfirmationDialog newInstance(String title, String message) {
-        ConfirmationDialog f = new ConfirmationDialog();
+    public void setArgs(String title, String message) {
         Bundle args = new Bundle();
         args.putString("message", message);
         args.putString("title", title);
-        f.setArguments(args);
-        return f;
+        setArguments(args);
     }
 
 
     @Override
     public StyledDialog onCreateDialog(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        Resources res = AnkiDroidApp.getAppResources();
+        Resources res = getActivity().getResources();
         StyledDialog.Builder builder = new StyledDialog.Builder(getActivity());
         // Set title if specified
         String title = getArguments().getString("title");
@@ -53,20 +44,29 @@ public class ConfirmationDialog extends DialogFragment {
         builder.setPositiveButton(res.getString(R.string.dialog_ok), new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int which) {
-                mConfirmListener.confirm();
+                confirm();
             }
         });
         // Set cancel action
         builder.setNegativeButton(res.getString(R.string.dialog_cancel), new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int which) {
-                mConfirmListener.cancel();
+                cancel();
             }
         });
         return builder.create();
     }
 
-    public void setListener(ConfirmationDialogListener listener) {
-        mConfirmListener = listener;
+
+    /**
+     * Must override this method to handle confirmation event
+     */
+    public abstract void confirm();
+
+
+    /**
+     * Optionally override this method to do something special when operation cancelled
+     */
+    public void cancel() {
     }
 }

--- a/src/com/ichi2/anki/dialogs/DialogHandler.java
+++ b/src/com/ichi2/anki/dialogs/DialogHandler.java
@@ -6,8 +6,6 @@ import android.os.Message;
 
 import com.ichi2.anki.AnkiActivity;
 import com.ichi2.anki.DeckPicker;
-import com.ichi2.anki.dialogs.ConfirmationDialog.ConfirmationDialogListener;
-
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
@@ -78,21 +76,15 @@ public class DialogHandler extends Handler {
             ((DeckPicker) mActivity.get()).showDatabaseErrorDialog(msgData.getInt("dialogType"));
         } else if (msg.what == MSG_SHOW_FORCE_FULL_SYNC_DIALOG) {
             // Confirmation dialog for forcing full sync
-            final AnkiActivity activity = ((AnkiActivity) mActivity.get());
-            String message = msgData.getString("message");
-            ConfirmationDialog dialog = ConfirmationDialog.newInstance(message);
-            dialog.setListener(new ConfirmationDialogListener() {
+            ConfirmationDialog dialog = new ConfirmationDialog () {
                 @Override
                 public void confirm() {
                     // Bypass the check once the user confirms
-                    activity.getCol().modSchemaNoCheck();
+                    ((AnkiActivity) getActivity()).getCol().modSchemaNoCheck();
                 }
-                @Override
-                public void cancel() {
-                    // Take no action
-                }
-            });
-            activity.showDialogFragment(dialog);
+            };
+            dialog.setArgs(msgData.getString("message"));
+            ((AnkiActivity) mActivity.get()).showDialogFragment(dialog);
         }
     }
 }


### PR DESCRIPTION
I've found a more elegant way to make a generic and reusable `DialogFragment`, which should fix [this crash](http://ankidroid-triage.appspot.com/report_crashes?bug_id=6184842194583552) which is occasionally occurring in 2.3.2
