### PR TITLE
Show a snackbar when there are unsynced changes by default

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:design:22.2.1'
     compile 'com.afollestad:material-dialogs:0.7.6.0'
-    compile 'net.i2p.android.ext:floatingactionbutton:1.9.0'
+    compile 'net.i2p.android.ext:floatingactionbutton:1.10.0'
     compile 'ch.acra:acra:4.6.2'
     compile 'com.jakewharton.timber:timber:2.5.1'
     compile 'com.google.code.gson:gson:2.3'

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
@@ -386,7 +386,9 @@ public class AnkiActivity extends AppCompatActivity implements LoaderManager.Loa
         // Make the text white to avoid interference from our theme colors.
         View view = sb.getView();
         TextView tv = (TextView) view.findViewById(android.support.design.R.id.snackbar_text);
+        TextView action = (TextView) view.findViewById(android.support.design.R.id.snackbar_action);
         tv.setTextColor(Color.WHITE);
+        action.setTextColor(getResources().getColor(R.color.theme_primary));
         sb.show();
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -153,6 +153,9 @@ public class DeckPicker extends NavigationDrawerActivity implements
     // flag asking user to do a full sync which is used in upgrade path
     boolean mRecommendFullSync = false;
 
+    // flag keeping track of when the app has been paused
+    private boolean mActivityPaused = false;
+
     /**
      * Flag to indicate whether the activity will perform a sync in its onResume.
      * Since syncing closes the database, this flag allows us to avoid doing any
@@ -621,6 +624,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
     protected void onResume() {
         Timber.d("onResume()");
         super.onResume();
+        mActivityPaused = false;
         selectNavigationItem(R.id.nav_decks);
         if (mSyncOnResume) {
             sync();
@@ -657,7 +661,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
     @Override
     protected void onPause() {
         Timber.d("onPause()");
-
+        mActivityPaused = true;
         super.onPause();
     }
 
@@ -957,13 +961,20 @@ public class DeckPicker extends NavigationDrawerActivity implements
     }
 
 
-    // Show dialogs to deal with sync issues etc
+    /**
+     * Show a specific sync error dialog
+     * @param id id of dialog to show
+     */
     @Override
     public void showSyncErrorDialog(int id) {
         showSyncErrorDialog(id, "");
     }
 
-
+    /**
+     * Show a specific sync error dialog
+     * @param id id of dialog to show
+     * @param message text to show
+     */
     @Override
     public void showSyncErrorDialog(int id, String message) {
         AsyncDialogFragment newFragment = SyncErrorDialog.newInstance(id, message);
@@ -971,26 +982,25 @@ public class DeckPicker extends NavigationDrawerActivity implements
     }
 
     /**
-     *  Show log message after sync, using "Sync Error" as the dialog title, and reload activity
+     *  Show simple error dialog with just the message and OK button. Reload the activity when dialog closed.
      * @param message
      */
