### PR TITLE
Clean up quotes ("…" → “…”), apostropes (x's → x’s ) and more

### DIFF
--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -18,15 +18,15 @@
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 --><resources>
-    <!-- Navigation Drawer items-->
+    <!-- Navigation drawer items-->
     <string name="decks">Decks</string>
-    <string name="card_browser">Card Browser</string>
+    <string name="card_browser">Card browser</string>
     <string name="statistics">Statistics</string>
     <string name="settings">Settings</string>
     <string name="help">Help</string>
-    <string name="send_feedback">Send Feedback</string>
+    <string name="send_feedback">Send feedback</string>
 
-    <string name="studyoptions_title">Study Options</string>
+    <string name="studyoptions_title">Study options</string>
     <string name="studyoptions_due_today">Due today:</string>
     <string name="studyoptions_new_total">Total new cards:</string>
     <string name="studyoptions_total_cards">Total cards:</string>
@@ -72,7 +72,7 @@
     <string name="menu_add">Add</string>
     <string name="menu_add_note">Add note</string>
     <string name="menu_my_account">Sync account</string>
-    <string name="menu_dismiss_note">Hide / Delete</string>
+    <string name="menu_dismiss_note">Hide / delete</string>
     <string name="menu_bury_card">Bury card</string>
     <string name="menu_bury_note">Bury note</string>
     <string name="menu_suspend_card">Suspend card</string>
@@ -114,9 +114,9 @@
     <string name="custom_study_deck_name">Custom study session</string>
     <string name="custom_study_deck_exists">Rename the existing custom study deck first</string>
     <string name="studyoptions_congrats_finished">Congratulations! You have finished for now.</string>
-    <string name="studyoptions_congrats_more_rev">Today\'s limit has been reached, but there are still cards to review.  You can increase the limit in the options.</string>
-    <string name="studyoptions_congrats_more_new">Today\'s limit has been reached. There are more new cards available; you can increase the limit in the options, but this will increase your short-term review workload.</string>
-    <string name="studyoptions_congrats_custom">To study outside of the normal schedule, touch the \"Custom study\" button below</string>
+    <string name="studyoptions_congrats_more_rev">Today’s limit has been reached, but there are still cards to review. You can increase the limit in the options.</string>
+    <string name="studyoptions_congrats_more_new">Today’s limit has been reached. There are more new cards available; you can increase the limit in the options, but this will increase your short-term review workload.</string>
+    <string name="studyoptions_congrats_custom">To study outside of the normal schedule, touch the “Custom study” button.</string>
     <string name="studyoptions_no_cards_due">No cards are due yet.</string>
 
     <string name="sd_card_not_mounted">Device storage not mounted</string>
@@ -124,17 +124,17 @@
     <string name="export">Export</string>
     <string name="nothing">Nothing</string>
 
-    <!-- Card Template Editor -->
-    <string name="title_activity_template_editor">Card Types for %s</string>
-    <string name="card_template_editor_front">Front Template</string>
-    <string name="card_template_editor_back">Back Template</string>
+    <!-- Card template editor -->
+    <string name="title_activity_template_editor">Card types for %s</string>
+    <string name="card_template_editor_front">Front template</string>
+    <string name="card_template_editor_back">Back template</string>
     <string name="card_template_editor_styling">Styling</string>
     <string name="card_template_editor_menu_add_reverse">Add reverse</string>
     <string name="card_template_editor_menu_delete">Delete</string>
     <string name="card_template_editor_cant_delete">At least one card type is required.</string>
     <plurals name="card_template_editor_confirm_delete">
-        <item quantity="one">Delete the \'%2$s\' card type, and its %1$d card?</item>
-        <item quantity="other">Delete the \'%2$s\' card type, and its %1$d cards?</item>
+        <item quantity="one">Delete the “%2$s” card type, and its %1$d card?</item>
+        <item quantity="other">Delete the “%2$s” card type, and its %1$d cards?</item>
     </plurals>
     <string name="card_template_editor_would_delete_note">Removing this card type would cause one or more notes to be deleted. Please create a new card type first.</string>
 </resources>

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -18,9 +18,9 @@
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 --><resources xmlns:tools="http://schemas.android.com/tools">
-    <!-- Navigation Drawer Strings -->
-    <string name="drawer_open">Open Drawer</string>
-    <string name="drawer_close">Close Drawer</string>
+    <!-- Navigation drawer strings -->
+    <string name="drawer_open">Open drawer</string>
+    <string name="drawer_close">Close drawer</string>
 
     <string name="CardEditorLaterMessage">Saved information for later</string>
     <string name="CardEditorCardDeck">Card deck:</string>
@@ -33,7 +33,7 @@
     <string name="add_tag">Add tag</string>
     <string name="check_all_tags">Check/uncheck all tags</string>
     <string name="filter_tags">Filter tags</string>
-    <string name="no_tags">You haven\'t added any tags yet.</string>
+    <string name="no_tags">You haven’t added any tags yet.</string>
     <string name="sdcard_missing_message">Switch off USB storage to access your decks</string>
 
     <!-- Reviewer.java -->
@@ -82,7 +82,7 @@
     <string name="select">Select</string>
     <string name="saving_changes">Saving changes…</string>
     <string name="reordering_cards">Reordering cards…</string>
-    <string name="field_remapping">%1$s (from \'%2$s\')</string>
+    <string name="field_remapping">%1$s (from “%2$s”)</string>
     <string name="confirm_map_cards_to_nothing">Any cards mapped to nothing will be deleted. If a note has no remaining cards, it will be lost. Are you sure you want to continue?</string>
 
     <plurals name="timebox_reached">
@@ -103,8 +103,8 @@
     <string name="card_editor_preview_card">Preview</string>
     <string name="error_insufficient_memory">Operation not possible due to insufficient memory on your device</string>
     <string name="rename">Rename</string>
-    <string name="rename_error">Deck %s could not be renamed</string>
-    <string name="default_conf_delete_error">The default options group can\'t be removed</string>
+    <string name="rename_error">Deck “%s” couldn’t be renamed</string>
+    <string name="default_conf_delete_error">The default options group can’t be removed</string>
 
     <plurals name="factadder_cards_added">
         <item quantity="one">%d card added</item>
@@ -115,7 +115,7 @@
     <string name="check_db">Check database</string>
     <string name="check_media">Check media</string>
     <string name="check_db_message">Checking database…</string>
-    <string name="empty_card_warning" tools:ignore="TypographyEllipsis">Empty card. Run \"Tools&gt;Empty Cards...\" on the desktop client.</string>
+    <string name="empty_card_warning" tools:ignore="TypographyEllipsis">Empty card. Run “Tools&gt;Empty Cards...” on the desktop client.</string>
     <!-- The ... instead of … is cut-and-pasted from the desktop client, so keep that one. -->
     <string name="unknown_type_field_warning">Type answer: unknown field %s</string>
     <string name="delete_deck">Deleting deck…</string>
@@ -127,22 +127,22 @@
     <string name="import_select_title">Choose a file to import</string>
     <string name="import_message_add">Add</string>
     <string name="import_message_replace_confirm">This will delete your existing collection and replace it with the data of file %s</string>
-    <string name="import_message_add_confirm">Add \"%s\" to collection? This may take a long time</string>
+    <string name="import_message_add_confirm">Add “%s” to collection? This may take a long time</string>
     <string name="import_log_success">Imported %d cards</string>
     <string name="import_log_error">Import failed</string>
-    <string name="import_log_no_apkg">This is not a valid apkg file</string>
-    <string name="import_error_not_apkg_extension">Filename %s does not have .apkg extension</string>
-    <string name="import_error_content_provider">The selected file could not be imported automatically by AnkiDroid. Please see the user manual for how to manually import anki files: \n %s</string>
+    <string name="import_log_no_apkg">This isn’t a valid apkg file</string>
+    <string name="import_error_not_apkg_extension">Filename “%s” doesn’t have .apkg extension</string>
+    <string name="import_error_content_provider">The selected file couldn’t be imported automatically by AnkiDroid. Please see the user manual for how to manually import anki files: \n%s</string>
     <string name="import_importing">Importing cards…</string>
     <string name="export_include_schedule">Include scheduling</string>
     <string name="export_include_media">Include media</string>
     <string name="confirm_apkg_export">Export collection as apkg file?</string>
-    <string name="confirm_apkg_export_deck">Export \"%s\" as apkg file?</string>
+    <string name="confirm_apkg_export_deck">Export “%s” as apkg file?</string>
     <string name="export_in_progress">Exporting apkg file…</string>
     <string name="export_successful_title">Email apkg?</string>
-    <string name="export_successful">File \"%s\" was exported. Do you want to email it?</string>
+    <string name="export_successful">File “%s” was exported. Do you want to email it?</string>
     <string name="export_unsuccessful">Error exporting collection</string>
-    <string name="import_hint">Place the apkg file in directory %s and press \"OK\" to import cards</string>
+    <string name="import_hint">Place the apkg file in directory “%s” and touch “OK” to import cards</string>
     <string name="upgrade_import_no_file_found">No importable %1$s file found</string>
     <string name="study_options">Deck options</string>
     <string name="custom_study">Custom study</string>
@@ -150,10 +150,10 @@
     <string name="steps_error">Steps must be numbers greater than 0</string>
     <string name="steps_min_error">At least one step is required</string>
     <string name="sched_end">(end)</string>
-    <string name="sched_unbury_button">To see them now, touch the \"Unbury\" button.</string>
+    <string name="sched_unbury_button">To see them now touch the “Unbury” button.</string>
     <string name="sched_has_buried">Some related or buried cards were delayed until tomorrow.</string>
-    <string name="tag_editor_add_feedback">Press \"%2$s\" to confirm adding \"%1$s\"</string>
-    <string name="tag_editor_add_feedback_existing">Existing tag \"%1$s\" selected</string>
+    <string name="tag_editor_add_feedback">Touch “%2$s” to confirm adding “%1$s”</string>
+    <string name="tag_editor_add_feedback_existing">Existing tag “%1$s” selected</string>
     <string name="lookup_hint">After copying the text, tap anywhere on the flashcard to show the search icon</string>
-    <string name="add_content_showcase_text">To get started, tap the + button to add some new study material.\n\n Press \'Help\' to see the manual.</string>
+    <string name="add_content_showcase_text">To get started, tap the + button to add some new study material.\n\nPress “Help” to see the manual.</string>
 </resources>

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -28,13 +28,13 @@
     <string name="delete_cram_deck_message">Send all cards in %s back to their original decks?</string>
     <string name="no_tts_available_message">No text-to-speech language available</string>
     <string name="initializing_tts">Initializing TTS…</string>
-    <string name="tts_no_tts">Don\'t speak</string>
+    <string name="tts_no_tts">Don’t speak</string>
 
     <string-array name="about_content">
         <item><![CDATA[<h2>%1$s:<br/>Flashcards for Android</h2>AnkiDroid is a flashcard application which is fully compatible with the desktop software <a href=\"%2$s\">Anki</a>. You can create, download and learn contents on both, AnkiDroid or Anki Desktop, and synchronize them very easily.]]></item>
-        <item><![CDATA[To help us make AnkiDroid better, please report any bug <a href=\"%1$s\">here</a>; new feature ideas are very welcome too! Use the <a href=\"%2$s\">wiki</a> and say Hi on the <a href=\"%3$s\">forum</a>.]]></item>
+        <item><![CDATA[To help us make AnkiDroid better, please report any bug <a href=\"%1$s\">here</a>; new feature ideas are very welcome too. Use the <a href=\"%2$s\">wiki</a> and say Hi on the <a href=\"%3$s\">forum</a>.]]></item>
         <item><![CDATA[AnkiDroid is <a href=\"%1$s\">open source software<a/>, so everyone is encouraged to <a href=\"%2$s\">join</a> the <a href=\"%3$s\">contributors</a> :-)]]></item>
-        <item><![CDATA[Non-developers can also help, for instance by <a href=\"%1$s\">translating</a> AnkiDroid, updating the wiki and screenshots, <a href=\"%2$s\">donating</a> to Anki Desktop, or blogging about AnkiDroid!]]></item>
+        <item><![CDATA[Non-developers can also help, for instance by <a href=\"%1$s\">translating</a> AnkiDroid, updating the wiki and screenshots, <a href=\"%2$s\">donating</a> to Anki Desktop, or blogging about AnkiDroid.]]></item>
         <item><![CDATA[AnkiDroid is released under the <a href=\"%1$s\">GNU-GPL v3 license</a> and the source code is available <a href=\"%2$s\">here</a>.]]></item>
     </string-array>
 
@@ -46,17 +46,17 @@
     <string name="reschedule_card_dialog_message">Reschedule for review in x days:</string>
     <string name="reschedule_card_dialog_acknowledge">Card rescheduled</string>
     <string name="answering_error_title">Database error</string>
-    <string name="answering_error_message">Writing to the collection failed. The databese could be corrupt or there may not to be enough empty space on disk.\n\nIf this happens more often, try checking the database, repairing the collection or restoring it from a backup. Touch \'options\' for that.\n\Or it could be an AnkiDroid bug as well; please report the error so that we can check this.</string>
+    <string name="answering_error_message">Writing to the collection failed. The databese could be corrupt or there may not to be enough empty space on disk.\n\nIf this happens more often, try checking the database, repairing the collection or restoring it from a backup. Touch “options” for that.\n\Or it could be an AnkiDroid bug as well; please report the error so that we can check this.</string>
     <string name="answering_error_report">Report error</string>
-    <string name="repair_deck_dialog">Do you really want to try to repair the database?\n\nBefore starting the attempt, a copy will be created in subfolder \'%s\'.</string>
+    <string name="repair_deck_dialog">Do you really want to try to repair the database?\n\nBefore starting the attempt, a copy will be created in subfolder “%s”.</string>
     <string name="intent_add_saved_information">Saved data</string>
     <string name="intent_add_clear_all">Clear all</string>
-    <string name="intent_aedict_empty">Category \'default\' is empty</string>
-    <string name="intent_aedict_category">To add cards to AnkiDroid remove all Notepad categories or add one named \'default\'</string>
+    <string name="intent_aedict_empty">Category “default” is empty</string>
+    <string name="intent_aedict_category">To add cards to AnkiDroid remove all Notepad categories or add one named “default”</string>
     <string name="custom_study_new_total_new">New cards in deck: %s</string>
     <string name="custom_study_rev_total_rev">Reviews due in deck: %s</string>
-    <string name="custom_study_new_extend">Increase today\'s new card limit by</string>
-    <string name="custom_study_rev_extend">Increase today\'s review limit by</string>
+    <string name="custom_study_new_extend">Increase today’s new card limit by</string>
+    <string name="custom_study_rev_extend">Increase today’s review limit by</string>
     <string name="custom_study_forgotten">Review cards forgotten in last x days:</string>
     <string name="custom_study_ahead">Review ahead by x days:</string>
     <string name="custom_study_random">Select x cards randomly from the deck:</string>
@@ -86,7 +86,7 @@
     <string name="dialog_positive_set">Set</string>
 
     <string name="lookup_button_content">Look up</string>
-    <string name="dialog_collection_path_not_dir">The path specified was not a valid directory</string>
+    <string name="dialog_collection_path_not_dir">The path specified wasn’t a valid directory</string>
 
     <!-- Media checking -->
     <string name="check_media_title">Check media?</string>
@@ -97,8 +97,8 @@
     <string name="check_media_invalid">Files with invalid encoding: %d</string>
     <string name="check_media_unused">Files in media folder but not used by any cards: %d</string>
     <string name="check_media_nohave">Files used on cards but not in media folder: %d</string>
-    <string name="check_media_no_unused_missing">No unused or missing files found.</string>
-    <string name="check_media_db_updated">Media database rebuilt.</string>
+    <string name="check_media_no_unused_missing">No unused or missing files found</string>
+    <string name="check_media_db_updated">Media database rebuilt</string>
     <string name="check_media_delete_unused">Delete unused</string>
     <string name="check_media_deleted">Files deleted: %d</string>
 

--- a/AnkiDroid/src/main/res/values/04-network.xml
+++ b/AnkiDroid/src/main/res/values/04-network.xml
@@ -21,7 +21,7 @@
 --><resources>
 
     <string name="youre_offline">You are offline</string>
-    <string name="sync_error">Sync Error</string>
+    <string name="sync_error">Sync error</string>
     <string name="vague_error">Error</string>
     <string name="retry">Retry</string>
     <string name="cancel">Cancel</string>
@@ -40,7 +40,7 @@
     <string name="password">Password</string>
     <string name="password_repeat">Repeat password</string>
     <string name="log_in">Log in</string>
-    <string name="sign_up_description">Don\'t have an AnkiWeb account? It\'s free!</string>
+    <string name="sign_up_description">Don’t have an AnkiWeb account? It’s free!</string>
     <string name="sign_up">Sign up</string>
     <string name="sign_up_terms">By touching <i>Sign up</i>, you confirm that you have read and agree to our <a href="https://ankiweb.net/account/terms">terms of use</a>.</string>
     <string name="logged_as">Logged in as</string>
@@ -53,7 +53,7 @@
     <string name="downloaddeck_search">Search</string>
     <string name="preferences_title">Preferences</string>
     <string name="deckpreferences_title">Options for XXX</string>
-    <string name="sync_conflict_message">You must either upload this collection or download it from Ankiweb, as they can\'t be merged. The collection on one side will be overwritten.</string>
+    <string name="sync_conflict_message">You must either upload this collection or download it from Ankiweb, as they can’t be merged. The collection on one side will be overwritten.</string>
     <string name="sync_conflict_local">Upload</string>
     <string name="sync_conflict_remote">Download</string>
     <string name="sync_conflict_remote_confirm">Overwrite your local collection?</string>
@@ -66,9 +66,9 @@
     <string name="sync_downloading_media">Downloading media %1$d/%2$d…</string>
     <string name="sync_log_uploading_message">Full sync from local</string>
     <string name="sync_log_downloading_message">Full sync from server</string>
-    <string name="sync_log_clocks_unsynchronized">Your clock\'s off by %1$d seconds%2$s. Make sure that the date, time, and timezone on your phone are set correctly, then sync again.</string>
-    <string name="sync_log_clocks_unsynchronized_tz">, the time zone\'s possibly wrong</string>
-    <string name="sync_log_clocks_unsynchronized_date">, the date\'s possibly wrong</string>
+    <string name="sync_log_clocks_unsynchronized">Your clock’s off by %1$d seconds%2$s. Make sure that the date, time, and timezone on your phone are set correctly, then sync again.</string>
+    <string name="sync_log_clocks_unsynchronized_tz">, the time zone’s possibly wrong</string>
+    <string name="sync_log_clocks_unsynchronized_date">, the date’s possibly wrong</string>
     <string name="sync_conflict_title">Syncing conflict</string>
     <string name="sync_no_changes_message">No changes found.</string>
     <string name="sync_database_acknowledge">Collection synchronized</string>
@@ -76,10 +76,10 @@
     <string name="sync_corrupt_database">Your database is corrupt. Please fix it before trying again to sync.\n\nSee %s for information about repairing your database.</string>
     <string name="sync_too_busy">Server busy. Try again later.</string>
     <string name="sync_remote_db_error">The downloaded database was corrupt. Please try again.</string>
-    <string name="sync_overwrite_error">Your current collection couldn\'t be overwritten by the downloaded file</string>
+    <string name="sync_overwrite_error">Your current collection couldn’t be overwritten by the downloaded file</string>
     <string name="sync_connection_error">Connection timed out. Either your internet connection is experiencing problems, or you have a very large file in your media folder.</string>
     <string name="sync_error_409">Only one client can access AnkiWeb at a time. If a previous sync failed, please try again in a few minutes.</string>
-    <string name="sync_write_access_error">The downloaded file couldn\'t be saved to the SD card. Either the card is mounted read-only or there isn\'t enough space.</string>
+    <string name="sync_write_access_error">The downloaded file couldn’t be saved to the SD card. Either the card is mounted read-only or there isn’t enough space.</string>
     <string name="sync_deletions_message">Syncing deletions…</string>
     <string name="sync_small_objects_message">Syncing small objects…</string>
     <string name="sync_finish_message">Finishing syncing…</string>
@@ -97,18 +97,18 @@
     <string name="sync_media_changes_count">%d media changes to upload</string>
     <string name="sync_media_downloaded_count">%d media files downloaded</string>
     <string name="sync_sanity_failed">After syncing, the collection was in an inconsistent state. To fix this problem, AnkiDroid will force a full sync. Choose which side you would like to keep.</string>
-    <string name="sync_media_sanity_failed">Media sync completed, but the media count doesn\'t agree with the server. The next media sync will be full to correct any error.</string>
+    <string name="sync_media_sanity_failed">Media sync completed, but the media count doesn’t agree with the server. The next media sync will be full to correct any error.</string>
     <string name="sync_media_error">Error syncing media data</string>
-    <string name="sync_media_unsupported">Complex media file names are not supported on Android 2.2 and below. Media syncing has been disabled.</string>
+    <string name="sync_media_unsupported">Complex media file names aren’t supported on Android 2.2 and below. Media syncing has been disabled.</string>
     <string name="register_error">An error occurred. Try again later.</string>
     <string name="register_title">Register account</string>
-    <string name="register_mismatch">The username/password repetition doesn\'t match or is empty.</string>
+    <string name="register_mismatch">The username/password repetition doesn’t match or is empty.</string>
     <string name="registering_message">Creating account…</string>
     <string name="sync_sanity_local">Local</string>
     <string name="sync_sanity_remote">Remote</string>
     <string name="force_full_sync_title">Force full sync</string>
     <string name="force_full_sync_summary">On next sync, force changes in one direction</string>
-    <string name="full_sync_confirmation">The requested change will require a full upload of the database when you next synchronize your collection. If you have reviews or other changes waiting on another device that haven\'t been synchronized here yet, they will be lost. Continue?</string>
-    <string name="full_sync_confirmation_upgrade">Due to a bug in the previously installed version of AnkiDroid, it\'s recommended to force a full sync.</string>
+    <string name="full_sync_confirmation">The requested change will require a full upload of the database when you next synchronize your collection. If you have reviews or other changes waiting on another device that haven’t been synchronized here yet, they will be lost. Continue?</string>
+    <string name="full_sync_confirmation_upgrade">Due to a bug in the previously installed version of AnkiDroid, it’s recommended to force a full sync.</string>
     <string name="sync_error_501_upgrade_required">Please upgrade to the latest version of AnkiDroid</string>
 </resources>

--- a/AnkiDroid/src/main/res/values/05-feedback.xml
+++ b/AnkiDroid/src/main/res/values/05-feedback.xml
@@ -23,9 +23,9 @@
     <!-- Feedback.java -->
     <string name="empty_string"/>
     <string name="error_reporting_choice">Error reporting mode</string>
-    <string name="feedback_disclaimer">Disclaimer: We don\'t collect any personal information such as your email address, phone number, or your phone IMEI. We do collect some information about your device such as the manufacturer, model and version of Android, as well as the nature of reported errors themselves and the steps which led up to them occurring.</string>
+    <string name="feedback_disclaimer">Disclaimer: We don’t collect any personal information such as your email address, phone number, or your phone IMEI. We do collect some information about your device such as the manufacturer, model and version of Android, as well as the nature of reported errors themselves and the steps which led up to them occurring.</string>
     <string name="feedback_title">Feedback</string>
-    <string name="feedback_default_text">Enter your feedback, or information about the nature of any errors you\'re reporting.</string>
+    <string name="feedback_default_text">Enter your feedback or information about the nature of any errors you’re reporting.</string>
     <string name="feedback_auto_toast_text">AnkiDroid has encountered a problem; a report is being sent to the developers…</string>
     <string name="feedback_manual_toast_text">AnkiDroid has encountered a problem; a report is being generated…</string>
     <string name="feedback_copy_debug">Copy debug info</string>

--- a/AnkiDroid/src/main/res/values/06-statistics.xml
+++ b/AnkiDroid/src/main/res/values/06-statistics.xml
@@ -20,21 +20,21 @@
 --><resources>
     <string name="statistics_young">Young</string>
     <string name="statistics_mature">Mature</string>
-    <string name="statistics_young_and_learn">Young+Learn</string>
+    <string name="statistics_young_and_learn">Young and learn</string>
     <string name="statistics_unlearned">Unseen</string>
     <string name="statistics_suspended">Suspended</string>
     <string name="statistics_relearn">Relearn</string>
     <string name="statistics_learn">Learn</string>
     <string name="statistics_cram">Cram</string>
     <string name="stats_cards">Cards</string>
-    <string name="stats_cards_intervals">Cards with given Interval</string>
-    <string name="stats_cumulative_cards">Cumulative Cards</string>
-    <string name="stats_cumulative_answers">Cumulative Answers</string>
-    <string name="stats_cumulative_time_minutes">Cumulative Minutes</string>
-    <string name="stats_cumulative_time_hours">Cumulative Hours</string>
+    <string name="stats_cards_intervals">Cards with given interval</string>
+    <string name="stats_cumulative_cards">Cumulative cards</string>
+    <string name="stats_cumulative_answers">Cumulative answers</string>
+    <string name="stats_cumulative_time_minutes">Cumulative minutes</string>
+    <string name="stats_cumulative_time_hours">Cumulative hours</string>
     <string name="stats_cumulative">Cumulative</string>
-    <string name="stats_cumulative_percentage">Cumulative Percentage</string>
-    <string formatted="false" name="stats_cumulative_correct_percentage">Cumulative Correct %</string>
+    <string name="stats_cumulative_percentage">Cumulative percentage</string>
+    <string formatted="false" name="stats_cumulative_correct_percentage">Cumulative correct %</string>
     <string name="stats_answers">Answers</string>
     <string name="stats_minutes">Minutes</string>
     <string name="stats_hours">Hours</string>
@@ -43,14 +43,14 @@
     <string name="stats_period_year">1 year</string>
     <string name="stats_period_lifetime">deck life</string>
     <string name="stats_deck_collection">collection</string>
-    <string name="stats_time_of_day">Time of Day</string>
-    <string name="stats_day_of_week">Day of Week</string>
-    <string formatted="false" name="stats_percentage_correct">% Correct</string>
+    <string name="stats_time_of_day">Time of day</string>
+    <string name="stats_day_of_week">Day of week</string>
+    <string formatted="false" name="stats_percentage_correct">% correct</string>
     <string name="stats_reviews">Reviews</string>
-    <string name="stats_answer_type">Answer Type</string>
+    <string name="stats_answer_type">Answer type</string>
     <string name="stats_today_again_count">Again count: &lt;b&gt;%d&lt;/b&gt;</string>
     <string name="stats_today_correct_count">(&lt;b&gt;%.1f%%&lt;/b&gt; correct)</string>
-    <string name="stats_today_type_breakdown">Learn: &lt;b&gt;%1$s&lt;/b&gt;, Review: &lt;b&gt;%2$s&lt;/b&gt;, Relearn: &lt;b&gt;%3$s&lt;/b&gt;, Filtered: &lt;b&gt;%4$s&lt;/b&gt;</string>
+    <string name="stats_today_type_breakdown">Learn: &lt;b&gt;%1$s&lt;/b&gt;, review: &lt;b&gt;%2$s&lt;/b&gt;, relearn: &lt;b&gt;%3$s&lt;/b&gt;, filtered: &lt;b&gt;%4$s&lt;/b&gt;</string>
     <string name="stats_today_mature_cards">Correct answers on mature cards: %1$d/%2$d (%3$.1f%%)</string>
     <string name="stats_today_no_mature_cards">No mature cards were studied today.</string>
     <string name="deck_summary_all_decks">All decks</string>
@@ -99,10 +99,10 @@
     <string name="stats_review_count">Review count</string>
     <string name="stats_review_time">Review time</string>
     <string name="stats_review_intervals">Intervals</string>
-    <string name="stats_breakdown">Hourly Breakdown</string>
-    <string name="stats_weekly_breakdown">Weekly Breakdown</string>
-    <string name="stats_answer_buttons">Answer Buttons</string>
-    <string name="stats_cards_types">Cards Types</string>
+    <string name="stats_breakdown">Hourly breakdown</string>
+    <string name="stats_weekly_breakdown">Weekly breakdown</string>
+    <string name="stats_answer_buttons">Answer buttons</string>
+    <string name="stats_cards_types">Cards types</string>
 
     <string-array name="stats_day_time_strings">
         <item>4AM</item>

--- a/AnkiDroid/src/main/res/values/07-cardbrowser.xml
+++ b/AnkiDroid/src/main/res/values/07-cardbrowser.xml
@@ -41,9 +41,9 @@
     <string name="card_browser_list_my_searches_save">Save search</string>
     <string name="card_browser_list_my_searches_title">Choose a saved search</string>
     <string name="card_browser_list_my_searches_new_name">Name for the current search</string>
-    <string name="card_browser_list_my_searches_new_search_error_empty_name">You can\'t save a search without a name.</string>
-    <string name="card_browser_list_my_searches_new_search_error_dup">Name already exists!</string>
-    <string name="card_browser_list_my_searches_remove_content">Delete \"%1$s\"?</string>
+    <string name="card_browser_list_my_searches_new_search_error_empty_name">You can’t save a search without a name</string>
+    <string name="card_browser_list_my_searches_new_search_error_dup">Name exists</string>
+    <string name="card_browser_list_my_searches_remove_content">Delete “%1$s”?</string>
     <string name="card_browser_change_display_order">Change display order</string>
     <string name="card_browser_change_display_order_title">Choose display order</string>
     <string name="card_browser_change_display_order_reverse">Select a field twice to reverse</string>

--- a/AnkiDroid/src/main/res/values/09-backup.xml
+++ b/AnkiDroid/src/main/res/values/09-backup.xml
@@ -25,9 +25,9 @@
     <string name="backup_restore">Restore from backup</string>
     <string name="backup_new_collection">New collection</string>
     <string name="backup_del_collection">Delete collection and create new one</string>
-    <string name="backup_del_collection_question">Delete the collection and create a new one? This will drop all your learning progress and delete all cards!</string>
+    <string name="backup_del_collection_question">Delete the collection and create a new one? This will drop all your learning progress and delete all cards.</string>
     <string name="backup_full_sync_from_server">Full sync from server</string>
-    <string name="backup_full_sync_from_server_question">Overwrite your collection with the one from AnkiWeb? This will drop all your learning progress and added information since your last sync!</string>
+    <string name="backup_full_sync_from_server_question">Overwrite your collection with the one from AnkiWeb? This will drop all your learning progress and added information since your last sync.</string>
     <string name="error_handling_title">Error handling</string>
     <string name="error_handling_options">Options</string>
     <string name="backup_retry_opening">Retry opening</string>
@@ -39,9 +39,9 @@
     <string name="backup_restore_select_title">Select backup to restore</string>
     <string name="backup_restore_no_backups">No backups available on this device. If you have backups on your desktop computer, copy them manually into your AnkiDroid folder.</string>
     <string name="open_collection_failed_title">Collection not opened</string>
-    <string name="open_collection_failed_message">Database could not be opened. It\'s either not a real Anki database or has been corrupted.\n\nTouch \'options\' for various options to restore the database, or for more information about repairing corrupted collections see:\n%1$s</string>
-    <string name="corrupt_db_message">Unfortunately your collection has become corrupted.\n\nTouch \'options\' to restore from a backup, or if that does not work, see the following instructions for manually repairing the database:\n%1$s</string>
-    <string name="access_collection_failed_message">An error occurred while accessing your collection. It may have been caused by a harmless bug, or there may be a problem with it. \n\nTry running check database, or restoring from backup by pressing the \'options\' button. If you continue to see this message, please file a bug report:\n%1$s</string>
-    <string name="deck_repair_error">Collection could not be repaired</string>
+    <string name="open_collection_failed_message">Database couldn’t be opened. It’s either not a real Anki database or has been corrupted.\n\nTouch “options” for various options to restore the database, or for more information about repairing corrupted collections see:\n%1$s</string>
+    <string name="corrupt_db_message">Your collection has become corrupted.\n\nTouch “options” to restore from a backup, or if that doesn’t work, see the following instructions for manually repairing the database:\n%1$s</string>
+    <string name="access_collection_failed_message">An error occurred while accessing your collection. It may have been caused by a harmless bug, or there may be a problem with it. \n\nTry running check database, or restoring from backup by pressing the “options” button. If you continue to see this message, please file a bug report:\n%1$s</string>
+    <string name="deck_repair_error">Collection couldn’t be repaired</string>
 
 </resources>

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -47,7 +47,7 @@
     <string name="whiteboard_black">Black strokes</string>
     <string name="whiteboard_black_summ">Uses less memory, unless in night mode</string>
     <string name="write_answers_disable">Disable typing in answer</string>
-    <string name="write_answers_disable_summ">Prevents keyboard from appearing on cards containing \'type in the answer\' fields</string>
+    <string name="write_answers_disable_summ">Prevents keyboard from appearing on cards containing type-the-answer fields</string>
     <string name="text_selection_click">Long press workaround</string>
     <string name="text_selection_click_summ">Enable this if you are not able to select text with a long press</string>
     <string name="dictionary">Lookup dictionary</string>
@@ -88,13 +88,13 @@
     <string name="tts">Text to speech</string>
     <string name="tts_summ">Reads out question and answer if no sound file is included</string>
     <string name="sync_fetch_missing_media">Fetch media on sync</string>
-    <string name="sync_fetch_missing_media_summ">Automatically fetch missing media when syncing.</string>
+    <string name="sync_fetch_missing_media_summ">Automatically fetch missing media when syncing</string>
     <string name="sync_account">AnkiWeb account</string>
     <string name="sync_account_summ_logged_out">Not logged in</string>
     <string name="sync_account_summ_logged_in">%s</string>
     <string name="fix_hebrew_text">Fix for Hebrew vowels</string>
     <string name="fix_hebrew_text_summ">Workaround for rendering Hebrew vowels correctly.</string>
-    <string name="fix_hebrew_instructions">This setting bypasses the RTL algorithm of Android to show Hebrew text with vowels correctly.\n\nFor this to work, you need to download font Tohu.ttf and copy it manually to:\n%s/fonts/\n\nYou won\'t have to modify your cards.</string>
+    <string name="fix_hebrew_instructions">This setting bypasses the RTL algorithm of Android to show Hebrew text with vowels correctly.\n\nFor this to work, you need to download font Tohu.ttf and copy it manually to\n“%s/fonts/”\n\nYou won’t have to modify your cards.</string>
     <string name="fix_hebrew_download_font">Download font</string>
     <string name="default_font">Default font</string>
     <string name="default_font_summ">XXX</string>
@@ -202,7 +202,7 @@
         <item quantity="other">%s subdecks will use this group</item>
     </plurals>
     <string name="deck_conf_set_subdecks_title">Set for all subdecks</string>
-    <string name="deck_conf_set_subdecks_message">Set current options group for all of this deck\'s subdecks?</string>
+    <string name="deck_conf_set_subdecks_message">Set current options group for all of this deck’s subdecks?</string>
     <string name="pref_browser_editor_font">Browser and editor font</string>
     <string name="pref_browser_editor_font_summ">XXX</string>
     <string name="deck_conf_cram_filter">Filter</string>

--- a/AnkiDroid/src/main/res/values/11-arrays.xml
+++ b/AnkiDroid/src/main/res/values/11-arrays.xml
@@ -58,8 +58,8 @@
         <item>Relative overdueness</item>
     </string-array>
     <string-array name="custom_study_options_labels">
-        <item>Increase today\'s new card limit</item>
-        <item>Increase today\'s review card limit</item>
+        <item>Increase today’s new card limit</item>
+        <item>Increase today’s review card limit</item>
         <item>Review forgotten cards</item>
         <item>Review ahead</item>
         <item>Study a random selection of cards</item>

--- a/AnkiDroid/src/main/res/values/styles.xml
+++ b/AnkiDroid/src/main/res/values/styles.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <!-- White Theme -->
+    <!-- White theme -->
     <style name="White">
         <item name="android:background">@color/white_background</item>
     </style>
 
-    
+
     <style name="Theme.CrashReportDialog" parent="@android:style/Theme.Dialog" />
 
-    <!-- Widget Elements -->
+    <!-- Widget elements -->
     <style name="Widget.ProgressBar.Horizontal" parent="@android:style/Widget.ProgressBar.Horizontal">
         <item name="android:progressDrawable">@drawable/progress_horizontal</item>
         <item name="android:orientation">vertical</item>

--- a/AnkiDroid/src/main/res/values/themes.xml
+++ b/AnkiDroid/src/main/res/values/themes.xml
@@ -3,7 +3,7 @@
 
     <style name="Theme_Base_Custom_Light" parent="@style/Theme.AppCompat.Light.DarkActionBar" />
     <style name="App_Theme" parent="Theme_White"/>
-    <!-- White Theme -->
+    <!-- White theme -->
     <style name="Theme_White" parent="@style/Theme_Base_Custom_Light">
         <item name="actionBarTextColor">@color/white</item>
         <item name="colorPrimary">@color/theme_primary</item>


### PR DESCRIPTION
Clean up of screen texts.

Mostly replacing " and ' when used as quotation marks with “, ”, and ' with ’ when used as apostrophes.
From the [style guide](https://www.google.com/design/spec/style/writing.html#writing-capitalization-punctuation):
> Never use the generic quotes ", ' (…). These are never right for quotation marks, apostrophes, or primes.

There was also a mix of double quotes \"like this\" and single quotes \'like this\'. Use only double quotes.

Also use a few more contractions, (… not → …n’t), by the [style guide](https://www.google.com/design/spec/style/writing.html#writing-capitalization-punctuation) again.

Replace a few !s. I dare you to exclaim “Non-developers can also help, for instance by translating AnkiDroid, updating the wiki and screenshots, donating to Anki Desktop, or blogging about AnkiDroid!” ([Style guide link](https://www.google.com/design/spec/style/writing.html#writing-capitalization-punctuation))

One exclamation point i left in: “It’s free!”. (The sync account, that is.) I think that is borderline. You can shout that, but it sounds quite excited. Yeah!!! Free stuff!!1!!eleven!!!

Use sentence-style caps. Card Browser → Card browser, Day of Week → Day of week &c.
