### PR TITLE
Dismiss context menu after deck rename

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -1747,9 +1747,8 @@ public class DeckPicker extends NavigationDrawerActivity implements
         Resources res = getResources();
         mDialogEditText = new EditText(DeckPicker.this);
         mDialogEditText.setSingleLine();
-        mDialogEditText.setText(getCol().getDecks().name(mContextMenuDid));
-        // mDialogEditText.setFilters(new InputFilter[] { mDeckNameFilter });
-
+        final String currentName = getCol().getDecks().name(mContextMenuDid);
+        mDialogEditText.setText(currentName);
         new MaterialDialog.Builder(DeckPicker.this)
                 .title(res.getString(R.string.contextmenu_deckpicker_rename_deck))
                 .customView(mDialogEditText, true)
@@ -1759,22 +1758,14 @@ public class DeckPicker extends NavigationDrawerActivity implements
                     @Override
                     public void onPositive(MaterialDialog dialog) {
                         String newName = mDialogEditText.getText().toString().replaceAll("\"", "");
-                        Timber.i("DeckPicker:: Renaming deck...", newName);
                         Collection col = getCol();
-                        if (col != null) {
-                            if (col.getDecks().rename(col.getDecks().get(mContextMenuDid), newName)) {
-                                updateDeckList();
-                            } else {
-                                try {
-                                    Themes.showThemedToast(
-                                            DeckPicker.this,
-                                            getResources().getString(R.string.rename_error,
-                                                    col.getDecks().get(mContextMenuDid).get("name")), false);
-                                } catch (JSONException e) {
-                                    throw new RuntimeException(e);
-                                }
-                            }
+                        if (!newName.equals(currentName) &&
+                                !col.getDecks().rename(col.getDecks().get(mContextMenuDid), newName)) {
+                            Themes.showThemedToast(DeckPicker.this,
+                                    getResources().getString(R.string.rename_error, currentName), false);
+
                         }
+                        dismissAllDialogFragments();
                         mDeckListAdapter.notifyDataSetChanged();
                         updateDeckList();
                     }


### PR DESCRIPTION
Also ignore attempts to rename deck to the same name. This saves us
from showing an error when there really wasn't anything wrong.