### PR TITLE
Switch error reporting over to ACRA @ ankidroid.org

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -34,5 +34,6 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:19.1.0'
     compile 'com.google.code.gson:gson:2.3'
+    compile 'ch.acra:acra:4.6.0RC1'
     compile project(":ShowcaseView:library")
 }

--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -47,9 +47,6 @@
         This ensures the correct ordering between the various types of releases (dev < alpha < beta < release) which is
         needed for upgrades to be offered correctly.
     -->
-    <uses-sdk
-        android:minSdkVersion="7"
-        android:targetSdkVersion="19" />
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.VIBRATE" />
@@ -199,6 +196,11 @@
             android:name="com.ichi2.anki.Feedback"
             android:configChanges="locale"
             android:label="@string/feedback_title" />
+        <activity android:name="org.acra.CrashReportDialog"
+            android:theme="@style/Theme.CrashReportDialog"
+            android:launchMode="singleInstance"
+            android:excludeFromRecents="true"
+            android:finishOnTaskLaunch="true" />
         <activity
             android:name="com.ichi2.anki.Statistics"
             android:theme="@style/Theme_White_Statistics"

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -81,7 +81,6 @@ import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.anki.receiver.SdCardReceiver;
 import com.ichi2.anki.stats.AnkiStatsTaskHandler;
 import com.ichi2.async.Connection;
-import com.ichi2.async.Connection.OldAnkiDeckFilter;
 import com.ichi2.async.Connection.Payload;
 import com.ichi2.async.DeckTask;
 import com.ichi2.async.DeckTask.TaskData;
@@ -935,6 +934,7 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
                     startActivityForResultWithoutAnimation(infoIntent, SHOW_INFO_NEW_VERSION);
                 }
             }
+        /* Old error reporting scheme before switching to ACRA
         } else if (skip < 4 && hasErrorFiles()) {
             // Need to submit error reports
             Intent i = new Intent(this, Feedback.class);
@@ -942,7 +942,7 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
                 startActivityForResultWithAnimation(i, REPORT_ERROR, ActivityTransitionAnimation.LEFT);
             } else {
                 startActivityForResultWithoutAnimation(i, REPORT_ERROR);
-            }
+            }*/
         } else {
             // This is the main call when there is nothing special required
             startLoadingCollection();
@@ -983,9 +983,8 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
             // Increase default number of backups
             preferences.edit().putInt("backupMax", 8).commit();
         }
-        // when upgrading from before 2.4alpha38
-        if (previousVersionCode < 20400138) {
-            // Reset the swipe sensitivity to 100% as the algorithm was changed
+        // reset swipeSensitivity from 2.4beta3
+        if (previousVersionCode < 20400203) {
             preferences.edit().putInt("swipeSensitivity", 100).commit();
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Info.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Info.java
@@ -18,6 +18,7 @@
 package com.ichi2.anki;
 
 import android.app.Dialog;
+import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -28,8 +29,10 @@ import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.net.Uri;
 import android.os.AsyncTask;
+import android.os.Build;
 import android.os.Bundle;
 import android.support.v7.app.ActionBarActivity;
+import android.text.ClipboardManager;
 import android.text.method.LinkMovementMethod;
 import android.util.Log;
 import android.view.KeyEvent;
@@ -51,6 +54,7 @@ import com.ichi2.themes.StyledDialog;
 import com.ichi2.themes.StyledProgressDialog;
 import com.ichi2.themes.Themes;
 
+import org.acra.util.Installation;
 import org.apache.commons.httpclient.contrib.ssl.EasySSLSocketFactory;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
@@ -193,6 +197,15 @@ public class Info extends ActionBarActivity {
                 sb.append("</body></html>");
                 mWebView.loadDataWithBaseURL("", sb.toString(), "text/html", "utf-8", null);
                 ((Button) findViewById(R.id.info_continue)).setText(res.getString(R.string.info_rate));
+                Button debugCopy = ((Button) findViewById(R.id.info_later));
+                debugCopy.setText(res.getString(R.string.feedback_copy_debug));
+                debugCopy.setVisibility(View.VISIBLE);
+                debugCopy.setOnClickListener(new OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+                        copyDebugInfo();
+                    }
+                });
                 break;
 
             case TYPE_NEW_VERSION:
@@ -1186,6 +1199,24 @@ public class Info extends ActionBarActivity {
             }
         });
         builder.show();
