### PR TITLE
Preserve deck selection by not setting did in setNote

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -485,6 +485,8 @@ public class NoteEditor extends AnkiActivity {
             }
         });
 
+        setDid(mEditorNote);
+
         setNote(mEditorNote);
         
         // Set current note type and deck positions in spinners
@@ -1322,15 +1324,9 @@ public class NoteEditor extends AnkiActivity {
     }
 
 
-    /** Make NOTE the current note. */
-    private void setNote() {
-        setNote(null);
-    }
-
-
-    private void setNote(Note note) {
-        try {
-            if (note == null || mAddNote) {
+    private void setDid(Note note) {
+        if (note == null || mAddNote) {
+            try {
                 JSONObject conf = getCol().getConf();
                 JSONObject model = getCol().getModels().current();
                 if (conf.optBoolean("addToCur", true)) {
@@ -1346,17 +1342,30 @@ public class NoteEditor extends AnkiActivity {
                 } else {
                     mCurrentDid = model.getLong("did");
                 }
-                mEditorNote = new Note(getCol(), model);
-                mEditorNote.model().put("did", mCurrentDid);
-            } else {
-                mEditorNote = note;
-                mCurrentDid = mCurrentEditedCard.getDid();
+            } catch (JSONException e) {
+                throw new RuntimeException(e);
             }
-            if (mSelectedTags == null) {
-                mSelectedTags = mEditorNote.getTags();
-            }
-        } catch (JSONException e) {
-            throw new RuntimeException(e);
+        } else {
+            mCurrentDid = mCurrentEditedCard.getDid();
+        }
+    }
+
+
+    /** Make NOTE the current note. */
+    private void setNote() {
+        setNote(null);
+    }
+
+
+    private void setNote(Note note) {
+        if (note == null || mAddNote) {
+            JSONObject model = getCol().getModels().current();
+            mEditorNote = new Note(getCol(), model);
+        } else {
+            mEditorNote = note;
+        }
+        if (mSelectedTags == null) {
+            mSelectedTags = mEditorNote.getTags();
         }
         updateDeckPosition();
         updateTags();


### PR DESCRIPTION
One annoyance that I only realized after implementing the `addToCur` code (a loooong time ago, sorry) is that the deck that was selected using the deck selector is reset to the current deck after a new card is added. This change pulls out the part in `setNote` that sets `mCurrentDid` so that later calls to `setNote` (e.g. after adding a note or changing the note type) will not overwrite the deck that was previously set. This is useful for adding many cards to the same deck (or less frustrating, rather), and also implemented like that in Anki Desktop.

I'd appreciate a thorough look at this. It has been a while to work with the AnkiDroid codebase and I'm not sure if I have considered all possible side-effects. I did remove `mEditorNote.model().put("did", mCurrentDid);` because this is what `saveNote` does. Now that the "Saved Cards" thing is gone, I don't think we have to do it twice.