### PR TITLE
Contentprovider

### DIFF
--- a/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/ContentProviderTest.java
+++ b/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/ContentProviderTest.java
@@ -1,0 +1,412 @@
+/***************************************************************************************
+ *                                                                                      *
+ * Copyright (c) 2015 Frank Oltmanns <frank.oltmanns@gmail.com>                         *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+
+package com.ichi2.anki.tests;
+
+import android.content.ContentResolver;
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.net.Uri;
+import android.test.AndroidTestCase;
+import android.util.Log;
+import com.ichi2.anki.AnkiDroidApp;
+import com.ichi2.anki.CollectionHelper;
+import com.ichi2.anki.provider.FlashCardsContract;
+import com.ichi2.libanki.Collection;
+
+import java.util.List;
+
+/**
+ * Test cases for {@link com.ichi2.anki.provider.CardContentProvider}.
+ * <p/>
+ * These tests should cover all supported operations for each URI.
+ */
+public class ContentProviderTest extends AndroidTestCase {
+
+    private static final String TEST_FIELD_VALUE = "test field value";
+    private static final String TEST_TAG = "aldskfhewjklhfczmxkjshf";
+    private static final String TEST_DECK = "glekrjterglknsdfflkgj";
+    private int mCreatedNotes;
+
+    /**
+     * Initially create one note for each model.
+     */
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        Log.i(AnkiDroidApp.TAG, "setUp()");
+        final ContentResolver cr = getContext().getContentResolver();
+        // Query all available models
+        final Cursor allModelsCursor = cr.query(FlashCardsContract.Model.CONTENT_URI, null, null, null, null);
+        assertNotNull(allModelsCursor);
+        mCreatedNotes = 0;
+        int idColumnIndex = allModelsCursor.getColumnIndexOrThrow(FlashCardsContract.Model._ID);
+        ContentValues values = new ContentValues();
+        try {
+            while (allModelsCursor.moveToNext()) {
+                long modelId = allModelsCursor.getLong(idColumnIndex);
+                values.clear();
+                values.put(FlashCardsContract.Note.MID, modelId);
+                Uri newNoteUri = cr.insert(FlashCardsContract.Note.CONTENT_URI, values);
+
+                // Now set a special tag, so that the note can easily be deleted after test
+                Uri newNoteDataUri = Uri.withAppendedPath(newNoteUri, "data");
+                values.clear();
+                values.put(FlashCardsContract.DataColumns.MIMETYPE, FlashCardsContract.Data.Tags.CONTENT_ITEM_TYPE);
+                values.put(FlashCardsContract.Data.Tags.TAG_CONTENT, TEST_TAG);
+                assertEquals("Tag set", 1, cr.update(newNoteDataUri, values, null, null));
+                mCreatedNotes++;
+            }
+        } finally {
+            allModelsCursor.close();
+        }
+        assertTrue("Check that at least one model exists, i.e. one note was created", mCreatedNotes != 0);
+    }
+
+    /**
+     * Remove the notes created in setUp().
+     * <p/>
+     * Using direct access to the collection, because there is no plan to include a delete
+     * interface in the content provider.
+     */
+    @Override
+    protected void tearDown() throws Exception {
+        Log.i(AnkiDroidApp.TAG, "tearDown()");
+        Collection col;
+        col = CollectionHelper.getInstance().getCol(getContext());
+        int deletedNotes;
+        List<Long> noteIds = col.findNotes("tag:" + TEST_TAG);
+        if ((noteIds != null) && (noteIds.size() > 0)) {
+            long[] delNotes = new long[noteIds.size()];
+            for (int i = 0; i < noteIds.size(); i++) {
+                delNotes[i] = noteIds.get(i);
+            }
+            col.remNotes(delNotes);
+            deletedNotes = noteIds.size();
+        } else {
+            deletedNotes = 0;
+        }
+        assertEquals("Check that all created notes have been deleted", mCreatedNotes, deletedNotes);
+        super.tearDown();
+    }
+
+    public void testQueryNoteIds() {
+        final ContentResolver cr = getContext().getContentResolver();
+        // Query all available notes
+        final Cursor allNotesCursor = cr.query(FlashCardsContract.Note.CONTENT_URI, null, "tag:" + TEST_TAG, null, null);
+        assertNotNull(allNotesCursor);
+        try {
+            assertEquals("Check number of results", mCreatedNotes, allNotesCursor.getCount());
+            while (allNotesCursor.moveToNext()) {
+                // Check that it's possible to leave out columns from the projection
+                for (int i = 0; i < FlashCardsContract.Note.DEFAULT_PROJECTION.length; i++) {
+                    String[] projection = removeFromProjection(FlashCardsContract.Note.DEFAULT_PROJECTION, i);
+                    String noteId = allNotesCursor.getString(allNotesCursor.getColumnIndex(FlashCardsContract.Note._ID));
+                    Uri noteUri = Uri.withAppendedPath(FlashCardsContract.Note.CONTENT_URI, noteId);
+                    final Cursor singleNoteCursor = cr.query(noteUri, projection, null, null, null);
+                    assertNotNull("Check that there is a valid cursor for detail data", singleNoteCursor);
+                    try {
+                        assertEquals("Check that there is exactly one result", 1, singleNoteCursor.getCount());
+                        assertTrue("Move to beginning of cursor after querying for detail data", singleNoteCursor.moveToFirst());
+                        // Check columns
+                        assertEquals("Check column count", projection.length, singleNoteCursor.getColumnCount());
+                        for (int j = 0; j < projection.length; j++) {
+                            assertEquals("Check column name " + j, projection[j], singleNoteCursor.getColumnName(j));
+                        }
+                    } finally {
+                        singleNoteCursor.close();
+                    }
+                }
+            }
+        } finally {
+            allNotesCursor.close();
+        }
+    }
+
+    public void testQueryNotesProjection() {
+        final ContentResolver cr = getContext().getContentResolver();
+        // Query all available notes
+        for (int i = 0; i < FlashCardsContract.Note.DEFAULT_PROJECTION.length; i++) {
+            String[] projection = removeFromProjection(FlashCardsContract.Note.DEFAULT_PROJECTION, i);
+            final Cursor allNotesCursor = cr.query(FlashCardsContract.Note.CONTENT_URI, projection, "tag:" + TEST_TAG, null, null);
+            assertNotNull("Check that there is a valid cursor", allNotesCursor);
+            try {
+                assertEquals("Check number of results", mCreatedNotes, allNotesCursor.getCount());
+                // Check columns
+                assertEquals("Check column count", projection.length, allNotesCursor.getColumnCount());
+                for (int j = 0; j < projection.length; j++) {
+                    assertEquals("Check column name " + j, projection[j], allNotesCursor.getColumnName(j));
+                }
+            } finally {
+                allNotesCursor.close();
+            }
+        }
+    }
+
+    private String[] removeFromProjection(String[] inputProjection, int idx) {
+        String[] outputProjection = new String[inputProjection.length - 1];
+        for (int i = 0; i < idx; i++) {
+            outputProjection[i] = inputProjection[i];
+        }
+        for (int i = idx + 1; i < inputProjection.length; i++) {
+            outputProjection[i - 1] = inputProjection[i];
+        }
+        return outputProjection;
+    }
+
+    public void testQueryNoteData() {
+        final ContentResolver cr = getContext().getContentResolver();
+        // Query all available notes
+        final Cursor allNotesCursor = cr.query(FlashCardsContract.Note.CONTENT_URI, null, "tag:" + TEST_TAG, null, null);
+        assertNotNull(allNotesCursor);
+        try {
+            assertEquals("Check number of results", mCreatedNotes, allNotesCursor.getCount());
+            while (allNotesCursor.moveToNext()) {
+                // Now iterate over all cursors
+                Uri dataUri = Uri.withAppendedPath(Uri.withAppendedPath(FlashCardsContract.Note.CONTENT_URI, allNotesCursor.getString(allNotesCursor.getColumnIndex(FlashCardsContract.Note._ID))), "data");
+                final Cursor noteDataCursor = cr.query(dataUri, null, null, null, null);
+                assertNotNull("Check that there is a valid cursor for detail data", noteDataCursor);
+                try {
+                    assertTrue("Check that there is at least one result for detail data", noteDataCursor.getCount() > 0);
+                    while (noteDataCursor.moveToNext()) {
+                        String mimeType = noteDataCursor.getString(noteDataCursor.getColumnIndex(FlashCardsContract.DataColumns.MIMETYPE));
+                        if (mimeType.equals(FlashCardsContract.Data.Field.CONTENT_ITEM_TYPE)) {
+                            assertEquals("Check field content", "temp", noteDataCursor.getString(noteDataCursor.getColumnIndex(FlashCardsContract.Data.Field.FIELD_CONTENT)));
+                        } else if (mimeType.equals(FlashCardsContract.Data.Tags.CONTENT_ITEM_TYPE)) {
+                            assertEquals("Unknown tag", TEST_TAG, noteDataCursor.getString(noteDataCursor.getColumnIndex(FlashCardsContract.Data.Tags.TAG_CONTENT)));
+                        } else {
+                            fail("Unknown MIME type " + noteDataCursor.getString(allNotesCursor.getColumnIndex(FlashCardsContract.DataColumns.MIMETYPE)));
+                        }
+                    }
+                } finally {
+                    noteDataCursor.close();
+                }
+            }
+        } finally {
+            allNotesCursor.close();
+        }
+    }
+
+    public void testUpdateNoteField() {
+        final ContentResolver cr = getContext().getContentResolver();
+        // Query all available notes
+        final Cursor allNotesCursor = cr.query(FlashCardsContract.Note.CONTENT_URI, null, "tag:" + TEST_TAG, null, null);
+        assertNotNull(allNotesCursor);
+        try {
+            assertEquals("Check number of results", mCreatedNotes, allNotesCursor.getCount());
+            while (allNotesCursor.moveToNext()) {
+                // Now iterate over all notes
+                Uri dataUri = Uri.withAppendedPath(Uri.withAppendedPath(FlashCardsContract.Note.CONTENT_URI, allNotesCursor.getString(allNotesCursor.getColumnIndex(FlashCardsContract.Note._ID))), "data");
+                Cursor noteDataCursor = cr.query(dataUri, null, null, null, null);
+                assertNotNull("Check that there is a valid cursor for detail data", noteDataCursor);
+                try {
+                    assertTrue("Check that there is at least one result for detail data", noteDataCursor.getCount() > 0);
+                    while (noteDataCursor.moveToNext()) {
+                        if (noteDataCursor.getString(noteDataCursor.getColumnIndex(FlashCardsContract.DataColumns.MIMETYPE)).equals(FlashCardsContract.Data.Field.CONTENT_ITEM_TYPE)) {
+                            // Update field
+                            ContentValues values = new ContentValues();
+                            values.put(FlashCardsContract.DataColumns.MIMETYPE, FlashCardsContract.Data.Field.CONTENT_ITEM_TYPE);
+                            values.put(FlashCardsContract.Data.Field.FIELD_NAME, noteDataCursor.getString(noteDataCursor.getColumnIndex(FlashCardsContract.Data.Field.FIELD_NAME)));
+                            values.put(FlashCardsContract.Data.Field.FIELD_CONTENT, TEST_FIELD_VALUE);
+                            assertEquals("Tag set", 1, cr.update(dataUri, values, null, null));
+                        } else {
+                            // ignore other data
+                        }
+                    }
+                } finally {
+                    noteDataCursor.close();
+                }
+
+                // After update query again
+                noteDataCursor = cr.query(dataUri, null, null, null, null);
+                assertNotNull("Check that there is a valid cursor for detail data after update", noteDataCursor);
+                try {
+                    assertTrue("Check that there is at least one result for detail data after update", noteDataCursor.getCount() > 0);
+                    while (noteDataCursor.moveToNext()) {
+                        if (noteDataCursor.getString(noteDataCursor.getColumnIndex(FlashCardsContract.DataColumns.MIMETYPE)).equals(FlashCardsContract.Data.Field.CONTENT_ITEM_TYPE)) {
+                            assertEquals("Check field content", TEST_FIELD_VALUE, noteDataCursor.getString(noteDataCursor.getColumnIndex(FlashCardsContract.Data.Field.FIELD_CONTENT)));
+                        } else {
+                            //ignore other data
+                        }
+                    }
+                } finally {
+                    noteDataCursor.close();
+                }
+            }
+        } finally {
+            allNotesCursor.close();
+        }
+    }
+
+    public void testQueryAllModels() {
+        final ContentResolver cr = getContext().getContentResolver();
+        // Query all available models
+        final Cursor allModelsCursor = cr.query(FlashCardsContract.Model.CONTENT_URI, null, null, null, null);
+        assertNotNull(allModelsCursor);
+        try {
+            assertTrue("Check that there is at least one result", allModelsCursor.getCount() > 0);
+            while (allModelsCursor.moveToNext()) {
+                long modelId = allModelsCursor.getLong(allModelsCursor.getColumnIndex(FlashCardsContract.Model._ID));
+                Uri modelUri = Uri.withAppendedPath(FlashCardsContract.Model.CONTENT_URI, Long.toString(modelId));
+                final Cursor singleModelCursor = cr.query(modelUri, null, null, null, null);
+                assertNotNull(singleModelCursor);
+                try {
+                    assertEquals("Check that there is exactly one result", 1, singleModelCursor.getCount());
+                    assertTrue("Move to beginning of cursor", singleModelCursor.moveToFirst());
+                    String nameFromModels = allModelsCursor.getString(allModelsCursor.getColumnIndex(FlashCardsContract.Model.NAME));
+                    String nameFromModel = singleModelCursor.getString(allModelsCursor.getColumnIndex(FlashCardsContract.Model.NAME));
+                    assertEquals("Check that model names are the same", nameFromModel, nameFromModels);
+                    String jsonFromModels = allModelsCursor.getString(allModelsCursor.getColumnIndex(FlashCardsContract.Model.JSONOBJECT));
+                    String jsonFromModel = singleModelCursor.getString(allModelsCursor.getColumnIndex(FlashCardsContract.Model.JSONOBJECT));
+                    assertEquals("Check that jsonobjects are the same", jsonFromModel, jsonFromModels);
+                } finally {
+                    singleModelCursor.close();
+                }
+            }
+        } finally {
+            allModelsCursor.close();
+        }
+    }
+
+    public void testMoveToOtherDeck() {
+        final ContentResolver cr = getContext().getContentResolver();
+        // Query all available notes
+        final Cursor allNotesCursor = cr.query(FlashCardsContract.Note.CONTENT_URI, null, "tag:" + TEST_TAG, null, null);
+        assertNotNull(allNotesCursor);
+        try {
+            assertEquals("Check number of results", mCreatedNotes, allNotesCursor.getCount());
+            while (allNotesCursor.moveToNext()) {
+                // Now iterate over all cursors
+                Uri cardsUri = Uri.withAppendedPath(Uri.withAppendedPath(FlashCardsContract.Note.CONTENT_URI, allNotesCursor.getString(allNotesCursor.getColumnIndex(FlashCardsContract.Note._ID))), "cards");
+                final Cursor cardsCursor = cr.query(cardsUri, null, null, null, null);
+                assertNotNull("Check that there is a valid cursor after query for cards", cardsCursor);
+                try {
+                    assertTrue("Check that there is at least one result for cards", cardsCursor.getCount() > 0);
+                    while (cardsCursor.moveToNext()) {
+                        String deckName = cardsCursor.getString(cardsCursor.getColumnIndex(FlashCardsContract.Card.DECK_NAME));
+                        assertEquals("Make sure that card is in default deck", "Default", deckName);
+                        // Move to test deck
+                        ContentValues values = new ContentValues();
+                        values.put(FlashCardsContract.Card.DECK_NAME, TEST_DECK);
+                        Uri cardUri = Uri.withAppendedPath(cardsUri, cardsCursor.getString(cardsCursor.getColumnIndex(FlashCardsContract.Card.CARD_ORD)));
+                        cr.update(cardUri, values, null, null);
+                        Cursor movedCardCur = cr.query(cardUri, null, null, null, null);
+                        assertNotNull("Check that there is a valid cursor after moving card", movedCardCur);
+                        assertTrue("Move to beginning of cursor after moving card", movedCardCur.moveToFirst());
+                        deckName = movedCardCur.getString(movedCardCur.getColumnIndex(FlashCardsContract.Card.DECK_NAME));
+                        assertEquals("Make sure that card is in test deck", TEST_DECK, deckName);
+                    }
+                } finally {
+                    cardsCursor.close();
+                }
+            }
+        } finally {
+            allNotesCursor.close();
+        }
+    }
+
+    public void testUnsupportedOperations() {
+        final ContentResolver cr = getContext().getContentResolver();
+        ContentValues dummyValues = new ContentValues();
+        Uri[] updateUris = {
+                FlashCardsContract.Note.CONTENT_URI,
+                FlashCardsContract.Note.CONTENT_URI.buildUpon()
+                        .appendPath("1234")
+                        .build(),
+                FlashCardsContract.Note.CONTENT_URI.buildUpon()
+                        .appendPath("1234")
+                        .appendPath("cards")
+                        .build(),
+                FlashCardsContract.Model.CONTENT_URI.buildUpon()
+                        .appendPath("1234")
+                        .build(),
+        };
+        for (Uri uri : updateUris) {
+            try {
+                cr.update(uri, dummyValues, null, null);
+                fail("Update on " + uri + " was supposed to throw exception");
+            } catch (UnsupportedOperationException e) {
+                // This was expected ...
+            } catch (IllegalArgumentException e) {
+                // ... or this.
+            }
+        }
+        Uri[] deleteUris = {
+                FlashCardsContract.Note.CONTENT_URI,
+                FlashCardsContract.Note.CONTENT_URI.buildUpon()
+                        .appendPath("1234")
+                        .build(),
+                FlashCardsContract.Note.CONTENT_URI.buildUpon()
+                        .appendPath("1234")
+                        .appendPath("data")
+                        .build(),
+                FlashCardsContract.Note.CONTENT_URI.buildUpon()
+                        .appendPath("1234")
+                        .appendPath("cards")
+                        .build(),
+                FlashCardsContract.Note.CONTENT_URI.buildUpon()
+                        .appendPath("1234")
+                        .appendPath("cards")
+                        .appendPath("2345")
+                        .build(),
+                FlashCardsContract.Model.CONTENT_URI,
+                FlashCardsContract.Model.CONTENT_URI.buildUpon()
+                        .appendPath("1234")
+                        .build(),
+        };
+        for (Uri uri : deleteUris) {
+            try {
+                cr.delete(uri, null, null);
+                fail("Delete on " + uri + " was supposed to throw exception");
+            } catch (UnsupportedOperationException e) {
+                // This was expected
+            }
+        }
+        Uri[] insertUris = {
+                FlashCardsContract.Note.CONTENT_URI.buildUpon()
+                        .appendPath("1234")
+                        .build(),
+                FlashCardsContract.Note.CONTENT_URI.buildUpon()
+                        .appendPath("1234")
+                        .appendPath("data")
+                        .build(),
+                FlashCardsContract.Note.CONTENT_URI.buildUpon()
+                        .appendPath("1234")
+                        .appendPath("cards")
+                        .build(),
+                FlashCardsContract.Note.CONTENT_URI.buildUpon()
+                        .appendPath("1234")
+                        .appendPath("cards")
+                        .appendPath("2345")
+                        .build(),
+                FlashCardsContract.Model.CONTENT_URI,
+                FlashCardsContract.Model.CONTENT_URI.buildUpon()
+                        .appendPath("1234")
+                        .build(),
+        };
+        for (Uri uri : insertUris) {
+            try {
+                cr.insert(uri, dummyValues);
+                fail("Insert on " + uri + " was supposed to throw exception");
+            } catch (UnsupportedOperationException e) {
+                // This was expected ...
+            } catch (IllegalArgumentException e) {
+                // ... or this.
+            }
+        }
+    }
+}

