### PR TITLE
Allow deck names to have apostrophe

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -736,7 +736,7 @@ public class CardBrowser extends NavigationDrawerActivity implements ActionBar.O
             } catch (JSONException e) {
                 throw new RuntimeException();
             }
-            mRestrictOnDeck = "deck:'" + deckName + "' ";
+            mRestrictOnDeck = "deck:\"" + deckName + "\" ";
         }
         searchCards();
         return true;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -1927,7 +1927,7 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
 
             @Override
             public void onClick(DialogInterface dialog, int which) {
-                String newName = mDialogEditText.getText().toString().replaceAll("['\"]", "");
+                String newName = mDialogEditText.getText().toString().replaceAll("\"", "");
                 Collection col = getCol();
                 if (col != null) {
                     if (col.getDecks().rename(col.getDecks().get(mContextMenuDid), newName)) {


### PR DESCRIPTION
Decks created on Anki Desktop can have an apostrophe in them, so we also need to handle this case properly. This bug was discovered [here](https://groups.google.com/forum/#!topic/anki-android/LGOG7OV_rWc).
