### PR TITLE
Sanity check error with apostrophe

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -188,7 +188,7 @@ public class Decks {
 
 
     public long id(String name, boolean create, String type) {
-        name = name.replace("\'", "").replace("\"", "");
+        name = name.replace("\"", "");
         for (Map.Entry<Long, JSONObject> g : mDecks.entrySet()) {
             try {
                 if (g.getValue().getString("name").equalsIgnoreCase(name)) {


### PR DESCRIPTION
Fix a bug where sanity check incorrectly fails when there's an apostrophe in the deck name, due to the id() method finding the wrong parent deck and thus applying the wrong limit, leading to incorrect review counts
