### PR TITLE
Check for invalid order by preference in filtered decks

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CramDeckOptions.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CramDeckOptions.java
@@ -450,7 +450,12 @@ public class CramDeckOptions extends PreferenceActivity implements OnSharedPrefe
                 continue;
             } else if (pref instanceof ListPreference) {
                 ListPreference lp = (ListPreference) pref;
-                value = lp.getEntry().toString();
+                CharSequence entry = lp.getEntry();
+                if (entry != null) {
+                    value = entry.toString();
+                } else {
+                    value = "";
+                }
             } else {
                 value = this.mPref.getString(key, "");
             }


### PR DESCRIPTION
There are eight entries numbered 0 through 7, but my saved preference was an 8, so getEntry returned null, and toString on the null caused a crash.

Quickly after verifying that I no longer crashed on deck options display, I lost the old out of bounds setting. I have not verified if the invalid setting would cause any other issues, and have only handle the deck options initial display crash.