### PR TITLE
Fix post-sync crash on tablet

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -1589,7 +1589,9 @@ public class DeckPicker extends NavigationDrawerActivity implements
         StudyOptionsFragment details = StudyOptionsFragment.newInstance(withDeckOptions);
         FragmentTransaction ft = getSupportFragmentManager().beginTransaction();
         ft.replace(R.id.studyoptions_fragment, details);
-        ft.commit();
+        // Commit allowing state loss in case the fragment tries to update while the activity is paused
+        // (e.g., after sync). Losing state here is fine since we build a fresh fragment on resume anyway.
+        ft.commitAllowingStateLoss();
     }
 
 


### PR DESCRIPTION
Crash from acra.

My earlier change to update the fragment after sync on tablets made it crash if you close the Activity and let the sync finish in the background. Here's a fix for that.