### PR TITLE
Make learn ahead limit behavior more consistent with Anki Desktop

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -605,7 +605,12 @@ public class DeckPicker extends NavigationDrawerActivity implements
             }
         } else if (requestCode == REQUEST_REVIEW && resultCode == Reviewer.RESULT_NO_MORE_CARDS) {
             // Show a message when reviewing has finished
-            showSimpleSnackbar(R.string.studyoptions_congrats_finished, false);
+            int[] studyOptionsCounts = getCol().getSched().counts();
+            if (studyOptionsCounts[0] + studyOptionsCounts[1] + studyOptionsCounts[2] == 0) {
+                showSimpleSnackbar(R.string.studyoptions_congrats_finished, false);
+            } else {
+                showSimpleSnackbar(R.string.studyoptions_no_cards_due, false);
+            }
             mCongratulationsShown = true;
         }
     }
@@ -1672,6 +1677,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
         // Get some info about the deck to handle special cases
         int pos = mDeckListAdapter.findDeckPosition(did);
         Sched.DeckDueTreeNode deckDueTreeNode = mDeckListAdapter.getDeckList().get(pos);
+        int[] studyOptionsCounts = getCol().getSched().counts();
         // Figure out what action to take
         if (getCol().getDecks().isDyn(did) || mFragmented) {
             // Go to StudyOptions screen when using filtered decks so that it's clearer to the user that it's different
@@ -1679,6 +1685,9 @@ public class DeckPicker extends NavigationDrawerActivity implements
         } else if (deckDueTreeNode.newCount + deckDueTreeNode.lrnCount + deckDueTreeNode.revCount > 0) {
             // If normal deck and there are cards to study then jump straight to the reviewer
             openReviewer();
+        } else if (studyOptionsCounts[0] + studyOptionsCounts[1] + studyOptionsCounts[2] > 0) {
+            // If there are cards due that can't be studied yet (due to the learn ahead limit) then go to study options
+            openStudyOptions(false);
         } else if (getCol().getSched().newDue() || getCol().getSched().revDue()) {
             // If there are no cards to review because of the daily study limit then give "Study more" option
             showSnackbar(R.string.studyoptions_limit_reached, false, R.string.study_more, new OnClickListener() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
@@ -30,7 +30,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.ichi2.anim.ActivityTransitionAnimation;
@@ -426,10 +425,12 @@ public class StudyOptionsFragment extends Fragment implements Toolbar.OnMenuItem
             }
         } else if (requestCode == AnkiActivity.REQUEST_REVIEW) {
             if (resultCode == Reviewer.RESULT_NO_MORE_CARDS) {
-                // If no more cards getting returned while counts > 0 then show a toast
+                // If no more cards getting returned while counts > 0 (due to learn ahead limit) then show a snackbar
                 int[] counts = getCol().getSched().counts();
-                if ((counts[0]+counts[1]+counts[2])>0) {
-                    Toast.makeText(getActivity(), R.string.studyoptions_no_cards_due , Toast.LENGTH_LONG).show();
+                if ((counts[0]+counts[1]+counts[2])>0 && mStudyOptionsView != null) {
+                    View rootLayout = mStudyOptionsView.findViewById(R.id.studyoptions_main);
+                    AnkiActivity activity = (AnkiActivity) getActivity();
+                    activity.showSnackbar(R.string.studyoptions_no_cards_due, false, 0, null, rootLayout);
                 }
             }
         } else if (requestCode == STATISTICS && mCurrentContentView == CONTENT_CONGRATS) {


### PR DESCRIPTION
Fix #3762 by opening the study options screen whenever the learn ahead limit is preventing cards from getting shown in the deck picker.