### PR TITLE
Trim whitespace around template tags

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/template/Template.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/template/Template.java
@@ -165,7 +165,7 @@ public class Template {
 
             String tag = match.group(0);
             String tag_type = match.group(1);
-            String tag_name = match.group(2);
+            String tag_name = match.group(2).trim();
             String replacement;
             if (tag_type == null) {
                 replacement = render_unescaped(tag_name, context);


### PR DESCRIPTION
I managed to miss this case in my tests. It's not a major problem so there's no hurry to rush a fix out for it.