### PR TITLE
Pass deck id to custom study context menu.

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -1682,7 +1682,9 @@ public class DeckPicker extends NavigationDrawerActivity implements
             showSnackbar(R.string.studyoptions_limit_reached, false, R.string.study_more, new OnClickListener() {
                 @Override
                 public void onClick(View v) {
-                    CustomStudyDialog d = CustomStudyDialog.newInstance(CustomStudyDialog.CONTEXT_MENU_LIMITS, true);
+                    CustomStudyDialog d = CustomStudyDialog.newInstance(
+                            CustomStudyDialog.CONTEXT_MENU_LIMITS,
+                            getCol().getDecks().selected(), true);
                     showDialogFragment(d);
                 }
             }, findViewById(R.id.root_layout), mSnackbarShowHideCallback);
@@ -1702,7 +1704,8 @@ public class DeckPicker extends NavigationDrawerActivity implements
                 @Override
                 public void onClick(View v) {
                     CustomStudyDialog d = CustomStudyDialog.newInstance(
-                            CustomStudyDialog.CONTEXT_MENU_EMPTY_SCHEDULE, true);
+                            CustomStudyDialog.CONTEXT_MENU_EMPTY_SCHEDULE,
+                            getCol().getDecks().selected(), true);
                     showDialogFragment(d);
                 }
             }, findViewById(R.id.root_layout), mSnackbarShowHideCallback);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
