### PR TITLE
Bypass StudyOptions screen when possible using hint SnackBars

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
@@ -42,6 +42,7 @@ public class AnkiActivity extends AppCompatActivity implements LoaderManager.Loa
         SimpleMessageDialog.SimpleMessageDialogListener {
 
     public final int SIMPLE_NOTIFICATION_ID = 0;
+    public static final int REQUEST_REVIEW = 901;
 
     private DialogHandler mHandler = new DialogHandler(this);
 
@@ -277,7 +278,7 @@ public class AnkiActivity extends AppCompatActivity implements LoaderManager.Loa
     }
 
 
-    protected void showProgressBar() {
+    public void showProgressBar() {
         ProgressBar progressBar = (ProgressBar) findViewById(R.id.progress_bar);
         if (progressBar != null) {
             progressBar.setVisibility(View.VISIBLE);
@@ -285,7 +286,7 @@ public class AnkiActivity extends AppCompatActivity implements LoaderManager.Loa
     }
 
 
-    protected void hideProgressBar() {
+    public void hideProgressBar() {
         ProgressBar progressBar = (ProgressBar) findViewById(R.id.progress_bar);
         if (progressBar != null) {
             progressBar.setVisibility(View.GONE);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -35,6 +35,7 @@ import android.view.View;
 import android.view.ViewConfiguration;
 import android.widget.FrameLayout;
 
+import com.ichi2.anim.ActivityTransitionAnimation;
 import com.ichi2.async.DeckTask;
 import com.ichi2.compat.CompatHelper;
 import com.ichi2.libanki.Collection;
@@ -173,6 +174,13 @@ public class Reviewer extends AbstractFlashcardViewer {
             case R.id.action_search_dictionary:
                 Timber.i("Reviewer:: Search dictionary button pressed");
                 lookUpOrSelectText();
+                break;
+
+            case R.id.action_open_deck_overview:
+                Intent intent = new Intent();
+                intent.putExtra("withDeckOptions", false);
+                intent.setClass(this, StudyOptionsActivity.class);
+                startActivityWithAnimation(intent, ActivityTransitionAnimation.LEFT);
                 break;
 
             default:

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.java
@@ -25,6 +25,7 @@ import android.view.View;
 
 import com.ichi2.anim.ActivityTransitionAnimation;
 import com.ichi2.anki.StudyOptionsFragment.StudyOptionsListener;
+import com.ichi2.anki.dialogs.CustomStudyDialog;
 import com.ichi2.themes.Themes;
 import com.ichi2.widget.WidgetStatus;
 
@@ -32,7 +33,8 @@ import org.json.JSONArray;
 
 import timber.log.Timber;
 
-public class StudyOptionsActivity extends NavigationDrawerActivity implements StudyOptionsListener {
+public class StudyOptionsActivity extends NavigationDrawerActivity implements StudyOptionsListener,
+        CustomStudyDialog.CustomStudyListener {
 
 
     @Override
@@ -149,9 +151,18 @@ public class StudyOptionsActivity extends NavigationDrawerActivity implements St
         getCurrentFragment().refreshInterface();
     }
 
+    /**
+     * Callback methods from CustomStudyDialog
+     */
+    @Override
+    public void onCreateCustomStudySession() {
+        // Sched already reset by DeckTask in CustomStudyDialog
+        getCurrentFragment().refreshInterface();
+    }
 
     @Override
-    public void createFilteredDeck(JSONArray delays, Object[] terms, Boolean resched) {
-        getCurrentFragment().createFilteredDeck(delays, terms, resched);
+    public void onExtendStudyLimits() {
+        // Sched needs to be reset so provide true argument
+        getCurrentFragment().refreshInterface(true);
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
@@ -1,68 +1,189 @@
 
 package com.ichi2.anki.dialogs;
 
-import android.annotation.SuppressLint;
+import android.app.Dialog;
+import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.res.Resources;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.v4.app.DialogFragment;
+import android.text.TextUtils;
+import android.view.KeyEvent;
 import android.view.View;
-import android.view.WindowManager.LayoutParams;
+import android.view.WindowManager;
 import android.widget.EditText;
 import android.widget.TextView;
 
+import com.afollestad.materialdialogs.DialogAction;
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.ichi2.anki.AnkiActivity;
 import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.CollectionHelper;
+import com.ichi2.anki.DeckOptions;
+import com.ichi2.anki.DeckPicker;
 import com.ichi2.anki.R;
-import com.ichi2.anki.StudyOptionsFragment;
-import com.ichi2.anki.StudyOptionsFragment.StudyOptionsListener;
+import com.ichi2.anki.Reviewer;
+import com.ichi2.async.DeckTask;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Consts;
-import com.ichi2.themes.Themes;
 
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 
 public class CustomStudyDialog extends DialogFragment {
-    // These numbers must correspond to R.array.custom_study_options_labels
-    public static final int CUSTOM_STUDY_NEW = 0;
-    public static final int CUSTOM_STUDY_REV = 1;
-    public static final int CUSTOM_STUDY_FORGOT = 2;
-    public static final int CUSTOM_STUDY_AHEAD = 3;
-    public static final int CUSTOM_STUDY_RANDOM = 4;
-    public static final int CUSTOM_STUDY_PREVIEW = 5;
-    public static final int CUSTOM_STUDY_TAGS = 6;
-    
-    private EditText mEditText;
-    private CustomStudyDialogListener mCustomStudyDialogListener = null;
+    // Different configurations for the context menu
+    public static final int CONTEXT_MENU_STANDARD = 0;
+    public static final int CONTEXT_MENU_LIMITS = 1;
+    public static final int CONTEXT_MENU_EMPTY_SCHEDULE = 2;
+    // Standard custom study options to show in the context menu
+    private static final int CUSTOM_STUDY_NEW = 100;
+    private static final int CUSTOM_STUDY_REV = 101;
+    private static final int CUSTOM_STUDY_FORGOT = 102;
+    private static final int CUSTOM_STUDY_AHEAD = 103;
+    private static final int CUSTOM_STUDY_RANDOM = 104;
+    private static final int CUSTOM_STUDY_PREVIEW = 105;
+    private static final int CUSTOM_STUDY_TAGS = 106;
+    // Special items to put in the context menu
+    private static final int DECK_OPTIONS = 107;
+    private static final int MORE_OPTIONS = 108;
 
-    public interface CustomStudyDialogListener {
-        void onPositive(int option);
+    public interface CustomStudyListener {
+        void onCreateCustomStudySession();
+        void onExtendStudyLimits();
     }
 
+    /**
+     * Context menu entries
+     */
+    private ArrayList<Integer> mEntries = new ArrayList<>();
+
+    /**
+     * Instance factories
+     */
     public static CustomStudyDialog newInstance(int id) {
+        return newInstance(id, false);
+    }
+
+    public static CustomStudyDialog newInstance(int id, boolean jumpToReviewer) {
         CustomStudyDialog f = new CustomStudyDialog();
         Bundle args = new Bundle();
         args.putInt("id", id);
+        args.putBoolean("jumpToReviewer", jumpToReviewer);
         f.setArguments(args);
         return f;
     }
 
-    @SuppressLint("InflateParams")
-	@Override
-    public MaterialDialog onCreateDialog(Bundle savedInstanceState) {
-        super.onCreateDialog(savedInstanceState);
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        final int dialogId = getArguments().getInt("id");
+        if (dialogId < 100) {
+            return buildContextMenu(dialogId);
+        } else {
+            return buildInputDialog(dialogId);
+        }
+    }
+
+    /**
+     * Build a context menu for custom study
+     * @param id
+     * @return
+     */
+    private MaterialDialog buildContextMenu(int id) {
+        String[] entries = getListEntries(id);
+        final boolean jumpToReviewer = getArguments ().getBoolean("jumpToReviewer");
+        return new MaterialDialog.Builder(this.getActivity())
+                .title(R.string.custom_study)
+                .cancelable(true)
+                .items(entries)
+                .itemsCallback(new MaterialDialog.ListCallback() {
+                    @Override
+                    public void onSelection(MaterialDialog materialDialog, View view, int which,
+                                            CharSequence charSequence) {
+                        AnkiActivity activity = (AnkiActivity) getActivity();
+                        if (mEntries.get(which) == DECK_OPTIONS) {
+                            // User asked to permanently change the deck options
+                            Intent i = new Intent(activity, DeckOptions.class);
+                            i.putExtra("did", activity.getCol().getDecks().selected());
+                            getActivity().startActivity(i);
+                        } else if (mEntries.get(which) == MORE_OPTIONS) {
+                            // User asked to see all custom study options
+                            CustomStudyDialog d = CustomStudyDialog.newInstance(CONTEXT_MENU_STANDARD, jumpToReviewer);
+                            activity.showDialogFragment(d);
+                        } else if (mEntries.get(which) == CUSTOM_STUDY_TAGS) {
+                            /*
+                             * This is a special Dialog for CUSTOM STUDY, where instead of only collecting a
+                             * number, it is necessary to collect a list of tags. This case handles the creation
+                             * of that Dialog.
+                             */
+                            TagsDialog dialogFragment = TagsDialog.newInstance(
+                                    TagsDialog.TYPE_CUSTOM_STUDY_TAGS, new ArrayList<String>(),
+                                    new ArrayList<>(activity.getCol().getTags().all()));
+                            dialogFragment.setTagsDialogListener(new TagsDialog.TagsDialogListener() {
+                                @Override
+                                public void onPositive(List<String> selectedTags, int option) {
+                                    /*
+                                     * Here's the method that gathers the final selection of tags, type of cards and
+                                     * generates the search screen for the custom study deck.
+                                     */
+                                    StringBuilder sb = new StringBuilder();
+                                    switch (option) {
+                                        case 1:
+                                            sb.append("is:new ");
+                                            break;
+                                        case 2:
+                                            sb.append("is:due ");
+                                            break;
+                                        default:
+                                            // Logging here might be appropriate : )
+                                            break;
+                                    }
+                                    List<String> arr = new ArrayList<>();
+                                    if (selectedTags.size() > 0) {
+                                        for (String tag : selectedTags) {
+                                            arr.add(String.format("tag:'%s'", tag));
+                                        }
+                                        sb.append("(").append(TextUtils.join(" or ", arr)).append(")");
+                                    }
+                                    createCustomStudySession(new JSONArray(), new Object[]{sb.toString(),
+                                            Consts.DYN_MAX_SIZE, Consts.DYN_RANDOM}, false);
+                                }
+                            });
+                            activity.showDialogFragment(dialogFragment);
+                        } else {
+                            // User asked for a standard custom study option
+                            CustomStudyDialog d = CustomStudyDialog.newInstance(mEntries.get(which), jumpToReviewer);
+                            ((AnkiActivity) getActivity()).showDialogFragment(d);
+                        }
+                    }
+                })
+                .build();
+    }
+
+    /**
+     * Build an input dialog that is used to get a parameter related to custom study from the user
+     * @param dialogId
+     * @return
+     */
+    private MaterialDialog buildInputDialog(final int dialogId) {
+        /*
+            TODO: Try to change to a standard input dialog (currently the thing holding us back is having the extra
+            TODO: hint line for the number of cards available, and having the pre-filled text selected by default)
+        */
+        // Input dialogs
         Resources res = getActivity().getResources();
-        // Set custom view
+        // Show input dialog for an individual custom study dialog
         View v = getActivity().getLayoutInflater().inflate(R.layout.styled_custom_study_details_dialog, null);
         TextView textView1 = (TextView) v.findViewById(R.id.custom_study_details_text1);
         TextView textView2 = (TextView) v.findViewById(R.id.custom_study_details_text2);
-        mEditText = (EditText) v.findViewById(R.id.custom_study_details_edittext2);
+        final EditText mEditText = (EditText) v.findViewById(R.id.custom_study_details_edittext2);
         // Set the text
         textView1.setText(getText1());
         textView2.setText(getText2());
@@ -70,54 +191,41 @@ public class CustomStudyDialog extends DialogFragment {
         // Give EditText focus and show keyboard
         mEditText.setSelectAllOnFocus(true);
         mEditText.requestFocus();
-
-        MaterialDialog dialog = new MaterialDialog.Builder(getActivity())
+        // Whether or not to jump straight to the reviewer
+        final boolean jumpToReviewer = getArguments ().getBoolean("jumpToReviewer");
+        // Set builder parameters
+        MaterialDialog.Builder builder = new MaterialDialog.Builder(getActivity())
                 .customView(v, true)
                 .positiveText(res.getString(R.string.dialog_ok))
                 .negativeText(res.getString(R.string.dialog_cancel))
                 .callback(new MaterialDialog.ButtonCallback() {
                     @Override
                     public void onPositive(MaterialDialog dialog) {
-                        Collection col;
+                        Collection col = CollectionHelper.getInstance().getCol(getActivity());
                         // Get the value selected by user
                         int n = Integer.parseInt(mEditText.getText().toString());
                         // Set behavior when clicking OK button
-                        int choice = getArguments().getInt("id");
-                        switch (choice) {
+                        switch (dialogId) {
                             case CUSTOM_STUDY_NEW:
-                                // Get col, exit if not open
-                                //TODO: Find a cleaner way to get the col() from StudyOptionsFragment loader
-                                col = CollectionHelper.getInstance().getCol(getActivity());
-                                if (col == null || col.getDb()== null) {
-                                    Themes.showThemedToast(getActivity().getBaseContext(), getResources()
-                                            .getString(R.string.open_collection_failed_title), false);
-                                    return;
-                                }
                                 try {
                                     AnkiDroidApp.getSharedPrefs(getActivity()).edit().putInt("extendNew", n).commit();
                                     JSONObject deck = col.getDecks().current();
                                     deck.put("extendNew", n);
                                     col.getDecks().save(deck);
                                     col.getSched().extendLimits(n, 0);
+                                    onLimitsExtended(jumpToReviewer);
                                 } catch (JSONException e) {
                                     throw new RuntimeException(e);
                                 }
                                 break;
                             case CUSTOM_STUDY_REV:
-                                // Get col, exit if not open
-                                //TODO: Find a cleaner way to get the col() from StudyOptionsFragment loader
-                                col = CollectionHelper.getInstance().getCol(getActivity());
-                                if (col == null || col.getDb()== null) {
-                                    Themes.showThemedToast(getActivity().getBaseContext(), getResources()
-                                            .getString(R.string.open_collection_failed_title), false);
-                                    return;
-                                }
                                 try {
                                     AnkiDroidApp.getSharedPrefs(getActivity()).edit().putInt("extendRev", n).commit();
                                     JSONObject deck = col.getDecks().current();
                                     deck.put("extendRev", n);
                                     col.getDecks().save(deck);
                                     col.getSched().extendLimits(0, n);
+                                    onLimitsExtended(jumpToReviewer);
                                 } catch (JSONException e) {
                                     throw new RuntimeException(e);
                                 }
@@ -126,41 +234,129 @@ public class CustomStudyDialog extends DialogFragment {
                                 JSONArray ar = new JSONArray();
                                 try {
                                     ar.put(0, 1);
-                                    ((StudyOptionsListener) getActivity()).createFilteredDeck(ar, new Object[] {
-                                            String.format(Locale.US, "rated:%d:1", n), Consts.DYN_MAX_SIZE, Consts.DYN_RANDOM }, false);
+                                    createCustomStudySession(ar, new Object[]{String.format(Locale.US,
+                                            "rated:%d:1", n), Consts.DYN_MAX_SIZE, Consts.DYN_RANDOM}, false);
                                 } catch (JSONException e) {
                                     throw new RuntimeException(e);
                                 }
                                 break;
                             case CUSTOM_STUDY_AHEAD:
-                                ((StudyOptionsListener) getActivity()).createFilteredDeck(new JSONArray(),
-                                        new Object[] { String.format(Locale.US, "prop:due<=%d", n),Consts.DYN_MAX_SIZE, Consts.DYN_DUE }, true);
+                                createCustomStudySession(new JSONArray(), new Object[]{String.format(Locale.US,
+                                        "prop:due<=%d", n), Consts.DYN_MAX_SIZE, Consts.DYN_DUE}, true);
                                 break;
                             case CUSTOM_STUDY_RANDOM:
-                                ((StudyOptionsListener) getActivity()).createFilteredDeck(new JSONArray(),
-                                        new Object[] { "", n, Consts.DYN_RANDOM }, true);
+                                createCustomStudySession(new JSONArray(),
+                                        new Object[]{"", n, Consts.DYN_RANDOM}, true);
                                 break;
                             case CUSTOM_STUDY_PREVIEW:
-                                ((StudyOptionsListener) getActivity()).createFilteredDeck(new JSONArray(),
-                                        new Object[] { "is:new added:" + Integer.toString(n), Consts.DYN_MAX_SIZE, Consts.DYN_OLDEST }, false);
+                                createCustomStudySession(new JSONArray(), new Object[]{"is:new added:" +
+                                        Integer.toString(n), Consts.DYN_MAX_SIZE, Consts.DYN_OLDEST}, false);
                                 break;
                             default:
                                 break;
                         }
-                        mCustomStudyDialogListener.onPositive(choice);
                     }
 
                     @Override
                     public void onNegative(MaterialDialog dialog) {
                         ((AnkiActivity) getActivity()).dismissAllDialogFragments();
                     }
-                })
-                .build();
-
+                });
+        final MaterialDialog dialog = builder.build();
+        mEditText.setOnKeyListener(new View.OnKeyListener() {
+            @Override
+            public boolean onKey(View view, int i, KeyEvent keyEvent) {
+                if (((EditText) view).getText().length() == 0) {
+                    dialog.getActionButton(DialogAction.POSITIVE).setEnabled(false);
+                } else {
+                    dialog.getActionButton(DialogAction.POSITIVE).setEnabled(true);
+                }
+                return false;
+            }
+        });
         // Show soft keyboard
-        dialog.getWindow().setSoftInputMode(LayoutParams.SOFT_INPUT_STATE_VISIBLE);
+        dialog.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE);
         return dialog;
     }
+
+    /**
+     * Build the list of options to show in the custom study dialog, and the map between position and task name
+     * @param idx option to specify which tasks are shown in the list
+     * @return the strings to show in the list
+     */
+    private String[] getListEntries(int idx) {
+        mEntries.clear();
+        Resources res = getResources();
+        String[] entries;
+        Collection col = ((AnkiActivity) getActivity()).getCol();
+        switch (idx) {
+            case CONTEXT_MENU_STANDARD:
+                // Standard custom study options
+                mEntries.add(CUSTOM_STUDY_NEW);
+                mEntries.add(CUSTOM_STUDY_REV);
+                mEntries.add(CUSTOM_STUDY_FORGOT);
+                mEntries.add(CUSTOM_STUDY_AHEAD);
+                mEntries.add(CUSTOM_STUDY_RANDOM);
+                mEntries.add(CUSTOM_STUDY_PREVIEW);
+                mEntries.add(CUSTOM_STUDY_TAGS);
+                entries = new String[7];
+                entries[0] = res.getString(R.string.custom_study_increase_new_limit);
+                entries[1] = res.getString(R.string.custom_study_increase_review_limit);
+                entries[2] = res.getString(R.string.custom_study_review_forgotten);
+                entries[3] = res.getString(R.string.custom_study_review_ahead);
+                entries[4] = res.getString(R.string.custom_study_random_selection);
+                entries[5] = res.getString(R.string.custom_study_preview_new);
+                entries[6] = res.getString(R.string.custom_study_limit_tags);
+                break;
+            case CONTEXT_MENU_LIMITS:
+                // Special custom study options to show when the daily study limit has been reached
+                if (col.getSched().newDue() && col.getSched().revDue()) {
+                    // Both new and due limits have been reached
+                    entries = new String[4];
+                    entries[0] = res.getString(R.string.custom_study_increase_new_limit);
+                    entries[1] = res.getString(R.string.custom_study_increase_review_limit);
+                    entries[2] = res.getString(R.string.study_options);
+                    entries[3] = res.getString(R.string.custom_study);
+                    mEntries.add(CUSTOM_STUDY_NEW);
+                    mEntries.add(CUSTOM_STUDY_REV);
+                } else {
+                    // One and only one of the limits has been reached -- don't show both
+                    entries = new String[3];
+                    if (col.getSched().newDue()) {
+                        entries[0] = res.getString(R.string.custom_study_increase_new_limit);
+                        mEntries.add(CUSTOM_STUDY_NEW);
+                    } else {
+                        entries[0] = res.getString(R.string.custom_study_increase_review_limit);
+                        mEntries.add(CUSTOM_STUDY_REV);
+                    }
+                    entries[1] = res.getString(R.string.study_options);
+                    entries[2] = res.getString(R.string.more_options);
+                }
+                mEntries.add(DECK_OPTIONS);
+                mEntries.add(MORE_OPTIONS);
+                break;
+            case CONTEXT_MENU_EMPTY_SCHEDULE:
+                // Special custom study options to show when extending the daily study limits is not applicable
+                mEntries.add(CUSTOM_STUDY_FORGOT);
+                mEntries.add(CUSTOM_STUDY_AHEAD);
+                mEntries.add(CUSTOM_STUDY_RANDOM);
+                mEntries.add(CUSTOM_STUDY_PREVIEW);
+                mEntries.add(CUSTOM_STUDY_TAGS);
+                mEntries.add(DECK_OPTIONS);
+                entries = new String[6];
+                entries[0] = res.getString(R.string.custom_study_review_forgotten);
+                entries[1] = res.getString(R.string.custom_study_review_ahead);
+                entries[2] = res.getString(R.string.custom_study_random_selection);
+                entries[3] = res.getString(R.string.custom_study_preview_new);
+                entries[4] = res.getString(R.string.custom_study_limit_tags);
+                entries[5] = res.getString(R.string.study_options);
+                break;
+            default:
+                entries = null;
+        }
+        return entries;
+    }
+
 
     private String getText1() {
         Resources res = AnkiDroidApp.getAppResources();
@@ -174,7 +370,7 @@ public class CustomStudyDialog extends DialogFragment {
                 return "";
         }
     }
-    
+
     private String getText2() {
         Resources res = AnkiDroidApp.getAppResources();
         switch (getArguments().getInt("id")) {
@@ -215,7 +411,86 @@ public class CustomStudyDialog extends DialogFragment {
         }
     }
 
-    public void setCustomStudyDialogListener(CustomStudyDialogListener listener) {
-        mCustomStudyDialogListener = listener;
+    /**
+     * Create a custom study session
+     * @param delays delay options for scheduling algorithm
+     * @param terms search terms
+     * @param resched whether to reschedule the cards based on the answers given (or ignore them if false)
+     */
+    private void createCustomStudySession(JSONArray delays, Object[] terms, Boolean resched) {
+        JSONObject dyn;
+        final AnkiActivity activity = (AnkiActivity) getActivity();
+        Collection col = CollectionHelper.getInstance().getCol(activity);
+        try {
+            String deckName = col.getDecks().current().getString("name");
+            String customStudyDeck = getResources().getString(R.string.custom_study_deck_name);
+            JSONObject cur = col.getDecks().byName(customStudyDeck);
+            if (cur != null) {
+                if (cur.getInt("dyn") != 1) {
+                    new MaterialDialog.Builder(getActivity())
+                            .content(R.string.custom_study_deck_exists)
+                            .negativeText(R.string.dialog_cancel)
+                            .build().show();
+                    return;
+                } else {
+                    // safe to empty
+                    col.getSched().emptyDyn(cur.getLong("id"));
+                    // reuse; don't delete as it may have children
+                    dyn = cur;
+                    col.getDecks().select(cur.getLong("id"));
+                }
+            } else {
+                long did = col.getDecks().newDyn(customStudyDeck);
+                dyn = col.getDecks().get(did);
+            }
+            // and then set various options
+            if (delays.length() > 0) {
+                dyn.put("delays", delays);
+            } else {
+                dyn.put("delays", JSONObject.NULL);
+            }
+            JSONArray ar = dyn.getJSONArray("terms");
+            ar.getJSONArray(0).put(0, "deck:\"" + deckName + "\" " + terms[0]);
+            ar.getJSONArray(0).put(1, terms[1]);
+            ar.getJSONArray(0).put(2, terms[2]);
+            dyn.put("resched", resched);
+            // Rebuild the filtered deck
+            DeckTask.launchDeckTask(DeckTask.TASK_TYPE_REBUILD_CRAM, new DeckTask.TaskListener() {
+                @Override
+                public void onCancelled() {
+                }
+
+                @Override
+                public void onPreExecute() {
+                    activity.showProgressBar();
+                }
+
+                @Override
+                public void onPostExecute(DeckTask.TaskData result) {
+                    activity.hideProgressBar();
+                    ((CustomStudyListener) activity).onCreateCustomStudySession();
+                }
+
+                @Override
+                public void onProgressUpdate(DeckTask.TaskData... values) {
+                }
+            });
+
+        } catch (JSONException e) {
+            throw new RuntimeException(e);
+        }
+        // Hide the dialogs
+        activity.dismissAllDialogFragments();
+    }
+
+    private void onLimitsExtended(boolean jumpToReviewer) {
+        AnkiActivity activity = (AnkiActivity) getActivity();
+        if (jumpToReviewer) {
+            activity.startActivityForResult(new Intent(activity, Reviewer.class), AnkiActivity.REQUEST_REVIEW);
+            CollectionHelper.getInstance().getCol(activity).startTimebox();
+        } else {
+            ((CustomStudyListener) activity).onExtendStudyLimits();
+        }
+        activity.dismissAllDialogFragments();
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.java
@@ -8,6 +8,7 @@ import android.support.v4.app.DialogFragment;
 import android.view.View;
 
 import com.afollestad.materialdialogs.MaterialDialog;
+import com.ichi2.anki.AnkiActivity;
 import com.ichi2.anki.DeckPicker;
 import com.ichi2.anki.R;
 
@@ -19,8 +20,10 @@ public class DeckPickerContextMenu extends DialogFragment {
      */
     private static final int CONTEXT_MENU_RENAME_DECK = 0;
     private static final int CONTEXT_MENU_DECK_OPTIONS = 1;
-    private static final int CONTEXT_MENU_DELETE_DECK = 2;
-    private static final int CONTEXT_MENU_EXPORT_DECK = 3;
+    private static final int CONTEXT_MENU_CUSTOM_STUDY = 2;
+    private static final int CONTEXT_MENU_DELETE_DECK = 3;
+    private static final int CONTEXT_MENU_EXPORT_DECK = 4;
+
 
 
     public static DeckPickerContextMenu newInstance(String dialogTitle) {
@@ -36,11 +39,13 @@ public class DeckPickerContextMenu extends DialogFragment {
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         Resources res = getResources();
-        String[] entries = new String[4];
+        String[] entries = new String[5];
         entries[CONTEXT_MENU_RENAME_DECK] = res.getString(R.string.contextmenu_deckpicker_rename_deck);
         entries[CONTEXT_MENU_DECK_OPTIONS] = res.getString(R.string.study_options);
+        entries[CONTEXT_MENU_CUSTOM_STUDY] = res.getString(R.string.custom_study);
         entries[CONTEXT_MENU_DELETE_DECK] = res.getString(R.string.contextmenu_deckpicker_delete_deck);
         entries[CONTEXT_MENU_EXPORT_DECK] = res.getString(R.string.export);
+
         return new MaterialDialog.Builder(getActivity())
                 .title(getArguments().getString("dialogTitle"))
                 .cancelable(true)
@@ -64,6 +69,13 @@ public class DeckPickerContextMenu extends DialogFragment {
                 case CONTEXT_MENU_DECK_OPTIONS:
                     Timber.i("Open deck options selected");
                     ((DeckPicker) getActivity()).showContextMenuDeckOptions();
+                    return;
+                case CONTEXT_MENU_CUSTOM_STUDY:
+                    // TODO: hide this option when it's a filtered deck
+                    Timber.i("Custom study option selected");
+                    CustomStudyDialog d = CustomStudyDialog.newInstance(
+                            CustomStudyDialog.CONTEXT_MENU_STANDARD);
+                    ((AnkiActivity) getActivity()).showDialogFragment(d);
                     return;
 
                 case CONTEXT_MENU_RENAME_DECK:

--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.java
@@ -297,11 +297,7 @@ public class DeckAdapter extends RecyclerView.Adapter<DeckAdapter.ViewHolder> {
         return mNew + mLrn + mRev;
     }
 
-    public boolean hasCards(long did) {
-        if (mCol.cardCount(new long[]{did}) > 0) {
-            return true;
-        }
-        int i = findDeckPosition(did);
-        return mDeckList.get(i).children.size() > 0;
+    public List<Sched.DeckDueTreeNode> getDeckList() {
+        return mDeckList;
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
@@ -733,10 +733,7 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
             double progressMature = ((double) sched.matureCount()) / ((double) totalCount);
             double progressAll = 1 - (((double) (totalNewCount + counts[1])) / ((double) totalCount));
             double[][] serieslist = null;
-            // only calculate stats if necessary
-            if ((Boolean) obj[1]) {
-                serieslist = Stats.getSmallDueStats(col);
-            }
+            serieslist = Stats.getSmallDueStats(col);
             return new TaskData(new Object[] { counts[0], counts[1], counts[2], totalNewCount, totalCount,
                     progressMature, progressAll, sched.eta(counts), serieslist });
         } catch (RuntimeException e) {
@@ -758,18 +755,16 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
     private TaskData doInBackgroundRebuildCram(TaskData... params) {
         Timber.d("doInBackgroundRebuildCram");
         Collection col = CollectionHelper.getInstance().getCol(mContext);
-        boolean fragmented = params[0].getBoolean();
         col.getSched().rebuildDyn(col.getDecks().selected());
-        return doInBackgroundUpdateValuesFromDeck(new DeckTask.TaskData(new Object[]{true, fragmented}));
+        return doInBackgroundUpdateValuesFromDeck(new DeckTask.TaskData(new Object[]{true}));
     }
 
 
     private TaskData doInBackgroundEmptyCram(TaskData... params) {
         Timber.d("doInBackgroundEmptyCram");
         Collection col = CollectionHelper.getInstance().getCol(mContext);
-        boolean fragmented = params[0].getBoolean();
         col.getSched().emptyDyn(col.getDecks().selected());
-        return doInBackgroundUpdateValuesFromDeck(new DeckTask.TaskData(new Object[]{true, fragmented}));
+        return doInBackgroundUpdateValuesFromDeck(new DeckTask.TaskData(new Object[]{true}));
     }
 
 

--- a/AnkiDroid/src/main/res/layout/studyoptions_fragment.xml
+++ b/AnkiDroid/src/main/res/layout/studyoptions_fragment.xml
@@ -169,6 +169,7 @@
                     android:id="@+id/studyoptions_congrats_layout"
                     android:layout_width="fill_parent"
                     android:layout_height="wrap_content"
+                    android:paddingTop="10dp"
                     android:orientation="vertical">
 
                     <TextView

--- a/AnkiDroid/src/main/res/layout/styled_custom_study_details_dialog.xml
+++ b/AnkiDroid/src/main/res/layout/styled_custom_study_details_dialog.xml
@@ -24,7 +24,7 @@
 
     android:layout_width="fill_parent"
     android:layout_height="wrap_content"
-    android:gravity="center"
+    android:gravity="left"
     android:orientation="vertical" >
 
     <TextView
@@ -38,35 +38,29 @@
         android:text=""
         android:textSize="16sp" />
 
-    <LinearLayout
+    <TextView
+        android:id="@+id/custom_study_details_text2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="left"
+        android:layout_marginBottom="16dip"
+        android:layout_marginLeft="4dip"
+        android:layout_weight="4"
+        android:gravity="left|center"
+        android:lines="2"
+        android:text=""
+        android:textSize="16sp" />
+
+    <EditText
+        android:id="@+id/custom_study_details_edittext2"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal" >
-
-        <TextView
-            android:id="@+id/custom_study_details_text2"
-            android:layout_width="0dip"
-            android:layout_height="wrap_content"
-            android:layout_gravity="left"
-            android:layout_marginBottom="16dip"
-            android:layout_marginLeft="4dip"
-            android:layout_weight="4"
-            android:gravity="left|center"
-            android:lines="2"
-            android:text=""
-            android:textSize="16sp" />
-
-        <EditText
-            android:id="@+id/custom_study_details_edittext2"
-            android:layout_width="0dip"
-            android:layout_height="38dip"
-            android:layout_marginBottom="16dip"
-            android:layout_marginRight="4dip"
-            android:layout_weight="1"
-            android:gravity="bottom"
-            android:inputType="number"
-            android:text="1"
-            tools:ignore="HardcodedText"/>
-    </LinearLayout>
-
+        android:layout_marginBottom="16dip"
+        android:layout_marginLeft="4dip"
+        android:layout_marginRight="4dip"
+        android:layout_weight="1"
+        android:gravity="left|bottom"
+        android:inputType="number"
+        android:text="1"
+        tools:ignore="HardcodedText"/>
 </LinearLayout>

--- a/AnkiDroid/src/main/res/menu/deck_picker.xml
+++ b/AnkiDroid/src/main/res/menu/deck_picker.xml
@@ -2,29 +2,15 @@
     xmlns:ankidroid="http://schemas.android.com/apk/res-auto" >
 
     <item
-        android:id="@+id/action_add_decks"
-        android:icon="@drawable/ic_add_white_24dp"
-        android:title="@string/menu_add"
-        ankidroid:showAsAction="always"
-            android:visible="false">
-        <menu>
-            <item
-                android:id="@+id/action_add_note_from_deck_picker"
-                android:title="@string/menu_add_note"/>
-            <item
-                android:id="@+id/action_shared_decks"
-                android:title="@string/menu_get_shared_decks"/>
-            <item
-                android:id="@+id/action_new_deck"
-                android:title="@string/new_deck"/>
-        </menu>
-    </item>
-    <item
         android:id="@+id/action_sync"
-        android:enabled="false"
         android:icon="@drawable/ic_sync_white_24dp"
         android:title="@string/sync_title"
         ankidroid:showAsAction="always"/>
+    <item
+        android:id="@+id/action_unbury"
+        android:enabled="false"
+        android:title="@string/unbury"
+        ankidroid:showAsAction="never"/>
     <item
         android:id="@+id/action_new_filtered_deck"
         android:enabled="false"

--- a/AnkiDroid/src/main/res/menu/reviewer.xml
+++ b/AnkiDroid/src/main/res/menu/reviewer.xml
@@ -62,4 +62,7 @@
     <item
         android:id="@+id/action_enable_whiteboard"
         android:title="@string/enable_whiteboard" />
+    <item
+        android:id="@+id/action_open_deck_overview"
+        android:title="@string/studyoptions_title" />
 </menu>

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -34,6 +34,7 @@
     <string name="studyoptions_start">Study</string>
 
     <!-- DeckPicker.java -->
+    <string name="study_more">Study more</string>
     <plurals name="deckpicker_title">
         <item quantity="one">%1$d card due (%2$s)</item>
         <item quantity="other">%1$d cards due (%2$s)</item>
@@ -108,7 +109,10 @@
     <string name="empty_cram_deck">Emptying cram deck…</string>
     <string name="custom_study_deck_name">Custom study session</string>
     <string name="custom_study_deck_exists">Rename the existing custom study deck first</string>
-    <string name="studyoptions_empty">This deck is empty</string>
+    <string name="empty_deck">This deck is empty</string>
+    <string name="studyoptions_empty">This deck is empty. Press the + button to add new content.</string>
+    <string name="studyoptions_limit_reached">Daily study limit reached</string>
+    <string name="studyoptions_empty_schedule">No cards scheduled to study</string>
     <string name="studyoptions_congrats_finished">Congratulations! You have finished for now.</string>
     <string name="studyoptions_congrats_more_rev">Today’s limit has been reached, but there are still cards to review. You can increase the limit in the options.</string>
     <string name="studyoptions_congrats_more_new">Today’s limit has been reached. There are more new cards available; you can increase the limit in the options, but this will increase your short-term review workload.</string>

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -73,6 +73,15 @@
         -->
     </string-array>
 
+    <!-- Custom study options -->
+    <string name="custom_study_increase_new_limit">Increase today’s new card limit</string>
+    <string name="custom_study_increase_review_limit">Increase today’s review card limit</string>
+    <string name="custom_study_review_forgotten">Review forgotten cards</string>
+    <string name="custom_study_review_ahead">Review ahead</string>
+    <string name="custom_study_random_selection">Study a random selection of cards</string>
+    <string name="custom_study_preview_new">Preview new cards</string>
+    <string name="custom_study_limit_tags">Limit to particular tags</string>
+
     <!-- Card editor -->
     <string name="cardeditor_title_add_note">Add note</string>
     <string name="cardeditor_title_edit_card">Edit note</string>
@@ -149,6 +158,7 @@
     <string name="upgrade_import_no_file_found">No importable %1$s file found</string>
     <string name="study_options">Deck options</string>
     <string name="custom_study">Custom study</string>
+    <string name="more_options">More</string>
     <string name="dyn_deck_desc">This is a special deck for studying outside of the normal schedule. Cards will be automatically returned to their original decks after you review them. Deleting this deck from the deck list will return all remaining cards to their original deck.</string>
     <string name="steps_error">Steps must be numbers greater than 0</string>
     <string name="steps_min_error">At least one step is required</string>

--- a/AnkiDroid/src/main/res/values/11-arrays.xml
+++ b/AnkiDroid/src/main/res/values/11-arrays.xml
@@ -60,13 +60,13 @@
         <item>Relative overdueness</item>
     </string-array>
     <string-array name="custom_study_options_labels">
-        <item>Increase today’s new card limit</item>
-        <item>Increase today’s review card limit</item>
-        <item>Review forgotten cards</item>
-        <item>Review ahead</item>
-        <item>Study a random selection of cards</item>
-        <item>Preview new cards</item>
-        <item>Limit to particular tags</item>
+        <item>@string/custom_study_increase_new_limit</item>
+        <item>@string/custom_study_increase_review_limit</item>
+        <item>@string/custom_study_review_forgotten</item>
+        <item>@string/custom_study_review_ahead</item>
+        <item>@string/custom_study_random_selection</item>
+        <item>@string/custom_study_preview_new</item>
+        <item>@string/custom_study_limit_tags</item>
     </string-array>
     <string-array name="add_to_cur_labels">
         <item>Use current deck</item>


### PR DESCRIPTION
The idea behind this PR is to avoid showing the ugly and confusing "study options" screen whenever possible by skipping directly to the reviewer for ordinary non-filtered decks, and using SnackBars to give hints to the user on how to do custom study when the scheduler isn't putting out any new cards.

Custom study can now be accessed via the long tap context menu in the deck picker, and unbury can be accessed from the main overflow menu in the deck picker. The old "study options" screen can also be accessed from the reviewer to aid those that don't know about the long click menu.

In the case of tablet layout and filtered decks, the study options screen is continued to be used as before.

There are still a few minor TODOs for this, for example:
* Long clicking on a filtered deck will give the option to do custom study, which doesn't really make sense. This should be removed from the menu.
* The overflow menu item that takes the user to "study options" from the Reviewer should be removed on tablet layouts as it's redundant.
* It could be a good idea to add something like "Open deck overview" to the long click listener on the DeckPicker, so that users can go there if they want to. This should let them do undo on their last study session as well.
* Remove some dead code from the old graph in the tablet layout

I will address these issues later; for now I just want to get some feedback from users