### PR TITLE
Fix broken font override behavior

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiFont.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiFont.java
@@ -110,21 +110,21 @@ public class AnkiFont {
 
     public String getDeclaration() {
         StringBuilder sb = new StringBuilder("@font-face {");
-        sb.append(getCSS()).append(" src: url(\"file://").append(mPath).append("\");}");
+        sb.append(getCSS(false)).append(" src: url(\"file://").append(mPath).append("\");}");
         return sb.toString();
     }
 
 
-    public String getCSS() {
+    public String getCSS(boolean override) {
         StringBuilder sb = new StringBuilder("font-family: \"").append(mFamily);
-        if (mIsOverride) {
+        if (override) {
             sb.append("\" !important;");
         } else {
             sb.append("\";");
         }
         for (String attr : mAttributes) {
             sb.append(" ").append(attr);
-            if (mIsOverride) {
+            if (override) {
                 if (sb.charAt(sb.length() - 1) == ';') {
                     sb.deleteCharAt(sb.length() - 1);
                     sb.append(" !important;");

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/CustomFontsReviewerExt.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/CustomFontsReviewerExt.java
@@ -109,7 +109,7 @@ public class CustomFontsReviewerExt implements ReviewerExt {
             SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(context);
             AnkiFont defaultFont = customFontsMap.get(preferences.getString("defaultFont", null));
             if (defaultFont != null) {
-                mDefaultFontStyle = "BODY { " + defaultFont.getCSS() + " }\n";
+                mDefaultFontStyle = "BODY { " + defaultFont.getCSS(false) + " }\n";
             } else {
                 mDefaultFontStyle = "";
             }
@@ -129,7 +129,7 @@ public class CustomFontsReviewerExt implements ReviewerExt {
             AnkiFont defaultFont = customFontsMap.get(preferences.getString("defaultFont", null));
             boolean overrideFont = preferences.getString("overrideFontBehavior", "0").equals("1");
             if (defaultFont != null && overrideFont) {
-                mOverrideFontStyle = "BODY, .card, * { " + defaultFont.getCSS() + " }\n";
+                mOverrideFontStyle = "BODY, .card, * { " + defaultFont.getCSS(true) + " }\n";
             } else {
                 mOverrideFontStyle = "";
             }


### PR DESCRIPTION
We were using !important in the actual CSS font definitions which is wrong. E.g. `@font-face {font-family: "kochi-mincho-subst" !important; font-weight: normal !important; font-style: normal !important; src: url("file:///sdcard/AnkiDroid/fonts/kochi-mincho-subst.ttf");}`.
`!important` should only go in the class:
`BODY, .card, * { font-family: "kochi-mincho-subst" !important; font-weight: normal !important; font-style: normal !important; }`

Older versions of Android/Webview may have supported this, but the latest version of Chrome Desktop / Webview does not. This probably closes #3581