### PR TITLE
Try to fix NPE in NoteEditor.setNote

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1489,7 +1489,7 @@ public class NoteEditor extends AnkiActivity {
 
     private void setNote(Note note) {
         try {
-            if (note == null) {
+            if (note == null || mAddNote) {
                 JSONObject conf = getCol().getConf();
                 JSONObject model = getCol().getModels().current();
                 if (conf.optBoolean("addToCur", true)) {


### PR DESCRIPTION
It seems that occasionally `note!=null` even in add note mode which is causing an NPE here:

```
Caused by: java.lang.NullPointerException
at com.ichi2.anki.NoteEditor.setNote(NoteEditor.java:1512)
at com.ichi2.anki.NoteEditor.onCollectionLoaded(NoteEditor.java:515)
```