### PR TITLE
Always reload newest card of stack after performing an operation in note editor

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -154,7 +154,7 @@ public class NoteEditor extends AnkiActivity {
 
     private boolean mChanged = false;
     private boolean mFieldEdited = false;
-    private boolean mRescheduled = false;
+    private boolean mReloadRequired = false;
 
 
     /**
@@ -808,10 +808,10 @@ public class NoteEditor extends AnkiActivity {
     private void changeNoteType(JSONObject oldModel, JSONObject newModel) throws ConfirmModSchemaException {
         final long [] nids = {mEditorNote.getId()};
         getCol().getModels().change(oldModel, nids, newModel, mModelChangeFieldMap, mModelChangeCardMap);
-        // refresh the note & card objects to reflect the database changes
-        mCurrentEditedCard.load();
-        mEditorNote = mCurrentEditedCard.note();
+        // refresh the note object to reflect the database changes
+        mEditorNote.load();
         // close note editor
+        mReloadRequired = true;
         closeNoteEditor();
     }
 
@@ -1005,12 +1005,13 @@ public class NoteEditor extends AnkiActivity {
         } else {
             result = RESULT_CANCELED;
         }
-        if (mRescheduled) {
+        if (mReloadRequired) {
             if (intent == null) {
                 intent = new Intent();
             }
-            intent.putExtra("rescheduled", true);
+            intent.putExtra("reloadRequired", true);
         }
+
         closeNoteEditor(result, intent);
     }
 
@@ -1088,7 +1089,7 @@ public class NoteEditor extends AnkiActivity {
                         Timber.i("NoteEditor:: OK button pressed");
                         getCol().getSched().forgetCards(new long[] { mCurrentEditedCard.getId() });
                         getCol().reset();
-                        mRescheduled = true;
+                        mReloadRequired = true;
                         Themes.showThemedToast(NoteEditor.this,
                                 getResources().getString(R.string.reset_card_dialog_acknowledge), true);
                     }
@@ -1112,7 +1113,7 @@ public class NoteEditor extends AnkiActivity {
                         int days = Integer.parseInt(((EditText) rescheduleEditText).getText().toString());
                         getCol().getSched().reschedCards(new long[] { mCurrentEditedCard.getId() }, days, days);
                         getCol().reset();
-                        mRescheduled = true;
+                        mReloadRequired = true;
                         Themes.showThemedToast(NoteEditor.this,
                                 getResources().getString(R.string.reschedule_card_dialog_acknowledge), true);
                     }


### PR DESCRIPTION
This fixes two bugs:

1) Changing the note type from a card with `getOrd()>0` to a note type with only one card was causing a [crash](https://ankidroid.org/couchdb/acralyzer/_design/acralyzer/index.html#/report-details/ankidroid/d4ee961f-c991-4454-acc2-0ec793d817c2). It crashes because the card ceases to exist.

2) Changing the deck of a card from the reviewer via the note editor, in such a way that the current card is no longer supposed to be reviewed, would not force an update of the card in the reviewer.

@hssm do you have time to review this?