### PR TITLE
Limit tags in custom study dialog to those in the selected deck

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
@@ -140,9 +140,10 @@ public class CustomStudyDialog extends DialogFragment {
                                  * number, it is necessary to collect a list of tags. This case handles the creation
                                  * of that Dialog.
                                  */
+                                long currentDeck = getArguments().getLong("did");
                                 TagsDialog dialogFragment = TagsDialog.newInstance(
                                         TagsDialog.TYPE_CUSTOM_STUDY_TAGS, new ArrayList<String>(),
-                                        new ArrayList<>(activity.getCol().getTags().all()));
+                                        new ArrayList<>(activity.getCol().getTags().byDeck(currentDeck, true)));
                                 dialogFragment.setTagsDialogListener(new TagsDialog.TagsDialogListener() {
                                     @Override
                                     public void onPositive(List<String> selectedTags, int option) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Tags.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Tags.java
@@ -180,6 +180,31 @@ public class Tags {
 
 
     /**
+    * byDeck returns the tags of the cards in the deck
+    * @param did the deck id
+    * @param children whether to include the deck's children
+    * @return a list of the tags
+    */
+    public ArrayList<String> byDeck(long did, boolean children) {
+        String sql;
+        if (children) {
+            ArrayList<Long> dids = new ArrayList<Long>();
+            dids.add(did);
+            for (long id : mCol.getDecks().children(did).values()) {
+                dids.add(id);
+            }
+            sql = "SELECT DISTINCT n.tags FROM cards c, notes n WHERE c.nid = n.id AND c.did IN " + Utils.ids2str(Utils.arrayList2array(dids));
+        } else {
+            sql = "SELECT DISTINCT n.tags FROM cards c, notes n WHERE c.nid = n.id AND c.did = " + did;
+        }
+        List<String> tags = mCol.getDb().queryColumn(String.class, sql, 0);
+        // Cast to set to remove duplicates
+        // Use methods used to get all tags to parse tags here as well.
+        return new ArrayList<String>(new HashSet<String>(split(TextUtils.join(" ", tags))));
+    }
+
+
+    /**
      * Bulk addition/removal from notes
      * ***********************************************************
      */


### PR DESCRIPTION
This PR is mainly looking to fix https://github.com/ankidroid/Anki-Android/issues/3791.

Some issues I discovered along the way:

1. Tags seem to be quite weird. I have a deck that has tags separated with space. I'm not sure how anki wants to differentiate through tags(I'm guessing anki uses spaces and the author wanted to use tags containing spaces). They do get saved properly in the database, but I am unable to create a deck from them. If anki does not allow spaces in tags I guess it's just a limitation that the author wasn't aware of, if not, this might be a bug.

2. I'm trying to use `activity.getCol().getDecks().selected();` to get the current deck id, but it doesn't seem to work properly. I need to start reviews in a deck for it to be considered selected. 
For example:
  - Make reviews in deck A
  - Long press deck B and try to filter through it's tags
  - A's tags show up

Until 2 is somehow fixed, I think it'd be a bad idea to merge this since it's rather confusing.

Also I'm sorry for any bad practices regarding java, I haven't written any in quite a while. I'm open to any suggestions.