### PR TITLE
Fix white-on-white status bar.

### DIFF
--- a/AnkiDroid/src/main/res/layout-xlarge/deck_picker.xml
+++ b/AnkiDroid/src/main/res/layout-xlarge/deck_picker.xml
@@ -5,7 +5,8 @@
     android:id="@+id/drawer_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="?android:attr/colorBackground" >
+    android:background="?android:attr/colorBackground"
+    android:fitsSystemWindows="true">
     <RelativeLayout
             android:layout_width="fill_parent"
             android:layout_height="fill_parent"
@@ -61,4 +62,4 @@
         <include layout="@layout/floating_add_button"/>
     </RelativeLayout>
     <include layout="@layout/navigation_drawer" />
-</android.support.v4.widget.DrawerLayout>   
+</android.support.v4.widget.DrawerLayout>


### PR DESCRIPTION
Use “android:fitsSystemWindows="true"” for the xlarge deck picker as well so we get white on blue instead of white on white symbols/text in the status bar.

This has bugged my since i got myself a 20cm tablet and put Android 5 on it.

The status bar was white-on-white on the deck picker (+ study options) screen.
Before:
![what_time](https://cloud.githubusercontent.com/assets/1690429/9404741/416deff4-47f2-11e5-82d6-2f9de56a49eb.png)
How late is it? How much battery have i left? No idea. That gray smudge to the top left of the “sync” button is the “data in” marker in the wlan symbol. 

Looks like the fix is to simply set ` android:fitsSystemWindows="true"`, [as it is done](https://github.com/ospalh/Anki-Android/blob/develop/AnkiDroid/src/main/res/layout/deck_picker.xml#L7) in the non-`xlarge` version of `deck_picker.xml`.
After:
![usable_status_bar](https://cloud.githubusercontent.com/assets/1690429/9404784/91ec58c6-47f2-11e5-923e-bf665abe5449.png)

This is a fix for #3552.