-    private void showSyncLogDialog(String message) {
-        // Reload activity since collection always closed at end of sync
-        showSyncLogDialog(message, true);
+    private void showSyncErrorMessage(String message) {
+        // Restart activity so that the Collection is also reloaded
+        String title = getResources().getString(R.string.sync_error);
+        showSimpleMessageDialog(title, message, true);
     }
 
     /**
-     *  Show log message after sync, and reload activity
-     * @param message
-     * @param error Show "Sync Error" as dialog title if this flag is set, otherwise use no title
+     *  Show a simple snackbar message or notification if the activity is not in foreground
+     * @param messageResource String resource for message
      */
-    private void showSyncLogDialog(String message, boolean error) {
-        // Reload activity since collection always closed at end of sync
-        if (error) {
-            String title = getResources().getString(R.string.sync_error);
-            showSimpleMessageDialog(title, message, true);
+    private void showSyncLogMessage(int messageResource) {
+        if (mActivityPaused) {
+            Resources res = AnkiDroidApp.getAppResources();
+            showSimpleNotification(res.getString(R.string.app_name), res.getString(messageResource));
         } else {
-            showSimpleMessageDialog(message, true);
+            showSimpleSnackbar(messageResource, false);
         }
     }
 
@@ -1217,7 +1227,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
         @Override
         public void onDisconnected() {
-            showSyncLogDialog(getResources().getString(R.string.youre_offline));
+            showSyncLogMessage(R.string.youre_offline);
         }
 
 
@@ -1300,8 +1310,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
                         showSyncErrorDialog(SyncErrorDialog.DIALOG_USER_NOT_LOGGED_IN_SYNC);
                     } else if (resultType.equals("noChanges")) {
                         // show no changes message, use false flag so we don't show "sync error" as the Dialog title
-                        dialogMessage = res.getString(R.string.sync_no_changes_message);
-                        showSyncLogDialog(joinSyncMessages(dialogMessage, syncMessage), false);
+                        showSyncLogMessage(R.string.sync_no_changes_message);
                     } else if (resultType.equals("clockOff")) {
                         long diff = (Long) result[1];
                         if (diff >= 86100) {
@@ -1316,7 +1325,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
                         } else {
                             dialogMessage = res.getString(R.string.sync_log_clocks_unsynchronized, diff, "");
                         }
-                        showSyncLogDialog(joinSyncMessages(dialogMessage, syncMessage));
+                        showSyncErrorMessage(joinSyncMessages(dialogMessage, syncMessage));
                     } else if (resultType.equals("fullSync")) {
                         if (getCol().isEmpty()) {
                             // don't prompt user to resolve sync conflict if local collection empty
@@ -1330,37 +1339,37 @@ public class DeckPicker extends NavigationDrawerActivity implements
                     } else if (resultType.equals("dbError")  || resultType.equals("basicCheckFailed")) {
                         String repairUrl = res.getString(R.string.repair_deck);
                         dialogMessage = res.getString(R.string.sync_corrupt_database, repairUrl);
-                        showSyncLogDialog(joinSyncMessages(dialogMessage, syncMessage));
+                        showSyncErrorMessage(joinSyncMessages(dialogMessage, syncMessage));
                     } else if (resultType.equals("overwriteError")) {
                         dialogMessage = res.getString(R.string.sync_overwrite_error);
-                        showSyncLogDialog(joinSyncMessages(dialogMessage, syncMessage));
+                        showSyncErrorMessage(joinSyncMessages(dialogMessage, syncMessage));
                     } else if (resultType.equals("remoteDbError")) {
                         dialogMessage = res.getString(R.string.sync_remote_db_error);
-                        showSyncLogDialog(joinSyncMessages(dialogMessage, syncMessage));
+                        showSyncErrorMessage(joinSyncMessages(dialogMessage, syncMessage));
                     } else if (resultType.equals("sdAccessError")) {
                         dialogMessage = res.getString(R.string.sync_write_access_error);
-                        showSyncLogDialog(joinSyncMessages(dialogMessage, syncMessage));
+                        showSyncErrorMessage(joinSyncMessages(dialogMessage, syncMessage));
                     } else if (resultType.equals("finishError")) {
                         dialogMessage = res.getString(R.string.sync_log_finish_error);
-                        showSyncLogDialog(joinSyncMessages(dialogMessage, syncMessage));
+                        showSyncErrorMessage(joinSyncMessages(dialogMessage, syncMessage));
                     } else if (resultType.equals("connectionError")) {
                         dialogMessage = res.getString(R.string.sync_connection_error);
-                        showSyncLogDialog(joinSyncMessages(dialogMessage, syncMessage));
+                        showSyncErrorMessage(joinSyncMessages(dialogMessage, syncMessage));
                     } else if (resultType.equals("IOException")) {
                         handleDbError();
                     } else if (resultType.equals("genericError")) {
                         dialogMessage = res.getString(R.string.sync_generic_error);
-                        showSyncLogDialog(joinSyncMessages(dialogMessage, syncMessage));
+                        showSyncErrorMessage(joinSyncMessages(dialogMessage, syncMessage));
                     } else if (resultType.equals("OutOfMemoryError")) {
                         dialogMessage = res.getString(R.string.error_insufficient_memory);
-                        showSyncLogDialog(joinSyncMessages(dialogMessage, syncMessage));
+                        showSyncErrorMessage(joinSyncMessages(dialogMessage, syncMessage));
                     } else if (resultType.equals("sanityCheckError")) {
                         dialogMessage = res.getString(R.string.sync_sanity_failed);
                         showSyncErrorDialog(SyncErrorDialog.DIALOG_SYNC_SANITY_ERROR,
                                 joinSyncMessages(dialogMessage, syncMessage));
                     } else if (resultType.equals("serverAbort")) {
                         // syncMsg has already been set above, no need to fetch it here.
-                        showSyncLogDialog(joinSyncMessages(dialogMessage, syncMessage));
+                        showSyncErrorMessage(joinSyncMessages(dialogMessage, syncMessage));
                     } else {
                         if (result.length > 1 && result[1] instanceof Integer) {
                             int type = (Integer) result[1];
@@ -1384,29 +1393,28 @@ public class DeckPicker extends NavigationDrawerActivity implements
                         } else {
                             dialogMessage = res.getString(R.string.sync_generic_error);
                         }
-                        showSyncLogDialog(joinSyncMessages(dialogMessage, syncMessage));
+                        showSyncErrorMessage(joinSyncMessages(dialogMessage, syncMessage));
                     }
                 }
             } else {
-                if (data.data[2] != null) {
-                    dialogMessage = (String) data.data[2];
+                if (data.data[2] != null && !data.data[2].equals("")) {
+                    String message = res.getString(R.string.sync_database_acknowledge) + "\n\n" + data.data[2];
+                    showSimpleMessageDialog(message);
                 } else if (data.data.length > 0 && data.data[0] instanceof String
                         && ((String) data.data[0]).length() > 0) {
                     String dataString = (String) data.data[0];
                     if (dataString.equals("upload")) {
-                        dialogMessage = res.getString(R.string.sync_log_uploading_message);
+                        showSyncLogMessage(R.string.sync_log_uploading_message);
                     } else if (dataString.equals("download")) {
-                        dialogMessage = res.getString(R.string.sync_log_downloading_message);
+                        showSyncLogMessage(R.string.sync_log_downloading_message);
                         // set downloaded collection as current one
                     } else {
-                        dialogMessage = res.getString(R.string.sync_database_acknowledge);
+                        showSyncLogMessage(R.string.sync_database_acknowledge);
                     }
                 } else {
-                    dialogMessage = res.getString(R.string.sync_database_acknowledge);
+                    showSyncLogMessage(R.string.sync_database_acknowledge);
                 }
-                showSyncLogDialog(joinSyncMessages(dialogMessage, syncMessage), false);
-
-                // Note: the interface is not refreshed since the activity is restarted after sync.
+                updateDeckList();
             }
 
             // Write the time last sync was carried out. Useful for automatic sync interval.
@@ -1671,7 +1679,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
                         }
                     };
                     View rootLayout = findViewById(R.id.root_layout);
