### PR TITLE
Use UTF-8 as project encoding

### DIFF
--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding" useUTFGuessing="true" native2AsciiForPropertiesFiles="false">
+    <file url="PROJECT" charset="UTF-8" />
+  </component>
+</project>


### PR DESCRIPTION
In at least two files, [one](https://github.com/ankidroid/Anki-Android/blob/develop/AnkiDroid/src/main/java/com/ichi2/anki/Lookup.java#L109) still [sort-of](https://code.google.com/p/ankidroid/issues/detail?id=2676) in use, it is not just in comments.

@timrae: Could you please check if this is a help for Android Studio on Windows by looking if the mojibake at [this](https://github.com/ankidroid/Anki-Android/blob/develop/AnkiDroid/src/main/java/com/ichi2/anki/Lookup.java#L109) or [this](https://github.com/ankidroid/Anki-Android/blob/develop/AnkiDroid/src/main/java/com/ichi2/anki/provider/FlashCardsContract.java#L535) line goes away?