--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -317,6 +317,13 @@
         <meta-data
             android:name="com.sec.minimode.icon.landscape.normal"
             android:resource="@drawable/anki" />
+
+        <provider
+            android:name=".provider.CardContentProvider"
+            android:authorities="com.ichi2.anki.flashcards"
+            android:enabled="true"
+            android:exported="true" >
+        </provider>
     </application>
 
 </manifest>

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
@@ -1,0 +1,556 @@
+/***************************************************************************************
+ *                                                                                      *
+ * Copyright (c) 2015 Frank Oltmanns <frank.oltmanns@gmail.com>                         *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+
+package com.ichi2.anki.provider;
+
+import android.content.ContentProvider;
+import android.content.ContentValues;
+import android.content.UriMatcher;
+import android.database.Cursor;
+import android.database.MatrixCursor;
+import android.database.SQLException;
+import android.net.Uri;
+import com.ichi2.anki.CollectionHelper;
+import com.ichi2.anki.provider.FlashCardsContract.Data.Field;
+import com.ichi2.anki.provider.FlashCardsContract.DataColumns;
+import com.ichi2.libanki.Card;
+import com.ichi2.libanki.Collection;
+import com.ichi2.libanki.Note;
+import com.ichi2.libanki.Utils;
+import org.json.JSONException;
+import org.json.JSONObject;
+import timber.log.Timber;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Supported URIs:
+ * .../notes (search for notes)
+ * .../notes/# (direct access to note)
+ * .../notes/#/data (access to detail data of note)
+ * .../notes/#/cards (access cards of note)
+ * .../notes/#/cards/# (access specific card of note)
+ * .../models (search for models)
+ * .../models/# (direct access to model)
+ * <p/>
+ * Note that unlike Android's contact providers:
+ * <ul>
+ * <li>it's not possible to access detail data of more than one note</li>
+ * <li>it's not possible to access cards of more than one note</li>
+ * <li>it's not possible to access detail data of a note without providing its ID</li>
+ * <li>it's not possible to access cards of a note without providing the note's ID</li>
+ * <li>detail data of a notes only have fake temporary numeric ID (i.e. column "_ID"), this
+ * is due to the storage system of the AnkiDatabase.</li>
+ * </ul>
+ */
+public class CardContentProvider extends ContentProvider {
+
+    /* URI types */
+    private static final int NOTES = 1000;
+    private static final int NOTES_ID = 1001;
+    private static final int NOTES_ID_DATA = 1002;
+    private static final int NOTES_ID_CARDS = 1003;
+    private static final int NOTES_ID_CARDS_ORD = 1004;
+    private static final int MODELS = 2000;
+    private static final int MODELS_ID = 2001;
+
+    private static final UriMatcher sUriMatcher =
+            new UriMatcher(UriMatcher.NO_MATCH);
+
+    /* Based on proposal from Tim's comment on https://github.com/ankidroid/Anki-Android/pull/725
+     */
+    static {
+        // Here you can see all the URIs at a glance
+        sUriMatcher.addURI(FlashCardsContract.AUTHORITY, "notes", NOTES);
+        sUriMatcher.addURI(FlashCardsContract.AUTHORITY, "notes/#", NOTES_ID);
+        sUriMatcher.addURI(FlashCardsContract.AUTHORITY, "notes/#/data", NOTES_ID_DATA);
+        sUriMatcher.addURI(FlashCardsContract.AUTHORITY, "notes/#/cards", NOTES_ID_CARDS);
+        sUriMatcher.addURI(FlashCardsContract.AUTHORITY, "notes/#/cards/#", NOTES_ID_CARDS_ORD);
+        sUriMatcher.addURI(FlashCardsContract.AUTHORITY, "models", MODELS);
+        sUriMatcher.addURI(FlashCardsContract.AUTHORITY, "models/#", MODELS_ID);
+    }
+
+    /**
+     * The names of the columns returned by this content provider differ slightly from the names
+     * given of the database columns. This list is used to convert the column names used in a
+     * projection by the user into DB column names.
+     * <p/>
+     * This is currently only "_id" (projection) vs. "id" (Anki DB). But should probably be
+     * applied to more columns. "MID", "USN", "MOD" are not really user friendly.
+     */
+    private static final String[] sDefaultNoteProjectionDBAccess = FlashCardsContract.Note.DEFAULT_PROJECTION.clone();
+
+    static {
+        for (int idx = 0; idx < sDefaultNoteProjectionDBAccess.length; idx++) {
+            if (sDefaultNoteProjectionDBAccess[idx].equals(FlashCardsContract.Note._ID)) {
+                sDefaultNoteProjectionDBAccess[idx] = "id as _id";
+            }
+        }
+    }
+
+    @Override
+    public boolean onCreate() {
+        // Initialize content provider on startup.
+        Timber.d("CardContentProvider: onCreate");
+
+        return true;
+    }
+
+    @Override
+    public String getType(Uri uri) {
+        // Find out what data the user is requesting
+        int match = sUriMatcher.match(uri);
+
+        switch (match) {
+            case NOTES:
+                return FlashCardsContract.Note.CONTENT_TYPE;
+            case NOTES_ID:
+                return FlashCardsContract.Note.CONTENT_ITEM_TYPE;
+            case NOTES_ID_DATA:
+                return FlashCardsContract.Data.CONTENT_TYPE;
+            case NOTES_ID_CARDS:
+                return FlashCardsContract.Card.CONTENT_TYPE;
+            case NOTES_ID_CARDS_ORD:
+                return FlashCardsContract.Card.CONTENT_ITEM_TYPE;
+            case MODELS:
+                return FlashCardsContract.Model.CONTENT_TYPE;
+            case MODELS_ID:
+                return FlashCardsContract.Model.CONTENT_ITEM_TYPE;
+            default:
+                // Unknown URI type
+                throw new IllegalArgumentException("uri " + uri + " is not supported");
+        }
+    }
+
+    @Override
+    public Cursor query(Uri uri, String[] projection, String selection,
+                        String[] selectionArgs, String sortOrder) {
+        Timber.d("CardContentProvider.query");
+        Collection col = CollectionHelper.getInstance().getCol(getContext());
+        if (col == null) {
+            return null;
+        }
+
+        // Find out what data the user is requesting
+        int match = sUriMatcher.match(uri);
+
+        switch (match) {
+            case NOTES: {
+                /* Search for notes
+                 */
+                // TODO: Allow sort order, then also update description in FlashCardContract
+                String columnsStr = proj2str(projection);
+                String query = (selection != null) ? selection : "";
+                List<Long> noteIds = col.findNotes(query);
+                if ((noteIds != null) && (!noteIds.isEmpty())) {
+                    String selectedIds = "id in " + Utils.ids2str(noteIds);
+                    Cursor cur;
+                    try {
+                        cur = col.getDb().getDatabase().rawQuery("select " + columnsStr + " from notes where " + selectedIds, null);
+                    } catch (SQLException e) {
+                        throw new IllegalArgumentException("Not possible to query for data for IDs " +
+                                selectedIds, e);
+                    }
+                    return cur;
+                } else {
+                    return null;
+                }
+            }
+            case NOTES_ID: {
+                /* Direct access note
+                 */
+                long noteId;
+                noteId = Long.parseLong(uri.getPathSegments().get(1));
+                String columnsStr = proj2str(projection);
+                String selectedIds = "id = " + noteId;
+                Cursor cur;
+                try {
+                    cur = col.getDb().getDatabase().rawQuery("select " + columnsStr + " from notes where " + selectedIds, null);
+                } catch (SQLException e) {
+                    throw new IllegalArgumentException("Not possible to query for data for ID \"" +
+                            noteId + "\"", e);
+                }
+                return cur;
+            }
+            case NOTES_ID_DATA: {
+                /* Direct access note details
+                 */
+                Note currentNote = getNoteFromUri(uri, col);
+                MatrixCursor rv;
+                String[] columns = ((projection != null) ? projection : DataColumns.DEFAULT_PROJECTION);
+                rv = new MatrixCursor(columns, 1);
+                long id = 0;
+
+                /* First add the data from all the fields ...
+                 */
+                String[][] currentNoteItems = currentNote.items();
+                for (String[] field : currentNoteItems) {
+                    id++;
+                    MatrixCursor.RowBuilder rb = rv.newRow();
+                    for (String column : columns) {
+                        if (column.equals(DataColumns._ID)) {
+                            rb.add(id);
+                        } else if (column.equals(DataColumns.NOTE_ID)) {
+                            rb.add(currentNote.getId());
+                        } else if (column.equals(DataColumns.MIMETYPE)) {
+                            rb.add(FlashCardsContract.Data.Field.CONTENT_ITEM_TYPE);
+                        } else if (column.equals(Field.FIELD_NAME)) {
+                            rb.add(field[0]);
+                        } else if (column.equals(Field.FIELD_CONTENT)) {
+                            rb.add(field[1]);
+                        } else {
+                            throw new UnsupportedOperationException("Support for column \"" + column + "\" is not yet implemented for MIME type " + Field.CONTENT_ITEM_TYPE);
+                        }
+                    }
+                }
+
+                /* ... and then the tags. */
+                {
+                    id++;
+                    MatrixCursor.RowBuilder rb = rv.newRow();
+                    for (String column : columns) {
+                        if (column.equals(DataColumns._ID)) {
+                            rb.add(id);
+                        } else if (column.equals(DataColumns.NOTE_ID)) {
+                            rb.add(currentNote.getId());
+                        } else if (column.equals(DataColumns.MIMETYPE)) {
+                            rb.add(FlashCardsContract.Data.Tags.CONTENT_ITEM_TYPE);
+                        } else if (column.equals(FlashCardsContract.Data.Tags.TAG_CONTENT)) {
+                            rb.add(currentNote.stringTags().trim());
+                        } else // noinspection StatementWithEmptyBody
+                            if (column.equals(DataColumns.DATA2)) {
+                            /* Ignore: This column is not used for tags */
+                            } else {
+                                throw new UnsupportedOperationException("Support for column \"" + column + "\" is not implemented for MIME type " + Field.CONTENT_ITEM_TYPE);
+                            }
+                    }
+                }
+                return rv;
+            }
+            case NOTES_ID_CARDS: {
+                Note currentNote = getNoteFromUri(uri, col);
+                MatrixCursor rv;
+                String[] columns = ((projection != null) ? projection : FlashCardsContract.Card.DEFAULT_PROJECTION);
+                rv = new MatrixCursor(columns, 1);
+                for (Card currentCard : currentNote.cards()) {
+                    addCardToCursor(currentCard, rv, col, columns);
+                }
+                return rv;
+            }
+            case NOTES_ID_CARDS_ORD: {
+                Card currentCard = getCardFromUri(uri, col);
+                MatrixCursor rv;
+                String[] columns = ((projection != null) ? projection : FlashCardsContract.Card.DEFAULT_PROJECTION);
+                rv = new MatrixCursor(columns, 1);
+                addCardToCursor(currentCard, rv, col, columns);
+                return rv;
+            }
+            case MODELS: {
+                HashMap<Long, JSONObject> models = col.getModels().getModels();
+                MatrixCursor rv;
+                String[] columns = ((projection != null) ? projection : FlashCardsContract.Model.DEFAULT_PROJECTION);
+                rv = new MatrixCursor(columns, 1);
+
+                for (Long modelId : models.keySet()) {
+                    try {
+                        addModelToCursor(modelId, models, rv, columns);
+                    } catch (JSONException e) {
+                        throw new IllegalArgumentException("Model " + modelId + " is malformed", e);
+                    }
+                }
+                return rv;
+            }
+            case MODELS_ID: {
+                long modelId;
+                MatrixCursor rv;
+                String[] columns = ((projection != null) ? projection : FlashCardsContract.Model.DEFAULT_PROJECTION);
+                rv = new MatrixCursor(columns, 1);
+                modelId = Long.parseLong(uri.getPathSegments().get(1));
+                HashMap<Long, JSONObject> models = col.getModels().getModels();
+                try {
+                    addModelToCursor(modelId, models, rv, columns);
+                } catch (JSONException e) {
+                    throw new IllegalArgumentException("Model " + modelId + " is malformed", e);
+                }
+                return rv;
+            }
+            default:
+                // Unknown URI type
+                throw new IllegalArgumentException("uri " + uri + " is not supported");
+        }
+    }
+
+    @Override
+    public int update(Uri uri, ContentValues values, String selection,
+                      String[] selectionArgs) {
+        Timber.d("CardContentProvider.update");
+        Collection col = CollectionHelper.getInstance().getCol(getContext());
+        if (col == null) {
+            return 0;
+        }
+
+        // Find out what data the user is requesting
+        int match = sUriMatcher.match(uri);
+
+        int updated = 0; // Number of updated entries (return value)
+        switch (match) {
+            case NOTES:
+                throw new IllegalArgumentException("Not possible to update notes directly (only through data URI)");
+            case NOTES_ID:
+                throw new IllegalArgumentException("Not possible to update notes directly (only through data URI)");
+            case NOTES_ID_DATA: {
+                /* Direct access note details
+                 */
+                Note currentNote = getNoteFromUri(uri, col);
+                boolean isField = false;
+                boolean isTag = false;
+                String data1 = null;
+                String data2 = null;
+                // the key of the ContentValues contains the column name
+                // the value of the ContentValues contains the row value.
+                Set<Map.Entry<String, Object>> valueSet = values.valueSet();
+                for (Map.Entry<String, Object> entry : valueSet) {
+                    String key = entry.getKey();
+                    if (key.equals(DataColumns.MIMETYPE)) {
+                        isField = values.getAsString(key).equals(Field.CONTENT_ITEM_TYPE);
+                        isTag = values.getAsString(key).equals(FlashCardsContract.Data.Tags.CONTENT_ITEM_TYPE);
+                    } else if (key.equals(DataColumns.DATA1)) {
+                        data1 = values.getAsString(key);
+                    } else if (key.equals(DataColumns.DATA2)) {
+                        data2 = values.getAsString(key);
+                    } else {
+                        // Unknown column
+                        throw new IllegalArgumentException("Unknown/unsupported column: " + key);
+                    }
+                }
+
+                /* now update the note
+                 */
+                if ((isField) && (data1 != null) && (data2 != null)) {
+                    Timber.d("CardContentProvider: Saving note after field update...");
+                    currentNote.setitem(data1, data2);
+                    currentNote.flush();
+                    updated++;
+                } else if ((isTag) && (data1 != null)) {
+                    Timber.d("CardContentProvider: Saving note after tags update...");
+                    currentNote.setTagsFromStr(data1);
+                    currentNote.flush();
+                    updated++;
+                } else {
+                    // User tries an operation that is not (yet?) supported.
+                    throw new IllegalArgumentException("Currently only updates of fields are supported");
+                }
+                break;
+            }
+            case NOTES_ID_CARDS:
+                // TODO: To be implemented
+                throw new UnsupportedOperationException("Not yet implemented");
+//                break;
+            case NOTES_ID_CARDS_ORD: {
+                Card currentCard = getCardFromUri(uri, col);
+                boolean isDeckUpdate = false;
+                String newDeckName = null;
+                // the key of the ContentValues contains the column name
+                // the value of the ContentValues contains the row value.
+                Set<Map.Entry<String, Object>> valueSet = values.valueSet();
+                for (Map.Entry<String, Object> entry : valueSet) {
+                    // Only updates on deck name is supported
+                    String key = entry.getKey();
+                    isDeckUpdate = key.equals(FlashCardsContract.Card.DECK_NAME);
+                    newDeckName = values.getAsString(key);
+                }
+
+                /* now update the card
+                 */
+                if ((isDeckUpdate) && (newDeckName != null)) {
+                    Timber.d("CardContentProvider: Moving card to other deck...");
+                    long did = col.getDecks().id(newDeckName); // create new deck if not exists
+                    col.getDecks().flush();
+                    currentCard.setDid(did);
+                    currentCard.flush();
+                    updated++;
+                } else {
+                    // User tries an operation that is not (yet?) supported.
+                    throw new IllegalArgumentException("Currently only updates of decks are supported");
+                }
+                break;
+            }
+            case MODELS:
+                throw new UnsupportedOperationException("Not yet implemented");
+//                break;
+            case MODELS_ID:
+                throw new UnsupportedOperationException("Not yet implemented");
+//                break;
+            default:
+                // Unknown URI type
+                throw new IllegalArgumentException("uri " + uri + " is not supported");
+        }
+        return updated;
+    }
+
+    @Override
+    public int delete(Uri uri, String selection, String[] selectionArgs) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Uri insert(Uri uri, ContentValues values) {
+        Timber.d("CardContentProvider.insert");
+        Collection col = CollectionHelper.getInstance().getCol(getContext());
+        if (col == null) {
+            return null;
+        }
+
+        // Find out what data the user is requesting
+        int match = sUriMatcher.match(uri);
+
+        switch (match) {
+            case NOTES: {
+                /* Insert new note
+                 */
+                Long modelId = values.getAsLong(FlashCardsContract.Note.MID);
+                com.ichi2.libanki.Note newNote = new com.ichi2.libanki.Note(col, col.getModels().get(modelId));
+                String[] fields = newNote.getFields();
+                for (int i = 0; i < fields.length; i++) {
+                    newNote.setField(i, "temp");
+                }
+                col.addNote(newNote);
+                return Uri.withAppendedPath(FlashCardsContract.Note.CONTENT_URI, Long.toString(newNote.getId()));
+            }
+            case NOTES_ID: {
+                /* Direct access note
+                 */
+                throw new IllegalArgumentException("Not possible to insert note with specific ID");
+            }
+            case NOTES_ID_DATA:
+                throw new IllegalArgumentException("Not possible to insert note data");
+            case NOTES_ID_CARDS:
+                throw new IllegalArgumentException("Not possible to insert cards directly (only through inserting notes)");
+            case NOTES_ID_CARDS_ORD:
+                throw new IllegalArgumentException("Not possible to insert cards directly (only through inserting notes)");
+            case MODELS:
+                // TODO: To be implemented
+                throw new UnsupportedOperationException("Not yet implemented");
+//                break;
+            case MODELS_ID:
+                throw new IllegalArgumentException("Not possible to insert model with specific ID");
+            default:
+                // Unknown URI type
+                throw new IllegalArgumentException("uri " + uri + " is not supported");
+        }
+    }
+
+    private static String proj2str(String[] projection) {
+        StringBuilder rv = new StringBuilder();
+        if (projection != null) {
+            for (String column : projection) {
+                int idx = projSearch(FlashCardsContract.Note.DEFAULT_PROJECTION, column);
+                if (idx >= 0) {
+                    rv.append(sDefaultNoteProjectionDBAccess[idx]);
+                    rv.append(",");
+                } else {
+                    throw new IllegalArgumentException("Unknown column " + column);
+                }
+            }
+        } else {
+            for (String column : sDefaultNoteProjectionDBAccess) {
+                rv.append(column);
+                rv.append(",");
+            }
+        }
+        rv.deleteCharAt(rv.length() - 1);
+        return rv.toString();
+    }
+
+    private static int projSearch(String[] projection, String column) {
+        for (int i = 0; i < projection.length; i++) {
+            if (projection[i].equals(column)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private void addModelToCursor(Long modelId, HashMap<Long, JSONObject> models, MatrixCursor rv, String[] columns) throws JSONException {
+        JSONObject jsonObject = models.get(modelId);
+        MatrixCursor.RowBuilder rb = rv.newRow();
+        for (String column : columns) {
+            if (column.equals(FlashCardsContract.Model._ID)) {
+                rb.add(modelId);
+            } else if (column.equals(FlashCardsContract.Model.NAME)) {
+                rb.add(jsonObject.getString("name"));
+            } else if (column.equals(FlashCardsContract.Model.JSONOBJECT)) {
+                rb.add(jsonObject);
+            } else {
+                throw new UnsupportedOperationException("Column \"" + column + "\" is unknown");
+            }
+        }
+
+    }
+
+    private void addCardToCursor(Card currentCard, MatrixCursor rv, Collection col, String[] columns) {
+        String cardName;
+        String deckName;
+        try {
+            cardName = currentCard.template().getString("name");
+            deckName = col.getDecks().get(currentCard.getDid()).getString("name");
+        } catch (JSONException je) {
+            throw new IllegalArgumentException("Card is using an invalid template", je);
+        }
+        String question = currentCard.q();
+        String answer = currentCard.a();
+        MatrixCursor.RowBuilder rb = rv.newRow();
+        for (String column : columns) {
+            if (column.equals(FlashCardsContract.Card.NOTE_ID)) {
+                rb.add(currentCard.note().getId());
+            } else if (column.equals(FlashCardsContract.Card.CARD_ORD)) {
+                rb.add(currentCard.getOrd());
+            } else if (column.equals(FlashCardsContract.Card.CARD_NAME)) {
+                rb.add(cardName);
+            } else if (column.equals(FlashCardsContract.Card.DECK_NAME)) {
+                rb.add(deckName);
+            } else if (column.equals(FlashCardsContract.Card.QUESTION)) {
+                rb.add(question);
+            } else if (column.equals(FlashCardsContract.Card.ANSWER)) {
+                rb.add(answer);
+            } else {
+                throw new UnsupportedOperationException("Column \"" + column + "\" is unknown");
+            }
+        }
+    }
+
+    private Card getCardFromUri(Uri uri, Collection col) {
+        long noteId;
+        int ord;
+        noteId = Long.parseLong(uri.getPathSegments().get(1));
+        ord = Integer.parseInt(uri.getPathSegments().get(3));
+        Note currentNote = col.getNote(noteId);
+        if (currentNote.cards().size() <= ord) {
+            throw new IllegalArgumentException("Card with ord " + ord + " does not exist for note " + noteId);
+        }
+        return currentNote.cards().get(ord);
+    }
+
+    private Note getNoteFromUri(Uri uri, Collection col) {
+        long noteId;
+        noteId = Long.parseLong(uri.getPathSegments().get(1));
+        return col.getNote(noteId);
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/FlashCardsContract.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/FlashCardsContract.java
@@ -1,0 +1,843 @@
+/*
+ * Copying and distribution of this file, with or without modification, are permitted in any
+ * medium without royalty. This file is offered as-is, without any warranty.
+ */
+
+package com.ichi2.anki.provider;
+
+import android.net.Uri;
+
+/**
+ * <p>
+ * The contract between AnkiDroid and applications. Contains definitions for the supported URIs and
+ * columns.
+ * </p>
+ * <h3>Overview</h3>
+ * <p>
+ * FlashCardsContract defines the access to flash card related information. Flash cards consist of
+ * notes and cards. To find out more about notes and cards, see
+ * <a href="http://ankisrs.net/docs/manual.html#the-basics">the basics section in the Anki manual.</a>
+ * </p>
+ * <p/>
+ * <p>
+ * In short, you can think of cards as instances of notes, with the limitation that the number of
+ * instances and their names are pre-defined.
+ * </p>
+ * <p>
+ * The most important data of notes/cards are "fields". Fields contain the actual information of the
+ * flashcard that is used for learning. Typical fields are "Japanese" and "English" (for a native
+ * English speaker to learn Japanese), or just "front" and "back" (for a generic front side and back
+ * side of a card, without saying anything about the purpose). Fields can be accessed through the
+ * {@link FlashCardsContract.Data} content provider using the special
+ * {@link FlashCardsContract.Data.Field#MIMETYPE} for fields.
+ * </p>
+ * <p/>
+ * Note and card information is accessed in the following way:
+ * </p>
+ * <ul>
+ * <li>
+ * Each row from the {@link Note} provider represents a note that is stored in AnkiDroid.
+ * This provider must be used in order to find flashcards. Some of the data that is returned by
+ * this provider can also be obtained through the {@link Data} in a more compact way. The notes
+ * can be accessed by the {@link Note#CONTENT_URI}, like this to search for note:
+ * <pre>
+ *     <code>
+ *         // Query all available notes
+ *         final Cursor cursor = cr.query(FlashCardsContract.Note.CONTENT_URI, null, null, null, null);
+ *     </code>
+ * </pre>
+ * or this if you know the note's ID:
+ * <pre>
+ *     <code>
+ *         String noteId = ... // Use the known note ID
+ *         Uri noteUri = Uri.withAppendedPath(FlashCardsContract.Note.CONTENT_URI, noteId);
+ *         final Cursor cur = cr.query(noteUri, null, null, null, null);
+ *     </code>
+ * </pre>
+ * </li>
+ * <li>
+ * A row from the {@link Data} provider gives access to notes data, such as fields and tags. The
+ * data is accessed as described in the {@link FlashCardsContract.DataColumns} description.
+ * </li>
+ * <li>
+ * A row from the {@link Card} provider gives access to notes cards. The
+ * cards are accessed as described in the {@link FlashCardsContract.Card} description.
+ * </li>
+ * <li>
+ * The format of notes and cards is described in models. The models are accessed as described
+ * in the {@link FlashCardsContract.Model} description.
+ * </li>
+ * </ul>
+ * <p/>
+ * The AnkiDroid Flashcard content provider supports the following operation on it's URIs:
+ * <p/>
+ * <table class="memberSummary" border="0" cellpadding="3" cellspacing="0" summary="URIs and Operations supported by CardContentProvider">
+ * <caption><span>URIs and operations</span><span class="tabEnd">&nbsp;</span></caption>
+ * <tr>
+ * <th class="colFirst" scope="col">URI</th>
+ * <th class="colLast" scope="col">Description</th>
+ * </tr>
+ * <tr class="altColor">
+ * <td class="colFirst"><code>notes</code></td>
+ * <td class="colLast">Note with id <code>note_id</code> as raw data
+ * <div class="block">Supports insert(mid), query(). For code examples see class description of {@link Note}.</div>
+ * </td>
+ * </tr>
+ * <tr class="rowColor">
+ * <td class="colFirst"><code>notes/&lt;note_id&gt;</code></td>
+ * <td class="colLast">Note with id <code>note_id</code> as raw data
+ * <div class="block">Supports query(). For code examples see class description of {@link Note}.</div>
+ * </td>
+ * </tr>
+ * <tr class="altColor">
+ * <td class="colFirst"><code>notes/&lt;note_id&gt;/data</code></td>
+ * <td class="colLast">Note with id <code>note_id</code> as high level data (i.e. split fields, tags).
+ * <div class="block">Supports update(), query(). For code examples see class description of {@link DataColumns}.</div>
+ * </td>
+ * </tr>
+ * <tr class="rowColor">
+ * <td class="colFirst"><code>notes/&lt;note_id&gt;/cards</code></td>
+ * <td class="colLast">All cards belonging to note <code>note_id</code> as high level data (Deck name, question, answer).
+ * <div class="block">Supports query(). For code examples see class description of {@link Card}.</div>
+ * </td>
+ * </tr>
+ * <tr class="altColor">
+ * <td class="colFirst"><code>notes/&lt;note_id&gt;/cards/&lt;ord&gt;</code></td>
+ * <td class="colLast">NoteCard <code>ord</code> (with ord = 0... num_cards-1) belonging to note <code>note_id</code> as high level data (Deck name, question, answer).
+ * <div class="block">Supports update(), query(). For code examples see class description of {@link Card}.</div>
+ * </td>
+ * </tr>
+ * <tr class="rowColor">
+ * <td class="colFirst"><code>models</code></td>
+ * <td class="colLast">All models as JSONObjects.
+ * <div class="block">Supports query(). For code examples see class description of {@link Model}.</div>
+ * </td>
+ * </tr>
+ * <tr class="altColor">
+ * <td class="colFirst"><code>model/&lt;model_id&gt;</code></td>
+ * <td class="colLast">Direct access to model <code>model_id</code> as JSONObject.
+ * <div class="block">Supports query(). For code examples see class description of {@link Model}.</div>
+ * </td>
+ * </tr>
+ * </table>
+ */
+public class FlashCardsContract {
+    public static final String AUTHORITY = "com.ichi2.anki.flashcards";
+
+    /**
+     * A content:// style uri to the authority for the flash card provider
+     */
+    public static final Uri AUTHORITY_URI = Uri.parse("content://" + AUTHORITY);
+
+    /* Don't create instances of this class. */
+    private FlashCardsContract() {
+    }
+
+    ;
+
+    /**
+     * The Notes can be accessed by
+     * the {@link #CONTENT_URI}. If the {@link #CONTENT_URI} is appended by the note's ID, this
+     * note can be directly accessed. If no ID is appended the content provides functions return
+     * all the notes that match the query as defined in {@code selection} argument in the
+     * {@code query(Uri uri, String[] projection, String selection, String[] selectionArgs, String sortOrder)} call.
+     * The {@code selectionArgs} parameter is always ignored. The query syntax that must go in the
+     * {@code selection} argument is described
+     * <a href="http://ankisrs.net/docs/manual.html#searching">in the search section of the Anki manual</a>.
+     * <p/>
+     * <p>
+     * Example for querying notes with a certain tag:
+     * <pre>
+     *     <code>
+     *         final Cursor cursor = cr.query(FlashCardsContract.Note.CONTENT_URI,
+     *                                        null,         // projection
+     *                                        "tag:my_tag", // example query
+     *                                        null,         // selectionArgs is ignored for this URI
+     *                                        null          // sortOrder is ignored for this URI
+     *                                        );
+     *     </code>
+     * </pre>
+     * </p>
+     * Example for querying notes with a certain note id with direct URI:
+     * <pre>
+     *     <code>
+     *         Uri noteUri = Uri.withAppendedPath(FlashCardsContract.Note.CONTENT_URI, Long.toString(noteId));
+     *         final Cursor cursor = cr.query(noteUri,
+     *                                        null,  // projection
+     *                                        null,  // selection is ignored for this URI
+     *                                        null,  // selectionArgs is ignored for this URI
+     *                                        null   // sortOrder is ignored for this URI
+     *                                        );
+     *     </code>
+     * </pre>
+     * <p/>
+     * In order to insert a new note (the cards for this note will be added to the default deck)
+     * the {@link #CONTENT_URI} must be used together with a model (see {@link Model})
+     * ID, e.g.
+     * <pre>
+     *     <code>
+     *         Long mId = ... // Use the correct model ID
+     *         ContentValues values = new ContentValues();
+     *         values.put(FlashCardsContract.Note.MID, mId);
+     *         Uri newNoteUri = cr.insert(FlashCardsContract.Note.CONTENT_URI, values);
+     *     </code>
+     * </pre>
+     * <p/>
+     * It's not possible to update notes through this interface. Instead the {@link DataColumns}
+     * interface and it's implementations should be used.
+     * <p/>
+     * A note consists of the following columns:
+     * <p/>
+     * <table class="jd-sumtable">
+     * <tr>
+     * <th>Type</th><th>Name</th><th>access</th><th>description</th>
+     * </tr>
+     * <tr>
+     * <td>long</td>
+     * <td>{@link #_ID}</td>
+     * <td>read-only</td>
+     * <td>Row ID. This is the ID of the note. It is the same as the note ID in Anki. This
+     * ID can be used for accessing the data of a note using the URI
+     * "content://com.ichi2.anki.flashcards/notes/&lt;ID&gt;/data</td>
+     * </tr>
+     * <tr>
+     * <td>long</td>
+     * <td>{@link #GUID}</td>
+     * <td>read-only</td>
+     * <td>???</td>
+     * </tr>
+     * <tr>
+     * <td>long</td>
+     * <td>{@link #MID}</td>
+     * <td>read-only</td>
+     * <td>This is the ID of the model that is used for rendering the cards. This ID can be used for
+     * accessing the data of the model using the URI
+     * "content://com.ichi2.anki.flashcards/model/&lt;ID&gt;</td>
+     * </tr>
+     * <tr>
+     * <td>long</td>
+     * <td>{@link #MOD}</td>
+     * <td>read-only</td>
+     * <td>???</td>
+     * </tr>
+     * <tr>
+     * <td>long</td>
+     * <td>{@link #USN}</td>
+     * <td>read-only</td>
+     * <td>???</td>
+     * </tr>
+     * <tr>
+     * <td>long</td>
+     * <td>{@link #TAGS}</td>
+     * <td>read-only</td>
+     * <td>Tags of this note. Tags are separated  by spaces.</td>
+     * </tr>
+     * <tr>
+     * <td>String</td>
+     * <td>{@link #FLDS}</td>
+     * <td>read-only</td>
+     * <td>Fields of this note. Fields are separated by "\\x1f"</td>
+     * </tr>
+     * <tr>
+     * <td>long</td>
+     * <td>{@link #SFLD}</td>
+     * <td>read-only</td>
+     * <td>???</td>
+     * </tr>
+     * <tr>
+     * <td>long</td>
+     * <td>{@link #CSUM}</td>
+     * <td>read-only</td>
+     * <td>???</td>
+     * </tr>
+     * <tr>
+     * <td>long</td>
+     * <td>{@link #FLAGS}</td>
+     * <td>read-only</td>
+     * <td>???</td>
+     * </tr>
+     * <tr>
+     * <td>long</td>
+     * <td>{@link #DATA}</td>
+     * <td>read-only</td>
+     * <td>???</td>
+     * </tr>
+     * </table>
+     */
+    public static class Note {
+        /**
+         * The content:// style URI for notes. If the it is appended by the note's ID, this
+         * note can be directly accessed, e.g.
+         * <p>
+         * <pre>
+         *         Uri noteUri = Uri.withAppendedPath(FlashCardsContract.Note.CONTENT_URI, Long.toString(noteId));
+         *     </pre>
+         * </p>
+         *
+         * <p>
+         * If the URI is appended by the note ID and then the keyword "data", it is possible to
+         * access the details of a note:
+         * <p>
+         * <pre>
+         *         Uri noteUri = Uri.withAppendedPath(FlashCardsContract.Note.CONTENT_URI, Long.toString(noteId));
+         *         Uri dataUri = Uri.withAppendedPath(noteUri, "data");
+         *     </pre>
+         * </p>
+         * </p>
+         *
+         * For examples on how to use the URI for queries see class description.
+         */
+        public static final Uri CONTENT_URI = Uri.withAppendedPath(AUTHORITY_URI, "notes");
+
+        /**
+         * This is the ID of the note. It is the same as the note ID in Anki. This ID can be
+         * used for accessing the data of a note using the URI
+         * "content://com.ichi2.anki.flashcards/notes/&lt;ID&gt;/data
+         */
+        public static final String _ID = "_id";
+        public static final String GUID = "guid";
+        public static final String MID = "mid";
+        public static final String MOD = "mod";
+        public static final String USN = "usn";
+        public static final String TAGS = "tags";
+        public static final String FLDS = "flds";
+        public static final String SFLD = "sfld";
+        public static final String CSUM = "csum";
+        public static final String FLAGS = "flags";
+        public static final String DATA = "data";
+
+        public static final String[] DEFAULT_PROJECTION = {
+                Note._ID,
+                Note.GUID,
+                Note.MID,
+                Note.MOD,
+                Note.USN,
+                Note.TAGS,
+                Note.FLDS,
+                Note.SFLD,
+                Note.CSUM,
+                Note.FLAGS,
+                Note.DATA};
+
+        /**
+         * MIME type used for a note.
+         */
+        public static final String CONTENT_ITEM_TYPE = "vnd.android.cursor.item/vnd.com.ichi2.anki.note";
+
+        /**
+         * MIME type used for notes.
+         */
+        public static final String CONTENT_TYPE = "vnd.android.cursor.dir/vnd.com.ichi2.anki.note";
+    }
+
+    /**
+     * This is the generic interface class that describes the detailed content of notes.
+     * <p/>
+     * The note details consist of four columns:
+     * <p/>
+     * <table class="jd-sumtable">
+     * <tr>
+     * <th>Type</th><th>Name</th><th>access</th><th>description</th>
+     * </tr>
+     * <tr>
+     * <td>long</td>
+     * <td>{@link #_ID}</td>
+     * <td>read-only</td>
+     * <td>Row ID. This is a virtual ID which actually does not exist in AnkiDroid's data base.</td>
+     * </tr>
+     * <tr>
+     * <td>long</td>
+     * <td>{@link #NOTE_ID}</td>
+     * <td>read-only</td>
+     * <td>This is the ID of the note that this row belongs to (i.e. {@link Note#_ID}).
+     * </td>
+     * </tr>
+     * <tr>
+     * <td>String</td>
+     * <td>{@link #MIMETYPE}</td>
+     * <td>read-only</td>
+     * <td>This describes the MIME type of the row, which describes how to interpret the columns
+     * {@link #DATA1} and {@link #DATA2}.
+     * </td>
+     * </tr>
+     * <tr>
+     * <td>MIMETYPE dependent.</td>
+     * <td>{@link #DATA1}</td>
+     * <td>MIMETYPE dependent.</td>
+     * <td>This is the first of two data columns. The column must be interpreted according to the
+     * {@link #MIMETYPE} column.
+     * </td>
+     * </tr>
+     * <tr>
+     * <td>long</td>
+     * <td>{@link #DATA2}</td>
+     * <td>MIMETYPE dependent.</td>
+     * <td>This is the second of two data columns. The column must be interpreted according to the
+     * {@link #MIMETYPE} column.
+     * </td>
+     * </tr>
+     * </table>
+     * <p/>
+     * Example for querying data and using the aliases from {@link Data.Field} and
+     * {@link Data.Tags}:
+     * <pre>
+     *     <code>
+     *         Uri noteUri = Uri.withAppendedPath(FlashCardsContract.Note.CONTENT_URI, Long.toString(noteId));
+     *         Uri dataUri = Uri.withAppendedPath(noteUri, "data");
+     *         final Cursor cur = cr.query(dataUri,
+     *                                     null,  // projection
+     *                                     null,  // selection is ignored for this URI
+     *                                     null,  // selectionArgs is ignored for this URI
+     *                                     null   // sortOrder is ignored for this URI
+     *                                     );
+     *         do {
+     *             if (cur.getString(cur.getColumnIndex(FlashCardsContract.DataColumns.MIMETYPE)).equals(FlashCardsContract.Data.Field.CONTENT_ITEM_TYPE)) {
+     *                 String fieldContent = cur.getString(cur.getColumnIndex(FlashCardsContract.Data.Field.FIELD_CONTENT));
+     *                 String fieldName = cur.getString(cur.getColumnIndex(FlashCardsContract.Data.Field.FIELD_NAME));
+     *                 // Do something
+     *             } else if (cur.getString(cur.getColumnIndex(FlashCardsContract.DataColumns.MIMETYPE)).equals(FlashCardsContract.Data.Tags.CONTENT_ITEM_TYPE)) {
+     *                 String tags = cur.getString(cur.getColumnIndex(FlashCardsContract.Data.Tags.TAG_CONTENT));
+     *                 // Do something
+     *             } else {
+     *                 // Unknown MIME type
+     *             }
+     *         } while (cur.moveToNext());
+     *     </code>
+     * </pre>
+     * <p/>
+     * Example for updating fields using the aliases from {@link Data.Field}:
+     * <pre>
+     *     <code>
+     *         Uri noteUri = Uri.withAppendedPath(FlashCardsContract.Note.CONTENT_URI, Long.toString(noteId));
+     *         Uri dataUri = Uri.withAppendedPath(noteUri, "data");
+     *         Cursor cur = cr.query(dataUri, null, null, null, null);
+     *         assertNotNull("Check that there is a valid cursor for detail data", cur);
+     *         assertEquals("Move to beginning of cursor after querying for detail data", true, cur.moveToFirst());
+     *         do {
+     *             if (cur.getString(cur.getColumnIndex(FlashCardsContract.DataColumns.MIMETYPE)).equals(FlashCardsContract.Data.Field.CONTENT_ITEM_TYPE)) {
+     *                 // Update field
+     *                 ContentValues values = new ContentValues();
+     *                 values.put(FlashCardsContract.DataColumns.MIMETYPE, FlashCardsContract.Data.Field.CONTENT_ITEM_TYPE);
+     *                 values.put(FlashCardsContract.Data.Field.FIELD_NAME, cur.getString(cur.getColumnIndex(FlashCardsContract.Data.Field.FIELD_NAME)));
+     *                 values.put(FlashCardsContract.Data.Field.FIELD_CONTENT, TEST_FIELD_VALUE);
+     *                 cr.update(dataUri, values, null, null);
+     *             } else {
+     *                 // ignore other data
+     *             }
+     *         } while (cur.moveToNext());
+     *     </code>
+     * </pre>
+     */
+    public interface DataColumns {
+        /**
+         * Row ID. This is a virtual ID which actually does not exist in AnkiDroid's data base.
+         * This column only exists so that this interface can be used with existing CursorAdapters
+         * that require the existence of a "_id" column. This means, that it CAN NOT be used
+         * reliably over subsequent queries. Especially if the number of cards or fields changes,
+         * the _ID will change too.
+         */
+        public static final String _ID = "_id";
+
+        /**
+         * This is the ID of the note that this row belongs to (i.e. {@link Note#_ID}).
+         */
+        public static final String NOTE_ID = "note_id";
+
+        /**
+         * This describes the MIME type of the row, which describes how to interpret the columns
+         * {@link #DATA1} and {@link #DATA2}. Allowed values are:
+         * <ul>
+         * <li>{@link FlashCardsContract.Data.Field#CONTENT_ITEM_TYPE}:
+         * You can use the aliases described in
+         * {@link FlashCardsContract.Data.Field} to access the
+         * columns instead of the generic "DATA1" or "DATA2".
+         * </li>
+         * <li>{@link FlashCardsContract.Data.Tags#CONTENT_ITEM_TYPE}:
+         * You can use the aliases described in
+         * {@link FlashCardsContract.Data.Tags} to access the
+         * columns instead of the generic "DATA1" or "DATA2".
+         * </li>
+         * </ul>
+         */
+        public static final String MIMETYPE = "mimetype";
+
+        /**
+         * This is the first of two data columns. The column must be interpreted according to the
+         * {@link #MIMETYPE} column.
+         */
+        public static final String DATA1 = "data1";
+
+        /**
+         * This is the second of two data columns. The column must be interpreted according to the
+         * {@link #MIMETYPE} column.
+         */
+        public static final String DATA2 = "data2";
+
+        /**
+         * Default columns that are returned when querying the ...notes/#/data URI.
+         */
+        public static final String[] DEFAULT_PROJECTION = {
+                _ID,
+                NOTE_ID,
+                MIMETYPE,
+                DATA1,
+                DATA2};
+    }
+
+    /**
+     * Container for definitions of common data types returned by the data content provider.
+     */
+    public class Data {
+
+        /**
+         * MIME type used for data.
+         */
+        public static final String CONTENT_TYPE = "vnd.android.cursor.dir/vnd.com.ichi2.anki.note_data";
+
+        /**
+         * A data kind representing a field in a note.
+         * <p/>
+         * You can use the columns defined for
+         * {@link FlashCardsContract.DataColumns} as well as the following
+         * aliases.
+         * <table class="jd-sumtable">
+         * <tr>
+         * <th>Type</th><th>Alias</th><th>Data column</th><th>access</th><th></th>
+         * </tr>
+         * <tr>
+         * <td>String</td>
+         * <td>{@link #FIELD_NAME}</td>
+         * <td>{@link FlashCardsContract.DataColumns#DATA1}</td>
+         * <td>read-only</td>
+         * <td>Field name</td>
+         * </tr>
+         * <tr>
+         * <td>String</td>
+         * <td>{@link #FIELD_CONTENT}</td>
+         * <td>{@link FlashCardsContract.DataColumns#DATA2}</td>
+         * <td>read-write</td>
+         * <td>Field content</td>
+         * </tr>
+         * </table>
+         * <p/>
+         * Since the fields are defined by the model type, it is not possible to insert or delete
+         * fields. To update a field see the class description of {@link FlashCardsContract.DataColumns}.
+         */
+        public class Field implements DataColumns {
+            /**
+             * MIME type used for fields.
+             */
+            public static final String CONTENT_ITEM_TYPE = "vnd.android.cursor.item/vnd.com.ichi2.anki.note_field";
+
+            /**
+             * The field name as defined by the model, e.g. "front" or "back".
+             */
+            public static final String FIELD_NAME = DATA1;
+
+            /**
+             * The content of the field, e.g. "dog" or "犬".
+             */
+            public static final String FIELD_CONTENT = DATA2;
+        }
+
+        /**
+         * A data kind representing tags in a note.
+         * <p/>
+         * You can use the columns defined for
+         * {@link FlashCardsContract.DataColumns} as well as the following
+         * aliases.
+         * <table class="jd-sumtable">
+         * <tr>
+         * <th>Type</th><th>Alias</th><th>Data column</th><th>access</th><th></th>
+         * </tr>
+         * <tr>
+         * <td>String</td>
+         * <td>{@link #TAG_CONTENT}</td>
+         * <td>{@link FlashCardsContract.DataColumns#DATA1}</td>
+         * <td>read-write</td>
+         * <td>Tags, seperated by spaces</td>
+         * </tr>
+         * </table>
+         */
+        public class Tags implements DataColumns {
+            /**
+             * MIME type used for tags.
+             */
+            public static final String CONTENT_ITEM_TYPE = "vnd.android.cursor.item/vnd.com.ichi2.anki.note_tags";
+
+            /**
+             * The tags of this note, e.g. "fruits".
+             */
+            public static final String TAG_CONTENT = DATA1;
+        }
+    }
+
+    /**
+     * A model describes what cards look like. This information is described in the
+     * column {@link #JSONOBJECT}.
+     * <table class="jd-sumtable">
+     * <tr>
+     * <th>Type</th><th>Name</th><th>access</th><th>description</th>
+     * </tr>
+     * <tr>
+     * <td>long</td>
+     * <td>{@link #_ID}</td>
+     * <td>read-only</td>
+     * <td>Model ID.</td>
+     * </tr>
+     * <tr>
+     * <td>long</td>
+     * <td>{@link #NAME}</td>
+     * <td>read-only</td>
+     * <td>Name of the model.
+     * </td>
+     * </tr>
+     * <tr>
+     * <td>String</td>
+     * <td>{@link #JSONOBJECT}</td>
+     * <td>read-only</td>
+     * <td>Describes what the cards for this model will look like.
+     * </td>
+     * </tr>
+     * </table>
+     * <p/>
+     * It's possible to query all models at once like this
+     * <p>
+     * <pre>
+     *         Uri noteUri = Uri.withAppendedPath(FlashCardsContract.Note.CONTENT_URI, Long.toString(noteId));
+     *         final Cursor cursor = cr.query(FlashCardsContract.Model.CONTENT_URI,
+     *                                     null,  // projection
+     *                                     null,  // selection is ignored for this URI
+     *                                     null,  // selectionArgs is ignored for this URI
+     *                                     null   // sortOrder is ignored for this URI
+     *                                     );
+     *     </pre>
+     * </p>
+     *
+     * It's also possible to access a specific model like this:
+     * <p>
+     * <pre>
+     *         long modelId = ...// Use the correct model ID
+     *         Uri modelUri = Uri.withAppendedPath(FlashCardsContract.Model.CONTENT_URI, Long.toString(modelId));
+     *         final Cursor cur = cr.query(modelUri,
+     *                                     null,  // projection
+     *                                     null,  // selection is ignored for this URI
+     *                                     null,  // selectionArgs is ignored for this URI
+     *                                     null   // sortOrder is ignored for this URI
+     *                                     );
+     *     </pre>
+     * </p>
+     */
+    public static class Model {
+        /**
+         * The content:// style URI for model. If the it is appended by the model's ID, this
+         * note can be directly accessed. See class description above for further details.
+         */
+        public static final Uri CONTENT_URI = Uri.withAppendedPath(AUTHORITY_URI, "models");
+
+        /**
+         * This is the ID of the model. It is the same as the note ID in Anki. This ID can be
+         * used for accessing the data of the model using the URI
+         * "content://com.ichi2.anki.flashcards/models/&lt;ID&gt;
+         */
+        public static final String _ID = "_id";
+        public static final String NAME = "name";
+
+        // TODO: The fields need description.
+        /**
+         * The JSONOBJECT can be converted into a org.json.JSONObject and describes the model
+         * in detail. A model consists of
+         * <ul>
+         * <li>sortf: What is this</li>
+         * <li>did: What is this</li>
+         * <li>latexPre: What is this</li>
+         * <li>latexPost: What is this</li>
+         * <li>mod: What is this</li>
+         * <li>usn: What is this</li>
+         * <li>vers: What is this</li>
+         * <li>type: What is this</li>
+         * <li>css: What is this</li>
+         * <li>name: The name of the model (same as in column {@link #NAME})</li>
+         * <li>flds: What is this</li>
+         * <li>tmpls: This is a JSONArray describing the template. Each entry in this array
+         * describes which cards exist for each note that uses this model.</li>
+         * <li>tags: What is this</li>
+         * <li>id: The ID of the model (same as in column {@link #_ID})</li>
+         * <li>req (optional): This seems to describe which fields(?) or cards(?) are required. But required for what?</li>
+         * </ul>
+         */
+        public static final String JSONOBJECT = "jsonobject";
+
+        public static final String[] DEFAULT_PROJECTION = {
+                _ID,
+                NAME,
+                JSONOBJECT};
+
+        /**
+         * MIME type used for a model.
+         */
+        public static final String CONTENT_ITEM_TYPE = "vnd.android.cursor.item/vnd.com.ichi2.anki.model";
+
+        /**
+         * MIME type used for model.
+         */
+        public static final String CONTENT_TYPE = "vnd.android.cursor.dir/vnd.com.ichi2.anki.model";
+    }
+
+    /**
+     * A card is an instance of a note.
+     * <p/>
+     * If the URI of a note is appended by the keyword "cards", it is possible to
+     * access all the cards that are associated with this note:
+     * <p>
+     * <pre>
+     *         Uri noteUri = Uri.withAppendedPath(FlashCardsContract.Note.CONTENT_URI, Long.toString(noteId));
+     *         Uri cardsUri = Uri.withAppendedPath(noteUri, "cards");
+     *         final Cursor cur = cr.query(cardsUri,
+     *                                     null,  // projection
+     *                                     null,  // selection is ignored for this URI
+     *                                     null,  // selectionArgs is ignored for this URI
+     *                                     null   // sortOrder is ignored for this URI
+     *                                     );
+     *     </pre>
+     * </p>
+     * If it is furthermore appended by the cards ordinal (see {@link #CARD_ORD}) it's possible to
+     * directly access a specific card.
+     * <p>
+     * <pre>
+     *         Uri noteUri = Uri.withAppendedPath(FlashCardsContract.Note.CONTENT_URI, Long.toString(noteId));
+     *         Uri cardsUri = Uri.withAppendedPath(noteUri, "cards");
+     *         Uri specificCardUri = Uri.withAppendedPath(noteUri, Integer.toString(cardOrd));
+     *         final Cursor cur = cr.query(specificCardUri,
+     *                                     null,  // projection
+     *                                     null,  // selection is ignored for this URI
+     *                                     null,  // selectionArgs is ignored for this URI
+     *                                     null   // sortOrder is ignored for this URI
+     *                                     );
+     *     </pre>
+     * </p>
+     *
+     * A card consists of the following columns:
+     * <table class="jd-sumtable">
+     * <tr>
+     * <th>Type</th><th>Name</th><th>access</th><th>description</th>
+     * </tr>
+     * <tr>
+     * <td>long</td>
+     * <td>{@link #NOTE_ID}</td>
+     * <td>read-only</td>
+     * <td>This is the ID of the note that this row belongs to (i.e. {@link Note#_ID}).
+     * </td>
+     * </tr>
+     * <tr>
+     * <td>int</td>
+     * <td>{@link #CARD_ORD}</td>
+     * <td>read-only</td>
+     * <td>This is the ordinal of the card. A note has 1..n cards. The ordinal can also be used
+     * to directly access a card as describe in the class description.
+     * </tr>
+     * <tr>
+     * <td>String</td>
+     * <td>{@link #CARD_NAME}</td>
+     * <td>read-only</td>
+     * <td>The card's name.
+     * </td>
+     * </tr>
+     * <tr>
+     * <td>String</td>
+     * <td>{@link #DECK_NAME}</td>
+     * <td>read-write</td>
+     * <td>The name of the deck that this card is part of.
+     * </td>
+     * </tr>
+     * <tr>
+     * <td>String</td>
+     * <td>{@link #QUESTION}</td>
+     * <td>read-only</td>
+     * <td>The question for this card.
+     * </td>
+     * </tr>
+     * <tr>
+     * <td>String</td>
+     * <td>{@link #ANSWER}</td>
+     * <td>read-only</td>
+     * <td>The answer for this card.
+     * </td>
+     * </tr>
+     * </table>
+     *
+     * The only writable column is the {@link #DECK_NAME}. Moving a card to another deck, can be
+     * done as shown in this example
+     * <pre>
+     *     <code>
+     *         Uri noteUri = Uri.withAppendedPath(FlashCardsContract.Note.CONTENT_URI, Long.toString(noteId));
+     *         Uri cardsUri = Uri.withAppendedPath(noteUri, "cards");
+     *         final Cursor cur = cr.query(cardsUri,
+     *                                     null,  // selection is ignored for this URI
+     *                                     null,  // selectionArgs is ignored for this URI
+     *                                     null   // sortOrder is ignored for this URI
+     *                                     );
+     *         do {
+     *             String deckName = cur.getString(cur.getColumnIndex(FlashCardsContract.Card.DECK_NAME));
+     *             if(!deckName.equals("MyDeck")){
+     *                 // Move to "MyDeck"
+     *                 ContentValues values = new ContentValues();
+     *                 values.put(FlashCardsContract.Card.DECK_NAME, "MyDeck");
+     *                 Uri cardUri = Uri.withAppendedPath(cardsUri, cur.getString(cur.getColumnIndex(FlashCardsContract.Card.CARD_ORD)));
+     *                 cr.update(cardUri, values, null, null);
+     *             }
+     *         } while (cur.moveToNext());
+     *     </code>
+     * </pre>
+     */
+    public static class Card {
+        /**
+         * This is the ID of the note that this card belongs to (i.e. {@link Note#_ID}).
+         */
+        public static final String NOTE_ID = "note_id";
+
+        /**
+         * This is the ordinal of the card. A note has 1..n cards. The ordinal can also be used
+         * to directly access a card as describe in the class description.
+         */
+        public static final String CARD_ORD = "ord";
+
+        /**
+         * The card's name.
+         */
+        public static final String CARD_NAME = "card_name";
+
+        /**
+         * The name of the deck that this card is part of.
+         */
+        public static final String DECK_NAME = "deck_name";
+
+        /**
+         * The question for this card.
+         */
+        public static final String QUESTION = "question";
+
+        /**
+         * The answer for this card.
+         */
+        public static final String ANSWER = "answer";
+
+        public static final String[] DEFAULT_PROJECTION = {
+                NOTE_ID,
+                CARD_ORD,
+                CARD_NAME,
+                DECK_NAME,
+                QUESTION,
+                ANSWER};
+
+        /**
+         * MIME type used for a card.
+         */
+        public static final String CONTENT_ITEM_TYPE = "vnd.android.cursor.item/vnd.com.ichi2.anki.card";
+
+        /**
+         * MIME type used for cards.
+         */
+        public static final String CONTENT_TYPE = "vnd.android.cursor.dir/vnd.com.ichi2.anki.card";
+    }
+}


### PR DESCRIPTION
This is a pull request for a content provider as discussed here:
https://groups.google.com/forum/#!msg/anki-android/SitMpj7J6fw/swqcuJKcld8J

It currently supports getting the unprocessed data from the Anki DB using the following URI:
content://com.ichi2.anki.flashcard/flashcards

and fields and cards/decks using

content://com.ichi2.anki.flashcard/flashcards/<note_id>/data

The contract is described in FlashCardsContract.java. I release this file into the public domain so that it can be used by any third party software without any attribution or royalty. I.e. this file (and this file only) is not licensed under GPL.

The content provider currently only supports notes/cards, but not models.

It also only supports the query() function, no insert() or update() yet.

For update() on fields I intended to use the same mechanism as NoteEditor, but there is some kind of check that prevents updates from any other Thread than the main thread.

The first intention of this PR is to discuss if the proposed data structure is acceptable/understandable for the AnkiDroid developers and to discuss implementation details such as the above (concerning the main thread problem). Of course, I hope that it will later merged into the main branch.