### PR TITLE
Re-work deck list building and interface refreshes

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1177,7 +1177,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
     protected long getParentDid() {
         long deckID;
         try {
-            deckID = mSched.getCol().getDecks().current().getLong("id");
+            deckID = AnkiDroidApp.getCol().getDecks().current().getLong("id");
         } catch (JSONException e) {
             throw new RuntimeException(e);
         }
@@ -1232,7 +1232,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
 
 
     protected void undo() {
-        if (mSched.getCol().undoAvailable()) {
+        if (AnkiDroidApp.getCol().undoAvailable()) {
             if (mProgressDialog != null && mProgressDialog.isShowing()) {
                 mProgressDialog.setMessage(getResources().getString(R.string.saving_changes));
             } else {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CramDeckOptions.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CramDeckOptions.java
@@ -369,8 +369,12 @@ public class CramDeckOptions extends PreferenceActivity implements OnSharedPrefe
             finish();
             return;
         }
-        mDeck = mCol.getDecks().current();
-
+        Bundle extras = getIntent().getExtras();
+        if (extras != null && extras.containsKey("did")) {
+            mDeck = mCol.getDecks().get(extras.getLong("did"));
+        } else {
+            mDeck = mCol.getDecks().current();
+        }
         Bundle initialConfig = getIntent().getBundleExtra("cramInitialConfig");
         if (initialConfig != null) {
             if (initialConfig.containsKey("searchSuffix")) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
@@ -507,8 +507,12 @@ public class DeckOptions extends PreferenceActivity implements OnSharedPreferenc
             finish();
             return;
         }
-        mDeck = mCol.getDecks().current();
-
+        Bundle extras = getIntent().getExtras();
+        if (extras != null && extras.containsKey("did")) {
+            mDeck = mCol.getDecks().get(extras.getLong("did"));
+        } else {
+            mDeck = mCol.getDecks().current();
+        }
         registerExternalStorageListener();
 
         if (mCol == null) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -22,7 +22,6 @@
 package com.ichi2.anki;
 
 import android.annotation.SuppressLint;
-import android.app.Activity;
 import android.content.ActivityNotFoundException;
 import android.content.BroadcastReceiver;
 import android.content.Context;
@@ -38,6 +37,7 @@ import android.graphics.PixelFormat;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.Handler;
 import android.os.Message;
 import android.support.v4.app.DialogFragment;
 import android.support.v4.app.Fragment;
@@ -48,8 +48,6 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.View.OnClickListener;
-import android.view.ViewTreeObserver;
-import android.view.ViewTreeObserver.OnGlobalLayoutListener;
 import android.view.Window;
 import android.widget.AbsListView;
 import android.widget.AdapterView;
@@ -84,6 +82,7 @@ import com.ichi2.async.Connection.Payload;
 import com.ichi2.async.DeckTask;
 import com.ichi2.async.DeckTask.TaskData;
 import com.ichi2.libanki.Collection;
+import com.ichi2.libanki.Sched;
 import com.ichi2.themes.StyledDialog;
 import com.ichi2.themes.StyledOpenCollectionDialog;
 import com.ichi2.themes.StyledProgressDialog;
@@ -99,7 +98,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
-import java.util.TreeSet;
 
 import timber.log.Timber;
 
@@ -141,8 +139,7 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
     // private static final int LOG_IN = 13;
     private static final int BROWSE_CARDS = 14;
     private static final int ADD_SHARED_DECKS = 15;
-    private static final int ADD_CRAM_DECK = 17;
-    private static final int REQUEST_REVIEW = 19;
+
 
     private StyledProgressDialog mProgressDialog;
     private StyledOpenCollectionDialog mNotMountedDialog;
@@ -169,6 +166,13 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
     // flag asking user to do a full sync which is used in upgrade path
     boolean mRecommendFullSync = false;
 
+    /**
+     * Keep track of which deck was last given focus in the deck list. If we find that this value
+     * has changed between deck list refreshes, we need to recenter the deck list to the new current
+     * deck (e.g., when a filtered deck was created in a study options fragment).
+     */
+    private Long mFocusedDeck;
+
     // ----------------------------------------------------------------------------
     // LISTENERS
     // ----------------------------------------------------------------------------
@@ -181,59 +185,6 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
         }
     };
 
-    DeckTask.TaskListener mLoadCountsHandler = new DeckTask.TaskListener() {
-
-        @SuppressWarnings("unchecked")
-        @Override
-        public void onPostExecute(DeckTask.TaskData result) {
-            if (result == null) {
-                Timber.w("loadCounts() onPostExecute :: result = null");
-                return;
-            }
-            Object[] res = result.getObjArray();
-            TreeSet<Object[]> countList = (TreeSet<Object[]>) res[0];
-            Timber.d("loadCounts() onPostExecute :: result = (length %d TreeSet, %d, %d)", countList.size(), res[1], res[2]);
-            updateDecksList(countList, (Integer) res[1], (Integer) res[2]);
-            dismissOpeningCollectionDialog();
-            try {
-                // Ensure we have the correct deck selected in the deck list after we have updated it. Check first
-                // if the collection is open since it might have been closed before this task completes.
-                if (colOpen()) {
-                    Long did = getCol().getDecks().current().getLong("id");
-                    setSelectedDeck(did);
-                    if (mFragmented) {
-                        try {
-                            loadStudyOptionsFragment(did, null);
-                        } catch (IllegalStateException e) {
-                            // If activity has been stopped then just ignore the updated counts
-                            Timber.e("DeckPicker mLoadCountsHandler -- could not update StudyOptionsFragment");
-                        }
-                    } else {
-                        // Show the ShowcaseView tutorial unless in tablet mode (which shows it after loading StudyOptionsFragment)
-                        reloadShowcaseView();
-                    }
-                }
-            } catch (JSONException e) {
-                throw new RuntimeException();
-            }
-        }
-
-
-        @Override
-        public void onPreExecute() {
-        }
-
-
-        @Override
-        public void onProgressUpdate(DeckTask.TaskData... values) {
-        }
-
-
-        @Override
-        public void onCancelled() {
-            Timber.d("loadCounts onCancelled()");
-        }
-    };
 
     DeckTask.TaskListener mImportAddListener = new DeckTask.TaskListener() {
         @SuppressWarnings("unchecked")
@@ -256,8 +207,7 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
                 } else {
                     message = res.getString(R.string.import_log_success, count);
                     showSimpleMessageDialog(message);
-                    Object[] info = result.getObjArray();
-                    updateDecksList((TreeSet<Object[]>) info[0], (Integer) info[1], (Integer) info[2]);
+                    updateDeckList();
                 }
             } else {
                 showSimpleMessageDialog(res.getString(R.string.import_log_error));
@@ -306,8 +256,7 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
                     // not a valid apkg file
                     showSimpleMessageDialog(res.getString(R.string.import_log_no_apkg));
                 }
-                Object[] info = result.getObjArray();
-                updateDecksList((TreeSet<Object[]>) info[0], (Integer) info[1], (Integer) info[2]);
+                updateDeckList();
                 dismissOpeningCollectionDialog();
             } else {
                 showSimpleMessageDialog(res.getString(R.string.import_log_no_apkg), true);
@@ -419,10 +368,8 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
         mDeckList = new ArrayList<HashMap<String, String>>();
         mDeckListView = (ListView) findViewById(R.id.files);
         mDeckListAdapter = new SimpleAdapter(this, mDeckList, R.layout.deck_item, new String[] { "name", "new", "lrn",
-                "rev", // "complMat", "complAll",
-                "sep", "dyn" }, new int[] { R.id.DeckPickerName, R.id.deckpicker_new, R.id.deckpicker_lrn,
-                R.id.deckpicker_rev, // R.id.deckpicker_bar_mat, R.id.deckpicker_bar_all,
-                R.id.deckpicker_deck, R.id.DeckPickerName });
+                "rev", "sep", "dyn" }, new int[] { R.id.DeckPickerName, R.id.deckpicker_new, R.id.deckpicker_lrn,
+                R.id.deckpicker_rev, R.id.deckpicker_deck, R.id.DeckPickerName });
         mDeckListAdapter.setViewBinder(new SimpleAdapter.ViewBinder() {
             @Override
             public boolean setViewValue(View view, Object data, String text) {
@@ -484,18 +431,9 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
         });
         mDeckListView.setAdapter(mDeckListAdapter);
         mTodayTextView = (TextView) findViewById(R.id.today_stats_text_view);
-
-        if (mFragmented) {
-            mDeckListView.setChoiceMode(AbsListView.CHOICE_MODE_SINGLE);
-        }
-
-        if (getCol() == null) {
-            // Show splash screen and load collection if it's null
-            showStartupScreensAndDialogs(preferences, 0);
-        } else {
-            // Otherwise just update the deck list
-            loadCounts();
-        }
+        mDeckListView.setChoiceMode(AbsListView.CHOICE_MODE_SINGLE);
+        // Show splash screen and load collection
+        showStartupScreensAndDialogs(preferences, 0);
     }
 
 
