### PR TITLE
Open preferences to allow user to change directory if currently invalid

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
@@ -33,6 +33,7 @@ import com.ichi2.anki.dialogs.SimpleMessageDialog;
 import com.ichi2.async.CollectionLoader;
 import com.ichi2.libanki.Collection;
 import com.ichi2.themes.StyledOpenCollectionDialog;
+import com.ichi2.themes.Themes;
 
 import timber.log.Timber;
 
@@ -43,6 +44,19 @@ public class AnkiActivity extends ActionBarActivity implements LoaderManager.Loa
 
     private StyledOpenCollectionDialog mOpenCollectionDialog;
     private DialogHandler mHandler = new DialogHandler(this);
+
+    @Override
+    protected void onCreate(Bundle savedInstance) {
+        super.onCreate(savedInstance);
+        // Take user to preferences editor if there was a storage access exception on app startup
+        if (AnkiDroidApp.sStorageAccessExceptionFlag) {
+            Intent i = new Intent(this, Preferences.class);
+            finishWithoutAnimation();
+            startActivityWithoutAnimation(i);
+            Themes.showThemedToast(this, getResources().getString(R.string.directory_inaccessible), false);
+            return;
+        }
+    }
 
     @Override
     protected void onResume() {
@@ -330,7 +344,7 @@ public class AnkiActivity extends ActionBarActivity implements LoaderManager.Loa
      * If a DialogFragment cannot be shown due to the Activity being stopped then the message is shown in the
      * notification bar instead.
      * 
-     * @param String message
+     * @param message
      */
     protected void showSimpleMessageDialog(String message) {
         showSimpleMessageDialog(message, false);
@@ -435,3 +449,4 @@ public class AnkiActivity extends ActionBarActivity implements LoaderManager.Loa
         this.finishWithoutAnimation();
     }
 }
