### PR TITLE
300% maximum zoom for card review 

### DIFF
--- a/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
@@ -76,7 +76,7 @@
         <com.ichi2.ui.SeekBarPreference
             android:defaultValue="100"
             android:key="cardZoom"
-            android:max="150"
+            android:max="300"
             android:summary="@string/preference_summary_percentage"
             android:text=" %"
             android:title="@string/card_zoom"


### PR DESCRIPTION
Hello,
some non-Latin languages show up very small on screen. Since there is no stylesheet editor available in AnkiDroid, a zoom of up to 300% enables a much more comfortable and eye-friendly display.