### PR TITLE
Don't add edits to undo queue

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
@@ -590,8 +590,6 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
             try {
                 if (card != null) {
                     Note note = card.note();
-                    col.markUndo(Collection.UNDO_MARK_NOTE,
-                            new Object[]{note.getId(), note.stringTags(), card.getId()});
                     if (note.hasTag("marked")) {
                         note.delTag("marked");
                     } else {

--- a/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
@@ -404,10 +404,6 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
         Note editNote = editCard.note();
         boolean fromReviewer = params[0].getBoolean();
 
-        // mark undo
-        col.markUndo(Collection.UNDO_EDIT_NOTE, new Object[]{col.getNote(editNote.getId()), editCard.getId(),
-                fromReviewer});
-
         try {
             col.getDb().getDatabase().beginTransaction();
             try {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -113,7 +113,6 @@ public class Collection {
     public static final int UNDO_SUSPEND_CARD = 3;
     public static final int UNDO_SUSPEND_NOTE = 4;
     public static final int UNDO_DELETE_NOTE = 5;
-    public static final int UNDO_MARK_NOTE = 6;
     public static final int UNDO_BURY_CARD = 7;
 
     private static final int[] fUndoNames = new int[]{
@@ -1273,12 +1272,6 @@ public class Collection {
     		mDb.execute("DELETE FROM graves WHERE oid IN " + Utils.ids2str(Utils.arrayList2array(ids)));
     		return (Long) data[3];
 
-    	case UNDO_MARK_NOTE:
-    		Note note3 = getNote((Long) data[1]);
-    		note3.setTagsFromStr((String) data[2]);
-    		note3.flush(note3.getMod(), false);
-    		return (Long) data[3];
-
         case UNDO_BURY_CARD:
             for (Card cc : (ArrayList<Card>)data[2]) {
                 cc.flush(false);
@@ -1308,9 +1301,6 @@ public class Collection {
             mUndo.add(new Object[]{type, o[0], o[1]});
             break;
     	case UNDO_DELETE_NOTE:
-    		mUndo.add(new Object[]{type, o[0], o[1], o[2]});
-    		break;
-    	case UNDO_MARK_NOTE:
     		mUndo.add(new Object[]{type, o[0], o[1], o[2]});
     		break;
         case UNDO_BURY_CARD:


### PR DESCRIPTION
As per the discussion in #3969, Anki Desktop doesn't allow the undoing of note edits, so here I've unexposed this functionality to bring AnkiDroid in line with Anki Desktop. I've kept it there as we might want to allow undo of edits from the browser, although Anki Desktop doesn't do that either.

As in #3969, I've completely removed the undo mark note functionality as I can't see any valid usage case for that.