### PR TITLE
Try to fix apkg import errors

### DIFF
--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -133,6 +133,11 @@
                 <data android:mimeType="application/apkg"/>
                 <data android:mimeType="application/octet-stream"/>
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="application/x-apkg"/>
+            </intent-filter>
         </activity>
         <activity
             android:name="com.ichi2.anki.DeckPicker"

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -663,6 +663,40 @@ public class AnkiDroidApp extends Application {
         editor.commit();
     }
 
+    /**
+     * Get the url for the feedback page
+     * @return
+     */
+    public static String getFeedbackUrl() {
+        if (isCurrentLanguage("ja")) {
+            return sInstance.getResources().getString(R.string.link_help_ja);
+        } else {
+            return sInstance.getResources().getString(R.string.link_help);
+        }
+    }
+
+    /**
+     * Get the url for the manual
+     * @return
+     */
+    public static String getManualUrl() {
+        if (isCurrentLanguage("ja")) {
+            return sInstance.getResources().getString(R.string.link_manual_ja);
+        } else {
+            return sInstance.getResources().getString(R.string.link_manual);
+        }
+    }
+
+    /**
+     * Check whether l is the currently set language code
+     * @param l ISO2 language code
+     * @return
+     */
+    private static boolean isCurrentLanguage(String l) {
+        String pref = getSharedPrefs(sInstance).getString(Preferences.LANGUAGE, "");
+        return pref.equals(l) || pref.equals("") && Locale.getDefault().getLanguage().equals(l);
+    }
+
     /** A tree which logs necessary data for crash reporting. */
     public static class ProductionCrashReportingTree extends Timber.HollowTree {
         private static final ThreadLocal<String> NEXT_TAG = new ThreadLocal<String>();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -246,11 +246,11 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
         @Override
         public void onPostExecute(DeckTask.TaskData result) {
             String message = "";
+            Resources res = getResources();
             if (mProgressDialog != null && mProgressDialog.isShowing()) {
                 mProgressDialog.dismiss();
             }
             if (result != null && result.getBoolean()) {
-                Resources res = getResources();
                 int count = result.getInt();
                 if (count < 0) {
                     if (count == -2) {
@@ -266,7 +266,7 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
                     updateDecksList((TreeSet<Object[]>) info[0], (Integer) info[1], (Integer) info[2]);
                 }
             } else {
-                handleDbError();
+                showSimpleMessageDialog(res.getString(R.string.import_log_error));
             }
             // delete temp file if necessary and reset import path so that it's not incorrectly imported next time
             // Activity starts

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
@@ -158,12 +158,12 @@ public class NavigationDrawerActivity extends AnkiActivity {
                 break;
             
             case DRAWER_HELP:
-                Intent helpIntent = new Intent("android.intent.action.VIEW", Uri.parse(getManualUrl()));
+                Intent helpIntent = new Intent("android.intent.action.VIEW", Uri.parse(AnkiDroidApp.getManualUrl()));
                 startActivityWithoutAnimation(helpIntent);
                 break;
                 
             case DRAWER_FEEDBACK:
-                Intent feedbackIntent = new Intent("android.intent.action.VIEW", Uri.parse(getFeedbackUrl()));
+                Intent feedbackIntent = new Intent("android.intent.action.VIEW", Uri.parse(AnkiDroidApp.getFeedbackUrl()));
                 startActivityWithoutAnimation(feedbackIntent);
                 break;
             
@@ -172,40 +172,6 @@ public class NavigationDrawerActivity extends AnkiActivity {
         }
     }
 
-    /**
-     * Get the url for the feedback page
-     * @return
-     */
-    private String getFeedbackUrl() {
-        if (isCurrentLanguage("ja")) {
-            return getResources().getString(R.string.link_help_ja);
-        } else {
-            return getResources().getString(R.string.link_help);
-        }
-    }
-
-    /**
-     * Get the url for the manual
-     * @return
-     */
-    private String getManualUrl() {
-        if (isCurrentLanguage("ja")) {
-            return getResources().getString(R.string.link_manual_ja);
-        } else {
-            return getResources().getString(R.string.link_manual);
-        }
-    }
-
-    /**
-     * Check whether l is the currently set language code
-     * @param l ISO2 language code
-     * @return
-     */
-    private boolean isCurrentLanguage(String l) {
-        String pref = AnkiDroidApp.getSharedPrefs(this).getString(Preferences.LANGUAGE, "");
-        return pref.equals(l) || pref.equals("") && Locale.getDefault().getLanguage().equals(l);
-    }
-    
     protected void deselectAllNavigationItems() {
         // Deselect all entries in navigation drawer
         for (int i=0; i< mDrawerList.getCount(); i++) {

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -161,6 +161,7 @@
     <string name="import_log_error">Import failed</string>
     <string name="import_log_no_apkg">This is not a valid apkg file</string>
     <string name="import_error_not_apkg_extension">Filename %s does not have .apkg extension</string>
+    <string name="import_error_content_provider">The selected file could not be imported automatically by AnkiDroid. Please see the user manual for how to manually import anki files: \n %s</string>
     <string name="import_importing">Importing cards…</string>
     <string name="export_include_schedule">Include scheduling</string>
     <string name="export_include_media">Include media</string>


### PR DESCRIPTION
When a file is opened via a ContentProvider like the Android Download manager, and there is an error getting the filename, try to import it if it's a valid zipfile

Also:

* Show "import failed" message instead of collection error dialog when an exception occurs during importAdd

* Show a link to the importing section of the manual when the file can't be automatically imported

* The Lollipop native email client seems to use mimetype "application/x-EXTENSION" when trying to open unknown extensions, so support that