### PR TITLE
Use Sticky Immersive mode for fullscreen reviewer on KitKat+

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -50,8 +50,8 @@ import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.View.OnClickListener;
-import android.view.ViewGroup;  // Looks like these …
-import android.view.WindowManager;  // … two have LayoutParams members that are not the same.
+import android.view.ViewGroup;
+import android.view.WindowManager;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputMethodManager;
 import android.webkit.JsResult;
@@ -853,10 +853,22 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
         setContentView(R.layout.flashcard);
         View mainView = findViewById(android.R.id.content);
         initNavigationDrawer(mainView);
+        // Set full screen/immersive mode if needed
+        if (mPrefFullscreenReview) {
+            CompatHelper.getCompat().setFullScreen(this);
+        }
         // Load the collection
         startLoadingCollection();
     }
 
+    @Override
+    public void onWindowFocusChanged(boolean hasFocus) {
+        super.onWindowFocusChanged(hasFocus);
+        // Restore full screen once we regain focus
+        if (mPrefFullscreenReview) {
+            CompatHelper.getCompat().setFullScreen(this);
+        }
+    }
 
     @ Override
     public void onConfigurationChanged(Configuration config) {
@@ -875,10 +887,6 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
         super.onCollectionLoaded(col);
         mSched = col.getSched();
         mBaseUrl = Utils.getBaseUrl(col.getMedia().dir());
-
-        if (mPrefFullscreenReview) {
-            UIUtils.setFullScreen(this);
-        }
 
         registerExternalStorageListener();
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
@@ -61,7 +61,6 @@ public class NavigationDrawerActivity extends AnkiActivity implements Navigation
         mDrawerLayout.setDrawerShadow(R.drawable.drawer_shadow, GravityCompat.START);
         mNavigationView = (NavigationView) mDrawerLayout.findViewById(R.id.navdrawer_items_container);
         mNavigationView.setNavigationItemSelectedListener(this);
-
         Toolbar toolbar = (Toolbar) mainView.findViewById(R.id.toolbar);
         if (toolbar != null) {
             setSupportActionBar(toolbar);
@@ -253,5 +252,14 @@ public class NavigationDrawerActivity extends AnkiActivity implements Navigation
 
     public static boolean isWholeCollection() {
         return sIsWholeCollection;
+    }
+
+    /**
+     * Get the drawer layout.
+     *
+     * The drawer layout is the parent layout for activities that use the Navigation Drawer.
+     */
+    public DrawerLayout getDrawerLayout() {
+        return mDrawerLayout;
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/UIUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/UIUtils.java
@@ -1,19 +1,13 @@
 
 package com.ichi2.anki;
 
-import android.app.Activity;
 import android.content.Context;
-
-import android.support.v7.app.ActionBar;
-import android.support.v7.app.AppCompatActivity;
-import android.text.SpannableStringBuilder;
-import android.text.style.CharacterStyle;
-import android.text.style.ForegroundColorSpan;
+import android.os.Build;
+import android.view.View;
 import android.view.WindowManager;
 
 import com.ichi2.async.DeckTask;
 import com.ichi2.async.DeckTask.TaskData;
-import com.ichi2.themes.Themes;
 
 import java.util.Calendar;
 
@@ -37,7 +31,6 @@ public class UIUtils {
         cal.set(Calendar.MILLISECOND, 0);
         return cal.getTimeInMillis();
     }
-
 
 
     public static void saveCollectionInBackground(Context context) {
@@ -65,11 +58,5 @@ public class UIUtils {
                 }
             }, new DeckTask.TaskData(CollectionHelper.getInstance().getCol(context)));
         }
-    }
-
-
-    public static void setFullScreen(Activity activity) {
-        activity.getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN,
-                WindowManager.LayoutParams.FLAG_FULLSCREEN);
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
@@ -23,6 +23,7 @@ import android.view.View;
 import android.widget.RemoteViews;
 
 import com.ichi2.anki.AnkiActivity;
