### PR TITLE
Fix newer Java language feature from develop breaking the build

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/hooks/HebrewFixFilter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/hooks/HebrewFixFilter.java
@@ -41,11 +41,11 @@ public class HebrewFixFilter extends Hook {
     private String applyFixForHebrew(String text) {
         // Track the regions of text that belong to a media reference so we can skip them.
         // Modifying these regions would break the proper display/playback of the media.
-        List<Pair<Integer, Integer>> mediaRegions = new ArrayList<>();
+        List<Pair<Integer, Integer>> mediaRegions = new ArrayList<Pair<Integer, Integer>>();
         for (Pattern p : Media.mRegexps) {
             Matcher m = p.matcher(text);
             while (m.find()) {
-                mediaRegions.add(new Pair<>(m.start(), m.end()));
+                mediaRegions.add(new Pair<Integer, Integer>(m.start(), m.end()));
             }
         }
 


### PR DESCRIPTION
https://github.com/ankidroid/Anki-Android/pull/826 actually broke the build, but for some convenient reason there wasn't a travis build to catch it.

The `develop` branch is using a newer version of the Java language than our hotfix branch so we have to be careful when backporting commits from it, or this happens.