### PR TITLE
Use AnkiDroidApp.closeCollection() instead of getCol().close()

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
@@ -303,7 +303,7 @@ public class NavigationDrawerActivity extends AnkiActivity {
                 restartActivity();
             } else {
                 // collection path has changed so kick the user back to the DeckPicker
-                AnkiDroidApp.getCol().close(true);
+                AnkiDroidApp.closeCollection(true);
                 Intent deckPicker = new Intent(this, DeckPicker.class);
                 deckPicker.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
                 startActivityWithoutAnimation(deckPicker);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -603,7 +603,7 @@ public class Preferences extends PreferenceActivity implements OnSharedPreferenc
     @Override
     public boolean onKeyDown(int keyCode, KeyEvent event) {
         if (keyCode == KeyEvent.KEYCODE_BACK && event.getRepeatCount() == 0) {
-            Log.i(AnkiDroidApp.TAG, "DeckOptions - onBackPressed()");
+            Log.i(AnkiDroidApp.TAG, "Preferences - onBackPressed()");
             closePreferences();
             return true;
         }

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionLoader.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionLoader.java
@@ -42,6 +42,7 @@ public class CollectionLoader extends AsyncTaskLoader<Collection> {
     
     @Override
     public void deliverResult(Collection col) {
+        Log.v(AnkiDroidApp.TAG, "CollectionLoader.deliverResult()");
         // Loader has been reset so don't forward data to listener
         if (isReset()) {
             if (col != null) {
@@ -58,17 +59,17 @@ public class CollectionLoader extends AsyncTaskLoader<Collection> {
     protected void onStartLoading() {
         // Don't touch collection if sync in progress
         if (AnkiDroidApp.getSyncInProgress()) {
-            Log.i(AnkiDroidApp.TAG, "CollectionLoader.onStartLoading() -- sync in progress; don't load collection");
+            Log.v(AnkiDroidApp.TAG, "CollectionLoader.onStartLoading() -- sync in progress; don't load collection");
             return;
         }
         String colPath = AnkiDroidApp.getCollectionPath();
         if (AnkiDroidApp.colIsOpen() && AnkiDroidApp.getCol() != null && AnkiDroidApp.getCol().getPath().equals(colPath)) {
             // deliver current path if open and valid
-            Log.i(AnkiDroidApp.TAG, "CollectionLoader.onStartLoading() -- deliverResult as col already open");
+            Log.v(AnkiDroidApp.TAG, "CollectionLoader.onStartLoading() -- deliverResult as col already open");
             deliverResult(AnkiDroidApp.getCol());
         } else {
             // otherwise reload the collection
-            Log.i(AnkiDroidApp.TAG, "CollectionLoader.onStartLoading() -- force load collection");
+            Log.v(AnkiDroidApp.TAG, "CollectionLoader.onStartLoading() -- force load collection");
             forceLoad();
         }        
     }
@@ -76,12 +77,14 @@ public class CollectionLoader extends AsyncTaskLoader<Collection> {
     @Override
     protected void onStopLoading() {
         // The Loader has been put in a stopped state, so we should attempt to cancel the current load (if there is one).
+        Log.v(AnkiDroidApp.TAG, "CollectionLoader.onStopLoading()");
         cancelLoad();
     }
     
     @Override
     protected void onReset() {
         // Ensure the loader is stopped.
+        Log.v(AnkiDroidApp.TAG, "CollectionLoader.onReset()");
         onStopLoading();
     }
     


### PR DESCRIPTION
When changing the collection path it's necessary to use AnkiDroidApp.closeCollection() so that resources are freed properly, and the Activity starts back up again as expected. This fixes a bug introduced in #656 where changing the Collection path would result in endless inescapable "Loading collection..." splash scren

Also added more logging
