### PR TITLE
Update support library versions to 23.1.1

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -42,18 +42,17 @@ play {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    // Note: support library 23.1.0 causes a crash opening prefs: https://github.com/ankidroid/Anki-Android/issues/3739
-    compile 'com.android.support:appcompat-v7:23.0.1'
+    compile 'com.android.support:appcompat-v7:23.1.1'
     // Note: the design support library can be quite buggy, so test everything thoroughly before updating it
-    compile 'com.android.support:design:23.0.1'
-    compile 'com.android.support:customtabs:23.0.1'
-    compile 'com.android.support:recyclerview-v7:23.0.1'
+    compile 'com.android.support:design:23.1.1'
+    compile 'com.android.support:customtabs:23.1.1'
+    compile 'com.android.support:recyclerview-v7:23.1.1'
     compile('com.afollestad.material-dialogs:core:0.8.5.0@aar') {
+        //exclude group: 'com.android.support'  // uncomment to force our local support lib version
         transitive = true
-        exclude group: 'com.android.support'
     }
     compile('com.mikepenz:materialdrawer:4.4.3@aar') {
-        exclude group: 'com.android.support'
+        //exclude group: 'com.android.support' // uncomment to force our local support lib version
         transitive = true
     }
     compile 'net.i2p.android.ext:floatingactionbutton:1.10.0'


### PR DESCRIPTION
v23.1.1 includes quite a few bug fixes (including the one that was causing #3739) so I think it's worth updating. Hopefully there aren't any regressions, or if there are then we can pick them up pretty quickly with the beta testing.