### PR TITLE
Don't throw exception on query with no results

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sched.java
@@ -27,7 +27,6 @@ import android.graphics.Typeface;
 import android.text.SpannableStringBuilder;
 import android.text.TextUtils;
 import android.text.style.StyleSpan;
-
 import android.util.Pair;
 
 import com.ichi2.anki.AnkiDroidApp;
@@ -42,10 +41,8 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Calendar;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -1245,7 +1242,7 @@ public class Sched {
     private int _cntFnRev(long did, int lim) {
         return mCol.getDb().queryScalar(
                 "SELECT count() FROM (SELECT id FROM cards WHERE did = " + did + " AND queue = 2 and due <= " + mToday
-                        + " LIMIT " + lim + ")");
+                        + " LIMIT " + lim + ")", false);
     }
 
 


### PR DESCRIPTION
Fix for [this crash](https://ankidroid.org/couchdb/acralyzer/_design/acralyzer/index.html#/reports-browser/ankidroid/bug/6822f3821f58384b05fa97dc949eb934). This is the 10th most common crash with 408 reports. I haven't reproduced this but I'm almost certain I know what the problem is.

I've fixed a number of these `queryScalar` bugs in the past, so this isn't new to me. For some reason we have a parameter to *choose* whether we want an exception or not if there are no results to the query. I can't imagine a valid use case for this and I don't think we use it anywhere. I'm going to remove the option completely on the dev branch.

Anyway, this crash, for some reason, stems from a widget call every time. The widget was always doing funny stuff and the particular method that leads up to this is removed on the dev branch so it's even less of a problem for future builds.