### PR TITLE
Fixed RecyclerView crash on Tablet

### DIFF
--- a/AnkiDroid/src/main/res/layout-xlarge/deck_picker.xml
+++ b/AnkiDroid/src/main/res/layout-xlarge/deck_picker.xml
@@ -27,7 +27,7 @@
                 android:layout_weight="2"
                 android:orientation="vertical" >
 
-                <ListView
+                <android.support.v7.widget.RecyclerView
                     android:id="@+id/files"
                     android:layout_width="fill_parent"
                     android:layout_height="wrap_content"


### PR DESCRIPTION
Missed the xlarge/deck_picker layout when migrating to RecyclerView from ListView.
This fix adds a RecyclerView to the tablet layout.