### PR TITLE
Note editor small changes

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
@@ -101,9 +101,9 @@ public class CardTemplateEditor extends AnkiActivity {
                 finishWithAnimation(ActivityTransitionAnimation.RIGHT);
                 return true;
 
-            case R.id.action_preview:
+            /*case R.id.action_preview:
                 //openReviewer();
-                return true;
+                return true;*/
 
             default:
                 return super.onOptionsItemSelected(item);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -604,13 +604,6 @@ public class NoteEditor extends AnkiActivity {
     }
 
 
-    private void openReviewer() {
-        Intent reviewer = new Intent(NoteEditor.this, Previewer.class);
-        reviewer.putExtra("currentCardId", mCurrentEditedCard.getId());
-        startActivityWithoutAnimation(reviewer);
-    }
-
-
     private boolean addFromAedict(String extra_text) {
         String category = "";
         String[] notepad_lines = extra_text.split("\n");
@@ -845,7 +838,6 @@ public class NoteEditor extends AnkiActivity {
             menu.findItem(R.id.action_saved_notes).setVisible(false);
             menu.findItem(R.id.action_add_card_from_card_editor).setVisible(true);
             menu.findItem(R.id.action_reset_card_progress).setVisible(true);
-            menu.findItem(R.id.action_preview).setVisible(true);
             menu.findItem(R.id.action_reschedule_card).setVisible(true);
             menu.findItem(R.id.action_reset_card_progress).setVisible(true);
             // if Arabic reshaping is enabled, disable the Save button to avoid
@@ -882,10 +874,6 @@ public class NoteEditor extends AnkiActivity {
 
             case R.id.action_save:
                 saveNote();
-                return true;
-
-            case R.id.action_preview:
-                openReviewer();
                 return true;
 
             case R.id.action_later:

--- a/AnkiDroid/src/main/res/menu/card_editor.xml
+++ b/AnkiDroid/src/main/res/menu/card_editor.xml
@@ -2,12 +2,6 @@
     xmlns:ankidroid="http://schemas.android.com/apk/res-auto" >
 
     <item
-        android:id="@+id/action_preview"
-        android:icon="@drawable/ic_menu_view"
-        android:title="@string/card_editor_preview_card"
-        android:visible="false"
-        ankidroid:showAsAction="ifRoom"/>
-    <item
         android:id="@+id/action_save"
         android:icon="@drawable/ic_action_accept"
         android:title="@string/add"


### PR DESCRIPTION
- Only allow remapping of fields when more than 2 fields in original note
  --> this is likely to confuse beginner users who might try to swap front -> back when changing note type, is unlikely to be used by anyone, and if users really do want to do it, they can manually edit it with a few extra operations
- remove the preview button as it doesn't work for unsaved notes
