### PR TITLE
Get rid of flicker with night-mode enabled

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -31,6 +31,7 @@ import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.content.res.TypedArray;
+import android.graphics.Color;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.Handler;
@@ -1496,7 +1497,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
         // Problems with focus and input tags is the reason we keep the old type answer mechanism for old Androids.
         webView.setFocusableInTouchMode(USE_INPUT_TAG);
         webView.setScrollbarFadingEnabled(true);
-        Timber.d("Focusable = %s, Focusable in touch mode = %s",webView.isFocusable(),webView.isFocusableInTouchMode());
+        Timber.d("Focusable = %s, Focusable in touch mode = %s", webView.isFocusable(), webView.isFocusableInTouchMode());
 
         webView.setWebViewClient(new WebViewClient() {
             // Filter any links using the custom "playsound" protocol defined in Sound.java.
@@ -1538,7 +1539,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
                 Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
                 try {
                     startActivityWithoutAnimation(intent);
-                } catch(ActivityNotFoundException e) {
+                } catch (ActivityNotFoundException e) {
                     e.printStackTrace(); // Don't crash if the intent is not handled
                 }
                 return true;
@@ -1552,7 +1553,8 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
                 view.loadUrl("javascript:onPageFinished();");
             }
         });
-
+        // Set transparent color to prevent flashing white when night mode enabled
+        webView.setBackgroundColor(Color.argb(1, 0, 0, 0));
         return webView;
     }
 


### PR DESCRIPTION
With night mode enabled the screen flickers white for a little bit when the reviewer is first opened. Setting the webview to be transparent appears to make that flicker be grey until the card background itself is loaded, which is less stressful on the eyes. You can get rid of the flicker entirely by [setting the background color of your cards in night mode to `#303030`](https://github.com/ankidroid/Anki-Android/wiki/FAQ#how-to-customize-the-colors-used-with-night-mode)