### PR TITLE
Fix crash when play button is pressed twice

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/AudioView.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/AudioView.java
@@ -238,7 +238,7 @@ public class AudioView extends LinearLayout {
                         } catch (Exception e) {
                             Log.e("AudioView", e.getMessage());
                             showToast(gtxt(R.string.multimedia_editor_audio_view_playing_failed));
-                            mStatus = Status.STOPPED;
+                            mStatus = Status.IDLE;
                         }
                         break;
 


### PR DESCRIPTION
Tricky beast: if the `Play` button is pressed without recording something first, the playback will fail and the state will change to `STOPPED`. When `Play` is clicked again, it will try to seek to 0, and throw an exception because there is no media file. The exception is caught, but doesn't contain a message, which crashes `Log.d`.

The fix sets the state back to `IDLE` instead of `STOPPED`.
