### PR TITLE
Fix browser spinner always set to "all decks"

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
@@ -404,6 +404,10 @@ public class AnkiActivity extends AppCompatActivity implements LoaderManager.Loa
         View root = findViewById(R.id.root_layout);
         showSnackbar(mainTextResource, shortLength, -1, null, root);
     }
+    protected void showSimpleSnackbar(String mainText, boolean shortLength) {
+        View root = findViewById(R.id.root_layout);
+        showSnackbar(mainText, shortLength, -1, null, root, null);
+    }
 
     /**
      * Show a snackbar with an action
@@ -419,6 +423,11 @@ public class AnkiActivity extends AppCompatActivity implements LoaderManager.Loa
     }
     protected void showSnackbar(int mainTextResource, boolean shortLength, int actionTextResource,
                                 View.OnClickListener listener, View root, Snackbar.Callback callback) {
+        String mainText = getResources().getString(mainTextResource);
+        showSnackbar(mainText, shortLength, actionTextResource, listener, root, callback);
+    }
+    protected void showSnackbar(String mainText, boolean shortLength, int actionTextResource,
+                                View.OnClickListener listener, View root, Snackbar.Callback callback) {
         if (root == null) {
             root = findViewById(android.R.id.content);
             if (root == null) {
@@ -427,7 +436,7 @@ public class AnkiActivity extends AppCompatActivity implements LoaderManager.Loa
             }
         }
         int length = shortLength ? Snackbar.LENGTH_SHORT : Snackbar.LENGTH_LONG;
-        Snackbar sb = Snackbar.make(root, mainTextResource, length);
+        Snackbar sb = Snackbar.make(root, mainText, length);
         if (listener != null) {
             sb.setAction(actionTextResource, listener);
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -105,6 +105,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
     private MenuItem mMySearchesItem;
 
     public static Card sCardBrowserCard;
+    private static int sLastSelectedDeckIndex = -1;
 
     private int mPositionInCardsList;
 
@@ -341,7 +342,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
         Timber.d("onCreate()");
         View mainView = getLayoutInflater().inflate(R.layout.card_browser, null);
         setContentView(mainView);
-        
+
         initNavigationDrawer(mainView);
         startLoadingCollection();
     }
@@ -496,7 +497,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
         mSearchTerms = "";
 
         // set the currently selected deck
-        if (!sIsWholeCollection) {
+        if (sLastSelectedDeckIndex == -1) {
             String currentDeckName;
             try {
                 currentDeckName = getCol().getDecks().current().getString("name");
@@ -516,6 +517,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
                     break;
                 }
             }
+        } else if (sLastSelectedDeckIndex > 0 && sLastSelectedDeckIndex < mDropDownDecks.size()) {
+            selectDropDownItem(sLastSelectedDeckIndex);
         }
     }
 
@@ -765,11 +768,10 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
     public void selectDropDownItem(int position) {
         mActionBarSpinner.setSelection(position);
+        sLastSelectedDeckIndex = position;
         if (position == 0) {
-            sIsWholeCollection = true;
             mRestrictOnDeck = "";
         } else {
-            sIsWholeCollection = false;
             JSONObject deck = mDropDownDecks.get(position - 1);
             String deckName;
             try {
@@ -1090,6 +1092,10 @@ public class CardBrowser extends NavigationDrawerActivity implements
     private void closeCardBrowser(int result, Intent data) {
         setResult(result, data);
         finishWithAnimation(ActivityTransitionAnimation.RIGHT);
+    }
+
+    public static void clearSelectedDeck() {
+        sLastSelectedDeckIndex = -1;
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1041,6 +1041,9 @@ public class CardBrowser extends NavigationDrawerActivity implements
             if (result != null && mCards != null) {
                 Timber.i("CardBrowser:: Completed doInBackgroundSearchCards Successfuly");
                 updateList();
+                if (!mSearchView.isIconified()) {
+                    showSimpleSnackbar(getSubtitleText(), false);
+                }
                 // After the initial searchCards query, start rendering the question and answer in the background
                 DeckTask.launchDeckTask(DeckTask.TASK_TYPE_RENDER_BROWSER_QA, mRenderQAHandler,
                         new DeckTask.TaskData(new Object[]{mCards, 0, 100}));

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -422,6 +422,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
                                                 .replaceAll("[\'\"\\n\\r\\[\\]\\(\\)]", "");
                                         Timber.i("DeckPicker:: Creating new deck...");
                                         getCol().getDecks().id(deckName, true);
+                                        CardBrowser.clearSelectedDeck();
                                         updateDeckList();
                                     }
                                 })
@@ -1946,6 +1947,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
                         Timber.e(e, "onPostExecute - Exception dismissing dialog");
                     }
                 }
+                CardBrowser.clearSelectedDeck();
             }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -379,8 +379,6 @@ public class DeckPicker extends NavigationDrawerActivity implements
         // set protected variable from NavigationDrawerActivity
         mFragmented = studyoptionsFrame != null && studyoptionsFrame.getVisibility() == View.VISIBLE;
 
-        sIsWholeCollection = !mFragmented;
-
         registerExternalStorageListener();
 
         // create inherited navigation drawer layout here so that it can be used by parent class
@@ -641,7 +639,6 @@ public class DeckPicker extends NavigationDrawerActivity implements
             updateDeckList();
         }
         setTitle(getResources().getString(R.string.app_name));
-        sIsWholeCollection = !mFragmented;
     }
 
 
@@ -1656,6 +1653,8 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
 
     private void handleDeckSelection(long did) {
+        // Forget what the last used deck was in the browser
+        CardBrowser.clearSelectedDeck();
         // Select the deck
         getCol().getDecks().select(did);
         mFocusedDeck = did;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
@@ -46,8 +46,6 @@ public class NavigationDrawerActivity extends AnkiActivity implements Drawer.OnD
     /** Navigation Drawer */
     protected CharSequence mTitle;
     protected Boolean mFragmented = false;
