### PR TITLE
Fix some issues with deck picker and study options

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -199,6 +199,9 @@ public class DeckPicker extends NavigationDrawerActivity implements
             long deckId = (long) v.getTag();
             Timber.i("DeckPicker:: Selected deck with id %d", deckId);
             handleDeckSelection(deckId);
+            if (mFragmented) {
+                mDeckListAdapter.notifyDataSetChanged();
+            }
         }
     };
 
@@ -1638,9 +1641,22 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
 
     private void handleDeckSelection(long did) {
-        getCol().getDecks().select(did);
-        mFocusedDeck = did;
-        openStudyOptions(false);
+        if (getCol().cardCount(new long[]{did}) > 0) {
+            // Select the deck and open studyoptions if the deck isn't empty
+            getCol().getDecks().select(did);
+            mFocusedDeck = did;
+            openStudyOptions(false);
+        } else {
+            // If the deck is empty then just show a snackbar saying the deck is empty, with a link to help
+            showSnackbar(R.string.studyoptions_empty, false, R.string.help, new OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    Intent helpIntent = new Intent("android.intent.action.VIEW", Uri.parse(getResources()
+                            .getString(R.string.link_manual_getting_started)));
+                    startActivityWithoutAnimation(helpIntent);
+                }
+            }, findViewById(R.id.root_layout));
+        }
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
@@ -82,6 +82,7 @@ public class StudyOptionsFragment extends Fragment implements LoaderManager.Load
      */
     public static final int CONTENT_STUDY_OPTIONS = 0;
     public static final int CONTENT_CONGRATS = 1;
+    public static final int CONTENT_EMPTY = 2;
 
     // Threshold at which the total number of new cards is truncated by libanki
     private static final int NEW_CARD_COUNT_TRUNCATE_THRESHOLD = 1000;
@@ -512,7 +513,7 @@ public class StudyOptionsFragment extends Fragment implements LoaderManager.Load
 
 
     private void updateChart(double[][] serieslist) {
-        if (mChartView != null) {
+        if (mChartView != null && mCurrentContentView != CONTENT_EMPTY) {
             Collection col = CollectionHelper.getInstance().getCol(getActivity());
             AnkiStatsTaskHandler.createSmallDueChartChart(col, serieslist, mChartView);
             if (mChartView.getVisibility() == View.INVISIBLE) {
@@ -745,8 +746,17 @@ public class StudyOptionsFragment extends Fragment implements LoaderManager.Load
                         return;
                     }
 
-                    // Switch between the ordinary view and "congratulations" view
-                    if (newCards + lrnCards + revCards == 0) {
+                    // Switch between the empty view, the ordinary view, and the "congratulations" view
+                    if (totalCards == 0) {
+                        mCurrentContentView = CONTENT_EMPTY;
+                        mDeckInfoLayout.setVisibility(View.GONE);
+                        mCongratsLayout.setVisibility(View.VISIBLE);
+                        mTextCongratsMessage.setText(R.string.studyoptions_empty);
+                        mButtonStart.setVisibility(View.GONE);
+                        if (mChartView != null) {
+                            mChartView.setVisibility(View.INVISIBLE);
+                        }
+                    } else if (newCards + lrnCards + revCards == 0) {
                         mCurrentContentView = CONTENT_CONGRATS;
                         mDeckInfoLayout.setVisibility(View.GONE);
                         mCongratsLayout.setVisibility(View.VISIBLE);

--- a/AnkiDroid/src/main/res/layout/deck_picker.xml
+++ b/AnkiDroid/src/main/res/layout/deck_picker.xml
@@ -37,8 +37,8 @@
                 android:layout_centerInParent="true"
                 android:gravity="center"/>
         </RelativeLayout>
-        <include layout="@layout/floating_add_button"/>
         <include layout="@layout/anki_progress"/>
+        <include layout="@layout/floating_add_button"/>
     </android.support.design.widget.CoordinatorLayout>
     <include layout="@layout/navigation_drawer" />
 </android.support.v4.widget.DrawerLayout>

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -108,6 +108,7 @@
     <string name="empty_cram_deck">Emptying cram deck…</string>
     <string name="custom_study_deck_name">Custom study session</string>
     <string name="custom_study_deck_exists">Rename the existing custom study deck first</string>
+    <string name="studyoptions_empty">This deck is empty</string>
     <string name="studyoptions_congrats_finished">Congratulations! You have finished for now.</string>
     <string name="studyoptions_congrats_more_rev">Today’s limit has been reached, but there are still cards to review. You can increase the limit in the options.</string>
     <string name="studyoptions_congrats_more_new">Today’s limit has been reached. There are more new cards available; you can increase the limit in the options, but this will increase your short-term review workload.</string>


### PR DESCRIPTION
Highlight selected deck properly on tablet (closes #3666)
Don't show "congratulations" message or graph when deck is empty
Offer the user some help if they click on an empty deck
Fix issue where FAB wasn't rising above SnackBar