### PR TITLE
Fixes for Navdrawer, Actionbar, DeckPickerContextMenu

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -952,17 +952,9 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
         // Initialize dictionary lookup feature
         Lookup.initialize(this);
 
-        deselectAllNavigationItems();
+        updateScreenCounts();
         supportInvalidateOptionsMenu();
         dismissOpeningCollectionDialog();
-    }
-
-
-    @Override
-    protected void deselectAllNavigationItems() {
-        super.deselectAllNavigationItems();
-        setTitle();
-        updateScreenCounts();
     }
 
 
@@ -989,7 +981,8 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
         // Set the context for the Sound manager
         Sound.setContext(new WeakReference<Activity>(this));
         // Reset the activity title
-        deselectAllNavigationItems();
+        setTitle();
+        updateScreenCounts();
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -333,6 +333,13 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
     // ANDROID ACTIVITY METHODS
     // ----------------------------------------------------------------------------
 
+    /** Returns the navdrawer item that corresponds to this Activity. */
+    @Override
+    protected int getSelfNavDrawerItem() {
+        return DRAWER_DECK_PICKER;
+    }
+
+
     /** Called when the activity is first created. */
     @Override
     protected void onCreate(Bundle savedInstanceState) throws SQLException {
@@ -358,6 +365,7 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
 
         Themes.setContentStyle(mFragmented ? mainView : mainView.findViewById(R.id.deckpicker_view),
                 Themes.CALLER_DECKPICKER);
+        sIsWholeCollection = !mFragmented;
 
         registerExternalStorageListener();
 
@@ -416,8 +424,11 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
                 }
                 mContextMenuDid = Long.parseLong(mDeckList.get(position).get("did"));
                 String deckName = getCol().getDecks().name(mContextMenuDid);
-                boolean isCollapsed = getCol().getDecks().get(mContextMenuDid).optBoolean("collapsed", false);
-                showDialogFragment(DeckPickerContextMenu.newInstance(deckName, isCollapsed));
+                boolean hasSubdecks = getCol().getDecks().children(mContextMenuDid).size() > 0;
+                boolean isCollapsed = getCol().getDecks().get(mContextMenuDid).
+                        optBoolean("collapsed", false);
+                showDialogFragment(DeckPickerContextMenu.newInstance(deckName, hasSubdecks,
+                        isCollapsed));
                 return true;
             }
         });
@@ -694,7 +705,8 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
             updateDeckList();
             dismissOpeningCollectionDialog();
         }
-        selectNavigationItem(DRAWER_DECK_PICKER);
+        setTitle(getResources().getString(R.string.app_name));
+        sIsWholeCollection = !mFragmented;
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
@@ -15,8 +15,6 @@
  ****************************************************************************************/
 package com.ichi2.anki;
 
-import android.app.Activity;
-import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.res.Configuration;
@@ -29,17 +27,12 @@ import android.support.v4.app.ActionBarDrawerToggle;
 import android.support.v4.view.GravityCompat;
 import android.support.v4.widget.DrawerLayout;
 import android.support.v7.widget.Toolbar;
-import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.AdapterView;
-import android.widget.BaseAdapter;
 import android.widget.ImageView;
-import android.widget.ListView;
 import android.widget.TextView;
 
 import com.ichi2.anim.ActivityTransitionAnimation;
-import com.ichi2.anki.stats.AnkiStatsTaskHandler;
 
 import java.util.ArrayList;
 import timber.log.Timber;
