### PR TITLE
Rename "Edit card" to "Edit note"

### DIFF
--- a/AnkiDroid/src/main/res/menu/reviewer.xml
+++ b/AnkiDroid/src/main/res/menu/reviewer.xml
@@ -27,7 +27,7 @@
     <item
         android:id="@+id/action_edit"
         android:icon="@drawable/ic_menu_edit"
-        android:title="@string/menu_edit_card"
+        android:title="@string/cardeditor_title_edit_card"
         ankidroid:showAsAction="ifRoom"/>
     <item
         android:id="@+id/action_replay"

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -101,7 +101,6 @@
     <string name="menu_save_note">Save note</string>
     <string name="menu_delete_note">Delete note</string>
     <string name="delete_note_message">Really delete this note and all its cards?\n%s</string>
-    <string name="menu_edit_card">Edit card</string>
     <string name="menu_select">Select text</string>
     <string name="menu_search">Lookup in %1$s</string>
     <string name="menu_mark_card">Mark card</string>


### PR DESCRIPTION
See #689.

@timrae I removed `menu_edit_card` after checking that there are no further occurrences.