### PR TITLE
Add gradient and remove redundancies from studyoptions layouts

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
@@ -38,6 +38,7 @@ import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.ImageButton;
 import android.widget.LinearLayout;
+import android.widget.TableLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -106,7 +107,6 @@ public class StudyOptionsFragment extends Fragment implements LoaderManager.Load
     private Button mButtonStart;
     private Button mButtonCustomStudy;
     private Button mButtonUnbury;
-    private ImageButton mFloatingActionButton;
     private TextView mTextDeckName;
     private TextView mTextDeckDescription;
     private TextView mTextTodayNew;
@@ -115,14 +115,11 @@ public class StudyOptionsFragment extends Fragment implements LoaderManager.Load
     private TextView mTextNewTotal;
     private TextView mTextTotal;
     private TextView mTextETA;
-    private LinearLayout mSmallChart;
-    private LinearLayout mDeckCounts;
-    private LinearLayout mDeckChart;
     private Button mDeckOptions;
     private Button mCramOptions;
     private TextView mTextCongratsMessage;
     private View mCongratsLayout;
-
+    private ChartView mChartView;
     private String mSearchTerms;
 
     // Flag to indicate if the fragment should load the deck options immediately after it loads
@@ -323,6 +320,14 @@ public class StudyOptionsFragment extends Fragment implements LoaderManager.Load
 
 
     private void initAllContentViews() {
+        // The fragmented view contains a chart
+        if (mFragmented) {
+            mChartView = (ChartView) mStudyOptionsView.findViewById(R.id.chart_view_small_chart);
+            // Since the chart takes a while to build, we start with it hidden and fade it into
+            // view later once it has finished building.
+            mChartView.setVisibility(View.INVISIBLE);
+        }
+
         mDeckInfoLayout = mStudyOptionsView.findViewById(R.id.studyoptions_deckinformation);
         mTextDeckName = (TextView) mStudyOptionsView.findViewById(R.id.studyoptions_deck_name);
         mTextDeckDescription = (TextView) mStudyOptionsView.findViewById(R.id.studyoptions_deck_description);
@@ -356,11 +361,6 @@ public class StudyOptionsFragment extends Fragment implements LoaderManager.Load
         mTextNewTotal = (TextView) mStudyOptionsView.findViewById(R.id.studyoptions_total_new);
         mTextTotal = (TextView) mStudyOptionsView.findViewById(R.id.studyoptions_total);
         mTextETA = (TextView) mStudyOptionsView.findViewById(R.id.studyoptions_eta);
-        mSmallChart = (LinearLayout) mStudyOptionsView.findViewById(R.id.studyoptions_mall_chart);
-
-        mDeckCounts = (LinearLayout) mStudyOptionsView.findViewById(R.id.studyoptions_deckcounts);
-        mDeckChart = (LinearLayout) mStudyOptionsView.findViewById(R.id.studyoptions_chart);
-
         mButtonStart.setOnClickListener(mButtonClickListener);
         mButtonCustomStudy.setOnClickListener(mButtonClickListener);
         mDeckOptions.setOnClickListener(mButtonClickListener);
@@ -519,17 +519,13 @@ public class StudyOptionsFragment extends Fragment implements LoaderManager.Load
 
 
     private void updateChart(double[][] serieslist) {
-        if (mSmallChart != null) {
-
-            ChartView chartView = (ChartView) mSmallChart.findViewById(R.id.chart_view_small_chart);
-            chartView.setBackgroundColor(Color.BLACK);
+        if (mChartView != null) {
             Collection col = CollectionHelper.getInstance().getCol(getActivity());
-            AnkiStatsTaskHandler.createSmallDueChartChart(col, serieslist, chartView);
-            if (mDeckChart.getVisibility() == View.INVISIBLE) {
-                mDeckChart.setVisibility(View.VISIBLE);
-                mDeckChart.setAnimation(ViewAnimation.fade(ViewAnimation.FADE_IN, 500, 0));
+            AnkiStatsTaskHandler.createSmallDueChartChart(col, serieslist, mChartView);
+            if (mChartView.getVisibility() == View.INVISIBLE) {
+                mChartView.setVisibility(View.VISIBLE);
+                mChartView.setAnimation(ViewAnimation.fade(ViewAnimation.FADE_IN, 500, 0));
             }
-
         }
     }
 
@@ -681,7 +677,7 @@ public class StudyOptionsFragment extends Fragment implements LoaderManager.Load
         // Load the deck counts for the deck from Collection asynchronously
         DeckTask.launchDeckTask(DeckTask.TASK_TYPE_UPDATE_VALUES_FROM_DECK,
                 getDeckTaskListener(resetDecklist),
-                new DeckTask.TaskData(getCol(), new Object[]{resetSched, mSmallChart != null}));
+                new DeckTask.TaskData(getCol(), new Object[]{resetSched, mChartView != null}));
     }
 
 
@@ -764,7 +760,6 @@ public class StudyOptionsFragment extends Fragment implements LoaderManager.Load
                         mTextCongratsMessage.setText(getCol().getSched().finishedMsg(getActivity()));
                         mButtonStart.setVisibility(View.GONE);
                     } else {
-                        mDeckCounts.setVisibility(View.VISIBLE); // not working without this... why?
                         mCurrentContentView = CONTENT_STUDY_OPTIONS;
                         mDeckInfoLayout.setVisibility(View.VISIBLE);
                         mCongratsLayout.setVisibility(View.GONE);

--- a/AnkiDroid/src/main/res/drawable/shadow_left.xml
+++ b/AnkiDroid/src/main/res/drawable/shadow_left.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <gradient
+        android:angle="0"
+        android:gradientRadius="0dp"
+        android:startColor="#10000000"
+        android:endColor="?android:attr/colorBackground"/>
+</shape>

--- a/AnkiDroid/src/main/res/layout-xlarge/studyoptions_fragment.xml
+++ b/AnkiDroid/src/main/res/layout-xlarge/studyoptions_fragment.xml
@@ -1,35 +1,39 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/studyoptions_main"
     android:layout_width="fill_parent"
-    android:layout_height="wrap_content"
-    android:layout_gravity="center"
-    android:gravity="center"
-    android:orientation="vertical"
-    android:paddingTop="12dp" >
+    android:layout_height="fill_parent"
+    android:orientation="vertical">
+
+    <View
+        android:id="@+id/studyoptions_gradient"
+        android:layout_width="15dp"
+        android:layout_height="fill_parent"
+        android:background="@drawable/shadow_left" />
 
     <LinearLayout
         android:id="@+id/studyoptions_mainframe"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
-        android:gravity="center"
-        android:orientation="vertical" >
+        android:layout_centerInParent="true"
+        android:orientation="vertical">
 
         <ScrollView
+            android:id="@+id/studyoptions_scrollview"
             android:layout_width="fill_parent"
             android:layout_height="0dp"
             android:layout_weight="1"
             android:fadeScrollbars="false"
-            android:fillViewport="true" >
+            android:fillViewport="true">
+
             <LinearLayout
                 android:id="@+id/studyoptions_scrollcontainer"
                 android:layout_width="fill_parent"
                 android:layout_height="wrap_content"
                 android:gravity="center"
-                android:orientation="vertical" >
-        	    <TextView
+                android:orientation="vertical">
+
+                <TextView
                     android:id="@+id/studyoptions_deck_name"
                     android:layout_width="fill_parent"
                     android:layout_height="wrap_content"
@@ -40,251 +44,195 @@
                     android:text=""
                     android:textSize="28sp"
                     android:textStyle="bold" />
-	            <LinearLayout
-	                android:id="@+id/studyoptions_deckinformation"
-	                android:layout_width="fill_parent"
-	                android:layout_height="wrap_content"
-	                android:gravity="center"
-	                android:orientation="vertical" >
-	                <LinearLayout
-	                    android:id="@+id/studyoptions_deckcounts"
-	                    android:layout_width="wrap_content"
-	                    android:layout_height="wrap_content"
-	                    android:layout_marginBottom="5dip"
-	                    android:layout_marginLeft="5dip"
-	                    android:layout_marginRight="3dip"
-	                    android:gravity="center"
-	                    android:orientation="vertical"
-	                    android:visibility="invisible" >
-	
-	                    <TableLayout
-	                        android:layout_width="fill_parent"
-	                        android:layout_height="wrap_content"
-	                        android:layout_gravity="center_horizontal"
-	                        android:layout_marginBottom="5dip" >
-	
-	                        <TableRow>
-	
-	                            <TextView
-	                                android:layout_width="wrap_content"
-	                                android:layout_height="wrap_content"
-	                                android:paddingRight="5dip"
-	                                android:text="@string/studyoptions_due_today" />
-	
-	                            <LinearLayout
-	                                android:layout_width="wrap_content"
-	                                android:layout_height="wrap_content"
-	                                android:gravity="right"
-	                                android:orientation="horizontal" >
-	
-	                                <TextView
-	                                    android:id="@+id/studyoptions_new"
-	                                    android:layout_width="wrap_content"
-	                                    android:layout_height="wrap_content"
-	                                    android:paddingRight="5dip"
-                                        android:textColor="?attr/newCountColor" />
-	
-	                                <TextView
-	                                    android:id="@+id/studyoptions_lrn"
-	                                    android:layout_width="wrap_content"
-	                                    android:layout_height="wrap_content"
-	                                    android:layout_gravity="center"
-	                                    android:paddingRight="5dip"
-                                        android:textColor="?attr/learnCountColor" />
-	
-	                                <TextView
-	                                    android:id="@+id/studyoptions_rev"
-	                                    android:layout_width="wrap_content"
-	                                    android:layout_height="wrap_content"
-                                        android:textColor="?attr/reviewCountColor" />
-	                            </LinearLayout>
-	                        </TableRow>
-	
-	                        <TableRow>
-	
-	                            <TextView
-	                                android:layout_width="wrap_content"
-	                                android:layout_height="wrap_content"
-	                                android:paddingRight="5dip"
-	                                android:text="@string/studyoptions_new_total" />
-	
-	                            <TextView
-	                                android:id="@+id/studyoptions_total_new"
-	                                android:layout_width="wrap_content"
-	                                android:layout_height="wrap_content"
-	                                android:gravity="right" />
-	                        </TableRow>
-	
-	                        <TableRow>
-	
-	                            <TextView
-	                                android:layout_width="wrap_content"
-	                                android:layout_height="wrap_content"
-	                                android:paddingRight="5dip"
-	                                android:text="@string/studyoptions_total_cards" />
-	
-	                            <TextView
-	                                android:id="@+id/studyoptions_total"
-	                                android:layout_width="wrap_content"
-	                                android:layout_height="wrap_content"
-	                                android:gravity="right" />
-	                        </TableRow>
-	
-	                        <TableRow>
-	
-	                            <TextView
-	                                android:layout_width="wrap_content"
-	                                android:layout_height="wrap_content"
-	                                android:paddingRight="5dip"
-	                                android:text="@string/studyoptions_eta" />
-	
-	                            <TextView
-	                                android:id="@+id/studyoptions_eta"
-	                                android:layout_width="wrap_content"
-	                                android:layout_height="wrap_content"
-	                                android:gravity="right" />
-	                        </TableRow>
-	                    </TableLayout>
-	                </LinearLayout>
-	
-	                <LinearLayout
-	                    android:layout_width="fill_parent"
-	                    android:layout_height="wrap_content"
-	                    android:orientation="vertical" >
-	
-	                    <TextView
-	                        android:id="@+id/studyoptions_deck_description"
-	                        android:layout_width="fill_parent"
-	                        android:layout_height="wrap_content"
-	                        android:layout_marginBottom="5dp"
-	                        android:layout_marginLeft="5dp"
-	                        android:layout_marginRight="5dp"
-	                        android:gravity="center"
-	                        android:text="" />
-	                </LinearLayout>
-	            </LinearLayout>
-	                <LinearLayout
-	                    android:id="@+id/studyoptions_congrats_layout"
-	                    android:layout_width="fill_parent"
-	                    android:layout_height="wrap_content"
-	                    android:orientation="vertical" >
-	
-	                    <TextView
-	                        android:id="@+id/studyoptions_congrats_message"
-	                        android:layout_width="fill_parent"
-	                        android:layout_height="wrap_content"
-	                        android:layout_marginBottom="5dp"
-	                        android:layout_marginLeft="5dp"
-	                        android:layout_marginRight="5dp"
-	                        android:gravity="center"
-	                        android:text="" />
-	                </LinearLayout>
-		        <LinearLayout
-		            android:id="@+id/studyoptions_chart"
-		            android:layout_width="fill_parent"
-		            android:layout_height="wrap_content"
-		            android:orientation="horizontal"
-		            android:visibility="invisible"
-		            tools:ignore="InconsistentLayout" >
-		
-		            <LinearLayout
-		                android:layout_width="0dip"
-		                android:layout_height="wrap_content"
-		                android:layout_weight="1" />
-		
-		            <LinearLayout
-		                android:id="@+id/studyoptions_mall_chart"
-		                android:layout_width="0dip"
-		                android:layout_height="250dip"
-		                android:layout_weight="3"
-		                android:orientation="vertical">
 
-                        <com.ichi2.anki.stats.ChartView
-                            android:layout_width="match_parent"
-                            android:id="@+id/chart_view_small_chart"
-                            android:layout_height="match_parent"
-                            android:background="@android:color/black"
-                            android:textColor="#FFFFFF"
-                            android:layout_margin="0dp"
-                            android:visibility="visible"/>
+                <LinearLayout
+                    android:id="@+id/studyoptions_deckinformation"
+                    android:layout_width="fill_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="center"
+                    android:orientation="vertical">
+
+                    <TableLayout
+                        android:id="@+id/studyoptions_deckcounts"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center_horizontal"
+                        android:layout_marginBottom="5dip"
+                        android:layout_marginEnd="3dip"
+                        android:layout_marginLeft="5dip"
+                        android:layout_marginRight="3dip"
+                        android:layout_marginStart="5dip"
+                        android:orientation="vertical">
+
+                        <TableRow>
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:paddingLeft="0dip"
+                                android:paddingRight="5dip"
+                                android:text="@string/studyoptions_due_today" />
+
+                            <LinearLayout
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content">
+
+                                <TextView
+                                    android:id="@+id/studyoptions_new"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:textColor="?attr/newCountColor" />
+
+                                <TextView
+                                    android:id="@+id/studyoptions_lrn"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_marginLeft="5dip"
+                                    android:layout_marginStart="5dip"
+                                    android:textColor="?attr/learnCountColor" />
+
+                                <TextView
+                                    android:id="@+id/studyoptions_rev"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_marginLeft="5dip"
+                                    android:layout_marginStart="5dip"
+                                    android:textColor="?attr/reviewCountColor" />
+                            </LinearLayout>
+                        </TableRow>
+
+                        <TableRow>
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:paddingLeft="0dip"
+                                android:paddingRight="5dip"
+                                android:text="@string/studyoptions_new_total" />
+
+                            <TextView
+                                android:id="@+id/studyoptions_total_new"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:gravity="end" />
+                        </TableRow>
+
+                        <TableRow>
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:paddingLeft="0dip"
+                                android:paddingRight="5dip"
+                                android:text="@string/studyoptions_total_cards" />
+
+                            <TextView
+                                android:id="@+id/studyoptions_total"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:gravity="end" />
+                        </TableRow>
+
+                        <TableRow>
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:paddingLeft="0dip"
+                                android:paddingRight="5dip"
+                                android:text="@string/studyoptions_eta" />
+
+                            <TextView
+                                android:id="@+id/studyoptions_eta"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:gravity="end" />
+                        </TableRow>
+                    </TableLayout>
+
+                    <LinearLayout
+                        android:layout_width="fill_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical">
+
+                        <TextView
+                            android:id="@+id/studyoptions_deck_description"
+                            android:layout_width="fill_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginBottom="5dp"
+                            android:layout_marginLeft="10dp"
+                            android:layout_marginRight="10dp"
+                            android:gravity="center"
+                            android:text="" />
                     </LinearLayout>
-		
-		            <LinearLayout
-		                android:layout_width="0dip"
-		                android:layout_height="wrap_content"
-		                android:layout_weight="1" />
-		        </LinearLayout>	                
-            </LinearLayout>            
+                </LinearLayout>
+
+                <LinearLayout
+                    android:id="@+id/studyoptions_congrats_layout"
+                    android:layout_width="fill_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical">
+
+                    <TextView
+                        android:id="@+id/studyoptions_congrats_message"
+                        android:layout_width="fill_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginBottom="5dp"
+                        android:layout_marginLeft="5dp"
+                        android:layout_marginRight="5dp"
+                        android:gravity="center"
+                        android:text="" />
+                </LinearLayout>
+
+                <LinearLayout
+                    android:id="@+id/studyoptions_chart"
+                    android:layout_width="fill_parent"
+                    android:layout_height="wrap_content"
+                    android:baselineAligned="false"
+                    android:gravity="center"
+                    android:weightSum="5">
+
+                    <com.ichi2.anki.stats.ChartView
+                        android:id="@+id/chart_view_small_chart"
+                        android:layout_width="0dip"
+                        android:layout_height="250dip"
+                        android:layout_weight="3"
+                        android:orientation="vertical" />
+
+                </LinearLayout>
+
+            </LinearLayout>
         </ScrollView>
 
         <LinearLayout
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
-            android:gravity="center"
-            android:orientation="vertical" >
+            android:orientation="vertical"
+            android:paddingTop="5dip">
 
             <LinearLayout
                 android:layout_width="fill_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal" >
+                android:orientation="horizontal">
 
                 <Button
                     android:id="@+id/studyoptions_start"
                     android:layout_width="0dip"
                     android:layout_height="fill_parent"
                     android:layout_weight="1"
-                    android:lines="1"
-                    android:paddingLeft="16dip"
+                    android:lines="3"
                     android:text="@string/studyoptions_start"
                     android:textSize="20sp"
                     android:textStyle="bold" />
             </LinearLayout>
-            <!--
-                 	<LinearLayout
-				    android:layout_width="0dip"
-				    android:layout_height="wrap_content"
-				    android:layout_weight="1"
-				    android:orientation="vertical" >
-				    <ToggleButton
-						android:id="@+id/studyoptions_limittoggle"
-						android:singleLine="true"
-						android:layout_height="0dip"
-       		  			android:layout_width="fill_parent"
-    			     	android:layout_weight="1"
-						android:textOff="-"
-						android:textOn="2" />
-				</LinearLayout>
-				<LinearLayout
-				    android:layout_width="0dip"
-				    android:layout_height="wrap_content"
-				    android:layout_weight="1"
-				    android:orientation="vertical" >
 
-				    <Button android:text="up"
-				        android:id="@+id/studyoptions_limitup"
-				        android:layout_width="fill_parent"
-				        android:layout_height="0dip"
-				        android:layout_weight="1"
-				        android:singleLine="true"
-				        />
-
-				    <Button android:text="down"
-				        android:id="@+id/studyoptions_limitdown"
-				        android:layout_width="fill_parent"
-				        android:layout_height="0dip"
-				        android:layout_weight="1"
-				        android:singleLine="true"
-				        />
-				</LinearLayout>
-            -->
-
-            <!-- The below layout contains the components which are only shown when we DO NOT have a filtered deck -->
-
+            <!-- This is the layout for a normal deck (not filtered). We show this by default and
+            hide/replace it with another one if it's a filtered deck.-->
             <LinearLayout
                 android:id="@+id/studyoptions_regular_buttons"
                 android:layout_width="fill_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal" >
+                android:orientation="horizontal">
 
                 <Button
                     android:id="@+id/studyoptions_options"
@@ -318,56 +266,48 @@
                     android:visibility="gone" />
             </LinearLayout>
 
-            <!--
-                  The below layout contains the components which are only shown when we have a filtered deck
-					It's set to hidden by default, and made visible in StudyOptionsFragment if filtered
-            -->
-
+            <!-- This is the layout used for filtered decks. It is hidden by default and made visible
+            at runtime if we are loading a filtered deck. -->
             <LinearLayout
                 android:id="@+id/studyoptions_cram_buttons"
                 android:layout_width="fill_parent"
                 android:layout_height="wrap_content"
                 android:orientation="horizontal"
-                android:visibility="gone" >
+                android:visibility="gone">
 
-                <LinearLayout
-                    android:layout_width="fill_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="horizontal" >
+                <Button
+                    android:id="@+id/studyoptions_options_cram"
+                    android:layout_width="0px"
+                    android:layout_height="fill_parent"
+                    android:layout_weight="1"
+                    android:text="@string/study_options"
+                    android:textSize="12sp" />
 
-                    <Button
-                        android:id="@+id/studyoptions_options_cram"
-                        android:layout_width="0px"
-                        android:layout_height="fill_parent"
-                        android:layout_weight="1"
-                        android:text="@string/study_options"
-                        android:textSize="12sp" />
+                <Button
+                    android:id="@+id/studyoptions_rebuild_cram"
+                    android:layout_width="0px"
+                    android:layout_height="fill_parent"
+                    android:layout_weight="1"
+                    android:text="@string/rebuild_cram_label"
+                    android:textSize="12sp" />
 
-                    <Button
-                        android:id="@+id/studyoptions_rebuild_cram"
-                        android:layout_width="0px"
-                        android:layout_height="fill_parent"
-                        android:layout_weight="1"
-                        android:text="@string/rebuild_cram_label"
-                        android:textSize="12sp" />
+                <Button
+                    android:id="@+id/studyoptions_empty_cram"
+                    android:layout_width="0px"
+                    android:layout_height="fill_parent"
+                    android:layout_weight="1"
+                    android:text="@string/empty_cram_label"
+                    android:textSize="12sp" />
 
-                    <Button
-                        android:id="@+id/studyoptions_empty_cram"
-                        android:layout_width="0px"
-                        android:layout_height="fill_parent"
-                        android:layout_weight="1"
-                        android:text="@string/empty_cram_label"
-                        android:textSize="12sp" />
-                    <Button
-                        android:id="@+id/studyoptions_unbury_cram"
-                        android:layout_width="0px"
-                        android:layout_height="fill_parent"
-                        android:layout_weight="1"
-                        android:text="@string/unbury"
-                        android:textSize="12sp"
-                        android:visibility="gone" />
-                </LinearLayout>
+                <Button
+                    android:id="@+id/studyoptions_unbury_cram"
+                    android:layout_width="0px"
+                    android:layout_height="fill_parent"
+                    android:layout_weight="1"
+                    android:text="@string/unbury"
+                    android:textSize="12sp"
+                    android:visibility="gone" />
             </LinearLayout>
         </LinearLayout>
     </LinearLayout>
-</LinearLayout>
+</RelativeLayout>

--- a/AnkiDroid/src/main/res/layout/studyoptions_fragment.xml
+++ b/AnkiDroid/src/main/res/layout/studyoptions_fragment.xml
@@ -1,33 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/studyoptions_main"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
-    android:layout_gravity="center"
-    android:gravity="center"
-    android:orientation="vertical"
-    android:paddingTop="12dp" >
+    android:orientation="vertical">
 
     <LinearLayout
         android:id="@+id/studyoptions_mainframe"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
-        android:gravity="center"
-        android:orientation="vertical" >
+        android:layout_centerInParent="true"
+        android:orientation="vertical">
 
         <ScrollView
+            android:id="@+id/studyoptions_scrollview"
             android:layout_width="fill_parent"
             android:layout_height="0dp"
             android:layout_weight="1"
             android:fadeScrollbars="false"
-            android:fillViewport="true" >
+            android:fillViewport="true">
+
             <LinearLayout
                 android:id="@+id/studyoptions_scrollcontainer"
                 android:layout_width="fill_parent"
                 android:layout_height="wrap_content"
                 android:gravity="center"
-                android:orientation="vertical" >
-        	    <TextView
+                android:orientation="vertical">
+
+                <TextView
                     android:id="@+id/studyoptions_deck_name"
                     android:layout_width="fill_parent"
                     android:layout_height="wrap_content"
@@ -38,217 +38,177 @@
                     android:text=""
                     android:textSize="28sp"
                     android:textStyle="bold" />
-	            <LinearLayout
-	                android:id="@+id/studyoptions_deckinformation"
-	                android:layout_width="fill_parent"
-	                android:layout_height="wrap_content"
-	                android:gravity="center"
-	                android:orientation="vertical" >
-	                <LinearLayout
-	                    android:id="@+id/studyoptions_deckcounts"
-	                    android:layout_width="wrap_content"
-	                    android:layout_height="wrap_content"
-	                    android:layout_marginBottom="5dip"
-	                    android:layout_marginLeft="5dip"
-	                    android:layout_marginRight="3dip"
-	                    android:gravity="center"
-	                    android:orientation="vertical"
-	                    android:visibility="visible" >
-	
-	                    <TableLayout
-	                        android:layout_width="fill_parent"
-	                        android:layout_height="wrap_content"
-	                        android:layout_gravity="center_horizontal"
-	                        android:layout_marginBottom="5dip" >
-	
-	                        <TableRow>
-	
-	                            <TextView
-	                                android:layout_width="wrap_content"
-	                                android:layout_height="wrap_content"
-	                                android:paddingRight="5dip"
-	                                android:text="@string/studyoptions_due_today" />
-	
-	                            <LinearLayout
-	                                android:layout_width="wrap_content"
-	                                android:layout_height="wrap_content"
-	                                android:gravity="right"
-	                                android:orientation="horizontal" >
-	
-	                                <TextView
-	                                    android:id="@+id/studyoptions_new"
-	                                    android:layout_width="wrap_content"
-	                                    android:layout_height="wrap_content"
-	                                    android:paddingRight="5dip"
-	                                    android:textColor="?attr/newCountColor" />
-	
-	                                <TextView
-	                                    android:id="@+id/studyoptions_lrn"
-	                                    android:layout_width="wrap_content"
-	                                    android:layout_height="wrap_content"
-	                                    android:layout_gravity="center"
-	                                    android:paddingRight="5dip"
-	                                    android:textColor="?attr/learnCountColor" />
-	
-	                                <TextView
-	                                    android:id="@+id/studyoptions_rev"
-	                                    android:layout_width="wrap_content"
-	                                    android:layout_height="wrap_content"
-	                                    android:textColor="?attr/reviewCountColor" />
-	                            </LinearLayout>
-	                        </TableRow>
-	
-	                        <TableRow>
-	
-	                            <TextView
-	                                android:layout_width="wrap_content"
-	                                android:layout_height="wrap_content"
-	                                android:paddingRight="5dip"
-	                                android:text="@string/studyoptions_new_total" />
-	
-	                            <TextView
-	                                android:id="@+id/studyoptions_total_new"
-	                                android:layout_width="wrap_content"
-	                                android:layout_height="wrap_content"
-	                                android:gravity="right" />
-	                        </TableRow>
-	
-	                        <TableRow>
-	
-	                            <TextView
-	                                android:layout_width="wrap_content"
-	                                android:layout_height="wrap_content"
-	                                android:paddingRight="5dip"
-	                                android:text="@string/studyoptions_total_cards" />
-	
-	                            <TextView
-	                                android:id="@+id/studyoptions_total"
-	                                android:layout_width="wrap_content"
-	                                android:layout_height="wrap_content"
-	                                android:gravity="right" />
-	                        </TableRow>
-	
-	                        <TableRow>
-	
-	                            <TextView
-	                                android:layout_width="wrap_content"
-	                                android:layout_height="wrap_content"
-	                                android:paddingRight="5dip"
-	                                android:text="@string/studyoptions_eta" />
-	
-	                            <TextView
-	                                android:id="@+id/studyoptions_eta"
-	                                android:layout_width="wrap_content"
-	                                android:layout_height="wrap_content"
-	                                android:gravity="right" />
-	                        </TableRow>
-	                    </TableLayout>
-	                </LinearLayout>
-	
-	                <LinearLayout
-	                    android:layout_width="fill_parent"
-	                    android:layout_height="wrap_content"
-	                    android:orientation="vertical" >
-	
-	                    <TextView
-	                        android:id="@+id/studyoptions_deck_description"
-	                        android:layout_width="fill_parent"
-	                        android:layout_height="wrap_content"
-	                        android:layout_marginBottom="5dp"
-	                        android:layout_marginLeft="5dp"
-	                        android:layout_marginRight="5dp"
-	                        android:gravity="center"
-	                        android:text="" />
-	                </LinearLayout>
-	            </LinearLayout>
-	                <LinearLayout
-	                    android:id="@+id/studyoptions_congrats_layout"
-	                    android:layout_width="fill_parent"
-	                    android:layout_height="wrap_content"
-	                    android:orientation="vertical" >
-	
-	                    <TextView
-	                        android:id="@+id/studyoptions_congrats_message"
-	                        android:layout_width="fill_parent"
-	                        android:layout_height="wrap_content"
-	                        android:layout_marginBottom="5dp"
-	                        android:layout_marginLeft="5dp"
-	                        android:layout_marginRight="5dp"
-	                        android:gravity="center"
-	                        android:text="" />
-	                </LinearLayout>
-            </LinearLayout>            
+
+                <LinearLayout
+                    android:id="@+id/studyoptions_deckinformation"
+                    android:layout_width="fill_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="center"
+                    android:orientation="vertical">
+
+                    <TableLayout
+                        android:id="@+id/studyoptions_deckcounts"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center_horizontal"
+                        android:layout_marginBottom="5dip"
+                        android:layout_marginEnd="3dip"
+                        android:layout_marginLeft="5dip"
+                        android:layout_marginRight="3dip"
+                        android:layout_marginStart="5dip"
+                        android:orientation="vertical">
+
+                        <TableRow>
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:paddingLeft="0dip"
+                                android:paddingRight="5dip"
+                                android:text="@string/studyoptions_due_today" />
+
+                            <LinearLayout
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content">
+
+                                <TextView
+                                    android:id="@+id/studyoptions_new"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:textColor="?attr/newCountColor" />
+
+                                <TextView
+                                    android:id="@+id/studyoptions_lrn"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_marginLeft="5dip"
+                                    android:layout_marginStart="5dip"
+                                    android:textColor="?attr/learnCountColor" />
+
+                                <TextView
+                                    android:id="@+id/studyoptions_rev"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_marginLeft="5dip"
+                                    android:layout_marginStart="5dip"
+                                    android:textColor="?attr/reviewCountColor" />
+                            </LinearLayout>
+                        </TableRow>
+
+                        <TableRow>
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:paddingLeft="0dip"
+                                android:paddingRight="5dip"
+                                android:text="@string/studyoptions_new_total" />
+
+                            <TextView
+                                android:id="@+id/studyoptions_total_new"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:gravity="end" />
+                        </TableRow>
+
+                        <TableRow>
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:paddingLeft="0dip"
+                                android:paddingRight="5dip"
+                                android:text="@string/studyoptions_total_cards" />
+
+                            <TextView
+                                android:id="@+id/studyoptions_total"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:gravity="end" />
+                        </TableRow>
+
+                        <TableRow>
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:paddingLeft="0dip"
+                                android:paddingRight="5dip"
+                                android:text="@string/studyoptions_eta" />
+
+                            <TextView
+                                android:id="@+id/studyoptions_eta"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:gravity="end" />
+                        </TableRow>
+                    </TableLayout>
+
+                    <LinearLayout
+                        android:layout_width="fill_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical">
+
+                        <TextView
+                            android:id="@+id/studyoptions_deck_description"
+                            android:layout_width="fill_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginBottom="5dp"
+                            android:layout_marginLeft="10dp"
+                            android:layout_marginRight="10dp"
+                            android:gravity="center"
+                            android:text="" />
+                    </LinearLayout>
+                </LinearLayout>
+
+                <LinearLayout
+                    android:id="@+id/studyoptions_congrats_layout"
+                    android:layout_width="fill_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical">
+
+                    <TextView
+                        android:id="@+id/studyoptions_congrats_message"
+                        android:layout_width="fill_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginBottom="5dp"
+                        android:layout_marginLeft="5dp"
+                        android:layout_marginRight="5dp"
+                        android:gravity="center"
+                        android:text="" />
+                </LinearLayout>
+            </LinearLayout>
         </ScrollView>
 
         <LinearLayout
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
-            android:gravity="center"
-            android:orientation="vertical" >
+            android:orientation="vertical"
+            android:paddingTop="5dip">
 
             <LinearLayout
                 android:layout_width="fill_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal" >
+                android:orientation="horizontal">
 
                 <Button
                     android:id="@+id/studyoptions_start"
                     android:layout_width="0dip"
-					android:layout_height="wrap_content"
+                    android:layout_height="fill_parent"
                     android:layout_weight="1"
                     android:lines="3"
-                    android:paddingLeft="16dip"
                     android:text="@string/studyoptions_start"
                     android:textSize="20sp"
                     android:textStyle="bold" />
             </LinearLayout>
-            <!--
-                 	<LinearLayout
-				    android:layout_width="0dip"
-				    android:layout_height="wrap_content"
-				    android:layout_weight="1"
-				    android:orientation="vertical" >
-				    <ToggleButton
-						android:id="@+id/studyoptions_limittoggle"
-						android:singleLine="true"
-						android:layout_height="0dip"
-       		  			android:layout_width="fill_parent"
-    			     	android:layout_weight="1"
-						android:textOff="-"
-						android:textOn="2" />
-				</LinearLayout>
-				<LinearLayout
-				    android:layout_width="0dip"
-				    android:layout_height="wrap_content"
-				    android:layout_weight="1"
-				    android:orientation="vertical" >
 
-				    <Button android:text="up"
-				        android:id="@+id/studyoptions_limitup"
-				        android:layout_width="fill_parent"
-				        android:layout_height="0dip"
-				        android:layout_weight="1"
-				        android:singleLine="true"
-				        />
-
-				    <Button android:text="down"
-				        android:id="@+id/studyoptions_limitdown"
-				        android:layout_width="fill_parent"
-				        android:layout_height="0dip"
-				        android:layout_weight="1"
-				        android:singleLine="true"
-				        />
-				</LinearLayout>
-            -->
-
-
-            <!-- The below layout contains the components which are only shown when we DO NOT have a filtered deck -->
-
+            <!-- This is the layout for a normal deck (not filtered). We show this by default and
+            hide/replace it with another one if it's a filtered deck.-->
             <LinearLayout
                 android:id="@+id/studyoptions_regular_buttons"
                 android:layout_width="fill_parent"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal" >
+                android:orientation="horizontal">
 
                 <Button
                     android:id="@+id/studyoptions_options"
@@ -282,57 +242,48 @@
                     android:visibility="gone" />
             </LinearLayout>
 
-            <!--
-                  The below layout contains the components which are only shown when we have a filtered deck
-					It's set to hidden by default, and made visible in StudyOptionsFragment if filtered
-            -->
-
+            <!-- This is the layout used for filtered decks. It is hidden by default and made visible
+            at runtime if we are loading a filtered deck. -->
             <LinearLayout
                 android:id="@+id/studyoptions_cram_buttons"
                 android:layout_width="fill_parent"
                 android:layout_height="wrap_content"
                 android:orientation="horizontal"
-                android:visibility="gone" >
+                android:visibility="gone">
 
-                <LinearLayout
-                    android:layout_width="fill_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="horizontal" >
+                <Button
+                    android:id="@+id/studyoptions_options_cram"
+                    android:layout_width="0px"
+                    android:layout_height="fill_parent"
+                    android:layout_weight="1"
+                    android:text="@string/study_options"
+                    android:textSize="12sp" />
 
-                    <Button
-                        android:id="@+id/studyoptions_options_cram"
-                        android:layout_width="0px"
-                        android:layout_height="fill_parent"
-                        android:layout_weight="1"
-                        android:text="@string/study_options"
-                        android:textSize="12sp" />
+                <Button
+                    android:id="@+id/studyoptions_rebuild_cram"
+                    android:layout_width="0px"
+                    android:layout_height="fill_parent"
+                    android:layout_weight="1"
+                    android:text="@string/rebuild_cram_label"
+                    android:textSize="12sp" />
 
-                    <Button
-                        android:id="@+id/studyoptions_rebuild_cram"
-                        android:layout_width="0px"
-                        android:layout_height="fill_parent"
-                        android:layout_weight="1"
-                        android:text="@string/rebuild_cram_label"
-                        android:textSize="12sp" />
+                <Button
+                    android:id="@+id/studyoptions_empty_cram"
+                    android:layout_width="0px"
+                    android:layout_height="fill_parent"
+                    android:layout_weight="1"
+                    android:text="@string/empty_cram_label"
+                    android:textSize="12sp" />
 
-                    <Button
-                        android:id="@+id/studyoptions_empty_cram"
-                        android:layout_width="0px"
-                        android:layout_height="fill_parent"
-                        android:layout_weight="1"
-                        android:text="@string/empty_cram_label"
-                        android:textSize="12sp" />
-                     <Button
-                        android:id="@+id/studyoptions_unbury_cram"
-                        android:layout_width="0px"
-                        android:layout_height="fill_parent"
-                        android:layout_weight="1"
-                        android:text="@string/unbury"
-                        android:textSize="12sp"
-                        android:visibility="gone" />
-                </LinearLayout>
+                <Button
+                    android:id="@+id/studyoptions_unbury_cram"
+                    android:layout_width="0px"
+                    android:layout_height="fill_parent"
+                    android:layout_weight="1"
+                    android:text="@string/unbury"
+                    android:textSize="12sp"
+                    android:visibility="gone" />
             </LinearLayout>
         </LinearLayout>
     </LinearLayout>
-
-</LinearLayout>
+</RelativeLayout>


### PR DESCRIPTION
Fixes #3553. I've toned down the gradient a bit since the screenshots that appear on the issue.

I had to make some changes to the layout to make the gradient work, and little by little I found myself fixing up everything else I found wrong with it. I've mostly removed redundant layouts and fixed up most of the warnings. Some were performance suggestions but I doubt they're the noticable kind. Only some RTL warnings remain.

The xlarge and normal layout are almost identical now except for the gradient and the graph. I think in the future we can factor out our layouts and [`<include>`](http://developer.android.com/training/improving-layouts/reusing-layouts.html) them, but that's for another time.

And yes I tested the rotation and overflow on tiny screens to make sure they still work.