### PR TITLE
When using SEND intent with SUBJECT empty, make TEXT the first field

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -593,6 +593,12 @@ public class NoteEditor extends AnkiActivity {
             } else {
                 second = "";
             }
+            // Some users add cards via SEND intent from clipboard. In this case SUBJECT is empty
+            if (first.equals("")) {
+                // Assume that if only one field was sent then it should be the front
+                first = second;
+                second = "";
+            }
             Pair<String, String> messages = new Pair<String, String>(first, second);
 
             /* Filter garbage information */


### PR DESCRIPTION
AnkiDroid accepts the generic Android SEND intent, but it expects the front to be in EXTRA_SUBJECT and the back to be in EXTRA_TEXT. As per [forum thread](https://groups.google.com/forum/#!topic/anki-android/8Tu5tUlZgmI), generic apps like Gmail can send a selected word via SEND, but it sends the single word in EXTRA_TEXT with EXTRA_SUBJECT empty. 

In hindsight, having EXTRA_SUBJECT map to the first field was not an optimal design decision. It makes much more sense to have TEXT map to the first field (which should always be included) and SUBJECT map to the second field (which is optional), but we can't really change it now, so I've implemented this workaround.