### PR TITLE
Recreate the backstack when night mode is toggled

### DIFF
--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -146,15 +146,33 @@
         <activity
             android:name="com.ichi2.anki.StudyOptionsActivity"
             android:configChanges="keyboardHidden|locale|orientation|screenSize"
-            android:label="StudyOptions" />
+            android:label="StudyOptions"
+            android:parentActivityName=".DeckPicker">
+            <!-- The meta-data element is needed for versions lower than 4.1 -->
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="com.ichi2.anki.DeckPicker" />
+        </activity>
         <activity
             android:name="com.ichi2.anki.CardBrowser"
             android:configChanges="keyboardHidden|orientation|locale|screenSize"
-            android:label="Card Browser" />
+            android:label="Card Browser"
+            android:parentActivityName=".DeckPicker">
+            <!-- The meta-data element is needed for versions lower than 4.1 -->
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="com.ichi2.anki.DeckPicker" />
+        </activity>
         <activity
             android:name="com.ichi2.anki.Reviewer"
             android:configChanges="keyboardHidden|orientation|locale|screenSize"
-            android:windowSoftInputMode="stateAlwaysHidden" />
+            android:windowSoftInputMode="stateAlwaysHidden"
+            android:parentActivityName=".StudyOptionsActivity">
+            <!-- The meta-data element is needed for versions lower than 4.1 -->
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="com.ichi2.anki.StudyOptionsActivity" />
+        </activity>
         <activity
             android:name="com.ichi2.anki.VideoPlayer"
             android:configChanges="keyboardHidden|orientation|locale|screenSize"
@@ -207,7 +225,13 @@
         <activity
             android:name="com.ichi2.anki.Statistics"
             android:theme="@style/Theme_White_Statistics"
-            android:configChanges="keyboardHidden|orientation|locale|screenSize" />
+            android:configChanges="keyboardHidden|orientation|locale|screenSize"
+            android:parentActivityName=".DeckPicker">
+            <!-- The meta-data element is needed for versions lower than 4.1 -->
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="com.ichi2.anki.DeckPicker" />
+        </activity>
         <activity
             android:name="com.ichi2.anki.Previewer"
             android:configChanges="locale"
@@ -299,7 +323,6 @@
         </activity>
         <activity
             android:name="com.ichi2.anki.CardTemplateEditor"
-            android:parentActivityName="com.ichi2.anki.NoteEditor"
             android:configChanges="keyboardHidden|orientation|locale|screenSize"
             android:label="@string/title_activity_template_editor"
             android:windowSoftInputMode="stateAlwaysHidden" >

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
@@ -479,12 +479,5 @@ public class AnkiActivity extends AppCompatActivity implements LoaderManager.Loa
         this.startActivityWithoutAnimation(intent);
         this.finishWithoutAnimation();
     }
-
-    protected void rebootApp() {
-        finishWithoutAnimation();
-        Intent deckPicker = new Intent(this, DeckPicker.class);
-        deckPicker.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
-        startActivityWithoutAnimation(deckPicker);
-    }
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -455,9 +455,9 @@ public class DeckPicker extends NavigationDrawerActivity implements OnShowcaseEv
         menu.findItem(R.id.action_new_filtered_deck).setEnabled(sdCardAvailable);
         menu.findItem(R.id.action_check_database).setEnabled(sdCardAvailable);
         menu.findItem(R.id.action_check_media).setEnabled(sdCardAvailable);
-
+        boolean isNightMode = AnkiDroidApp.getSharedPrefs(this).getBoolean("invertedColors", false);
         // Show the welcome screen here if col empty to be sure that the action bar exists
