### PR TITLE
Warn before undoing edit, optionally keep new version

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1178,6 +1178,10 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
 
     protected void undo() {
         if (getCol().undoAvailable()) {
+	    if (getCol().lastUndoIsEdit()) {
+		showUndoEditDialog();
+		return;
+	    }
             DeckTask.launchDeckTask(DeckTask.TASK_TYPE_UNDO, mAnswerCardHandler);
         }
     }
@@ -1261,6 +1265,37 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
                         DeckTask.launchDeckTask(DeckTask.TASK_TYPE_DISMISS_NOTE, mDismissCardHandler,
                                 new DeckTask.TaskData(mCurrentCard, 3));
                     }
+                })
+                .build().show();
+    }
+
+
+    protected void showUndoEditDialog() {
+        Resources res = getResources();
+        new MaterialDialog.Builder(this)
+                .title(res.getString(R.string.undo_edit_title))
+                .iconAttr(R.attr.dialogErrorIcon)
+                .content(String.format(res.getString(R.string.undo_edit_message),
+                        Utils.stripHTML(mCurrentCard.q(true))))
+                .positiveText(res.getString(R.string.undo_edit_new_version))
+                .negativeText(res.getString(R.string.undo_edit_old_version))
+                .neutralText(res.getString(R.string.undo_edit_cancel))
+                .callback(new MaterialDialog.ButtonCallback() {
+                    @Override
+                    public void onPositive(MaterialDialog dialog) {
+                        Timber.i("AbstractFlashcardViewer:: Button pressed to discard edit undo records");
+			// Discard all edit undo records for this card
+			while (getCol().lastUndoIsEdit())
+			    getCol().discardEditUndo();
+
+			if (getCol().undoAvailable())
+			    DeckTask.launchDeckTask(DeckTask.TASK_TYPE_UNDO, mAnswerCardHandler);
+                    }
+		    @Override
+		    public void onNegative(MaterialDialog dialog) {
+                        Timber.i("AbstractFlashcardViewer:: Button pressed to revert edit");
+			DeckTask.launchDeckTask(DeckTask.TASK_TYPE_UNDO, mAnswerCardHandler);
+		    }
                 })
                 .build().show();
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1285,8 +1285,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
                     public void onPositive(MaterialDialog dialog) {
                         Timber.i("AbstractFlashcardViewer:: Button pressed to discard edit undo records");
 			// Discard all edit undo records for this card
-			while (getCol().lastUndoIsEdit())
-			    getCol().discardEditUndo();
+			getCol().discardEditUndo();
 
 			if (getCol().undoAvailable())
 			    DeckTask.launchDeckTask(DeckTask.TASK_TYPE_UNDO, mAnswerCardHandler);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1179,7 +1179,7 @@ public class Collection {
 
 
     public void discardEditUndo() {
-	if (lastUndoIsEdit())
+	while (lastUndoIsEdit())
 	    mUndo.removeLast();
     }
 
@@ -1286,6 +1286,10 @@ public class Collection {
 
 
     public void markUndo(int type, Object[] o) {
+	if (type != UNDO_EDIT_NOTE && type != UNDO_MARK_NOTE) {
+	    // Moving to another card - discard all edit undo records
+	    discardEditUndo();
+	}
     	switch(type) {
     	case UNDO_REVIEW:
     		mUndo.add(new Object[]{type, ((Card)o[0]).clone(), o[1]});

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1292,7 +1292,8 @@ public class Collection {
     		mUndo.add(new Object[]{type, o[0], o[1], o[2]});
     		break;
     	case UNDO_MARK_NOTE:
-    		mUndo.add(new Object[]{type, o[0], o[1], o[2]});
+		// There is no reason to ever undo this.
+    		//mUndo.add(new Object[]{type, o[0], o[1], o[2]});
     		break;
         case UNDO_BURY_CARD:
             mUndo.add(new Object[]{type, o[0], o[1], o[2]});

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1170,6 +1170,20 @@ public class Collection {
     }
 
 
+    public boolean lastUndoIsEdit() {
+	if (!undoAvailable())
+	    return false;
+        Object[] data = mUndo.getLast();
+	return (Integer)data[0] == UNDO_EDIT_NOTE;
+    }
+
+
+    public void discardEditUndo() {
+	if (lastUndoIsEdit())
+	    mUndo.removeLast();
+    }
+
+
     public boolean undoAvailable() {
         return mUndo.size() > 0;
     }

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -106,6 +106,13 @@
     <string name="check_media_delete_unused">Delete unused</string>
     <string name="check_media_deleted">Files deleted: %d</string>
 
+    <!-- Undoing edits -->
+    <string name="undo_edit_title">Undo edit?</string>
+    <string name="undo_edit_message">Before you can undo any more actions, you must decide which version of this card to keep. Whichever version you choose to keep, the other version will be deleted.</string>
+    <string name="undo_edit_old_version">Keep old version</string>
+    <string name="undo_edit_new_version">Keep new version</string>
+    <string name="undo_edit_cancel">Do nothing</string>
+
     <!-- Tags Dialog Options -->
     <string name="tags_dialog_option_all_cards">All cards</string>
     <string name="tags_dialog_option_new_cards">New</string>


### PR DESCRIPTION
Fixes #3968 and #3374.

The user is given 3 options:

1. To keep the new version of the card, discarding all undo-edit records on the card, and then process the next undo record (i.e. go to the previous card without making any destructive changes to this one).
2. To revert to the previous version of the card, discarding the new version.
3. To do nothing (i.e. cancel).

The question and answers are phrased in such a way as to make it unlikely that the user will get confused.

After moving to another card, the edit undo records are deleted.

Also, marking (i.e. starring) a note is simply not added to the undo queue. You can just as easily press the star button, and I don't think people really expect "undo" to change what's in their favourites list.

The messages are not yet internationalised.