-    // Preselection for DeckDropDownAdapter
-    protected static boolean sIsWholeCollection = true;
     private Drawer mDrawer;
     private AccountHeader mHeader = null;
     // Other members
@@ -186,14 +184,6 @@ public class NavigationDrawerActivity extends AnkiActivity implements Drawer.OnD
         }
     }
 
-
-    public static void setIsWholeCollection(boolean isWholeCollection){
-        sIsWholeCollection = isWholeCollection;
-    }
-
-    public static boolean isWholeCollection() {
-        return sIsWholeCollection;
-    }
 
     /**
      * Get the drawer layout.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
@@ -182,7 +182,6 @@ public class StudyOptionsFragment extends Fragment implements Toolbar.OnMenuItem
         restorePreferences();
         mStudyOptionsView = inflater.inflate(R.layout.studyoptions_fragment, container, false);
         mFragmented = getActivity().getClass() != StudyOptionsActivity.class;
-        NavigationDrawerActivity.setIsWholeCollection(false);
         initAllContentViews();
         if (getArguments() != null) {
             mLoadWithDeckOptions = getArguments().getBoolean("withDeckOptions");

--- a/AnkiDroid/src/main/java/com/ichi2/anki/stats/InfoStatsBuilder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/stats/InfoStatsBuilder.java
@@ -22,7 +22,6 @@ import android.webkit.WebView;
 import com.ichi2.anki.R;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Stats;
-import com.ichi2.libanki.Utils;
 
 public class InfoStatsBuilder {
     private final int CARDS_INDEX = 0;
@@ -38,7 +37,6 @@ public class InfoStatsBuilder {
     private final WebView mWebView; //for resources access
     private final Collection mCollectionData;
     private final boolean mIsWholeCollection;
-    private String mTodayString = "";
 
     public InfoStatsBuilder(WebView chartView, Collection collectionData, boolean isWholeCollection){
         mWebView = chartView;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Stats.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Stats.java
@@ -42,18 +42,6 @@ public class Stats {
 
     public static enum ChartType {FORECAST, REVIEW_COUNT, REVIEW_TIME,
         INTERVALS, HOURLY_BREAKDOWN, WEEKLY_BREAKDOWN, ANSWER_BUTTONS, CARDS_TYPES, OTHER};
-    public static final int TYPE_FORECAST = 0;
-    public static final int TYPE_REVIEW_COUNT = 1;
-    public static final int TYPE_REVIEW_TIME = 2;
-    public static final int TYPE_INTERVALS = 3;
-    public static final int TYPE_HOURLY_BREAKDOWN = 4;
-    public static final int TYPE_WEEKLY_BREAKDOWN = 5;
-    public static final int TYPE_ANSWER_BUTTONS = 6;
-    public static final int TYPE_CARDS_TYPES = 7;
-
-    //public static final int TYPE_REVIEWS = 4;
-    //public static final int TYPE_REVIEWING_TIME = 5;
-    // public static final int TYPE_DECK_SUMMARY = 5;
 
     private static Stats sCurrentInstance;
 


### PR DESCRIPTION
Also remember the last selected deck in the browser until a new deck is selected (#3319)
and show the number of cards found in a search via a snackbar when the SearchView is expanded (#3592)