### PR TITLE
bug fix: kicked back to import dialog after selecting apkg file.

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
@@ -298,6 +298,7 @@ public class AnkiActivity extends ActionBarActivity implements LoaderManager.Loa
         // save transaction to the back stack
         ft.addToBackStack("dialog");
         newFragment.show(ft, "dialog");
+        getSupportFragmentManager().executePendingTransactions();
     }
 
 


### PR DESCRIPTION
Bug description copied from the doc file:
>Dialog which does importing of apkg doesn’t work properly (probably due to changing the target SDK?). Instead of confirmation dialog appearing when you select an apkg, you get kicked back to the previous dialog.

I don't know exactly why, but calling ```executePendingTransactions()``` just after the  ```transaction.commit() ``` seems to have solved the issue.

I haven't seen any problems in other dialogs because of this method call and I think there will be no problems, ```executePendingTransactions()``` is just (according to [here](http://developer.android.com/guide/components/fragments.html))
> for the UI thread to immediately execute transactions submitted by commit().