### PR TITLE
Allow user to change AnkiDroid directory if current one is invalid

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
@@ -30,9 +30,11 @@ import com.ichi2.anim.ActivityTransitionAnimation;
 import com.ichi2.anki.dialogs.AsyncDialogFragment;
 import com.ichi2.anki.dialogs.DialogHandler;
 import com.ichi2.anki.dialogs.SimpleMessageDialog;
+import com.ichi2.anki.exception.StorageAccessException;
 import com.ichi2.async.CollectionLoader;
 import com.ichi2.libanki.Collection;
 import com.ichi2.themes.StyledOpenCollectionDialog;
+import com.ichi2.themes.Themes;
 
 import timber.log.Timber;
 
@@ -43,6 +45,26 @@ public class AnkiActivity extends ActionBarActivity implements LoaderManager.Loa
 
     private StyledOpenCollectionDialog mOpenCollectionDialog;
     private DialogHandler mHandler = new DialogHandler(this);
+
+    @Override
+    protected void onCreate(Bundle savedInstance) {
+        super.onCreate(savedInstance);
+
+        // Make sure the AnkiDroid directory exists and we have permission to use it. There is no
+        // point trying to do anything with a collection if we cannot get past this point.
+        try {
+            AnkiDroidApp.initializeAnkiDroidDirectory();
+        } catch (StorageAccessException e) {
+            Timber.e(e, "Failed to initialize AnkiDroid directory");
+            // If we end up here we open the Preferences activity to allow the user to pick a
+            // usable directory.
+            Intent i = new Intent(this, Preferences.class);
+            finishWithoutAnimation();
+            startActivityWithoutAnimation(i);
+            Themes.showThemedToast(this, getResources().getString(R.string.directory_inaccessible), false);
+            return;
+        }
+    }
 
     @Override
     protected void onResume() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.java
@@ -10,7 +10,6 @@ import android.os.Message;
 import android.provider.OpenableColumns;
 import android.support.v4.content.IntentCompat;
 
-
 import com.ichi2.anim.ActivityTransitionAnimation;
 import com.ichi2.anki.dialogs.DialogHandler;
 import com.ichi2.themes.StyledDialog;
@@ -27,7 +26,7 @@ import timber.log.Timber;
 /**
  * Class which handles how the application responds to different intents, forcing it to always be single task,
  * but allowing custom behavior depending on the intent
- * 
+ *
  * @author Tim
  *
  */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
@@ -353,8 +353,6 @@ public class NavigationDrawerActivity extends AnkiActivity {
                 // collection path has changed so kick the user back to the DeckPicker
                 AnkiDroidApp.closeCollection(true);
                 finishWithoutAnimation();
-                // Ensure the new collection directory exists before reloading
-                AnkiDroidApp.initializeAnkiDroidDirectory();
                 Intent deckPicker = new Intent(this, DeckPicker.class);
                 deckPicker.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
                 startActivityWithoutAnimation(deckPicker);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -186,6 +186,10 @@ public class Preferences extends PreferenceActivity implements OnSharedPreferenc
         // Check that input is valid when changing the collection path
         collectionPathPreference.setOnPreferenceChangeListener(new OnPreferenceChangeListener() {
             public boolean onPreferenceChange(Preference preference, final Object newValue) {
+                // Don't save the change if the user just cleared the path
+                if (TextUtils.isEmpty((String) newValue)) {
+                    return false;
+                }
                 File collectionPath = new File((String) newValue);
                 if (!collectionPath.exists()) {
                     Dialog pathCheckDialog = new AlertDialog.Builder(Preferences.this)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/exception/StorageAccessException.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/exception/StorageAccessException.java
@@ -1,0 +1,13 @@
+
+package com.ichi2.anki.exception;
+
+public class StorageAccessException extends Exception {
+
+    public StorageAccessException() {
+    }
+
+
+    public StorageAccessException(String msg) {
+        super(msg);
+    }
+}

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -112,6 +112,7 @@
     <string name="studyoptions_feedback">Feedback</string>
     <!-- <string name="studyoptions_load_sample_deck">Load sample deck</string> -->
     <string name="night_mode">Night mode</string>
+    <string name="directory_inaccessible">AnkiDroid directory is inaccessible</string>
 
     <string-array name="next_review_s">
         <item>1 second</item>


### PR DESCRIPTION
So now instead of crashing you get a toast that tells you what is wrong and the Preferences activity is opened to let you change the path.

@timrae Need your opinion on this. I'm not sure where the best place is for the check. I figured since `IntentHandler` is the launcher activity it will run before anything else does and we avoid trying to use the collection when there isn't one. Also by reloading the `IntentHandler` activity after changing the path, we solve the problem of having to do the check in more than one place.

The problem is you can still open other activities from other intents which skips this entirely. E.g., I tried adding a note with aedict which opens the note editor, and it brings up a misleading error about a backup not being saved due to no space on SD card (this is its own problem).

What would be the better place to put this code? Would the CollectionLoader class or the AnkiActivity class be a better place? The current code handles the common case at least (launching with the icon), so it might be "good enough" for now.
