### PR TITLE
Increase height of input box in reviewer

### DIFF
--- a/AnkiDroid/src/main/assets/flashcard.css
+++ b/AnkiDroid/src/main/assets/flashcard.css
@@ -31,6 +31,7 @@ body.night_mode {
 
 #typeans {
   width: 100%;
+  height: 150%;
 }
 
 .typePrompt {


### PR DESCRIPTION
@ospalh Someone on the forum complained about the tiny input box so I'm making it bigger. I agree that it's too small as well. I don't use typing fields myself so I'm basing this on the default sizes when you add a typing field on the desktop.

On the desktop, the size of the input box in the *reviewer* is determined by the `Editing Font` field setting, which seems counter-intuitive but that's how it is. I think by default it's 20px which is also the font size in the default template.

Anyway, we don't use this value in AnkiDroid at the moment so I'm just making it arbitrarily bigger by 50%. It's a little larger but still smaller than what I get on the desktop.