@@ -594,7 +532,7 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
                                 .replaceAll("[\'\"\\n\\r\\[\\]\\(\\)]", "");
                         Timber.i("DeckPicker:: Creating new deck...");
                         getCol().getDecks().id(deckName, true);
-                        loadCounts();
+                        updateDeckList();
                     }
                 });
                 builder2.setNegativeButton(res.getString(R.string.dialog_cancel), null);
@@ -613,21 +551,21 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
                 mDialogEditText = new EditText(DeckPicker.this);
                 ArrayList<String> names = getCol().getDecks().allNames();
                 int n = 1;
-                String cramDeckName = "Cram 1";
-                while (names.contains(cramDeckName)) {
+                String filteredDeckName = "Filtered Deck 1"; // TODO: needs to be a resource
+                while (names.contains(filteredDeckName)) {
                     n++;
-                    cramDeckName = "Cram " + n;
+                    filteredDeckName = "Filtered Deck " + n;
                 }
-                mDialogEditText.setText(cramDeckName);
+                mDialogEditText.setText(filteredDeckName);
                 // mDialogEditText.setFilters(new InputFilter[] { mDeckNameFilter });
                 builder3.setView(mDialogEditText, false, false);
                 builder3.setPositiveButton(res.getString(R.string.create), new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
                         String enteredCramDeckName = mDialogEditText.getText().toString();
-                        Timber.i("DeckPicker:: Creating cram deck...");
-                        long id = getCol().getDecks().newDyn(enteredCramDeckName);
-                        openStudyOptions(id, new Bundle());
+                        Timber.i("DeckPicker:: Creating filtered deck...");
+                        long did = getCol().getDecks().newDyn(enteredCramDeckName);
+                        openStudyOptions(did, true);
                     }
                 });
                 builder3.setNegativeButton(res.getString(R.string.dialog_cancel), null);
@@ -672,17 +610,8 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
             handleDbError();
             return;
         }
-        if (requestCode == SHOW_STUDYOPTIONS && resultCode == RESULT_OK) {
-            loadCounts();
-        } else if (requestCode == ADD_NOTE && resultCode != RESULT_CANCELED) {
-            loadCounts();
-        } else if (requestCode == BROWSE_CARDS
-                && (resultCode == Activity.RESULT_OK || resultCode == Activity.RESULT_CANCELED)) {
-            loadCounts();
-        } else if (requestCode == ADD_CRAM_DECK) {
-            // TODO: check, if ok has been clicked
-            loadCounts();
-        } else if (requestCode == REPORT_ERROR) {
+
+        if (requestCode == REPORT_ERROR) {
             showStartupScreensAndDialogs(AnkiDroidApp.getSharedPrefs(getBaseContext()), 4);
         } else if (requestCode == SHOW_INFO_WELCOME || requestCode == SHOW_INFO_NEW_VERSION) {
             if (resultCode == RESULT_OK) {
@@ -703,19 +632,6 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
                         mImportPath, true));
                 mImportPath = null;
             }
-        } else if (requestCode == REQUEST_REVIEW) {
-            switch (resultCode) {
-                default:
-                    // do not reload counts, if activity is created anew because it has been before destroyed by android
-                    loadCounts();
-                    break;
-                case AbstractFlashcardViewer.RESULT_NO_MORE_CARDS:
-                    Intent i = new Intent();
-                    i.setClass(this, StudyOptionsActivity.class);
-                    startActivityForResultWithAnimation(i, SHOW_STUDYOPTIONS, ActivityTransitionAnimation.RIGHT);
-                    break;
-            }
-
         }
     }
 
@@ -725,7 +641,8 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
         Timber.d("onResume()");
         super.onResume();
         if (colOpen() && AnkiDroidApp.isSdCardMounted()) {
-            loadCounts();
+            updateDeckList();
+            dismissOpeningCollectionDialog();
         }
         selectNavigationItem(DRAWER_DECK_PICKER);
     }
@@ -809,11 +726,6 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
         if (started) {
             // Themes.showThemedToast(this, getResources().getString(R.string.backup_collection), true);
         }
-        // select last loaded deck if any
-        if (mFragmented) {
-            long did = col.getDecks().selected();
-            selectDeck(did);
-        }
         // Force a full sync if flag was set in upgrade path, asking the user to confirm if necessary
         if (mRecommendFullSync) {
             mRecommendFullSync = false;
@@ -833,7 +745,22 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
             }
         }
         // prepare deck counts and mini-today-statistic
-        loadCounts();
+        updateDeckList();
+        // Open StudyOptionsFragment if in fragmented mode
+        if (mFragmented) {
+            // Create the fragment in a new handler since Android won't let you perform fragment
+            // transactions in a loader's onLoadFinished.
+            new Handler().post(new Runnable() {
+                public void run() {
+                    loadStudyOptionsFragment(getCol().getDecks().current().optLong("id"), false);
+                }
+            });
+        }
+        dismissOpeningCollectionDialog();
+        // Show the ShowcaseView tutorial unless in tablet mode (which shows it after loading StudyOptionsFragment)
+        if (!mFragmented) {
+            reloadShowcaseView();
+        }
     }
 
 
@@ -842,16 +769,6 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
         // Show dialogs for handling collection load error
         setOpeningCollectionDialogMessage(getResources().getString(R.string.col_load_failed));
         getDialogHandler().sendEmptyMessage(DialogHandler.MSG_SHOW_COLLECTION_LOADING_ERROR_DIALOG);
-    }
-
-
-    // Load deck counts, and update the today overview
-    private void loadCounts() {
-        if (colOpen()) {
-            DeckTask.launchDeckTask(DeckTask.TASK_TYPE_LOAD_DECK_COUNTS, mLoadCountsHandler, new TaskData(getCol()));
-            mTodayTextView.setVisibility(View.GONE);
-            AnkiStatsTaskHandler.createSmallTodayOverview(getCol(), mTodayTextView);
-        }
     }
 
 
