### PR TITLE
Cleaner way to signal opening study options on fragment load

### DIFF
--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -174,7 +174,7 @@
             android:configChanges="keyboardHidden|orientation|locale|screenSize"
             android:label="@string/deckpreferences_title" />
         <activity
-            android:name="com.ichi2.anki.CramDeckOptions"
+            android:name=".FilteredDeckOptions"
             android:configChanges="keyboardHidden|orientation|locale|screenSize"
             android:label="@string/deckpreferences_title" />
         <activity

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -562,10 +562,10 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
                 builder3.setPositiveButton(res.getString(R.string.create), new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
-                        String enteredCramDeckName = mDialogEditText.getText().toString();
+                        String filteredDeckName = mDialogEditText.getText().toString();
                         Timber.i("DeckPicker:: Creating filtered deck...");
-                        long did = getCol().getDecks().newDyn(enteredCramDeckName);
-                        openStudyOptions(did, true);
+                        getCol().getDecks().newDyn(filteredDeckName);
+                        openStudyOptions(true);
                     }
                 });
                 builder3.setNegativeButton(res.getString(R.string.dialog_cancel), null);
@@ -752,7 +752,7 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
             // transactions in a loader's onLoadFinished.
             new Handler().post(new Runnable() {
                 public void run() {
-                    loadStudyOptionsFragment(getCol().getDecks().current().optLong("id"), false);
+                    loadStudyOptionsFragment(false);
                 }
             });
         }
@@ -1505,9 +1505,8 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
      * modify the filter settings before being shown the fragment. The fragment itself will handle
      * rebuilding the deck if the settings change.
      */
-    private void loadStudyOptionsFragment(long deckId, boolean withDeckOptions) {
-        Bundle b = withDeckOptions ? new Bundle() : null;
-        StudyOptionsFragment details = StudyOptionsFragment.newInstance(deckId, b);
+    private void loadStudyOptionsFragment(boolean withDeckOptions) {
+        StudyOptionsFragment details = StudyOptionsFragment.newInstance(withDeckOptions);
         FragmentTransaction ft = getSupportFragmentManager().beginTransaction();
         ft.replace(R.id.studyoptions_fragment, details);
         ft.commit();
@@ -1570,13 +1569,13 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
     }
 
 
-    private void openStudyOptions(long deckId, boolean withDeckOptions) {
+    private void openStudyOptions(boolean withDeckOptions) {
         if (mFragmented) {
             // The fragment will show the study options screen instead of launching a new activity.
-            loadStudyOptionsFragment(deckId, withDeckOptions);
+            loadStudyOptionsFragment(withDeckOptions);
         } else {
             Intent intent = new Intent();
-            intent.putExtra("index", deckId);
+            intent.putExtra("withDeckOptions", withDeckOptions);
             intent.setClass(this, StudyOptionsActivity.class);
             startActivityForResultWithAnimation(intent, SHOW_STUDYOPTIONS, ActivityTransitionAnimation.LEFT);
         }
@@ -1589,7 +1588,7 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
         long did = Long.parseLong(data.get("did"));
         getCol().getDecks().select(did);
         mFocusedDeck = did;
-        openStudyOptions(did, false);
+        openStudyOptions(false);
     }
 
 
@@ -1821,8 +1820,7 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
         // open deck options
         if (getCol().getDecks().isDyn(mContextMenuDid)) {
             // open cram options if filtered deck
-            Intent i = new Intent(DeckPicker.this, CramDeckOptions.class);
-            i.putExtra("cramInitialConfig", (String) null);
+            Intent i = new Intent(DeckPicker.this, FilteredDeckOptions.class);
             i.putExtra("did", mContextMenuDid);
             startActivityWithAnimation(i, ActivityTransitionAnimation.FADE);
         } else {
@@ -1939,7 +1937,7 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
                 // new current deck. Otherwise we just update the list normally.
                 if (mFragmented && removingCurrent) {
                     updateDeckList();
-                    openStudyOptions(getCol().getDecks().current().optLong("id"), false);
+                    openStudyOptions(false);
                 } else {
                     updateDeckList();
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.java
@@ -58,7 +58,7 @@ public class StudyOptionsActivity extends NavigationDrawerActivity implements St
         // create inherited navigation drawer layout here so that it can be used by parent class
         initNavigationDrawer(mainView);
         if (savedInstanceState == null) {
-            loadStudyOptionsFragment(getCol().getDecks().current().optLong("did"), null);
+            loadStudyOptionsFragment();
         }
         registerExternalStorageListener();
     }
@@ -75,13 +75,12 @@ public class StudyOptionsActivity extends NavigationDrawerActivity implements St
     }
 
 
-    private void loadStudyOptionsFragment(long deckId, Bundle cramConfig) {
-        StudyOptionsFragment currentFragment = StudyOptionsFragment.newInstance(deckId, null);
-        Bundle args = getIntent().getExtras();
-        if (cramConfig != null) {
-            args.putBundle("cramInitialConfig", cramConfig);
+    private void loadStudyOptionsFragment() {
+        boolean withDeckOptions = false;
+        if (getIntent().getExtras() != null) {
+            withDeckOptions = getIntent().getExtras().getBoolean("withDeckOptions");
         }
-        currentFragment.setArguments(args);
+        StudyOptionsFragment currentFragment = StudyOptionsFragment.newInstance(withDeckOptions);
         getSupportFragmentManager().beginTransaction().replace(R.id.studyoptions_frame, currentFragment).commit();
     }
 


### PR DESCRIPTION
Removed some redundant fragment/activity arguments and renamed extras and methods to something more descriptive, 

Renamed several mentions of "cram" decks to "filtered" decks including the CramDeckOptions class.

This also fixes a bug I introduced earlier where the deck options didn't open when creating a new filtered deck from the menu on the single-panel version (i.e., when StudyOptionsActivity loads the fragment instead of DeckPicker).