### PR TITLE
Apply text colour to Snackbars

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
@@ -26,6 +26,7 @@ import android.view.View;
 import android.view.ViewGroup.LayoutParams;
 import android.view.animation.Animation;
 import android.widget.ProgressBar;
+import android.widget.TextView;
 
 import com.ichi2.anim.ActivityTransitionAnimation;
 import com.ichi2.anki.dialogs.AsyncDialogFragment;
@@ -382,6 +383,10 @@ public class AnkiActivity extends AppCompatActivity implements LoaderManager.Loa
         if (listener != null) {
             sb.setAction(actionTextResource, listener);
         }
+        // Make the text white to avoid interference from our theme colors.
+        View view = sb.getView();
+        TextView tv = (TextView) view.findViewById(android.support.design.R.id.snackbar_text);
+        tv.setTextColor(Color.WHITE);
         sb.show();
     }
 


### PR DESCRIPTION
@timrae

Our Snackbar colour problem is exactly the same as [this SO thread](http://stackoverflow.com/questions/31061474/how-to-set-support-library-snackbar-text-color-to-something-other-than-androidt).

I copied the accepted answer. Is the hardcoded colour too lazy? Should I make a new attribute for it?