### PR TITLE
Add theming to About dialog and update links

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Info.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Info.java
@@ -27,8 +27,8 @@ import android.os.Bundle;
 import android.support.v7.widget.Toolbar;
 import android.text.ClipboardManager;
 import android.text.method.LinkMovementMethod;
+import android.util.TypedValue;
 import android.view.KeyEvent;
-import android.view.MenuItem;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.webkit.WebChromeClient;
@@ -38,7 +38,6 @@ import android.widget.TextView;
 
 import com.ichi2.anim.ActivityTransitionAnimation;
 import com.ichi2.compat.CompatHelper;
-import com.ichi2.themes.Themes;
 import com.ichi2.utils.VersionUtils;
 
 import org.acra.util.Installation;
@@ -78,14 +77,16 @@ public class Info extends AnkiActivity {
         setTitle(String.format("%s v%s", VersionUtils.getAppName(), VersionUtils.getPkgVersionName()));
         webView = (WebView) findViewById(R.id.info);
         webView.setWebChromeClient(new WebChromeClient() {
-            public void onProgressChanged(WebView view, int progress)
-            {
+            public void onProgressChanged(WebView view, int progress) {
                 // Hide the progress indicator when the page has finished loaded
-                if(progress == 100) {
+                if (progress == 100) {
                     mainView.findViewById(R.id.progress_bar).setVisibility(View.GONE);
                 }
             }
         });
+
+
+
 
         TextView termsAndConditionsView = (TextView) findViewById(R.id.info_terms_and_conditions);
         termsAndConditionsView.setMovementMethod(LinkMovementMethod.getInstance());
@@ -119,7 +120,16 @@ public class Info extends AnkiActivity {
         switch (mType) {
             case TYPE_ABOUT:
                 String[] content = res.getStringArray(R.array.about_content);
-                sb.append("<html><body text=\"#000000\" link=\"#E37068\" alink=\"#E37068\" vlink=\"#E37068\">");
+
+                // Apply theme colours.
+                TypedValue typedValue = new TypedValue();
+                getTheme().resolveAttribute(android.R.attr.colorBackground, typedValue, true);
+                webView.setBackgroundColor(typedValue.data);
+                getTheme().resolveAttribute(android.R.attr.textColor, typedValue, true);
+                String textColor = String.format("#%06X", (0xFFFFFF & typedValue.data)); // Color to hex string
+                sb.append("<html><style>body {color:"+textColor+";}</style>");
+
+                sb.append("<body text=\"#000000\" link=\"#E37068\" alink=\"#E37068\" vlink=\"#E37068\">");
                 sb.append(
                         String.format(content[0], res.getString(R.string.app_name), res.getString(R.string.link_anki)))
                         .append("<br/><br/>");
@@ -129,8 +139,7 @@ public class Info extends AnkiActivity {
                         "<br/><br/>");
                 sb.append(
                         String.format(content[2], res.getString(R.string.link_wikipedia_open_source),
-                                res.getString(R.string.link_contribution),
-                                res.getString(R.string.link_contribution_contributors))).append(" ");
+                                res.getString(R.string.link_contribution))).append(" ");
                 sb.append(
                         String.format(content[3], res.getString(R.string.link_translation),
                                 res.getString(R.string.link_donation))).append("<br/><br/>");

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -35,11 +35,11 @@
     <string name="tts_no_tts">Don’t speak</string>
 
     <string-array name="about_content">
-        <item><![CDATA[<h2>%1$s:<br/>Flashcards for Android</h2>AnkiDroid is a flashcard application which is fully compatible with the desktop software <a href=\"%2$s\">Anki</a>. You can create, download and learn contents on both, AnkiDroid or Anki Desktop, and synchronize them very easily.]]></item>
-        <item><![CDATA[To help us make AnkiDroid better, please report any bug <a href=\"%1$s\">here</a>; new feature ideas are very welcome too. Use the <a href=\"%2$s\">wiki</a> and say Hi on the <a href=\"%3$s\">forum</a>.]]></item>
-        <item><![CDATA[AnkiDroid is <a href=\"%1$s\">open source software<a/>, so everyone is encouraged to <a href=\"%2$s\">join</a> the <a href=\"%3$s\">contributors</a> :-)]]></item>
-        <item><![CDATA[Non-developers can also help, for instance by <a href=\"%1$s\">translating</a> AnkiDroid, updating the wiki and screenshots, <a href=\"%2$s\">donating</a> to Anki Desktop, or blogging about AnkiDroid.]]></item>
-        <item><![CDATA[AnkiDroid is released under the <a href=\"%1$s\">GNU-GPL v3 license</a> and the source code is available <a href=\"%2$s\">here</a>.]]></item>
+        <item><![CDATA[<h2>%1$s:<br/>Flashcards for Android</h2>AnkiDroid is a flashcard application which is fully compatible with the desktop software <a href=\"%2$s\">Anki</a>. You can create, download and learn material on both AnkiDroid or Anki Desktop, and synchronize them easily with AnkiWeb.]]></item>
+        <item><![CDATA[To help us make AnkiDroid better, please report bugs to <a href=\"%1$s\">the issue tracker</a>; new feature ideas are very welcome too. Find answers on <a href=\"%2$s\">the wiki</a> or start a discussion on <a href=\"%3$s\">the forum</a>.]]></item>
+        <item><![CDATA[AnkiDroid is <a href=\"%1$s\">open source software<a/>, so everyone is encouraged to <a href=\"%2$s\">become a contributor</a> :-)]]></item>
+        <item><![CDATA[Non-developers can also help. For instance, you can <a href=\"%1$s\">help translate</a> AnkiDroid, update the wiki, provide screenshots, <a href=\"%2$s\">donate</a> to Anki Desktop, or blog about AnkiDroid.]]></item>
+        <item><![CDATA[AnkiDroid is released under the <a href=\"%1$s\">GNU-GPL v3 license</a> and the source code is available <a href=\"%2$s\">on GitHub</a>.]]></item>
     </string-array>
 
     <string name="preview_title">Preview</string>

--- a/AnkiDroid/src/main/res/values/constants.xml
+++ b/AnkiDroid/src/main/res/values/constants.xml
@@ -105,21 +105,20 @@
     </string-array>
     <string name="link_anki">http://ankisrs.net</string>
     <string name="link_forum">http://groups.google.com/group/anki-android</string>
-    <string name="link_wiki">http://code.google.com/p/ankidroid/wiki/Index</string>
-    <string name="link_issue_tracker">http://code.google.com/p/ankidroid/issues</string>
+    <string name="link_wiki">https://github.com/ankidroid/Anki-Android/wiki</string>
+    <string name="link_issue_tracker">https://github.com/ankidroid/Anki-Android/issues</string>
     <string name="licence_wiki">http://www.gnu.org/licenses/gpl.html</string>
     <string name="link_source">https://github.com/ankidroid/Anki-Android</string>
     <string name="link_donation">http://ankisrs.net/support</string>
     <string name="link_translation">http://crowdin.net/project/ankidroid</string>
     <string name="link_wikipedia_open_source">http://en.wikipedia.org/wiki/Open_source_software</string>
-    <string name="link_contribution">http://code.google.com/p/ankidroid/wiki/Contribution</string>
-    <string name="link_contribution_contributors">http://code.google.com/p/ankidroid/wiki/Contribution</string>
+    <string name="link_contribution">https://github.com/ankidroid/Anki-Android/wiki/Contributing</string>
     <string name="link_help">https://ankidroid.org/docs/help.html</string>
     <string name="link_manual">https://ankidroid.org/docs/manual.html</string>
     <string name="link_help_ja">https://ankidroid.org/docs/help-ja.html</string>
     <string name="link_manual_ja">https://ankidroid.org/docs/manual-ja.html</string>
     <string name="link_manual_getting_started">https://ankidroid.org/docs/manual.html#gettingStarted</string>
-    <string name="link_hebrew_font">http://code.google.com/p/ankidroid/downloads/detail?name=Tohu.ttf</string>
+    <string name="link_hebrew_font">https://github.com/ankidroid/Anki-Android/releases/download/tohu-font/Tohu.ttf</string>
     <string name="shared_decks_url">https://ankiweb.net/shared/decks/</string>
     <string name="repair_deck">http://ankisrs.net/docs/manual.html#corrupt-collections</string>
     <string name="resetpw_url">http://ankiweb.net/account/resetpw</string>


### PR DESCRIPTION
- Make the About dialog use theme colours so it looks good in the dark
theme.
- Updated links to point to their new GitHub locations.
- Improved the text in the About dialog and removed a redundant link.

---
Also, there was a link to a font that was hosted on Google Code which isn't available any more. I uploaded it as a release on GitHub and changed the link to that.