### PR TITLE
Remove optional exception throw on number-based queries

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDb.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDb.java
@@ -134,31 +134,20 @@ public class AnkiDb {
      * @param query The raw SQL query to use.
      * @return The integer result of the query.
      */
-    public int queryScalar(String query) throws SQLException {
-        return queryScalar(query, true);
-    }
-
-
-    public int queryScalar(String query, boolean throwException) throws SQLException {
+    public int queryScalar(String query) {
         Cursor cursor = null;
         int scalar;
         try {
             cursor = mDatabase.rawQuery(query, null);
             if (!cursor.moveToNext()) {
-                if (throwException) {
-                    throw new SQLException("No result for query: " + query);
-                } else {
-                    return 0;
-                }
+                return 0;
             }
-
             scalar = cursor.getInt(0);
         } finally {
             if (cursor != null) {
                 cursor.close();
             }
         }
-
         return scalar;
     }
 
@@ -179,22 +168,13 @@ public class AnkiDb {
     }
 
 
-    public long queryLongScalar(String query) throws SQLException {
-        return queryLongScalar(query, true);
-    }
-
-
-    public long queryLongScalar(String query, boolean throwException) throws SQLException {
+    public long queryLongScalar(String query) {
         Cursor cursor = null;
         long scalar;
         try {
             cursor = mDatabase.rawQuery(query, null);
             if (!cursor.moveToNext()) {
-                if (throwException) {
-                    throw new SQLException("No result for query: " + query);
-                } else {
-                    return 0;
-                }
+                return 0;
             }
             scalar = cursor.getLong(0);
         } finally {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
@@ -840,7 +840,7 @@ public class StudyOptionsFragment extends Fragment implements LoaderManager.Load
                                 sbQuery.append("SELECT count(*) FROM cards WHERE did IN ");
                                 sbQuery.append(Utils.ids2str(collection.getDecks().active()));
                                 sbQuery.append(" AND queue = 0");
-                                final int fullNewCount = collection.getDb().queryScalar(sbQuery.toString(), false);
+                                final int fullNewCount = collection.getDb().queryScalar(sbQuery.toString());
                                 if (fullNewCount > 0) {
                                     Runnable setNewTotalText = new Runnable() {
                                         @Override

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -815,7 +815,7 @@ public class Collection {
      */
 
     public boolean isEmpty() {
-        return mDb.queryScalar("SELECT 1 FROM cards LIMIT 1", false) == 0;
+        return mDb.queryScalar("SELECT 1 FROM cards LIMIT 1") == 0;
     }
 
 
@@ -1312,12 +1312,12 @@ public class Collection {
      */
     public boolean basicCheck() {
         // cards without notes
-        if (mDb.queryScalar("select 1 from cards where nid not in (select id from notes) limit 1", false) > 0) {
+        if (mDb.queryScalar("select 1 from cards where nid not in (select id from notes) limit 1") > 0) {
             return false;
         }
         boolean badNotes = mDb.queryScalar(String.format(Locale.US,
                 "select 1 from notes where id not in (select distinct nid from cards) " +
-                "or mid not in %s limit 1", Utils.ids2str(mModels.ids())), false) > 0;
+                "or mid not in %s limit 1", Utils.ids2str(mModels.ids()))) > 0;
         // notes without cards or models
         if (badNotes) {
             return false;
@@ -1339,7 +1339,7 @@ public class Collection {
                 boolean badOrd = mDb.queryScalar(String.format(Locale.US,
                         "select 1 from cards where ord not in %s and nid in ( " +
                         "select id from notes where mid = %d) limit 1",
-                        Utils.ids2str(ords), m.getLong("id")), false) > 0;
+                        Utils.ids2str(ords), m.getLong("id"))) > 0;
                 if (badOrd) {
                     return false;
                 }
@@ -1459,7 +1459,7 @@ public class Collection {
                 mDb.execute("UPDATE cards SET due = 1000000, mod = " + Utils.intNow() + ", usn = " + usn()
                         + " WHERE due > 1000000 AND queue = 0");
                 // new card position
-                mConf.put("nextPos", mDb.queryScalar("SELECT max(due) + 1 FROM cards WHERE type = 0", false));
+                mConf.put("nextPos", mDb.queryScalar("SELECT max(due) + 1 FROM cards WHERE type = 0"));
                 // reviews should have a reasonable due
                 ids = mDb.queryColumn(Long.class, "SELECT id FROM cards WHERE queue = 2 AND due > 10000", 0);
                 if (ids.size() > 0) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Media.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Media.java
@@ -570,7 +570,7 @@ public class Media {
 
 
     public boolean haveDirty() {
-        return mDb.queryScalar("select 1 from media where dirty=1 limit 1", false) > 0;
+        return mDb.queryScalar("select 1 from media where dirty=1 limit 1") > 0;
     }
 
 
@@ -715,7 +715,7 @@ public class Media {
      */
 
     public int lastUsn() {
-        return mDb.queryScalar("select lastUsn from meta", false);
+        return mDb.queryScalar("select lastUsn from meta");
     }
 
 
@@ -761,12 +761,12 @@ public class Media {
 
 
     public int mediacount() {
-        return mDb.queryScalar("select count() from media where csum is not null", false);
+        return mDb.queryScalar("select count() from media where csum is not null");
     }
 
 
     public int dirtyCount() {
-        return mDb.queryScalar("select count() from media where dirty=1", false);
+        return mDb.queryScalar("select count() from media where dirty=1");
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -793,7 +793,7 @@ public class Models {
             // all notes with this template must have at least two cards, or we could end up creating orphaned notes
             sql = "select nid, count() from cards where nid in (select nid from cards where id in " +
                     Utils.ids2str(cids) + ") group by nid having count() < 2 limit 1";
-            if (mCol.getDb().queryScalar(sql, false) != 0) {
+            if (mCol.getDb().queryScalar(sql) != 0) {
                 return false;
             }
             // ok to proceed; remove cards

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Note.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Note.java
@@ -136,7 +136,7 @@ public class Note implements Cloneable {
         String fields = joinedFields();
         if (mod == null && mCol.getDb().queryScalar(String.format(Locale.US,
                 "select 1 from notes where id = ? and tags = ? and flds = ?",
-                mId, tags, fields), false) > 0) {
+                mId, tags, fields)) > 0) {
             return;
         }
         long csum = Utils.fieldChecksum(mFields[0]);
@@ -302,7 +302,7 @@ public class Note implements Cloneable {
      * have we been added yet?
      */
     private void _preFlush() {
-        mNewlyAdded = mCol.getDb().queryScalar("SELECT 1 FROM cards WHERE nid = " + mId, false) == 0;
+        mNewlyAdded = mCol.getDb().queryScalar("SELECT 1 FROM cards WHERE nid = " + mId) == 0;
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sched.java
@@ -52,7 +52,6 @@ import java.util.ListIterator;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
-import java.util.TreeSet;
 
 import timber.log.Timber;
 
@@ -738,7 +737,7 @@ public class Sched {
     		return 0;
     	}
     	lim = Math.min(lim, mReportLimit);
-    	return mCol.getDb().queryScalar("SELECT count() FROM (SELECT 1 FROM cards WHERE did = " + did + " AND queue = 0 LIMIT " + lim + ")", false);
+    	return mCol.getDb().queryScalar("SELECT count() FROM (SELECT 1 FROM cards WHERE did = " + did + " AND queue = 0 LIMIT " + lim + ")");
     }
 
 
@@ -756,7 +755,7 @@ public class Sched {
     }
 
     public int totalNewForCurrentDeck() {
-        return mCol.getDb().queryScalar("SELECT count() FROM cards WHERE id IN (SELECT id FROM cards WHERE did IN " + Utils.ids2str(mCol.getDecks().active()) + " AND queue = 0 LIMIT " + mReportLimit + ")", false);
+        return mCol.getDb().queryScalar("SELECT count() FROM cards WHERE id IN (SELECT id FROM cards WHERE did IN " + Utils.ids2str(mCol.getDecks().active()) + " AND queue = 0 LIMIT " + mReportLimit + ")");
     }
 
     /**
@@ -765,14 +764,14 @@ public class Sched {
 
     private void _resetLrnCount() {
         // sub-day
-        mLrnCount = (int) mCol.getDb().queryScalar(
+        mLrnCount = mCol.getDb().queryScalar(
                 "SELECT sum(left / 1000) FROM (SELECT left FROM cards WHERE did IN " + _deckLimit()
-                + " AND queue = 1 AND due < " + mDayCutoff + " LIMIT " + mReportLimit + ")", false);
+                + " AND queue = 1 AND due < " + mDayCutoff + " LIMIT " + mReportLimit + ")");
 
         // day
-        mLrnCount += (int) mCol.getDb().queryScalar(
+        mLrnCount += mCol.getDb().queryScalar(
                 "SELECT count() FROM cards WHERE did IN " + _deckLimit() + " AND queue = 3 AND due <= " + mToday
-                        + " LIMIT " + mReportLimit, false);
+                        + " LIMIT " + mReportLimit);
     }
 
 
@@ -1192,11 +1191,11 @@ public class Sched {
             int cnt = mCol.getDb().queryScalar(
                     "SELECT sum(left / 1000) FROM (SELECT left FROM cards WHERE did = " + did
                             + " AND queue = 1 AND due < " + (Utils.intNow() + mCol.getConf().getInt("collapseTime"))
-                            + " LIMIT " + mReportLimit + ")", false);
+                            + " LIMIT " + mReportLimit + ")");
             return cnt + mCol.getDb().queryScalar(
                     "SELECT count() FROM (SELECT 1 FROM cards WHERE did = " + did
                             + " AND queue = 3 AND due <= " + mToday
-                            + " LIMIT " + mReportLimit + ")", false);
+                            + " LIMIT " + mReportLimit + ")");
         } catch (SQLException e) {
             throw new RuntimeException(e);
         } catch (JSONException e) {
@@ -1233,7 +1232,7 @@ public class Sched {
 
     public int _revForDeck(long did, int lim) {
     	lim = Math.min(lim, mReportLimit);
-    	return mCol.getDb().queryScalar("SELECT count() FROM (SELECT 1 FROM cards WHERE did = " + did + " AND queue = 2 AND due <= " + mToday + " LIMIT " + lim + ")", false);
+    	return mCol.getDb().queryScalar("SELECT count() FROM (SELECT 1 FROM cards WHERE did = " + did + " AND queue = 2 AND due <= " + mToday + " LIMIT " + lim + ")");
     }
 
 
@@ -1342,7 +1341,7 @@ public class Sched {
     public int totalRevForCurrentDeck() {
         return mCol.getDb().queryScalar(String.format(Locale.US,
         		"SELECT count() FROM cards WHERE id IN (SELECT id FROM cards WHERE did IN %s AND queue = 2 AND due <= %d LIMIT %s)",
-        		Utils.ids2str(mCol.getDecks().active()), mToday, mReportLimit), false);
+        		Utils.ids2str(mCol.getDecks().active()), mToday, mReportLimit));
     }
 
 
@@ -1955,21 +1954,20 @@ public class Sched {
         return mCol.getDb()
                 .queryScalar(
                         "SELECT 1 FROM cards WHERE did IN " + _deckLimit() + " AND queue = 2 AND due <= " + mToday
-                                + " LIMIT 1", false) != 0;
+                                + " LIMIT 1") != 0;
     }
 
 
     /** true if there are any new cards due. */
     public boolean newDue() {
-        return mCol.getDb().queryScalar("SELECT 1 FROM cards WHERE did IN " + _deckLimit() + " AND queue = 0 LIMIT 1",
-                false) != 0;
+        return mCol.getDb().queryScalar("SELECT 1 FROM cards WHERE did IN " + _deckLimit() + " AND queue = 0 LIMIT 1") != 0;
     }
 
 
     public boolean haveBuried() {
         String sdids = Utils.ids2str(mCol.getDecks().active());
         int cnt = mCol.getDb().queryScalar(String.format(Locale.US,
-                "select 1 from cards where queue = -2 and did in %s limit 1", sdids), false);
+                "select 1 from cards where queue = -2 and did in %s limit 1", sdids));
         return cnt != 0;
     }
 
@@ -2166,7 +2164,7 @@ public class Sched {
         remFromDyn(ids);
         mCol.getDb().execute("update cards set type=0,queue=0,ivl=0,due=0,odue=0,factor=2500" +
                 " where id in " + Utils.ids2str(ids));
-        int pmax = mCol.getDb().queryScalar("SELECT max(due) FROM cards WHERE type=0", false);
+        int pmax = mCol.getDb().queryScalar("SELECT max(due) FROM cards WHERE type=0");
         // takes care of mod + usn
         sortCards(ids, pmax + 1);
         mCol.log(ids);
@@ -2245,7 +2243,7 @@ public class Sched {
         // shift?
         if (shift) {
             int low = mCol.getDb().queryScalar(
-                    "SELECT min(due) FROM cards WHERE due >= " + start + " AND type = 0 AND id NOT IN " + scids, false);
+                    "SELECT min(due) FROM cards WHERE due >= " + start + " AND type = 0 AND id NOT IN " + scids);
             if (low != 0) {
                 int shiftby = high - low + 1;
                 mCol.getDb().execute(
@@ -2366,14 +2364,13 @@ public class Sched {
 
     public int cardCount() {
         String dids = _deckLimit();
-        return mCol.getDb().queryScalar("SELECT count() FROM cards WHERE did IN " + dids, false);
+        return mCol.getDb().queryScalar("SELECT count() FROM cards WHERE did IN " + dids);
     }
 
 
     public int matureCount() {
         String dids = _deckLimit();
-        return mCol.getDb().queryScalar("SELECT count() FROM cards WHERE type = 2 AND ivl >= 21 AND did IN " + dids,
-                false);
+        return mCol.getDb().queryScalar("SELECT count() FROM cards WHERE type = 2 AND ivl >= 21 AND did IN " + dids);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
@@ -440,7 +440,7 @@ public class Utils {
         // be careful not to create multiple objects without flushing them, or they
         // may share an ID.
         long t = intNow(1000);
-        while (db.queryScalar("SELECT id FROM " + table + " WHERE id = " + t, false) != 0) {
+        while (db.queryScalar("SELECT id FROM " + table + " WHERE id = " + t) != 0) {
             t += 1;
         }
         return t;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
@@ -19,11 +19,9 @@ package com.ichi2.libanki.importer;
 import android.content.res.Resources;
 import android.database.Cursor;
 
-
 import com.google.gson.stream.JsonReader;
 import com.ichi2.anki.AnkiDatabaseManager;
 import com.ichi2.anki.BackupManager;
-import com.ichi2.anki.CollectionHelper;
 import com.ichi2.anki.R;
 import com.ichi2.async.DeckTask;
 import com.ichi2.libanki.Collection;
@@ -744,7 +742,7 @@ public class Anki2Importer {
         try {
             // make sure new position is correct
             mDst.getConf().put("nextPos",
-                    mDst.getDb().queryLongScalar("SELECT max(due) + 1 FROM cards WHERE type = 0", false));
+                    mDst.getDb().queryLongScalar("SELECT max(due) + 1 FROM cards WHERE type = 0"));
             mDst.save();
         } catch (JSONException e) {
             throw new RuntimeException(e);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.java
@@ -305,33 +305,32 @@ public class Syncer {
     public JSONObject sanityCheck() {
         JSONObject result = new JSONObject();
         try {
-            if (mCol.getDb().queryScalar("SELECT count() FROM cards WHERE nid NOT IN (SELECT id FROM notes)", false) != 0) {
+            if (mCol.getDb().queryScalar("SELECT count() FROM cards WHERE nid NOT IN (SELECT id FROM notes)") != 0) {
                 Timber.e("Sync - SanityCheck: there are cards without mother notes");
                 result.put("client", "missing notes");
                 return result;
             }
-            if (mCol.getDb().queryScalar("SELECT count() FROM notes WHERE id NOT IN (SELECT DISTINCT nid FROM cards)",
-                    false) != 0) {
+            if (mCol.getDb().queryScalar("SELECT count() FROM notes WHERE id NOT IN (SELECT DISTINCT nid FROM cards)") != 0) {
                 Timber.e("Sync - SanityCheck: there are notes without cards");
                 result.put("client", "missing cards");
                 return result;
             }
-            if (mCol.getDb().queryScalar("SELECT count() FROM cards WHERE usn = -1", false) != 0) {
+            if (mCol.getDb().queryScalar("SELECT count() FROM cards WHERE usn = -1") != 0) {
                 Timber.e("Sync - SanityCheck: there are unsynced cards");
                 result.put("client", "cards had usn = -1");
                 return result;
             }
-            if (mCol.getDb().queryScalar("SELECT count() FROM notes WHERE usn = -1", false) != 0) {
+            if (mCol.getDb().queryScalar("SELECT count() FROM notes WHERE usn = -1") != 0) {
                 Timber.e("Sync - SanityCheck: there are unsynced notes");
                 result.put("client", "notes had usn = -1");
                 return result;
             }
-            if (mCol.getDb().queryScalar("SELECT count() FROM revlog WHERE usn = -1", false) != 0) {
+            if (mCol.getDb().queryScalar("SELECT count() FROM revlog WHERE usn = -1") != 0) {
                 Timber.e("Sync - SanityCheck: there are unsynced revlogs");
                 result.put("client", "revlog had usn = -1");
                 return result;
             }
-            if (mCol.getDb().queryScalar("SELECT count() FROM graves WHERE usn = -1", false) != 0) {
+            if (mCol.getDb().queryScalar("SELECT count() FROM graves WHERE usn = -1") != 0) {
                 Timber.e("Sync - SanityCheck: there are unsynced graves");
                 result.put("client", "graves had usn = -1");
                 return result;


### PR DESCRIPTION
Every intsance opted to not have an exception thrown. Queries that forgot to opt out and passed in queries that resulted with no rows returned threw an exception instead of returning 0 which is not the expected behaviour.