@@ -50,8 +43,10 @@ public class NavigationDrawerActivity extends AnkiActivity {
     /** Navigation Drawer */
     protected CharSequence mTitle;
     protected Boolean mFragmented = false;
+    // Preselection for DeckDropDownAdapter
+    protected static boolean sIsWholeCollection = true;
     private DrawerLayout mDrawerLayout;
-    private ListView mDrawerList;
+    private ViewGroup mDrawerList;
     private ActionBarDrawerToggle mDrawerToggle;
     private String[] mNavigationTitles;
     private TypedArray mNavigationImages;
@@ -59,41 +54,41 @@ public class NavigationDrawerActivity extends AnkiActivity {
     private ArrayList<Integer> mNavDrawerItems = new ArrayList<>();
     // Other members
     private String mOldColPath;
-    // Navigation drawer list item entries
+    // Navigation drawer list item entries (titles and icons must be in the same order)
     protected static final int DRAWER_DECK_PICKER = 0;
     protected static final int DRAWER_BROWSER = 1;
     protected static final int DRAWER_STATISTICS = 2;
     protected static final int DRAWER_SETTINGS = 3;
     protected static final int DRAWER_HELP = 4;
     protected static final int DRAWER_FEEDBACK = 5;
-    protected static final int DRAWER_SEPARATOR = -1;
+    protected static final int DRAWER_INVALID = -1;
+    protected static final int DRAWER_SEPARATOR = -2;
     // Intent request codes
     public static final int REQUEST_PREFERENCES_UPDATE = 100;
     public static final int REQUEST_BROWSE_CARDS = 101;
     public static final int REQUEST_STATISTICS = 102;
+
+    /**
+     * Returns the navdrawer item that corresponds to this Activity. Subclasses override this to
+     * indicate what navdrawer item corresponds to them.
+     * Return DRAWER_INVALID to mean that this Activity should not have a navdrawer.
+     */
+    protected int getSelfNavDrawerItem() {
+        return DRAWER_INVALID;
+    }
     
-    
-    // navigation drawer stuff
+    // Navigation drawer initialisation
     protected void initNavigationDrawer(View mainView){
         // Create inherited navigation drawer layout here so that it can be used by parent class
         mDrawerLayout = (DrawerLayout) mainView.findViewById(R.id.drawer_layout);
-        mDrawerList = (ListView) mainView.findViewById(R.id.left_drawer);
         mTitle = getTitle();
         mNavigationTitles = getResources().getStringArray(R.array.navigation_titles);
         mNavigationImages = getResources().obtainTypedArray(R.array.drawer_images);
         // set a custom shadow that overlays the main content when the drawer opens
         mDrawerLayout.setDrawerShadow(R.drawable.drawer_shadow, GravityCompat.START);
-        // set up the drawer's list view with items and click listener
-        mDrawerList.setAdapter(new NavDrawerListAdapter(this, mNavigationTitles, mNavigationImages, mNavDrawerItems));
-        mDrawerList.setOnItemClickListener(new DrawerItemClickListener());
 
-        mNavDrawerItems.add(DRAWER_DECK_PICKER);
-        mNavDrawerItems.add(DRAWER_BROWSER);
-        mNavDrawerItems.add(DRAWER_STATISTICS);
-        mNavDrawerItems.add(DRAWER_SEPARATOR);
-        mNavDrawerItems.add(DRAWER_SETTINGS);
-        mNavDrawerItems.add(DRAWER_HELP);
-        mNavDrawerItems.add(DRAWER_FEEDBACK);
+        populateNavDrawerItems();
+        createNavDrawerItems(mainView);
 
         Toolbar toolbar = (Toolbar) mainView.findViewById(R.id.toolbar);
         if (toolbar != null) {
@@ -125,54 +120,113 @@ public class NavigationDrawerActivity extends AnkiActivity {
         };
         mDrawerLayout.setDrawerListener(mDrawerToggle);
     }
-    
-    /* The click listener for ListView in the navigation drawer */
-    private class DrawerItemClickListener implements ListView.OnItemClickListener {
-        @Override
-        public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-            Timber.i("Item %d selected in navigation drawer", position);
-            selectNavigationItem(position);
+
+
+    /** Set the items to be included in the navigation drawer */
+    private void populateNavDrawerItems() {
+        mNavDrawerItems.add(DRAWER_DECK_PICKER);
+        mNavDrawerItems.add(DRAWER_BROWSER);
+        mNavDrawerItems.add(DRAWER_STATISTICS);
+
+        mNavDrawerItems.add(DRAWER_SEPARATOR);
+
+        mNavDrawerItems.add(DRAWER_SETTINGS);
+        mNavDrawerItems.add(DRAWER_HELP);
+        mNavDrawerItems.add(DRAWER_FEEDBACK);
+    }
+
+
+    /** Collect the views for all navigation drawer items */
+    private void createNavDrawerItems(View mainview) {
+        mDrawerList = (ViewGroup) mainview.findViewById(R.id.navdrawer_items_container);
+        if (mDrawerList == null) {
+            return;
+        }
+
+        mDrawerList.removeAllViews();
+        for (int itemId : mNavDrawerItems) {
+            mDrawerList.addView(makeNavDrawerItem(itemId, mDrawerList));
         }
     }
 
-    protected void selectNavigationItem(int position) {
-        // switch to new activity... be careful not to start own activity or we can get stuck in a loop
-        // update selected item and title, then close the drawer
-        int itemId = mNavDrawerItems.get(position);
-        mDrawerList.setItemChecked(position, true);
-        setTitle(mNavigationTitles[itemId]);
-        mDrawerLayout.closeDrawer(mDrawerList);
 
+    /** Returns the view for the specified navigation drawer item */
+    private View makeNavDrawerItem(final int itemId, ViewGroup container) {
+        boolean selected = getSelfNavDrawerItem() == itemId;
+        View view = getLayoutInflater().inflate(isSeparator(itemId) ?
+                R.layout.navdrawer_divider :
+                R.layout.navdrawer_item, container, false);
+        if (isSeparator(itemId)) {
+            // nothing else necessary for separators
+            return view;
+        }
+        // set the text and image according to lists specified in resources
+        TextView txtTitle = (TextView) view.findViewById(R.id.drawer_list_item_text);
+        ImageView imgIcon = (ImageView) view.findViewById(R.id.drawer_list_item_icon);
+
+        txtTitle.setText(mNavigationTitles[itemId]);
+        imgIcon.setImageResource(mNavigationImages.getResourceId(itemId, -1));
+
+        formatNavDrawerItem(view, selected);
+        view.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                Timber.i("Item %d selected in navigation drawer", itemId);
+                selectNavigationItem(itemId);
+            }
+        });
+        return view;
+    }
+
+
+    /** configure item appearance according to whether or not it's selected */
+    private void formatNavDrawerItem(View view, boolean selected) {
+        TextView txtTitle = (TextView) view.findViewById(R.id.drawer_list_item_text);
+        ImageView imgIcon = (ImageView) view.findViewById(R.id.drawer_list_item_icon);
+
+        if (selected) view.setBackgroundColor(
+                getResources().getColor(R.color.navdrawer_background_selected));
+        txtTitle.setTypeface(null, selected ?
+                Typeface.BOLD :
+                Typeface.NORMAL);
+        txtTitle.setTextColor(selected ?
+                getResources().getColor(R.color.navdrawer_text_color_selected) :
+                getResources().getColor(R.color.navdrawer_text_color));
+        imgIcon.setColorFilter(selected ?
+                getResources().getColor(R.color.navdrawer_icon_tint_selected) :
+                getResources().getColor(R.color.navdrawer_icon_tint), PorterDuff.Mode.SRC_IN);
+    }
+
+
+    /** Launches target activity for selected navigation drawer item */
+    protected void selectNavigationItem(int itemId) {
+        mDrawerLayout.closeDrawer(mDrawerList);
+        // Return if trying to start own activity
+        if (itemId == getSelfNavDrawerItem()) {
+            return;
+        }
+
+        // Set title and launch target activity
+        setTitle(mNavigationTitles[itemId]);
         switch (itemId){
             case DRAWER_DECK_PICKER:
-                if (!(this instanceof DeckPicker)) {
-                    Intent deckPicker = new Intent(this, DeckPicker.class);
-                    deckPicker.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);    // opening DeckPicker should clear back history
-                    startActivityWithAnimation(deckPicker, ActivityTransitionAnimation.RIGHT);
-                }
+                Intent deckPicker = new Intent(this, DeckPicker.class);
+                deckPicker.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);    // opening DeckPicker should clear back history
+                startActivityWithAnimation(deckPicker, ActivityTransitionAnimation.RIGHT);
                 break;
+
             case DRAWER_BROWSER:
                 Intent cardBrowser = new Intent(this, CardBrowser.class);
-                if (!(this instanceof CardBrowser)) {
-                    if (this instanceof DeckPicker && !mFragmented){
-                        cardBrowser.putExtra("fromDeckpicker", true);
-                    }                    
-                    startActivityForResultWithAnimation(cardBrowser, REQUEST_BROWSE_CARDS, ActivityTransitionAnimation.LEFT);
-                }
+                cardBrowser.putExtra("selectedDeck", getCol().getDecks().selected());
+                startActivityForResultWithAnimation(cardBrowser, REQUEST_BROWSE_CARDS, ActivityTransitionAnimation.LEFT);
                 break;
-            case DRAWER_STATISTICS:
-            	boolean selectAllDecksButton = false;
-                if(!(this instanceof Statistics)) {
-                    if ((this instanceof DeckPicker && !mFragmented)) {
-                        selectAllDecksButton = true;
-                    }
-                    AnkiStatsTaskHandler.setIsWholeCollection(selectAllDecksButton);
-                    Intent intent = new Intent(this, Statistics.class);
-                    intent.putExtra("selectedDeck", getCol().getDecks().selected());
-                    startActivityForResultWithAnimation(intent, REQUEST_STATISTICS, ActivityTransitionAnimation.LEFT);
-                }
 
+            case DRAWER_STATISTICS:
+                Intent intent = new Intent(this, Statistics.class);
+                intent.putExtra("selectedDeck", getCol().getDecks().selected());
+                startActivityForResultWithAnimation(intent, REQUEST_STATISTICS, ActivityTransitionAnimation.LEFT);
                 break;
+
             case DRAWER_SETTINGS:
                 mOldColPath = CollectionHelper.getCurrentAnkiDroidDirectory(this);
                 startActivityForResultWithAnimation(new Intent(this, Preferences.class), REQUEST_PREFERENCES_UPDATE, ActivityTransitionAnimation.FADE);
@@ -197,15 +251,7 @@ public class NavigationDrawerActivity extends AnkiActivity {
      * @return the name of the currently checked item in the navigation drawer
      */
     protected String getSelectedNavDrawerTitle() {
-        int position = mDrawerList.getCheckedItemPosition();
-        return mNavigationTitles[position];
-    }
-
-    protected void deselectAllNavigationItems() {
-        // Deselect all entries in navigation drawer
-        for (int i=0; i< mDrawerList.getCount(); i++) {
-            mDrawerList.setItemChecked(i, false);
-        }
+        return mNavigationTitles[getSelfNavDrawerItem()];
     }
 
     @Override
@@ -232,83 +278,7 @@ public class NavigationDrawerActivity extends AnkiActivity {
         // Pass any configuration change to the drawer toggles
         mDrawerToggle.onConfigurationChanged(newConfig);
     }
-    
-    
-    /* Adapter which controls how to display the items in the navigation drawer */
-    private class NavDrawerListAdapter extends BaseAdapter {
-        
-        private Context context;
-        private String[] navDrawerTitles;
-        private TypedArray navDrawerImages;
-        private ArrayList<Integer> navDrawerItems;
 
-        public NavDrawerListAdapter(Context context, String[] navDrawerTitles,
-                TypedArray navDrawerImages, ArrayList<Integer> navDrawerItems){
-            this.context = context;
-            this.navDrawerTitles = navDrawerTitles;
-            this.navDrawerImages = navDrawerImages;
-            this.navDrawerItems = navDrawerItems;
-        }
-
-        @Override
-        public int getCount() {
-            return navDrawerItems.size();
-        }
-
-        @Override
-        public Object getItem(int position) {
-            return navDrawerTitles[navDrawerItems.get(position)];
-        }
-
-        @Override
-        public long getItemId(int position) {
-            return navDrawerItems.get(position);
-        }
-
-        @Override
-        public View getView(int position, View convertView, ViewGroup parent) {
-            int itemId = navDrawerItems.get(position);
-            if (convertView == null) {
-                LayoutInflater mInflater = (LayoutInflater)
-                        context.getSystemService(Activity.LAYOUT_INFLATER_SERVICE);
-                convertView = mInflater.inflate(isSeparator(itemId) ?
-                            R.layout.navdrawer_divider :
-                            R.layout.navdrawer_item, parent, false);
-            }
-            if (isSeparator(itemId)) {
-                // nothing else necessary for separators
-                return convertView;
-            }
-            // set the text and image according to lists specified in resources
-            TextView txtTitle = (TextView) convertView.findViewById(R.id.drawer_list_item_text);
-            ImageView imgIcon = (ImageView) convertView.findViewById(R.id.drawer_list_item_icon);
-
-            txtTitle.setText(navDrawerTitles[itemId]);
-            imgIcon.setImageResource(navDrawerImages.getResourceId(itemId, -1));
-
-            formatNavDrawerItem(convertView, NavigationDrawerActivity.this.mDrawerList.getCheckedItemPosition()==position);
-            return convertView;
-        }
-
-        // configure item appearance according to whether or not it's selected
-        private void formatNavDrawerItem(View view, boolean selected) {
-            TextView txtTitle = (TextView) view.findViewById(R.id.drawer_list_item_text);
-            ImageView imgIcon = (ImageView) view.findViewById(R.id.drawer_list_item_icon);
-
-            view.setBackgroundColor(selected ?
-                    getResources().getColor(R.color.navdrawer_background_selected) :
-                    getResources().getColor(R.color.navdrawer_background));
-            txtTitle.setTypeface(null, selected ?
-                    Typeface.BOLD :
-                    Typeface.NORMAL);
-            txtTitle.setTextColor(selected ?
-                    getResources().getColor(R.color.navdrawer_text_color_selected) :
-                    getResources().getColor(R.color.navdrawer_text_color));
-            imgIcon.setColorFilter(selected ?
-                    getResources().getColor(R.color.navdrawer_icon_tint_selected) :
-                    getResources().getColor(R.color.navdrawer_icon_tint), PorterDuff.Mode.SRC_IN);
-        }
-    }
 
     private boolean isSeparator(int itemId) {
         return itemId == DRAWER_SEPARATOR;
@@ -320,14 +290,6 @@ public class NavigationDrawerActivity extends AnkiActivity {
     protected void onDestroy() {       
         super.onDestroy();
         mNavigationImages.recycle();
-    }
-
-    public DrawerLayout getDrawerLayout() {
-        return mDrawerLayout;
-    }
-    
-    public ListView getDrawerList() {
-        return mDrawerList;
     }
     
     public ActionBarDrawerToggle getDrawerToggle() {
@@ -382,5 +344,14 @@ public class NavigationDrawerActivity extends AnkiActivity {
         } else {
             super.onActivityResult(requestCode, resultCode, data);
         }
+    }
+
+
+    public static void setIsWholeCollection(boolean isWholeCollection){
+        sIsWholeCollection = isWholeCollection;
+    }
+
+    public static boolean isWholeCollection() {
+        return sIsWholeCollection;
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -464,10 +464,12 @@ public class Reviewer extends AbstractFlashcardViewer {
             }
         }
     }
+
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
-        if (requestCode == REQUEST_STATISTICS) {
-            // select original deck if the statistics was opened, which can change the selected deck
+        if (requestCode == REQUEST_STATISTICS || requestCode == REQUEST_BROWSE_CARDS) {
+            // select original deck if the statistics or card browser were opened,
+            // which can change the selected deck
             if (data.hasExtra("originalDeck")) {
                 getCol().getDecks().select(data.getLongExtra("originalDeck", 0L));
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.java
@@ -92,13 +92,6 @@ public class StudyOptionsActivity extends NavigationDrawerActivity implements St
 
 
     @Override
-    protected void onResume() {
-        super.onResume();
-        deselectAllNavigationItems();
-    }    
-
-
-    @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         // The action bar home/up action should open or close the drawer.
         // ActionBarDrawerToggle will take care of this.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
@@ -249,6 +249,7 @@ public class StudyOptionsFragment extends Fragment implements LoaderManager.Load
         restorePreferences();
         mStudyOptionsView = inflater.inflate(R.layout.studyoptions_fragment, container, false);
         mFragmented = getActivity().getClass() != StudyOptionsActivity.class;
+        NavigationDrawerActivity.setIsWholeCollection(false);
         startLoadingCollection();
         return mStudyOptionsView;
     }
@@ -615,6 +616,13 @@ public class StudyOptionsFragment extends Fragment implements LoaderManager.Load
         }
 
         // perform some special actions depending on which activity we're returning from
+        if (requestCode == STATISTICS || requestCode == BROWSE_CARDS) {
+            // select original deck if the statistics or card browser were opened,
+            // which can change the selected deck
+            if (intent.hasExtra("originalDeck")) {
+                getCol().getDecks().select(intent.getLongExtra("originalDeck", 0L));
+            }
+        }
         if (requestCode == DECK_OPTIONS) {
             if (mLoadWithDeckOptions == true) {
                 mLoadWithDeckOptions = false;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.java
@@ -19,17 +19,19 @@ public class DeckPickerContextMenu extends DialogFragment {
     /**
      * Context Menus
      */
-    private static final int CONTEXT_MENU_COLLAPSE_DECK = 0;
-    private static final int CONTEXT_MENU_RENAME_DECK = 1;
-    private static final int CONTEXT_MENU_DECK_OPTIONS = 2;
-    private static final int CONTEXT_MENU_DELETE_DECK = 3;
-    private static final int CONTEXT_MENU_EXPORT_DECK = 4;
+    private static final int CONTEXT_MENU_RENAME_DECK = 0;
+    private static final int CONTEXT_MENU_DECK_OPTIONS = 1;
+    private static final int CONTEXT_MENU_DELETE_DECK = 2;
+    private static final int CONTEXT_MENU_EXPORT_DECK = 3;
+    private static final int CONTEXT_MENU_COLLAPSE_DECK = 4;
 
 
-    public static DeckPickerContextMenu newInstance(String dialogTitle, boolean isCollapsed) {
+    public static DeckPickerContextMenu newInstance(String dialogTitle, boolean hasSubdecks,
+            boolean isCollapsed) {
         DeckPickerContextMenu f = new DeckPickerContextMenu();
         Bundle args = new Bundle();
         args.putString("dialogTitle", dialogTitle);
+        args.putBoolean("hasSubdecks", hasSubdecks);
         args.putBoolean("isCollapsed", isCollapsed);
         f.setArguments(args);
         return f;
@@ -42,15 +44,19 @@ public class DeckPickerContextMenu extends DialogFragment {
         Resources res = getResources();
         Drawable icon = res.getDrawable(R.drawable.ic_settings_applications_black_36dp);
         icon.setAlpha(Themes.ALPHA_ICON_ENABLED_DARK);
-        String[] entries = new String[5];
-        entries[CONTEXT_MENU_COLLAPSE_DECK] = res.getString(
-                getArguments().getBoolean("isCollapsed") ?
-                        R.string.contextmenu_deckpicker_inflate_deck :
-                        R.string.contextmenu_deckpicker_collapse_deck);
+
+        boolean hasSubdecks = getArguments().getBoolean("hasSubdecks");
+        String[] entries = new String[hasSubdecks ? 5 : 4];
         entries[CONTEXT_MENU_RENAME_DECK] = res.getString(R.string.contextmenu_deckpicker_rename_deck);
         entries[CONTEXT_MENU_DECK_OPTIONS] = res.getString(R.string.study_options);
         entries[CONTEXT_MENU_DELETE_DECK] = res.getString(R.string.contextmenu_deckpicker_delete_deck);
         entries[CONTEXT_MENU_EXPORT_DECK] = res.getString(R.string.export);
+        if (hasSubdecks) {
+            entries[CONTEXT_MENU_COLLAPSE_DECK] = res.getString(
+                    getArguments().getBoolean("isCollapsed") ?
+                            R.string.contextmenu_deckpicker_inflate_deck :
+                            R.string.contextmenu_deckpicker_collapse_deck);
+        }
         return new MaterialDialog.Builder(getActivity())
                 .title(getArguments().getString("dialogTitle"))
                 .icon(icon)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/stats/AnkiStatsTaskHandler.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/stats/AnkiStatsTaskHandler.java
@@ -23,6 +23,8 @@ import android.view.View;
 import android.webkit.WebView;
 import android.widget.ProgressBar;
 import android.widget.TextView;
+
+import com.ichi2.anki.NavigationDrawerActivity;
 import com.ichi2.anki.Statistics;
 import com.ichi2.anki.R;
 import com.ichi2.libanki.Collection;
@@ -45,7 +47,6 @@ public class AnkiStatsTaskHandler {
     private float mStandardTextSize = 10f;
     private int mStatType = Stats.TYPE_MONTH;
 
-    private static boolean sIsWholeCollection = false;
     private static long sSelectedDeckId;
     private static Lock sLock = new ReentrantLock();
 
@@ -62,14 +63,6 @@ public class AnkiStatsTaskHandler {
 
     public static void setsSelectedDeckId(long sSelectedDeckId) {
         AnkiStatsTaskHandler.sSelectedDeckId = sSelectedDeckId;
-    }
-
-    public static void setIsWholeCollection(boolean isWholeCollection){
-        sIsWholeCollection = isWholeCollection;
-    }
-
-    public static boolean isWholeCollection() {
-        return sIsWholeCollection;
     }
 
     public static AnkiStatsTaskHandler getInstance() {
@@ -129,7 +122,8 @@ public class AnkiStatsTaskHandler {
                     Timber.d("starting Create ChartTask, type: %s", mChartType.name());
                 mImageView = (ChartView) params[0];
                 mProgressBar = (ProgressBar) params[1];
-                ChartBuilder chartBuilder = new ChartBuilder(mImageView, mCollectionData, sIsWholeCollection, mChartType);
+                ChartBuilder chartBuilder = new ChartBuilder(mImageView, mCollectionData,
+                        NavigationDrawerActivity.isWholeCollection(), mChartType);
                 return chartBuilder.renderChart(mStatType);
             }finally {
                 sLock.unlock();
@@ -180,7 +174,8 @@ public class AnkiStatsTaskHandler {
                 } else
                     Timber.d("starting CreateSmallDueChart");
                 mImageView = (ChartView) params[0];
-                ChartBuilder chartBuilder = new ChartBuilder(mImageView, mCollection, sIsWholeCollection, Stats.ChartType.OTHER);
+                ChartBuilder chartBuilder = new ChartBuilder(mImageView, mCollection,
+                        NavigationDrawerActivity.isWholeCollection(), Stats.ChartType.OTHER);
                 return chartBuilder.createSmallDueChart(mSeriesList);
             }finally {
                 sLock.unlock();
@@ -229,7 +224,8 @@ public class AnkiStatsTaskHandler {
                 mWebView = (WebView) params[0];
                 mProgressBar = (ProgressBar) params[1];
                 String html = "";
-                InfoStatsBuilder infoStatsBuilder = new InfoStatsBuilder(mWebView, mCollectionData, sIsWholeCollection);
+                InfoStatsBuilder infoStatsBuilder = new InfoStatsBuilder(mWebView, mCollectionData,
+                        NavigationDrawerActivity.isWholeCollection());
                 html = infoStatsBuilder.createInfoHtmlString();
                 return html;
             }finally {

--- a/AnkiDroid/src/main/res/layout-xlarge/deck_picker.xml
+++ b/AnkiDroid/src/main/res/layout-xlarge/deck_picker.xml
@@ -6,48 +6,59 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="?android:attr/colorBackground" >
-    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        android:id="@+id/deckpicker_view"
-        android:layout_width="fill_parent"
-        android:layout_height="fill_parent"
-        android:background="?android:attr/colorBackground"
-        android:orientation="horizontal" >
-
-        <RelativeLayout
-            android:layout_width="0dip"
+    <RelativeLayout
+            android:layout_width="fill_parent"
             android:layout_height="fill_parent"
-            android:layout_weight="2"
             android:orientation="vertical" >
 
-            <ListView
-                android:id="@+id/files"
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
-                android:layout_alignParentTop="true"
-                android:background="?android:attr/colorBackground"
-                android:drawSelectorOnTop="true"
-                android:fastScrollEnabled="true"
-                android:layout_above="@+id/today_stats_text_view"
-                android:focusable="true" />
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:id="@+id/today_stats_text_view"
-                android:layout_alignParentBottom="true"
-                android:layout_centerInParent="true"
-                android:layout_marginBottom="5dp"
-                android:gravity="center"/>
-        </RelativeLayout>
+        <include layout="@layout/toolbar" />
 
-        <FrameLayout
-            android:id="@+id/studyoptions_fragment"
-            android:name="com.ichi2.anki.StudyOptionsFragment"
-            android:layout_width="0dip"
+        <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+            android:id="@+id/deckpicker_view"
+            android:layout_width="fill_parent"
             android:layout_height="fill_parent"
-            android:layout_weight="3"
-            tools:ignore="InconsistentLayout" >
-        </FrameLayout>
+            android:background="?android:attr/colorBackground"
+            android:orientation="horizontal"
+            android:layout_below="@+id/toolbar">
 
-    </LinearLayout>
+            <RelativeLayout
+                android:layout_width="0dip"
+                android:layout_height="fill_parent"
+                android:layout_weight="2"
+                android:orientation="vertical" >
+
+                <ListView
+                    android:id="@+id/files"
+                    android:layout_width="fill_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_alignParentTop="true"
+                    android:background="?android:attr/colorBackground"
+                    android:drawSelectorOnTop="true"
+                    android:fastScrollEnabled="true"
+                    android:layout_above="@+id/today_stats_text_view"
+                    android:focusable="true" />
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:id="@+id/today_stats_text_view"
+                    android:layout_alignParentBottom="true"
+                    android:layout_centerInParent="true"
+                    android:layout_marginBottom="5dp"
+                    android:gravity="center"/>
+            </RelativeLayout>
+
+            <FrameLayout
+                android:id="@+id/studyoptions_fragment"
+                android:name="com.ichi2.anki.StudyOptionsFragment"
+                android:layout_width="0dip"
+                android:layout_height="fill_parent"
+                android:layout_weight="3"
+                tools:ignore="InconsistentLayout" >
+            </FrameLayout>
+
+        </LinearLayout>
+
+        <include layout="@layout/floating_action_button"/>
+    </RelativeLayout>
     <include layout="@layout/navigation_drawer" />
 </android.support.v4.widget.DrawerLayout>   

--- a/AnkiDroid/src/main/res/layout/navdrawer_divider.xml
+++ b/AnkiDroid/src/main/res/layout/navdrawer_divider.xml
@@ -6,4 +6,4 @@
       android:gravity="start|center_vertical"
       android:layout_width="match_parent"
       android:background="@color/navdrawer_divider"
-      android:layout_height="2dp" />
+      android:layout_height="1dp" />

--- a/AnkiDroid/src/main/res/layout/navdrawer_item.xml
+++ b/AnkiDroid/src/main/res/layout/navdrawer_item.xml
@@ -4,7 +4,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
               android:id="@+id/drawer_list_item_layout"
               android:orientation="horizontal"
-              android:background="?android:selectableItemBackground"
+              android:background="?attr/selectableItemBackground"
               android:gravity="start|center_vertical"
               android:paddingLeft="@dimen/keyline_1"
               android:paddingRight="@dimen/keyline_1"

--- a/AnkiDroid/src/main/res/layout/navigation_drawer.xml
+++ b/AnkiDroid/src/main/res/layout/navigation_drawer.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>    
-<ListView xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/left_drawer"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/navdrawer_items_container"
     style="@style/NavDrawer"
     android:layout_height="match_parent"
     android:layout_gravity="start"
     android:background="?android:attr/colorBackground"
-    android:choiceMode="singleChoice"
-    android:dividerHeight="-1dp" />
+    android:orientation="vertical"
+    android:clickable="true" />


### PR DESCRIPTION
Change Navdrawer from ListView to Linearlayout for easier theming.
Fix issues with selected deck in DeckDropdownWidget, it's now centrally managed in NavigationDrawerActivity whether the whole collection or a deck is selected.
Include Toolbar in DeckPicker layout for large devices.
Show 'Collapse Subdecks' option in DeckPickerContextMenu only when relevant.