### PR TITLE
Completely remove WAL

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -471,13 +471,6 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                     pm.setComponentEnabledSetting(providerName, state, PackageManager.DONT_KILL_APP);
                     break;
                 }
-                case "enableWal": {
-                    if (((CheckBoxPreference) pref).isChecked()) {
-                        CompatHelper.getCompat().enableDatabaseWriteAheadLogging(getCol().getDb().getDatabase());
-                    } else {
-                        CompatHelper.getCompat().disableDatabaseWriteAheadLogging(getCol().getDb().getDatabase());
-                    }
-                }
             }
             // Update the summary text to reflect new value
             updateSummary(pref);

--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
@@ -50,7 +50,6 @@ public interface Compat {
     String detagged(String txt);
     void setTtsOnUtteranceProgressListener(TextToSpeech tts);
     void disableDatabaseWriteAheadLogging(SQLiteDatabase db);
-    void enableDatabaseWriteAheadLogging(SQLiteDatabase db);
     boolean isWriteAheadLoggingEnabled(SQLiteDatabase db);
     void enableCookiesForFileSchemePages();
     void updateWidgetDimensions(Context context, RemoteViews updateViews, Class<?> cls);

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV10.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV10.java
@@ -58,10 +58,6 @@ public class CompatV10 implements Compat {
         return false;
     }
 
-    public void enableDatabaseWriteAheadLogging(SQLiteDatabase db) {
-        // don't use WAL mode on Gingerbread
-    }
-
     public void disableDatabaseWriteAheadLogging(SQLiteDatabase db) {
         // don't use WAL mode on Gingerbread
     }

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV11.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV11.java
@@ -34,11 +34,6 @@ public class CompatV11 extends CompatV10 implements Compat {
     }
 
     @Override
-    public void enableDatabaseWriteAheadLogging(SQLiteDatabase db) {
-        db.enableWriteAheadLogging();
-    }
-
-    @Override
     public void disableDatabaseWriteAheadLogging(SQLiteDatabase db) {
         // disableWriteAheadLogging() method only available from API 16
         db.rawQuery("PRAGMA journal_mode = DELETE", null);

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -113,8 +113,6 @@
     <string name="select_locale_title">Select language</string>
     <string name="safe_display">Safe display mode</string>
     <string name="safe_display_summ">Disable all animations and use safer method for drawing cards. E-ink and older devices using custom fonts may require this.</string>
-    <string name="wal_enable">Enable write-ahead-logging</string>
-    <string name="wal_enable_summ">This can reduce database latency when reviewing, but may increase the risk of errors.</string>
     <string name="vertical_centering">Center align</string>
     <string name="vertical_centering_summ">Center the content of cards vertically</string>
     <string name="pref_backup_max">Max number of backups</string>

--- a/AnkiDroid/src/main/res/xml/preferences_advanced.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_advanced.xml
@@ -45,11 +45,6 @@
                 android:title="@string/pref_backup_max"
                 app:interval="1"
                 app:min="0" />
-            <CheckBoxPreference
-                android:key="enableWal"
-                android:defaultValue="false"
-                android:summary="@string/wal_enable_summ"
-                android:title="@string/wal_enable" />
         </PreferenceCategory>
         <PreferenceCategory
             android:key="category_workarounds"


### PR DESCRIPTION
@hssm 
There's no evidence of any issues obviously caused by changing the rollback mode in the crash logs, and I haven't noticed any performance degradation (nor has anyone complained of one), so I propose that we go ahead and just gut the WAL stuff if there are no objections. 

I'm pretty confident that it won't cause any issues, and going back over the git logs it seemed that it was just introduced because it "might" improve performance. I haven't seen any benchmarks (or even anecdotal evidence) to justify having it, and IMO it just adds one extra level of complexity that we don't need (i.e. in switching it on and off every time we open the DB) .

I'll wait for a review on this change and the other PR, and maybe we can call the next beta RC1