### PR TITLE
Make sure the card count is always rebuilt in StudyOptionsFragment

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1016,6 +1016,8 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
         restartTimer();
         // Set the context for the Sound manager
         Sound.setContext(new WeakReference<Activity>(this));
+        // Reset the activity title
+        deselectAllNavigationItems();
     }
 
 


### PR DESCRIPTION
Always do `resetAndRefreshInterface()` in StudyOptionsFragment unless last activity was cancelled. 

I made the `onActivityResult()` code a bit more readable as well while I was in the process, and also fixed a bug where Activity title was incorrect in Reviewer after using navigation drawer.