### PR TITLE
DeckTask cleanup

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1099,15 +1099,15 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
                note type could have lead to the card being deleted */
             if (data!=null && data.hasExtra("reloadRequired")) {
                 getCol().getSched().reset();
-                DeckTask.launchDeckTask(DeckTask.TASK_TYPE_ANSWER_CARD, mAnswerCardHandler, new DeckTask.TaskData(
-                        getCol(), mSched, null, 0));
+                DeckTask.launchDeckTask(DeckTask.TASK_TYPE_ANSWER_CARD, mAnswerCardHandler,
+                        new DeckTask.TaskData(null, 0));
             }
 
             if (resultCode == RESULT_OK) {
                 // content of note was changed so update the note and current card
                 Timber.i("AbstractFlashcardViewer:: Saving card...");
-                DeckTask.launchDeckTask(DeckTask.TASK_TYPE_UPDATE_FACT, mUpdateCardHandler, new DeckTask.TaskData(
-                        getCol(), mSched, mCurrentCard, true));
+                DeckTask.launchDeckTask(DeckTask.TASK_TYPE_UPDATE_FACT, mUpdateCardHandler,
+                        new DeckTask.TaskData(mCurrentCard, true));
             } else if (resultCode == RESULT_CANCELED && !(data!=null && data.hasExtra("reloadRequired"))) {
                 // nothing was changed by the note editor so just redraw the card
                 fillFlashcard();
@@ -1189,7 +1189,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
                 mProgressDialog = StyledProgressDialog.show(AbstractFlashcardViewer.this, "",
                         getResources().getString(R.string.saving_changes), false);
             }
-            DeckTask.launchDeckTask(DeckTask.TASK_TYPE_UNDO, mAnswerCardHandler, new DeckTask.TaskData(getCol(), mSched));
+            DeckTask.launchDeckTask(DeckTask.TASK_TYPE_UNDO, mAnswerCardHandler);
         }
     }
 
@@ -1272,7 +1272,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
                     public void onPositive(MaterialDialog dialog) {
                         Timber.i("AbstractFlashcardViewer:: OK button pressed to delete note %d", mCurrentCard.getNid());
                         DeckTask.launchDeckTask(DeckTask.TASK_TYPE_DISMISS_NOTE, mDismissCardHandler,
-                                new DeckTask.TaskData(getCol(), mSched, mCurrentCard, 3));
+                                new DeckTask.TaskData(mCurrentCard, 3));
                     }
                 })
                 .build().show();
@@ -1343,8 +1343,8 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
         Sound.stopSounds();
         mCurrentEase = ease;
 
-        DeckTask.launchDeckTask(DeckTask.TASK_TYPE_ANSWER_CARD, mAnswerCardHandler, new DeckTask.TaskData(
-                getCol(), mSched, mCurrentCard, mCurrentEase));
+        DeckTask.launchDeckTask(DeckTask.TASK_TYPE_ANSWER_CARD, mAnswerCardHandler,
+                new DeckTask.TaskData(mCurrentCard, mCurrentEase));
     }
 
 
@@ -2465,27 +2465,27 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
                 editCard();
                 break;
             case GESTURE_MARK:
-                DeckTask.launchDeckTask(DeckTask.TASK_TYPE_MARK_CARD, mMarkCardHandler, new DeckTask.TaskData(
-                        getCol(), mSched, mCurrentCard, 0));
+                DeckTask.launchDeckTask(DeckTask.TASK_TYPE_MARK_CARD, mMarkCardHandler,
+                        new DeckTask.TaskData(mCurrentCard, 0));
                 break;
             case GESTURE_LOOKUP:
                 lookUpOrSelectText();
                 break;
             case GESTURE_BURY_CARD:
-                DeckTask.launchDeckTask(DeckTask.TASK_TYPE_DISMISS_NOTE, mDismissCardHandler, new DeckTask.TaskData(
-                        getCol(), mSched, mCurrentCard, 4));
+                DeckTask.launchDeckTask(DeckTask.TASK_TYPE_DISMISS_NOTE, mDismissCardHandler,
+                        new DeckTask.TaskData(mCurrentCard, 4));
                 break;
             case GESTURE_BURY_NOTE:
-                DeckTask.launchDeckTask(DeckTask.TASK_TYPE_DISMISS_NOTE, mDismissCardHandler, new DeckTask.TaskData(
-                        getCol(), mSched, mCurrentCard, 0));
+                DeckTask.launchDeckTask(DeckTask.TASK_TYPE_DISMISS_NOTE, mDismissCardHandler,
+                        new DeckTask.TaskData(mCurrentCard, 0));
                 break;
             case GESTURE_SUSPEND_CARD:
-                DeckTask.launchDeckTask(DeckTask.TASK_TYPE_DISMISS_NOTE, mDismissCardHandler, new DeckTask.TaskData(
-                        getCol(), mSched, mCurrentCard, 1));
+                DeckTask.launchDeckTask(DeckTask.TASK_TYPE_DISMISS_NOTE, mDismissCardHandler,
+                        new DeckTask.TaskData(mCurrentCard, 1));
                 break;
             case GESTURE_SUSPEND_NOTE:
-                DeckTask.launchDeckTask(DeckTask.TASK_TYPE_DISMISS_NOTE, mDismissCardHandler, new DeckTask.TaskData(
-                        getCol(), mSched, mCurrentCard, 2));
+                DeckTask.launchDeckTask(DeckTask.TASK_TYPE_DISMISS_NOTE, mDismissCardHandler,
+                        new DeckTask.TaskData(mCurrentCard, 2));
                 break;
             case GESTURE_DELETE:
                 showDeleteNoteDialog();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.java
@@ -355,11 +355,6 @@ public class BackupManager {
     }
 
 
