### PR TITLE
Fix the notification and widget counts

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
@@ -440,13 +440,6 @@ public class AnkiActivity extends AppCompatActivity implements LoaderManager.Loa
             Intent resultIntent = new Intent(this, DeckPicker.class);
             resultIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | IntentCompat.FLAG_ACTIVITY_CLEAR_TASK);
             PendingIntent resultPendingIntent = PendingIntent.getActivity(this, 0, resultIntent, PendingIntent.FLAG_UPDATE_CURRENT);
-            if (resultPendingIntent == null) {
-                // PendingIntent could not be created... probably something wrong with the extras
-                // try again without the extras, though the original dialog will not be shown when app started
-                Timber.e("AnkiActivity.showSimpleNotification() failed due to null PendingIntent");
-                resultIntent = new Intent(this, DeckPicker.class);
-                resultPendingIntent = PendingIntent.getActivity(this, 0, resultIntent, PendingIntent.FLAG_UPDATE_CURRENT);
-            }
             builder.setContentIntent(resultPendingIntent);
             NotificationManager notificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
             // mId allows you to update the notification later on.

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sched.java
@@ -2425,7 +2425,7 @@ public class Sched {
                     for (String s : cs) {
                         done += deck.getJSONArray(s + "Today").getInt(1);
                     }
-                    mCachedDeckCounts.put(d.did, new Pair<String[], long[]> (d.names, new long[]{done, d.newCount, d.lrnCount, d.newCount}));
+                    mCachedDeckCounts.put(d.did, new Pair<String[], long[]> (d.names, new long[]{done, d.newCount, d.lrnCount, d.revCount}));
                 }
             }
 


### PR DESCRIPTION
* Get rid of deprecated `notification.setLatestEventInfo()` for Android M compatibility
* Fix calculation of total cards due for notification and widget (closes #3500)
* Put the cards due in the title (closes #3594)
