### PR TITLE
Remove material drawer depenency

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -50,10 +50,6 @@ dependencies {
         //exclude group: 'com.android.support'  // uncomment to force our local support lib version
         transitive = true
     }
-    compile('com.mikepenz:materialdrawer:4.4.9@aar') {
-        //exclude group: 'com.android.support' // uncomment to force our local support lib version
-        transitive = true
-    }
     compile 'com.getbase:floatingactionbutton:1.10.1'
     compile 'ch.acra:acra:4.6.2'
     compile 'com.jakewharton.timber:timber:2.7.1'

--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -187,7 +187,7 @@
         <activity
             android:name="com.ichi2.anki.Reviewer"
             android:configChanges="keyboardHidden|orientation|locale|screenSize"
-            android:windowSoftInputMode="stateAlwaysHidden"
+            android:windowSoftInputMode="adjustResize"
             android:parentActivityName=".DeckPicker">
             <!-- The meta-data element is needed for versions lower than 4.1 -->
             <meta-data

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -843,9 +843,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
         // create inherited navigation drawer layout here so that it can be used by parent class
         setContentView(R.layout.flashcard);
         View mainView = findViewById(android.R.id.content);
-        initNavigationDrawer(mainView, mPrefFullscreenReview);
-        // Ensure software keyboard resizes the screen when used in typing fields
-        allowResizeForSoftKeyboard();
+        initNavigationDrawer(mainView);
         // Load the collection
         startLoadingCollection();
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -598,7 +598,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
     protected void onResume() {
         Timber.d("onResume()");
         super.onResume();
-        selectNavigationItem(DRAWER_BROWSER);
+        selectNavigationItem(R.id.nav_browser);
     }
 
 
