### PR TITLE
Don't create or import invalid backups

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
@@ -904,6 +904,14 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
                 tmpCol.close();
                 return new TaskData(-2, null, false);
             }
+        } catch (Exception e) {
+            Timber.e("Error opening new collection file... probably it's invalid");
+            try {
+                tmpCol.close();
+            } catch (Exception e2) {
+                // do nothing
+            }
+            return new TaskData(-2, null, false);
         } finally {
             if (tmpCol != null) {
                 tmpCol.close();


### PR DESCRIPTION
When AnkiDroid is started for the first time, it tries to make a backup of the uninitialized empty collection, which when imported crashes AnkiDroid. This is a workaround for those two bugs, but really we probably shouldn't be doing the backup while the database is open