### PR TITLE
Improve swipe detection

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -2833,28 +2833,35 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
         public boolean onFling(MotionEvent e1, MotionEvent e2, float velocityX, float velocityY) {
             if (mGesturesEnabled) {
                 try {
-                    if (e2.getY() - e1.getY() > AnkiDroidApp.sSwipeMinDistance
-                            && Math.abs(velocityY) > AnkiDroidApp.sSwipeThresholdVelocity
-                            && Math.abs(e1.getX() - e2.getX()) < AnkiDroidApp.sSwipeMaxOffPath && !mIsYScrolling) {
-                        // down
-                        executeCommand(mGestureSwipeDown);
-                    } else if (e1.getY() - e2.getY() > AnkiDroidApp.sSwipeMinDistance
-                            && Math.abs(velocityY) > AnkiDroidApp.sSwipeThresholdVelocity
-                            && Math.abs(e1.getX() - e2.getX()) < AnkiDroidApp.sSwipeMaxOffPath && !mIsYScrolling) {
-                        // up
-                        executeCommand(mGestureSwipeUp);
-                    } else if (e2.getX() - e1.getX() > AnkiDroidApp.sSwipeMinDistance
-                            && Math.abs(velocityX) > AnkiDroidApp.sSwipeThresholdVelocity
-                            && Math.abs(e1.getY() - e2.getY()) < AnkiDroidApp.sSwipeMaxOffPath && !mIsXScrolling
-                            && !mIsSelecting) {
-                        // right
-                        executeCommand(mGestureSwipeRight);
-                    } else if (e1.getX() - e2.getX() > AnkiDroidApp.sSwipeMinDistance
-                            && Math.abs(velocityX) > AnkiDroidApp.sSwipeThresholdVelocity
-                            && Math.abs(e1.getY() - e2.getY()) < AnkiDroidApp.sSwipeMaxOffPath && !mIsXScrolling
-                            && !mIsSelecting) {
-                        // left
-                        executeCommand(mGestureSwipeLeft);
+                    float dy = e2.getY() - e1.getY();
+                    float dx = e2.getX() - e1.getX();
+
+                    if (Math.abs(dx) > Math.abs(dy)) {
+                        // horizontal swipe if moved further in x direction than y direction
+                        if (dx > AnkiDroidApp.sSwipeMinDistance
+                                && Math.abs(velocityX) > AnkiDroidApp.sSwipeThresholdVelocity
+                                && !mIsXScrolling && !mIsSelecting) {
+                            // right
+                            executeCommand(mGestureSwipeRight);
+                        } else if (dx < -AnkiDroidApp.sSwipeMinDistance
+                                && Math.abs(velocityX) > AnkiDroidApp.sSwipeThresholdVelocity
+                                && !mIsXScrolling && !mIsSelecting) {
+                            // left
+                            executeCommand(mGestureSwipeLeft);
+                        }
+                    } else {
+                        // otherwise vertical swipe
+                        if (dy > AnkiDroidApp.sSwipeMinDistance
+                                && Math.abs(velocityY) > AnkiDroidApp.sSwipeThresholdVelocity
+                                && !mIsYScrolling) {
+                            // down
+                            executeCommand(mGestureSwipeDown);
+                        } else if (dy < -AnkiDroidApp.sSwipeMinDistance
+                                && Math.abs(velocityY) > AnkiDroidApp.sSwipeThresholdVelocity
+                                && !mIsYScrolling) {
+                            // up
+                            executeCommand(mGestureSwipeUp);
+                        }
                     }
                 } catch (Exception e) {
                     Log.e(AnkiDroidApp.TAG, "onFling Exception = " + e.getMessage());

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -983,6 +983,11 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
             // Increase default number of backups
             preferences.edit().putInt("backupMax", 8).commit();
         }
+        // when upgrading from before 2.4alpha38
+        if (previousVersionCode < 20400138) {
+            // Reset the swipe sensitivity to 100% as the algorithm was changed
+            preferences.edit().putInt("swipeSensitivity", 100).commit();
+        }
     }
 
 


### PR DESCRIPTION
Improve the swipe detection algorithm:
- Remove the `sSwipeMaxOffPath` threshold. Instead assume that a swipe is either horizontal or vertical based on which direction the delta was greater. This is how it's done in native ViewPager and is much more natural. 
- Use `ViewConfiguration.getScaledPagingTouchSlop()` and `getScaledMinimumFlingVelocity()` (as per ViewPager) for the swipe thresholds instead of manually trying to calculate them.
- Redefine the sensitivity so that it has a larger effect. 20% now increases thresholds by 5x, and 180% increases by 1.8x. The new thresholds are generally significantly lower than before so users probably shouldn't need a value much greater than 100%.
- Make the sensitivity be applied properly when a user changes preferences. Before they weren't being updated until AnkiDroid was force closed.
