### PR TITLE
Show progress bars when loading count tree in deck picker

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -1758,11 +1758,13 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
             @Override
             public void onPreExecute() {
+                showProgressBar();
                 Timber.d("Refreshing deck list");
             }
 
             @Override
             public void onPostExecute(TaskData result) {
+                hideProgressBar();
                 if (result == null) {
                     Timber.e("null result loading deck counts");
                     onCollectionLoadError();


### PR DESCRIPTION
I've noticed there are times when a blank activity is shown with really big collections