### PR TITLE
Catch runtime exceptions when trying to enable cookies

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV12.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV12.java
@@ -3,6 +3,8 @@ package com.ichi2.compat;
 import android.annotation.TargetApi;
 import android.webkit.CookieManager;
 
+import timber.log.Timber;
+
 /** Implementation of {@link Compat} for SDK level 12 */
 @TargetApi(12)
 public class CompatV12 extends CompatV9 implements Compat {
@@ -11,7 +13,11 @@ public class CompatV12 extends CompatV9 implements Compat {
     // This function removes this restriction.
     @Override
     public void enableCookiesForFileSchemePages() {
-        CookieManager.setAcceptFileSchemeCookies(true);
+        try {
+            CookieManager.setAcceptFileSchemeCookies(true);
+        } catch (Throwable e) {
+            Timber.e(e, "Runtime exception enabling cookies");
+        }
     }
 
 }

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV8.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV8.java
@@ -14,6 +14,8 @@ import com.ichi2.anki.exception.APIVersionException;
 
 import java.util.regex.Pattern;
 
+import timber.log.Timber;
+
 /** Implementation of {@link Compat} for SDK level 7 */
 @TargetApi(8)
 public class CompatV8 implements Compat {
@@ -80,7 +82,9 @@ public class CompatV8 implements Compat {
 
 
     // Below API level 12, file scheme pages are not restricted, so no adjustment is needed.
-    public void enableCookiesForFileSchemePages() { }
+    public void enableCookiesForFileSchemePages() {
+        Timber.w("Cookies not supported in API version %d", CompatHelper.getSdkVersion());
+    }
 
 
     // Below API level 16, widget dimensions cannot be adjusted


### PR DESCRIPTION
It seems [some devices crash when trying to enable cookies](https://code.google.com/p/ankidroid/issues/detail?id=2510). A fix has been pushed into 2.4.3 a while ago, this adds it to 2.5
