### PR TITLE
Name change and bugfix of getPureAnswerForReading

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -97,8 +97,6 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.lang.ref.WeakReference;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -2197,7 +2195,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
             ReadText.textToSpeech(Utils.stripHTML(card.q(true)), getDeckIdForCard(card), card.getOrd(),
                     Sound.SOUNDS_QUESTION);
         } else if (Sound.SOUNDS_ANSWER == cardSide) {
-            ReadText.textToSpeech(Utils.stripHTML(card.getPureAnswerForReading()), getDeckIdForCard(card),
+            ReadText.textToSpeech(Utils.stripHTML(card.getPureAnswer()), getDeckIdForCard(card),
                     card.getOrd(), Sound.SOUNDS_ANSWER);
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.java
@@ -400,16 +400,18 @@ public class Card implements Cloneable {
     }
 
 
-    public String getPureAnswerForReading() {
+    /*
+     * Returns the answer with anything before the <hr id=answer> tag removed
+     */
+    public String getPureAnswer() {
         String s = _getQA(false).get("a");
-        String target = "<hr id=answer>\n\n";
+        String target = "<hr id=answer>";
         int pos = s.indexOf(target);
         if (pos == -1) {
             return s;
         }
-        return s.substring(pos + target.length());
+        return s.substring(pos + target.length()).trim();
     }
-
 
     public void stopTimer() {
         mTimerStopped = Utils.now();


### PR DESCRIPTION
Hey guys,
I needed a way to get the pure answer of a card and saw that getPureAnswerForReading was already supposed to do pretty much that.
But on some decks it didn't work for me, and I found out that these decks did not put the two new lines after &lt;hr id=answer>.

Also @hssm [pointed out](https://github.com/ankidroid/Anki-Android/pull/823#discussion_r30011834) that the name should be changed to make it more universal.