### PR TITLE
Fix error added when two strings were made translatable

### DIFF
--- a/AnkiDroid/src/main/res/values/16-multimedia-editor.xml
+++ b/AnkiDroid/src/main/res/values/16-multimedia-editor.xml
@@ -107,8 +107,8 @@
     <string name="multimedia_editor_progress_wait_title">Wait</string>
     <!-- not a good message, when an unexpected error happens -->
     <string name="multimedia_editor_something_wrong">Something went wrong</string>
-    <string name="multimedia_editor_attach_mm_content">"Attach multimedia content to the note</string>
-    <string name="multimedia_editor_attach_media">"Attach media</string>
+    <string name="multimedia_editor_attach_mm_content">Attach multimedia content to the note</string>
+    <string name="multimedia_editor_attach_media">Attach media</string>
 
     <!-- Audio view -->
     <!-- Message when recording fails -->


### PR DESCRIPTION
A while ago i made some string translatable: 3797ce725.
It looks like for two i accidentally copy-and-pasted an extra quotation mark.
This fixes that error.
These two texts are used only by screen readers (somewhat like the original idea for HTML’s alt attribute for images).