### PR TITLE
Remove margin around flashcard content

### DIFF
--- a/AnkiDroid/src/main/res/layout/flashcard.xml
+++ b/AnkiDroid/src/main/res/layout/flashcard.xml
@@ -106,8 +106,7 @@
             <FrameLayout
                 android:id="@+id/flashcard"
                 android:layout_width="fill_parent"
-                android:layout_height="fill_parent"
-                android:padding="4.6667dip" />
+                android:layout_height="fill_parent" />
 
             <RelativeLayout
                 android:layout_width="fill_parent"
@@ -191,10 +190,6 @@
                         android:id="@+id/flip_card"
                         android:layout_width="fill_parent"
                         android:layout_height="56dp"
-                        android:layout_marginBottom="2dp"
-                        android:layout_marginLeft="4dp"
-                        android:layout_marginRight="4dp"
-                        android:layout_marginTop="8dp"
                         android:clickable="false"
                         android:text="@string/show_answer" />
                 </LinearLayout>
@@ -206,9 +201,6 @@
                     android:layout_width="0dip"
                     android:layout_height="56dp"
                     android:layout_weight="1"
-                    android:layout_marginBottom="4dp"
-                    android:layout_marginLeft="4dp"
-                    android:layout_marginTop="8dp"
                     android:orientation="vertical"
                     android:visibility="gone" >
 
@@ -228,8 +220,6 @@
                         android:layout_width="0dip"
                         android:layout_height="56dp"
                         android:layout_weight="1"
-                        android:layout_marginBottom="4dp"
-                        android:layout_marginTop="8dp"
                         android:orientation="vertical"
                         android:visibility="gone" >
 
@@ -250,8 +240,6 @@
                         android:layout_width="0dip"
                         android:layout_height="56dp"
                         android:layout_weight="1"
-                        android:layout_marginBottom="4dp"
-                        android:layout_marginTop="8dp"
                         android:orientation="vertical"
                         android:visibility="gone" >
 
@@ -271,9 +259,6 @@
                         android:layout_width="0dip"
                         android:layout_height="56dp"
                         android:layout_weight="1"
-                        android:layout_marginBottom="4dp"
-                        android:layout_marginRight="4dp"
-                        android:layout_marginTop="8dp"
                         android:orientation="vertical"
                         android:visibility="gone" >
 
@@ -289,7 +274,6 @@
         </LinearLayout>
 
     </RelativeLayout>
-    
+
     <include layout="@layout/navigation_drawer" />
 </android.support.v4.widget.DrawerLayout>
-


### PR DESCRIPTION
This removes the white (black in night mode) border around the flashcard. I guess it was just a remnant from the pre-material design layout.
(What border? I see no border. You only see it when you set the background to something other than white.
![flashcard_border_day](https://cloud.githubusercontent.com/assets/1690429/8158132/9a0beee4-135a-11e5-812c-7b9013957dfe.png)
See between the blue bar and the beige card background. The card background is also not as wide as the blue bar, with this margin on the left and right.)
With this change the border is gone:
![flashcard_no_border](https://cloud.githubusercontent.com/assets/1690429/8158156/d2956092-135a-11e5-8780-0462f1ee82e1.png)

Similarly, this reduces the size of the white (in day *and* night mode) border around the buttons at the bottom:
before:
![answer_border_night](https://cloud.githubusercontent.com/assets/1690429/8158185/0c77031a-135b-11e5-9b5d-f474420b8f49.png)
after:
![smaller_answer_border_night](https://cloud.githubusercontent.com/assets/1690429/8158188/13c8b94c-135b-11e5-8dd0-f570d5264a8b.png)

I think the border around the buttons should either be removed completely or switched to black for night mode. a) I don’t know which one and b) that is a bit more work than this PR.