@@ -1470,10 +1387,8 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
                     }
                 }
             } else {
-                updateDecksList((TreeSet<Object[]>) data.result, (Integer) data.data[2], (Integer) data.data[3]);
-
-                if (data.data[4] != null) {
-                    dialogMessage = (String) data.data[4];
+                if (data.data[2] != null) {
+                    dialogMessage = (String) data.data[2];
                 } else if (data.data.length > 0 && data.data[0] instanceof String
                         && ((String) data.data[0]).length() > 0) {
                     String dataString = (String) data.data[0];
@@ -1488,8 +1403,9 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
                 } else {
                     dialogMessage = res.getString(R.string.sync_database_acknowledge);
                 }
-
                 showSyncLogDialog(joinSyncMessages(dialogMessage, syncMessage), false);
+
+                // Note: the interface is not refreshed since the activity is restarted after sync.
             }
         }
     };
@@ -1583,26 +1499,18 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
     }
 
 
-    public void loadStudyOptionsFragment() {
-        loadStudyOptionsFragment(0, null);
-    }
-
-
-    public void loadStudyOptionsFragment(long deckId, Bundle cramConfig) {
-        StudyOptionsFragment details = StudyOptionsFragment.newInstance(deckId, cramConfig);
+    /**
+     * Load a new studyOptionsFragment. If withDeckOptions is true, the deck options activity will
+     * be loaded on top of it. Use this flag when creating a new filtered deck to allow the user to
+     * modify the filter settings before being shown the fragment. The fragment itself will handle
+     * rebuilding the deck if the settings change.
+     */
+    private void loadStudyOptionsFragment(long deckId, boolean withDeckOptions) {
+        Bundle b = withDeckOptions ? new Bundle() : null;
+        StudyOptionsFragment details = StudyOptionsFragment.newInstance(deckId, b);
         FragmentTransaction ft = getSupportFragmentManager().beginTransaction();
-        ft.setTransition(FragmentTransaction.TRANSIT_FRAGMENT_CLOSE);
         ft.replace(R.id.studyoptions_fragment, details);
         ft.commit();
-    }
-
-
-    /** Callback from StudyOptionsFragment via OnStudyOptionsReloadListener
-     * This allows us to update the deck list and reload the StudyOptionsFragment
-     * when in tablet mode
-     */
-    public void refreshMainInterface() {
-        loadCounts();
     }
 
 
@@ -1662,75 +1570,15 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
     }
 
 
