### PR TITLE
Fix issue 1499

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -771,7 +771,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
     /**
      * Format question field when it contains typeAnswer or clozes. If there was an error during type text extraction, a
      * warning is displayed
-     * 
+     *
      * @param buf The question text
      * @return The formatted question text
      */
@@ -790,7 +790,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
 
     /**
      * Fill the placeholder for the type comparison. Show the correct answer, and the comparison if appropriate.
-     * 
+     *
      * @param buf The answer text
      * @param userAnswer Text typed by the user, or empty.
      * @param correctAnswer The correct answer, taken from the note.
@@ -835,7 +835,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
 
     /**
      * Return the correct answer to use for {{type::cloze::NN}} fields.
-     * 
+     *
      * @param txt The field text with the clozes
      * @param idx The index of the cloze to use
      * @return A string with a comma-separeted list of unique cloze strings with the corret index.
@@ -951,7 +951,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
         }
 
         mUseQuickUpdate = shouldUseQuickUpdate();
-       
+
         initLayout();
 
         setTitle();
@@ -1110,7 +1110,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
     /**
      * Returns the text stored in the clipboard or the empty string if the clipboard is empty or contains something that
      * cannot be convered to text.
-     * 
+     *
      * @return the text in clipboard or the empty string.
      */
     private CharSequence clipboardGetText() {
@@ -2022,7 +2022,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
 
     /**
      * Clean up the correct answer text, so it can be used for the comparison with the typed text
-     * 
+     *
      * @param answer The content of the field the text typed by the user is compared to.
      * @return The correct answer text, with actual HTML and media references removed, and HTML entities unescaped.
      */
@@ -2047,7 +2047,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
 
     /**
      * Clean up the typed answer text, so it can be used for the comparison with the correct answer
-     * 
+     *
      * @param answer The answer text typed by the user.
      * @return The typed answer text, cleaned up.
      */
@@ -2240,7 +2240,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
     /**
      * Converts characters in Unicode Supplementary Multilingual Plane (SMP) to their equivalent Html Entities. This is
      * done because webview has difficulty displaying these characters.
-     * 
+     *
      * @param text
      * @return
      */
@@ -2258,7 +2258,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
 
     /**
      * Plays sounds (or TTS, if configured) for currently shown side of card.
-     * 
+     *
      * @param doAudioReplay indicates an anki desktop-like replay call is desired, whose behavior is identical to
      *            pressing the keyboard shortcut R on the desktop
      */
@@ -2303,7 +2303,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
 
     /**
      * Reads the text (using TTS) for the given side of a card.
-     * 
+     *
      * @param card The card to play TTS for
      * @param cardSide The side of the current card to play TTS for
      */
@@ -2320,7 +2320,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
 
     /**
      * Returns the configuration for the current {@link Card}.
-     * 
+     *
      * @return The configuration for the current {@link Card}
      */
     private JSONObject getConfigForCurrentCard() {
@@ -2330,7 +2330,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
 
     /**
      * Returns the deck ID of the given {@link Card}.
-     * 
+     *
      * @param card The {@link Card} to get the deck ID
      * @return The deck ID of the {@link Card}
      */
@@ -2409,7 +2409,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
 
     /**
      * Adds a div html tag around the contents to have an indication, where answer/question is displayed
-     * 
+     *
      * @param content
      * @param isAnswer if true then the class attribute is set to "answer", "question" otherwise.
      * @return
@@ -2438,7 +2438,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
      * this logic, eg nested span/divs with CSS classes having font-size declarations with relative units (40% dif
      * inside 120% div inside 60% div). Broken HTML also breaks this. Feel free to improve, but please keep it short and
      * fast.
-     * 
+     *
      * @param content The HTML content that will be font-size-adjusted.
      * @param percentage The relative font size percentage defined in preferences
      * @return
@@ -2506,7 +2506,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
     /**
      * Calculates a dynamic font size depending on the length of the contents taking into account that the input string
      * contains html-tags, which will not be displayed and therefore should not be taken into account.
-     * 
+     *
      * @param htmlContent
      * @return font size respecting MIN_DYNAMIC_FONT_SIZE and MAX_DYNAMIC_FONT_SIZE
      */
@@ -2655,7 +2655,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
      * WebView.
      * <p>
      * It is also needed to solve a refresh issue on Nook devices.
-     * 
+     *
      * @return true if we should use a single WebView
      */
     private boolean shouldUseQuickUpdate() {
@@ -3033,7 +3033,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
 
     /**
      * Removes first occurrence in answerContent of any audio that is present due to use of
-     * {{FrontSide}} on the answer. 
+     * {{FrontSide}} on the answer.
      * @param answerContent     The content from which to remove front side audio.
      * @return                  The content stripped of audio due to {{FrontSide}} inclusion.
      */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -578,12 +578,14 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
 
         @Override
         public void onProgressUpdate(DeckTask.TaskData... values) {
+            boolean cardChanged = false;
             if (mCurrentCard != values[0].getCard()) {
                 /*
                  * Before updating mCurrentCard, we check whether it is changing or not. If the current card changes,
                  * then we need to display it as a new card, without showing the answer.
                  */
                 sDisplayAnswer = false;
+                cardChanged = true;  // Keep track of that so we can run a bit of new-card code
             }
             mCurrentCard = values[0].getCard();
             if (mCurrentCard == null) {
@@ -603,6 +605,9 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
                 generateQuestionSoundList(); // questions must be intentionally regenerated
                 displayCardAnswer();
             } else {
+                if (cardChanged) {
+                    updateTypeAnswerInfo();
+                }
                 displayCardQuestion();
                 initTimer();
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.java
@@ -1,6 +1,6 @@
 /***************************************************************************************
  * Copyright (c) 2011 Kostas Spyropoulos <inigo.aldana@gmail.com>                       *
- * Copyright (c) 2013 Jolta Technologies												*
+ * Copyright (c) 2013 Jolta Technologies                                                *
  * Copyright (c) 2014 Bruno Romero de Azevedo <brunodea@inf.ufsm.br>                    *
  *                                                                                      *
  * This program is free software; you can redistribute it and/or modify it under        *

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -46,7 +46,7 @@ public class Reviewer extends AbstractFlashcardViewer {
     private boolean mHasDrawerSwipeConflicts = false;
     private boolean mShowWhiteboard = true;
     private boolean mBlackWhiteboard = true;
-    
+
     @Override
     protected void setTitle() {
         try {
@@ -66,7 +66,7 @@ public class Reviewer extends AbstractFlashcardViewer {
         // Load the first card and start reviewing. Uses the answer card
         // task to load a card, but since we send null
         // as the card to answer, no card will be answered.
-        
+
         mPrefWhiteboard = MetaDB.getWhiteboardState(this, getParentDid());
         if (mPrefWhiteboard) {
             setWhiteboardEnabledState(true);
@@ -152,7 +152,7 @@ public class Reviewer extends AbstractFlashcardViewer {
             case R.id.action_clear_whiteboard:
                 Timber.i("Reviewer:: Clear whiteboard button pressed");
                 if (mWhiteboard != null) {
-                    mWhiteboard.clear();    
+                    mWhiteboard.clear();
                 }
                 break;
 
@@ -341,7 +341,7 @@ public class Reviewer extends AbstractFlashcardViewer {
         }
         return super.onKeyUp(keyCode, event);
     }
-    
+
 
     @Override
     protected SharedPreferences restorePreferences() {
@@ -350,7 +350,7 @@ public class Reviewer extends AbstractFlashcardViewer {
         mBlackWhiteboard = preferences.getBoolean("blackWhiteboard", true);
         return preferences;
     }
-    
+
     @Override
     public void fillFlashcard() {
         super.fillFlashcard();
@@ -416,7 +416,7 @@ public class Reviewer extends AbstractFlashcardViewer {
                 }
                 return getGestureDetector().onTouchEvent(event);
             }
-        });  
+        });
         mWhiteboard.setEnabled(true);
     }
 
@@ -434,7 +434,7 @@ public class Reviewer extends AbstractFlashcardViewer {
         }
     }
 
-    
+
     private void disableDrawerSwipeOnConflicts() {
         SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(getBaseContext());
         boolean gesturesEnabled = AnkiDroidApp.initiateGestures(preferences);
@@ -448,6 +448,6 @@ public class Reviewer extends AbstractFlashcardViewer {
                 mHasDrawerSwipeConflicts = true;
                 super.disableDrawerSwipe();
             }
-        } 
+        }
     }
 }


### PR DESCRIPTION
When moving a card, we forgot to call `updateTypeAnswerInfo` to get the correct text for the type answer feature, causing [issue 1499](https://code.google.com/p/ankidroid/issues/detail?id=1499). Maybe something went wrong with cloze deletions without that call, too, but i don't use clozes much.