### PR TITLE
A switch to turn off the input tag write answer

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -611,6 +611,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
         PreferenceCategory workarounds = (PreferenceCategory) screen.findPreference("category_workarounds");
         if (workarounds != null) {
             CheckBoxPreference writeAnswersDisable = (CheckBoxPreference) screen.findPreference("writeAnswersDisable");
+            CheckBoxPreference useInputTag = (CheckBoxPreference) screen.findPreference("useInputTag");
             CheckBoxPreference inputWorkaround = (CheckBoxPreference) screen.findPreference("inputWorkaround");
             CheckBoxPreference longclickWorkaround =
                 (CheckBoxPreference) screen.findPreference("textSelectionLongclickWorkaround");
@@ -626,10 +627,12 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
             if (CompatHelper.getSdkVersion() >= 15) {
                 workarounds.removePreference(writeAnswersDisable);
                 workarounds.removePreference(inputWorkaround);
+            } else {
+                // For older Androids we never use the input tag anyway.
+                workarounds.removePreference(useInputTag);
             }
             if (CompatHelper.getSdkVersion() >= 16) {
                 workarounds.removePreference(fixHebrewText);
-                screen.removePreference(workarounds);     // group itself can be hidden for API 16
             }
         }
     }

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -47,6 +47,8 @@
     <string name="whiteboard_black_summ">Uses less memory, unless in night mode</string>
     <string name="write_answers_disable">Disable typing in answer</string>
     <string name="write_answers_disable_summ">Prevents keyboard from appearing on cards containing type-the-answer fields</string>
+    <string name="use_input_tag">Type answer into the card</string>
+    <string name="use_input_tag_summ">Use a text input box inside the card to type in the answer</string>
     <string name="text_selection_click">Long press workaround</string>
     <string name="text_selection_click_summ">Enable this if you are not able to select text with a long press</string>
     <string name="dictionary">Lookup dictionary</string>

--- a/AnkiDroid/src/main/res/xml/preferences_advanced.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_advanced.xml
@@ -66,6 +66,11 @@
                 android:title="@string/input_workaround" />
             <CheckBoxPreference
                 android:defaultValue="false"
+                android:key="useInputTag"
+                android:summary="@string/use_input_tag_summ"
+                android:title="@string/use_input_tag" />
+            <CheckBoxPreference
+                android:defaultValue="false"
                 android:key="textSelectionLongclickWorkaround"
                 android:summary="@string/text_selection_click_summ"
                 android:title="@string/text_selection_click" />


### PR DESCRIPTION
For those that griped (#3912) about the input tag or otherwise don’t like it.

The switch is a “workaround”, and that prefs category is always shown with this.

(I decided against using the old input field automatically when the white board is on. I for one am OK with an input tag that i can’t get to because of the white board. I may use the box on desktop Anki, but am happy to write with the finger in AnkiDroid.)

(edit: i missed the “against” at first.)