### PR TITLE
Reset the schedule on deck selection in deck picker

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -1688,6 +1688,8 @@ public class DeckPicker extends NavigationDrawerActivity implements
         CardBrowser.clearSelectedDeck();
         // Select the deck
         getCol().getDecks().select(did);
+        // Reset the schedule so that we get the counts for the currently selected deck
+        getCol().getSched().reset();
         mFocusedDeck = did;
         // Get some info about the deck to handle special cases
         int pos = mDeckListAdapter.findDeckPosition(did);


### PR DESCRIPTION
Fixes a bug where the count which would be shown in the study options was being loaded from the previously selected deck