### PR TITLE
Fix NullPointerException in Decks.java

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -119,7 +119,7 @@ public class Decks {
             }
             JSONObject confarray = new JSONObject(dconf);
             ids = confarray.names();
-            for (int i = 0; i < ids.length(); i++) {
+            for (int i = 0; ids != null && i < ids.length(); i++) {
                 String id = ids.getString(i);
                 mDconf.put(Long.parseLong(id), confarray.getJSONObject(id));
             }


### PR DESCRIPTION
If dconf is an empty object ({}), confarray.names() will return null, so don't loop in this case.

N.B. Files where dconf={} are loaded successfully by desktop Anki.