### PR TITLE
Update Material Dialogs to 0.7.3.1

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     compile 'com.android.support:appcompat-v7:22.0.0'
     compile 'com.android.support:recyclerview-v7:22.0.0'
     compile 'com.google.code.gson:gson:2.3'
-    compile 'com.afollestad:material-dialogs:0.7.1.3'
+    compile 'com.afollestad:material-dialogs:0.7.3.1'
     compile 'ch.acra:acra:4.6.1'
     compile 'com.jakewharton.timber:timber:2.5.1'
     compile project(":ShowcaseView:library")


### PR DESCRIPTION
Update Material Dialogs again. Older build is no longer available and breaks our build.