### PR TITLE
Add return code to error log when checking TTS language availability

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.java
@@ -167,10 +167,11 @@ public class ReadText {
         Locale[] systemLocales = Locale.getAvailableLocales();
         for (Locale loc : systemLocales) {
             try {
-                if (mTts.isLanguageAvailable(loc) == TextToSpeech.LANG_COUNTRY_AVAILABLE) {
+                int retCode = mTts.isLanguageAvailable(loc);
+                if (retCode >= TextToSpeech.LANG_COUNTRY_AVAILABLE) {
                     availableTtsLocales.add(loc);
                 } else {
-                    Log.v(AnkiDroidApp.TAG, "ReadText.buildAvailableLanguages() :: " + loc.getDisplayName() + " not available");
+                    Log.v(AnkiDroidApp.TAG, "ReadText.buildAvailableLanguages() :: " + loc.getDisplayName() + " not available (error code "+Integer.toString(retCode)+")");
                 }
             } catch (IllegalArgumentException e) {
                 Log.e(AnkiDroidApp.TAG, "Error checking if language " + loc.getDisplayName() + " available");


### PR DESCRIPTION
Spit out a bit more info for issue 2394