-    // public static boolean deleteAllBackups() {
-    // return removeDir(getBackupDirectory());
-    // }
-    //
-
     public static boolean removeDir(File dir) {
         if (dir.isDirectory()) {
             File[] files = dir.listFiles();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -180,7 +180,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 case CardBrowserContextMenu.CONTEXT_MENU_MARK:
                     DeckTask.launchDeckTask(DeckTask.TASK_TYPE_MARK_CARD,
                             mUpdateCardHandler,
-                            new DeckTask.TaskData(getCol(), getCol().getSched(), getCol().getCard(Long.parseLong(getCards().get(
+                            new DeckTask.TaskData(getCol().getCard(Long.parseLong(getCards().get(
                                     mPositionInCardsList).get("id"))), 0));
                     return;
 
@@ -188,7 +188,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
                     DeckTask.launchDeckTask(
                             DeckTask.TASK_TYPE_DISMISS_NOTE,
                             mSuspendCardHandler,
-                            new DeckTask.TaskData(getCol(), getCol().getSched(), getCol().getCard(Long.parseLong(getCards().get(
+                            new DeckTask.TaskData(getCol().getCard(Long.parseLong(getCards().get(
                                     mPositionInCardsList).get("id"))), 1));
                     return;
 
@@ -209,7 +209,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
                                     Card card = getCol().getCard(Long.parseLong(getCards().get(mPositionInCardsList).get("id")));
                                     deleteNote(card);
                                     DeckTask.launchDeckTask(DeckTask.TASK_TYPE_DISMISS_NOTE, mDeleteNoteHandler,
-                                                            new DeckTask.TaskData(getCol(), getCol().getSched(), card, 3));
+                                                            new DeckTask.TaskData(card, 3));
                                 }
                             })
                             .build().show();
@@ -705,7 +705,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
         if (requestCode == EDIT_CARD && resultCode != RESULT_CANCELED) {
             Timber.i("CardBrowser:: CardBrowser: Saving card...");
             DeckTask.launchDeckTask(DeckTask.TASK_TYPE_UPDATE_FACT, mUpdateCardHandler,
-                    new DeckTask.TaskData(getCol(), getCol().getSched(), sCardBrowserCard, false));
+                    new DeckTask.TaskData(sCardBrowserCard, false));
         } else if (requestCode == ADD_NOTE && resultCode == RESULT_OK) {
             if (mSearchView != null) {
                 mSearchTerms = mSearchView.getQuery().toString();
@@ -817,7 +817,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
             mCardsAdapter.notifyDataSetChanged();
             // Perform database query to get all card ids / sfld. Shows "filtering cards..." progress message
             DeckTask.launchDeckTask(DeckTask.TASK_TYPE_SEARCH_CARDS, mSearchCardsHandler, new DeckTask.TaskData(
-                    new Object[] { getCol(), mDeckNames, searchText, ((mOrder != CARD_ORDER_NONE)) }));
+                    new Object[] { mDeckNames, searchText, ((mOrder != CARD_ORDER_NONE)) }));
         }
     }
 
@@ -1079,8 +1079,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 updateList();
                 dismissProgressDialog();
                 // After the initial searchCards query, start rendering the question and answer in the background
-                DeckTask.launchDeckTask(DeckTask.TASK_TYPE_RENDER_BROWSER_QA, mRenderQAHandler, new DeckTask.TaskData(
-                        new Object[] { getCol(), mCards, 0, 100 }));
+                DeckTask.launchDeckTask(DeckTask.TASK_TYPE_RENDER_BROWSER_QA, mRenderQAHandler,
+                        new DeckTask.TaskData(new Object[] { mCards, 0, 100 }));
             } else {
                 // this is a hack -- see DeckTask.launchDeckTask for more info
                 Timber.w("doInBackgroundSearchCards onPostExecute() called but result was null");
@@ -1154,7 +1154,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 int startIdx = listView.getFirstVisiblePosition();
                 int numVisible = listView.getLastVisiblePosition() - startIdx;
                 DeckTask.launchDeckTask(DeckTask.TASK_TYPE_RENDER_BROWSER_QA, mRenderQAHandler, new DeckTask.TaskData(
-                        new Object[] { getCol(), getCards(), startIdx - 5 , 2*numVisible + 5}));
+                        new Object[] {getCards(), startIdx - 5 , 2*numVisible + 5}));
             }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
@@ -454,7 +454,7 @@ public class CardTemplateEditor extends AnkiActivity {
         private void deleteTemplate(JSONObject tmpl, JSONObject model) {
             CardTemplateEditor activity = ((CardTemplateEditor) getActivity());
             activity.getCol().modSchemaNoCheck();
-            Object [] args = new Object[] {activity.getCol(), model, tmpl};
+            Object [] args = new Object[] {model, tmpl};
             DeckTask.launchDeckTask(DeckTask.TASK_TYPE_REMOVE_TEMPLATE,
                     activity.mUpdateTemplateHandler,  new DeckTask.TaskData(args));
             activity.dismissAllDialogFragments();
@@ -508,7 +508,7 @@ public class CardTemplateEditor extends AnkiActivity {
                 throw new RuntimeException(e);
             }
             // Add new template to the current model via AsyncTask
-            Object [] args = new Object[] {activity.getCol(), model, newTemplate};
+            Object [] args = new Object[] {model, newTemplate};
             DeckTask.launchDeckTask(DeckTask.TASK_TYPE_ADD_TEMPLATE,
                     activity.mUpdateTemplateHandler,  new DeckTask.TaskData(args));
             activity.dismissAllDialogFragments();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
@@ -167,7 +167,7 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
                             if (oldValue != newValue) {
                                 mOptions.getJSONObject("new").put("order", newValue);
                                 DeckTask.launchDeckTask(DeckTask.TASK_TYPE_REORDER, mConfChangeHandler,
-                                        new DeckTask.TaskData(new Object[] { mCol, mOptions }));
+                                        new DeckTask.TaskData(new Object[] { mOptions }));
                             }
                             mOptions.getJSONObject("new").put("order", Integer.parseInt((String) value));
                         } else if (key.equals("newPerDay")) {
@@ -225,7 +225,7 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
                             long newConfId = Long.parseLong((String) value);
                             mOptions = mCol.getDecks().getConf(newConfId);
                             DeckTask.launchDeckTask(DeckTask.TASK_TYPE_CONF_CHANGE, mConfChangeHandler,
-                                    new DeckTask.TaskData(new Object[] { mCol, mDeck, mOptions }));
+                                    new DeckTask.TaskData(new Object[] { mDeck, mOptions }));
                             // Restart to reflect the new preference values
                             restartActivity();
                         } else if (key.equals("confRename")) {
@@ -236,7 +236,7 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
                         } else if (key.equals("confReset")) {
                             if ((Boolean) value) {
                                 DeckTask.launchDeckTask(DeckTask.TASK_TYPE_CONF_RESET, mConfChangeHandler,
-                                        new DeckTask.TaskData(new Object[] { mCol, mOptions }));
+                                        new DeckTask.TaskData(new Object[] { mOptions }));
                             }
                         } else if (key.equals("confAdd")) {
                             String newName = (String) value;
@@ -280,7 +280,7 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
                         } else if (key.equals("confSetSubdecks")) {
                             if ((Boolean) value) {
                                 DeckTask.launchDeckTask(DeckTask.TASK_TYPE_CONF_SET_SUBDECKS, mConfChangeHandler,
-                                        new DeckTask.TaskData(new Object[] { mCol, mDeck, mOptions }));
+                                        new DeckTask.TaskData(new Object[] { mDeck, mOptions }));
                             }
                         }
                     }
