### PR TITLE
Fix for latex fields in media check

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Media.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Media.java
@@ -307,7 +307,7 @@ public class Media {
                 // NOTE: python uses the named group 'fname'. Java doesn't have named groups, so we have to determine
                 // the index based on which pattern we are using
                 int fnameIdx = p == fSoundRegexps ? 2 : p == fImgRegExpU ? 2 : 3;
-                m = p.matcher(string);
+                m = p.matcher(s);
                 while (m.find()) {
                     String fname = m.group(fnameIdx);
                     boolean isLocal = !fRemotePattern.matcher(fname.toLowerCase(Locale.US)).find();


### PR DESCRIPTION
Fix for [Issue 2454](https://code.google.com/p/ankidroid/issues/detail?id=2454). It's a small fix so I think it should go into 2.4. This code is used in the exporter as well so I'm assuming exporting decks with latex images could be broken as well without it (haven't tried).