### PR TITLE
Handle case where note ID is Integer, not Long

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.java
@@ -875,7 +875,7 @@ public class Syncer {
     private void mergeNotes(JSONArray notes) {
         for (Object[] n : newerRows(notes, "notes", 4)) {
             mCol.getDb().execute("INSERT OR REPLACE INTO notes VALUES (?,?,?,?,?,?,?,?,?,?,?)", n);
-            mCol.updateFieldCache(new long[] { (Long) n[0] });
+            mCol.updateFieldCache(new long[] { Long.valueOf(((Number) n[0]).longValue()) });
         }
     }
 


### PR DESCRIPTION
NOTE: I wasn't able to test (or even compile) this change because I don't have Android Studio set-up.

When syncing my collection, I'm getting this error:

W/System.err(17831): java.lang.ClassCastException: java.lang.Integer cannot be cast to java.lang.Long
W/System.err(17831): 	at com.ichi2.libanki.sync.Syncer.mergeNotes(Syncer.java:881)
W/System.err(17831): 	at com.ichi2.libanki.sync.Syncer.applyChunk(Syncer.java:566)
W/System.err(17831): 	at com.ichi2.libanki.sync.Syncer.sync(Syncer.java:182)
[...]

So sometimes the note ID is an Integer rather than a Long.

Using Long.valueOf(((Number) foo).longValue()) will work for both Longs
and Integers.