### PR TITLE
Use up animation to open deck picker

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.java
@@ -180,7 +180,7 @@ public class IntentHandler extends Activity {
     /** Finish Activity using FADE animation **/
     private void finishWithFade() {
     	finish();
-    	ActivityTransitionAnimation.slide(this, ActivityTransitionAnimation.FADE);
+    	ActivityTransitionAnimation.slide(this, ActivityTransitionAnimation.UP);
     }
 
     /**


### PR DESCRIPTION
With the intent handler activity set to transparent we can actually make the opening animation look consistent with every other app in the launcher now.