### PR TITLE
Work around Triage (pytz) failing to parse TZ+x timezone strings

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Feedback.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Feedback.java
@@ -505,7 +505,16 @@ public class Feedback extends AnkiActivity {
 
         String reportsentutc = String.format("%s", df1.format(ts));
         String reportsenttzoffset = String.format("%s", df2.format(ts));
-        String reportsenttz = String.format("%s", localTz.getID());
+        String reportsenttz;
+        if (AnkiDroidApp.isChromebook()) {
+            // Chrome creates timezone strings such as GMT+5, which are not supported
+            // by ankidroid-triage (pytz) and result in a 500 error. This is something that
+            // should be fixed on the server-side. In the meantime, I would much rather have
+            // issue reports in the wrong timezone than no issue reports at all.
+            reportsenttz = "GMT";
+        } else {
+            reportsenttz = String.format("%s", localTz.getID());
+        }
 
         pairs.add(new BasicNameValuePair("reportsentutc", reportsentutc));
         pairs.add(new BasicNameValuePair("reportsenttzoffset", reportsenttzoffset));


### PR DESCRIPTION
See issue [2342](https://code.google.com/p/ankidroid/issues/detail?id=2342) and the code comment for more details.
Example bug report: http://ankidroid-triage.appspot.com/view_crash?crash_id=4751692675416064 (I didn't report this yet because that was my secret bug to reproduce a crash, lol)
