### PR TITLE
Move collection path to advanced preferences

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -188,7 +188,9 @@ public class AnkiDroidApp extends Application {
                 CollectionHelper.initializeAnkiDroidDirectory(dir);
             } catch (StorageAccessException e) {
                 Timber.e(e, "Could not initialize AnkiDroid directory");
-                if (isSdCardMounted()) {
+                String defaultDir = CollectionHelper.getDefaultAnkiDroidDirectory();
+                if (isSdCardMounted() && CollectionHelper.getCurrentAnkiDroidDirectory(this).equals(defaultDir)) {
+                    // Don't send report if the user is using a custom directory as SD cards trip up here a lot
                     sendExceptionReport(e, "AnkiDroidApp.onCreate");
                 }
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
@@ -207,7 +207,7 @@ public class CollectionHelper {
      * external storage directory.
      * @return the folder path
      */
-    private static String getDefaultAnkiDroidDirectory() {
+    public static String getDefaultAnkiDroidDirectory() {
         return new File(Environment.getExternalStorageDirectory(), "AnkiDroid").getAbsolutePath();
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -236,21 +236,6 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                 screen = listener.getPreferenceScreen();
                 // Build languages
                 initializeLanguageDialog(screen);
-                // Check that input is valid before committing change in the collection path
-                EditTextPreference collectionPathPreference = (EditTextPreference) screen.findPreference("deckPath");
-                collectionPathPreference.setOnPreferenceChangeListener(new OnPreferenceChangeListener() {
-                    public boolean onPreferenceChange(Preference preference, final Object newValue) {
-                        final String newPath = (String) newValue;
-                        try {
-                            CollectionHelper.initializeAnkiDroidDirectory(newPath);
-                            return true;
-                        } catch (StorageAccessException e) {
-                            Timber.e(e, "Could not initialize directory: %s", newPath);
-                            Toast.makeText(getApplicationContext(), R.string.dialog_collection_path_not_dir, Toast.LENGTH_LONG).show();
-                            return false;
-                        }
-                    }
-                });
                 break;
             case "com.ichi2.anki.prefs.reviewing":
                 listener.addPreferencesFromResource(R.xml.preferences_reviewing);
@@ -266,6 +251,21 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
             case "com.ichi2.anki.prefs.advanced":
                 listener.addPreferencesFromResource(R.xml.preferences_advanced);
                 screen = listener.getPreferenceScreen();
+                // Check that input is valid before committing change in the collection path
+                EditTextPreference collectionPathPreference = (EditTextPreference) screen.findPreference("deckPath");
+                collectionPathPreference.setOnPreferenceChangeListener(new OnPreferenceChangeListener() {
+                    public boolean onPreferenceChange(Preference preference, final Object newValue) {
+                        final String newPath = (String) newValue;
+                        try {
+                            CollectionHelper.initializeAnkiDroidDirectory(newPath);
+                            return true;
+                        } catch (StorageAccessException e) {
+                            Timber.e(e, "Could not initialize directory: %s", newPath);
+                            Toast.makeText(getApplicationContext(), R.string.dialog_collection_path_not_dir, Toast.LENGTH_LONG).show();
+                            return false;
+                        }
+                    }
+                });
                 // Force full sync option
                 Preference fullSyncPreference = screen.findPreference("force_full_sync");
                 fullSyncPreference.setOnPreferenceClickListener(new OnPreferenceClickListener() {

--- a/AnkiDroid/src/main/res/xml/preferences_advanced.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_advanced.xml
@@ -26,6 +26,11 @@
     android:title="@string/pref_cat_advanced"
     android:summary="@string/pref_cat_advanced_summ"
     android:key="pref_screen_advanced">
+        <EditTextPreference
+            android:defaultValue="/sdcard/AnkiDroid"
+            android:key="deckPath"
+            android:summary="@string/preference_summary_literal"
+            android:title="@string/col_path" />
         <Preference
             android:key="force_full_sync"
             android:title="@string/force_full_sync_title"

--- a/AnkiDroid/src/main/res/xml/preferences_general.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_general.xml
@@ -22,14 +22,8 @@
 
 <!--  General Preferences -->
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://arbitrary.app.namespace/com.ichi2.anki"
     android:title="@string/pref_cat_general"
     android:summary="@string/pref_cat_general_summ" >
-    <EditTextPreference
-        android:defaultValue="/sdcard/AnkiDroid"
-        android:key="deckPath"
-        android:summary="@string/preference_summary_literal"
-        android:title="@string/col_path" />
     <Preference
         android:dialogTitle="@string/sync_account"
         android:key="syncAccount"


### PR DESCRIPTION
A user recently got confused, thinking this was the path where they need to put apkg files to import. This preference really belongs in advanced, as normal users shouldn't be touching it.

I also disabled sending exception reports when the dir fails to initialize for custom paths