-        if (mShowShowcaseView && colIsOpen() && getCol().isEmpty() && mDeckList != null && mDeckList.size() <=1) {
+        if (mShowShowcaseView && colIsOpen() && getCol().isEmpty() && mDeckList != null && mDeckList.size() <=1 && !isNightMode) {
             mShowShowcaseView = false;
             final Resources res = getResources();
             try {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
@@ -30,6 +30,7 @@ import android.view.MenuItem;
 import android.view.View;
 
 import com.ichi2.anim.ActivityTransitionAnimation;
+import com.ichi2.compat.CompatHelper;
 
 import timber.log.Timber;
 
@@ -146,7 +147,7 @@ public class NavigationDrawerActivity extends AnkiActivity implements Navigation
                     preferences.edit().putBoolean("invertedColors", true).commit();
                 }
                 setNightModeIcon();
-                rebootApp();
+                CompatHelper.getCompat().restartActivityInvalidateBackstack(this);
                 return true;
             case R.id.nav_settings:
                 mOldColPath = CollectionHelper.getCurrentAnkiDroidDirectory(this);
@@ -238,7 +239,7 @@ public class NavigationDrawerActivity extends AnkiActivity implements Navigation
             } else {
                 // collection path has changed so kick the user back to the DeckPicker
                 CollectionHelper.getInstance().closeCollection(true);
-                rebootApp();
+                CompatHelper.getCompat().restartActivityInvalidateBackstack(this);
             }
         } else {
             super.onActivityResult(requestCode, resultCode, data);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -226,7 +226,7 @@ public class Reviewer extends AbstractFlashcardViewer {
             menu.findItem(R.id.action_hide_whiteboard).setVisible(true);
             menu.findItem(R.id.action_clear_whiteboard).setVisible(true);
 
-            Drawable whiteboardIcon = getResources().getDrawable(R.drawable.ic_gesture_white_24dp, null);
+            Drawable whiteboardIcon = getResources().getDrawable(R.drawable.ic_gesture_white_24dp);
             if (mShowWhiteboard) {
                 whiteboardIcon.setAlpha(255);
                 menu.findItem(R.id.action_hide_whiteboard).setIcon(whiteboardIcon);

--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
@@ -22,6 +22,7 @@ import android.speech.tts.TextToSpeech;
 import android.view.View;
 import android.widget.RemoteViews;
 
+import com.ichi2.anki.AnkiActivity;
 import com.ichi2.anki.exception.APIVersionException;
 
 /**
@@ -45,13 +46,14 @@ import com.ichi2.anki.exception.APIVersionException;
  * unless the behaviour is supposed to be different there.
  */
 public interface Compat {
-    public abstract String nfcNormalized(String txt) throws APIVersionException;
-    public abstract String detagged(String txt);
-    public abstract void setOverScrollModeNever(View v);
-    public abstract void setTtsOnUtteranceProgressListener(TextToSpeech tts);
-    public abstract void disableDatabaseWriteAheadLogging(SQLiteDatabase db);
-    public abstract void enableCookiesForFileSchemePages();
-    public abstract void updateWidgetDimensions(Context context, RemoteViews updateViews, Class<?> cls);
-    public abstract void setAlpha(View view, float alpha);
+    String nfcNormalized(String txt) throws APIVersionException;
+    String detagged(String txt);
+    void setOverScrollModeNever(View v);
+    void setTtsOnUtteranceProgressListener(TextToSpeech tts);
+    void disableDatabaseWriteAheadLogging(SQLiteDatabase db);
+    void enableCookiesForFileSchemePages();
+    void updateWidgetDimensions(Context context, RemoteViews updateViews, Class<?> cls);
+    void setAlpha(View view, float alpha);
+    void restartActivityInvalidateBackstack(AnkiActivity activity);
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatHelper.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatHelper.java
@@ -35,6 +35,8 @@ public class CompatHelper {
             mCompat = new CompatV16();
         } else if (getSdkVersion() >= 15) {
             mCompat = new CompatV15();
+        } else if (getSdkVersion() >= 11) {
+            mCompat = new CompatV11();
         } else if (getSdkVersion() >= 12) {
             mCompat = new CompatV12();
         } else if (getSdkVersion() >= 9) {

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV11.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV11.java
@@ -1,0 +1,37 @@
+
+package com.ichi2.compat;
+
+import android.annotation.TargetApi;
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.v4.app.TaskStackBuilder;
+import android.view.View;
+
+import com.ichi2.anki.AnkiActivity;
+
+import java.text.Normalizer;
+
+import timber.log.Timber;
+
+/** Implementation of {@link Compat} for SDK level 11 (Honeycomb) */
+@TargetApi(11)
+public class CompatV11 extends CompatV9 implements Compat {
+    @Override
+    public void setAlpha(View view, float alpha) {
+        view.setAlpha(alpha);
+    }
+
+    /**
+     * Restart the activity and discard old backstack, creating it new from the heirarchy in the manifest
+     */
+    public void restartActivityInvalidateBackstack(AnkiActivity activity) {
+        Timber.i("AnkiActivity -- restartActivityInvalidateBackstack()");
+        Intent intent = new Intent();
+        intent.setClass(activity, activity.getClass());
+        TaskStackBuilder stackBuilder = TaskStackBuilder.create(activity);
+        stackBuilder.addNextIntentWithParentStack(intent);
+        stackBuilder.startActivities(new Bundle());
+        activity.finishWithoutAnimation();
+    }
+
+}

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV12.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV12.java
@@ -1,14 +1,13 @@
 package com.ichi2.compat;
 
 import android.annotation.TargetApi;
-import android.view.View;
 import android.webkit.CookieManager;
 
 import timber.log.Timber;
 
 /** Implementation of {@link Compat} for SDK level 12 */
 @TargetApi(12)
-public class CompatV12 extends CompatV9 implements Compat {
+public class CompatV12 extends CompatV11 implements Compat {
 
     // On API level 12 and higher, WebKit prevents file scheme pages from accessing cookies.
     // This function removes this restriction.
@@ -20,10 +19,4 @@ public class CompatV12 extends CompatV9 implements Compat {
             Timber.e(e, "Runtime exception enabling cookies");
         }
     }
-
-    @Override
-    public void setAlpha(View view, float alpha) {
-        view.setAlpha(alpha);
-    }
-
 }

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV8.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV8.java
@@ -3,6 +3,7 @@ package com.ichi2.compat;
 
 import android.annotation.TargetApi;
 import android.content.Context;
+import android.content.Intent;
 import android.database.sqlite.SQLiteDatabase;
 import android.speech.tts.TextToSpeech;
 import android.speech.tts.TextToSpeech.OnUtteranceCompletedListener;
@@ -10,6 +11,8 @@ import android.view.View;
 import android.view.animation.AlphaAnimation;
 import android.widget.RemoteViews;
 
+import com.ichi2.anki.AnkiActivity;
+import com.ichi2.anki.DeckPicker;
 import com.ichi2.anki.ReadText;
 import com.ichi2.anki.exception.APIVersionException;
 
@@ -99,5 +102,16 @@ public class CompatV8 implements Compat {
         alphaAnimation.setDuration(0); // Make animation instant
         alphaAnimation.setFillAfter(true); // Tell it to persist after the animation ends
         view.startAnimation(alphaAnimation);
+    }
+
+    /**
+     * Pre-honeycomb just completely boot back to the DeckPicker
+     */
+    public void restartActivityInvalidateBackstack(AnkiActivity activity) {
+        Timber.i("AnkiActivity -- restartActivityInvalidateBackstack()");
+        //TODO: Find a way to recreate the backstack even pre-Honeycomb
+        Intent intent = new Intent(activity, DeckPicker.class);
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        activity.startActivityWithoutAnimation(intent);
     }
 }


### PR DESCRIPTION
Instead of booting back to the deck picker every time night mode is toggled, stay on the same activity and try to recreate the backstack.

Only works on Android 3.0+ and the backstack is recreated from the hierarchy so for example if the user does the following:

Start from deck picker -> tap on default deck -> press study button -> open browser via navigation menu -> toggle night mode -> press hardware back button

They will be taken back to the deck picker instead of the reviewer. I can't see any simple way to avoid this unfortunately.