@@ -406,7 +406,7 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
                     mCol.getDecks().remConf(mOptions.getLong("id"));
                     // Run the CPU intensive re-sort operation in a background thread
                     DeckTask.launchDeckTask(DeckTask.TASK_TYPE_CONF_REMOVE, mConfChangeHandler,
-                            new DeckTask.TaskData(new Object[] { mCol, mOptions }));
+                            new DeckTask.TaskData(new Object[] { mOptions }));
                     mDeck.put("conf", 1);
                 } catch (JSONException e) {
                     throw new RuntimeException(e);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -616,8 +616,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
                 mImportPath = intent.getStringExtra("importPath");
             }
             if (colIsOpen() && mImportPath != null) {
-                DeckTask.launchDeckTask(DeckTask.TASK_TYPE_IMPORT, mImportAddListener, new TaskData(getCol(),
-                        mImportPath, true));
+                DeckTask.launchDeckTask(DeckTask.TASK_TYPE_IMPORT, mImportAddListener, new TaskData(mImportPath, true));
                 mImportPath = null;
             }
         }
@@ -1062,7 +1061,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
             @Override
             public void onCancelled() {
             }
-        }, new DeckTask.TaskData(getCol(), CollectionHelper.getCollectionPath(this)));
+        });
     }
 
 
@@ -1107,7 +1106,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
             @Override
             public void onCancelled() {
             }
-        }, new DeckTask.TaskData(getCol()));
+        });
     }
 
 
@@ -1144,7 +1143,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
             @Override
             public void onCancelled() {
             }
-        }, new DeckTask.TaskData(getCol()));
+        });
     }
 
 
@@ -1450,15 +1449,14 @@ public class DeckPicker extends NavigationDrawerActivity implements
     @Override
     public void importAdd(String importPath) {
         DeckTask.launchDeckTask(DeckTask.TASK_TYPE_IMPORT, mImportAddListener,
-                new TaskData(getCol(), importPath, false));
+                new TaskData(importPath, false));
     }
 
 
     // Callback to import a file -- replacing the existing collection
     @Override
     public void importReplace(String importPath) {
-        DeckTask.launchDeckTask(DeckTask.TASK_TYPE_IMPORT_REPLACE, mImportReplaceListener, new TaskData(getCol(),
-                importPath));
+        DeckTask.launchDeckTask(DeckTask.TASK_TYPE_IMPORT_REPLACE, mImportReplaceListener, new TaskData(importPath));
     }
 
 
@@ -1679,7 +1677,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
             public void onCancelled() {
             }
 
-        }, new TaskData(getCol()));
+        });
     }
 
 
@@ -1850,7 +1848,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
             @Override
             public void onCancelled() {
             }
-        }, new TaskData(getCol(), mContextMenuDid));
+        }, new TaskData(mContextMenuDid));
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -84,8 +84,8 @@ public class Reviewer extends AbstractFlashcardViewer {
         }
 
         col.getSched().reset();     // Reset schedule incase card had previous been loaded
-        DeckTask.launchDeckTask(DeckTask.TASK_TYPE_ANSWER_CARD, mAnswerCardHandler, new DeckTask.TaskData(getCol(), mSched, null,
-                0));
+        DeckTask.launchDeckTask(DeckTask.TASK_TYPE_ANSWER_CARD, mAnswerCardHandler,
+                new DeckTask.TaskData(null, 0));
 
         disableDrawerSwipeOnConflicts();
         // Add a weak reference to current activity so that scheduler can talk to to Activity
