### PR TITLE
Purge temporary media sync files and improve stream management

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/FullSyncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/FullSyncer.java
@@ -87,7 +87,10 @@ public class FullSyncer extends HttpSyncer {
         mCol.close(false);
         mCol = null;
         String tpath = path + ".tmp";
-        if (!super.writeToFile(cont, tpath)) {
+        try {
+            super.writeToFile(cont, tpath);
+        } catch (IOException e) {
+            Timber.e(e, "Full sync failed to download collection.");
             return new Object[] { "sdAccessError" };
         }
         // first check, if account needs upgrade (from 1.2)

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HttpSyncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HttpSyncer.java
@@ -254,7 +254,7 @@ public class HttpSyncer {
     }
 
 
-    public boolean writeToFile(InputStream source, String destination) {
+    public void writeToFile(InputStream source, String destination) throws IOException {
         File file = new File(destination);
         OutputStream output = null;
         try {
@@ -267,19 +267,17 @@ public class HttpSyncer {
                 bytesReceived += len;
                 publishProgress();
             }
-            output.close();
-            return true;
         } catch (IOException e) {
-            try {
-                if (output != null) {
-                    output.close();
-                }
-            } catch (IOException e1) {
-                // do nothing
+            if (file.exists()) {
+                // Don't keep the file if something went wrong. It'll be corrupt.
+                file.delete();
             }
-            // no write access or sd card full
-            file.delete();
-            return false;
+            // Re-throw so we know what the error was.
+            throw e;
+        } finally {
+            if (output != null) {
+                output.close();
+            }
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteMediaServer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteMediaServer.java
@@ -98,7 +98,12 @@ public class RemoteMediaServer extends HttpSyncer {
     }
 
 
-    // args: files
+    /**
+     * args: files
+     * <br>
+     * This method returns a ZipFile with the OPEN_DELETE flag, ensuring that the file on disk will
+     * be automatically deleted when the stream is closed.
+     */
     public ZipFile downloadFiles(List<String> top) throws UnknownHttpResponseException {
         try {
             HttpResponse resp;
@@ -107,11 +112,11 @@ public class RemoteMediaServer extends HttpSyncer {
             String zipPath = mCol.getPath().replaceFirst("collection\\.anki2$", "tmpSyncFromServer.zip");
             // retrieve contents and save to file on disk:
             super.writeToFile(resp.getEntity().getContent(), zipPath);
-            return new ZipFile(new File(zipPath), ZipFile.OPEN_READ);
+            return new ZipFile(new File(zipPath), ZipFile.OPEN_READ | ZipFile.OPEN_DELETE);
         } catch (JSONException e) {
             throw new RuntimeException(e);
         } catch (IOException e) {
-            Timber.e(e, "Failed to create temp media sync zip file");
+            Timber.e(e, "Failed to download requested media files");
             throw new RuntimeException(e);
         }
     }


### PR DESCRIPTION
This commit cleans up some of the media syncing code and addresses a couple of the TODOs left in there.

1 - The temporary files (`tmpSyncToServer.zip` and `tmpSyncFromServer.zip`) are now properly deleted when we are done with them. They weren't really causing any problems but they clutter up the AnkiDroid directory and in general it's better to clean up after ourselves.

2- Better try/finally usage for stream management. As an extension to this, I've also updated comments to be more explicit about how streams are being used .

3 - Better exception handling. Don't catch-all or swallow exceptions.

4 - Removed some duplicate logging lines.

Extra:
I've removed the comment about investigating in-memory zip performance since I've effectively done just that in https://github.com/ankidroid/Anki-Android/pull/740 and deemed it not viable.

On top of that, the *real* culprit of our FileNotFoundException (from [Issue 1583](https://code.google.com/p/ankidroid/issues/detail?id=1583) isn't the mysteriously disappearing `tmpSyncFromServer.zip`, but the fact that the `writeToFile` method that writes it is swallowing an IOException and carrying on like nothing has happened. That is, the problem is most likely one step before we get to writing this file (the stream from `resp.getEntity().getContent()`). I can make many guesses as to what that could be, but since we are letting the IOException bubble up now we should at least get the *real* exception message to help us diagnose it.

With that said I will close https://github.com/ankidroid/Anki-Android/pull/740 since even its approach would be susceptible to this problem.