### PR TITLE
Use a wake lock during syncing

### DIFF
--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -53,6 +53,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
     <!--
 	<uses-permission android:name="android.permission.BLUETOOTH" />
         <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />


### PR DESCRIPTION
A likely fix for #3574.

With this commit, we acquire and release a wake lock before and after syncing to ensure the device remains awake during sync so that the sync isn't interrupted.

I'm surprised we weren't doing this already. I suppose syncing doesn't really take that long, and for most users it completes before the device is put into sleep mode (which, as I understand, can vary between devices and user settings), so it isn't a common occurrence.