### PR TITLE
Hack to prevent tests failing due to hooks not being initalized

### DIFF
--- a/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/MediaTest.java
+++ b/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/MediaTest.java
@@ -18,6 +18,7 @@ package com.ichi2.anki.tests;
 import android.test.AndroidTestCase;
 import android.test.suitebuilder.annotation.Suppress;
 
+import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.BackupManager;
 import com.ichi2.anki.exception.APIVersionException;
 import com.ichi2.libanki.Collection;
@@ -37,6 +38,14 @@ import com.ichi2.utils.*;
  */
 public class MediaTest extends AndroidTestCase {
     public void testAdd() throws IOException, APIVersionException {
+        // Hack to wait for the main application to be initialized since it runs in a different thread
+        while (AnkiDroidApp.getInstance() == null || AnkiDroidApp.getHooks() == null) {
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                // do nothing
+            }
+        }
         Collection d = Shared.getEmptyCol();
         File dir = Shared.getTestDir(mContext);
         BackupManager.removeDir(dir);


### PR DESCRIPTION
Changes introduced in #681 are causing tests to fail. We established that it's because the runner for `AndroidTestCase` is running in a different thread from the main application, and doesn't seem to synchronize to wait for `Application.onCreate()` to finish. This seems like a bug in `AndroidTestCase`, although there is a possibility we're doing something wrong.

A better solution would probably be to use a more advanced testing class that doesn't suffer from this problem, but this hack does the job, so we can use it if nobody is motivated to make a more robust fix