@@ -115,8 +115,7 @@ public class Reviewer extends AbstractFlashcardViewer {
 
             case R.id.action_mark_card:
                 Timber.i("Reviewer:: Mark button pressed");
-                DeckTask.launchDeckTask(DeckTask.TASK_TYPE_MARK_CARD, mMarkCardHandler, new DeckTask.TaskData(
-                        getCol(), mSched, mCurrentCard, 0));
+                DeckTask.launchDeckTask(DeckTask.TASK_TYPE_MARK_CARD, mMarkCardHandler, new DeckTask.TaskData(mCurrentCard, 0));
                 break;
 
             case R.id.action_replay:
@@ -130,26 +129,22 @@ public class Reviewer extends AbstractFlashcardViewer {
 
             case R.id.action_bury_card:
                 Timber.i("Reviewer:: Bury card button pressed");
-                DeckTask.launchDeckTask(DeckTask.TASK_TYPE_DISMISS_NOTE, mDismissCardHandler, new DeckTask.TaskData(
-                        getCol(), mSched, mCurrentCard, 4));
+                DeckTask.launchDeckTask(DeckTask.TASK_TYPE_DISMISS_NOTE, mDismissCardHandler, new DeckTask.TaskData(mCurrentCard, 4));
                 break;
 
             case R.id.action_bury_note:
                 Timber.i("Reviewer:: Bury note button pressed");
-                DeckTask.launchDeckTask(DeckTask.TASK_TYPE_DISMISS_NOTE, mDismissCardHandler, new DeckTask.TaskData(
-                        getCol(), mSched, mCurrentCard, 0));
+                DeckTask.launchDeckTask(DeckTask.TASK_TYPE_DISMISS_NOTE, mDismissCardHandler, new DeckTask.TaskData(mCurrentCard, 0));
                 break;
 
             case R.id.action_suspend_card:
                 Timber.i("Reviewer:: Suspend card button pressed");
-                DeckTask.launchDeckTask(DeckTask.TASK_TYPE_DISMISS_NOTE, mDismissCardHandler, new DeckTask.TaskData(
-                        getCol(), mSched, mCurrentCard, 1));
+                DeckTask.launchDeckTask(DeckTask.TASK_TYPE_DISMISS_NOTE, mDismissCardHandler, new DeckTask.TaskData(mCurrentCard, 1));
                 break;
 
             case R.id.action_suspend_note:
                 Timber.i("Reviewer:: Suspend note button pressed");
-                DeckTask.launchDeckTask(DeckTask.TASK_TYPE_DISMISS_NOTE, mDismissCardHandler, new DeckTask.TaskData(
-                        getCol(), mSched, mCurrentCard, 2));
+                DeckTask.launchDeckTask(DeckTask.TASK_TYPE_DISMISS_NOTE, mDismissCardHandler, new DeckTask.TaskData(mCurrentCard, 2));
                 break;
 
             case R.id.action_delete:
@@ -282,28 +277,23 @@ public class Reviewer extends AbstractFlashcardViewer {
 	            return true;
 	        }
 	        if (keyPressed == '*') {
-	            DeckTask.launchDeckTask(DeckTask.TASK_TYPE_MARK_CARD, mMarkCardHandler, new DeckTask.TaskData(
-                        getCol(), mSched, mCurrentCard, 0));
+	            DeckTask.launchDeckTask(DeckTask.TASK_TYPE_MARK_CARD, mMarkCardHandler, new DeckTask.TaskData(mCurrentCard, 0));
 	            return true;
 	        }
 	        if (keyPressed == '-') {
-	            DeckTask.launchDeckTask(DeckTask.TASK_TYPE_DISMISS_NOTE, mDismissCardHandler, new DeckTask.TaskData(
-                        getCol(), mSched, mCurrentCard, 4));
+	            DeckTask.launchDeckTask(DeckTask.TASK_TYPE_DISMISS_NOTE, mDismissCardHandler, new DeckTask.TaskData(mCurrentCard, 4));
 	            return true;
 	        }
 	        if (keyPressed == '=') {
-	            DeckTask.launchDeckTask(DeckTask.TASK_TYPE_DISMISS_NOTE, mDismissCardHandler, new DeckTask.TaskData(
-                        getCol(), mSched, mCurrentCard, 0));
+	            DeckTask.launchDeckTask(DeckTask.TASK_TYPE_DISMISS_NOTE, mDismissCardHandler, new DeckTask.TaskData(mCurrentCard, 0));
 	            return true;
 	        }
 	        if (keyPressed == '@') {
-	            DeckTask.launchDeckTask(DeckTask.TASK_TYPE_DISMISS_NOTE, mDismissCardHandler, new DeckTask.TaskData(
-                        getCol(), mSched, mCurrentCard, 1));
+	            DeckTask.launchDeckTask(DeckTask.TASK_TYPE_DISMISS_NOTE, mDismissCardHandler, new DeckTask.TaskData(mCurrentCard, 1));
 	            return true;
 	        }
 	        if (keyPressed == '!') {
-	            DeckTask.launchDeckTask(DeckTask.TASK_TYPE_DISMISS_NOTE, mDismissCardHandler, new DeckTask.TaskData(
-                        getCol(), mSched, mCurrentCard, 2));
+	            DeckTask.launchDeckTask(DeckTask.TASK_TYPE_DISMISS_NOTE, mDismissCardHandler, new DeckTask.TaskData(mCurrentCard, 2));
 	            return true;
 	        }
 	        if (keyPressed == 'r' || keyCode == KeyEvent.KEYCODE_F5) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
@@ -187,14 +187,14 @@ public class StudyOptionsFragment extends Fragment implements LoaderManager.Load
                     mProgressDialog = StyledProgressDialog.show(getActivity(), "",
                             getResources().getString(R.string.rebuild_cram_deck), true);
                     DeckTask.launchDeckTask(DeckTask.TASK_TYPE_REBUILD_CRAM, getDeckTaskListener(true),
-                            new DeckTask.TaskData(getCol(), getCol().getDecks().selected(), mFragmented));
+                            new DeckTask.TaskData(mFragmented));
                     return;
                 case R.id.studyoptions_empty_cram:
                     Timber.i("StudyOptionsFragment:: empty cram deck button pressed");
                     mProgressDialog = StyledProgressDialog.show(getActivity(), "",
                             getResources().getString(R.string.empty_cram_deck), false);
                     DeckTask.launchDeckTask(DeckTask.TASK_TYPE_EMPTY_CRAM, getDeckTaskListener(true),
-                            new DeckTask.TaskData(col, col.getDecks().selected(), mFragmented));
+                            new DeckTask.TaskData(mFragmented));
                     return;
                 default:
             }
@@ -502,8 +502,7 @@ public class StudyOptionsFragment extends Fragment implements LoaderManager.Load
                 mProgressDialog = StyledProgressDialog.show(getActivity(), "",
                         getResources().getString(R.string.rebuild_custom_study_deck), false);
                 DeckTask.launchDeckTask(DeckTask.TASK_TYPE_REBUILD_CRAM, getDeckTaskListener(true),
-                        new DeckTask.TaskData(getCol(), getCol().getDecks().selected(),
-                                mFragmented));
+                        new DeckTask.TaskData(mFragmented));
             } catch (JSONException e) {
                 throw new RuntimeException(e);
             }
@@ -610,7 +609,7 @@ public class StudyOptionsFragment extends Fragment implements LoaderManager.Load
                     mProgressDialog = StyledProgressDialog.show(getActivity(), "",
                             getResources().getString(R.string.rebuild_cram_deck), true);
                     DeckTask.launchDeckTask(DeckTask.TASK_TYPE_REBUILD_CRAM, getDeckTaskListener(true),
-                            new DeckTask.TaskData(getCol(), getCol().getDecks().selected(), mFragmented));
+                            new DeckTask.TaskData(mFragmented));
             } else {
                 DeckTask.waitToFinish();
                 refreshInterface(true);
@@ -677,7 +676,7 @@ public class StudyOptionsFragment extends Fragment implements LoaderManager.Load
         // Load the deck counts for the deck from Collection asynchronously
         DeckTask.launchDeckTask(DeckTask.TASK_TYPE_UPDATE_VALUES_FROM_DECK,
                 getDeckTaskListener(resetDecklist),
-                new DeckTask.TaskData(getCol(), new Object[]{resetSched, mChartView != null}));
+                new DeckTask.TaskData(new Object[]{resetSched, mChartView != null}));
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/UIUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/UIUtils.java
@@ -56,7 +56,7 @@ public class UIUtils {
                 @Override
                 public void onCancelled() {
                 }
-            }, new DeckTask.TaskData(CollectionHelper.getInstance().getCol(context)));
+            });
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
@@ -22,7 +22,6 @@ import android.content.Context;
 import android.content.res.Resources;
 import android.os.AsyncTask;
 
-
 import com.google.gson.stream.JsonReader;
 import com.ichi2.anki.AnkiDb;
 import com.ichi2.anki.AnkiDroidApp;
@@ -41,7 +40,6 @@ import com.ichi2.libanki.Stats;
 import com.ichi2.libanki.Storage;
 import com.ichi2.libanki.Utils;
 import com.ichi2.libanki.importer.Anki2Importer;
