### PR TITLE
Hide action bar together with system status bar in fullscreen mode

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -47,11 +47,11 @@ dependencies {
     compile 'com.android.support:design:23.1.1'
     compile 'com.android.support:customtabs:23.1.1'
     compile 'com.android.support:recyclerview-v7:23.1.1'
-    compile('com.afollestad.material-dialogs:core:0.8.5.0@aar') {
+    compile('com.afollestad.material-dialogs:core:0.8.5.1@aar') {
         //exclude group: 'com.android.support'  // uncomment to force our local support lib version
         transitive = true
     }
-    compile('com.mikepenz:materialdrawer:4.4.3@aar') {
+    compile('com.mikepenz:materialdrawer:4.4.9@aar') {
         //exclude group: 'com.android.support' // uncomment to force our local support lib version
         transitive = true
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
@@ -127,8 +127,10 @@ public class NavigationDrawerActivity extends AnkiActivity implements Drawer.OnD
 
     /** Sets selected navigation drawer item */
     protected void selectNavigationItem(int itemId) {
-        mDrawer.setSelection(itemId, false);
-        mSelectedItem = itemId;
+        if (mDrawer != null) {
+            mDrawer.setSelection(itemId, false);
+            mSelectedItem = itemId;
+        }
     }
 
 
@@ -169,12 +171,16 @@ public class NavigationDrawerActivity extends AnkiActivity implements Drawer.OnD
      * activity that extends this class.
      */
     protected void allowResizeForSoftKeyboard() {
-        mDrawer.keyboardSupportEnabled(this, true);
+        if (mDrawer != null) {
+            mDrawer.keyboardSupportEnabled(this, true);
+        }
     }
 
 
     protected void showBackIcon() {
-        mDrawer.getActionBarDrawerToggle().setDrawerIndicatorEnabled(false);
+        if (mDrawer != null) {
+            mDrawer.getActionBarDrawerToggle().setDrawerIndicatorEnabled(false);
+        }
         if (getSupportActionBar() != null) {
             getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         }
@@ -213,7 +219,11 @@ public class NavigationDrawerActivity extends AnkiActivity implements Drawer.OnD
      * The drawer layout is the parent layout for activities that use the Navigation Drawer.
      */
     public DrawerLayout getDrawerLayout() {
-        return mDrawer.getDrawerLayout();
+        if (mDrawer != null) {
+            return mDrawer.getDrawerLayout();
+        } else {
+            return null;
+        }
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -53,6 +53,7 @@ public class Reviewer extends AbstractFlashcardViewer {
     private boolean mHasDrawerSwipeConflicts = false;
     private boolean mShowWhiteboard = true;
     private boolean mBlackWhiteboard = true;
+    private boolean mPrefFullscreenReview = false;
 
     @Override
     protected void setTitle() {
@@ -92,8 +93,12 @@ public class Reviewer extends AbstractFlashcardViewer {
         disableDrawerSwipeOnConflicts();
         // Add a weak reference to current activity so that scheduler can talk to to Activity
         mSched.setContext(new WeakReference<Activity>(this));
-    }
 
+        // Set full screen/immersive mode if needed
+        if (mPrefFullscreenReview) {
+            CompatHelper.getCompat().setFullScreen(this);
+        }
+    }
 
 
     @Override
@@ -315,6 +320,7 @@ public class Reviewer extends AbstractFlashcardViewer {
         super.restorePreferences();
         SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(getBaseContext());
         mBlackWhiteboard = preferences.getBoolean("blackWhiteboard", true);
+        mPrefFullscreenReview = preferences.getBoolean("fullscreenReview", false);
         return preferences;
     }
 
@@ -423,6 +429,17 @@ public class Reviewer extends AbstractFlashcardViewer {
         // Tell the browser the current card ID so that it can tell us when we need to reload
         setCurrentCardId(mCurrentCard.getId());
         return super.onItemClick(view, i, iDrawerItem);
+    }
+
+    @Override
+    public void onWindowFocusChanged(boolean hasFocus) {
+        super.onWindowFocusChanged(hasFocus);
+        // Restore full screen once we regain focus
+        if (hasFocus) {
+            delayedHide(INITIAL_HIDE_DELAY);
+        } else {
+            mFullScreenHandler.removeMessages(0);
+        }
     }
 
     @Override

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/NoteEditorRescheduleCard.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/NoteEditorRescheduleCard.java
@@ -1,7 +1,6 @@
 
 package com.ichi2.anki.dialogs;
 
-import android.content.res.Resources;
 import android.os.Bundle;
 import android.support.v4.app.DialogFragment;
 import android.text.InputType;
@@ -24,7 +23,7 @@ public class NoteEditorRescheduleCard extends DialogFragment {
                 .positiveText(getResources().getString(R.string.dialog_ok))
                 .negativeText(R.string.cancel)
                 .inputType(InputType.TYPE_CLASS_NUMBER)
-                .inputRange(1, -1)
+                .inputRange(1, 9999)
                 .input(R.string.reschedule_card_dialog_message, R.string.empty_string, new MaterialDialog.InputCallback() {
                     @Override
                     public void onInput(MaterialDialog dialog, CharSequence text) {

--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
@@ -23,6 +23,7 @@ import android.speech.tts.TextToSpeech;
 import android.view.View;
 import android.widget.RemoteViews;
 
+import com.ichi2.anki.AbstractFlashcardViewer;
 import com.ichi2.anki.AnkiActivity;
 import com.ichi2.anki.NavigationDrawerActivity;
 
@@ -55,7 +56,7 @@ public interface Compat {
     void enableCookiesForFileSchemePages();
     void updateWidgetDimensions(Context context, RemoteViews updateViews, Class<?> cls);
     void restartActivityInvalidateBackstack(AnkiActivity activity);
-    void setFullScreen(NavigationDrawerActivity activity);
+    void setFullScreen(AbstractFlashcardViewer activity);
     void setSelectableBackground(View view);
     void openUrl(AnkiActivity activity, Uri uri);
 }

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV10.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV10.java
@@ -14,6 +14,7 @@ import android.view.View;
 import android.view.WindowManager;
 import android.widget.RemoteViews;
 
+import com.ichi2.anki.AbstractFlashcardViewer;
 import com.ichi2.anki.AnkiActivity;
 import com.ichi2.anki.DeckPicker;
 import com.ichi2.anki.NavigationDrawerActivity;
@@ -91,7 +92,7 @@ public class CompatV10 implements Compat {
     }
 
     @Override
-    public void setFullScreen(NavigationDrawerActivity activity) {
+    public void setFullScreen(AbstractFlashcardViewer activity) {
         activity.getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN,
                 WindowManager.LayoutParams.FLAG_FULLSCREEN);
     }

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV11.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV11.java
@@ -8,11 +8,8 @@ import android.database.SQLException;
 import android.database.sqlite.SQLiteDatabase;
 import android.os.Bundle;
 import android.support.v4.app.TaskStackBuilder;
-import android.view.View;
 
 import com.ichi2.anki.AnkiActivity;
-
-import java.text.Normalizer;
 
 import timber.log.Timber;
 

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV19.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV19.java
@@ -1,33 +1,86 @@
 
 package com.ichi2.compat;
 
+import android.animation.Animator;
+import android.animation.AnimatorListenerAdapter;
 import android.annotation.TargetApi;
+import android.content.res.Resources;
 import android.support.v4.widget.DrawerLayout;
+import android.support.v7.widget.Toolbar;
 import android.view.View;
+import android.widget.RelativeLayout;
 
+import com.ichi2.anki.AbstractFlashcardViewer;
 import com.ichi2.anki.NavigationDrawerActivity;
+import com.ichi2.anki.R;
 
 /** Implementation of {@link Compat} for SDK level 19 */
 @TargetApi(19)
 public class CompatV19 extends CompatV16 implements Compat {
+    private static final int ANIMATION_DURATION = 200;
 
     @Override
-    public void setFullScreen(NavigationDrawerActivity activity) {
-        // This setting is enabled on Navigation Drawer activities in order to correctly
-        // display the status bar. Having it enabled prevents the window from consuming
-        // all the space made available when hiding the system UI, so we turn it off here.
-        // Since we are hiding the status bar, there is no problem with turning this off.
-        DrawerLayout drawerLayout = activity.getDrawerLayout();
-        if (drawerLayout != null) {
-            drawerLayout.setFitsSystemWindows(false);
-        }
+    public void setFullScreen(final AbstractFlashcardViewer a) {
         // Set appropriate flags to enable Sticky Immersive mode.
-        activity.getWindow().getDecorView().setSystemUiVisibility(
+        a.getWindow().getDecorView().setSystemUiVisibility(
                         View.SYSTEM_UI_FLAG_LAYOUT_STABLE
                         | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
                         | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
                         | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
                         | View.SYSTEM_UI_FLAG_FULLSCREEN
-                        | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
+                        | View.SYSTEM_UI_FLAG_LOW_PROFILE
+                        | View.SYSTEM_UI_FLAG_IMMERSIVE);
+
+        // Hack required by MaterialDrawer library to get the Toolbar to display correctly in fullscreen mode
+        Resources res = a.getResources();
+        a.findViewById(R.id.main_layout).setFitsSystemWindows(true);
+        int topMargin = (int) res.getDimension(R.dimen.tool_bar_top_padding);
+        RelativeLayout.LayoutParams lp = (RelativeLayout.LayoutParams)a.findViewById(R.id.toolbar).getLayoutParams();
+        lp.setMargins(0, topMargin, 0, 0);
+        a.findViewById(R.id.toolbar).setLayoutParams(lp);
+
+        // Show / hide the Action bar together with the status bar
+        View decorView = a.getWindow().getDecorView();
+        decorView.setOnSystemUiVisibilityChangeListener
+                (new View.OnSystemUiVisibilityChangeListener() {
+                    @Override
+                    public void onSystemUiVisibilityChange(int flags) {
+                        final Toolbar toolbar = (Toolbar) a.findViewById(R.id.toolbar);
+                        final RelativeLayout topbar = (RelativeLayout) a.findViewById(R.id.top_bar);
+                        if (toolbar == null || topbar == null) {
+                            return;
+                        }
+                        // Note that system bars will only be "visible" if none of the
+                        // LOW_PROFILE, HIDE_NAVIGATION, or FULLSCREEN flags are set.
+                        boolean visible = (flags & View.SYSTEM_UI_FLAG_HIDE_NAVIGATION) == 0;
+                        if (visible) {
+                            toolbar.setAlpha(0.0f);
+                            toolbar.setVisibility(View.VISIBLE);
+                            toolbar.animate().alpha(1f).setDuration(ANIMATION_DURATION).setListener(null);
+                            topbar.setAlpha(0.0f);
+                            topbar.setVisibility(View.VISIBLE);
+                            topbar.animate().alpha(1f).setDuration(ANIMATION_DURATION).setListener(null);
+                        } else {
+                            toolbar.animate()
+                                    .alpha(0f)
+                                    .setDuration(ANIMATION_DURATION)
+                                    .setListener(new AnimatorListenerAdapter() {
+                                        @Override
+                                        public void onAnimationEnd(Animator animation) {
+                                            toolbar.setVisibility(View.GONE);
+                                        }
+                                    });
+                            topbar.animate()
+                                    .alpha(0f)
+                                    .setDuration(ANIMATION_DURATION)
+                                    .setListener(new AnimatorListenerAdapter() {
+                                        @Override
+                                        public void onAnimationEnd(Animator animation) {
+                                            topbar.setVisibility(View.GONE);
+                                        }
+                                    });
+                        }
+                    }
+                });
     }
 }


### PR DESCRIPTION
I finally got something working after the discussion in #3850

It was a real pain to figure it out... You have to add an extra padding to the toolbar when fullscreen is enabled. It took me hours to figure this out. The behavior appears to be a "feature" rather than a bug in the MaterialDrawer library. We should probably just switch back to the design support library at some point.