-                    showSnackbar(R.string.sync_prompt, false, R.string.button_sync, listener, findViewById(R.id.add_content_menu));
+                    showSnackbar(R.string.sync_prompt, false, R.string.button_sync, listener, rootLayout);
                 }
             }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/FabBehavior.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/FabBehavior.java
@@ -1,0 +1,78 @@
+/****************************************************************************************
+ * Copyright (c) 2015 Timothy Rae <perceptualchaos2@gmail.com>                          *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+package com.ichi2.anki.widgets;
+
+import android.content.Context;
+import android.support.design.widget.CoordinatorLayout;
+import android.support.design.widget.Snackbar;
+import android.support.v4.view.ViewCompat;
+import android.util.AttributeSet;
+import android.view.View;
+
+import net.i2p.android.ext.floatingactionbutton.FloatingActionsMenu;
+
+import java.util.List;
+
+/**
+ * Originally created by Paul Woitaschek (http://www.paul-woitaschek.de, woitaschek@posteo.de)
+ * Defines the behavior for the floating action button. If the dependency is a Snackbar, move the
+ * fab up.
+ */
+public class FabBehavior extends CoordinatorLayout.Behavior<FloatingActionsMenu> {
+
+    private float mTranslationY;
+
+    public FabBehavior() {
+        super();
+    }
+
+    public FabBehavior(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    private static float getFabTranslationYForSnackbar(CoordinatorLayout parent, FloatingActionsMenu fab) {
+        float minOffset = 0.0F;
+        List dependencies = parent.getDependencies(fab);
+        int i = 0;
+
+        for (int z = dependencies.size(); i < z; ++i) {
+            View view = (View) dependencies.get(i);
+            if (view instanceof Snackbar.SnackbarLayout && parent.doViewsOverlap(fab, view)) {
+                minOffset = Math.min(minOffset, ViewCompat.getTranslationY(view) - (float) view.getHeight());
+            }
+        }
+
+        return minOffset;
+    }
+
+    @Override
+    public boolean layoutDependsOn(CoordinatorLayout parent, FloatingActionsMenu child, View dependency) {
+        return dependency instanceof Snackbar.SnackbarLayout;
+    }
+
+    @Override
+    public boolean onDependentViewChanged(CoordinatorLayout parent, FloatingActionsMenu fab, View dependency) {
+        if (dependency instanceof Snackbar.SnackbarLayout && fab.getVisibility() == View.VISIBLE) {
+            float translationY = getFabTranslationYForSnackbar(parent, fab);
+            if (translationY != this.mTranslationY) {
+                ViewCompat.animate(fab).cancel();
+                ViewCompat.setTranslationY(fab, translationY);
+                this.mTranslationY = translationY;
+            }
+        }
+        return false;
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
@@ -478,7 +478,7 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
             if (prefs.getString("hkey", "").length() > 0 && prefs.getString("automaticSync", "1").equals(prompt) &&
                     Connection.isOnline()) {
                 slc = slc || col.schemaChanged();
-                slc=slc||col.getDb().getDatabase().rawQuery("SELECT usn FROM revlog WHERE usn==-1", null).getCount()>0;
+                slc=slc||col.getDb().getDatabase().rawQuery("SELECT usn FROM revlog WHERE usn==-1", null).getCount() >0;
                 slc=slc||col.getDb().getDatabase().rawQuery("SELECT usn FROM notes WHERE usn==-1", null).getCount() > 0;
                 slc=slc||col.getDb().getDatabase().rawQuery("SELECT usn FROM cards WHERE usn==-1", null).getCount() > 0;
                 slc=slc||col.getDb().getDatabase().rawQuery("SELECT usn FROM graves WHERE usn==-1", null).getCount() >0;

--- a/AnkiDroid/src/main/res/layout/deck_picker.xml
+++ b/AnkiDroid/src/main/res/layout/deck_picker.xml
@@ -36,9 +36,8 @@
                 android:layout_alignParentBottom="true"
                 android:layout_centerInParent="true"
                 android:gravity="center"/>
-
-            <include layout="@layout/floating_add_button"/>
         </RelativeLayout>
+        <include layout="@layout/floating_add_button"/>
     </android.support.design.widget.CoordinatorLayout>
 
     <include layout="@layout/navigation_drawer" />

--- a/AnkiDroid/src/main/res/layout/floating_add_button.xml
+++ b/AnkiDroid/src/main/res/layout/floating_add_button.xml
@@ -6,16 +6,13 @@
     android:id="@+id/add_content_menu"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:layout_alignParentBottom="true"
-    android:layout_alignParentRight="true"
-    android:layout_alignParentEnd="true"
+    android:layout_gravity="end|bottom"
+    android:layout_margin="16dp"
     fab:fab_addButtonColorNormal="@color/fab_normal"
     fab:fab_addButtonColorPressed="@color/fab_pressed"
     fab:fab_icon="@drawable/ic_add_white_24dp"
     fab:fab_labelStyle="@style/menu_labels_style"
-    android:layout_marginBottom="16dp"
-    android:layout_marginRight="16dp"
-    android:layout_marginEnd="16dp">
+    fab:layout_behavior="com.ichi2.anki.widgets.FabBehavior">
     <net.i2p.android.ext.floatingactionbutton.FloatingActionButton
         android:id="@+id/add_deck_action"
         android:layout_width="wrap_content"

--- a/AnkiDroid/src/main/res/layout/tags_dialog_title.xml
+++ b/AnkiDroid/src/main/res/layout/tags_dialog_title.xml
@@ -7,7 +7,7 @@
     android:minHeight="?attr/actionBarSize"
     android:background="?attr/colorPrimary"
     android:layout_alignParentTop="true"
-    app:theme="@style/ActionBar"
+    android:theme="@style/ActionBar"
     app:popupTheme="?attr/actionBarPopupThemeRef">
 
 

--- a/AnkiDroid/src/main/res/layout/toolbar.xml
+++ b/AnkiDroid/src/main/res/layout/toolbar.xml
@@ -10,7 +10,7 @@
     android:layout_alignParentTop="true"
     app:navigationContentDescription="@string/abc_action_bar_up_description"
     app:navigationIcon="?attr/homeAsUpIndicator"
-    app:theme="?attr/actionBarThemeRef"
+    android:theme="?attr/actionBarThemeRef"
     app:popupTheme="?attr/actionBarPopupThemeRef">
     <ProgressBar
         android:id="@+id/progress_spinner"

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -116,6 +116,7 @@
 
     <string name="sd_card_not_mounted">Device storage not mounted</string>
     <string name="button_sync">Sync</string>
+    <string name="sync_prompt">There are unsynced changes</string>
     <string name="export">Export</string>
     <string name="nothing">Nothing</string>
 

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -86,12 +86,15 @@
     <string name="sync_account">AnkiWeb account</string>
     <string name="sync_account_summ_logged_out">Not logged in</string>
     <string name="sync_account_summ_logged_in">%s</string>
-    <string name="automatic_sync_choice">Automatic synchronization</string>
-    <string name="automatic_sync_choice_summ">Sync automatically on app start/exit if the last sync was more than 10
-        minutes ago.</string>
+    <string name="automatic_sync_title">Automatic sync on app start/exit</string>
+    <string name="automatic_sync_choice_disabled">Disabled</string>
+    <string name="automatic_sync_choice_prompt">Show reminder</string>
+    <string name="automatic_sync_choice_enabled">If >10min since last sync</string>
     <string name="fix_hebrew_text">Fix for Hebrew vowels</string>
     <string name="fix_hebrew_text_summ">Workaround for rendering Hebrew vowels correctly.</string>
-    <string name="fix_hebrew_instructions">This setting bypasses the RTL algorithm of Android to show Hebrew text with vowels correctly.\n\nFor this to work, you need to download font Tohu.ttf and copy it manually to\n“%s/fonts/”\n\nYou won’t have to modify your cards.</string>
+    <string name="fix_hebrew_instructions">This setting bypasses the RTL algorithm of Android to show Hebrew text with
+        vowels correctly.\n\nFor this to work, you need to download font Tohu.ttf and copy it manually to\n“%s/fonts/”
+        \n\nYou won’t have to modify your cards.</string>
     <string name="fix_hebrew_download_font">Download font</string>
     <string name="default_font">Default font</string>
     <string name="override_font">Default font applicability</string>

--- a/AnkiDroid/src/main/res/values/constants.xml
+++ b/AnkiDroid/src/main/res/values/constants.xml
@@ -158,4 +158,14 @@
         <item>0</item>
         <item>1</item>
     </string-array>
+    <string-array name="automatic_sync_pref_values">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+    </string-array>
+    <string-array name="automatic_sync_pref_labels">
+        <item>@string/automatic_sync_choice_disabled</item>
+        <item>@string/automatic_sync_choice_prompt</item>
+        <item>@string/automatic_sync_choice_enabled</item>
+    </string-array>
 </resources>

--- a/AnkiDroid/src/main/res/xml/preferences_general.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_general.xml
@@ -45,6 +45,12 @@
         android:summary="@string/sync_fetch_missing_media_summ"
         android:title="@string/sync_fetch_missing_media" />
     <ListPreference
+        android:defaultValue="1"
+        android:key="automaticSync"
+        android:entries="@array/automatic_sync_pref_labels"
+        android:entryValues="@array/automatic_sync_pref_values"
+        android:title="@string/automatic_sync_title"/>
+    <ListPreference
         android:defaultValue=""
         android:entries="@array/add_to_cur_labels"
         android:entryValues="@array/add_to_cur_values"
@@ -56,11 +62,6 @@
         android:key="language"
         android:summary="@string/preference_summary_literal"
         android:title="@string/language" />
-    <CheckBoxPreference
-        android:defaultValue="false"
-        android:key="automaticSyncMode"
-        android:summary="@string/automatic_sync_choice_summ"
-        android:title="@string/automatic_sync_choice" />
     <ListPreference
         android:defaultValue="2"
         android:entries="@array/error_reporting_choice_labels"

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.0.0'
+        classpath 'com.android.tools.build:gradle:1.3.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
The fully automatic sync has been driving me insane... I definitely want to have more control over when a sync occurs. How about adding an extra behavior (enabled by default) where a SnackBar shows up when there are local changes that need to be synced?

![snackbar](https://cloud.githubusercontent.com/assets/2818274/9552159/e309dea0-4df0-11e5-9a70-2390052610ca.png)

@ospalh previously mentioned a similar idea of having some kind of visual indicator when there are unsynced changes... 

This currently only works for local changes (and intentionally doesn't take into account small changes like the selected deck), but it might be possible to be able to extend it to also check for remote changes (in the background) after establishing that there are no local changes.