### PR TITLE
Update "cancel sync" dialog strings.

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -1284,10 +1284,10 @@ public class DeckPicker extends NavigationDrawerActivity implements
                         if (keyCode == KeyEvent.KEYCODE_BACK && Connection.isCancellable() &&
                                 !Connection.getIsCancelled()) {
                             MaterialDialog.Builder builder = new MaterialDialog.Builder(mProgressDialog.getContext());
-                            builder.content("Are you sure you want to cancel?")
+                            builder.content(R.string.cancel_sync_confirm)
                                     .cancelable(false)
-                                    .positiveText(android.R.string.ok)
-                                    .negativeText(android.R.string.cancel)
+                                    .positiveText(R.string.dialog_ok)
+                                    .negativeText(R.string.continue_sync)
                                     .callback(new MaterialDialog.ButtonCallback() {
                                         @Override
                                         public void onPositive(MaterialDialog dialog) {

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -122,6 +122,7 @@
     <string name="sd_card_not_mounted">Device storage not mounted</string>
     <string name="button_sync">Sync</string>
     <string name="cancel_sync_confirm">Do you want to cancel the sync?</string>
+    <string name="continue_sync">Continue sync</string>
     <string name="sync_cancelled">Sync cancelled</string>
     <string name="export">Export</string>
     <string name="export_collection">Export collection</string>


### PR DESCRIPTION
Replaced literal string with resource. This dialog is a bit tricky, because the positive dialog action would be "Cancel", which normally cancels the dialog. Therefore I used "OK" and "Continue sync" to avoid any ambiguity.

Fixes #3761.