### PR TITLE
Refresh studyoptions if daily limits extended

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
@@ -399,7 +399,7 @@ public class StudyOptionsFragment extends Fragment implements LoaderManager.Load
                 .itemsCallback(new MaterialDialog.ListCallback() {
                     @Override
                     public void onSelection(MaterialDialog materialDialog, View view, int which,
-                            CharSequence charSequence) {
+                                            CharSequence charSequence) {
                         DialogFragment dialogFragment;
                         if (which == CustomStudyDialog.CUSTOM_STUDY_TAGS) {
                             /*
@@ -411,7 +411,7 @@ public class StudyOptionsFragment extends Fragment implements LoaderManager.Load
                                     TagsDialog.TYPE_CUSTOM_STUDY_TAGS, new ArrayList<String>(),
                                     new ArrayList<String>(getCol().getTags().all()));
 
-                            ((TagsDialog)dialogFragment).setTagsDialogListener(new TagsDialogListener() {
+                            ((TagsDialog) dialogFragment).setTagsDialogListener(new TagsDialogListener() {
                                 @Override
                                 public void onPositive(List<String> selectedTags, int option) {
                                     /*
@@ -444,13 +444,24 @@ public class StudyOptionsFragment extends Fragment implements LoaderManager.Load
                                         sb.append(")"); // Only if we added anything to the tag list
                                     }
                                     mSearchTerms = sb.toString();
-                                    createFilteredDeck(new JSONArray(), new Object[] { mSearchTerms, Consts.DYN_MAX_SIZE,
-                                            Consts.DYN_RANDOM }, false);
+                                    createFilteredDeck(new JSONArray(), new Object[]{mSearchTerms, Consts.DYN_MAX_SIZE,
+                                            Consts.DYN_RANDOM}, false);
                                 }
                             });
                         } else {
                             // Show CustomStudyDialog for all options other than the tags dialog
                             dialogFragment = CustomStudyDialog.newInstance(which);
+                            // If we increase limits, refresh the interface to reflect the new counts
+                            ((CustomStudyDialog) dialogFragment).setCustomStudyDialogListener(
+                                    new CustomStudyDialog.CustomStudyDialogListener() {
+                                        @Override
+                                        public void onPositive(int option) {
+                                            if (option == CustomStudyDialog.CUSTOM_STUDY_NEW ||
+                                                    option == CustomStudyDialog.CUSTOM_STUDY_REV) {
+                                                refreshInterfaceAndDecklist(true);
+                                            }
+                                        }
+                                    });
                         }
                         // Show the DialogFragment via Activity
                         ((AnkiActivity) getActivity()).showDialogFragment(dialogFragment);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
@@ -16,6 +16,7 @@ import com.ichi2.anki.AnkiActivity;
 import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.CollectionHelper;
 import com.ichi2.anki.R;
+import com.ichi2.anki.StudyOptionsFragment;
 import com.ichi2.anki.StudyOptionsFragment.StudyOptionsListener;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Consts;
@@ -38,9 +39,10 @@ public class CustomStudyDialog extends DialogFragment {
     public static final int CUSTOM_STUDY_TAGS = 6;
     
     private EditText mEditText;
+    private CustomStudyDialogListener mCustomStudyDialogListener = null;
 
     public interface CustomStudyDialogListener {
-        public void dismissSimpleMessageDialog(boolean reload);
+        void onPositive(int option);
     }
 
     public static CustomStudyDialog newInstance(int id) {
@@ -80,7 +82,8 @@ public class CustomStudyDialog extends DialogFragment {
                         // Get the value selected by user
                         int n = Integer.parseInt(mEditText.getText().toString());
                         // Set behavior when clicking OK button
-                        switch (getArguments().getInt("id")) {
+                        int choice = getArguments().getInt("id");
+                        switch (choice) {
                             case CUSTOM_STUDY_NEW:
                                 // Get col, exit if not open
                                 //TODO: Find a cleaner way to get the col() from StudyOptionsFragment loader
@@ -144,6 +147,7 @@ public class CustomStudyDialog extends DialogFragment {
                             default:
                                 break;
                         }
+                        mCustomStudyDialogListener.onPositive(choice);
                     }
 
                     @Override
@@ -209,5 +213,9 @@ public class CustomStudyDialog extends DialogFragment {
             default:
                 return "";
         }
+    }
+
+    public void setCustomStudyDialogListener(CustomStudyDialogListener listener) {
+        mCustomStudyDialogListener = listener;
     }
 }


### PR DESCRIPTION
Fix for the issue raised earlier about increasing daily limits not refreshing the StudyOptionsFragment anymore. I copied the approach used in TagsDialog for the listener.