### PR TITLE
Always go back to deck picker upon finishing reviewing

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -624,7 +624,8 @@ public class DeckPicker extends NavigationDrawerActivity implements
                 DeckTask.launchDeckTask(DeckTask.TASK_TYPE_IMPORT, mImportAddListener, new TaskData(mImportPath, true));
                 mImportPath = null;
             }
-        } else if (requestCode == REQUEST_REVIEW && resultCode == Reviewer.RESULT_NO_MORE_CARDS) {
+        } else if ((requestCode == REQUEST_REVIEW || requestCode == SHOW_STUDYOPTIONS)
+                && resultCode == Reviewer.RESULT_NO_MORE_CARDS) {
             // Show a message when reviewing has finished
             int[] studyOptionsCounts = getCol().getSched().counts();
             if (studyOptionsCounts[0] + studyOptionsCounts[1] + studyOptionsCounts[2] == 0) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
@@ -226,7 +226,14 @@ public class StudyOptionsFragment extends Fragment implements Toolbar.OnMenuItem
 
     private void openReviewer() {
         Intent reviewer = new Intent(getActivity(), Reviewer.class);
-        startActivityForResult(reviewer, AnkiActivity.REQUEST_REVIEW);
+        if (mFragmented) {
+            startActivityForResult(reviewer, AnkiActivity.REQUEST_REVIEW);
+        } else {
+            // Go to DeckPicker after studying when not tablet
+            reviewer.setFlags(Intent.FLAG_ACTIVITY_FORWARD_RESULT);
+            startActivity(reviewer);
+            getActivity().finish();
+        }
         animateLeft();
         getCol().startTimebox();
     }


### PR DESCRIPTION
A user recently complained that with the new tap zone in the deck picker, the number of taps to get back to the deck picker depends on where they launched the reviewer from, which confuses the brain.