### PR TITLE
Default value for first field when inserting notes through ContentProvider

### DIFF
--- a/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/ContentProviderTest.java
+++ b/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/ContentProviderTest.java
@@ -182,10 +182,14 @@ public class ContentProviderTest extends AndroidTestCase {
                 assertNotNull("Check that there is a valid cursor for detail data", noteDataCursor);
                 try {
                     assertTrue("Check that there is at least one result for detail data", noteDataCursor.getCount() > 0);
+                    boolean firstFieldChecked = false;
                     while (noteDataCursor.moveToNext()) {
                         String mimeType = noteDataCursor.getString(noteDataCursor.getColumnIndex(FlashCardsContract.DataColumns.MIMETYPE));
-                        if (mimeType.equals(FlashCardsContract.Data.Field.CONTENT_ITEM_TYPE)) {
+                        if (!firstFieldChecked && mimeType.equals(FlashCardsContract.Data.Field.CONTENT_ITEM_TYPE)) {
                             assertEquals("Check field content", "temp", noteDataCursor.getString(noteDataCursor.getColumnIndex(FlashCardsContract.Data.Field.FIELD_CONTENT)));
+                            firstFieldChecked = true;
+                        } else if (mimeType.equals(FlashCardsContract.Data.Field.CONTENT_ITEM_TYPE)) {
+                            assertEquals("Check field content", "", noteDataCursor.getString(noteDataCursor.getColumnIndex(FlashCardsContract.Data.Field.FIELD_CONTENT)));
                         } else if (mimeType.equals(FlashCardsContract.Data.Tags.CONTENT_ITEM_TYPE)) {
                             assertEquals("Unknown tag", TEST_TAG, noteDataCursor.getString(noteDataCursor.getColumnIndex(FlashCardsContract.Data.Tags.TAG_CONTENT)));
                         } else {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
@@ -428,9 +428,8 @@ public class CardContentProvider extends ContentProvider {
                 Long modelId = values.getAsLong(FlashCardsContract.Note.MID);
                 com.ichi2.libanki.Note newNote = new com.ichi2.libanki.Note(col, col.getModels().get(modelId));
                 String[] fields = newNote.getFields();
-                for (int i = 0; i < fields.length; i++) {
-                    newNote.setField(i, "temp");
-                }
+                //Setting the first field is a mandatory action. Users should overwrite this with a meaningful value.
+                newNote.setField(0, "temp");
                 col.addNote(newNote);
                 return Uri.withAppendedPath(FlashCardsContract.Note.CONTENT_URI, Long.toString(newNote.getId()));
             }


### PR DESCRIPTION
When inserting a note via content provider, all field values are set to “temp”. It's possible to later set the fields to an empty value through the update method. But it is a problem if the fields triggers the creation of a conditional card like the “Add Reversed” in the “basic (optional reversed card)” note type.

The default value “temp” was introduced, because some fields are required to have a non-empty value. According to @timrae in #725 this probably applies only to the first field of a note.