### PR TITLE
ContentProvider: Fix for wrong "IllegalArgumentException"

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
@@ -794,10 +794,16 @@ public class CardContentProvider extends ContentProvider {
 
     private Card getCard(long noteId, int ord, Collection col){
         Note currentNote = col.getNote(noteId);
-        if (currentNote.cards().size() <= ord) {
+        Card currentCard = null;
+        for(Card card : currentNote.cards()){
+            if(card.getOrd() == ord){
+                currentCard = card;
+            }
+        }
+        if (currentCard == null) {
             throw new IllegalArgumentException("Card with ord " + ord + " does not exist for note " + noteId);
         }
-        return currentNote.cards().get(ord);
+        return currentCard;
     }
 
     private Note getNoteFromUri(Uri uri, Collection col) {


### PR DESCRIPTION
Fix for the problem reported [here](https://github.com/ankidroid/Anki-Android/issues/3326#issuecomment-125635018)

@timrae this fixes the problem for me. Performance might suffer though for notes with huge amounts cards, since we'd now have to compare all cards of a note to find the one with the right ord.