### PR TITLE
Add several network availability checks before network requests and s…

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/LoadPronounciationActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/LoadPronounciationActivity.java
@@ -40,6 +40,7 @@ import com.ichi2.anki.multimediacard.beolingus.parsing.BeolingusParser;
 import com.ichi2.anki.multimediacard.language.LanguageListerBeolingus;
 import com.ichi2.anki.runtimetools.TaskOperations;
 import com.ichi2.anki.web.HttpFetcher;
+import com.ichi2.async.Connection;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
@@ -151,6 +152,10 @@ public class LoadPronounciationActivity extends Activity implements OnCancelList
      * @param v Start of the story.
      */
     protected void onLoadPronunciation(View v) {
+        if(!Connection.isOnline()) {
+            showToast(gtxt(R.string.network_no_connection));
+            return;
+        }
 
         String message = gtxt(R.string.multimedia_editor_searching_word);
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/SearchImageActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/SearchImageActivity.java
@@ -43,6 +43,7 @@ import com.ichi2.anki.multimediacard.googleimagesearch.json.ResponseData;
 import com.ichi2.anki.multimediacard.googleimagesearch.json.Result;
 import com.ichi2.anki.web.HttpFetcher;
 import com.ichi2.anki.web.UrlTools;
+import com.ichi2.async.Connection;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
@@ -206,6 +207,11 @@ public class SearchImageActivity extends Activity implements DialogInterface.OnC
 
 
     protected void pickImage() {
+        if(!Connection.isOnline()) {
+            returnFailure(gtxt(R.string.network_no_connection));
+            return;
+        }
+
         String imageUrl = mImages.get(mCurrentImage);
 
         // And here it is possible to download it... so on,
@@ -339,6 +345,11 @@ public class SearchImageActivity extends Activity implements DialogInterface.OnC
 
         progressDialog.setCancelable(true);
         progressDialog.setOnCancelListener(this);
+
+        if(!Connection.isOnline()) {
+            returnFailure(gtxt(R.string.network_no_connection));
+            return;
+        }
 
         BackgroundPost p = new BackgroundPost();
         p.setQuery(mSource);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/TranslationActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/TranslationActivity.java
@@ -47,6 +47,7 @@ import com.ichi2.anki.multimediacard.glosbe.json.Tuc;
 import com.ichi2.anki.multimediacard.language.LanguagesListerGlosbe;
 import com.ichi2.anki.runtimetools.TaskOperations;
 import com.ichi2.anki.web.HttpFetcher;
+import com.ichi2.async.Connection;
 import com.ichi2.utils.HtmlUtil;
 
 import java.io.UnsupportedEncodingException;
@@ -193,6 +194,10 @@ public class TranslationActivity extends FragmentActivity implements DialogInter
 
 
     protected void translate() {
+        if(!Connection.isOnline()) {
+            showToast(gtxt(R.string.network_no_connection));
+            return;
+        }
 
         progressDialog = ProgressDialog.show(this, getText(R.string.multimedia_editor_progress_wait_title),
                 getText(R.string.multimedia_editor_trans_translating_online), true, false);

--- a/AnkiDroid/src/main/res/values/16-multimedia-editor.xml
+++ b/AnkiDroid/src/main/res/values/16-multimedia-editor.xml
@@ -122,4 +122,7 @@
     <string name="title_activity_load_pronounciation">Pronunciation</string>
     <string name="title_activity_search_image">Google Image Search</string>
 
+	<!-- Network failure -->
+	<string name="network_no_connection">No internet connection. Please check
+your internet connection or try again later.</string>
 </resources>

--- a/AnkiDroid/src/main/res/values/16-multimedia-editor.xml
+++ b/AnkiDroid/src/main/res/values/16-multimedia-editor.xml
@@ -123,6 +123,5 @@
     <string name="title_activity_search_image">Google Image Search</string>
 
 	<!-- Network failure -->
-	<string name="network_no_connection">No internet connection. Please check
-your internet connection or try again later.</string>
+	<string name="network_no_connection">No connection.</string>
 </resources>


### PR DESCRIPTION
It is desirable to check network connectivity before each network request, especially considering the super unstable mobile network. If there is no available network, we do not need to send out the request.

Also, we may want to tell users explicitly if there is no connection. The original error messages "search returned no results", "something went wrong" mean that something goes wrong in the searching process, which is quite confusing. Therefore I add new error message "No internet connection. Please check your internet connection or try again later."  for this purpose. 

Screen snapshots of this fix are attached: 

For image search:
![screenshot_2015-07-20-08-46-23](https://cloud.githubusercontent.com/assets/4992756/8780490/16806b84-2ebe-11e5-8054-8c06c30bfeba.png)

For translation search:
![screenshot_2015-07-20-08-46-33](https://cloud.githubusercontent.com/assets/4992756/8780491/16817b00-2ebe-11e5-8839-a3f9c546a765.png)

For pronunciation search:
![screenshot_2015-07-20-08-46-46](https://cloud.githubusercontent.com/assets/4992756/8780489/167e8e90-2ebe-11e5-922a-e3abaf4fdb2c.png)

     