+

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDb.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDb.java
@@ -81,7 +81,7 @@ public class AnkiDb {
             Timber.e("The database has been corrupted...");
             AnkiDroidApp.sendExceptionReport(new RuntimeException("Database corrupted"), "AnkiDb.MyDbErrorHandler.onCorruption", "Db has been corrupted ");
             AnkiDroidApp.closeCollection(false);
-            AnkiDroidApp.setDbCorruptedFlag();
+            AnkiDroidApp.sDatabaseCorruptFlag = true;
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.java
@@ -58,8 +58,8 @@ public class BackupManager {
     public final static int RETURN_LOW_SYSTEM_SPACE = 7;
     public final static int RETURN_BACKUP_NEEDED = 8;
 
-    public final static String BACKUP_SUFFIX = "/backup";
-    public final static String BROKEN_DECKS_SUFFIX = "/broken";
+    public final static String BACKUP_SUFFIX = "backup";
+    public final static String BROKEN_DECKS_SUFFIX = "broken";
 
     private static boolean mUseBackups = true;
 
@@ -81,9 +81,7 @@ public class BackupManager {
 
 
     private static File getBackupDirectory() {
-        SharedPreferences prefs = AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance().getBaseContext());
-        File directory = new File(prefs.getString("deckPath", AnkiDroidApp.getCurrentAnkiDroidDirectory())
-                + BACKUP_SUFFIX);
+        File directory = new File(AnkiDroidApp.getCurrentAnkiDroidDirectory(), BACKUP_SUFFIX);
         if (!directory.isDirectory()) {
             directory.mkdirs();
         }
@@ -92,9 +90,7 @@ public class BackupManager {
 
 
     private static File getBrokenDirectory() {
-        SharedPreferences prefs = AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance().getBaseContext());
-        File directory = new File(prefs.getString("deckPath", AnkiDroidApp.getCurrentAnkiDroidDirectory())
-                + BROKEN_DECKS_SUFFIX);
+        File directory = new File(AnkiDroidApp.getCurrentAnkiDroidDirectory(), BROKEN_DECKS_SUFFIX);
         if (!directory.isDirectory()) {
             directory.mkdirs();
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
@@ -153,7 +153,7 @@ public class NavigationDrawerActivity extends AnkiActivity {
 
                 break;
             case DRAWER_SETTINGS:
-                mOldColPath = AnkiDroidApp.getSharedPrefs(this).getString("deckPath", "oldPath");
+                mOldColPath = AnkiDroidApp.getCurrentAnkiDroidDirectory();
                 startActivityForResultWithAnimation(new Intent(this, Preferences.class), REQUEST_PREFERENCES_UPDATE, ActivityTransitionAnimation.LEFT);
                 break;
             
@@ -306,7 +306,7 @@ public class NavigationDrawerActivity extends AnkiActivity {
         AnkiDroidApp.setLanguage(preferences.getString(Preferences.LANGUAGE, ""));
         // Restart the activity on preference change
         if (requestCode == REQUEST_PREFERENCES_UPDATE) {
-            if (mOldColPath!=null && preferences.getString("deckPath", "").equals(mOldColPath)) {
+            if (mOldColPath!=null && AnkiDroidApp.getCurrentAnkiDroidDirectory().equals(mOldColPath)) {
                 // collection path hasn't been changed so just restart the current activity
                 if ((this instanceof Reviewer) && preferences.getBoolean("tts", false)) {
                     // Workaround to kick user back to StudyOptions after opening settings from Reviewer
@@ -319,8 +319,6 @@ public class NavigationDrawerActivity extends AnkiActivity {
                 // collection path has changed so kick the user back to the DeckPicker
                 AnkiDroidApp.closeCollection(true);
                 finishWithoutAnimation();
-                // Ensure the new collection directory exists before reloading
-                AnkiDroidApp.initializeAnkiDroidDirectory();
                 Intent deckPicker = new Intent(this, DeckPicker.class);
                 deckPicker.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
                 startActivityWithoutAnimation(deckPicker);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.java
@@ -371,7 +371,7 @@ public class DatabaseErrorDialog extends AsyncDialogFragment {
                     // Before honeycomb there's no way to know if the db has actually been corrupted
                     // so we show a non-specific message.
                     return res().getString(R.string.open_collection_failed_message, res().getString(R.string.repair_deck));
-                } else if (AnkiDroidApp.getDbCorruptedFlag()) {
+                } else if (AnkiDroidApp.sDatabaseCorruptFlag) {
                     // The sqlite database has been corrupted (DatabaseErrorHandler.onCorrupt() was called)
                     // Show a specific message appropriate for the situation
                     return res().getString(R.string.corrupt_db_message, res().getString(R.string.repair_deck));

--- a/AnkiDroid/src/main/java/com/ichi2/anki/exception/StorageAccessException.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/exception/StorageAccessException.java
@@ -1,0 +1,13 @@
+
+package com.ichi2.anki.exception;
+
+public class StorageAccessException extends Exception {
+
+    public StorageAccessException() {
+    }
+
+
+    public StorageAccessException(String msg) {
+        super(msg);
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionLoader.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionLoader.java
@@ -58,18 +58,18 @@ public class CollectionLoader extends AsyncTaskLoader<Collection> {
     @Override
     protected void onStartLoading() {
         // Don't touch collection if sync in progress
-        if (AnkiDroidApp.getSyncInProgress()) {
-            Timber.v("CollectionLoader.onStartLoading() -- sync in progress; don't load collection");
+        if (AnkiDroidApp.sSyncInProgressFlag) {
+            Timber.w("CollectionLoader.onStartLoading() -- sync in progress; don't load collection");
             return;
         }
         String colPath = AnkiDroidApp.getCollectionPath();
         if (AnkiDroidApp.colIsOpen() && AnkiDroidApp.getCol() != null && AnkiDroidApp.getCol().getPath().equals(colPath)) {
             // deliver current path if open and valid
-            Timber.v("CollectionLoader.onStartLoading() -- deliverResult as col already open");
+            Timber.d("CollectionLoader.onStartLoading() -- deliverResult as col already open");
             deliverResult(AnkiDroidApp.getCol());
         } else {
             // otherwise reload the collection
-            Timber.v("CollectionLoader.onStartLoading() -- force load collection");
+            Timber.d("CollectionLoader.onStartLoading() -- force load collection");
             forceLoad();
         }        
     }

--- a/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
@@ -407,7 +407,7 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
         }
         String path = AnkiDroidApp.getCollectionPath();
         try {
-            AnkiDroidApp.setSyncInProgress(true);
+            AnkiDroidApp.sSyncInProgressFlag = true;
             HttpSyncer server = new RemoteServer(this, hkey);
             Syncer client = new Syncer(col, server);
 
@@ -579,7 +579,7 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
             // Close collection to roll back any sync failures and
             Timber.d("doInBackgroundSync -- closing collection on outer finally statement");
             col.close(false);
-            AnkiDroidApp.setSyncInProgress(false);
+            AnkiDroidApp.sSyncInProgressFlag = false;
             Timber.d("doInBackgroundSync -- reopening collection on outer finally statement");
             AnkiDroidApp.openCollection(AnkiDroidApp.getCollectionPath());
         }

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -112,6 +112,7 @@
     <string name="studyoptions_feedback">Feedback</string>
     <!-- <string name="studyoptions_load_sample_deck">Load sample deck</string> -->
     <string name="night_mode">Night mode</string>
+    <string name="directory_inaccessible">AnkiDroid directory is inaccessible</string>
 
     <string-array name="next_review_s">
         <item>1 second</item>


### PR DESCRIPTION
Modified patch for #724... the main differences being:

 * `AnkiDroidApp.initializeDirectory()` is called in `AnkiDroidApp.onCreate()` which guarantees that it's called on first app startup, whereas #733 assumes that `AnkiActivity.onCreate()` is called before the path is used.

 * `AnkiDroidApp.initializeDirectory()` is additionally called at the time of setting the path in Preferences, which prevents the user from ever setting an incorrect directory

 * An ACRA report is sent when `initializeDirectory()` fails on first app startup, as that's an unexpected condition. ACRA reports are not sent on failed attempts to change the path from Preferences

 * A few other code cleanups