### PR TITLE
Don't try to update showcaseview element if view not drawn yet

### DIFF
--- a/ShowcaseView/library/src/main/java/com/github/amlcurran/showcaseview/ShowcaseView.java
+++ b/ShowcaseView/library/src/main/java/com/github/amlcurran/showcaseview/ShowcaseView.java
@@ -185,9 +185,12 @@ public class ShowcaseView extends RelativeLayout
     private void updateBitmap() {
         if (bitmapBuffer == null || haveBoundsChanged()) {
             if(bitmapBuffer != null)
-        		bitmapBuffer.recycle();
-            bitmapBuffer = Bitmap.createBitmap(getMeasuredWidth(), getMeasuredHeight(), Bitmap.Config.ARGB_8888);
+                bitmapBuffer.recycle();
 
+            bitmapBuffer = Bitmap.createBitmap(
+                    getMeasuredWidth()  > 0 ? getMeasuredWidth()  : 1,
+                    getMeasuredHeight() > 0 ? getMeasuredHeight() : 1,
+                    Bitmap.Config.ARGB_8888);
         }
     }
 


### PR DESCRIPTION
Here is a fix for a showcaseview bug. It's our 13th most reported crash with 314 reports. ([link](https://ankidroid.org/couchdb/acralyzer/_design/acralyzer/index.html#/reports-browser/ankidroid/bug/057241882460544c212ccf5523d0f3f3)). I managed to reproduce it on an emulator running Android 2.3 after noticing all but one of the crashes on Acra were on that version.

The bug is in the library itself and there are a few [reports about it on its issue page](https://github.com/amlcurran/ShowcaseView/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+width+and+height). Since the bug was first reported 10 months ago it's probably not going to be fixed any time soon so I don't have any qualms about modifying the library code itself.

The code is from [this StackOverflow answer](http://stackoverflow.com/a/25521608/987046).



