### PR TITLE
Don't show the progress bar when DeckPicker is resumed

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -753,6 +753,8 @@ public class DeckPicker extends NavigationDrawerActivity implements
     protected void onCollectionLoaded(Collection col) {
         // keep reference to collection in parent
         super.onCollectionLoaded(col);
+        // Since the deck list won't show until we get the deck counts, we show the progress bar again
+        showProgressBar();
         // create backup in background if needed
         Boolean started = BackupManager.performBackupInBackground(col.getPath());
         if (started) {
@@ -1758,7 +1760,9 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
             @Override
             public void onPreExecute() {
-                showProgressBar();
+                if (!colIsOpen()) {
+                    showProgressBar();
+                }
                 Timber.d("Refreshing deck list");
             }
 


### PR DESCRIPTION
@hssm I could reproduce the issue you mentioned on a physical device, and it's pretty annoying so I went ahead and fixed it