### PR TITLE
Decouple the namespace for custom XML attributes from app name

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -128,7 +128,7 @@ import timber.log.Timber;
 public class AnkiDroidApp extends Application {
 
     public static final int SDK_VERSION = android.os.Build.VERSION.SDK_INT;
-    public static final String APP_NAMESPACE = "http://schemas.android.com/apk/res/com.ichi2.anki";
+    public static final String XML_CUSTOM_NAMESPACE = "http://arbitrary.app.namespace/com.ichi2.anki";
     public static final String FEEDBACK_REPORT_ASK = "2";
     public static final String FEEDBACK_REPORT_NEVER = "1";
     public static final String FEEDBACK_REPORT_ALWAYS = "0";

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/NumberRangePreference.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/NumberRangePreference.java
@@ -125,7 +125,7 @@ public class NumberRangePreference extends EditTextPreference {
      * This method should only be called once from the constructor.
      */
     private int getMinFromAttributes(AttributeSet attrs) {
-        return attrs == null ? 0 : attrs.getAttributeIntValue(AnkiDroidApp.APP_NAMESPACE, "min", 0);
+        return attrs == null ? 0 : attrs.getAttributeIntValue(AnkiDroidApp.XML_CUSTOM_NAMESPACE, "min", 0);
     }
 
 
@@ -135,7 +135,7 @@ public class NumberRangePreference extends EditTextPreference {
      * This method should only be called once from the constructor.
      */
     private int getMaxFromAttributes(AttributeSet attrs) {
-        return attrs == null ? Integer.MAX_VALUE : attrs.getAttributeIntValue(AnkiDroidApp.APP_NAMESPACE, "max",
+        return attrs == null ? Integer.MAX_VALUE : attrs.getAttributeIntValue(AnkiDroidApp.XML_CUSTOM_NAMESPACE, "max",
                 Integer.MAX_VALUE);
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/StepsPreference.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/StepsPreference.java
@@ -168,6 +168,6 @@ public class StepsPreference extends EditTextPreference {
         if (attrs == null) {
             return true;
         }
-        return attrs.getAttributeBooleanValue(AnkiDroidApp.APP_NAMESPACE, "allowEmpty", true);
+        return attrs.getAttributeBooleanValue(AnkiDroidApp.XML_CUSTOM_NAMESPACE, "allowEmpty", true);
     }
 }

--- a/AnkiDroid/src/main/res/xml/cram_deck_options.xml
+++ b/AnkiDroid/src/main/res/xml/cram_deck_options.xml
@@ -16,7 +16,7 @@
 -->
 
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res/com.ichi2.anki" >
+    xmlns:app="http://arbitrary.app.namespace/com.ichi2.anki" >
 
     <PreferenceCategory android:title="@string/deck_conf_cram_filter" >
         <EditTextPreference

--- a/AnkiDroid/src/main/res/xml/deck_options.xml
+++ b/AnkiDroid/src/main/res/xml/deck_options.xml
@@ -16,7 +16,7 @@
 -->
 
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res/com.ichi2.anki" >
+    xmlns:app="http://arbitrary.app.namespace/com.ichi2.anki" >
         <ListPreference
             android:key="deckConf"
             android:title="@string/deck_conf_group" />

--- a/AnkiDroid/src/main/res/xml/preferences.xml
+++ b/AnkiDroid/src/main/res/xml/preferences.xml
@@ -22,7 +22,7 @@
 
 <!--  General Preferences -->
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res/com.ichi2.anki" >
+    xmlns:app="http://arbitrary.app.namespace/com.ichi2.anki" >
     <PreferenceScreen android:title="@string/pref_cat_general"
         android:summary="@string/pref_cat_general_summ" >
         <EditTextPreference


### PR DESCRIPTION
Currently the namespace used to store custom XML attributes is hardcoded to `http://schemas.android.com/apk/res/com.ichi2.anki`, which prevents us from changing the [`applicationId`](http://tools.android.com/tech-docs/new-build-system/applicationid-vs-packagename). This PR fixes that by changing to a new namespace separate from the app name