### PR TITLE
Fix bug where preferences editor shown if SD card was unmounted on app startup

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
@@ -30,6 +30,7 @@ import com.ichi2.anim.ActivityTransitionAnimation;
 import com.ichi2.anki.dialogs.AsyncDialogFragment;
 import com.ichi2.anki.dialogs.DialogHandler;
 import com.ichi2.anki.dialogs.SimpleMessageDialog;
+import com.ichi2.anki.exception.StorageAccessException;
 import com.ichi2.async.CollectionLoader;
 import com.ichi2.libanki.Collection;
 import com.ichi2.themes.StyledOpenCollectionDialog;
@@ -45,18 +46,6 @@ public class AnkiActivity extends ActionBarActivity implements LoaderManager.Loa
     private StyledOpenCollectionDialog mOpenCollectionDialog;
     private DialogHandler mHandler = new DialogHandler(this);
 
-    @Override
-    protected void onCreate(Bundle savedInstance) {
-        super.onCreate(savedInstance);
-        // Take user to preferences editor if there was a storage access exception on app startup
-        if (AnkiDroidApp.sStorageAccessExceptionFlag) {
-            Intent i = new Intent(this, Preferences.class);
-            finishWithoutAnimation();
-            startActivityWithoutAnimation(i);
-            Themes.showThemedToast(this, getResources().getString(R.string.directory_inaccessible), false);
-            return;
-        }
-    }
 
     @Override
     protected void onResume() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
@@ -30,11 +30,9 @@ import com.ichi2.anim.ActivityTransitionAnimation;
 import com.ichi2.anki.dialogs.AsyncDialogFragment;
 import com.ichi2.anki.dialogs.DialogHandler;
 import com.ichi2.anki.dialogs.SimpleMessageDialog;
-import com.ichi2.anki.exception.StorageAccessException;
 import com.ichi2.async.CollectionLoader;
 import com.ichi2.libanki.Collection;
 import com.ichi2.themes.StyledOpenCollectionDialog;
-import com.ichi2.themes.Themes;
 
 import timber.log.Timber;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -156,7 +156,6 @@ public class AnkiDroidApp extends Application {
      */
     public static boolean sSyncInProgressFlag = false;
     public static boolean sDatabaseCorruptFlag = false;
-    public static boolean sStorageAccessExceptionFlag = false;
 
     /** Global hooks */
     private Hooks mHooks;
@@ -255,14 +254,14 @@ public class AnkiDroidApp extends Application {
         }
         DEFAULT_SWIPE_THRESHOLD_VELOCITY = vc.getScaledMinimumFlingVelocity();
 
-        // Create the AnkiDroid directory if missing
+        // Create the AnkiDroid directory if missing. Send exception report if inaccessible.
         try {
             initializeAnkiDroidDirectory(getCurrentAnkiDroidDirectory());
-            sStorageAccessExceptionFlag = false;
         } catch (StorageAccessException e) {
             Timber.e(e, "Could not initialize AnkiDroid directory");
-            sendExceptionReport(e, "AnkiDroidApp.onCreate");
-            sStorageAccessExceptionFlag = true;
+            if (isSdCardMounted()) {
+                sendExceptionReport(e, "AnkiDroidApp.onCreate");
+            }
         }
     }
 
@@ -390,6 +389,19 @@ public class AnkiDroidApp extends Application {
 
     public static boolean isSdCardMounted() {
         return Environment.MEDIA_MOUNTED.equals(Environment.getExternalStorageState());
+    }
+
+    /**
+     * Try to access the current AnkiDroid directory
+     * @return whether or not dir is accessible
+     */
+    public static boolean isCurrentAnkiDroidDirAccessible() {
+        try {
+            initializeAnkiDroidDirectory(getCurrentAnkiDroidDirectory());
+            return true;
+        } catch (StorageAccessException e) {
+            return false;
+        }
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -162,7 +162,6 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
 
     private BroadcastReceiver mUnmountReceiver = null;
 
-    private String mPrefDeckPath = null;
     private long mContextMenuDid;
 
     private EditText mDialogEditText;
@@ -401,7 +400,7 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
 
         setTitle(getResources().getString(R.string.app_name));
 
-        SharedPreferences preferences = restorePreferences();
+        SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(getBaseContext());
 
         View mainView = getLayoutInflater().inflate(R.layout.deck_picker, null);
         setContentView(mainView);
@@ -869,12 +868,6 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
         startActivityForResultWithAnimation(intent, ADD_NOTE, ActivityTransitionAnimation.LEFT);
     }
 
-    private SharedPreferences restorePreferences() {
-        SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(getBaseContext());
-        mPrefDeckPath = AnkiDroidApp.getCurrentAnkiDroidDirectory();
-        return preferences;
-    }
-
 
     private void showStartupScreensAndDialogs(SharedPreferences preferences, int skip) {
         if (!AnkiDroidApp.isSdCardMounted()) {
@@ -885,7 +878,7 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
             Intent i = new Intent(this, Preferences.class);
             startActivityWithoutAnimation(i);
             Themes.showThemedToast(this, getResources().getString(R.string.directory_inaccessible), false);
-        } else if (!BackupManager.enoughDiscSpace(mPrefDeckPath)) {
+        } else if (!BackupManager.enoughDiscSpace(AnkiDroidApp.getCurrentAnkiDroidDirectory())) {
             // Not enough space to do backup
             showDialogFragment(DeckPickerNoSpaceLeftDialog.newInstance());
         } else if (preferences.getBoolean("noSpaceLeft", false)) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -878,8 +878,13 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
 
     private void showStartupScreensAndDialogs(SharedPreferences preferences, int skip) {
         if (!AnkiDroidApp.isSdCardMounted()) {
-            // SD Card mounted
+            // SD Card not mounted
             showSdCardNotMountedDialog();
+        } else if (!AnkiDroidApp.isCurrentAnkiDroidDirAccessible()) {
+            // AnkiDroid directory inaccessible
+            Intent i = new Intent(this, Preferences.class);
+            startActivityWithoutAnimation(i);
+            Themes.showThemedToast(this, getResources().getString(R.string.directory_inaccessible), false);
         } else if (!BackupManager.enoughDiscSpace(mPrefDeckPath)) {
             // Not enough space to do backup
             showDialogFragment(DeckPickerNoSpaceLeftDialog.newInstance());

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -188,7 +188,6 @@ public class Preferences extends PreferenceActivity implements OnSharedPreferenc
                 final String newPath = (String) newValue;
                 try {
                     AnkiDroidApp.initializeAnkiDroidDirectory(newPath);
-                    AnkiDroidApp.sStorageAccessExceptionFlag = false;
                     return true;
                 } catch (StorageAccessException e) {
                     Timber.e(e, "Could not initialize directory: %s", newPath);


### PR DESCRIPTION
Currently, if the SD card was unmounted during app startup, the only way to get AnkiDroid working is to force close the app. This fixes that bug by checking if the dir is accessible everytime an AnkiActivity is created. We need to retain the `initializeAnkiDroidDirectory()` call in AnkiDroidApp due to the reason mentioned in #733 

I haven't tested whether the app works properly even with manually mounting and unmounting the sdcard, but it's a simple change that's unlikely to introduce any bugs that didn't exist before.