### PR TITLE
Expose "relative overdueness" ordering for filtered decks

### DIFF
--- a/AnkiDroid/src/main/res/values/11-arrays.xml
+++ b/AnkiDroid/src/main/res/values/11-arrays.xml
@@ -55,6 +55,7 @@
         <item>Order added</item>
         <item>Order due</item>
         <item>Latest added first</item>
+        <item>Relative overdueness</item>
     </string-array>
     <string-array name="custom_study_options_labels">
         <item>Increase today\'s new card limit</item>

--- a/AnkiDroid/src/main/res/values/constants.xml
+++ b/AnkiDroid/src/main/res/values/constants.xml
@@ -140,6 +140,7 @@
         <item>5</item>
         <item>6</item>
         <item>7</item>
+        <item>8</item>
     </string-array>
     <string-array name="add_to_cur_values">
         <item>0</item>


### PR DESCRIPTION
[Issue 2622](https://code.google.com/p/ankidroid/issues/detail?id=2622)

The *relative overdueness* ordering for filtered decks is already implemented but we never exposed it to the user in the selection list. I've added that here.