### PR TITLE
Fix cards with queue type 3 not being underlined

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1805,7 +1805,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
             revCount = new SpannableString("???");
         }
 
-        switch (mCurrentCard.getQueue()) {
+        switch (mSched.countIdx(mCurrentCard)) {
             case Card.TYPE_NEW:
                 newCount.setSpan(new UnderlineSpan(), 0, newCount.length(), 0);
                 break;


### PR DESCRIPTION
Cards with queue type 3 (learn cards that fall into the next day) were not getting underlined in the remaining card count indicator thing.