### PR TITLE
Hide import, export, restore in deck picker on Chromebooks

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -527,6 +527,15 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
         } else if (mShowcaseDialog != null && colOpen() && !getCol().isEmpty()) {
             hideShowcaseView();
         }
+
+        // Hide import, export, and restore backup on ChromeOS as users
+        // don't have access to the file system.
+        if (AnkiDroidApp.isChromebook()) {
+            menu.findItem(R.id.action_restore_backup).setVisible(false);
+            menu.findItem(R.id.action_import).setVisible(false);
+            menu.findItem(R.id.action_export).setVisible(false);
+        }
+
         return super.onCreateOptionsMenu(menu);
     }
 


### PR DESCRIPTION
Users don't have access to the filesystem, so _Import_ and _Export_ will not work as expected. _Restore_ just crashes ATM, will investigate later.
