### PR TITLE
Tweak to two strings. (No re-translation.)

### DIFF
--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -163,7 +163,7 @@
     <string name="steps_error">Steps must be numbers greater than 0</string>
     <string name="steps_min_error">At least one step is required</string>
     <string name="sched_end">(end)</string>
-    <string name="sched_unbury_button">To see them now touch the “Unbury” button.</string>
+    <string name="sched_unbury_button">To see them now touch the “Unbury” item in the deck overview menu.</string>
     <string name="sched_has_buried">Some related or buried cards were delayed until tomorrow.</string>
     <string name="tag_editor_add_feedback">Touch “%2$s” to confirm adding “%1$s”</string>
     <string name="tag_editor_add_feedback_existing">Existing tag “%1$s” selected</string>

--- a/AnkiDroid/src/main/res/values/17-model-manager.xml
+++ b/AnkiDroid/src/main/res/values/17-model-manager.xml
@@ -50,7 +50,7 @@
     <string name="model_field_editor_options">Field options</string>
     <string name="model_field_editor_rename">Rename field</string>
     <string name="model_field_editor_reposition_menu">Reposition field</string>
-    <string name="model_field_editor_reposition" formatted="false">Reposition field (enter a value %1$d - %2$d)</string>
+    <string name="model_field_editor_reposition" formatted="false">Reposition field (enter a value %1$d–%2$d)</string>
     <string name="model_field_editor_changing">Updating fields</string>
     <string name="model_field_editor_sort_field">Sort by this field</string>
     <string name="model_clone_suffix">copy</string>


### PR DESCRIPTION
Tweak two other strings. These would not need re-translating. (This separation is according to a request with respect to PR #3583.)

* Fix reference to “Unbury”. No longer a button.
* Use an n-dash for number range (“1–12” instead of “1 - 12”)