### PR TITLE
Fix review time counting and max timer display

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sched.java
@@ -1149,7 +1149,7 @@ public class Sched {
     }
 
 
-    private void log(long id, int usn, int ease, int ivl, int lastIvl, int factor, long timeTaken, int type) {
+    private void log(long id, int usn, int ease, int ivl, int lastIvl, int factor, int timeTaken, int type) {
         try {
             mCol.getDb().execute("INSERT INTO revlog VALUES (?,?,?,?,?,?,?,?,?)",
                     new Object[]{Utils.now() * 1000, id, usn, ease, ivl, lastIvl, factor, timeTaken, type});

--- a/AnkiDroid/src/main/res/values/attrs.xml
+++ b/AnkiDroid/src/main/res/values/attrs.xml
@@ -50,6 +50,7 @@
     <attr name="easyButtonRef" format= "reference"/>
     <!-- Reviewer other colors -->
     <attr name="topBarColor" format="color"/>
+    <attr name="maxTimerColor" format="color"/>
     <!-- Browser colors -->
     <attr name="suspendedColor" format="color"/>
     <attr name="markedColor" format="color"/>

--- a/AnkiDroid/src/main/res/values/colors.xml
+++ b/AnkiDroid/src/main/res/values/colors.xml
@@ -90,6 +90,8 @@
     <color name="review_count_night">@color/material_green_200</color>
     <color name="zero_count_night">#202020</color>
     <color name="actionbar_background">#f5f5f5</color>
+    <color name="max_timer">@color/material_red_500</color>
+    <color name="max_timer_night">@color/material_red_300</color>
 
     <!-- Material Design: http://www.google.com/design/spec/style/color.html#color-color-palette -->
     <!-- Can eventually be shortened once settled on a color scheme -->

--- a/AnkiDroid/src/main/res/values/theme_dark.xml
+++ b/AnkiDroid/src/main/res/values/theme_dark.xml
@@ -22,6 +22,7 @@
         <item name="collapseRef">@drawable/ic_expand_more_white_36dp</item>
         <!-- Reviewer colors -->
         <item name="topBarColor">@color/theme_primary_light_inv</item>
+        <item name="maxTimerColor">@color/max_timer_night</item>
         <item name="newCountColor">@color/new_count_night</item>
         <item name="learnCountColor">@color/learn_count_night</item>
         <item name="zeroCountColor">@color/zero_count_night</item>

--- a/AnkiDroid/src/main/res/values/theme_white.xml
+++ b/AnkiDroid/src/main/res/values/theme_white.xml
@@ -29,6 +29,7 @@
         <item name="collapseRef">@drawable/ic_expand_more_black_36dp</item>
         <!-- Reviewer colors -->
         <item name="topBarColor">@color/theme_primary_light</item>
+        <item name="maxTimerColor">@color/max_timer</item>
         <item name="newCountColor">@color/new_count</item>
         <item name="learnCountColor">@color/learn_count</item>
         <item name="zeroCountColor">@color/zero_count</item>


### PR DESCRIPTION
The timer displayed during review will now stop counting up when it
reaches the maximal answer time and will be highlighted red to indicate
that it has reached its limit (the desktop client does both).

This commit also changes the technique used to account for a card's true
review time after a pause and resume of the reviewer. The new technique
shifts back the *current* time by the elapsed interval instead of trying
to shift the original start time by the elapsed time.This prevents clock
changes from impacting the elapsed time.

This resolves the long-standing negative review time bug for which
there was a workaround in place, and thus removed in this commit.

--
Edit: I've updated the commit to make the paragraph below invalid.

The review time stored internally was wildly inaccurate when the review session was paused and resumed. If anyone in the past had mentioned inaccurate review times this could be it. Also the timer widget itself now bases its time entirely on the elapsed time kept internally by the `Card` so the time it displays should no longer diverge (read: lie to you), and it's a lot simpler without its own start/stop commands.