+import com.ichi2.anki.NavigationDrawerActivity;
 import com.ichi2.anki.exception.APIVersionException;
 
 /**
@@ -55,5 +56,6 @@ public interface Compat {
     void updateWidgetDimensions(Context context, RemoteViews updateViews, Class<?> cls);
     void setAlpha(View view, float alpha);
     void restartActivityInvalidateBackstack(AnkiActivity activity);
+    void setFullScreen(NavigationDrawerActivity activity);
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatHelper.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatHelper.java
@@ -29,8 +29,11 @@ public class CompatHelper {
 
 
     private CompatHelper() {
+
         if (isNookHdOrHdPlus() && getSdkVersion() == 15) {
             mCompat = new CompatV15NookHdOrHdPlus();
+        } else if (getSdkVersion() >= 19) {
+            mCompat = new CompatV19();
         } else if (getSdkVersion() >= 16) {
             mCompat = new CompatV16();
         } else if (getSdkVersion() >= 15) {

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV19.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV19.java
@@ -1,0 +1,41 @@
+
+package com.ichi2.compat;
+
+import android.annotation.TargetApi;
+import android.appwidget.AppWidgetManager;
+import android.appwidget.AppWidgetProviderInfo;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.res.Configuration;
+import android.database.sqlite.SQLiteDatabase;
+import android.os.Bundle;
+import android.text.Html;
+import android.util.TypedValue;
+import android.view.View;
+import android.widget.RemoteViews;
+
+import com.ichi2.anki.NavigationDrawerActivity;
+import com.ichi2.anki.R;
+
+/** Implementation of {@link Compat} for SDK level 19 */
+@TargetApi(19)
+public class CompatV19 extends CompatV16 implements Compat {
+
+    @Override
+    public void setFullScreen(NavigationDrawerActivity activity) {
+        // This setting is enabled on Navigation Drawer activities in order to correctly
+        // display the status bar. Having it enabled prevents the window from consuming
+        // all the space made available when hiding the system UI, so we turn it off here.
+        // Since we are hiding the status bar, there is no problem with turning this off.
+        activity.getDrawerLayout().setFitsSystemWindows(false);
+
+        // Set appropriate flags to enable Sticky Immersive mode.
+        activity.getWindow().getDecorView().setSystemUiVisibility(
+                        View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+                        | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+                        | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+                        | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+                        | View.SYSTEM_UI_FLAG_FULLSCREEN
+                        | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV8.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV8.java
@@ -8,11 +8,13 @@ import android.database.sqlite.SQLiteDatabase;
 import android.speech.tts.TextToSpeech;
 import android.speech.tts.TextToSpeech.OnUtteranceCompletedListener;
 import android.view.View;
+import android.view.WindowManager;
 import android.view.animation.AlphaAnimation;
 import android.widget.RemoteViews;
 
 import com.ichi2.anki.AnkiActivity;
 import com.ichi2.anki.DeckPicker;
+import com.ichi2.anki.NavigationDrawerActivity;
 import com.ichi2.anki.ReadText;
 import com.ichi2.anki.exception.APIVersionException;
 
@@ -113,5 +115,11 @@ public class CompatV8 implements Compat {
         Intent intent = new Intent(activity, DeckPicker.class);
         intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
         activity.startActivityWithoutAnimation(intent);
+    }
+
+    @Override
+    public void setFullScreen(NavigationDrawerActivity activity) {
+        activity.getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN,
+                WindowManager.LayoutParams.FLAG_FULLSCREEN);
     }
 }


### PR DESCRIPTION
Fixes #2916.

KitKat introduced [Immersive Mode](https://developer.android.com/training/system-ui/immersive.html) for better full screen support. This commit makes use of the Sticky Immersive mode on devices that support it when the full screen reviewing option is enabled.

It looks quite nice with the recent slimming down of the interface.