### PR TITLE
Added support for custom Anki Server URL (SYNC_BASE).

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -312,6 +312,10 @@ public class AnkiDroidApp extends Application {
         return context.getSharedPreferences(SHARED_PREFS_NAME, Context.MODE_PRIVATE);
     }
 
+    public static SharedPreferences getApplicationPrefs() {
+        return getSharedPrefs(sInstance.getApplicationContext());
+    }
+
 
     public static AnkiDroidApp getInstance() {
         return sInstance;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -104,7 +104,7 @@ public class Preferences extends PreferenceActivity implements OnSharedPreferenc
     private static String[] sShowValueInSummSeek = { "relativeDisplayFontSize", "relativeCardBrowserFontSize",
             "relativeImageSize", "answerButtonSize", "whiteBoardStrokeWidth", "swipeSensitivity",
             "timeoutAnswerSeconds", "timeoutQuestionSeconds", "backupMax", "dayOffset" };
-    private static String[] sShowValueInSummEditText = { "simpleInterfaceExcludeTags", "deckPath" };
+    private static String[] sShowValueInSummEditText = { "simpleInterfaceExcludeTags", "deckPath", "syncBaseUrl" };
     private static String[] sShowValueInSummNumRange = { "timeLimit", "learnCutoff" };
     private TreeMap<String, String> mListsToUpdate = new TreeMap<String, String>();
     private StyledProgressDialog mProgressDialog;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/FullSyncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/FullSyncer.java
@@ -26,7 +26,6 @@ import com.ichi2.anki.R;
 import com.ichi2.anki.exception.UnknownHttpResponseException;
 import com.ichi2.async.Connection;
 import com.ichi2.libanki.Collection;
-import com.ichi2.libanki.Consts;
 import com.ichi2.libanki.Utils;
 
 import org.apache.http.HttpResponse;
@@ -60,7 +59,7 @@ public class FullSyncer extends HttpSyncer {
 
     @Override
     public String syncURL() {
-        return Consts.SYNC_BASE + "sync/";
+        return syncBase() + "sync/";
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HttpSyncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HttpSyncer.java
@@ -193,7 +193,7 @@ public class HttpSyncer {
             bos.flush();
             bos.close();
             // connection headers
-            String url = Consts.SYNC_BASE;
+            String url = syncBase();
             if (method.equals("register")) {
                 url = url + "account/signup" + "?username=" + registerData.getString("u") + "&password="
                         + registerData.getString("p");
@@ -447,9 +447,12 @@ public class HttpSyncer {
         return null;
     }
 
+    public String syncBase() {
+        return AnkiDroidApp.getApplicationPrefs().getString("syncBaseUrl", Consts.SYNC_BASE);
+    }
 
     public String syncURL() {
-        return Consts.SYNC_BASE + "sync/";
+        return syncBase() + "sync/";
     }
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteMediaServer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteMediaServer.java
@@ -24,7 +24,6 @@ import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.exception.UnknownHttpResponseException;
 import com.ichi2.async.Connection;
 import com.ichi2.libanki.Collection;
-import com.ichi2.libanki.Consts;
 import com.ichi2.libanki.Utils;
 
 import org.apache.http.HttpResponse;
@@ -55,7 +54,7 @@ public class RemoteMediaServer extends HttpSyncer {
 
     @Override
     public String syncURL() {
-        return Consts.SYNC_BASE + "msync/";
+        return syncBase() + "msync/";
     }
 
 

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -90,6 +90,8 @@
     <string name="tts_summ">Reads out question and answer if no sound file is included</string>
     <string name="sync_fetch_missing_media">Fetch media on sync</string>
     <string name="sync_fetch_missing_media_summ">Automatically fetch missing media when syncing.</string>
+    <string name="sync_base_url">Anki Server URL</string>
+    <string name="sync_base_url_summ">XXX</string>
     <string name="sync_account">AnkiWeb account</string>
     <string name="sync_account_summ_logged_out">Not logged in</string>
     <string name="sync_account_summ_logged_in">%s</string>

--- a/AnkiDroid/src/main/res/xml/preferences.xml
+++ b/AnkiDroid/src/main/res/xml/preferences.xml
@@ -339,6 +339,11 @@
     <!-- Advanced Preferences -->
     <PreferenceScreen android:title="@string/pref_cat_advanced"
         android:summary="@string/pref_cat_advanced_summ" >
+        <EditTextPreference
+            android:defaultValue="https://ankiweb.net/"
+            android:key="syncBaseUrl"
+            android:summary="@string/sync_base_url_summ"
+            android:title="@string/sync_base_url" />
 	    <Preference 
 	        android:key="force_full_sync"
 	        android:title="@string/force_full_sync_title"


### PR DESCRIPTION
Hi,

This is a small PR that adds the ability for users to specify a custom SYNC_BASE url in the preferences. The default is the https://ankiweb.net/ URL.

Would anyone have a suggestion as how to replicate the functionality I added in AndroidApp.getApplicationPrefs() so it may not be necessary?

This also does not verify if the given URL ends with a slash. It is currently left to the user to format this url properly.