### PR TITLE
Fix: correct search if using search term "deck:".

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -804,7 +804,12 @@ public class CardBrowser extends NavigationDrawerActivity implements ActionBar.O
     }
 
     private void searchCards() {
-        String searchText = mRestrictOnDeck + mSearchTerms;
+        String searchText;
+        if (mSearchTerms.contains("deck:")) {
+            searchText = mSearchTerms;
+        } else {
+            searchText = mRestrictOnDeck + mSearchTerms;
+        }
         if (colIsOpen()) {
             // clear the existing card list
             getCards().clear();


### PR DESCRIPTION
Description of the problem (from [here](https://github.com/ankidroid/Anki-Android/pull/800#issuecomment-90987130)):
> if you recall a search like "deck:default foo" while you have any deck other than the default selected then no cards will appear.