### PR TITLE
Insert media at cursor position in note editor.

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
@@ -270,7 +270,6 @@ public class MultimediaEditFieldActivity extends AnkiActivity
 
         if (bChangeToText) {
             mField = new TextField();
-            mField.setText(" - ");
         }
 
         resultData.putExtra(EXTRA_RESULT_FIELD, mField);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicTextFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicTextFieldController.java
@@ -52,7 +52,7 @@ import java.util.List;
 public class BasicTextFieldController extends FieldControllerBase implements IFieldController,
         DialogInterface.OnClickListener {
 
-    // Additional activities are started to perform translation/image search and
+    // Additional activities are started to perform translation/pronunciation search and
     // so on, here are their request codes, to differentiate, when they return.
     private static final int REQUEST_CODE_TRANSLATE_GLOSBE = 101;
     private static final int REQUEST_CODE_PRONOUNCIATION = 102;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/TextField.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/TextField.java
@@ -26,7 +26,7 @@ import com.ichi2.libanki.Collection;
  */
 public class TextField extends FieldBase implements IField {
     private static final long serialVersionUID = -6508967905716947525L;
-    String mText = " - ";
+    String mText = "";
     private String mName;
 
 


### PR DESCRIPTION
Behaviour is now the following:
* Text from text fields is always passed in (not only when editing notes).
* For text fields, the previous text is completely replaced.
* For fields with focus, media are inserted at the cursor position.
* For fields without focus, media are inserted at the end.
* Removed the " - " that was inserted when changing to a text field.

Fixes #3669 