### PR TITLE
Catch exceptions with ShowcaseView

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -519,20 +519,25 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
         if (mShowShowcaseView && colOpen() && getCol().isEmpty() && mDeckList!= null && mDeckList.size() <=1) {
             mShowShowcaseView = false;
             final Resources res = getResources();
-            ActionItemTarget target = new ActionItemTarget(this, R.id.action_add_decks);
-            mShowcaseDialog = new ShowcaseView.Builder(this).setTarget(target)
-                    .setContentTitle(res.getString(R.string.studyoptions_welcome_title))
-                    .setStyle(R.style.ShowcaseView_Light).setShowcaseEventListener(this)
-                    .setOnClickListener(new OnClickListener() {
-                        @Override
-                        public void onClick(View v) {
-                            mShowcaseDialog.hide();
-                            Intent helpIntent = new Intent("android.intent.action.VIEW", Uri.parse(res
-                                    .getString(R.string.link_manual_getting_started)));
-                            startActivityWithoutAnimation(helpIntent);
-                        }
-                    }).setContentText(res.getString(R.string.add_content_showcase_text)).hideOnTouchOutside().build();
-            mShowcaseDialog.setButtonText(getResources().getString(R.string.help_title));
+            try {
+                ActionItemTarget target = new ActionItemTarget(this, R.id.action_add_decks);
+                mShowcaseDialog = new ShowcaseView.Builder(this).setTarget(target)
+                        .setContentTitle(res.getString(R.string.studyoptions_welcome_title))
+                        .setStyle(R.style.ShowcaseView_Light).setShowcaseEventListener(this)
+                        .setOnClickListener(new OnClickListener() {
+                            @Override
+                            public void onClick(View v) {
+                                mShowcaseDialog.hide();
+                                Intent helpIntent = new Intent("android.intent.action.VIEW", Uri.parse(res
+                                        .getString(R.string.link_manual_getting_started)));
+                                startActivityWithoutAnimation(helpIntent);
+                            }
+                        }).setContentText(res.getString(R.string.add_content_showcase_text)).hideOnTouchOutside().build();
+                mShowcaseDialog.setButtonText(getResources().getString(R.string.help_title));
+            } catch (Exception e) {
+                Timber.e(e, "Error showing ShowcaseView");
+                Themes.showThemedToast(this, res.getString(R.string.add_content_showcase_text), false);
+            }
         } else if (mShowcaseDialog != null && colOpen() && !getCol().isEmpty()) {
             hideShowcaseView();
         }


### PR DESCRIPTION
There seem to be a bunch of Gingerbread users experiencing problems with ShowcaseView.

```
java.lang.IllegalArgumentException: width and height must be > 0
at android.graphics.Bitmap.nativeCreate(Native Method)
at android.graphics.Bitmap.createBitmap(Bitmap.java:695)
at com.github.amlcurran.showcaseview.ShowcaseView.updateBitmap(ShowcaseView.java:189)
at com.github.amlcurran.showcaseview.ShowcaseView.access$300(ShowcaseView.java:46)
at com.github.amlcurran.showcaseview.ShowcaseView$UpdateOnGlobalLayout.onGlobalLayout(ShowcaseView.java:625)
at android.view.ViewTreeObserver.dispatchOnGlobalLayout(ViewTreeObserver.java:549)
at android.view.ViewRoot.performTraversals(ViewRoot.java:1266)
at android.view.ViewRoot.handleMessage(ViewRoot.java:1991)
at android.os.Handler.dispatchMessage(Handler.java:99)
at android.os.Looper.loop(Looper.java:150)
at android.app.ActivityThread.main(ActivityThread.java:4385)
at java.lang.reflect.Method.invokeNative(Native Method)
at java.lang.reflect.Method.invoke(Method.java:507)
at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:849)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:607)
at dalvik.system.NativeStart.main(Native Method)
```

Hopefully this will catch those