### PR TITLE
Remove the rest of edit undo and mark card async

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -64,7 +64,6 @@ import android.widget.Chronometer;
 import android.widget.EditText;
 import android.widget.FrameLayout;
 import android.widget.LinearLayout;
-import android.widget.ProgressBar;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
@@ -79,11 +78,11 @@ import com.ichi2.compat.CompatHelper;
 import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Consts;
+import com.ichi2.libanki.Note;
 import com.ichi2.libanki.Sched;
 import com.ichi2.libanki.Sound;
 import com.ichi2.libanki.Utils;
 import com.ichi2.themes.HtmlColors;
-import com.ichi2.themes.StyledProgressDialog;
 import com.ichi2.themes.Themes;
 import com.ichi2.utils.DiffEngine;
 import com.ichi2.utils.HtmlUtil;
@@ -470,33 +469,6 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
         }
     };
 
-    public DeckTask.TaskListener mMarkCardHandler = new DeckTask.TaskListener() {
-        @Override
-        public void onPreExecute() {
-            showProgressBar();
-        }
-
-
-        @Override
-        public void onProgressUpdate(DeckTask.TaskData... values) {
-            hideProgressBar();
-        }
-
-
-        @Override
-        public void onPostExecute(DeckTask.TaskData result) {
-            refreshActionBar();
-            if (!result.getBoolean()) {
-                // RuntimeException occured on marking cards
-                closeReviewer(DeckPicker.RESULT_DB_ERROR, true);
-            }
-        }
-
-
-        @Override
-        public void onCancelled() {
-        }
-    };
 
     protected DeckTask.TaskListener mDismissCardHandler = new DeckTask.TaskListener() {
         @Override
@@ -2463,8 +2435,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
                 editCard();
                 break;
             case GESTURE_MARK:
-                DeckTask.launchDeckTask(DeckTask.TASK_TYPE_MARK_CARD, mMarkCardHandler,
-                        new DeckTask.TaskData(mCurrentCard, 0));
+                onMark(mCurrentCard);
                 break;
             case GESTURE_LOOKUP:
                 lookUpOrSelectText();
@@ -2725,5 +2696,15 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
         if (mReplayOnTtsInit) {
             playSounds(true);
         }
+    }
+
+    protected void onMark(Card card) {
+        Note note = card.note();
+        if (note.hasTag("marked")) {
+            note.delTag("marked");
+        } else {
+            note.addTag("marked");
+        }
+        note.flush();
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -175,10 +175,9 @@ public class CardBrowser extends NavigationDrawerActivity implements
             }
             switch (which) {
                 case CardBrowserContextMenu.CONTEXT_MENU_MARK:
-                    DeckTask.launchDeckTask(DeckTask.TASK_TYPE_MARK_CARD,
-                            mUpdateCardHandler,
-                            new DeckTask.TaskData(getCol().getCard(Long.parseLong(getCards().get(
-                                    mPositionInCardsList).get("id"))), 0));
+                    Card card = getCol().getCard(Long.parseLong(getCards().get(mPositionInCardsList).get("id")));
+                    onMark(card);
+                    updateCardInList(card, null);
                     return;
 
                 case CardBrowserContextMenu.CONTEXT_MENU_SUSPEND:
@@ -339,6 +338,15 @@ public class CardBrowser extends NavigationDrawerActivity implements
         searchCards();
     }
 
