### PR TITLE
Decrement timebox label count instead of scheduler rep count

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -648,7 +648,9 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
 
             Long[] elapsed = getCol().timeboxReached();
             if (elapsed != null) {
-                int nCards = elapsed[1].intValue();
+                // AnkiDroid is always counting one rep ahead, so we decrement it before displaying
+                // it to the user.
+                int nCards = elapsed[1].intValue() - 1;
                 int nMins = elapsed[0].intValue() / 60;
                 String mins = res.getQuantityString(R.plurals.timebox_reached_minutes, nMins, nMins);
                 String timeboxMessage = res.getQuantityString(R.plurals.timebox_reached, nCards, nCards, mins);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -85,8 +85,6 @@ public class Reviewer extends AbstractFlashcardViewer {
         DeckTask.launchDeckTask(DeckTask.TASK_TYPE_ANSWER_CARD, mAnswerCardHandler, new DeckTask.TaskData(getCol(), mSched, null,
                 0));
 
-        // Since we aren't actually answering a card, decrement the rep count
-        mSched.setReps(mSched.getReps() - 1);
         disableDrawerSwipeOnConflicts();
         // Add a weak reference to current activity so that scheduler can talk to to Activity
         mSched.setContext(new WeakReference<Activity>(this));


### PR DESCRIPTION
Background: In the past I had added a decrement of the rep count in the scheduler at the start of every review session in order to result in an accurate number for the timebox feature. The reason being that AnkiDroid is always 1 rep ahead because of the way it loads the next card. That is, they are loaded when a card is answered and the very first answer is a fake card just to get the process going, but the rep is still counted.

I realised today that this interferes with the decision of when to show a new or review card. It's incredibly minor and has no appreciable impact on reviewing behaviour and it only applies to the "mix new cards and reviews" setting. In practice, it means it will (for example) show a new card every 3 reps starting from review 4 instead of every 3 reps starting from review 3. It's slightly annoying when trying to debug an issue where you are stepping through cards on both AnkiDroid and the desktop client simultaneously and it behaves a little differently.

I moved the rep decrement to the final stage where the label is built.