### PR TITLE
Updated MaterialDialogs version to 0.7.1.3

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     compile 'com.android.support:appcompat-v7:22.0.0'
     compile 'com.android.support:recyclerview-v7:22.0.0'
     compile 'com.google.code.gson:gson:2.3'
-    compile 'com.afollestad:material-dialogs:0.7.0.1'
+    compile 'com.afollestad:material-dialogs:0.7.1.3'
     compile 'ch.acra:acra:4.6.1'
     compile 'com.jakewharton.timber:timber:2.5.1'
     compile project(":ShowcaseView:library")


### PR DESCRIPTION
We should always keep up-to-date the Material Dialogs.