### PR TITLE
Remove longclick action from gestures as it intereferes with text selection

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -98,7 +98,7 @@ public class Preferences extends PreferenceActivity implements OnSharedPreferenc
     private static String[] sShowValueInSummList = { LANGUAGE, "dictionary", "reportErrorMode",
             "gestureSwipeUp", "gestureSwipeDown", "gestureSwipeLeft",
             "gestureSwipeRight", "gestureDoubleTap", "gestureTapTop", "gestureTapBottom", "gestureTapRight",
-            "gestureLongclick", "gestureTapLeft", "newSpread", "useCurrent", "defaultFont", "overrideFontBehavior", "browserEditorFont" };
+            "gestureTapLeft", "newSpread", "useCurrent", "defaultFont", "overrideFontBehavior", "browserEditorFont" };
     private static String[] sListNumericCheck = {"minimumCardsDueForNotification"};
     private static String[] sShowValueInSummSeek = { "relativeDisplayFontSize", "relativeCardBrowserFontSize",
             "relativeImageSize", "answerButtonSize", "whiteBoardStrokeWidth", "swipeSensitivity",

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -80,7 +80,6 @@
     <string name="gestures_tap_bottom">Touch bottom</string>
     <string name="gestures_tap_left">Touch left</string>
     <string name="gestures_tap_right">Touch right</string>
-    <string name="gestures_longclick">Long press</string>
     <string name="more_scrolling_buttons">eReader</string>
     <string name="more_scrolling_buttons_summ">Also use kanji/katakana, emoji/kao-moji buttons for scrolling</string>
     <string name="double_scrolling_gap">Double scrolling</string>

--- a/AnkiDroid/src/main/res/xml/preferences.xml
+++ b/AnkiDroid/src/main/res/xml/preferences.xml
@@ -333,14 +333,6 @@
                 android:key="gestureTapRight"
                 android:summary=""
                 android:title="@string/gestures_tap_right" />
-            <ListPreference
-                android:defaultValue="11"
-                android:dependency="gestures"
-                android:entries="@array/gestures_labels"
-                android:entryValues="@array/gestures_values"
-                android:key="gestureLongclick"
-                android:summary=""
-                android:title="@string/gestures_longclick" />
         </PreferenceCategory>
     </PreferenceScreen>
 


### PR DESCRIPTION
The longclick gesture functionality was removed sometime ago, but it was never removed from preferences
https://code.google.com/p/ankidroid/issues/detail?id=2428
