### PR TITLE
Fixed File not found error

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/MediaSyncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/MediaSyncer.java
@@ -37,7 +37,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.zip.ZipFile;
+import java.util.zip.ZipInputStream;
 
 import timber.log.Timber;
 
@@ -222,7 +222,7 @@ public class MediaSyncer {
             try {
                 List<String> top = fnames.subList(0, Math.min(fnames.size(), Consts.SYNC_ZIP_COUNT));
                 mCol.log("fetch " + top);
-                ZipFile zipData = mServer.downloadFiles(top);
+                ZipInputStream zipData = mServer.downloadFiles(top);
                 int cnt = mCol.getMedia().addFilesFromZip(zipData);
                 mDownloadCount += cnt;
                 mCol.log("received " + cnt + " files");

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteMediaServer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteMediaServer.java
@@ -33,12 +33,13 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.File;
+import java.io.InputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
-import java.util.zip.ZipFile;
+import java.util.zip.ZipInputStream;
 
 import timber.log.Timber;
 
@@ -98,15 +99,16 @@ public class RemoteMediaServer extends HttpSyncer {
 
 
     // args: files
-    public ZipFile downloadFiles(List<String> top) throws UnknownHttpResponseException {
+    public ZipInputStream downloadFiles(List<String> top) throws UnknownHttpResponseException {
         try {
             HttpResponse resp;
             resp = super.req("downloadFiles",
                     super.getInputStream(Utils.jsonToString(new JSONObject().put("files", new JSONArray(top)))));
             String zipPath = mCol.getPath().replaceFirst("collection\\.anki2$", "tmpSyncFromServer.zip");
             // retrieve contents and save to file on disk:
-            super.writeToFile(resp.getEntity().getContent(), zipPath);
-            return new ZipFile(new File(zipPath), ZipFile.OPEN_READ);
+            InputStream is = resp.getEntity().getContent();
+            ZipInputStream zis = new ZipInputStream(is);
+            return zis;
         } catch (JSONException e) {
             throw new RuntimeException(e);
         } catch (IOException e) {


### PR DESCRIPTION
Continuation of #734

Worked around the temp file not found error by using ZipInputStream
(does not require the file to be written to the disk). In any case, the
data was already in memory from the HTTP input stream, so no additional
device memory should be used than before.