### PR TITLE
Abort all DeckTasks if Col can't be opened to avoid NPE

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
@@ -226,6 +226,11 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
         sLatestInstance = this;
         mContext = AnkiDroidApp.getInstance().getApplicationContext();
 
+        // Skip the task if the collection cannot be opened
+        if (mType != TASK_TYPE_REPAIR_DECK && CollectionHelper.getInstance().getCol(mContext) == null) {
+            Timber.e("Aborting DeckTask %d as Collection could not be opened", mType);
+            return null;
+        }
         // Actually execute the task now that we are at the front of the queue.
         switch (mType) {
             case TASK_TYPE_LOAD_DECK_COUNTS:


### PR DESCRIPTION
Should avoid all crashes like [this](https://ankidroid.org/couchdb/acralyzer/_design/acralyzer/index.html#/reports-browser/ankidroid/bug/1e2b0b3d76de349d94d493e5b40b559a)