### PR TITLE
initialize AnkiDroid dir in openCollection method

### DIFF
--- a/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/MediaTest.java
+++ b/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/MediaTest.java
@@ -38,15 +38,7 @@ import com.ichi2.utils.*;
  */
 public class MediaTest extends AndroidTestCase {
     public void testAdd() throws IOException, APIVersionException {
-        // Hack to wait for the main application to be initialized since it runs in a different thread
-        while (AnkiDroidApp.getInstance() == null || AnkiDroidApp.getHooks() == null) {
-            try {
-                Thread.sleep(100);
-            } catch (InterruptedException e) {
-                // do nothing
-            }
-        }
-        Collection d = Shared.getEmptyCol();
+        Collection d = Shared.getEmptyCol(mContext);
         File dir = Shared.getTestDir(mContext);
         BackupManager.removeDir(dir);
         dir.mkdirs();
@@ -69,7 +61,7 @@ public class MediaTest extends AndroidTestCase {
 
 
     public void testStrings() throws IOException {
-        Collection d = Shared.getEmptyCol();
+        Collection d = Shared.getEmptyCol(mContext);
         Long mid = d.getModels().getModels().entrySet().iterator().next().getKey();
         List<String> expected;
         List<String> actual;
@@ -123,7 +115,7 @@ public class MediaTest extends AndroidTestCase {
     }
 
     public void testDeckIntegration() throws IOException, APIVersionException {
-        Collection d = Shared.getEmptyCol();
+        Collection d = Shared.getEmptyCol(mContext);
         // create a media dir
         d.getMedia().dir();
         // Put a file into it
@@ -171,7 +163,7 @@ public class MediaTest extends AndroidTestCase {
     }
 
     public void testChanges() throws IOException, APIVersionException {
-        Collection d = Shared.getEmptyCol();
+        Collection d = Shared.getEmptyCol(mContext);
         assertTrue(d.getMedia()._changed() != null);
         assertTrue(added(d).size() == 0);
         assertTrue(removed(d).size() == 0);
@@ -210,7 +202,7 @@ public class MediaTest extends AndroidTestCase {
 
 
     public void testIllegal() throws IOException {
-        Collection d = Shared.getEmptyCol();
+        Collection d = Shared.getEmptyCol(mContext);
         String aString = "a:b|cd\\e/f\0g*h";
         String good = "abcdefgh";
         assertTrue(d.getMedia().stripIllegal(aString).equals(good));

--- a/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/Shared.java
+++ b/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/Shared.java
@@ -19,7 +19,6 @@ package com.ichi2.anki.tests;
 import android.content.Context;
 
 import com.ichi2.anki.AnkiDroidApp;
-import com.ichi2.anki.BackupManager;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Storage;
 
@@ -31,12 +30,13 @@ import java.io.IOException;
  */
 public class Shared {
 
-    public static Collection getEmptyCol() throws IOException {
+    public static Collection getEmptyCol(Context context) throws IOException {
         File f = File.createTempFile("test", ".anki2");
         // Provide a string instead of an actual File. Storage.Collection won't populate the DB
         // if the file already exists (it assumes it's an existing DB).
         String path = f.getAbsolutePath();
         f.delete();
+        AnkiDroidApp.initializeHooks(context);
         return Storage.Collection(path);
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -864,15 +864,16 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
 
 
     private void showStartupScreensAndDialogs(SharedPreferences preferences, int skip) {
+        String mainDirectory = AnkiDroidApp.getCurrentAnkiDroidDirectory();
         if (!AnkiDroidApp.isSdCardMounted()) {
             // SD Card not mounted
             showSdCardNotMountedDialog();
-        } else if (!AnkiDroidApp.isCurrentAnkiDroidDirAccessible()) {
+        } else if (!AnkiDroidApp.isAnkiDroidDirAccessible(mainDirectory)) {
             // AnkiDroid directory inaccessible
             Intent i = new Intent(this, Preferences.class);
             startActivityWithoutAnimation(i);
             Themes.showThemedToast(this, getResources().getString(R.string.directory_inaccessible), false);
-        } else if (!BackupManager.enoughDiscSpace(AnkiDroidApp.getCurrentAnkiDroidDirectory())) {
+        } else if (!BackupManager.enoughDiscSpace(mainDirectory)) {
             // Not enough space to do backup
             showDialogFragment(DeckPickerNoSpaceLeftDialog.newInstance());
         } else if (preferences.getBoolean("noSpaceLeft", false)) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -186,11 +186,10 @@ public class Preferences extends PreferenceActivity implements OnSharedPreferenc
         collectionPathPreference.setOnPreferenceChangeListener(new OnPreferenceChangeListener() {
             public boolean onPreferenceChange(Preference preference, final Object newValue) {
                 final String newPath = (String) newValue;
-                try {
-                    AnkiDroidApp.initializeAnkiDroidDirectory(newPath);
+                if (AnkiDroidApp.isAnkiDroidDirAccessible(newPath)) {
                     return true;
-                } catch (StorageAccessException e) {
-                    Timber.e(e, "Could not initialize directory: %s", newPath);
+                } else {
+                    Timber.e("Could not initialize directory: %s", newPath);
                     Toast.makeText(getApplicationContext(), R.string.dialog_collection_path_not_dir, Toast.LENGTH_LONG).show();
                     return false;
                 }


### PR DESCRIPTION
Media tests and the new ContentProvider require direct access to the collection from a different thread than the AnkiDroidApp. This PR decouples those processes from AnkiDroidApp by making sure that the AnkiDroid directory has been initialized before opening the collection, regardless of whether the `AnkiDroidApp.onCreate()` method has been completed.

@hssm what do you think?