-import com.ichi2.widget.WidgetStatus;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -51,16 +49,11 @@ import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.TreeSet;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -73,7 +66,6 @@ import timber.log.Timber;
  */
 public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData, DeckTask.TaskData> {
 
-    public static final int TASK_TYPE_OPEN_COLLECTION = 0;
     public static final int TASK_TYPE_SAVE_COLLECTION = 2;
     public static final int TASK_TYPE_ANSWER_CARD = 3;
     public static final int TASK_TYPE_MARK_CARD = 5;
@@ -82,11 +74,7 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
     public static final int TASK_TYPE_UNDO = 8;
     public static final int TASK_TYPE_DISMISS_NOTE = 11;
     public static final int TASK_TYPE_CHECK_DATABASE = 14;
-    public static final int TASK_TYPE_DELETE_BACKUPS = 16;
-    public static final int TASK_TYPE_UPDATE_CARD_BROWSER_LIST = 18;
-    //public static final int TASK_TYPE_LOAD_TUTORIAL = 19;
     public static final int TASK_TYPE_REPAIR_DECK = 20;
-    public static final int TASK_TYPE_CLOSE_DECK = 21;
     public static final int TASK_TYPE_LOAD_DECK_COUNTS = 22;
     public static final int TASK_TYPE_UPDATE_VALUES_FROM_DECK = 23;
     public static final int TASK_TYPE_DELETE_DECK = 25;
@@ -105,6 +93,11 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
     public static final int TASK_TYPE_CHECK_MEDIA = 38;
     public static final int TASK_TYPE_ADD_TEMPLATE = 39;
     public static final int TASK_TYPE_REMOVE_TEMPLATE = 40;
+
+    /**
+     * A reference to the application context to use to fetch the current Collection object.
+     */
+    private Context mContext;
 
     /**
      * The most recently started {@link DeckTask} instance.
@@ -219,12 +212,6 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
         // Wait for previous thread (if any) to finish before continuing
         if (mPreviousTask != null && mPreviousTask.getStatus() != AsyncTask.Status.FINISHED) {
             Timber.d("Waiting for %d to finish before starting %d", mPreviousTask.mType, mType);
-
-            // Let user know if the last deck close is still performing a backup.
-            if (mType == TASK_TYPE_OPEN_COLLECTION && mPreviousTask.mType == TASK_TYPE_CLOSE_DECK) {
-                publishProgress(new TaskData(AnkiDroidApp.getInstance().getBaseContext().getResources()
-                        .getString(R.string.finish_operation)));
-            }
             try {
                 mPreviousTask.get();
                 Timber.d("Finished waiting for %d to finish. Status= %s", mPreviousTask.mType, mPreviousTask.getStatus());
@@ -241,6 +228,8 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
                 Timber.e(e, "previously running task was cancelled: %d", mPreviousTask.mType);
             }
         }
+
+        mContext = AnkiDroidApp.getInstance().getApplicationContext();
 
         // Actually execute the task now that we are at the front of the queue.
         switch (mType) {
@@ -274,17 +263,8 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
             case TASK_TYPE_CHECK_DATABASE:
                 return doInBackgroundCheckDatabase(params);
 
-            case TASK_TYPE_DELETE_BACKUPS:
-                return doInBackgroundDeleteBackups();
-
-            case TASK_TYPE_UPDATE_CARD_BROWSER_LIST:
-                return doInBackgroundUpdateCardBrowserList(params);
-
             case TASK_TYPE_REPAIR_DECK:
                 return doInBackgroundRepairDeck(params);
-
-            case TASK_TYPE_CLOSE_DECK:
-                return doInBackgroundCloseCollection(params);
 
             case TASK_TYPE_UPDATE_VALUES_FROM_DECK:
                 return doInBackgroundUpdateValuesFromDeck(params);
@@ -374,8 +354,7 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
     private TaskData doInBackgroundAddNote(TaskData[] params) {
         Timber.d("doInBackgroundAddNote");
         Note note = params[0].getNote();
-        Collection col = note.getCol();
-
+        Collection col = CollectionHelper.getInstance().getCol(mContext);
         try {
             AnkiDb ankiDB = col.getDb();
             ankiDB.getDatabase().beginTransaction();
@@ -397,15 +376,15 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
     private TaskData doInBackgroundUpdateNote(TaskData[] params) {
         Timber.d("doInBackgroundUpdateNote");
         // Save the note
-        Sched sched = params[0].getSched();
-        Collection col = params[0].getCollection();
+        Collection col = CollectionHelper.getInstance().getCol(mContext);
+        Sched sched = col.getSched();
         Card editCard = params[0].getCard();
         Note editNote = editCard.note();
         boolean fromReviewer = params[0].getBoolean();
 
         // mark undo
-        col.markUndo(Collection.UNDO_EDIT_NOTE, new Object[] { col.getNote(editNote.getId()), editCard.getId(),
-                fromReviewer });
+        col.markUndo(Collection.UNDO_EDIT_NOTE, new Object[]{col.getNote(editNote.getId()), editCard.getId(),
+                fromReviewer});
 
         try {
             col.getDb().getDatabase().beginTransaction();
@@ -442,8 +421,8 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
 
 
     private TaskData doInBackgroundAnswerCard(TaskData... params) {
-        Collection col = params[0].getCollection();
-        Sched sched = params[0].getSched();
+        Collection col = CollectionHelper.getInstance().getCol(mContext);
+        Sched sched = col.getSched();
         Card oldCard = params[0].getCard();
         int ease = params[0].getInt();
         Card newCard = null;
@@ -483,9 +462,10 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
         return sched.getCard();
     }
 
+
     private TaskData doInBackgroundLoadDeckCounts(TaskData... params) {
         Timber.d("doInBackgroundLoadDeckCounts");
-        Collection col = params[0].getCollection();
+        Collection col = CollectionHelper.getInstance().getCol(mContext);
         try {
             Object[] o = new Object[] {col.getSched().deckDueTree()};
             return new TaskData(o);
@@ -495,9 +475,10 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
         }
     }
 
+
     private TaskData doInBackgroundSaveCollection(TaskData... params) {
         Timber.d("doInBackgroundSaveCollection");
-        Collection col = params[0].getCollection();
+        Collection col = CollectionHelper.getInstance().getCol(mContext);
         if (col != null) {
             try {
                 col.save();
@@ -510,8 +491,8 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
 
 
     private TaskData doInBackgroundDismissNote(TaskData... params) {
-        Sched sched = params[0].getSched();
-        Collection col = params[0].getCollection();
+        Collection col = CollectionHelper.getInstance().getCol(mContext);
+        Sched sched = col.getSched();
         Card card = params[0].getCard();
         Note note = card.note();
         int type = params[0].getInt();
@@ -561,10 +542,6 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
                     case 3:
                         // collect undo information
                         ArrayList<Card> allCs = note.cards();
-                        long[] cardIds = new long[allCs.size()];
-                        for (int i = 0; i < allCs.size(); i++) {
-                            cardIds[i] = allCs.get(i).getId();
-                        }
                         col.markUndo(Collection.UNDO_DELETE_NOTE, new Object[] { note, allCs, card.getId() });
                         // delete note
                         col.remNotes(new long[] { note.getId() });
@@ -587,7 +564,7 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
 
     private TaskData doInBackgroundMarkCard(TaskData... params) {
         Card card = params[0].getCard();
-        Collection col = params[0].getCollection();
+        Collection col = CollectionHelper.getInstance().getCol(mContext);
         try {
             AnkiDb ankiDB = col.getDb();
             ankiDB.getDatabase().beginTransaction();
@@ -595,7 +572,7 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
                 if (card != null) {
                     Note note = card.note();
                     col.markUndo(Collection.UNDO_MARK_NOTE,
-                            new Object[] { note.getId(), note.stringTags(), card.getId() });
+                            new Object[]{note.getId(), note.stringTags(), card.getId()});
                     if (note.hasTag("marked")) {
                         note.delTag("marked");
                     } else {
@@ -618,8 +595,8 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
 
 
     private TaskData doInBackgroundUndo(TaskData... params) {
-        Sched sched = params[0].getSched();
-        Collection col = params[0].getCollection();
+        Collection col = CollectionHelper.getInstance().getCol(mContext);
+        Sched sched = col.getSched();
         try {
             col.getDb().getDatabase().beginTransaction();
             Card newCard;
@@ -654,10 +631,10 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
 
     private TaskData doInBackgroundSearchCards(TaskData... params) {
         Timber.d("doInBackgroundSearchCards");
-        Collection col = (Collection) params[0].getObjArray()[0];
-        HashMap<String, String> deckNames = (HashMap<String, String>) params[0].getObjArray()[1];
-        String query = (String) params[0].getObjArray()[2];
-        Boolean order = (Boolean) params[0].getObjArray()[3];
+        Collection col = CollectionHelper.getInstance().getCol(mContext);
+        HashMap<String, String> deckNames = (HashMap<String, String>) params[0].getObjArray()[0];
+        String query = (String) params[0].getObjArray()[1];
+        Boolean order = (Boolean) params[0].getObjArray()[2];
         ArrayList<HashMap<String,String>> searchResult = col.findCardsForCardBrowser(query, order, deckNames);
         if (isCancelled() || CardBrowser.sSearchCancelled) {
             Timber.d("doInBackgroundSearchCards was cancelled so return null");
@@ -671,10 +648,10 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
 
     private TaskData doInBackgroundRenderBrowserQA(TaskData... params) {
         Timber.d("doInBackgroundRenderBrowserQA");
-        Collection col = (Collection) params[0].getObjArray()[0];
-        ArrayList<HashMap<String, String>> items = (ArrayList<HashMap<String, String>>) params[0].getObjArray()[1];
-        Integer startPos = (Integer) params[0].getObjArray()[2];
-        Integer n = (Integer) params[0].getObjArray()[3];
+        Collection col = CollectionHelper.getInstance().getCol(mContext);
+        ArrayList<HashMap<String, String>> items = (ArrayList<HashMap<String, String>>) params[0].getObjArray()[0];
+        Integer startPos = (Integer) params[0].getObjArray()[1];
+        Integer n = (Integer) params[0].getObjArray()[2];
 
         // for each specified card in the browser list
         for (int i = startPos; i < startPos + n; i++) {
@@ -698,7 +675,7 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
 
     private TaskData doInBackgroundCheckDatabase(TaskData... params) {
         Timber.d("doInBackgroundCheckDatabase");
-        Collection col = params[0].getCollection();
+        Collection col = CollectionHelper.getInstance().getCol(mContext);
         // Don't proceed if collection closed
         if (col == null) {
             Timber.e("doInBackgroundCheckDatabase :: supplied collection was null");
@@ -718,34 +695,18 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
 
     private TaskData doInBackgroundRepairDeck(TaskData... params) {
         Timber.d("doInBackgroundRepairDeck");
-        //String deckPath = params[0].getString();
-        Collection col = params[0].getCollection();
+        Collection col = CollectionHelper.getInstance().getCol(mContext);
         if (col != null) {
             col.close(false);
         }
         return new TaskData(BackupManager.repairCollection(col));
     }
 
-    private TaskData doInBackgroundCloseCollection(TaskData... params) {
-        Timber.d("doInBackgroundCloseCollection");
-        Collection col = params[0].getCollection();
-        if (col != null) {
-            try {
-                WidgetStatus.waitToFinish();
-                String path = col.getPath();
-                CollectionHelper.getInstance().closeCollection(true);
-                BackupManager.performBackupInBackground(path);
-            } catch (RuntimeException e) {
-                Timber.e("doInBackgroundCloseCollection: error occurred - collection not properly closed");
-            }
-        }
-        return null;
-    }
 
     private TaskData doInBackgroundUpdateValuesFromDeck(TaskData... params) {
         Timber.d("doInBackgroundUpdateValuesFromDeck");
         try {
-            Collection col = params[0].getCollection();
+            Collection col = CollectionHelper.getInstance().getCol(mContext);
             Sched sched = col.getSched();
             Object[] obj = params[0].getObjArray();
             boolean reset = (Boolean) obj[0];
@@ -771,46 +732,37 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
     }
 
 
-
-    private TaskData doInBackgroundDeleteBackups() {
-        Timber.d("doInBackgroundDeleteBackups");
-        return null;// ew TaskData(BackupManager.deleteAllBackups());
-    }
-
-
     private TaskData doInBackgroundDeleteDeck(TaskData... params) {
         Timber.d("doInBackgroundDeleteDeck");
-        Collection col = params[0].getCollection();
+        Collection col = CollectionHelper.getInstance().getCol(mContext);
         long did = params[0].getLong();
         col.getDecks().rem(did, true);
-        return new TaskData(col);
+        return new TaskData(true);
     }
 
 
     private TaskData doInBackgroundRebuildCram(TaskData... params) {
         Timber.d("doInBackgroundRebuildCram");
-        Collection col = params[0].getCollection();
+        Collection col = CollectionHelper.getInstance().getCol(mContext);
         boolean fragmented = params[0].getBoolean();
-        long did = params[0].getLong();
-        col.getSched().rebuildDyn(did);
-        return doInBackgroundUpdateValuesFromDeck(new DeckTask.TaskData(col, new Object[] { true, fragmented }));
+        col.getSched().rebuildDyn(col.getDecks().selected());
+        return doInBackgroundUpdateValuesFromDeck(new DeckTask.TaskData(new Object[]{true, fragmented}));
     }
 
 
     private TaskData doInBackgroundEmptyCram(TaskData... params) {
         Timber.d("doInBackgroundEmptyCram");
-        Collection col = params[0].getCollection();
+        Collection col = CollectionHelper.getInstance().getCol(mContext);
         boolean fragmented = params[0].getBoolean();
-        long did = params[0].getLong();
-        col.getSched().emptyDyn(did);
-        return doInBackgroundUpdateValuesFromDeck(new DeckTask.TaskData(col, new Object[] { true, fragmented }));
+        col.getSched().emptyDyn(col.getDecks().selected());
+        return doInBackgroundUpdateValuesFromDeck(new DeckTask.TaskData(new Object[]{true, fragmented}));
     }
 
 
     private TaskData doInBackgroundImportAdd(TaskData... params) {
         Timber.d("doInBackgroundImportAdd");
         Resources res = AnkiDroidApp.getInstance().getBaseContext().getResources();
-        Collection col = params[0].getCollection();
+        Collection col = CollectionHelper.getInstance().getCol(mContext);
         String path = params[0].getString();
         boolean sharedDeckImport = params[0].getBoolean();
 
@@ -859,7 +811,7 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
 
     private TaskData doInBackgroundImportReplace(TaskData... params) {
         Timber.d("doInBackgroundImportReplace");
-        Collection col = params[0].getCollection();
+        Collection col = CollectionHelper.getInstance().getCol(mContext);
         String path = params[0].getString();
         Resources res = AnkiDroidApp.getInstance().getBaseContext().getResources();
 
@@ -1008,37 +960,11 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
     }
 
 
-    private TaskData doInBackgroundUpdateCardBrowserList(TaskData... params) {
-        Timber.d("doInBackgroundSortCards");
-        if (params.length == 1) {
-            Comparator comparator = params[0].getComparator();
-            ArrayList<HashMap<String, String>> card = params[0].getCards();
-            Collections.sort(card, comparator);
-        } else {
-            ArrayList<HashMap<String, String>> allCard = params[0].getCards();
-            ArrayList<HashMap<String, String>> cards = params[1].getCards();
-            cards.clear();
-            HashSet<String> tags = new HashSet<String>();
-            for (String s : (HashSet<String>) params[2].getObjArray()[0]) {
-                tags.add(s.toLowerCase(Locale.getDefault()));
-            }
-            for (int i = 0; i < allCard.size(); i++) {
-                HashMap<String, String> card = allCard.get(i);
-                if (Arrays.asList(card.get("tags").toLowerCase(Locale.getDefault()).trim().split("\\s"))
-                        .containsAll(tags)) {
-                    cards.add(allCard.get(i));
-                }
-            }
-        }
-        return null;
-    }
-
-
     private TaskData doInBackgroundReorder(TaskData... params) {
         Timber.d("doInBackgroundReorder");
+        Collection col = CollectionHelper.getInstance().getCol(mContext);
         Object[] data = params[0].getObjArray();
-        Collection col = (Collection) data[0];
-        JSONObject conf = (JSONObject) data[1];
+        JSONObject conf = (JSONObject) data[0];
         col.getSched().resortConf(conf);
         return new TaskData(true);
     }
@@ -1046,10 +972,10 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
 
     private TaskData doInBackgroundConfChange(TaskData... params) {
         Timber.d("doInBackgroundConfChange");
+        Collection col = CollectionHelper.getInstance().getCol(mContext);
         Object[] data = params[0].getObjArray();
-        Collection col = (Collection) data[0];
-        JSONObject deck = (JSONObject) data[1];
-        JSONObject conf = (JSONObject) data[2];
+        JSONObject deck = (JSONObject) data[0];
+        JSONObject conf = (JSONObject) data[1];
         try {
             long newConfId = conf.getLong("id");
             // If new config has a different sorting order, reorder the cards
@@ -1075,9 +1001,9 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
 
     private TaskData doInBackgroundConfReset(TaskData... params) {
         Timber.d("doInBackgroundConfReset");
+        Collection col = CollectionHelper.getInstance().getCol(mContext);
         Object[] data = params[0].getObjArray();
-        Collection col = (Collection) data[0];
-        JSONObject conf = (JSONObject) data[1];
+        JSONObject conf = (JSONObject) data[0];
         col.getDecks().restoreToDefault(conf);
         return new TaskData(true);
     }
@@ -1085,9 +1011,9 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
 
     private TaskData doInBackgroundConfRemove(TaskData... params) {
         Timber.d("doInBackgroundConfRemove");
+        Collection col = CollectionHelper.getInstance().getCol(mContext);
         Object[] data = params[0].getObjArray();
-        Collection col = (Collection) data[0];
-        JSONObject conf = (JSONObject) data[1];
+        JSONObject conf = (JSONObject) data[0];
         try {
             // Note: We do the actual removing of the options group in the main thread so that we 
             // can ask the user to confirm if they're happy to do a full sync, and just do the resorting here
@@ -1109,10 +1035,10 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
 
     private TaskData doInBackgroundConfSetSubdecks(TaskData... params) {
         Timber.d("doInBackgroundConfSetSubdecks");
+        Collection col = CollectionHelper.getInstance().getCol(mContext);
         Object[] data = params[0].getObjArray();
-        Collection col = (Collection) data[0];
-        JSONObject deck = (JSONObject) data[1];
-        JSONObject conf = (JSONObject) data[2];
+        JSONObject deck = (JSONObject) data[0];
+        JSONObject conf = (JSONObject) data[1];
         try {
             TreeMap<String, Long> children = col.getDecks().children(deck.getLong("id"));
             for (Map.Entry<String, Long> entry : children.entrySet()) {
@@ -1138,9 +1064,9 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
      */
     private TaskData doInBackgroundCheckMedia(TaskData... params) {
         Timber.d("doInBackgroundCheckMedia");
+        Collection col = CollectionHelper.getInstance().getCol(mContext);
         try {
             // A media check on AnkiDroid will also update the media db
-            Collection col = params[0].getCollection();
             col.getMedia().findChanges(true);
             // Then do the actual check
             List<List<String>> result = col.getMedia().check();
@@ -1152,15 +1078,13 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
 
     /**
      * Add a new card template
-     * @param params
-     * @return
      */
     private TaskData doInBackgroundAddTemplate(TaskData... params) {
         Timber.d("doInBackgroundAddTemplate");
+        Collection col = CollectionHelper.getInstance().getCol(mContext);
         Object [] args = params[0].getObjArray();
-        Collection col = (Collection ) args[0];
-        JSONObject model = (JSONObject) args[1];
-        JSONObject template = (JSONObject) args[2];
+        JSONObject model = (JSONObject) args[0];
+        JSONObject template = (JSONObject) args[1];
         // add the new template
         try {
             col.getModels().addTemplate(model, template);
@@ -1172,21 +1096,18 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
     }
 
     /**
-     * Add a new card template
-     * @param params
-     * @return
+     * Remove a card template
      */
     private TaskData doInBackgroundRemoveTemplate(TaskData... params) {
         Timber.d("doInBackgroundRemoveTemplate");
+        Collection col = CollectionHelper.getInstance().getCol(mContext);
         Object [] args = params[0].getObjArray();
-        Collection col = (Collection ) args[0];
-        JSONObject model = (JSONObject) args[1];
-        JSONObject template = (JSONObject) args[2];
-        // add the new template
+        JSONObject model = (JSONObject) args[0];
+        JSONObject template = (JSONObject) args[1];
         try {
             boolean success = col.getModels().remTemplate(model, template);
             if (! success) {
-                return new TaskData(col, "removeTemplateFailed", false);
+                return new TaskData("removeTemplateFailed", false);
             }
         } catch (ConfirmModSchemaException e) {
             Timber.e("doInBackgroundRemoveTemplate :: ConfirmModSchemaException");
@@ -1202,7 +1123,7 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
      * <p>
      * Their semantics is equivalent to the methods of {@link AsyncTask}.
      */
-    public static interface Listener {
+    public interface Listener {
 
         /** Invoked before the task is started. */
         void onPreExecute(DeckTask task);
@@ -1324,12 +1245,7 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
         private Context mContext;
         private int mType;
         private Comparator mComparator;
-        private int[] mIntList;
-        private Collection mCol;
-        private Sched mSched;
-        private TreeSet<Object[]> mDeckList;
         private Object[] mObjects;
-        private List<Long> mIdList;
 
 
         public TaskData(Object[] obj) {
@@ -1397,88 +1313,27 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
         }
 
 
-        public TaskData(Collection col) {
-            mCol = col;
-        }
-
-
-        public TaskData(Collection col, Object[] obj) {
-            mCol = col;
-            mObjects = obj;
-        }
-
-
-        public TaskData(Collection col, String string) {
-            mCol = col;
-            mMsg = string;
-        }
-
-
-        public TaskData(Collection col, String string, boolean bool) {
-            mCol = col;
+        public TaskData(String string, boolean bool) {
             mMsg = string;
             mBool = bool;
         }
 
 
-        public TaskData(Collection col, int value) {
-            mCol = col;
-            mInteger = value;
-        }
-
-
-        public TaskData(Collection col, long value) {
-            mCol = col;
-            mLong = value;
-        }
-
-
-        public TaskData(Collection col, long value, boolean bool) {
-            mCol = col;
+        public TaskData(long value, boolean bool) {
             mLong = value;
             mBool = bool;
         }
 
 
-        public TaskData(Collection col, int value, boolean bool) {
-            mCol = col;
+        public TaskData(int value, boolean bool) {
             mInteger = value;
             mBool = bool;
         }
 
 
-        public TaskData(Collection col, Sched sched, Card card, int value) {
-            mCol = col;
-            mSched = sched;
-            mCard = card;
-            mInteger = value;
-        }
-
-
-        public TaskData(Collection col, Sched sched) {
-            mCol = col;
-            mSched = sched;
-        }
-
-
-        public TaskData(Sched sched, boolean bool) {
-            mSched = sched;
-            mBool = bool;
-        }
-
-
-        public TaskData(Collection col, Sched sched, Card card, boolean bool) {
-            mCol = col;
-            mSched = sched;
+        public TaskData(Card card, boolean bool) {
             mBool = bool;
             mCard = card;
-        }
-
-
-        public TaskData(Collection col, TreeSet<Object[]> decklist, int value) {
-            mCol = col;
-            mDeckList = decklist;
-            mInteger = value;
         }
 
 
@@ -1512,16 +1367,6 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
             mMsg = msg;
             mLong = cardId;
             mBool = bool;
-        }
-
-
-        public TaskData(int[] intlist) {
-            mIntList = intlist;
-        }
-
-
-        public TaskData(List<Long> idList) {
-            mIdList = idList;
         }
 
 
@@ -1580,43 +1425,8 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
         }
 
 
-        //
-        // public LinkedHashMap<Long, CardModel> getCardModels() {
-        // return mCardModels;
-        // }
-
-        public int[] getIntList() {
-            return mIntList;
-        }
-
-
-        public Collection getCollection() {
-            return mCol;
-        }
-
-
-        public Sched getSched() {
-            return mSched;
-        }
-
-
-        public TreeSet<Object[]> getDeckList() {
-            return mDeckList;
-        }
-
-
         public Object[] getObjArray() {
             return mObjects;
-        }
-
-
-        public List<Long> getIdList() {
-            return mIdList;
-        }
-
-
-        public void setIdList(List<Long> idList) {
-            mIdList = idList;
         }
     }
     
@@ -1625,11 +1435,6 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
     }
     
     public static boolean taskIsCancelled(int taskType){
-        if (sLatestInstance != null && sLatestInstance.mType == taskType){
-            return taskIsCancelled();
-        } else {
-            return false;
-        }
+        return sLatestInstance != null && sLatestInstance.mType == taskType && taskIsCancelled();
     }
-
 }

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -68,7 +68,6 @@
     <string name="undo_action_delete">delete note</string>
     <string name="undo_action_mark">mark note</string>
     <string name="unbury">Unbury</string>
-    <string name="finish_operation">Finishing previous operation (most likely backup creation)…</string>
     <string name="contextmenu_deckpicker_rename_deck">Rename deck</string>
     <string name="menu_add">Add</string>
     <string name="menu_add_note">Add note</string>
@@ -93,7 +92,7 @@
         The time_quantities are units of time. They are used without
         plurals or dots.
         s, min, h, d, are standard (ISO 31-1) units and should usually
-        not be tranlated, at least not for languages using the Latin
+        not be translated, at least not for languages using the Latin
         alphabet.
     -->
     <string name="time_quantity_seconds">%d s</string>


### PR DESCRIPTION
Fixes #3598.

1 - DeckTasks are queued up and executed in sequence.
2 - When a sync is finished, the collection is closed and reopened (I don't remember why we do this). 

If DeckTasks are queued up *before* a sync finishes and run *after* the sync finishes, they will be using stale references to the Collection since we pass in a Collection object for them to use. This commit changes all DeckTasks to use the CollectionHelper to get a current reference to the collection.

I did a bit of a cleanup of DeckTask while fixing this issue. I've removed any dead code, unused methods, and redundant parameters/TaskData things.