### PR TITLE
Restrict name of new decks to a single line

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -575,6 +575,7 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
                 StyledDialog.Builder builder2 = new StyledDialog.Builder(DeckPicker.this);
                 builder2.setTitle(res.getString(R.string.new_deck));
                 mDialogEditText = new EditText(DeckPicker.this);
+                mDialogEditText.setSingleLine(true);
                 // mDialogEditText.setFilters(new InputFilter[] { mDeckNameFilter });
                 builder2.setView(mDialogEditText, false, false);
                 builder2.setPositiveButton(res.getString(R.string.create), new DialogInterface.OnClickListener() {


### PR DESCRIPTION
Trivial change, but this has annoyed me two or three times already. The rename operation already has this.