### PR TITLE
Catch all simple interface exceptions

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1987,7 +1987,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
 
         if (mCurrentSimpleInterface) {
             mCardContent = convertToSimple(question);
-            if (mCardContent.length() == 0) {
+            if (mCardContent== null || mCardContent.length() == 0) {
                 SpannableString hint = new SpannableString(getResources().getString(R.string.simple_interface_hint,
                         R.string.card_details_question));
                 hint.setSpan(new StyleSpan(Typeface.ITALIC), 0, mCardContent.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
@@ -2090,7 +2090,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
 
         if (mCurrentSimpleInterface) {
             mCardContent = convertToSimple(answer);
-            if (mCardContent.length() == 0) {
+            if (mCardContent== null || mCardContent.length() == 0) {
                 SpannableString hint = new SpannableString(getResources().getString(R.string.simple_interface_hint,
                         R.string.card_details_answer));
                 hint.setSpan(new StyleSpan(Typeface.ITALIC), 0, mCardContent.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
@@ -3027,7 +3027,12 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
 
 
     private Spanned convertToSimple(String text) {
-        return Html.fromHtml(text, mSimpleInterfaceImagegetter, mSimpleInterfaceTagHandler);
+        try {
+            return Html.fromHtml(text, mSimpleInterfaceImagegetter, mSimpleInterfaceTagHandler);
+        } catch (Exception e) {
+            Timber.e(e, "Error converting to simple interface");
+            return null;
+        }
     }
 
 


### PR DESCRIPTION
Fix for [issue 2503](https://code.google.com/p/ankidroid/issues/detail?id=2503) and potentially any other crashes that occur because of simple interface.

To be honest, I think we should just remove simple interface entirely... It's not really necessary with the power of modern Android devices, and we could always add it back eventually as a plugin