### PR TITLE
Added auto sync on start/exit

### DIFF
--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -84,6 +84,9 @@
     <string name="sync_account">AnkiWeb account</string>
     <string name="sync_account_summ_logged_out">Not logged in</string>
     <string name="sync_account_summ_logged_in">%s</string>
+    <string name="automatic_sync_choice">Automatic synchronization</string>
+    <string name="automatic_sync_choice_summ">Sync automatically on app start/exit if the last sync was more than 10
+        minutes ago.</string>
     <string name="fix_hebrew_text">Fix for Hebrew vowels</string>
     <string name="fix_hebrew_text_summ">Workaround for rendering Hebrew vowels correctly.</string>
     <string name="fix_hebrew_instructions">This setting bypasses the RTL algorithm of Android to show Hebrew text with vowels correctly.\n\nFor this to work, you need to download font Tohu.ttf and copy it manually to\n“%s/fonts/”\n\nYou won’t have to modify your cards.</string>

--- a/AnkiDroid/src/main/res/xml/preferences_general.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_general.xml
@@ -56,6 +56,11 @@
         android:key="language"
         android:summary="@string/preference_summary_literal"
         android:title="@string/language" />
+    <CheckBoxPreference
+        android:defaultValue="false"
+        android:key="automaticSyncMode"
+        android:summary="@string/automatic_sync_choice_summ"
+        android:title="@string/automatic_sync_choice" />
     <ListPreference
         android:defaultValue="2"
         android:entries="@array/error_reporting_choice_labels"


### PR DESCRIPTION
See [issue 1062](https://code.google.com/p/ankidroid/issues/detail?id=1062)

Trying to sync at `onResume()` or `onPause()` didn't work. While the synchronization is taking place I get an error "Collection not opened", "An error occurred while accessing your collection", so this is just for when the user presses back button on `DeckPicker` interface.

Originally I recorded last sync time and the auto-sync would only occur if the last sync is more than 10 minutes ago. However I later removed it. 1. This is consistent with the behavior on desktop version 2. I don't think the user would exit the app that often 3. So as to not confuse the user with complexity. If that functionality is deemed necessary I will add it back.

I'm not that proficient in Android development so excuse me if I wrote some clumsy code.