### PR TITLE
Fix bug in #670

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -3035,7 +3035,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
             Matcher audioReferences = Sound.sSoundPattern.matcher(frontSideFormat);
             // remove the first instance of audio contained in "{{FrontSide}}"
             while (audioReferences.find()) {
-                answerContent = answerContent.replaceFirst(audioReferences.group(), "");
+                answerContent = answerContent.replaceFirst(Pattern.quote(audioReferences.group()), "");
             }
         }
         return answerContent;


### PR DESCRIPTION
The audio reference was getting treated as a regexp leading to this:
http://ankidroid-triage.appspot.com/view_crash?crash_id=4750522028392448
