### PR TITLE
Add timeout for Http requests

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/SearchImageActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/SearchImageActivity.java
@@ -292,6 +292,8 @@ public class SearchImageActivity extends Activity implements DialogInterface.OnC
                         + "v=1.0&q=Q&userip=IP".replaceAll("Q", getQuery()).replaceAll("IP", UrlTools.encodeUrl(ip)));
                 URLConnection connection = url.openConnection();
                 connection.addRequestProperty("Referer", "anki.ichi2.com");
+				connection.setConnectTimeout(5000);
+				connection.setReadTimeout(10000);
 
                 String line;
                 StringBuilder builder = new StringBuilder();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/SearchImageActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/SearchImageActivity.java
@@ -292,8 +292,8 @@ public class SearchImageActivity extends Activity implements DialogInterface.OnC
                         + "v=1.0&q=Q&userip=IP".replaceAll("Q", getQuery()).replaceAll("IP", UrlTools.encodeUrl(ip)));
                 URLConnection connection = url.openConnection();
                 connection.addRequestProperty("Referer", "anki.ichi2.com");
-				connection.setConnectTimeout(5000);
-				connection.setReadTimeout(10000);
+				connection.setConnectTimeout(10000);
+				connection.setReadTimeout(60000);
 
                 String line;
                 StringBuilder builder = new StringBuilder();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/web/HttpFetcher.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/web/HttpFetcher.java
@@ -56,8 +56,8 @@ public class HttpFetcher {
         try {
             HttpClient httpClient = new DefaultHttpClient();
 			HttpParams params = httpClient.getParams();
-			HttpConnectionParams.setConnectionTimeout(params, 5000);
-			HttpConnectionParams.setSoTimeout(params, 10000);
+			HttpConnectionParams.setConnectionTimeout(params, 10000);
+			HttpConnectionParams.setSoTimeout(params, 60000);
             HttpContext localContext = new BasicHttpContext();
             HttpGet httpGet = new HttpGet(address);
             HttpResponse response = httpClient.execute(httpGet, localContext);
@@ -142,8 +142,8 @@ public class HttpFetcher {
             urlConnection.setRequestProperty("Referer", "com.ichi2.anki");
             urlConnection.setRequestProperty("User-Agent", "Mozilla/5.0 ( compatible ) ");
             urlConnection.setRequestProperty("Accept", "*/*");
-			urlConnection.setConnectTimeout(5000);
-			urlConnection.setReadTimeout(10000);
+			urlConnection.setConnectTimeout(10000);
+			urlConnection.setReadTimeout(60000);
             urlConnection.connect();
 
             File file = File.createTempFile(prefix, extension, context.getCacheDir());

--- a/AnkiDroid/src/main/java/com/ichi2/anki/web/HttpFetcher.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/web/HttpFetcher.java
@@ -25,6 +25,8 @@ import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.params.HttpConnectionParams;
+import org.apache.http.params.HttpParams;
 import org.apache.http.protocol.BasicHttpContext;
 import org.apache.http.protocol.HttpContext;
 
@@ -53,6 +55,9 @@ public class HttpFetcher {
 
         try {
             HttpClient httpClient = new DefaultHttpClient();
+			HttpParams params = httpClient.getParams();
+			HttpConnectionParams.setConnectionTimeout(params, 5000);
+			HttpConnectionParams.setSoTimeout(params, 10000);
             HttpContext localContext = new BasicHttpContext();
             HttpGet httpGet = new HttpGet(address);
             HttpResponse response = httpClient.execute(httpGet, localContext);
@@ -137,6 +142,8 @@ public class HttpFetcher {
             urlConnection.setRequestProperty("Referer", "com.ichi2.anki");
             urlConnection.setRequestProperty("User-Agent", "Mozilla/5.0 ( compatible ) ");
             urlConnection.setRequestProperty("Accept", "*/*");
+			urlConnection.setConnectTimeout(5000);
+			urlConnection.setReadTimeout(10000);
             urlConnection.connect();
 
             File file = File.createTempFile(prefix, extension, context.getCacheDir());


### PR DESCRIPTION
The timeout of HttpURLConnection and Apache HttpClient is 0, which means the request would never return if either connection or read timeouts.

This patch set explicit timeout value (5s for connection timeout and 10s for read timeout), so the code would catch and handle timeout exceptions as you would expect. 