+    }
+
+    /**
+     * Copy debug information about the device to the clipboard
+     * @return debugInfo
+     */
+    public String copyDebugInfo() {
+        StringBuilder sb = new StringBuilder();
+        // AnkiDroid Version
+        sb.append("AnkiDroid Version = ").append(AnkiDroidApp.getPkgVersionName()).append("\n\n");
+        // Android SDK
+        sb.append("Android Version = " + Build.VERSION.RELEASE).append("\n\n");
+        // ACRA install ID
+        sb.append("ACRA UUID = ").append(Installation.id(this)).append("\n");
+        String debugInfo = sb.toString();
+        ClipboardManager clipboard = (ClipboardManager) getSystemService(Context.CLIPBOARD_SERVICE);
+        clipboard.setText(debugInfo);
+        return debugInfo;
     }
 
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -548,6 +548,9 @@ public class Preferences extends PreferenceActivity implements OnSharedPreferenc
                 mCol.setMod();
             } else if (key.equals("minimumCardsDueForNotification")) {
                 updateNotificationPreference();
+            } else if (key.equals("reportErrorMode")) {
+                String value = sharedPreferences.getString("reportErrorMode", "");
+                AnkiDroidApp.getInstance().setAcraReportingMode(value);
             }
             
             if (Arrays.asList(sShowValueInSummList).contains(key)) {

--- a/AnkiDroid/src/main/res/values-v14/styles.xml
+++ b/AnkiDroid/src/main/res/values-v14/styles.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <style name="Theme.CrashReportDialog" parent="@android:style/Theme.DeviceDefault.Dialog" />
+</resources>

--- a/AnkiDroid/src/main/res/values/05-feedback.xml
+++ b/AnkiDroid/src/main/res/values/05-feedback.xml
@@ -27,11 +27,12 @@
   <item quantity="other">There are %d errors to report</item>
 </plurals>
     -->
+    <string name="empty_string"></string>
     <string name="error_ok">Report errors</string>
     <string name="error_cancel">Don\'t report errors</string>
     <string name="error_reporting_choice">Error reporting mode</string>
     <string name="error_reporting_choice_summary">Errors can be reported automatically, never reported, or you can be prompted</string>
-    <string name="feedback_disclaimer">Disclaimer: We don\'t collect any personal information such as your email address, phone number, IP address or your phone IMEI. We do collect some information about your device such as the manufacturer, model and version of Android, as well as the nature of reported errors themselves.</string>
+    <string name="feedback_disclaimer">Disclaimer: We don\'t collect any personal information such as your email address, phone number, or your phone IMEI. We do collect some information about your device such as the manufacturer, model and version of Android, as well as the nature of reported errors themselves and the steps which led up to them occuring.</string>
     <string name="feedback_title">Feedback</string>
     <string name="feedback_send_feedback">Send us your feedback</string>
     <string name="feedback_send_feedback_and_errors">Send errors and your feedback</string>
@@ -49,5 +50,9 @@
     <string name="feedback_error_reply_issue_fixed_prod">Issue %1$d, fixed in the latest version</string>
     <string name="feedback_error_reply_malformed">Filed bug, no response</string>
     <string name="feedback_error_reply_failed">Failed to send</string>
+    <string name="feedback_auto_toast_text">AnkiDroid has encountered a problem; a report is being sent to the developers…</string>
+    <string name="feedback_manual_toast_text">AnkiDroid has encountered a problem; a report is being generated…</string>
+    <string name="feedback_copy_debug">Copy debug info</string>
+    <string name="feedback_report">Report</string>
 
 </resources>

--- a/AnkiDroid/src/main/res/values/styles.xml
+++ b/AnkiDroid/src/main/res/values/styles.xml
@@ -184,6 +184,8 @@
         <item name="android:typeface">monospace</item>
         <item name="android:textSize">30sp</item>
     </style>
+    
+    <style name="Theme.CrashReportDialog" parent="@android:style/Theme.Dialog" />
 
     <style name="White.Spinner">
         <item name="android:indeterminate">true</item>

--- a/AnkiDroid/src/main/res/xml/preferences.xml
+++ b/AnkiDroid/src/main/res/xml/preferences.xml
@@ -286,7 +286,7 @@
                 android:summary=""
                 android:title="@string/gestures_swipe_left" />
             <ListPreference
-                android:defaultValue="0"
+                android:defaultValue="2"
                 android:dependency="gestures"
                 android:entries="@array/gestures_labels"
                 android:entryValues="@array/gestures_values"


### PR DESCRIPTION
This PR switches the AnkiDroid error reporting over to ACRA / Acralyzer on ankidroid.org and makes the error reporting occur automatically in the background by default (a toast is shown so the user knows). This is not quite ready to merge as I need to finalize some details about the couchdb authentication with @agrueneberg 

See the [discussion on the forum](https://groups.google.com/forum/#!topic/anki-android/RQqxcITIqYE) for more background info