### PR TITLE
Improve check for online status

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
@@ -21,6 +21,7 @@ package com.ichi2.async;
 import android.content.Context;
 import android.database.Cursor;
 import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
 import android.net.Uri;
 import android.os.AsyncTask;
 
@@ -663,13 +664,13 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
 
 
     public static boolean isOnline() {
-        ConnectivityManager cm = (ConnectivityManager) AnkiDroidApp.getInstance().getApplicationContext().getSystemService(Context.CONNECTIVITY_SERVICE);
-
-        if (cm.getActiveNetworkInfo() != null) {
-            return cm.getActiveNetworkInfo().isConnectedOrConnecting();
-        } else {
+        ConnectivityManager cm = (ConnectivityManager) AnkiDroidApp.getInstance().getApplicationContext()
+                .getSystemService(Context.CONNECTIVITY_SERVICE);
+        NetworkInfo netInfo = cm.getActiveNetworkInfo();
+        if (netInfo == null || !netInfo.isConnected() || !netInfo.isAvailable()) {
             return false;
         }
+        return true;
     }
 
 


### PR DESCRIPTION
Our existing check for online status is making use of [isConnectedOrConnecting](http://developer.android.com/reference/android/net/NetworkInfo.html#isConnectedOrConnecting%28%29). The documentation states:
>This is good for applications that need to do anything related to the network other than read or write data. For the latter, call isConnected() instead, which guarantees that the network is fully usable.

Since reading and writing data sounds a lot like what we are doing, I've taken their advice and used `isConnected()` instead (and a couple other useful checks).

This *may* reduce syncing errors that occur from sync attempts that begin because the network was connecting and never made it all the way.