### PR TITLE
Workaround for issue 2406

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.java
@@ -595,8 +595,14 @@ public class Statistics extends NavigationDrawerActivity {
         }
 
         private void createStatisticOverview(){
-            mCreateStatisticsOverviewTask = (((Statistics)getActivity()).getTaskHandler()).createStatisticsOverview(
-                    mWebView, mProgressBar);
+            AnkiStatsTaskHandler handler = (((Statistics)getActivity()).getTaskHandler());
+            // Workaround for issue 2406.
+            // TODO: Implementing loader for Collection in Fragment itself would be a better solution.
+            if (handler != null) {
+                mCreateStatisticsOverviewTask = handler.createStatisticsOverview(mWebView, mProgressBar);
+            } else {
+                Log.e(AnkiDroidApp.TAG, "Statistics.createStatisticsOverview() TaskHandler not found");
+            }
         }
 
         @Override


### PR DESCRIPTION
Add null check when creating `mCreateStatisticsOverviewTask` as workaround for [issue 2406](https://code.google.com/p/ankidroid/issues/detail?id=2406). See the issue body for more details.
