### PR TITLE
Expose unbury button for filtered decks

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
@@ -171,6 +171,7 @@ public class StudyOptionsFragment extends Fragment implements LoaderManager.Load
                     showCustomStudyContextMenu();
                     return;
                 case R.id.studyoptions_unbury:
+                case R.id.studyoptions_unbury_cram:
                     Timber.i("StudyOptionsFragment:: unbury button pressed");
                     col.getSched().unburyCardsForDeck();
                     refreshInterfaceAndDecklist(true);
@@ -340,21 +341,20 @@ public class StudyOptionsFragment extends Fragment implements LoaderManager.Load
         mTextCongratsMessage = (TextView) mStudyOptionsView.findViewById(R.id.studyoptions_congrats_message);
         mFloatingActionButton = (ImageButton) mStudyOptionsView.findViewById(R.id.fab);
 
-
         if (getCol().getDecks().isDyn(getCol().getDecks().selected())) {
             Button rebBut = (Button) mStudyOptionsView.findViewById(R.id.studyoptions_rebuild_cram);
             rebBut.setOnClickListener(mButtonClickListener);
             Button emptyBut = (Button) mStudyOptionsView.findViewById(R.id.studyoptions_empty_cram);
             emptyBut.setOnClickListener(mButtonClickListener);
-            // If dynamic deck then enable the cram buttons group, and disable the new filtered deck / ordinary study
-            // options buttons group
+            // Enable the dynamic deck buttons and disable the normal ones
             ((LinearLayout) mStudyOptionsView.findViewById(R.id.studyoptions_cram_buttons)).setVisibility(View.VISIBLE);
             ((LinearLayout) mStudyOptionsView.findViewById(R.id.studyoptions_regular_buttons)).setVisibility(View.GONE);
+            // Dynamic decks have their own unbury button to keep a reference to
+            mButtonUnbury = (Button) mStudyOptionsView.findViewById(R.id.studyoptions_unbury_cram);
+        } else {
+            mButtonUnbury = (Button) mStudyOptionsView.findViewById(R.id.studyoptions_unbury);
         }
-        // Show the unbury button if there are cards to unbury
-        mButtonUnbury = (Button) mStudyOptionsView.findViewById(R.id.studyoptions_unbury);
         mButtonUnbury.setOnClickListener(mButtonClickListener);
-
         // Code common to both fragmented and non-fragmented view
         mTextTodayNew = (TextView) mStudyOptionsView.findViewById(R.id.studyoptions_new);
         mTextTodayLrn = (TextView) mStudyOptionsView.findViewById(R.id.studyoptions_lrn);

--- a/AnkiDroid/src/main/res/layout-xlarge/studyoptions_fragment.xml
+++ b/AnkiDroid/src/main/res/layout-xlarge/studyoptions_fragment.xml
@@ -369,6 +369,14 @@
                         android:layout_weight="1"
                         android:text="@string/empty_cram_label"
                         android:textSize="12sp" />
+                    <Button
+                        android:id="@+id/studyoptions_unbury_cram"
+                        android:layout_width="0px"
+                        android:layout_height="fill_parent"
+                        android:layout_weight="1"
+                        android:text="@string/unbury"
+                        android:textSize="12sp"
+                        android:visibility="gone" />
                 </LinearLayout>
             </LinearLayout>
         </LinearLayout>

--- a/AnkiDroid/src/main/res/layout/studyoptions_fragment.xml
+++ b/AnkiDroid/src/main/res/layout/studyoptions_fragment.xml
@@ -333,6 +333,14 @@
                         android:layout_weight="1"
                         android:text="@string/empty_cram_label"
                         android:textSize="12sp" />
+                     <Button
+                        android:id="@+id/studyoptions_unbury_cram"
+                        android:layout_width="0px"
+                        android:layout_height="fill_parent"
+                        android:layout_weight="1"
+                        android:text="@string/unbury"
+                        android:textSize="12sp"
+                        android:visibility="gone" />
                 </LinearLayout>
             </LinearLayout>
         </LinearLayout>


### PR DESCRIPTION
Fix for [Issue 2201](https://code.google.com/p/ankidroid/issues/detail?id=2201). We were not showing an unbury button for filtered decks, even though the completion text was saying there was such a button to click on.