### PR TITLE
Fix for 2661.

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -386,7 +386,7 @@ public class Reviewer extends AbstractFlashcardViewer {
         super.onStop();
 
         if (!isFinishing()) {
-            if (colIsOpen()) {
+            if (colIsOpen() && mSched != null) {
                 WidgetStatus.update(this, mSched.progressToday(null, mCurrentCard, true));
             }
         }


### PR DESCRIPTION
Look like you can stop the reviewer before `mSched` is set up. Don’t try to access it then.
Should fix [issue #2661](https://code.google.com/p/ankidroid/issues/detail?id=2661).