### PR TITLE
Rename search field to sort field in card browser order dialog

### DIFF
--- a/AnkiDroid/src/main/res/values/07-cardbrowser.xml
+++ b/AnkiDroid/src/main/res/values/07-cardbrowser.xml
@@ -67,7 +67,7 @@
 
     <string-array name="card_browser_order_labels">
         <item>No sorting (faster)</item>
-        <item>By search field</item>
+        <item>By sort field</item>
         <item>By created time</item>
         <item>By edited time</item>
         <item>By changed time</item>


### PR DESCRIPTION
I believe this should be sort field, not search field.