### PR TITLE
Fix new card dues

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -440,7 +440,7 @@ public class Collection {
      */
 
     public int nextID(String type) {
-        type = "next" + type.toUpperCase(Locale.US);
+        type = "next" + Character.toUpperCase(type.charAt(0)) + type.substring(1);
         int id;
         try {
             id = mConf.getInt(type);


### PR DESCRIPTION
I noticed that cards added in AnkiDroid tend to come before the ones I added in Anki Desktop.
The reason is that AnkiDroid uses the wrong counter to determine dues for new cards: it should be `nextPos`, not `nextPOS`.
