### PR TITLE
Small modificiations based on feedback from issue 1920

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDb.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDb.java
@@ -82,7 +82,6 @@ public class AnkiDb {
                 sRepaired = true;
                 Log.i(AnkiDroidApp.TAG, "Attempting to repair the database...");
                 BackupManager.repairDeck(AnkiDroidApp.COLLECTION_PATH);
-                AnkiDroidApp.openCollection(AnkiDroidApp.COLLECTION_PATH);
                 Log.i(AnkiDroidApp.TAG, "The database seems to have been successfully repaired");
                 AnkiDroidApp.saveExceptionReportFile("AnkiDb.MyDbErrorHandler.onCorruption", "Db successfully repaired");
             } else {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -1223,7 +1223,9 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
 
     @Override
     public void exit() {
+        AnkiDroidApp.closeCollection(false);
         finishWithoutAnimation();
+        System.exit(0);
     }
 
 


### PR DESCRIPTION
Don't try to reopen the database after attempting repair, and do a full force close of the app when "close" button is pressed on DB error dialog.