### PR TITLE
Improved directory initialisation

### DIFF
--- a/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/DirInitTest.java
+++ b/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/DirInitTest.java
@@ -1,0 +1,22 @@
+package com.ichi2.anki.tests;
+
+import android.test.AndroidTestCase;
+import com.ichi2.anki.AnkiDroidApp;
+
+/**
+ * This test case verifies that the directory initialization works even if the app is not yet fully initialized.
+ */
+public class DirInitTest extends AndroidTestCase{
+    public void testDirInit() {
+        assertNull("AnkiDroidApp is already initialized, test is pointless",
+                AnkiDroidApp.getInstance());
+        assertFalse("Collection is already open, test is pointless",
+                AnkiDroidApp.colIsOpen());
+        assertNull("Collection is already open, test is pointless",
+                AnkiDroidApp.getCol());
+        String path = AnkiDroidApp.getCollectionPath(getContext());
+        assertNotNull("Collection path is invalid", path);
+        assertNotNull("Collection could not be opened", AnkiDroidApp.openCollection(getContext(), path));
+    }
+
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -2233,7 +2233,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
 
             if (SAVE_CARD_CONTENT) {
                 try {
-                    FileOutputStream f = new FileOutputStream(new File(AnkiDroidApp.getCurrentAnkiDroidDirectory(),
+                    FileOutputStream f = new FileOutputStream(new File(AnkiDroidApp.getCurrentAnkiDroidDirectory(getApplicationContext()),
                             "card.html"));
                     try {
                         f.write(mCardContent.toString().getBytes());
@@ -3030,7 +3030,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
 
         @Override
         public Drawable getDrawable(String source) {
-            String path = AnkiDroidApp.getCurrentAnkiDroidDirectory() + "/collection.media/" + source;
+            String path = AnkiDroidApp.getCurrentAnkiDroidDirectory(getApplicationContext()) + "/collection.media/" + source;
             if ((new File(path)).exists()) {
                 Drawable d = Drawable.createFromPath(path);
                 d.setBounds(0, 0, d.getIntrinsicWidth(), d.getIntrinsicHeight());

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -522,11 +522,17 @@ public class AnkiDroidApp extends Application {
 
 
     public static synchronized Collection openCollection(Context context, String path, boolean force) {
-        mLock.lock();
         Timber.i("openCollection: %s", path);
         if (sHooks == null) {
             sHooks = new Hooks(getSharedPrefs(context));
         }
+        try {
+            initializeAnkiDroidDirectory(path);
+        } catch (StorageAccessException e) {
+            Timber.e(e, "Could not initialize AnkiDroid directory: %s", path);
+            return null;
+        }
+        mLock.lock();
         try {
             if (!colIsOpen() || !sCurrentCollection.getPath().equals(path) || force) {
                 if (colIsOpen()) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.java
@@ -16,6 +16,7 @@
 
 package com.ichi2.anki;
 
+import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.StatFs;
 
@@ -80,8 +81,8 @@ public class BackupManager {
     }
 
 
-    private static File getBackupDirectory() {
-        File directory = new File(AnkiDroidApp.getCurrentAnkiDroidDirectory(), BACKUP_SUFFIX);
+    private static File getBackupDirectory(Context context) {
+        File directory = new File(AnkiDroidApp.getCurrentAnkiDroidDirectory(context), BACKUP_SUFFIX);
         if (!directory.isDirectory()) {
             directory.mkdirs();
         }
@@ -89,8 +90,8 @@ public class BackupManager {
     }
 
 
-    private static File getBrokenDirectory() {
-        File directory = new File(AnkiDroidApp.getCurrentAnkiDroidDirectory(), BROKEN_DECKS_SUFFIX);
+    private static File getBrokenDirectory(Context context) {
+        File directory = new File(AnkiDroidApp.getCurrentAnkiDroidDirectory(context), BROKEN_DECKS_SUFFIX);
         if (!directory.isDirectory()) {
             directory.mkdirs();
         }
@@ -156,7 +157,7 @@ public class BackupManager {
         }
 
         // Abort backup if destination already exists (extremely unlikely)
-        final File backupFile = new File(getBackupDirectory().getPath(), backupFilename);
+        final File backupFile = new File(getBackupDirectory(AnkiDroidApp.getInstance()).getPath(), backupFilename);
         if (backupFile.exists()) {
             Timber.d("performBackup: No new backup created. File already exists");
             return false;
@@ -281,14 +282,15 @@ public class BackupManager {
     public static boolean moveDatabaseToBrokenFolder(String colPath, boolean moveConnectedFilesToo) {
         File colFile = new File(colPath);
 
+        Context context = AnkiDroidApp.getInstance();
         // move file
         Date value = Utils.genToday(Utils.utcOffset());
         String movedFilename = String.format(Utils.ENGLISH_LOCALE, colFile.getName().replace(".anki2", "")
                 + "-corrupt-%tF.anki2", value);
-        File movedFile = new File(getBrokenDirectory().getPath(), movedFilename);
+        File movedFile = new File(getBrokenDirectory(context).getPath(), movedFilename);
         int i = 1;
         while (movedFile.exists()) {
-            movedFile = new File(getBrokenDirectory().getPath(), movedFilename.replace(".anki2",
+            movedFile = new File(getBrokenDirectory(context).getPath(), movedFilename.replace(".anki2",
                     "-" + Integer.toString(i) + ".anki2"));
             i++;
         }
@@ -303,7 +305,7 @@ public class BackupManager {
             File directory = new File(colFile.getParent());
             for (File f : directory.listFiles()) {
                 if (f.getName().startsWith(deckName)) {
-                    if (!f.renameTo(new File(getBrokenDirectory().getPath(), f.getName().replace(deckName,
+                    if (!f.renameTo(new File(getBrokenDirectory(context).getPath(), f.getName().replace(deckName,
                             movedFilename)))) {
                         return false;
                     }
@@ -315,7 +317,7 @@ public class BackupManager {
 
 
     public static File[] getBackups(File colFile) {
-        File[] files = getBackupDirectory().listFiles();
+        File[] files = getBackupDirectory(AnkiDroidApp.getInstance()).listFiles();
         if (files == null) {
             files = new File[0];
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -867,12 +867,12 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
         if (!AnkiDroidApp.isSdCardMounted()) {
             // SD Card not mounted
             showSdCardNotMountedDialog();
-        } else if (!AnkiDroidApp.isCurrentAnkiDroidDirAccessible()) {
+        } else if (!AnkiDroidApp.isCurrentAnkiDroidDirAccessible(getApplicationContext())) {
             // AnkiDroid directory inaccessible
             Intent i = new Intent(this, Preferences.class);
             startActivityWithoutAnimation(i);
             Themes.showThemedToast(this, getResources().getString(R.string.directory_inaccessible), false);
-        } else if (!BackupManager.enoughDiscSpace(AnkiDroidApp.getCurrentAnkiDroidDirectory())) {
+        } else if (!BackupManager.enoughDiscSpace(AnkiDroidApp.getCurrentAnkiDroidDirectory(getApplicationContext()))) {
             // Not enough space to do backup
             showDialogFragment(DeckPickerNoSpaceLeftDialog.newInstance());
         } else if (preferences.getBoolean("noSpaceLeft", false)) {
@@ -913,7 +913,7 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
             // Delete the media database made by any version before 2.3 beta due to upgrade errors.
             // It is rebuilt on the next sync or media check
             if (previous < 20300200) {
-                File mediaDb = new File(AnkiDroidApp.getCurrentAnkiDroidDirectory(), "collection.media.ad.db2");
+                File mediaDb = new File(AnkiDroidApp.getCurrentAnkiDroidDirectory(getApplicationContext()), "collection.media.ad.db2");
                 if (mediaDb.exists()) {
                     mediaDb.delete();
                 }
@@ -1128,7 +1128,7 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
             @Override
             public void onCancelled() {
             }
-        }, new DeckTask.TaskData(AnkiDroidApp.getCol(), AnkiDroidApp.getCollectionPath()));
+        }, new DeckTask.TaskData(AnkiDroidApp.getCol(), AnkiDroidApp.getCollectionPath(getApplicationContext())));
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
@@ -153,7 +153,7 @@ public class NavigationDrawerActivity extends AnkiActivity {
 
                 break;
             case DRAWER_SETTINGS:
-                mOldColPath = AnkiDroidApp.getCurrentAnkiDroidDirectory();
+                mOldColPath = AnkiDroidApp.getCurrentAnkiDroidDirectory(getApplicationContext());
                 startActivityForResultWithAnimation(new Intent(this, Preferences.class), REQUEST_PREFERENCES_UPDATE, ActivityTransitionAnimation.LEFT);
                 break;
             
@@ -306,7 +306,7 @@ public class NavigationDrawerActivity extends AnkiActivity {
         AnkiDroidApp.setLanguage(preferences.getString(Preferences.LANGUAGE, ""));
         // Restart the activity on preference change
         if (requestCode == REQUEST_PREFERENCES_UPDATE) {
-            if (mOldColPath!=null && AnkiDroidApp.getCurrentAnkiDroidDirectory().equals(mOldColPath)) {
+            if (mOldColPath!=null && AnkiDroidApp.getCurrentAnkiDroidDirectory(getApplicationContext()).equals(mOldColPath)) {
                 // collection path hasn't been changed so just restart the current activity
                 if ((this instanceof Reviewer) && preferences.getBoolean("tts", false)) {
                     // Workaround to kick user back to StudyOptions after opening settings from Reviewer

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -623,7 +623,7 @@ public class Preferences extends PreferenceActivity implements OnSharedPreferenc
                 builder.setTitle(res.getString(R.string.fix_hebrew_text));
                 builder.setCancelable(false);
                 builder.setMessage(res.getString(R.string.fix_hebrew_instructions,
-                        AnkiDroidApp.getCurrentAnkiDroidDirectory()));
+                        AnkiDroidApp.getCurrentAnkiDroidDirectory(getApplicationContext())));
                 builder.setNegativeButton(R.string.dialog_cancel, null);
                 builder.setPositiveButton(res.getString(R.string.fix_hebrew_download_font), new OnClickListener() {
                     @Override

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
@@ -926,7 +926,7 @@ public class StudyOptionsFragment extends Fragment implements LoaderManager.Load
         if (col != null) {
             onCollectionLoaded(col);
         } else {
-            AnkiDatabaseManager.closeDatabase(AnkiDroidApp.getCollectionPath());
+            AnkiDatabaseManager.closeDatabase(AnkiDroidApp.getCollectionPath(getActivity()));
             //showDialog(DIALOG_LOAD_FAILED);
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.java
@@ -246,7 +246,7 @@ public class DatabaseErrorDialog extends AsyncDialogFragment {
 
             case DIALOG_RESTORE_BACKUP:
                 // Allow user to restore one of the backups
-                File[] files = BackupManager.getBackups(new File(AnkiDroidApp.getCollectionPath()));
+                File[] files = BackupManager.getBackups(new File(AnkiDroidApp.getCollectionPath(getActivity())));
                 mBackups = new File[files.length];
                 for (int i = 0; i < files.length; i++) {
                     mBackups[i] = files[files.length - 1 - i];
@@ -302,7 +302,7 @@ public class DatabaseErrorDialog extends AsyncDialogFragment {
                             @Override
                             public void onClick(DialogInterface dialog, int which) {
                                 AnkiDroidApp.closeCollection(false);
-                                String path = AnkiDroidApp.getCollectionPath();
+                                String path = AnkiDroidApp.getCollectionPath(getActivity());
                                 AnkiDatabaseManager.closeDatabase(path);
                                 if (BackupManager.moveDatabaseToBrokenFolder(path, false)) {
                                     ((DatabaseErrorDialogListener) getActivity()).startLoadingCollection();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportDialog.java
@@ -64,7 +64,7 @@ public class ImportDialog extends DialogFragment {
             case DIALOG_IMPORT_HINT:
                 // Instruct the user that they need to put their APKG files into the AnkiDroid directory
                 builder.setTitle(res.getString(R.string.import_title));
-                builder.setMessage(res.getString(R.string.import_hint, AnkiDroidApp.getCurrentAnkiDroidDirectory()));
+                builder.setMessage(res.getString(R.string.import_hint, AnkiDroidApp.getCurrentAnkiDroidDirectory(getActivity())));
                 builder.setPositiveButton(res.getString(R.string.dialog_ok), new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
@@ -78,7 +78,7 @@ public class ImportDialog extends DialogFragment {
                 // Allow user to choose from the list of available APKG files
                 builder.setTitle(res.getString(R.string.import_select_title));
                 StyledDialog dialog = builder.create();
-                List<File> fileList = Utils.getImportableDecks();
+                List<File> fileList = Utils.getImportableDecks(getActivity());
                 if (fileList.size() == 0) {
                     Themes.showThemedToast(getActivity(),
                             getResources().getString(R.string.upgrade_import_no_file_found, "'.apkg'"), false);

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionLoader.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionLoader.java
@@ -29,10 +29,9 @@ public class CollectionLoader extends AsyncTaskLoader<Collection> {
     @Override
     public Collection loadInBackground() {
         // load collection
-        Resources res = AnkiDroidApp.getInstance().getBaseContext().getResources();
-        String colPath = AnkiDroidApp.getCollectionPath();
+        String colPath = AnkiDroidApp.getCollectionPath(getContext());
         try {
-            return AnkiDroidApp.openCollection(colPath);
+            return AnkiDroidApp.openCollection(getContext(), colPath);
         } catch (RuntimeException e) {
             Timber.e(e, "loadInBackground - RuntimeException on opening collection");
             AnkiDroidApp.sendExceptionReport(e, "CollectionLoader.loadInBackground");
@@ -62,7 +61,7 @@ public class CollectionLoader extends AsyncTaskLoader<Collection> {
             Timber.w("CollectionLoader.onStartLoading() -- sync in progress; don't load collection");
             return;
         }
-        String colPath = AnkiDroidApp.getCollectionPath();
+        String colPath = AnkiDroidApp.getCollectionPath(getContext());
         if (AnkiDroidApp.colIsOpen() && AnkiDroidApp.getCol() != null && AnkiDroidApp.getCol().getPath().equals(colPath)) {
             // deliver current path if open and valid
             Timber.d("CollectionLoader.onStartLoading() -- deliverResult as col already open");

--- a/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
@@ -404,7 +404,7 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
                 return data;
             }
         }
-        String path = AnkiDroidApp.getCollectionPath();
+        String path = AnkiDroidApp.getCollectionPath(AnkiDroidApp.getInstance());
         try {
             AnkiDroidApp.sSyncInProgressFlag = true;
             HttpSyncer server = new RemoteServer(this, hkey);
@@ -454,13 +454,13 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
                         if (ret == null) {
                             data.success = false;
                             data.result = new Object[] { "genericError" };
-                            AnkiDroidApp.openCollection(path);
+                            AnkiDroidApp.openCollection(AnkiDroidApp.getInstance(), path);
                             return data;
                         }
                         if (!ret[0].equals(HttpSyncer.ANKIWEB_STATUS_OK)) {
                             data.success = false;
                             data.result = ret;
-                            AnkiDroidApp.openCollection(path);
+                            AnkiDroidApp.openCollection(AnkiDroidApp.getInstance(), path);
                             return data;
                         }
                     } else if (conflictResolution.equals("download")) {
@@ -470,19 +470,19 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
                         if (ret == null) {
                             data.success = false;
                             data.result = new Object[] { "genericError" };
-                            AnkiDroidApp.openCollection(path);
+                            AnkiDroidApp.openCollection(AnkiDroidApp.getInstance(), path);
                             return data;
                         }
                         if (!ret[0].equals("success")) {
                             data.success = false;
                             data.result = ret;
                             if (!colCorruptFullSync) {
-                                AnkiDroidApp.openCollection(path);
+                                AnkiDroidApp.openCollection(AnkiDroidApp.getInstance(), path);
                             }
                             return data;
                         }
                     }
-                    col = AnkiDroidApp.openCollection(path);
+                    col = AnkiDroidApp.openCollection(AnkiDroidApp.getInstance(), path);
                 } catch (OutOfMemoryError e) {
                     AnkiDroidApp.sendExceptionReport(e, "doInBackgroundSync-fullSync");
                     data.success = false;
@@ -580,7 +580,7 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
             col.close(false);
             AnkiDroidApp.sSyncInProgressFlag = false;
             Timber.d("doInBackgroundSync -- reopening collection on outer finally statement");
-            AnkiDroidApp.openCollection(AnkiDroidApp.getCollectionPath());
+            AnkiDroidApp.openCollection(AnkiDroidApp.getInstance(), AnkiDroidApp.getCollectionPath(AnkiDroidApp.getInstance()));
         }
 
     }
@@ -750,7 +750,7 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
 
     private Payload doInBackgroundDownloadSharedDeck(Payload data) {
         String url = (String) data.data[0];
-        String colFilename = AnkiDroidApp.getCurrentAnkiDroidDirectory() + "/tmpImportFile.apkg";
+        String colFilename = AnkiDroidApp.getCurrentAnkiDroidDirectory(AnkiDroidApp.getInstance()) + "/tmpImportFile.apkg";
         URL fileUrl;
         URLConnection conn;
         InputStream cont = null;

--- a/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
@@ -704,7 +704,7 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
         // Try to reopen the collection if it's null
         if (!AnkiDroidApp.colIsOpen()) {
             Timber.e("doInBackgroundCheckDatabase :: collection not open, trying to reload");
-            AnkiDroidApp.openCollection(AnkiDroidApp.getCollectionPath());
+            AnkiDroidApp.openCollection(AnkiDroidApp.getInstance(), AnkiDroidApp.getCollectionPath(AnkiDroidApp.getInstance()));
             col = AnkiDroidApp.getCol();
             if (col == null) {
                 Timber.e("doInBackgroundCheckDatabase :: collection reload failed");
@@ -875,7 +875,7 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
         Resources res = AnkiDroidApp.getInstance().getBaseContext().getResources();
 
         // extract the deck from the zip file
-        String fileDir = AnkiDroidApp.getCurrentAnkiDroidDirectory() + "/tmpzip";
+        String fileDir = AnkiDroidApp.getCurrentAnkiDroidDirectory(AnkiDroidApp.getInstance()) + "/tmpzip";
         File dir = new File(fileDir);
         if (dir.exists()) {
             BackupManager.removeDir(dir);
@@ -927,7 +927,7 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
             BackupManager.performBackupInBackground(colPath, true);
         }
         // overwrite collection
-        colPath = AnkiDroidApp.getCollectionPath();
+        colPath = AnkiDroidApp.getCollectionPath(AnkiDroidApp.getInstance());
         File f = new File(colFile);
         if (!f.renameTo(new File(colPath))) {
             // Exit early if this didn't work
@@ -936,7 +936,7 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
         int addedCount = -1;
         try {
             // open using force close of old collection, as background loader may have reopened the col
-            col = AnkiDroidApp.openCollection(colPath, true);
+            col = AnkiDroidApp.openCollection(AnkiDroidApp.getInstance(), colPath, true);
 
             // because users don't have a backup of media, it's safer to import new
             // data and rely on them running a media db check to get rid of any

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
@@ -1112,7 +1112,7 @@ public class Utils {
 
     /** Returns a list of files for the installed custom fonts. */
     public static List<AnkiFont> getCustomFonts(Context context) {
-        String deckPath = AnkiDroidApp.getCurrentAnkiDroidDirectory();
+        String deckPath = AnkiDroidApp.getCurrentAnkiDroidDirectory(context);
         String fontsPath = deckPath + "/fonts/";
         File fontsDir = new File(fontsPath);
         int fontsCount = 0;
@@ -1158,8 +1158,8 @@ public class Utils {
 
 
     /** Returns a list of apkg-files. */
-    public static List<File> getImportableDecks() {
-        String deckPath = AnkiDroidApp.getCurrentAnkiDroidDirectory();
+    public static List<File> getImportableDecks(Context context) {
+        String deckPath = AnkiDroidApp.getCurrentAnkiDroidDirectory(context);
         File dir = new File(deckPath);
         int deckCount = 0;
         File[] deckList = null;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
@@ -107,7 +107,7 @@ public class Anki2Importer {
         publishProgress(false, 0, 0, false);
         try {
             // extract the deck from the zip file
-            String tempDir = AnkiDroidApp.getCurrentAnkiDroidDirectory() + "/tmpzip";
+            String tempDir = AnkiDroidApp.getCurrentAnkiDroidDirectory(AnkiDroidApp.getInstance()) + "/tmpzip";
             // from anki2.py
             String colFile = tempDir + "/collection.anki2";
             if (!Utils.unzipFiles(mZip, tempDir, new String[] { "collection.anki2", "media" }, null)

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/FullSyncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/FullSyncer.java
@@ -78,7 +78,7 @@ public class FullSyncer extends HttpSyncer {
         } catch (IOException e1) {
             return null;
         }
-        String path = AnkiDroidApp.getCollectionPath();
+        String path = AnkiDroidApp.getCollectionPath(AnkiDroidApp.getInstance());
         if (mCol != null) {
             mCol.close(false);
             mCol = null;

--- a/AnkiDroid/src/main/java/com/ichi2/widget/WidgetStatus.java
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/WidgetStatus.java
@@ -189,7 +189,7 @@ public final class WidgetStatus {
             // } else {
             try {
                 if (sSmallWidgetStatus == null) {
-                    Collection col = AnkiDroidApp.openCollection(AnkiDroidApp.getCollectionPath());
+                    Collection col = AnkiDroidApp.openCollection(context, AnkiDroidApp.getCollectionPath(context));
                     mSmallWidgetStatus = col.getSched().progressToday(sDeckCounts, null, true);
                     AnkiDroidApp.closeCollection(false);
                 } else {

--- a/tools/travis/continuous-test.sh
+++ b/tools/travis/continuous-test.sh
@@ -16,6 +16,7 @@ function start_emulator() {
       --force \
       --name test \
       --target $TARGET \
+      --sdcard 10M \
       --abi $ABI
   emulator -avd test -no-skin -no-audio -no-window -gpu off &
 }


### PR DESCRIPTION
This is a follow-up of PR #759

In the content provider, in case the collection is not already open, we need to access the following methods quite early (i.e. might be before `AnkiDroidApp.onCreate()` has finished):
`AnkiDroidApp.getCollectionPath()`
`AnkiDroidApp.openCollection()`

For getting the collection path, access to shared preferences is needed. This then needs a context. Currently the context is retrieved by accessing `sInstance` which might not be initialised.

Opening the collection itself requires access to the hooks, so `openCollection()` should initialise the static `sHooks` member. For this, again, a context is needed. In PR #759 `sInstance` was used which might not be initialised.

So, my idea was to add a `Context` parameter to both `AnkiDroidApp.getCollectionPath()` and `AnkiDroidApp.openCollection()`. Unfortunately, the methods are called from quite a few places, which again required to extend other methods with a `Context` parameter. In some cases it was safe to assume that `sInstance` is initialised, in other places I could use `getContext()`, `getApplicationContext()`, or `getBaseContext()`.

This is a proof of concept and could maybe be fine-tuned in some cases. Let's use it for discussing the solution. But there are also two major concerns I have.

* I might not have identified all cases where `sInstance` is accessed. It seems that the whole code relies on this global variable quite a lot and my changes might make the code less readable for little benefit.
* Is it safe to access `SharedPreferences` using a context that is sometimes returned by `getContext()`, sometimes by `getApplicationContext()`, and sometimes by `getBaseContext()`? Do we really always get the same `SharedPreferences`?