### PR TITLE
Improve deck deletion messages

### DIFF
--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -23,8 +23,12 @@
     <string name="check_db_acknowledge">Database checked</string>
     <string name="check_db_acknowledge_shrunk">Database checked and optimized.\nShrunk by %d kB.</string>
     <string name="contextmenu_deckpicker_delete_deck">Delete deck</string>
+    <string name="delete_deck_default_deck">The default deck can’t be deleted.</string>
     <string name="delete_deck_title">Delete deck?</string>
-    <string name="delete_deck_message">Delete all cards in %s?</string>
+    <plurals name="delete_deck_message">
+        <item quantity="one">Delete all cards in %1$s? It contains %2$d card.</item>
+        <item quantity="other">Delete all cards in %1$s? It contains %2$d cards.</item>
+    </plurals>
     <string name="delete_cram_deck_message">Send all cards in %s back to their original decks?</string>
     <string name="no_tts_available_message">No text-to-speech language available</string>
     <string name="initializing_tts">Initializing TTS…</string>


### PR DESCRIPTION
Fixes #2808.

- Provide an appropriate warning when attempting to delete the default
deck instead of doing nothing.
- Don't show a warning when deleting an empty deck. The user might think
we are showing a warning because they are about to lose data, which is
not the case.
- Show the number of cards about to be deleted since we are already
calculating it. It's useful, and the desktop client shows it as well.