### PR TITLE
Fix not passing correct import card count

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
@@ -844,7 +844,7 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
             }
 
             publishProgress(new TaskData(res.getString(R.string.import_update_counts)));
-            return new TaskData(true);
+            return new TaskData(addedCount, null, true);
         } catch (RuntimeException e) {
             Timber.e(e, "doInBackgroundImportAdd - RuntimeException on importing cards");
             AnkiDroidApp.sendExceptionReport(e, "doInBackgroundImportAdd");


### PR DESCRIPTION
Import card count was always 0. I broke this with the deck counts update where I thought the extra parameters weren't needed.