-    private void openStudyOptions(long deckId) {
-        openStudyOptions(deckId, null);
-    }
-
-
-    private void openStudyOptions(long deckId, Bundle cramInitialConfig) {
+    private void openStudyOptions(long deckId, boolean withDeckOptions) {
         if (mFragmented) {
-            loadStudyOptionsFragment(deckId, cramInitialConfig);
+            // The fragment will show the study options screen instead of launching a new activity.
+            loadStudyOptionsFragment(deckId, withDeckOptions);
         } else {
             Intent intent = new Intent();
             intent.putExtra("index", deckId);
-            intent.putExtra("cramInitialConfig", cramInitialConfig);
             intent.setClass(this, StudyOptionsActivity.class);
             startActivityForResultWithAnimation(intent, SHOW_STUDYOPTIONS, ActivityTransitionAnimation.LEFT);
-        }
-    }
-
-
-    /**
-     * Programmatically click on a deck in the deck list.
-     * 
-     * @param did The deck ID of the deck to select.
-     */
-    private void selectDeck(long did) {
-        Timber.i("DeckPicker:: Selected deck with ID %d", did);
-        for (int i = 0; i < mDeckList.size(); i++) {
-            if (Long.parseLong(mDeckList.get(i).get("did")) == did) {
-                final int lastPosition = i;
-                mDeckListView.getViewTreeObserver().addOnGlobalLayoutListener(new OnGlobalLayoutListener() {
-                    @Override
-                    public void onGlobalLayout() {
-                        removeOnGlobalLayoutListener(mDeckListView, this);
-                        mDeckListView.performItemClick(null, lastPosition, 0);
-                        // Scroll the listView to the currently selected row, then offset it by half the
-                        // listview's height so that it is centered.
-                        mDeckListView.setSelectionFromTop(lastPosition, mDeckListView.getHeight() / 2);
-                    }
-                });
-                break;
-            }
-        }
-    }
-
-
-    @SuppressLint("NewApi")
-    @SuppressWarnings("deprecation")
-    public static void removeOnGlobalLayoutListener(View v, ViewTreeObserver.OnGlobalLayoutListener listener) {
-        if (AnkiDroidApp.SDK_VERSION < 16) {
-            v.getViewTreeObserver().removeGlobalOnLayoutListener(listener);
-        } else {
-            v.getViewTreeObserver().removeOnGlobalLayoutListener(listener);
-        }
-    }
-
-
-    /**
-     * Set which deck is selected (highlighted) in the deck list.
-     * <p>
-     * Note that this method does not change the currently selected deck in the collection, only the highlighted deck in
-     * the deck list. To select a deck, see {@link #selectDeck(long)}.
-     * 
-     * @param did The deck ID of the deck to select.
-     */
-    public void setSelectedDeck(long did) {
-        for (int i = 0; i < mDeckList.size(); i++) {
-            if (Long.parseLong(mDeckList.get(i).get("did")) == did) {
-                mDeckListView.setItemChecked(i, true);
-                break;
-            }
         }
     }
 
@@ -1738,74 +1586,191 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
     private void handleDeckSelection(int id) {
         @SuppressWarnings("unchecked")
         HashMap<String, String> data = (HashMap<String, String>) mDeckListAdapter.getItem(id);
-        long deckId = Long.parseLong(data.get("did"));
-        getCol().getDecks().select(deckId);
-        openStudyOptions(deckId);
+        long did = Long.parseLong(data.get("did"));
+        getCol().getDecks().select(did);
+        mFocusedDeck = did;
+        openStudyOptions(did, false);
     }
 
 
-    private void updateDecksList(TreeSet<Object[]> decks, int eta, int count) {
-        if (decks == null) {
-            Timber.e("updateDecksList: empty decks list");
-            return;
+    /**
+     * Scroll the deck list so that it is centered on the current deck.
+     */
+    private void focusDecklistOnDeck(long did) {
+        for (int i = 0; i < mDeckList.size(); i++) {
+            if (Long.parseLong(mDeckList.get(i).get("did")) == did) {
+                mDeckListView.setSelectionFromTop(i, (mDeckListView.getHeight() / 2));
+                break;
+            }
         }
-        mDeckList.clear();
-        int due = 0;
-        for (Object[] d : decks) {
-            HashMap<String, String> m = new HashMap<String, String>();
-            String[] name = ((String[]) d[0]);
-            m.put("name", readableDeckName(name));
-            m.put("did", ((Long) d[1]).toString());
-            m.put("new", ((Integer) d[2]).toString());
-            m.put("lrn", ((Integer) d[3]).toString());
-            m.put("rev", ((Integer) d[4]).toString());
-            m.put("dyn", ((Boolean) d[5]) ? "d1" : "d0");
-            // m.put("complMat", ((Float)d[5]).toString());
-            // m.put("complAll", ((Float)d[6]).toString());
-            if (name.length == 1) {
-                due += Integer.parseInt(m.get("new")) + Integer.parseInt(m.get("lrn")) + Integer.parseInt(m.get("rev"));
-                // top position
-                m.put("sep", "top");
-                // correct previous deck
-                if (mDeckList.size() > 0) {
-                    HashMap<String, String> map = mDeckList.get(mDeckList.size() - 1);
-                    if (map.get("sep").equals("top")) {
-                        map.put("sep", "ful");
-                    } else {
-                        map.put("sep", "bot");
+    }
+
+
+    /**
+     * Launch an asynchronous task to rebuild the deck list and recalculate the deck counts. Use this
+     * after any change to a deck (e.g., rename, collapse, add/delete) that needs to be reflected
+     * in the deck list.
+     *
+     * This method also triggers an update for the widget to reflect the newly calculated counts.
+     */
+    private void updateDeckList() {
+        DeckTask.launchDeckTask(DeckTask.TASK_TYPE_LOAD_DECK_COUNTS, new DeckTask.TaskListener() {
+            // Totals accumulated as each deck is processed
+            private int nNew;
+            private int nLrn;
+            private int nRev;
+
+            @Override
+            public void onPreExecute() {
+                Timber.d("Refreshing deck list");
+            }
+
+            @Override
+            public void onPostExecute(TaskData result) {
+                List<Sched.DeckDueTreeNode> nodes = (List<Sched.DeckDueTreeNode>) result.getObjArray()[0];
+                mDeckList.clear();
+                _renderDeckTree(nodes);
+                mDeckListAdapter.notifyDataSetChanged();
+
+                // Set the "x due in y minutes" subtitle
+                int eta = getCol().getSched().eta(new int[]{nNew, nLrn, nRev});
+                int due = nNew + nLrn + nRev;
+                Resources res = getResources();
+                if (getCol().cardCount() != -1) {
+                    String time = "-";
+                    if (eta != -1) {
+                        time = res.getQuantityString(R.plurals.deckpicker_title_minutes, eta, eta);
+                    }
+                    AnkiDroidApp.getCompat().setSubtitle(DeckPicker.this,
+                            res.getQuantityString(R.plurals.deckpicker_title, due, due, time));
+                }
+
+                Long did = getCol().getDecks().current().optLong("id");
+                if (mFocusedDeck == null || !mFocusedDeck.equals(did)) {
+                    focusDecklistOnDeck(did);
+                    mFocusedDeck = did;
+                }
+
+                // update widget
+                WidgetStatus.update(DeckPicker.this, nodes);
+                // update options menu and clear welcome screen
+                AnkiDroidApp.getCompat().invalidateOptionsMenu(DeckPicker.this);
+                // Update the mini statistics bar as well
+                AnkiStatsTaskHandler.createSmallTodayOverview(getCol(), mTodayTextView);
+            }
+
+            @Override
+            public void onProgressUpdate(TaskData... values) {
+            }
+
+            @Override
+            public void onCancelled() {
+            }
+
+
+            private void _renderDeckTree(List<Sched.DeckDueTreeNode> nodes) {
+                _renderDeckTree(nodes, 0);
+            }
+
+
+            private void _renderDeckTree(List<Sched.DeckDueTreeNode> nodes, int depth) {
+                for (Sched.DeckDueTreeNode node : nodes) {
+                    _deckRow(node, depth, nodes.size());
+                }
+            }
+
+
+            /**
+             * Create a row in the deck list using the given node.
+             *
+             * This method determines various visual elements of each row:
+             *  - Indenting level based on depth if it's a subdeck
+             *  - Addition of a unicode arrow to indicate subdeck status
+             *  - Addition of an indicator to notify collapsed state
+             *  - The type of padding given to each row
+             *
+             * NOTE: Each row in the list also contains the deck ID (did) which is later fetched
+             * to perform operations on the correct deck when the user interacts with the list.
+             *
+             * @param node The row data.
+             * @param depth The subdeck level this node is at.
+             * @param cnt The number of decks in the collection.
+             */
+            private void _deckRow(Sched.DeckDueTreeNode node, int depth, int cnt) {
+                HashMap<String, String> m = new HashMap<String, String>();
+                boolean collapsed = getCol().getDecks().get(node.did).optBoolean("collapsed", false);
+                m.put("name", decoratedDeckName(node.names[0], depth, collapsed));
+                m.put("did", Long.toString(node.did));
+                m.put("new", Integer.toString(node.newCount));
+                m.put("lrn", Integer.toString(node.lrnCount));
+                m.put("rev", Integer.toString(node.revCount));
+                m.put("dyn", getCol().getDecks().isDyn(node.did) ? "d1" : "d0");
+
+                // Add this node's counts to the totals
+                nNew += node.newCount;
+                nLrn += node.lrnCount;
+                nRev += node.revCount;
+
+                // If the default deck is empty, hide it
+                // We don't hide it if it's the only deck or if it has sub-decks
+                if (node.did == 1 && cnt > 1 && node.children.size() == 0) {
+                    if (getCol().getDb().queryScalar("select 1 from cards where did = 1", false) == 0) {
+                        return;
                     }
                 }
-            } else {
-                // center position
-                m.put("sep", "cen");
-            }
-            if (mDeckList.size() > 0 && mDeckList.size() == decks.size() - 1) {
-                // bottom position
-                if (name.length == 1) {
-                    m.put("sep", "ful");
+
+                // Add the appropriate separators
+                if (depth == 0 && node.children.size() > 0 && !collapsed) {
+                    // Top-level decks with expanded subdecks have only a top border
+                    m.put("sep", "top");
+                } else if (depth > 0) {
+                    // All subdecks begin with no borders (i.e., thin centered borders)
+                    m.put("sep", "cen");
                 } else {
-                    m.put("sep", "bot");
+                    // Every other deck gets full borders
+                    m.put("sep", "ful");
+                }
+
+                // Parent toggled for collapsing
+                for (JSONObject parent : getCol().getDecks().parents(node.did)) {
+                    if (parent.optBoolean("collapsed")) {
+                        return;
+                    }
+                }
+                // If this deck is the current deck, highlight it in the deck list
+                if (node.did == getCol().getDecks().current().optLong("id")) {
+                    mDeckListView.setItemChecked(mDeckList.size(), true);
+                }
+
+                mDeckList.add(m);
+                _renderDeckTree(node.children, depth + 1);
+
+                // If the deck contained expanded subdecks, ensure the last one has a bottom border
+                if (depth == 0 && node.children.size() > 0 && !collapsed) {
+                    mDeckList.get(mDeckList.size() - 1).put("sep", "bot");
                 }
             }
-            mDeckList.add(m);
-        }
-        mDeckListAdapter.notifyDataSetChanged();
 
-        // set title
-        Resources res = getResources();
-        if (count != -1) {
-            String time = "-";
-            if (eta != -1) {
-                time = res.getQuantityString(R.plurals.deckpicker_title_minutes, eta, eta);
+
+            /**
+             * Returns the name of the deck to be displayed in the deck list.
+             *
+             * Various properties of a deck are indicated to the user by the deck name in the deck list
+             * (as opposed to additional native UI elements). This includes the amount of indenting
+             * for nested decks based on depth and an indicator of collapsed state.
+             */
+            private String decoratedDeckName(String name, int depth, boolean collapsed) {
+                if (collapsed) {
+                    name = name + " (+)";
+                }
+                if (depth == 0) {
+                    return name;
+                } else {
+                    // Add 4 spaces for every level of nesting and prefix the deck name with an arrow
+                    return new String(new char[depth]).replace("\0", "    ") + "\u21aa" + name;
+                }
             }
-            AnkiDroidApp.getCompat().setSubtitle(this,
-                    res.getQuantityString(R.plurals.deckpicker_title, due, due, time));
-        }
-
-        // update widget
-        WidgetStatus.update(this, decks);
-        // update options menu and clear welcome screen
-        AnkiDroidApp.getCompat().invalidateOptionsMenu(this);
+        });
     }
 
 
@@ -1816,7 +1781,7 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
             if (getCol().getDecks().children(mContextMenuDid).size() > 0) {
                 deck.put("collapsed", !deck.getBoolean("collapsed"));
                 getCol().getDecks().save(deck);
-                loadCounts();
+                updateDeckList();
             }
         } catch (JSONException e1) {
             // do nothing
@@ -1826,19 +1791,17 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
 
     // Callback to show study options for currently selected deck
     public void showContextMenuDeckOptions() {
-        getCol().getDecks().select(mContextMenuDid);
-        if (mFragmented) {
-            loadStudyOptionsFragment(mContextMenuDid, null);
-        }
         // open deck options
         if (getCol().getDecks().isDyn(mContextMenuDid)) {
             // open cram options if filtered deck
             Intent i = new Intent(DeckPicker.this, CramDeckOptions.class);
             i.putExtra("cramInitialConfig", (String) null);
+            i.putExtra("did", mContextMenuDid);
             startActivityWithAnimation(i, ActivityTransitionAnimation.FADE);
         } else {
             // otherwise open regular options
             Intent i = new Intent(DeckPicker.this, DeckOptions.class);
+            i.putExtra("did", mContextMenuDid);
             startActivityWithAnimation(i, ActivityTransitionAnimation.FADE);
         }
     }
@@ -1883,7 +1846,7 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
                             }
                         }
                         mDeckListAdapter.notifyDataSetChanged();
-                        loadCounts();
+                        updateDeckList();
                     } else {
                         try {
                             Themes.showThemedToast(
@@ -1925,10 +1888,16 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
     // Callback to delete currently selected deck
     public void deleteContextMenuDeck() {
         DeckTask.launchDeckTask(DeckTask.TASK_TYPE_DELETE_DECK, new DeckTask.TaskListener() {
+            // Flag to indicate if the deck being deleted is the current deck.
+            private boolean removingCurrent;
+
             @Override
             public void onPreExecute() {
                 mProgressDialog = StyledProgressDialog.show(DeckPicker.this, "",
                         getResources().getString(R.string.delete_deck), true);
+                if (mContextMenuDid == getCol().getDecks().current().optLong("id")) {
+                    removingCurrent = true;
+                }
             }
 
 
@@ -1938,11 +1907,16 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
                 if (result == null) {
                     return;
                 }
-                Object[] res = result.getObjArray();
-                updateDecksList((TreeSet<Object[]>) res[0], (Integer) res[1], (Integer) res[2]);
-                if (mFragmented) {
-                    selectDeck(getCol().getDecks().selected());
+                // In fragmented mode, if the deleted deck was the current deck, we need to reload
+                // the study options fragment with a valid deck and re-center the deck list to the
+                // new current deck. Otherwise we just update the list normally.
+                if (mFragmented && removingCurrent) {
+                    updateDeckList();
+                    openStudyOptions(getCol().getDecks().current().optLong("id"), false);
+                } else {
+                    updateDeckList();
                 }
+
                 if (mProgressDialog.isShowing()) {
                     try {
                         mProgressDialog.dismiss();
@@ -1962,26 +1936,6 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
             public void onCancelled() {
             }
         }, new TaskData(getCol(), mContextMenuDid));
-    }
-
-
-    // ----------------------------------------------------------------------------
-    // INNER CLASSES
-    // ----------------------------------------------------------------------------
-
-    public static String readableDeckName(String[] name) {
-        int len = name.length;
-        StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < len; i++) {
-            if (i == len - 1) {
-                sb.append(name[i]);
-            } else if (i == len - 2) {
-                sb.append("\u21aa");
-            } else {
-                sb.append("    ");
-            }
-        }
-        return sb.toString();
     }
 
 
@@ -2037,6 +1991,11 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
         supportInvalidateOptionsMenu();
     }
 
+
+    @Override
+    public void onRequireDeckListUpdate() {
+        updateDeckList();
+    }
 
     @Override
     public void createFilteredDeck(JSONArray delays, Object[] terms, Boolean resched) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.java
@@ -57,7 +57,7 @@ public class StudyOptionsActivity extends NavigationDrawerActivity implements St
         // create inherited navigation drawer layout here so that it can be used by parent class
         initNavigationDrawer(mainView);
         if (savedInstanceState == null) {
-            loadStudyOptionsFragment();
+            loadStudyOptionsFragment(getCol().getDecks().current().optLong("did"), null);
         }
         registerExternalStorageListener();
     }
@@ -73,15 +73,10 @@ public class StudyOptionsActivity extends NavigationDrawerActivity implements St
         return true;
     }
 
-    private void loadStudyOptionsFragment() {
-        loadStudyOptionsFragment(0, null);
-    }
-
 
     private void loadStudyOptionsFragment(long deckId, Bundle cramConfig) {
         StudyOptionsFragment currentFragment = StudyOptionsFragment.newInstance(deckId, null);
         Bundle args = getIntent().getExtras();
-
         if (cramConfig != null) {
             args.putBundle("cramInitialConfig", cramConfig);
         }
@@ -212,8 +207,8 @@ public class StudyOptionsActivity extends NavigationDrawerActivity implements St
 
 
     @Override
-    public void refreshMainInterface() {
-        getCurrentFragment().resetAndRefreshInterface();
+    public void onRequireDeckListUpdate() {
+        getCurrentFragment().refreshInterface();
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
@@ -142,8 +142,6 @@ public class CustomStudyDialog extends DialogFragment {
                     default:
                         break;                       
                 }
-                // Refresh interface
-                ((StudyOptionsListener) getActivity()).refreshMainInterface();
             }
         });
         builder.setNegativeButton(res.getString(R.string.dialog_cancel), new DialogInterface.OnClickListener() {

--- a/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
@@ -548,9 +548,7 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
                 return data;
             } else {
                 data.success = true;
-                Object[] dc = col.getSched().deckCounts();
-                data.result = dc[0];
-                data.data = new Object[] { conflictResolution, col, dc[1], dc[2], mediaError };
+                data.data = new Object[] { conflictResolution, col, mediaError };
                 return data;
             }
         } catch (UnknownHttpResponseException e) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sched.java
@@ -27,7 +27,6 @@ import android.graphics.Typeface;
 import android.text.SpannableStringBuilder;
 import android.text.TextUtils;
 import android.text.style.StyleSpan;
-
 import android.util.Pair;
 
 import com.ichi2.anki.AnkiDroidApp;
@@ -42,18 +41,16 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Calendar;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
-import java.util.TreeSet;
 
 import timber.log.Timber;
 
@@ -386,138 +383,141 @@ public class Sched {
     /**
      * Returns [deckname, did, rev, lrn, new]
      */
-    public ArrayList<Object[]> deckDueList() {
+    public List<DeckDueTreeNode> deckDueList() {
         _checkDay();
         mCol.getDecks().recoverOrphans();
-        // LIBANKI: uses all() instead of sorted() and then sorts the decks
         ArrayList<JSONObject> decks = mCol.getDecks().allSorted();
         HashMap<String, Integer[]> lims = new HashMap<String, Integer[]>();
-        ArrayList<Object[]> data = new ArrayList<Object[]>();
+        ArrayList<DeckDueTreeNode> data = new ArrayList<DeckDueTreeNode>();
         try {
             for (JSONObject deck : decks) {
-            	// if we've already seen the exact same deck name, remove the
-            	// invalid duplicate and reload
-            	if (lims.containsKey(deck.getString("name"))) {
-            		mCol.getDecks().rem(deck.getLong("id"), false, true);
-            		return deckDueList();
-            	}
-            	String p;
+                // if we've already seen the exact same deck name, remove the
+                // invalid duplicate and reload
+                if (lims.containsKey(deck.getString("name"))) {
+                    mCol.getDecks().rem(deck.getLong("id"), false, true);
+                    return deckDueList();
+                }
+                String p;
                 List<String> parts = Arrays.asList(deck.getString("name").split("::"));
                 if (parts.size() < 2) {
                     p = null;
                 } else {
                     parts = parts.subList(0, parts.size() - 1);
                     p = TextUtils.join("::", parts);
-            	}
-            	// new
-            	int nlim = _deckNewLimitSingle(deck);
-            	if (!TextUtils.isEmpty(p)) {
-            		if (!lims.containsKey(p)) {
-                		// if parent was missing, this deck is invalid, and we need to reload the deck list
-                		mCol.getDecks().rem(deck.getLong("id"), false, true);
-            			return deckDueList();
-            		}
-            		nlim = Math.min(nlim, lims.get(p)[0]);
-            	}
-            	int newC = _newForDeck(deck.getLong("id"), nlim);
-            	// learning
-            	int lrn = _lrnForDeck(deck.getLong("id"));
-            	// reviews
-            	int rlim = _deckRevLimitSingle(deck);
-            	if (!TextUtils.isEmpty(p)) {
-            		rlim = Math.min(rlim,  lims.get(p)[1]);
-            	}
-            	int rev = _revForDeck(deck.getLong("id"), rlim);
-            	// save to list
-            	// LIBANKI: order differs from libanki (here: new, lrn, rev)  // TODO: why?
-            	data.add(new Object[]{deck.getString("name"), deck.getLong("id"), newC, lrn, rev});
-            	// add deck as a parent
-            	lims.put(deck.getString("name"), new Integer[]{nlim, rlim});
+                }
+                // new
+                int nlim = _deckNewLimitSingle(deck);
+                if (!TextUtils.isEmpty(p)) {
+                    if (!lims.containsKey(p)) {
+                        // if parent was missing, this deck is invalid, and we need to reload the deck list
+                        mCol.getDecks().rem(deck.getLong("id"), false, true);
+                        return deckDueList();
+                    }
+                    nlim = Math.min(nlim, lims.get(p)[0]);
+                }
+                int _new = _newForDeck(deck.getLong("id"), nlim);
+                // learning
+                int lrn = _lrnForDeck(deck.getLong("id"));
+                // reviews
+                int rlim = _deckRevLimitSingle(deck);
+                if (!TextUtils.isEmpty(p)) {
+                    rlim = Math.min(rlim, lims.get(p)[1]);
+                }
+                int rev = _revForDeck(deck.getLong("id"), rlim);
+                // save to list
+                data.add(new DeckDueTreeNode(deck.getString("name"), deck.getLong("id"), rev, lrn, _new));
+                // add deck as a parent
+                lims.put(deck.getString("name"), new Integer[]{nlim, rlim});
             }
         } catch (JSONException e) {
-        	throw new RuntimeException(e);
+            throw new RuntimeException(e);
         }
         return data;
     }
 
 
-    public TreeSet<Object[]> deckDueTree() {
+    public List<DeckDueTreeNode> deckDueTree() {
         return _groupChildren(deckDueList());
     }
 
 
-    private TreeSet<Object[]> _groupChildren(ArrayList<Object[]> grps) {
-        TreeSet<Object[]> set = new TreeSet<Object[]>(new DeckNameCompare());
+    private List<DeckDueTreeNode> _groupChildren(List<DeckDueTreeNode> grps) {
         // first, split the group names into components
-        for (Object[] g : grps) {
-            set.add(new Object[] { ((String) g[0]).split("::"), g[1], g[2], g[3], g[4] });
+        for (DeckDueTreeNode g : grps) {
+            g.names = g.names[0].split("::");
         }
-        return _groupChildrenMain(set);
+        // and sort based on those components
+        Collections.sort(grps);
+        // then run main function
+        return _groupChildrenMain(grps);
     }
 
 
-    private TreeSet<Object[]> _groupChildrenMain(TreeSet<Object[]> grps) {
-    	return _groupChildrenMain(grps, 0);
-    }
-    private TreeSet<Object[]> _groupChildrenMain(TreeSet<Object[]> grps, int depth) {
-        TreeSet<Object[]> tree = new TreeSet<Object[]>(new DeckNameCompare());
+    private List<DeckDueTreeNode> _groupChildrenMain(List<DeckDueTreeNode> grps) {
+        List<DeckDueTreeNode> tree = new ArrayList<DeckDueTreeNode>();
         // group and recurse
-        Iterator<Object[]> it = grps.iterator();
-        Object[] tmp = null;
-        while (tmp != null || it.hasNext()) {
-            Object[] head;
-            if (tmp != null) {
-                head = tmp;
-                tmp = null;
-            } else {
-                head = it.next();
-            }
-            String[] title = (String[]) head[0];
-            long did = (Long) head[1];
-            int newCount = (Integer) head[2];
-            int lrnCount = (Integer) head[3];
-            int revCount = (Integer) head[4];
-            TreeSet<Object[]> children = new TreeSet<Object[]>(new DeckNameCompare());
+        ListIterator<DeckDueTreeNode> it = grps.listIterator();
+        while (it.hasNext()) {
+            DeckDueTreeNode node = it.next();
+            String head = node.names[0];
+            // Compose the "tail" node list. The tail is a list of all the nodes that proceed
+            // the current one that contain the same name[0]. I.e., they are subdecks that stem
+            // from this node. This is our version of python's itertools.groupby.
+            List<DeckDueTreeNode> tail  = new ArrayList<DeckDueTreeNode>();
+            tail.add(node);
             while (it.hasNext()) {
-                Object[] o = it.next();
-                if (((String[])o[0])[depth].equals(title[depth])) {
-                    // add to children
-                    children.add(o);
+                DeckDueTreeNode next = it.next();
+                if (head.equals(next.names[0])) {
+                    // Same head - add to tail of current head.
+                    tail.add(next);
                 } else {
-                    // proceed with this as head
-                    tmp = o;
+                    // We've iterated past this head, so step back in order to use this node as the
+                    // head in the next iteration of the outer loop.
+                    it.previous();
                     break;
                 }
             }
-            children = _groupChildrenMain(children, depth + 1);
-            // tally up children counts, but skip deeper sub-decks
-            for (Object[] ch : children) {
-               if (((String[])ch[0]).length == ((String[])head[0]).length+1) {
-                  newCount += (Integer)ch[2];
-                  lrnCount += (Integer)ch[3];
-                  revCount += (Integer)ch[4];
-               }
+            Long did = null;
+            int rev = 0;
+            int _new = 0;
+            int lrn = 0;
+            List<DeckDueTreeNode> children = new ArrayList<DeckDueTreeNode>();
+            for (DeckDueTreeNode c : tail) {
+                if (c.names.length == 1) {
+                    // current node
+                    did = c.did;
+                    rev += c.revCount;
+                    lrn += c.lrnCount;
+                    _new += c.newCount;
+                } else {
+                    // set new string to tail
+                    String[] newTail = new String[c.names.length-1];
+                    System.arraycopy(c.names, 1, newTail, 0, c.names.length-1);
+                    c.names = newTail;
+                    children.add(c);
+                }
+            }
+            children = _groupChildrenMain(children);
+            // tally up children counts
+            for (DeckDueTreeNode ch : children) {
+                rev +=  ch.revCount;
+                lrn +=  ch.lrnCount;
+                _new += ch.newCount;
             }
             // limit the counts to the deck's limits
             JSONObject conf = mCol.getDecks().confForDid(did);
             JSONObject deck = mCol.getDecks().get(did);
             try {
                 if (conf.getInt("dyn") == 0) {
-                    revCount = Math.max(0, Math.min(revCount, conf.getJSONObject("rev").getInt("perDay") - deck.getJSONArray("revToday").getInt(1)));
-                    newCount = Math.max(0, Math.min(newCount, conf.getJSONObject("new").getInt("perDay") - deck.getJSONArray("newToday").getInt(1)));
+                    rev = Math.max(0, Math.min(rev, conf.getJSONObject("rev").getInt("perDay") - deck.getJSONArray("revToday").getInt(1)));
+                    _new = Math.max(0, Math.min(_new, conf.getJSONObject("new").getInt("perDay") - deck.getJSONArray("newToday").getInt(1)));
                 }
             } catch (JSONException e) {
                 throw new RuntimeException(e);
             }
-            tree.add(new Object[] {title, did, newCount, lrnCount, revCount,
-            children});
+            tree.add(new DeckDueTreeNode(head, did, rev, lrn, _new, children));
         }
-        TreeSet<Object[]> result = new TreeSet<Object[]>(new DeckNameCompare());
-        for (Object[] t : tree) {
-            result.add(new Object[]{t[0], t[1], t[2], t[3], t[4]});
-            result.addAll((TreeSet<Object[]>) t[5]);
-        }
-        return result;
+        return tree;
     }
 
 
@@ -803,7 +803,12 @@ public class Sched {
                 mLrnQueue.add(new long[] { cur.getLong(0), cur.getLong(1) });
             }
             // as it arrives sorted by did first, we need to sort it
-            Collections.sort(mLrnQueue, new DueComparator());
+            Collections.sort(mLrnQueue, new Comparator<long[]>() {
+                @Override
+                public int compare(long[] lhs, long[] rhs) {
+                    return Long.valueOf(lhs[0]).compareTo(rhs[0]);
+                }
+            });
             return !mLrnQueue.isEmpty();
         } finally {
             if (cur != null && !cur.isClosed()) {
@@ -1605,7 +1610,7 @@ public class Sched {
                 "UPDATE cards SET did = odid, queue = (CASE WHEN type = 1 THEN 0 "
                         + "ELSE type END), type = (CASE WHEN type = 1 THEN 0 ELSE type END), "
                         + "due = odue, odue = 0, odid = 0, usn = ?, mod = ? where " + lim,
-                new Object[] { mCol.usn(), Utils.intNow() });
+                new Object[]{mCol.usn(), Utils.intNow()});
     }
 
 
@@ -2156,8 +2161,8 @@ public class Sched {
     /** Put cards at the end of the new queue. */
     public void forgetCards(long[] ids) {
         remFromDyn(ids);
-        mCol.getDb().execute("update cards set type=0,queue=0,ivl=0,due=0,odue=0,factor=2500"+
-                             " where id in " + Utils.ids2str(ids));
+        mCol.getDb().execute("update cards set type=0,queue=0,ivl=0,due=0,odue=0,factor=2500" +
+                " where id in " + Utils.ids2str(ids));
         int pmax = mCol.getDb().queryScalar("SELECT max(due) FROM cards WHERE type=0", false);
         // takes care of mod + usn
         sortCards(ids, pmax + 1);
@@ -2184,7 +2189,7 @@ public class Sched {
         remFromDyn(ids);
         mCol.getDb().executeMany(
                 "update cards set type=2,queue=2,ivl=?,due=?,odue=0, " +
-                "usn=?,mod=?,factor=? where id=?", d);
+                        "usn=?,mod=?,factor=? where id=?", d);
         mCol.log(ids);
     }
 
@@ -2315,11 +2320,12 @@ public class Sched {
     }
 
 
-    /**
-     ***********************************************
-     * Everything below here is not in libanki.
-     ***********************************************
+    /*
+     * ***********************************************************
+     * The methods below are not in LibAnki.
+     * ***********************************************************
      */
+
 
     public String getName() {
         return mName;
@@ -2341,57 +2347,14 @@ public class Sched {
     }
 
 
-    public Collection getCol() {
-        return mCol;
-    }
-
-
-    public int getNewCount() {
-        return mNewCount;
-    }
-
     public int getReps(){
         return mReps;
     }
 
+
     public void setReps(int reps){
         mReps = reps;
     }
-
-
-    // Needed for tests
-    public LinkedList<Long> getNewQueue() {
-        return mNewQueue;
-    }
-
-    private class DeckNameCompare implements Comparator<Object[]> {
-        @Override
-        public int compare(Object[] lhs, Object[] rhs) {
-            String[] o1 = (String[]) lhs[0];
-            String[] o2 = (String[]) rhs[0];
-            for (int i = 0; i < Math.min(o1.length, o2.length); i++) {
-                int result = o1[i].compareToIgnoreCase(o2[i]);
-                if (result != 0) {
-                    return result;
-                }
-            }
-            if (o1.length < o2.length) {
-                return -1;
-            } else if (o1.length > o2.length) {
-                return 1;
-            } else {
-                return 0;
-            }
-        }
-    }
-
-    private class DueComparator implements Comparator<long[]> {
-        @Override
-        public int compare(long[] lhs, long[] rhs) {
-            return Long.valueOf(lhs[0]).compareTo(rhs[0]);
-        }
-    }
-
 
 
     /**
@@ -2399,21 +2362,13 @@ public class Sched {
      */
 
     public int cardCount() {
-        return cardCount(_deckLimit());
-    }
-
-
-    public int cardCount(String dids) {
+        String dids = _deckLimit();
         return mCol.getDb().queryScalar("SELECT count() FROM cards WHERE did IN " + dids, false);
     }
 
 
     public int matureCount() {
-        return matureCount(_deckLimit());
-    }
-
-
-    public int matureCount(String dids) {
+        String dids = _deckLimit();
         return mCol.getDb().queryScalar("SELECT count() FROM cards WHERE type = 2 AND ivl >= 21 AND did IN " + dids,
                 false);
     }
@@ -2425,7 +2380,7 @@ public class Sched {
      * @param card
      * @return [progressCurrentDeck, progressAllDecks, leftCards, eta]
      */
-    public float[] progressToday(TreeSet<Object[]> counts, Card card, boolean eta) {
+    public float[] progressToday(List<DeckDueTreeNode> counts, Card card, boolean eta) {
         try {
             int doneCurrent = 0;
             int[] leftCurrent = new int[]{0, 0, 0};
@@ -2458,15 +2413,15 @@ public class Sched {
                 mCachedDeckCounts.clear();
                 if (counts == null) {
                     // reload counts
-                    counts = (TreeSet<Object[]>)deckCounts()[0];
+                    counts = deckDueList();
                 }
-                for (Object[] d : counts) {
+                for (DeckDueTreeNode d : counts) {
                     int done = 0;
-                    JSONObject deck = mCol.getDecks().get((Long) d[1]);
+                    JSONObject deck = mCol.getDecks().get(d.did);
                     for (String s : cs) {
                         done += deck.getJSONArray(s + "Today").getInt(1);
                     }
-                    mCachedDeckCounts.put((Long)d[1], new Pair<String[], long[]> ((String[])d[0], new long[]{done, (Integer)d[2], (Integer)d[3], (Integer)d[4]}));
+                    mCachedDeckCounts.put(d.did, new Pair<String[], long[]> (d.names, new long[]{done, d.newCount, d.lrnCount, d.newCount}));
                 }
             }
 
@@ -2600,47 +2555,6 @@ public class Sched {
     }
 
 
-    public Object[] deckCounts() {
-        TreeSet<Object[]> decks = deckDueTree();
-        int[] counts = new int[] { 0, 0, 0 };
-        for (Object[] deck : decks) {
-            if (((String[]) deck[0]).length == 1) {
-                counts[0] += (Integer) deck[2];
-                counts[1] += (Integer) deck[3];
-                counts[2] += (Integer) deck[4];
-            }
-        }
-        TreeSet<Object[]> decksNet = new TreeSet<Object[]>(new DeckNameCompare());
-        for (Object[] d : decks) {
-            try {
-                boolean show = true;
-                for (JSONObject o : mCol.getDecks().parents((Long) d[1])) {
-                    if (o.getBoolean("collapsed")) {
-                        show = false;
-                        break;
-                    }
-                }
-                if (show) {
-                    JSONObject deck = mCol.getDecks().get((Long) d[1]);
-                    if (deck.getBoolean("collapsed")) {
-                        String[] name = (String[]) d[0];
-                        name[name.length - 1] = name[name.length - 1] + " (+)";
-                        d[0] = name;
-                    }
-                    decksNet.add(new Object[]{d[0], d[1], d[2], d[3], d[4], deck.getInt("dyn") != 0});
-                }
-            } catch (JSONException e) {
-                throw new RuntimeException(e);
-            }
-        }
-        return new Object[] { decksNet, eta(counts), mCol.cardCount() };
-    }
-
-
-    public void setSpreadRev(boolean mSpreadRev) {
-        this.mSpreadRev = mSpreadRev;
-    }
-
     /**
      * Sorts a card into the lrn queue LIBANKI: not in libanki
      */
@@ -2671,5 +2585,57 @@ public class Sched {
 
     public void setContext(WeakReference<Activity> contextReference) {
         mContextReference = contextReference;
+    }
+
+
+    /**
+     * Holds the data for a single node (row) in the deck due tree (the user-visible list
+     * of decks and their counts). A node also contains a list of nodes that refer to the
+     * next level of sub-decks for that particular deck (which can be an empty list).
+     *
+     * The names field is an array of names that build a deck name from a hierarchy (i.e., a nested
+     * deck will have an entry for every level of nesting). While the python version interchanges
+     * between a string and a list of strings throughout processing, we always use an array for
+     * this field and use names[0] for those cases.
+     */
+    public class DeckDueTreeNode implements Comparable {
+        public String[] names;
+        public long did;
+        public int revCount;
+        public int lrnCount;
+        public int newCount;
+        public List<DeckDueTreeNode> children = new ArrayList<DeckDueTreeNode>();
+
+        public DeckDueTreeNode(String[] names, long did, int revCount, int lrnCount, int newCount) {
+            this.names = names;
+            this.did = did;
+            this.revCount = revCount;
+            this.lrnCount = lrnCount;
+            this.newCount = newCount;
+        }
+
+        public DeckDueTreeNode(String name, long did, int revCount, int lrnCount, int newCount) {
+            this(new String[]{name}, did, revCount, lrnCount, newCount);
+        }
+
+        public DeckDueTreeNode(String name, long did, int revCount, int lrnCount, int newCount,
+                               List<DeckDueTreeNode> children) {
+            this(new String[]{name}, did, revCount, lrnCount, newCount);
+            this.children = children;
+        }
+
+        /**
+         * Sort on the head of the node.
+         */
+        @Override
+        public int compareTo(Object other) {
+            return this.names[0].compareTo(((DeckDueTreeNode)other).names[0]);
+        }
+
+        @Override
+        public String toString() {
+            return String.format("%s, %d, %d, %d, %d, %s",
+                    Arrays.toString(names), did, revCount, lrnCount, newCount, children);
+        }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/widget/WidgetStatus.java
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/WidgetStatus.java
@@ -20,15 +20,15 @@ import android.content.SharedPreferences;
 import android.database.SQLException;
 import android.os.AsyncTask;
 
-
 import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.MetaDB;
 import com.ichi2.anki.services.NotificationService;
 import com.ichi2.async.BaseAsyncTask;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Decks;
+import com.ichi2.libanki.Sched;
 
-import java.util.TreeSet;
+import java.util.List;
 
 import timber.log.Timber;
 
@@ -46,7 +46,7 @@ public final class WidgetStatus {
 
     private static DeckStatus sDeckStatus;
     private static float[] sSmallWidgetStatus;
-    private static TreeSet<Object[]> sDeckCounts;
+    private static List<Sched.DeckDueTreeNode> sDeckCounts;
 
     private static AsyncTask<Context, Void, Context> sUpdateDeckStatusAsyncTask;
 
@@ -68,7 +68,7 @@ public final class WidgetStatus {
     }
 
 
-    public static void update(Context context, TreeSet<Object[]> deckCounts) {
+    public static void update(Context context, List<Sched.DeckDueTreeNode> deckCounts) {
         update(context, true, null, null, deckCounts);
     }
 
@@ -79,7 +79,7 @@ public final class WidgetStatus {
 
 
     public static void update(Context context, boolean updateBigWidget, DeckStatus deckStatus,
-            float[] smallWidgetStatus, TreeSet<Object[]> deckCounts) {
+            float[] smallWidgetStatus, List<Sched.DeckDueTreeNode> deckCounts) {
         sDeckStatus = deckStatus;
         sSmallWidgetStatus = smallWidgetStatus;
         sDeckCounts = deckCounts;


### PR DESCRIPTION
I started out wanting to hide the default deck and realised it wasn't simple with the current way we were doing the deck list. The deck still needs to be shown if it has subdecks, and the existing approach didn't retain any relationship between rows in the deck list. After closely looking at the code I realised a lot of the steps to building the deck list were all over the place. This commit cleans up a lot of that, resolves some issues and enhances UI performance.

There are three main parts to this commit:

1 - The data structure used to build the deck list was rewritten to better match the desktop version. This also makes it easier to build the UI portion in a similar way and lets us resolve [Issue 1550](https://code.google.com/p/ankidroid/issues/detail?id=1550). Our version stores row data in a new class as it is easier to work with in Java. This class holds the comparator which decides the order of the deck list. That was modified as well and resolves [Issue 1860](https://code.google.com/p/ankidroid/issues/detail?id=1860). That does mean the order will change for a lot of users but it does mean we match the desktop order. The issue tracker has some good reasons for why we should do that.

2 - There were many cases where the deck list was rebuilt or the user interface refreshed that were redundant. This was especially bad on tablets where the decklist and study options fragment were frequently built twice or 3 times in some cases. This commit consolidates the refresh code into one method (for each component) so there is only one entry point to interface refreshes and removed a lot of the redundant updates. The UI should appear faster to anyone with a large collection, and it's significanlty better on tablets.

3 - There are times on tablets when the deck list and study options fragment are out of sync, like which deck is highlighted, the counts in each, or scrolling the deck list so that the current deck is visible. The logic for what to do for these tasks is now entirely in DeckPicker instead of trying to cross-communicate between comopnents so they should be mostly resolved.

Some UI changes with this commit:
- The current deck will be highlighted on the single-panel version as well. I think it's useful to show the current deck in every version mainly because of the "use current deck" adding option. I use this option and found myself opening a deck and going back just to be sure I have that deck set as the current deck, even though it probably already was. It's also faintly highlighted on the desktop version, so there's that too. Now, the *style* of the highlighting is not suitable on the phone version, but I think we can improve that later with all the theming work that others are doing.

- The indenting on subdecks is the same on all levels. It used to be much smaller on the first level. We can fix that easily if not desirable. I kind of liked it more.

- Removed animation from studyoptions loading on tablets. It felt sluggish when the fragment could load much faster than the animation.