### PR TITLE
Fix a typo. Hide the type prompt when typing is off, show when on

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -770,7 +770,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
             sb.append(">\n</center>\n");
         } else {
             sb.append("<span id=typeans class=\"typePrompt");
-            if (mPrefWriteAnswers) {
+            if (!mPrefWriteAnswers) {
                 sb.append(" typeOff");
             }
             sb.append("\">........</span>");


### PR DESCRIPTION
When i added the “`autocomplete=\"off\" `” for #3730, i changed too much too quickly.
I didn’t test the old style enough, and got the logic wrong.
With this the type prompt is again shown when typing is on and not shown when off.