+    private void onMark(Card card) {
+        Note note = card.note();
+        if (note.hasTag("marked")) {
+            note.delTag("marked");
+        } else {
+            note.addTag("marked");
+        }
+        note.flush();
+    }
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -718,8 +726,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
         if (requestCode == EDIT_CARD && resultCode != RESULT_CANCELED) {
             Timber.i("CardBrowser:: CardBrowser: Saving card...");
-            DeckTask.launchDeckTask(DeckTask.TASK_TYPE_UPDATE_FACT, mUpdateCardHandler,
-                    new DeckTask.TaskData(sCardBrowserCard, false));
+            onMark(sCardBrowserCard);
         } else if (requestCode == ADD_NOTE && resultCode == RESULT_OK) {
             if (mSearchView != null) {
                 mSearchTerms = mSearchView.getQuery().toString();
@@ -983,33 +990,6 @@ public class CardBrowser extends NavigationDrawerActivity implements
         updateList();
     }
 
-    private DeckTask.TaskListener mUpdateCardHandler = new DeckTask.TaskListener() {
-        @Override
-        public void onPreExecute() {
-            showProgressBar();
-        }
-
-
-        @Override
-        public void onProgressUpdate(DeckTask.TaskData... values) {
-            updateCardInList(values[0].getCard(), values[0].getString());
-        }
-
-
-        @Override
-        public void onPostExecute(DeckTask.TaskData result) {
-            Timber.d("Card Browser - mUpdateCardHandler.onPostExecute()");
-            if (!result.getBoolean()) {
-                closeCardBrowser(DeckPicker.RESULT_DB_ERROR);
-            }
-            hideProgressBar();
-        }
-
-
-        @Override
-        public void onCancelled() {
-        }
-    };
 
     private DeckTask.TaskListener mSuspendCardHandler = new DeckTask.TaskListener() {
         @Override

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -117,7 +117,8 @@ public class Reviewer extends AbstractFlashcardViewer {
 
             case R.id.action_mark_card:
                 Timber.i("Reviewer:: Mark button pressed");
-                DeckTask.launchDeckTask(DeckTask.TASK_TYPE_MARK_CARD, mMarkCardHandler, new DeckTask.TaskData(mCurrentCard, 0));
+                onMark(mCurrentCard);
+                refreshActionBar();
                 break;
 
             case R.id.action_replay:
@@ -287,7 +288,8 @@ public class Reviewer extends AbstractFlashcardViewer {
 	            return true;
 	        }
 	        if (keyPressed == '*') {
-	            DeckTask.launchDeckTask(DeckTask.TASK_TYPE_MARK_CARD, mMarkCardHandler, new DeckTask.TaskData(mCurrentCard, 0));
+                onMark(mCurrentCard);
+                refreshActionBar();
 	            return true;
 	        }
 	        if (keyPressed == '-') {

--- a/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
@@ -67,7 +67,6 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
 
     public static final int TASK_TYPE_SAVE_COLLECTION = 2;
     public static final int TASK_TYPE_ANSWER_CARD = 3;
-    public static final int TASK_TYPE_MARK_CARD = 5;
     public static final int TASK_TYPE_ADD_FACT = 6;
     public static final int TASK_TYPE_UPDATE_FACT = 7;
     public static final int TASK_TYPE_UNDO = 8;
@@ -240,9 +239,6 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
 
             case TASK_TYPE_ANSWER_CARD:
                 return doInBackgroundAnswerCard(params);
-
-            case TASK_TYPE_MARK_CARD:
-                return doInBackgroundMarkCard(params);
 
             case TASK_TYPE_ADD_FACT:
                 return doInBackgroundAddNote(params);
@@ -575,36 +571,6 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
         } catch (RuntimeException e) {
             Timber.e(e, "doInBackgroundSuspendCard - RuntimeException on suspending card");
             AnkiDroidApp.sendExceptionReport(e, "doInBackgroundSuspendCard");
-            return new TaskData(false);
-        }
-        return new TaskData(true);
-    }
-
-
-    private TaskData doInBackgroundMarkCard(TaskData... params) {
-        Card card = params[0].getCard();
-        Collection col = CollectionHelper.getInstance().getCol(mContext);
-        try {
-            AnkiDb ankiDB = col.getDb();
-            ankiDB.getDatabase().beginTransaction();
-            try {
-                if (card != null) {
-                    Note note = card.note();
-                    if (note.hasTag("marked")) {
-                        note.delTag("marked");
-                    } else {
-                        note.addTag("marked");
-                    }
-                    note.flush();
-                }
-                publishProgress(new TaskData(card));
-                ankiDB.getDatabase().setTransactionSuccessful();
-            } finally {
-                ankiDB.getDatabase().endTransaction();
-            }
-        } catch (RuntimeException e) {
-            Timber.e(e, "doInBackgroundMarkCard - RuntimeException on marking card");
-            AnkiDroidApp.sendExceptionReport(e, "doInBackgroundMarkCard");
             return new TaskData(false);
         }
         return new TaskData(true);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -108,7 +108,6 @@ public class Collection {
             + "'sortBackwards': False, 'addToCur': True }"; // add new to currently selected deck?
 
     public static final int UNDO_REVIEW = 0;
-    public static final int UNDO_EDIT_NOTE = 1;
     public static final int UNDO_BURY_NOTE = 2;
     public static final int UNDO_SUSPEND_CARD = 3;
     public static final int UNDO_SUSPEND_NOTE = 4;
@@ -1219,30 +1218,6 @@ public class Collection {
             mSched.setReps(mSched.getReps() - 1);
             return c.getId();
 
-    	case UNDO_EDIT_NOTE:
-    		Note note = (Note) data[1];
-    		note.flush(note.getMod(), false);
-    		long cid = (Long) data[2];
-            Card card = null;
-            if ((Boolean) data[3]) {
-                Card newCard = getCard(cid);
-                if (getDecks().active().contains(newCard.getDid())) {
-                    card = newCard;
-                    card.load();
-                    // Reloads the QA-cache.
-                    // Requests the simple interface version, since the only difference
-                    // is whether the CSS is added and that's not cached.
-                    card.q(true, true);
-                }
-            }
-            if (card == null) {
-            	card = getSched().getCard();
-            }
-            if (card != null) {
-            	return card.getId();
-            }
-    		return 0;
-
     	case UNDO_BURY_NOTE:
     		for (Card cc : (ArrayList<Card>)data[2]) {
     			cc.flush(false);
@@ -1287,9 +1262,6 @@ public class Collection {
     	switch(type) {
     	case UNDO_REVIEW:
     		mUndo.add(new Object[]{type, ((Card)o[0]).clone(), o[1]});
-    		break;
-    	case UNDO_EDIT_NOTE:
-    		mUndo.add(new Object[]{type, ((Note)o[0]).clone(), o[1], o[2]});
     		break;
         case UNDO_BURY_NOTE:
             mUndo.add(new Object[]{type, o[0], o[1], o[2]});


### PR DESCRIPTION
There was some left over stuff still for undoing edits which I removed in the first commit.

The second commit removes the DeckTask for card marking and just does it directly. All the set up and tear down around it is way more work than the actual task itself and I've always found the briefly appearing progress bar annoying.

I think we can safely do the same thing to the other options available in the menu.