@@ -264,7 +264,8 @@ public class StudyOptionsFragment extends Fragment implements Toolbar.OnMenuItem
      * Show the context menu for the custom study options
      */
     private void showCustomStudyContextMenu() {
-        CustomStudyDialog d = CustomStudyDialog.newInstance(CustomStudyDialog.CONTEXT_MENU_STANDARD);
+        CustomStudyDialog d = CustomStudyDialog.newInstance(CustomStudyDialog.CONTEXT_MENU_STANDARD,
+                getCol().getDecks().selected());
         ((AnkiActivity)getActivity()).showDialogFragment(d);
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
@@ -75,14 +75,15 @@ public class CustomStudyDialog extends DialogFragment {
     /**
      * Instance factories
      */
-    public static CustomStudyDialog newInstance(int id) {
-        return newInstance(id, false);
+    public static CustomStudyDialog newInstance(int id, long did) {
+        return newInstance(id, did, false);
     }
 
-    public static CustomStudyDialog newInstance(int id, boolean jumpToReviewer) {
+    public static CustomStudyDialog newInstance(int id, long did, boolean jumpToReviewer) {
         CustomStudyDialog f = new CustomStudyDialog();
         Bundle args = new Bundle();
         args.putInt("id", id);
+        args.putLong("did", did);
         args.putBoolean("jumpToReviewer", jumpToReviewer);
         f.setArguments(args);
         return f;
@@ -128,7 +129,8 @@ public class CustomStudyDialog extends DialogFragment {
                             }
                             case MORE_OPTIONS: {
                                 // User asked to see all custom study options
-                                CustomStudyDialog d = CustomStudyDialog.newInstance(CONTEXT_MENU_STANDARD, jumpToReviewer);
+                                CustomStudyDialog d = CustomStudyDialog.newInstance(CONTEXT_MENU_STANDARD,
+                                        getArguments().getLong("did"), jumpToReviewer);
                                 activity.showDialogFragment(d);
                                 break;
                             }
@@ -176,7 +178,8 @@ public class CustomStudyDialog extends DialogFragment {
                             }
                             default: {
                                 // User asked for a standard custom study option
-                                CustomStudyDialog d = CustomStudyDialog.newInstance(view.getId(), jumpToReviewer);
+                                CustomStudyDialog d = CustomStudyDialog.newInstance(view.getId(),
+                                        getArguments().getLong("did"), jumpToReviewer);
                                 ((AnkiActivity) getActivity()).showDialogFragment(d);
                             }
                         }
@@ -409,7 +412,8 @@ public class CustomStudyDialog extends DialogFragment {
         final AnkiActivity activity = (AnkiActivity) getActivity();
         Collection col = CollectionHelper.getInstance().getCol(activity);
         try {
-            String deckName = col.getDecks().current().getString("name");
+            long did = getArguments().getLong("did");
+            String deckName = col.getDecks().get(did).getString("name");
             String customStudyDeck = getResources().getString(R.string.custom_study_deck_name);
             JSONObject cur = col.getDecks().byName(customStudyDeck);
             if (cur != null) {
@@ -427,8 +431,8 @@ public class CustomStudyDialog extends DialogFragment {
                     col.getDecks().select(cur.getLong("id"));
                 }
             } else {
-                long did = col.getDecks().newDyn(customStudyDeck);
-                dyn = col.getDecks().get(did);
+                long customStudyDid = col.getDecks().newDyn(customStudyDeck);
+                dyn = col.getDecks().get(customStudyDid);
             }
             // and then set various options
             if (delays.length() > 0) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.java
@@ -123,8 +123,9 @@ public class DeckPickerContextMenu extends DialogFragment {
                     break;
                 case CONTEXT_MENU_CUSTOM_STUDY: {
                     Timber.i("Custom study option selected");
+                    long did = getArguments().getLong("did");
                     CustomStudyDialog d = CustomStudyDialog.newInstance(
-                            CustomStudyDialog.CONTEXT_MENU_STANDARD);
+                            CustomStudyDialog.CONTEXT_MENU_STANDARD, did);
                     ((AnkiActivity) getActivity()).showDialogFragment(d);
                     break;
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
@@ -1057,7 +1057,7 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
                 if (child.getInt("dyn") == 1) {
                     continue;
                 }
-                TaskData newParams = new TaskData(new Object[] { col, child, conf });
+                TaskData newParams = new TaskData(new Object[] { child, conf });
                 boolean changed = doInBackgroundConfChange(newParams).getBoolean();
                 if (!changed) {
                     return new TaskData(false);

--- a/AnkiDroid/src/main/res/values/06-statistics.xml
+++ b/AnkiDroid/src/main/res/values/06-statistics.xml
@@ -68,7 +68,7 @@
     <string name="stats_breakdown">Hourly breakdown</string>
     <string name="stats_weekly_breakdown">Weekly breakdown</string>
     <string name="stats_answer_buttons">Answer buttons</string>
-    <string name="stats_cards_types">Cards types</string>
+    <string name="stats_cards_types">Card types</string>
 
     <string-array name="stats_day_time_strings">
         <item>4AM</item>

--- a/AnkiDroid/src/main/res/xml/deck_options.xml
+++ b/AnkiDroid/src/main/res/xml/deck_options.xml
@@ -32,7 +32,7 @@
                 android:title="@string/deck_conf_add" />
 
             <com.ichi2.preferences.CustomDialogPreference
-                android:dialogIcon="@android:drawable/ic_dialog_alert"
+                android:dialogIcon="@drawable/ic_dialog_alert"
                 android:dialogMessage="@string/deck_conf_remove_message"
                 android:dialogTitle="@string/deck_conf_remove_title"
                 android:key="confRemove"
@@ -45,7 +45,7 @@
                 android:title="@string/deck_conf_rename" />
 
             <com.ichi2.preferences.CustomDialogPreference
-                android:dialogIcon="@android:drawable/ic_dialog_alert"
+                android:dialogIcon="@drawable/ic_dialog_alert"
                 android:dialogMessage="@string/deck_conf_reset_message"
                 android:dialogTitle="@string/deck_conf_reset_title"
                 android:key="confRestore"
@@ -53,7 +53,7 @@
                 android:positiveButtonText="@string/dialog_positive_restore"
                 android:title="@string/deck_conf_reset_title" />
             <com.ichi2.preferences.CustomDialogPreference
-                android:dialogIcon="@android:drawable/ic_dialog_alert"
+                android:dialogIcon="@drawable/ic_dialog_alert"
                 android:dialogMessage="@string/deck_conf_set_subdecks_message"
                 android:dialogTitle="@string/deck_conf_set_subdecks_title"
                 android:key="confSetSubdecks"

--- a/AnkiDroid/src/main/res/xml/preferences_advanced.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_advanced.xml
@@ -91,7 +91,7 @@
                 android:summary="@string/preference_summary_literal"
                 android:title="@string/dictionary" />
             <com.ichi2.preferences.CustomDialogPreference
-                android:dialogIcon="@android:drawable/ic_dialog_alert"
+                android:dialogIcon="@drawable/ic_dialog_alert"
                 android:dialogMessage="@string/reset_languages_question"
                 android:dialogTitle="@string/reset_languages"
                 android:negativeButtonText="@string/dialog_cancel"


### PR DESCRIPTION
Necessary because creating a custom session uses the current did, not the context menu did. Also refresh the deck list then, so that:
* clicking a deck which no cards to study moves the focus bar (it was already made current).
* the focus bar doesn't jump when going back to the deck picker after changing decks.