@@ -656,6 +656,9 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
+        if (getDrawerToggle().onOptionsItemSelected(item)) {
+            return true;
+        }
         switch (item.getItemId()) {
 
             case R.id.action_add_card_from_card_browser:

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -553,6 +553,9 @@ public class DeckPicker extends NavigationDrawerActivity implements
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         Resources res = getResources();
+        if (getDrawerToggle().onOptionsItemSelected(item)) {
+            return true;
+        }
         switch (item.getItemId()) {
 
             case R.id.action_undo:
@@ -702,7 +705,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
             sync();
             mSyncOnResume = false;
         } else if (colIsOpen()) {
-            selectNavigationItem(DRAWER_DECK_PICKER);
+            selectNavigationItem(R.id.nav_decks);
             updateDeckList();
             setTitle(getResources().getString(R.string.app_name));
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -41,7 +41,6 @@ import com.ichi2.compat.CompatHelper;
 import com.ichi2.libanki.Collection;
 import com.ichi2.themes.Themes;
 import com.ichi2.widget.WidgetStatus;
-import com.mikepenz.materialdrawer.model.interfaces.IDrawerItem;
 
 import org.json.JSONException;
 
@@ -103,6 +102,9 @@ public class Reviewer extends AbstractFlashcardViewer {
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
+        if (getDrawerToggle().onOptionsItemSelected(item)) {
+            return true;
+        }
         switch (item.getItemId()) {
 
             case android.R.id.home:
@@ -433,12 +435,12 @@ public class Reviewer extends AbstractFlashcardViewer {
     }
 
     @Override
-    public boolean onItemClick(View view, int i, IDrawerItem iDrawerItem) {
+    public boolean onNavigationItemSelected(MenuItem item) {
         // Tell the browser the current card ID so that it can tell us when we need to reload
         if (mCurrentCard != null) {
             setCurrentCardId(mCurrentCard.getId());
         }
-        return super.onItemClick(view, i, iDrawerItem);
+        return super.onNavigationItemSelected(item);
     }
 
     @Override

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.java
@@ -169,7 +169,7 @@ public class Statistics extends NavigationDrawerActivity implements
     @Override
     protected void onResume() {
         Timber.d("onResume()");
-        selectNavigationItem(DRAWER_STATISTICS);
+        selectNavigationItem(R.id.nav_stats);
         super.onResume();
     }
 
@@ -211,6 +211,9 @@ public class Statistics extends NavigationDrawerActivity implements
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
+        if (getDrawerToggle().onOptionsItemSelected(item)) {
+            return true;
+        }
         int itemId =item.getItemId();
         switch (itemId) {
             case R.id.item_time_month:

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.java
@@ -69,6 +69,9 @@ public class StudyOptionsActivity extends NavigationDrawerActivity implements St
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
+        if (getDrawerToggle().onOptionsItemSelected(item)) {
+            return true;
+        }
         switch (item.getItemId()) {
 
             case android.R.id.home:

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV19.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV19.java
@@ -31,15 +31,6 @@ public class CompatV19 extends CompatV16 implements Compat {
                         | View.SYSTEM_UI_FLAG_FULLSCREEN
                         | View.SYSTEM_UI_FLAG_LOW_PROFILE
                         | View.SYSTEM_UI_FLAG_IMMERSIVE);
-
-        // Hack required by MaterialDrawer library to get the Toolbar to display correctly in fullscreen mode
-        Resources res = a.getResources();
-        a.findViewById(R.id.main_layout).setFitsSystemWindows(true);
-        int topMargin = (int) res.getDimension(R.dimen.tool_bar_top_padding);
-        RelativeLayout.LayoutParams lp = (RelativeLayout.LayoutParams)a.findViewById(R.id.toolbar).getLayoutParams();
-        lp.setMargins(0, topMargin, 0, 0);
-        a.findViewById(R.id.toolbar).setLayoutParams(lp);
-
         // Show / hide the Action bar together with the status bar
         SharedPreferences prefs = AnkiDroidApp.getSharedPrefs(a);
         final int fullscreenMode = Integer.parseInt(prefs.getString("fullscreenMode", "0"));
@@ -52,12 +43,14 @@ public class CompatV19 extends CompatV16 implements Compat {
                         final LinearLayout answerButtons = (LinearLayout) a.findViewById(
                                 R.id.answer_options_layout);
                         final RelativeLayout topbar = (RelativeLayout) a.findViewById(R.id.top_bar);
+                        //final DrawerLayout drawerLayout = (DrawerLayout) a.findViewById(R.id.drawer_layout);
                         if (toolbar == null || topbar == null || answerButtons == null) {
                             return;
                         }
                         // Note that system bars will only be "visible" if none of the
                         // LOW_PROFILE, HIDE_NAVIGATION, or FULLSCREEN flags are set.
                         boolean visible = (flags & View.SYSTEM_UI_FLAG_HIDE_NAVIGATION) == 0;
+                        //drawerLayout.setFitsSystemWindows(visible);
                         if (visible) {
                             toolbar.setAlpha(0.0f);
                             toolbar.setVisibility(View.VISIBLE);

--- a/AnkiDroid/src/main/res/drawable/launch_screen.xml
+++ b/AnkiDroid/src/main/res/drawable/launch_screen.xml
@@ -1,6 +1,6 @@
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android" android:opacity="opaque">
   <!-- The background color, preferably the same as your normal theme -->
-  <item android:drawable="@color/material_drawer_dark_background"/>
+  <item android:drawable="@color/material_theme_grey"/>
   <!-- Your product logo - 144dp color version of your app icon -->
   <item>
     <bitmap

--- a/AnkiDroid/src/main/res/layout-xlarge/homescreen.xml
+++ b/AnkiDroid/src/main/res/layout-xlarge/homescreen.xml
@@ -1,18 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
-    android:id="@+id/deckpicker_view"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent"
-    android:background="?android:attr/colorBackground"
-    android:orientation="horizontal"
-    xmlns:android="http://schemas.android.com/apk/res/android">
-    <include layout="@layout/deck_picker"
-             android:layout_width="0dip"
-             android:layout_weight="3"
-             android:layout_height="match_parent"/>
-    <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                 android:id="@+id/studyoptions_fragment"
-                 android:layout_weight="2"
-                 android:layout_width="0dip"
-                 android:layout_height="fill_parent"/>
-</LinearLayout>
+<android.support.v4.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        android:id="@+id/drawer_layout"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="?android:attr/colorBackground"
+        android:fitsSystemWindows="true">
+    <LinearLayout
+            android:id="@+id/deckpicker_view"
+            android:layout_width="fill_parent"
+            android:layout_height="fill_parent"
+            android:background="?android:attr/colorBackground"
+            android:orientation="horizontal">
+        <include layout="@layout/deck_picker"
+                     android:layout_width="0dip"
+                     android:layout_weight="3"
+                     android:layout_height="match_parent"/>
+        <FrameLayout
+                     android:id="@+id/studyoptions_fragment"
+                     android:layout_weight="2"
+                     android:layout_width="0dip"
+                     android:layout_height="fill_parent"/>
+    </LinearLayout>
+    <include layout="@layout/navigation_drawer" />
+</android.support.v4.widget.DrawerLayout>
+

--- a/AnkiDroid/src/main/res/layout/activity_anki_stats.xml
+++ b/AnkiDroid/src/main/res/layout/activity_anki_stats.xml
@@ -1,26 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout
-	android:id="@+id/root_layout"
-	android:layout_width="fill_parent"
-	android:layout_height="fill_parent"
-	xmlns:android="http://schemas.android.com/apk/res/android"
-	xmlns:tools="http://schemas.android.com/tools">
-	<LinearLayout android:layout_width="match_parent"
-		android:layout_height="match_parent"
-		android:orientation="vertical">
-
-		<include layout="@layout/toolbar" />
-
-		<com.ichi2.ui.SlidingTabLayout
-			android:id="@+id/sliding_tabs"
-			android:layout_width="match_parent"
-			android:layout_height="wrap_content"/>
-
-		<android.support.v4.view.ViewPager
-			android:id="@+id/pager"
-			android:layout_width="match_parent"
+<android.support.v4.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
+	xmlns:tools="http://schemas.android.com/tools"
+	android:id="@+id/drawer_layout"
+	android:layout_width="match_parent"
+	android:layout_height="match_parent"
+	android:background="?android:attr/colorBackground"
+	android:fitsSystemWindows="true">
+	<android.support.design.widget.CoordinatorLayout
+		android:id="@+id/root_layout"
+		android:layout_width="fill_parent"
+		android:layout_height="fill_parent">
+		<LinearLayout android:layout_width="match_parent"
 			android:layout_height="match_parent"
-			tools:context=".Statistics"/>
-	</LinearLayout>
-	<include layout="@layout/anki_progress"/>
-</android.support.design.widget.CoordinatorLayout>
+			android:orientation="vertical">
+
+			<include layout="@layout/toolbar" />
+
+			<com.ichi2.ui.SlidingTabLayout
+				android:id="@+id/sliding_tabs"
+				android:layout_width="match_parent"
+				android:layout_height="wrap_content"/>
+
+			<android.support.v4.view.ViewPager
+				android:id="@+id/pager"
+				android:layout_width="match_parent"
+				android:layout_height="match_parent"
+				tools:context=".Statistics"/>
+		</LinearLayout>
+		<include layout="@layout/anki_progress"/>
+	</android.support.design.widget.CoordinatorLayout>
+	<include layout="@layout/navigation_drawer" />
+</android.support.v4.widget.DrawerLayout>

--- a/AnkiDroid/src/main/res/layout/card_browser.xml
+++ b/AnkiDroid/src/main/res/layout/card_browser.xml
@@ -1,46 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout
-    android:id="@+id/root_layout"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent"
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
-    <LinearLayout
+<android.support.v4.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/drawer_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="?android:attr/colorBackground"
+    android:fitsSystemWindows="true">
+    <android.support.design.widget.CoordinatorLayout
+        android:id="@+id/root_layout"
         android:layout_width="fill_parent"
-        android:layout_height="fill_parent"
-        android:orientation="vertical" >
-
-        <include layout="@layout/toolbar" />
-
+        android:layout_height="fill_parent">
         <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="?android:attr/colorBackground"
-            android:orientation="horizontal" >
-
-            <Spinner
-                android:id="@+id/browser_column1_spinner"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                app:popupTheme="?attr/actionBarPopupThemeRef"/>
-
-            <Spinner
-                android:id="@+id/browser_column2_spinner"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                app:popupTheme="?attr/actionBarPopupThemeRef"/>
-        </LinearLayout>
-
-        <ListView
-            android:id="@+id/card_browser_list"
             android:layout_width="fill_parent"
             android:layout_height="fill_parent"
-            android:background="?android:attr/colorBackground"
-            android:drawSelectorOnTop="true"
-            android:fastScrollEnabled="true" />
+            android:orientation="vertical" >
 
-    </LinearLayout>
-    <include layout="@layout/anki_progress"/>
-</android.support.design.widget.CoordinatorLayout>
+            <include layout="@layout/toolbar" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="?android:attr/colorBackground"
+                android:orientation="horizontal" >
+
+                <Spinner
+                    android:id="@+id/browser_column1_spinner"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    app:popupTheme="?attr/actionBarPopupThemeRef"/>
+
+                <Spinner
+                    android:id="@+id/browser_column2_spinner"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    app:popupTheme="?attr/actionBarPopupThemeRef"/>
+            </LinearLayout>
+
+            <ListView
+                android:id="@+id/card_browser_list"
+                android:layout_width="fill_parent"
+                android:layout_height="fill_parent"
+                android:background="?android:attr/colorBackground"
+                android:drawSelectorOnTop="true"
+                android:fastScrollEnabled="true" />
+
+        </LinearLayout>
+        <include layout="@layout/anki_progress"/>
+    </android.support.design.widget.CoordinatorLayout>
+    <include layout="@layout/navigation_drawer" />
+</android.support.v4.widget.DrawerLayout>

--- a/AnkiDroid/src/main/res/layout/deck_picker.xml
+++ b/AnkiDroid/src/main/res/layout/deck_picker.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout
+<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/root_layout"
     android:layout_width="fill_parent"
-    android:layout_height="fill_parent"
-    xmlns:android="http://schemas.android.com/apk/res/android">
+    android:layout_height="fill_parent">
     <RelativeLayout
         android:id="@+id/deckpicker_view"
         android:layout_width="fill_parent"
@@ -36,4 +35,3 @@
     <include layout="@layout/anki_progress"/>
     <include layout="@layout/floating_add_button"/>
 </android.support.design.widget.CoordinatorLayout>
-

--- a/AnkiDroid/src/main/res/layout/flashcard.xml
+++ b/AnkiDroid/src/main/res/layout/flashcard.xml
@@ -19,260 +19,267 @@
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<android.support.design.widget.CoordinatorLayout
-    android:id="@+id/root_layout"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent"
-    android:focusableInTouchMode="true"
-    xmlns:android="http://schemas.android.com/apk/res/android">
-    <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        android:id="@+id/main_layout"
+<android.support.v4.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/drawer_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="?android:attr/colorBackground"
+    android:fitsSystemWindows="true">
+    <android.support.design.widget.CoordinatorLayout
+        android:id="@+id/root_layout"
         android:layout_width="fill_parent"
-        android:layout_height="fill_parent">
-
-        <include layout="@layout/toolbar" />
-
-        <!-- Top bar -->
-
+        android:layout_height="fill_parent"
+        android:focusableInTouchMode="true">
         <RelativeLayout
-            android:id="@+id/top_bar"
+            android:id="@+id/main_layout"
             android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:paddingLeft="9dp"
-            android:paddingRight="10dp"
-            android:paddingTop="2dp"
-            android:paddingBottom="3dp"
-            android:gravity="center_vertical"
-            android:background="?attr/topBarColor"
-            android:layout_below="@+id/toolbar">
+            android:layout_height="fill_parent">
 
-            <TextView
-                android:id="@+id/new_number"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text=""
-                android:textColor="?attr/newCountColor"
-                android:textSize="14sp" />
+            <include layout="@layout/toolbar" />
 
-            <TextView
-                android:id="@+id/learn_number"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_toRightOf="@+id/new_number"
-                android:paddingLeft="8dp"
-                android:text=""
-                android:textColor="?attr/learnCountColor"
-                android:textSize="14sp" />
-
-            <TextView
-                android:id="@+id/review_number"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_toRightOf="@+id/learn_number"
-                android:paddingLeft="8dp"
-                android:text=""
-                android:textColor="?attr/reviewCountColor"
-                android:textSize="14sp" />
-
-            <TextView
-                android:id="@+id/choosen_answer"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_centerHorizontal="true"
-                android:gravity="center"
-                android:text=""
-                android:textSize="14sp" />
-
-            <Chronometer
-                android:id="@+id/card_time"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignParentRight="true"
-                android:gravity="center"
-                android:textSize="14sp"
-                android:visibility="invisible" />
-        </RelativeLayout>
-        <!-- Card and whiteboard -->
-
-        <FrameLayout
-            android:id="@+id/flashcard_frame"
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent"
-            android:layout_above="@+id/bottom_area_layout"
-            android:layout_below="@+id/top_bar"
-            android:layout_margin="0dip" >
-
-            <FrameLayout
-                android:id="@+id/flashcard"
-                android:layout_width="fill_parent"
-                android:layout_height="fill_parent" />
+            <!-- Top bar -->
 
             <RelativeLayout
+                android:id="@+id/top_bar"
                 android:layout_width="fill_parent"
-                android:layout_height="fill_parent" >
+                android:layout_height="wrap_content"
+                android:paddingLeft="9dp"
+                android:paddingRight="10dp"
+                android:paddingTop="2dp"
+                android:paddingBottom="3dp"
+                android:gravity="center_vertical"
+                android:background="?attr/topBarColor"
+                android:layout_below="@+id/toolbar">
 
-                <FrameLayout
-                    android:id="@+id/touch_layer"
-                    android:layout_width="fill_parent"
-                    android:layout_height="fill_parent"
-                    android:layout_marginBottom="20dip"
-                    android:layout_marginTop="20dip"
-                    android:longClickable="true" />
+                <TextView
+                    android:id="@+id/new_number"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text=""
+                    android:textColor="?attr/newCountColor"
+                    android:textSize="14sp" />
 
-                <ProgressBar
-                    android:id="@+id/flashcard_progressbar"
-                    style="@android:style/Widget.ProgressBar.Small"
+                <TextView
+                    android:id="@+id/learn_number"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_toRightOf="@+id/new_number"
+                    android:paddingLeft="8dp"
+                    android:text=""
+                    android:textColor="?attr/learnCountColor"
+                    android:textSize="14sp" />
+
+                <TextView
+                    android:id="@+id/review_number"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_toRightOf="@+id/learn_number"
+                    android:paddingLeft="8dp"
+                    android:text=""
+                    android:textColor="?attr/reviewCountColor"
+                    android:textSize="14sp" />
+
+                <TextView
+                    android:id="@+id/choosen_answer"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_centerHorizontal="true"
+                    android:gravity="center"
+                    android:text=""
+                    android:textSize="14sp" />
+
+                <Chronometer
+                    android:id="@+id/card_time"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_alignParentRight="true"
-                    android:layout_margin="9.3333dip"
-                    android:clickable="false"
-                    android:focusable="false"
-                    android:indeterminate="true"
+                    android:gravity="center"
+                    android:textSize="14sp"
                     android:visibility="invisible" />
             </RelativeLayout>
+            <!-- Card and whiteboard -->
 
             <FrameLayout
-                android:id="@+id/whiteboard"
+                android:id="@+id/flashcard_frame"
                 android:layout_width="fill_parent"
-                android:layout_height="fill_parent" />
+                android:layout_height="fill_parent"
+                android:layout_above="@+id/bottom_area_layout"
+                android:layout_below="@+id/top_bar"
+                android:layout_margin="0dip" >
 
-            <ImageView
-                android:id="@+id/lookup_button"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="right"
-                android:clickable="true"
-                android:padding="5dip"
-                android:src="@drawable/ic_lookup"
-                android:visibility="gone"
-                android:contentDescription="@string/lookup_button_content" />
-        </FrameLayout>
-
-        <LinearLayout
-            android:id="@+id/bottom_area_layout"
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:layout_alignParentBottom="true"
-            android:orientation="vertical" >
-
-            <!-- Answer bar -->
-
-            <EditText
-                android:id="@+id/answer_field"
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
-                android:hint="@string/type_answer_hint"
-                android:imeOptions="actionDone"
-                android:inputType="text|textNoSuggestions" />
-            <!--
-                 Looks like setting android:imeActionLabel confuses the
-                 original AOSP soft keyboard, so don't.
-            -->
-
-            <LinearLayout
-                android:id="@+id/answer_options_layout"
-                android:layout_width="fill_parent"
-                android:layout_height="fill_parent">
-
-                <LinearLayout
-                    android:id="@+id/flashcard_layout_flip"
+                <FrameLayout
+                    android:id="@+id/flashcard"
                     android:layout_width="fill_parent"
-                    android:layout_height="@dimen/touch_target"
-                    android:layout_weight="1"
-                    android:orientation="vertical" >
+                    android:layout_height="fill_parent" />
 
-                    <Button
-                        style="@style/FooterButtonLayout"
-                        android:background="?attr/hardButtonRef"
-                        android:id="@+id/flip_card"
+                <RelativeLayout
+                    android:layout_width="fill_parent"
+                    android:layout_height="fill_parent" >
+
+                    <FrameLayout
+                        android:id="@+id/touch_layer"
                         android:layout_width="fill_parent"
                         android:layout_height="fill_parent"
+                        android:layout_marginBottom="20dip"
+                        android:layout_marginTop="20dip"
+                        android:longClickable="true" />
+
+                    <ProgressBar
+                        android:id="@+id/flashcard_progressbar"
+                        style="@android:style/Widget.ProgressBar.Small"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_alignParentRight="true"
+                        android:layout_margin="9.3333dip"
                         android:clickable="false"
-                        android:text="@string/show_answer" />
-                </LinearLayout>
+                        android:focusable="false"
+                        android:indeterminate="true"
+                        android:visibility="invisible" />
+                </RelativeLayout>
+
+                <FrameLayout
+                    android:id="@+id/whiteboard"
+                    android:layout_width="fill_parent"
+                    android:layout_height="fill_parent" />
+
+                <ImageView
+                    android:id="@+id/lookup_button"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="right"
+                    android:clickable="true"
+                    android:padding="5dip"
+                    android:src="@drawable/ic_lookup"
+                    android:visibility="gone"
+                    android:contentDescription="@string/lookup_button_content" />
+            </FrameLayout>
+
+            <LinearLayout
+                android:id="@+id/bottom_area_layout"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:layout_alignParentBottom="true"
+                android:orientation="vertical" >
+
+                <!-- Answer bar -->
+
+                <EditText
+                    android:id="@+id/answer_field"
+                    android:layout_width="fill_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/type_answer_hint"
+                    android:imeOptions="actionDone"
+                    android:inputType="text|textNoSuggestions" />
+                <!--
+                     Looks like setting android:imeActionLabel confuses the
+                     original AOSP soft keyboard, so don't.
+                -->
 
                 <LinearLayout
-                    style="@style/FooterButtonLayout"
-                    android:background="?attr/againButtonRef"
-                    android:id="@+id/flashcard_layout_ease1"
-                    android:layout_width="0dip"
-                    android:layout_height="@dimen/touch_target"
-                    android:layout_weight="1"
-                    android:orientation="vertical"
-                    android:visibility="gone" >
+                    android:id="@+id/answer_options_layout"
+                    android:layout_width="fill_parent"
+                    android:layout_height="fill_parent">
 
-                    <TextView
-                            android:id="@+id/nextTime1"
-                            style="@style/FooterButtonNextTime" />
+                    <LinearLayout
+                        android:id="@+id/flashcard_layout_flip"
+                        android:layout_width="fill_parent"
+                        android:layout_height="@dimen/touch_target"
+                        android:layout_weight="1"
+                        android:orientation="vertical" >
 
-                    <TextView
-                            android:id="@+id/ease1"
-                            android:text="@string/ease_button_again"
-                            style="@style/FooterButtonEaseText"/>
-                </LinearLayout>
+                        <Button
+                            style="@style/FooterButtonLayout"
+                            android:background="?attr/hardButtonRef"
+                            android:id="@+id/flip_card"
+                            android:layout_width="fill_parent"
+                            android:layout_height="fill_parent"
+                            android:clickable="false"
+                            android:text="@string/show_answer" />
+                    </LinearLayout>
 
-                <LinearLayout
+                    <LinearLayout
                         style="@style/FooterButtonLayout"
-                        android:background="?attr/hardButtonRef"
-                        android:id="@+id/flashcard_layout_ease2"
+                        android:background="?attr/againButtonRef"
+                        android:id="@+id/flashcard_layout_ease1"
                         android:layout_width="0dip"
                         android:layout_height="@dimen/touch_target"
                         android:layout_weight="1"
                         android:orientation="vertical"
                         android:visibility="gone" >
 
-                    <TextView
-                            android:id="@+id/nextTime2"
-                            style="@style/FooterButtonNextTime" />
+                        <TextView
+                                android:id="@+id/nextTime1"
+                                style="@style/FooterButtonNextTime" />
 
-                    <TextView
-                            android:id="@+id/ease2"
-                            android:text="@string/ease_button_hard"
-                            style="@style/FooterButtonEaseText" />
-                </LinearLayout>
+                        <TextView
+                                android:id="@+id/ease1"
+                                android:text="@string/ease_button_again"
+                                style="@style/FooterButtonEaseText"/>
+                    </LinearLayout>
 
-                <LinearLayout
-                        style="@style/FooterButtonLayout"
-                        android:background="?attr/goodButtonRef"
-                        android:id="@+id/flashcard_layout_ease3"
-                        android:layout_width="0dip"
-                        android:layout_height="@dimen/touch_target"
-                        android:layout_weight="1"
-                        android:orientation="vertical"
-                        android:visibility="gone" >
+                    <LinearLayout
+                            style="@style/FooterButtonLayout"
+                            android:background="?attr/hardButtonRef"
+                            android:id="@+id/flashcard_layout_ease2"
+                            android:layout_width="0dip"
+                            android:layout_height="@dimen/touch_target"
+                            android:layout_weight="1"
+                            android:orientation="vertical"
+                            android:visibility="gone" >
 
-                    <TextView
-                            android:id="@+id/nextTime3"
-                            style="@style/FooterButtonNextTime" />
+                        <TextView
+                                android:id="@+id/nextTime2"
+                                style="@style/FooterButtonNextTime" />
 
-                    <TextView
-                            android:id="@+id/ease3"
-                            android:text="@string/ease_button_good"
-                            style="@style/FooterButtonEaseText"/>
-                </LinearLayout>
+                        <TextView
+                                android:id="@+id/ease2"
+                                android:text="@string/ease_button_hard"
+                                style="@style/FooterButtonEaseText" />
+                    </LinearLayout>
 
-                <LinearLayout
-                        style="@style/FooterButtonLayout"
-                        android:background="?attr/easyButtonRef"
-                        android:id="@+id/flashcard_layout_ease4"
-                        android:layout_width="0dip"
-                        android:layout_height="@dimen/touch_target"
-                        android:layout_weight="1"
-                        android:orientation="vertical"
-                        android:visibility="gone" >
+                    <LinearLayout
+                            style="@style/FooterButtonLayout"
+                            android:background="?attr/goodButtonRef"
+                            android:id="@+id/flashcard_layout_ease3"
+                            android:layout_width="0dip"
+                            android:layout_height="@dimen/touch_target"
+                            android:layout_weight="1"
+                            android:orientation="vertical"
+                            android:visibility="gone" >
 
-                    <TextView
-                            android:id="@+id/nextTime4"
-                            style="@style/FooterButtonNextTime" />
+                        <TextView
+                                android:id="@+id/nextTime3"
+                                style="@style/FooterButtonNextTime" />
 
-                    <TextView
-                            android:id="@+id/ease4"
-                            android:text="@string/ease_button_easy"
-                            style="@style/FooterButtonEaseText" />
+                        <TextView
+                                android:id="@+id/ease3"
+                                android:text="@string/ease_button_good"
+                                style="@style/FooterButtonEaseText"/>
+                    </LinearLayout>
+
+                    <LinearLayout
+                            style="@style/FooterButtonLayout"
+                            android:background="?attr/easyButtonRef"
+                            android:id="@+id/flashcard_layout_ease4"
+                            android:layout_width="0dip"
+                            android:layout_height="@dimen/touch_target"
+                            android:layout_weight="1"
+                            android:orientation="vertical"
+                            android:visibility="gone" >
+
+                        <TextView
+                                android:id="@+id/nextTime4"
+                                style="@style/FooterButtonNextTime" />
+
+                        <TextView
+                                android:id="@+id/ease4"
+                                android:text="@string/ease_button_easy"
+                                style="@style/FooterButtonEaseText" />
+                    </LinearLayout>
                 </LinearLayout>
             </LinearLayout>
-        </LinearLayout>
-    </RelativeLayout>
-    <include layout="@layout/anki_progress"/>
-</android.support.design.widget.CoordinatorLayout>
+        </RelativeLayout>
+        <include layout="@layout/anki_progress"/>
+    </android.support.design.widget.CoordinatorLayout>
+    <include layout="@layout/navigation_drawer" />
+</android.support.v4.widget.DrawerLayout>

--- a/AnkiDroid/src/main/res/layout/homescreen.xml
+++ b/AnkiDroid/src/main/res/layout/homescreen.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-           android:layout_height="fill_parent"
-           android:layout_width="fill_parent">
+<android.support.v4.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        android:id="@+id/drawer_layout"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="?android:attr/colorBackground"
+        android:fitsSystemWindows="true">
     <include layout="@layout/deck_picker"/>
-</LinearLayout>
+    <include layout="@layout/navigation_drawer" />
+</android.support.v4.widget.DrawerLayout>

--- a/AnkiDroid/src/main/res/layout/navdrawer_header.xml
+++ b/AnkiDroid/src/main/res/layout/navdrawer_header.xml
@@ -1,0 +1,10 @@
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="150dp"
+    android:orientation="vertical">
+    <ImageView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="?attr/navDrawerImage"
+        android:scaleType="centerCrop" />
+</FrameLayout>

--- a/AnkiDroid/src/main/res/layout/navigation_drawer.xml
+++ b/AnkiDroid/src/main/res/layout/navigation_drawer.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.design.widget.NavigationView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/navdrawer_items_container"
+    style="@style/NavDrawer"
+    android:layout_width="wrap_content"
+    android:layout_height="match_parent"
+    android:layout_gravity="start"
+    app:headerLayout="@layout/navdrawer_header"
+    app:menu="@menu/navigation_drawer" />

--- a/AnkiDroid/src/main/res/layout/night_mode_switch.xml
+++ b/AnkiDroid/src/main/res/layout/night_mode_switch.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="horizontal"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+    <android.support.v7.widget.SwitchCompat
+        android:id="@+id/switch_compat"
+        android:layout_width="fill_parent"
+        android:layout_height="match_parent" />
+</LinearLayout>

--- a/AnkiDroid/src/main/res/layout/studyoptions.xml
+++ b/AnkiDroid/src/main/res/layout/studyoptions.xml
@@ -1,17 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout
-    android:id="@+id/root_layout"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent"
-    xmlns:android="http://schemas.android.com/apk/res/android">
-    <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:orientation="vertical">
-        <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-            android:id="@+id/studyoptions_frame"
-            android:layout_width="fill_parent"
-            android:layout_height="fill_parent" />
-    </LinearLayout>
-</android.support.design.widget.CoordinatorLayout>
+<android.support.v4.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/drawer_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="?android:attr/colorBackground"
+    android:fitsSystemWindows="true">
+    <android.support.design.widget.CoordinatorLayout
+        android:id="@+id/root_layout"
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent">
+        <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:orientation="vertical">
+            <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                android:id="@+id/studyoptions_frame"
+                android:layout_width="fill_parent"
+                android:layout_height="fill_parent" />
+        </LinearLayout>
+    </android.support.design.widget.CoordinatorLayout>
+    <include layout="@layout/navigation_drawer" />
+</android.support.v4.widget.DrawerLayout>
 

--- a/AnkiDroid/src/main/res/layout/studyoptions_fragment.xml
+++ b/AnkiDroid/src/main/res/layout/studyoptions_fragment.xml
@@ -6,6 +6,7 @@
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
     android:orientation="vertical"
+    android:fitsSystemWindows="true"
     android:gravity="center">
     <RelativeLayout
         android:layout_width="fill_parent"

--- a/AnkiDroid/src/main/res/menu/navigation_drawer.xml
+++ b/AnkiDroid/src/main/res/menu/navigation_drawer.xml
@@ -1,0 +1,37 @@
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <group android:id="@+id/group1"
+        android:checkableBehavior="single">
+        <item
+            android:id="@+id/nav_decks"
+            android:icon="@drawable/ic_list_black_24dp"
+            android:title="@string/decks" />
+        <item
+            android:id="@+id/nav_browser"
+            android:icon="@drawable/ic_search_black_24dp"
+            android:title="@string/card_browser"/>
+        <item
+            android:id="@+id/nav_stats"
+            android:icon="@drawable/ic_equalizer_black_24dp"
+            android:title="@string/statistics"/>
+    </group>
+    <group  android:id="@+id/group2">
+        <item
+            android:id="@+id/nav_night_mode"
+            android:icon="@drawable/ic_brightness_3_black_24dp"
+            app:actionLayout="@layout/night_mode_switch"
+            android:title="@string/night_mode"/>
+        <item
+            android:id="@+id/nav_settings"
+            android:icon="@drawable/ic_settings_black_24dp"
+            android:title="@string/settings"/>
+        <item
+            android:id="@+id/nav_help"
+            android:icon="@drawable/ic_help_black_24dp"
+            android:title="@string/help"/>
+        <item
+            android:id="@+id/nav_feedback"
+            android:icon="@drawable/ic_feedback_black_24dp"
+            android:title="@string/send_feedback"/>
+    </group>
+</menu>

--- a/AnkiDroid/src/main/res/values-v21/styles.xml
+++ b/AnkiDroid/src/main/res/values-v21/styles.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <style name="App_Theme_White" parent="Theme_White">
+        <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="currentDeckBackground">@drawable/item_background_selected</item>
     </style>
     <style name="App_Theme_Dark" parent="Theme_Dark">
+        <item name="android:statusBarColor">@android:color/transparent</item>
         <item name="currentDeckBackground">@drawable/item_background_selected_night</item>
     </style>
 </resources>

--- a/AnkiDroid/src/main/res/values/colors.xml
+++ b/AnkiDroid/src/main/res/values/colors.xml
@@ -167,53 +167,8 @@
 
     <color name="text_color_black">#de000000</color> <!-- 87% black -->
 
-    <!-- navdrawer colors -->
-    <!-- Material DEFAULT colors -->
-    <color name="material_drawer_primary">#2196F3</color>
-    <color name="material_drawer_primary_dark">#1976D2</color>
-    <color name="material_drawer_primary_light">#BBDEFB</color>
-    <color name="material_drawer_accent">#FF4081</color>
-
-    <!-- OVERWRITE THESE COLORS FOR A LIGHT THEME -->
-    <!-- MaterialDrawer DEFAULT colors -->
-    <color name="material_drawer_background">#FFFFFF</color>
-    <!-- Material DEFAULT text / items colors -->
-    <color name="material_drawer_primary_text">#DE000000</color>
-    <color name="material_drawer_primary_icon">#8A000000</color>
-    <color name="material_drawer_secondary_text">#8A000000</color>
-    <color name="material_drawer_hint_text">#42000000</color>
-    <color name="material_drawer_divider">#1F000000</color>
-    <!-- Material DEFAULT drawer colors -->
-    <color name="material_drawer_selected">#E8E8E8</color>
-    <color name="material_drawer_selected_text">#2196F3</color>
-    <color name="material_drawer_header_selection_text">#FFF</color>
-
-    <!-- OVERWRITE THESE COLORS FOR A DARK THEME -->
-    <!-- MaterialDrawer DEFAULT DARK colors -->
-    <color name="material_drawer_dark_background">#303030</color>
-    <!-- MaterialDrawer DEFAULT DARK text / items colors -->
-    <color name="material_drawer_dark_primary_text">#DEFFFFFF</color>
-    <color name="material_drawer_dark_primary_icon">#8AFFFFFF</color>
-    <color name="material_drawer_dark_secondary_text">#8AFFFFFF</color>
-    <color name="material_drawer_dark_hint_text">#42FFFFFF</color>
-    <color name="material_drawer_dark_divider">#1FFFFFFF</color>
-    <!-- MaterialDrawer DEFAULT DARK drawer colors -->
-    <color name="material_drawer_dark_selected">#202020</color>
-    <color name="material_drawer_dark_selected_text">@color/material_drawer_primary</color>
-    <color name="material_drawer_dark_header_selection_text">#FFF</color>
-
-
-
-
-    <color name="navdrawer_text_color">@color/text_color_black</color>
-    <color name="navdrawer_text_color_selected">@color/theme_primary</color>
-    <color name="navdrawer_icon_tint">#8a000000</color> <!-- 54% black -->
-    <color name="navdrawer_icon_tint_selected">@color/theme_primary</color>
-    <color name="navdrawer_background_selected">#33999999</color> <!-- 20% grey (#999999) -->
-    <color name="navdrawer_divider">#e5e5e5</color>
-
     <color name="half_black">#808080</color>
     <color name="white_pressed">#f1f1f1</color>
     <color name="black_semi_transparent">#B2000000</color>
-
+    <color name="material_theme_grey">#303030</color>
 </resources>

--- a/AnkiDroid/src/main/res/values/constants.xml
+++ b/AnkiDroid/src/main/res/values/constants.xml
@@ -164,4 +164,14 @@
         <item>@string/full_screen_complete</item>
     </string-array>
 
+    <string-array name="navigation_titles">
+        <item>@string/decks</item>
+        <item>@string/card_browser</item>
+        <item>@string/statistics</item>
+        <item>@string/settings</item>
+        <item>@string/night_mode</item>
+        <item>@string/help</item>
+        <item>@string/send_feedback</item>
+    </string-array>
+
 </resources>

--- a/AnkiDroid/src/main/res/values/theme_dark.xml
+++ b/AnkiDroid/src/main/res/values/theme_dark.xml
@@ -44,16 +44,6 @@
         <item name="dialogErrorIcon">@drawable/ic_warning_white_36dp</item>
         <item name="dialogSyncErrorIcon">@drawable/ic_sync_problem_white_36dp</item>
         <item name="dialogSendIcon">@drawable/ic_send_white_36dp</item>
-        <!-- Navigation drawer colors -->
-        <item name="material_drawer_background">@color/material_drawer_dark_background</item>
-        <item name="material_drawer_primary_text">@color/material_drawer_dark_primary_text</item>
-        <item name="material_drawer_primary_icon">@color/material_drawer_dark_primary_icon</item>
-        <item name="material_drawer_secondary_text">@color/material_drawer_dark_secondary_text</item>
-        <item name="material_drawer_hint_text">@color/material_drawer_dark_hint_text</item>
-        <item name="material_drawer_divider">@color/material_drawer_dark_divider</item>
-        <item name="material_drawer_selected">@color/navdrawer_background_selected</item>
-        <item name="material_drawer_selected_text">@color/material_drawer_dark_selected_text</item>
-        <item name="material_drawer_header_selection_text">@color/material_drawer_dark_header_selection_text</item>
     </style>
 
 
@@ -65,7 +55,7 @@
     </style>
 
     <!-- Legacy action bar  (used in Preferences with no explicit Toolbar) -->
-    <style name="LegacyActionBarDark" parent="App_Theme_Dark">
+    <style name="LegacyActionBarDark" parent="Theme_Dark">
         <item name="windowActionBar">true</item>
         <item name="windowNoTitle">false</item>
     </style>

--- a/AnkiDroid/src/main/res/values/theme_white.xml
+++ b/AnkiDroid/src/main/res/values/theme_white.xml
@@ -52,16 +52,6 @@
         <item name="dialogErrorIcon">@drawable/ic_warning_black_36dp</item>
         <item name="dialogSyncErrorIcon">@drawable/ic_sync_problem_black_36dp</item>
         <item name="dialogSendIcon">@drawable/ic_send_black_36dp</item>
-        <!-- Navigation drawer colors -->
-        <item name="material_drawer_background">@color/material_drawer_background</item>
-        <item name="material_drawer_primary_text">@color/material_drawer_primary_text</item>
-        <item name="material_drawer_primary_icon">@color/material_drawer_primary_icon</item>
-        <item name="material_drawer_secondary_text">@color/material_drawer_secondary_text</item>
-        <item name="material_drawer_hint_text">@color/material_drawer_hint_text</item>
-        <item name="material_drawer_divider">@color/material_drawer_divider</item>
-        <item name="material_drawer_selected">@color/material_drawer_selected</item>
-        <item name="material_drawer_selected_text">@color/material_drawer_selected_text</item>
-        <item name="material_drawer_header_selection_text">@color/material_drawer_header_selection_text</item>
     </style>
 
     <style name="Theme_White_Statistics" parent="App_Theme_White">
@@ -69,7 +59,7 @@
     </style>
 
     <!-- Theme for showing legacy ActionBar without explicitly including a toolbar -->
-    <style name="LegacyActionBarWhite" parent="App_Theme_White">
+    <style name="LegacyActionBarWhite" parent="Theme_White">
         <item name="windowActionBar">true</item>
         <item name="windowNoTitle">false</item>
     </style>


### PR DESCRIPTION
In v2.4 we "manually" implemented the navigation drawer, only using the `DrawerLayout` view provided in the support library. This was quite messy and hard to extend, so when the design support library was released I switched over to the new `NavigationView` class, which simplified the code and allowed us to add the header image to the top of the drawer, to give a more "material" theme to the app, and increase Anki branding.

In the end we wanted to add a switch for night mode, and `NavigationView` didn't support this. So eventually we switched over to the 3rd party library "material drawer", which allowed custom views. This simplified life somewhat, but it also led to a few hidden bugs that were really painful to solve.

Google ended up releasing a new version of `NavigationView` which included support for custom views (like switches) shortly after we switched to the 3rd party library (lol), and this PR switches back to an implementation based on that class again, and removes our dependency on the material drawer library.

Fullscreen mode is currently broken; I'm waiting on some feedback from Google on what I think is a bug before I try to hack a solution (obviously I'm not holding my breath for their reply, but I'll fix it eventually one way or another). Another issue is that the colors in night mode are a bit different  from 2.5 also, I'll try to take a look at that later as well when I get time.