### PR TITLE
Don't show progress bar on card answer

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -597,7 +597,6 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
 
         @Override
         public void onPreExecute() {
-            showProgressBar();
             blockControls();
         }
 
@@ -656,7 +655,6 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
             if (mNoMoreCards) {
                 closeReviewer(RESULT_NO_MORE_CARDS, true);
             }
-            hideProgressBar();
             // set the correct mark/unmark icon on action bar
             refreshActionBar();
             findViewById(R.id.root_layout).requestFocus();


### PR DESCRIPTION
A user on the forum complained about visible progress bars in the middle of the card when answering. I noticed it as well, so I'm removing them in this commit. I think card answering is fast enough that this isn't warranted.