### PR TITLE
Load cards in overview mode (zoomed out)

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1501,6 +1501,8 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
         }
         webView.getSettings().setBuiltInZoomControls(true);
         webView.getSettings().setSupportZoom(true);
+        // Start at the most zoomed-out level
+        webView.getSettings().setLoadWithOverviewMode(true);
         webView.getSettings().setJavaScriptEnabled(true);
         webView.setWebChromeClient(new AnkiDroidWebChromeClient());
         if (AnkiDroidApp.SDK_VERSION > 7) {


### PR DESCRIPTION
Fix for [Issue 2515](https://code.google.com/p/ankidroid/issues/detail?id=2515). 

I went over this issue with a user over email and this fixed the problem. There is at least one device out there that zooms in a level or two on WebViews for whatever reason, and it makes reviewing difficult since WebViews now don't wrap text when zooming in.

I've witnessed no other side effects of adding this line in my tests so I think it's safe to add for everyone.