### PR TITLE
Allow some rendering of browser items while scrolling

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -45,10 +45,13 @@ dependencies {
     // Note: the design support library can be quite buggy, so test everything thoroughly before updating it
     compile 'com.android.support:design:23.0.1'
     compile 'com.android.support:customtabs:23.0.1'
-    compile('com.afollestad.material-dialogs:core:0.8.3.0@aar') {
+    compile 'com.android.support:recyclerview-v7:23.0.1'
+    compile('com.afollestad.material-dialogs:core:0.8.5.0@aar') {
         transitive = true
+        exclude group: 'com.android.support'
     }
-    compile('com.mikepenz:materialdrawer:4.3.6@aar') {
+    compile('com.mikepenz:materialdrawer:4.4.3@aar') {
+        exclude group: 'com.android.support'
         transitive = true
     }
     compile 'net.i2p.android.ext:floatingactionbutton:1.10.0'

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
@@ -102,6 +102,7 @@ public class NavigationDrawerActivity extends AnkiActivity implements Drawer.OnD
             mHeader = new AccountHeaderBuilder()
                     .withActivity(this)
                     .withHeaderBackground(ta.getResourceId(0, R.drawable.nav_drawer_logo))
+                    .withDividerBelowHeader(false)
                     .build();
         }
         // Add the items to the drawer and build it

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/NoteEditorRescheduleCard.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/NoteEditorRescheduleCard.java
@@ -24,6 +24,7 @@ public class NoteEditorRescheduleCard extends DialogFragment {
                 .positiveText(getResources().getString(R.string.dialog_ok))
                 .negativeText(R.string.cancel)
                 .inputType(InputType.TYPE_CLASS_NUMBER)
+                .inputRange(1, -1)
                 .input(R.string.reschedule_card_dialog_message, R.string.empty_string, new MaterialDialog.InputCallback() {
                     @Override
                     public void onInput(MaterialDialog dialog, CharSequence text) {


### PR DESCRIPTION
These changes allow the rendering of browser items to occur while the user is scrolling instead of having to stop scrolling completely to wait for the rendering to begin.

I also fixed a couple of minor bugs