### PR TITLE
Dim the DeckPicker behind ShowcaseView properly pre-Honeycomb

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -1997,15 +1997,12 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
     }
 
 
-    @SuppressLint("NewApi")
     @Override
     public void onShowcaseViewHide(ShowcaseView showcaseView) {
         // Undim the deck list when ShowcaseView is hidden
-        if (CompatHelper.isHoneycomb()) {
-            final float alpha = 1f;
-            mTodayTextView.setAlpha(alpha);
-            mRecyclerView.setAlpha(alpha);
-        }
+        final float alpha = 1f;
+        CompatHelper.getCompat().setAlpha(mTodayTextView, alpha);
+        CompatHelper.getCompat().setAlpha(mRecyclerView, alpha);
     }
 
 
@@ -2014,15 +2011,12 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
     }
 
 
-    @SuppressLint("NewApi")
     @Override
     public void onShowcaseViewShow(ShowcaseView showcaseView) {
         // Dim the deck list when ShowcaseView is shown
-        if (CompatHelper.isHoneycomb()) {
-            final float alpha = 0.1f;
-            mTodayTextView.setAlpha(alpha);
-            mRecyclerView.setAlpha(alpha);
-        }
+        final float alpha = 0.1f;
+        CompatHelper.getCompat().setAlpha(mTodayTextView, alpha);
+        CompatHelper.getCompat().setAlpha(mRecyclerView, alpha);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
@@ -52,5 +52,6 @@ public interface Compat {
     public abstract void disableDatabaseWriteAheadLogging(SQLiteDatabase db);
     public abstract void enableCookiesForFileSchemePages();
     public abstract void updateWidgetDimensions(Context context, RemoteViews updateViews, Class<?> cls);
+    public abstract void setAlpha(View view, float alpha);
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV12.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV12.java
@@ -1,6 +1,7 @@
 package com.ichi2.compat;
 
 import android.annotation.TargetApi;
+import android.view.View;
 import android.webkit.CookieManager;
 
 import timber.log.Timber;
@@ -18,6 +19,11 @@ public class CompatV12 extends CompatV9 implements Compat {
         } catch (Throwable e) {
             Timber.e(e, "Runtime exception enabling cookies");
         }
+    }
+
+    @Override
+    public void setAlpha(View view, float alpha) {
+        view.setAlpha(alpha);
     }
 
 }

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV8.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV8.java
@@ -7,6 +7,7 @@ import android.database.sqlite.SQLiteDatabase;
 import android.speech.tts.TextToSpeech;
 import android.speech.tts.TextToSpeech.OnUtteranceCompletedListener;
 import android.view.View;
+import android.view.animation.AlphaAnimation;
 import android.widget.RemoteViews;
 
 import com.ichi2.anki.ReadText;
@@ -91,5 +92,12 @@ public class CompatV8 implements Compat {
     @Override
     public void updateWidgetDimensions(Context context, RemoteViews updateViews, Class<?> cls) {
 
+    }
+
+    public void setAlpha(View view, float alpha) {
+        AlphaAnimation alphaAnimation = new AlphaAnimation(alpha, alpha);
+        alphaAnimation.setDuration(0); // Make animation instant
+        alphaAnimation.setFillAfter(true); // Tell it to persist after the animation ends
+        view.startAnimation(alphaAnimation);
     }
 }


### PR DESCRIPTION
The ShowcaseView text was very hard to read on Android 2.x due to not setting the alpha of the DeckPicker Views. I found a workaround and put it in the Compat class