### PR TITLE
Don't close the collection on every widget update

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/widget/WidgetStatus.java
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/WidgetStatus.java
@@ -192,7 +192,6 @@ public final class WidgetStatus {
                 if (sSmallWidgetStatus == null) {
                     Collection col = CollectionHelper.getInstance().getCol(context);
                     mSmallWidgetStatus = col.getSched().progressToday(sDeckCounts, null, true);
-                    CollectionHelper.getInstance().closeCollection(false);
                 } else {
                     mSmallWidgetStatus = sSmallWidgetStatus;
                 }


### PR DESCRIPTION
Not certain when this started happening but AnkiDroid behaves very badly everywhere if you have a widget enabled on the dev branch since it's closing the collection with every update. Removing this fixes the problem.