### PR TITLE
Disable WAL by default

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDb.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDb.java
@@ -71,7 +71,11 @@ public class AnkiDb {
 
         if (mDatabase != null && AnkiDroidApp.getInstance() != null) {
             if (AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance()).getBoolean("enableWal", false)) {
-                setWalJournalMode();
+                // Compat class internally prevents WAL from getting used before API 11
+                CompatHelper.getCompat().enableDatabaseWriteAheadLogging(mDatabase);
+            } else if (CompatHelper.getCompat().isWriteAheadLoggingEnabled(mDatabase)) {
+                // Disable WAL if it's been disabled in settings but currently enabled
+                CompatHelper.getCompat().disableDatabaseWriteAheadLogging(mDatabase);
             }
             mDatabase.rawQuery("PRAGMA synchronous = 2", null);
         }
@@ -97,7 +101,9 @@ public class AnkiDb {
     public void closeDatabase() {
         if (mDatabase != null) {
             // set journal mode again to delete in order to make the db accessible for anki desktop and for full upload
-            setDeleteJournalMode();
+            if (CompatHelper.getCompat().isWriteAheadLoggingEnabled(mDatabase)) {
+                disableWriteAheadLogging();
+            }
             mDatabase.close();
             Timber.d("closeDatabase, database %s closed = %s", mDatabase.getPath(), !mDatabase.isOpen());
             mDatabase = null;
@@ -354,31 +360,7 @@ public class AnkiDb {
 
 
     /**
-     * Anki desktop only uses a journal_mode of DELETE. We therefore set this before database closure to ensure
-     * compatibility. This allows full upload to AnkiWeb and manual collection migration, but has no bearing on partial
-     * progress syncs.
-     */
-    protected void setDeleteJournalMode() {
-        disableWriteAheadLogging();
-        queryString("PRAGMA journal_mode = DELETE");
-    }
-
-
-    /** to be called for each database upon opening */
-    private void setWalJournalMode() {
-        if (CompatHelper.isHoneycomb()) {
-            queryString("PRAGMA journal_mode = WAL");
-        } else {
-            setDeleteJournalMode();
-        }
-    }
-
-
-    /**
-     * Attempts to disable write ahead logging using a method on the {@link SQLiteDatabase} object.
-     * <p>
-     * The method might not exist (it is only included in API level 16) but we attempt anyway since it is part of
-     * present in a number of implementations.
+     * Ensures no transactions are in progress and disables write ahead logging with SDK dependent implementation
      */
     private void disableWriteAheadLogging() {
         SQLiteDatabase db = getDatabase();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDb.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDb.java
@@ -69,8 +69,10 @@ public class AnkiDb {
                             | SQLiteDatabase.NO_LOCALIZED_COLLATORS);
         }
 
-        if (mDatabase != null) {
-            setWalJournalMode();
+        if (mDatabase != null && AnkiDroidApp.getInstance() != null) {
+            if (AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance()).getBoolean("enableWal", false)) {
+                setWalJournalMode();
+            }
             mDatabase.rawQuery("PRAGMA synchronous = 2", null);
         }
         // getDatabase().beginTransactionNonExclusive();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -93,7 +93,6 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
 
     /** Key of the language preference */
     public static final String LANGUAGE = "language";
-    private Collection mCol;
 
     // Other variables
     private final HashMap<String, String> mOriginalSumarries = new HashMap<>();
@@ -111,7 +110,6 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
         Themes.setThemeLegacy(this);
 
         super.onCreate(savedInstanceState);
-        mCol = CollectionHelper.getInstance().getCol(this);
 
         // Legacy code using intents instead of PreferenceFragments
         String action = getIntent().getAction();
@@ -129,6 +127,10 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
         // Add a home button to the actionbar
         getSupportActionBar().setHomeButtonEnabled(true);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+    }
+
+    private Collection getCol() {
+        return CollectionHelper.getInstance().getCol(this);
     }
 
 
@@ -268,14 +270,10 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                 Preference fullSyncPreference = screen.findPreference("force_full_sync");
                 fullSyncPreference.setOnPreferenceClickListener(new OnPreferenceClickListener() {
                     public boolean onPreferenceClick(Preference preference) {
-                        if (mCol != null && mCol.getDb() != null) {
-                            // TODO: Could be useful to show the full confirmation dialog
-                            mCol.modSchemaNoCheck();
-                            mCol.setMod();
-                            Toast.makeText(getApplicationContext(), android.R.string.ok, Toast.LENGTH_SHORT).show();
-                        } else {
-                            Toast.makeText(getApplicationContext(), R.string.vague_error, Toast.LENGTH_SHORT).show();
-                        }
+                        // TODO: Could be useful to show the full confirmation dialog
+                        getCol().modSchemaNoCheck();
+                        getCol().setMod();
+                        Toast.makeText(getApplicationContext(), android.R.string.ok, Toast.LENGTH_SHORT).show();
                         return true;
                     }
                 });
@@ -316,9 +314,10 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
     private void initPreference(Preference pref) {
         // Load stored values from Preferences which are stored in the Collection
         if (Arrays.asList(sCollectionPreferences).contains(pref.getKey())) {
-            if (mCol != null) {
+            Collection col = getCol();
+            if (col != null) {
                 try {
-                    JSONObject conf = mCol.getConf();
+                    JSONObject conf = col.getConf();
                     switch (pref.getKey()) {
                         case "showEstimates":
                             ((CheckBoxPreference)pref).setChecked(conf.getBoolean("estTimes"));
@@ -340,7 +339,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                             break;
                         case "dayOffset":
                             Calendar calendar = new GregorianCalendar();
-                            Timestamp timestamp = new Timestamp(mCol.getCrt() * 1000);
+                            Timestamp timestamp = new Timestamp(col.getCrt() * 1000);
                             calendar.setTimeInMillis(timestamp.getTime());
                             ((SeekBarPreference)pref).setValue(calendar.get(Calendar.HOUR_OF_DAY));
                             break;
@@ -400,37 +399,37 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                     }
                     break;
                 case "showProgress":
-                    mCol.getConf().put("dueCounts", ((CheckBoxPreference) pref).isChecked());
-                    mCol.setMod();
+                    getCol().getConf().put("dueCounts", ((CheckBoxPreference) pref).isChecked());
+                    getCol().setMod();
                     break;
                 case "showEstimates":
-                    mCol.getConf().put("estTimes", ((CheckBoxPreference) pref).isChecked());
-                    mCol.setMod();
+                    getCol().getConf().put("estTimes", ((CheckBoxPreference) pref).isChecked());
+                    getCol().setMod();
                     break;
                 case "newSpread":
-                    mCol.getConf().put("newSpread", Integer.parseInt(((ListPreference) pref).getValue()));
-                    mCol.setMod();
+                    getCol().getConf().put("newSpread", Integer.parseInt(((ListPreference) pref).getValue()));
+                    getCol().setMod();
                     break;
                 case "timeLimit":
-                    mCol.getConf().put("timeLim", ((NumberRangePreference) pref).getValue() * 60);
-                    mCol.setMod();
+                    getCol().getConf().put("timeLim", ((NumberRangePreference) pref).getValue() * 60);
+                    getCol().setMod();
                     break;
                 case "learnCutoff":
-                    mCol.getConf().put("collapseTime", ((NumberRangePreference) pref).getValue() * 60);
-                    mCol.setMod();
+                    getCol().getConf().put("collapseTime", ((NumberRangePreference) pref).getValue() * 60);
+                    getCol().setMod();
                     break;
                 case "useCurrent":
-                    mCol.getConf().put("addToCur", ((ListPreference) pref).getValue().equals("0"));
-                    mCol.setMod();
+                    getCol().getConf().put("addToCur", ((ListPreference) pref).getValue().equals("0"));
+                    getCol().setMod();
                     break;
                 case "dayOffset": {
                     int hours = ((SeekBarPreference) pref).getValue();
-                    Timestamp crtTime = new Timestamp(mCol.getCrt() * 1000);
+                    Timestamp crtTime = new Timestamp(getCol().getCrt() * 1000);
                     Calendar date = GregorianCalendar.getInstance();
                     date.setTimeInMillis(crtTime.getTime());
                     date.set(Calendar.HOUR_OF_DAY, hours);
-                    mCol.setCrt(date.getTimeInMillis() / 1000);
-                    mCol.setMod();
+                    getCol().setCrt(date.getTimeInMillis() / 1000);
+                    getCol().setMod();
                     break;
                 }
                 case "minimumCardsDueForNotification": {
@@ -471,6 +470,13 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                     }
                     pm.setComponentEnabledSetting(providerName, state, PackageManager.DONT_KILL_APP);
                     break;
+                }
+                case "enableWal": {
+                    if (((CheckBoxPreference) pref).isChecked()) {
+                        CompatHelper.getCompat().enableDatabaseWriteAheadLogging(getCol().getDb().getDatabase());
+                    } else {
+                        CompatHelper.getCompat().disableDatabaseWriteAheadLogging(getCol().getDb().getDatabase());
+                    }
                 }
             }
             // Update the summary text to reflect new value
@@ -663,8 +669,8 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
     private void closePreferences() {
         finish();
         ActivityTransitionAnimation.slide(this, ActivityTransitionAnimation.FADE);
-        if (mCol != null && mCol.getDb()!= null) {
-            mCol.save();
+        if (getCol() != null && getCol().getDb()!= null) {
+            getCol().save();
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
@@ -51,6 +51,8 @@ public interface Compat {
     String detagged(String txt);
     void setTtsOnUtteranceProgressListener(TextToSpeech tts);
     void disableDatabaseWriteAheadLogging(SQLiteDatabase db);
+    void enableDatabaseWriteAheadLogging(SQLiteDatabase db);
+    boolean isWriteAheadLoggingEnabled(SQLiteDatabase db);
     void enableCookiesForFileSchemePages();
     void updateWidgetDimensions(Context context, RemoteViews updateViews, Class<?> cls);
     void restartActivityInvalidateBackstack(AnkiActivity activity);

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV10.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV10.java
@@ -53,8 +53,17 @@ public class CompatV10 implements Compat {
         });
     }
 
+    public boolean isWriteAheadLoggingEnabled(SQLiteDatabase db) {
+        // don't use WAL mode on Gingerbread
+        return false;
+    }
+
+    public void enableDatabaseWriteAheadLogging(SQLiteDatabase db) {
+        // don't use WAL mode on Gingerbread
+    }
 
     public void disableDatabaseWriteAheadLogging(SQLiteDatabase db) {
+        // don't use WAL mode on Gingerbread
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV11.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV11.java
@@ -3,6 +3,9 @@ package com.ichi2.compat;
 
 import android.annotation.TargetApi;
 import android.content.Intent;
+import android.database.Cursor;
+import android.database.SQLException;
+import android.database.sqlite.SQLiteDatabase;
 import android.os.Bundle;
 import android.support.v4.app.TaskStackBuilder;
 import android.view.View;
@@ -30,4 +33,29 @@ public class CompatV11 extends CompatV10 implements Compat {
         activity.finishWithoutAnimation();
     }
 
+    @Override
+    public void enableDatabaseWriteAheadLogging(SQLiteDatabase db) {
+        db.enableWriteAheadLogging();
+    }
+
+    @Override
+    public void disableDatabaseWriteAheadLogging(SQLiteDatabase db) {
+        // disableWriteAheadLogging() method only available from API 16
+        db.rawQuery("PRAGMA journal_mode = DELETE", null);
+    }
+
+    public boolean isWriteAheadLoggingEnabled(SQLiteDatabase db) {
+        Cursor cursor = null;
+        try {
+            cursor = db.rawQuery("pragma journal_mode", null);
+            if (!cursor.moveToNext()) {
+                throw new SQLException("No result for query: pragma journal_mode");
+            }
+            return cursor.getString(0).toLowerCase().equals("wal");
+        } finally {
+            if (cursor != null) {
+                cursor.close();
+            }
+        }
+    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV16.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV16.java
@@ -32,6 +32,10 @@ public class CompatV16 extends CompatV15 implements Compat {
         db.disableWriteAheadLogging();
     }
 
+    public boolean isWriteAheadLoggingEnabled(SQLiteDatabase db) {
+        return db.isWriteAheadLoggingEnabled();
+    }
+
     /*
      *  Return the input string in a form suitable for display on a HTML page.
      *

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -113,6 +113,8 @@
     <string name="select_locale_title">Select language</string>
     <string name="safe_display">Safe display mode</string>
     <string name="safe_display_summ">Disable all animations and use safer method for drawing cards. E-ink and older devices using custom fonts may require this.</string>
+    <string name="wal_enable">Enable write-ahead-logging</string>
+    <string name="wal_enable_summ">This can reduce database latency when reviewing, but may increase the risk of errors.</string>
     <string name="vertical_centering">Center align</string>
     <string name="vertical_centering_summ">Center the content of cards vertically</string>
     <string name="pref_backup_max">Max number of backups</string>

--- a/AnkiDroid/src/main/res/xml/preferences_advanced.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_advanced.xml
@@ -40,6 +40,11 @@
                 android:title="@string/pref_backup_max"
                 app:interval="1"
                 app:min="0" />
+            <CheckBoxPreference
+                android:key="enableWal"
+                android:defaultValue="false"
+                android:summary="@string/wal_enable_summ"
+                android:title="@string/wal_enable" />
         </PreferenceCategory>
         <PreferenceCategory
             android:key="category_workarounds"


### PR DESCRIPTION
I noticed in the logcat from the crash in #3794 that AnkiDroid was having trouble changing from WAL mode to ROLLBACK. Presumably the wal file became corrupted or too big or something. This prompted me to check if there was any performance difference when reviewing on my device, and I didn't find any.

So I propose disabling WAL by default and adding a setting to re-enable it if people are actually finding AnkiDroid slower without it. If nobody finds any significant difference then we could remove the setting before releasing.

I'd like to hear opinions on this change