### PR TITLE
Give dummy filename when querying URI fails for shared deck

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.java
@@ -9,6 +9,7 @@ import android.os.Bundle;
 import android.os.Message;
 import android.provider.OpenableColumns;
 import android.support.v4.content.IntentCompat;
+import android.util.Log;
 
 import com.ichi2.anim.ActivityTransitionAnimation;
 import com.ichi2.anki.dialogs.DialogHandler;
@@ -36,6 +37,7 @@ public class IntentHandler extends Activity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.styled_open_collection_dialog);
         Intent intent = getIntent();
+        Log.v(AnkiDroidApp.TAG, intent.toString());
         Intent reloadIntent = new Intent(this, DeckPicker.class);
         reloadIntent.setDataAndType(getIntent().getData(), getIntent().getType());
         String action = intent.getAction();
@@ -57,6 +59,15 @@ public class IntentHandler extends Activity {
                 } finally {
                     if (cursor != null)
                         cursor.close();
+                }
+                /* Querying the filename appears to fail for a small minority of users.
+                   If the data type is apkg then we can assume that it's a shared deck from AnkiWeb
+                   so we give it a dummy filename*/
+                if (filename == null) {
+                    Log.e(AnkiDroidApp.TAG, "Could not get filename from Content Provider. cursor = " + cursor);
+                    if (intent.getType().equals("application/apkg")) {
+                        filename = "unknown_filename.apkg";
+                    }
                 }
                 if (filename != null && filename.endsWith(".apkg")) {
                     Uri importUri = Uri.fromFile(new File(getCacheDir(), filename));


### PR DESCRIPTION
A bit more work on shared deck issue
