### PR TITLE
Correctly parse and render cloze fields and nested modifiers

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -93,9 +93,10 @@ public class Collection {
     private boolean mDebugLog;
     private PrintWriter mLogHnd;
 
-    // Cloze regex
-    private static final Pattern fClozePattern = Pattern.compile("\\{\\{cloze:");
-    private static final Pattern fAltClozePattern = Pattern.compile("<%cloze:");
+    private static final Pattern fClozePatternQ = Pattern.compile("\\{\\{(?!type:)(.*?)cloze:");
+    private static final Pattern fClozePatternA = Pattern.compile("\\{\\{(.*?)cloze:");
+    private static final Pattern fClozeTagStart = Pattern.compile("<%cloze:");
+
     // other options
     public static final String defaultConf = "{"
             +
@@ -985,9 +986,9 @@ public class Collection {
 
                 // runFilter mungeFields for type "q"
                 Models.fieldParser fparser = new Models.fieldParser(fields);
-                Matcher m = fClozePattern.matcher(qfmt);
-                format = m.replaceAll(String.format(Locale.US, "{{cq:%d:", cardNum));
-                m = fAltClozePattern.matcher(format);
+                Matcher m = fClozePatternQ.matcher(qfmt);
+                format = m.replaceAll(String.format(Locale.US, "{{$1cq-%d:", cardNum));
+                m = fClozeTagStart.matcher(format);
                 format = m.replaceAll(String.format(Locale.US, "<%%cq:%d:", cardNum));
                 html = mModels.getCmpldTemplate(format).execute(fparser);
                 html = (String) AnkiDroidApp.getHooks().runFilter("mungeQA", html, "q", fields, model, data, this);
@@ -1002,13 +1003,11 @@ public class Collection {
                 // the following line differs from inherited libanki (original in comment)
                 fields.put("FrontSide", d.get("q")); // fields.put("FrontSide", mMedia.stripAudio(d.get("q")));
 
-
-
                 // runFilter mungeFields for type "a"
                 fparser = new Models.fieldParser(fields);
-                m = fClozePattern.matcher(afmt);
-                format = m.replaceAll(String.format(Locale.US, "{{ca:%d:", cardNum));
-                m = fAltClozePattern.matcher(format);
+                m = fClozePatternA.matcher(afmt);
+                format = m.replaceAll(String.format(Locale.US, "{{$1ca-%d:", cardNum));
+                m = fClozeTagStart.matcher(format);
                 format = m.replaceAll(String.format(Locale.US, "<%%ca:%d:", cardNum));
                 html = mModels.getCmpldTemplate(format).execute(fparser);
                 html = (String) AnkiDroidApp.getHooks().runFilter("mungeQA", html, "a", fields, model, data, this);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -21,6 +21,7 @@ package com.ichi2.libanki;
 
 import android.content.ContentValues;
 import android.database.Cursor;
+import android.text.TextUtils;
 import android.util.Log;
 import android.util.Pair;
 
@@ -35,6 +36,8 @@ import org.json.JSONObject;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -47,8 +50,12 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class Models {
-    private static final Pattern fClozePattern1 = Pattern.compile("(?:\\{\\{|<%)cloze:(.+?)(?:\\}\\}|%>)");
-    private static final Pattern fClozePattern2 = Pattern.compile("\\{\\{c(\\d+)::.+?\\}\\}");
+    private static final Pattern fHookFieldMod = Pattern.compile("^(.*?)(?:\\((.*)\\))?$");
+    private static final Pattern fClozePattern1 = Pattern.compile("\\{\\{[^}]*?cloze:(?:[^}]?:)*(.+?)\\}\\}");
+    private static final Pattern fClozePattern2 = Pattern.compile("<%cloze:(.+?)%>");
+    private static final Pattern fClozeOrdPattern = Pattern.compile("\\{\\{c(\\d+)::.+?\\}\\}");
+
+    protected static final String clozeReg = "(?s)\\{\\{c%s::(.*?)(::(.*?))?\\}\\}";
 
     public static final String defaultModel =
               "{'sortf': 0, "
@@ -911,9 +918,8 @@ public class Models {
     }
 
 
-    // originally from anki.template.template
     // Handle fields fetched from templates and any anki-specific formatting
-    protected static final String clozeReg = "\\{\\{c%s::(.*?)(::(.*?))?\\}\\}";
+
     protected static class fieldParser implements Mustache.VariableFetcher {
         private Map<String, String> _fields;
 
@@ -923,6 +929,7 @@ public class Models {
         }
 
 
+        // libanki: render_unescaped
         public Object get(Object ctx, String tag_name) throws Exception {
             if (tag_name.length() == 0) {
                 return null;
@@ -933,57 +940,86 @@ public class Models {
             }
 
             // field modifiers
-            String[] parts = tag_name.split(":", 3);
-            String mod = null, extra = null, tag = null;
-            if (parts.length == 1 || parts[0].equals("")) {
-                return null;
-            } else if (parts.length == 2) {
-                mod = parts[0];
-                tag = parts[1];
-            } else if (parts.length == 3) {
-                mod = parts[0];
-                extra = parts[1];
-                tag = parts[2];
+            List<String> parts = Arrays.asList(tag_name.split(":"));
+            String extra = null;
+            List<String> mods;
+            String tag;
+            if (parts.size() == 1 || parts.get(0).equals("")) {
+                return String.format("{unknown field %s}", tag_name);
+            } else {
+                mods = parts.subList(0, parts.size() - 1);
+                tag = parts.get(parts.size()-1);
             }
 
             txt = _fields.get(tag);
 
-            Log.d(AnkiDroidApp.TAG, "Processing field modifier " + mod + ": extra = " + extra + ", field " + tag + " = " + txt);
+            // Since 'text:' and other mods can affect html on which Anki relies to
+            // process clozes, we need to make sure clozes are always
+            // treated after all the other mods, regardless of how they're specified
+            // in the template, so that {{cloze:text: == {{text:cloze:
+            // For type:, we return directly since no other mod than cloze (or other
+            // pre-defined mods) can be present and those are treated separately
+            Collections.reverse(mods);
+            Collections.sort(mods, new Comparator<String>() {
+                // This comparator ensures "type:" mods are ordered first in the list. The rest of
+                // the list remains in the same order.
+                @Override
+                public int compare(String lhs, String rhs) {
+                    if (lhs.equals("type")) {
+                        return 0;
+                    } else {
+                        return 1;
+                    }
+                };
+            });
 
-            // built-in modifiers
-            if (mod.equals("text")) {
-                // strip html
-                if (txt != null && txt.length() > 0) {
-                    return Utils.stripHTML(txt);
-                }
-                return "";
-            } else if (mod.equals("type")) {
-                // type answer field; convert it to [[type:...]] for the gui code to process
-                return "[[" + tag_name + "]]";
-            } else if (mod.equals("cq") || mod.equals("ca")) {
-                // cloze deletion
-                if (txt != null && txt.length() != 0 && extra != null && extra.length() != 0) {
-                    return clozeText(txt, extra, mod.charAt(1));
+            for (String mod : mods) {
+                Log.d(AnkiDroidApp.TAG, String.format("Processing field: modifier=%s, extra=%s, tag=%s, txt=%s", mod, extra, tag, txt));
+                // built-in modifiers
+                if (mod.equals("text")) {
+                    // strip html
+                    if (!TextUtils.isEmpty(txt)) {
+                        txt = Utils.stripHTML(txt);
+                    } else {
+                        txt = "";
+                    }
+                } else if (mod.equals("type")) {
+                    // type answer field; convert it to [[type:...]] for the gui code
+                    // to process
+                    return "[[" + tag_name + "]]";
+                } else if (mod.startsWith("cq-") || mod.startsWith("ca-")) {
+                    // cloze deletion
+                    String[] split = mod.split("-");
+                    mod = split[0];
+                    extra = split[1];
+                    if (!TextUtils.isEmpty(txt) && !TextUtils.isEmpty(extra)) {
+                        txt = clozeText(txt, extra, mod.charAt(1));
+                    }
                 } else {
-                    return "";
+                    // hook-based field modifier
+                    Matcher m = fHookFieldMod.matcher(mod);
+                    if (m.matches()) {
+                        mod = m.group(1);
+                        extra = m.group(2);
+                    }
+                    txt = (String) AnkiDroidApp.getHooks().runFilter("fmod_" + mod,
+                            txt == null ? "" : txt,
+                            extra == null ? "" : extra,
+                            AnkiDroidApp.getAppResources(),
+                            tag, tag_name);
+
+                    if (txt == null) {
+                        return String.format("{unknown field %s}", tag_name);
+                    }
                 }
-            } else {
-                // hook-based field modifier
-                if (txt == null) {
-                    txt = (String) AnkiDroidApp.getHooks().runFilter("fmod_" + mod, "", extra, AnkiDroidApp.getAppResources(), tag, tag_name);
-                } else {
-                    txt = (String) AnkiDroidApp.getHooks().runFilter("fmod_" + mod, txt, extra, AnkiDroidApp.getAppResources(), tag, tag_name);
-                }
-                if (txt == null) {
-                    return "{unknown field " + tag_name + "}";
-                }
-                return txt;
             }
+            return txt;
         }
 
 
         private static String clozeText(String txt, String ord, char type) {
             Matcher m = Pattern.compile(String.format(Locale.US, clozeReg, ord)).matcher(txt);
+
             StringBuffer rep = new StringBuffer();
             Boolean found = false;
 
@@ -1321,23 +1357,28 @@ public class Models {
         String[] sflds = Utils.splitFields(flds);
         Map<String, Pair<Integer, JSONObject>> map = fieldMap(m);
         Set<Integer> ords = new HashSet<Integer>();
-        Matcher matcher1 = null;
+        List<String> matches = new ArrayList<String>();
+        Matcher mm;
         try {
-            matcher1 = fClozePattern1.matcher(m.getJSONArray("tmpls").getJSONObject(0).getString("qfmt"));
-            // Libanki makes two finds for each case of the cloze tags, but we embed both in the pattern.
-            // Please note, that this approach is not 100% correct, as we allow cases like {{cloze:...%>
+            mm = fClozePattern1.matcher(m.getJSONArray("tmpls").getJSONObject(0).getString("qfmt"));
+            while (mm.find()) {
+                matches.add(mm.group(1));
+            }
+            mm = fClozePattern2.matcher(m.getJSONArray("tmpls").getJSONObject(0).getString("qfmt"));
+            while (mm.find()) {
+                matches.add(mm.group(1));
+            }
         } catch (JSONException e) {
             throw new RuntimeException(e);
         }
-        while (matcher1.find()) {
-            String fname = matcher1.group(1);
+        for (String fname : matches) {
             if (!map.containsKey(fname)) {
                 continue;
             }
             int ord = map.get(fname).first;
-            Matcher matcher2 = fClozePattern2.matcher(sflds[ord]);
-            while (matcher2.find()) {
-                ords.add(Integer.parseInt(matcher2.group(1)) - 1);
+            mm = fClozeOrdPattern.matcher(sflds[ord]);
+            while (mm.find()) {
+                ords.add(Integer.parseInt(mm.group(1)) - 1);
             }
         }
         if (ords.contains(-1)) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/hooks/FuriganaFilters.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/hooks/FuriganaFilters.java
@@ -27,7 +27,7 @@ public class FuriganaFilters {
     // Since there is no ruby tag support in Android before 3.0 (SDK version 11), we must use an alternative
     // approach to align the elements. Anki does the same thing in aqt/qt.py for earlier versions of qt.
     // The fallback approach relies on CSS in the file /assets/ruby.css
-    private static final String RUBY = AnkiDroidApp.SDK_VERSION >= 11 ? "<ruby>$1<rt>$2</rt></ruby>"
+    private static final String RUBY = AnkiDroidApp.SDK_VERSION >= 11 ? "<ruby><rb>$1</rb><rt>$2</rt></ruby>"
             : "<span class='legacy_ruby_rb'><span class='legacy_ruby_rt'>$2</span>$1</span>";
 
 


### PR DESCRIPTION
A fix for [Issue 2470](https://code.google.com/p/ankidroid/issues/detail?id=2470) and a bunch of other things. I went over the code that handles cloze tag parsing and rendering and found quite a few problems with it, including the related code that handles nesting and ordering of fields with multiple modifiers. This should bring things in line with the desktop client.

In short, nested modifiers in fields will now work correctly. Things like:
`<cloze:furigana:FieldName>`
`<type:cloze:FieldName>`
`<text:cloze:FieldName>`

There is a potential that this change will break something else so if you have any large or complex templates, I would appreciate a test run to see how things go.