### PR TITLE
Don't use FloatingActionsMenu below API 14

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -55,7 +55,7 @@ dependencies {
         //exclude group: 'com.android.support' // uncomment to force our local support lib version
         transitive = true
     }
-    compile 'net.i2p.android.ext:floatingactionbutton:1.10.0'
+    compile 'com.getbase:floatingactionbutton:1.10.1'
     compile 'ch.acra:acra:4.6.2'
     compile 'com.jakewharton.timber:timber:2.7.1'
     compile 'com.google.code.gson:gson:2.4'

--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -60,7 +60,7 @@
                 android:description="@string/read_write_permission_description"
                 android:protectionLevel="dangerous" />
     <!-- custom tabs library has minimum SDK of 16 -->
-    <uses-sdk tools:overrideLibrary="android.support.customtabs"/>
+    <uses-sdk tools:overrideLibrary="android.support.customtabs, com.getbase.floatingactionbutton"/>
 
     <supports-screens
         android:anyDensity="true"

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -91,8 +91,8 @@ import com.ichi2.ui.DividerItemDecoration;
 import com.ichi2.utils.VersionUtils;
 import com.ichi2.widget.WidgetStatus;
 
-import net.i2p.android.ext.floatingactionbutton.FloatingActionButton;
-import net.i2p.android.ext.floatingactionbutton.FloatingActionsMenu;
+import com.getbase.floatingactionbutton.FloatingActionButton;
+import com.getbase.floatingactionbutton.FloatingActionsMenu;
 
 import org.json.JSONException;
 
@@ -142,7 +142,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
     private RecyclerView mRecyclerView;
     private LinearLayoutManager mRecyclerViewLayoutManager;
     private DeckAdapter mDeckListAdapter;
-    private FloatingActionsMenu mActionsMenu;
+    private FloatingActionsMenu mActionsMenu;   // Note this will be null below SDK 14
 
     private TextView mTodayTextView;
 
@@ -195,7 +195,9 @@ public class DeckPicker extends NavigationDrawerActivity implements
         public void onClick(View v) {
             long deckId = (long) v.getTag();
             Timber.i("DeckPicker:: Selected deck with id %d", deckId);
-            mActionsMenu.collapse();
+            if (mActionsMenu != null && mActionsMenu.isExpanded()) {
+                mActionsMenu.collapse();
+            }
             handleDeckSelection(deckId, false);
             if (mFragmented || !CompatHelper.isLollipop()) {
                 // Calling notifyDataSetChanged() will update the color of the selected deck.
@@ -210,7 +212,9 @@ public class DeckPicker extends NavigationDrawerActivity implements
         public void onClick(View v) {
             long deckId = (long) v.getTag();
             Timber.i("DeckPicker:: Selected deck with id %d", deckId);
-            mActionsMenu.collapse();
+            if (mActionsMenu != null && mActionsMenu.isExpanded()) {
+                mActionsMenu.collapse();
+            }
             handleDeckSelection(deckId, true);
             if (mFragmented || !CompatHelper.isLollipop()) {
                 // Calling notifyDataSetChanged() will update the color of the selected deck.
@@ -411,32 +415,63 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
         // Setup the FloatingActionButtons
         mActionsMenu = (FloatingActionsMenu) findViewById(R.id.add_content_menu);
+        if (mActionsMenu != null) {
+            configureFloatingActionsMenu();
+        } else {
+            // FloatingActionsMenu only works properly on Android 14+ so fallback on a context menu below API 14
+            Timber.w("Falling back on design support library FloatingActionButton");
+            android.support.design.widget.FloatingActionButton addButton;
+            addButton = (android.support.design.widget.FloatingActionButton)findViewById(R.id.add_note_action);
+            addButton.setOnClickListener(new OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    CompatHelper.getCompat().supportAddContentMenu(DeckPicker.this);
+                }
+            });
+        }
+
+        mTodayTextView = (TextView) findViewById(R.id.today_stats_text_view);
+
+        mTodayTextView = (TextView) findViewById(R.id.today_stats_text_view);
+        if (! CollectionHelper.hasStorageAccessPermission(this)) {
+            ActivityCompat.requestPermissions(this, new String[] {Manifest.permission.WRITE_EXTERNAL_STORAGE},
+                    REQUEST_STORAGE_PERMISSION);
+        } else {
+            // Show splash screen and load collection
+            showStartupScreensAndDialogs(preferences, 0);
+        }
+    }
+
+    private void configureFloatingActionsMenu() {
         final FloatingActionButton addDeckButton = (FloatingActionButton) findViewById(R.id.add_deck_action);
         final FloatingActionButton addSharedButton = (FloatingActionButton) findViewById(R.id.add_shared_action);
         final FloatingActionButton addNoteButton = (FloatingActionButton) findViewById(R.id.add_note_action);
         addDeckButton.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View view) {
+                if (mActionsMenu == null) {
+                    return;
+                }
                 mActionsMenu.collapse();
                 mDialogEditText = new EditText(DeckPicker.this);
                 mDialogEditText.setSingleLine(true);
                 // mDialogEditText.setFilters(new InputFilter[] { mDeckNameFilter });
-                        new MaterialDialog.Builder(DeckPicker.this)
-                                .title(R.string.new_deck)
-                                .positiveText(R.string.dialog_ok)
-                                .customView(mDialogEditText, true)
-                                .callback(new MaterialDialog.ButtonCallback() {
-                                    @Override
-                                    public void onPositive(MaterialDialog dialog) {
-                                        String deckName = mDialogEditText.getText().toString();
-                                        Timber.i("DeckPicker:: Creating new deck...");
-                                        getCol().getDecks().id(deckName, true);
-                                        CardBrowser.clearSelectedDeck();
-                                        updateDeckList();
-                                    }
-                                })
-                                .negativeText(R.string.dialog_cancel)
-                                .show();
+                new MaterialDialog.Builder(DeckPicker.this)
+                        .title(R.string.new_deck)
+                        .positiveText(R.string.dialog_ok)
+                        .customView(mDialogEditText, true)
+                        .callback(new MaterialDialog.ButtonCallback() {
+                            @Override
+                            public void onPositive(MaterialDialog dialog) {
+                                String deckName = mDialogEditText.getText().toString();
+                                Timber.i("DeckPicker:: Creating new deck...");
+                                getCol().getDecks().id(deckName, true);
+                                CardBrowser.clearSelectedDeck();
+                                updateDeckList();
+                            }
+                        })
+                        .negativeText(R.string.dialog_cancel)
+                        .show();
             }
         });
         addSharedButton.setOnClickListener(new OnClickListener() {
@@ -453,17 +488,6 @@ public class DeckPicker extends NavigationDrawerActivity implements
                 addNote();
             }
         });
-
-        mTodayTextView = (TextView) findViewById(R.id.today_stats_text_view);
-
-        mTodayTextView = (TextView) findViewById(R.id.today_stats_text_view);
-        if (! CollectionHelper.hasStorageAccessPermission(this)) {
-            ActivityCompat.requestPermissions(this, new String[] {Manifest.permission.WRITE_EXTERNAL_STORAGE},
-                    REQUEST_STORAGE_PERMISSION);
-        } else {
-            // Show splash screen and load collection
-            showStartupScreensAndDialogs(preferences, 0);
-        }
     }
 
     @Override
@@ -733,7 +757,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
             super.onBackPressed();
         } else {
             Timber.i("Back key pressed");
-            if (mActionsMenu.isExpanded()) {
+            if (mActionsMenu != null && mActionsMenu.isExpanded()) {
                 mActionsMenu.collapse();
             } else {
                 automaticSync();
@@ -803,7 +827,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
     }
 
 
-    private void addNote() {
+    public void addNote() {
         Preferences.COMING_FROM_ADD = true;
         Intent intent = new Intent(DeckPicker.this, NoteEditor.class);
         intent.putExtra(NoteEditor.EXTRA_CALLER, NoteEditor.CALLER_DECKPICKER);
@@ -1665,7 +1689,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
     }
 
 
-    private void addSharedDeck() {
+    public void addSharedDeck() {
         openUrl(Uri.parse(getResources().getString(R.string.shared_decks_url)));
     }
 
@@ -2054,16 +2078,18 @@ public class DeckPicker extends NavigationDrawerActivity implements
         @Override
         public void onDismissed(Snackbar snackbar, int event) {
             if (!CompatHelper.isHoneycomb()) {
-                final FloatingActionsMenu actionsMenu = (FloatingActionsMenu) findViewById(R.id.add_content_menu);
-                actionsMenu.setEnabled(true);
+                final android.support.design.widget.FloatingActionButton b;
+                b = (android.support.design.widget.FloatingActionButton) findViewById(R.id.add_note_action);
+                b.setEnabled(true);
             }
         }
 
         @Override
         public void onShown(Snackbar snackbar) {
             if (!CompatHelper.isHoneycomb()) {
-                final FloatingActionsMenu actionsMenu = (FloatingActionsMenu) findViewById(R.id.add_content_menu);
-                actionsMenu.setEnabled(false);
+                final android.support.design.widget.FloatingActionButton b;
+                b = (android.support.design.widget.FloatingActionButton) findViewById(R.id.add_note_action);
+                b.setEnabled(false);
             }
         }
     };

--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/FabBehavior.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/FabBehavior.java
@@ -22,7 +22,7 @@ import android.support.v4.view.ViewCompat;
 import android.util.AttributeSet;
 import android.view.View;
 
-import net.i2p.android.ext.floatingactionbutton.FloatingActionsMenu;
+import com.getbase.floatingactionbutton.FloatingActionsMenu;
 
 import java.util.List;
 

--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
@@ -25,6 +25,7 @@ import android.widget.RemoteViews;
 
 import com.ichi2.anki.AbstractFlashcardViewer;
 import com.ichi2.anki.AnkiActivity;
+import com.ichi2.anki.DeckPicker;
 
 /**
  * This interface defines a set of functions that are not available on all platforms.
@@ -57,5 +58,6 @@ public interface Compat {
     void setFullScreen(AbstractFlashcardViewer activity);
     void setSelectableBackground(View view);
     void openUrl(AnkiActivity activity, Uri uri);
+    void supportAddContentMenu(final DeckPicker a);
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV10.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV10.java
@@ -10,14 +10,19 @@ import android.database.sqlite.SQLiteDatabase;
 import android.net.Uri;
 import android.speech.tts.TextToSpeech;
 import android.speech.tts.TextToSpeech.OnUtteranceCompletedListener;
+import android.support.annotation.NonNull;
 import android.view.View;
 import android.view.WindowManager;
+import android.widget.EditText;
 import android.widget.LinearLayout;
 import android.widget.RemoteViews;
 
+import com.afollestad.materialdialogs.DialogAction;
+import com.afollestad.materialdialogs.MaterialDialog;
 import com.ichi2.anki.AbstractFlashcardViewer;
 import com.ichi2.anki.AnkiActivity;
 import com.ichi2.anki.AnkiDroidApp;
+import com.ichi2.anki.CardBrowser;
 import com.ichi2.anki.DeckPicker;
 import com.ichi2.anki.R;
 import com.ichi2.anki.ReadText;
@@ -74,7 +79,6 @@ public class CompatV10 implements Compat {
 
 
     // Below API level 16, widget dimensions cannot be adjusted
-    @Override
     public void updateWidgetDimensions(Context context, RemoteViews updateViews, Class<?> cls) {
 
     }
@@ -90,7 +94,6 @@ public class CompatV10 implements Compat {
         activity.startActivityWithoutAnimation(intent);
     }
 
-    @Override
     public void setFullScreen(AbstractFlashcardViewer a) {
         a.getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN, WindowManager.LayoutParams.FLAG_FULLSCREEN);
         final int fullscreenMode = Integer.parseInt(AnkiDroidApp.getSharedPrefs(a).getString("fullscreenMode", "0"));
@@ -101,7 +104,6 @@ public class CompatV10 implements Compat {
     }
 
 
-    @Override
     public void setSelectableBackground(View view) {
         // NOTE: we can't use android.R.attr.selectableItemBackground until API 11
         Resources res = view.getContext().getResources();
@@ -111,8 +113,54 @@ public class CompatV10 implements Compat {
         ta.recycle();
     }
 
-    @Override
     public void openUrl(AnkiActivity activity, Uri uri) {
         new CustomTabsFallback().openUri(activity, uri);
+    }
+
+    /**
+     * FloatingActionsMenu has a bug on Android 2.3 where the collapsed menu items can still be clicked,
+     * so we revert to showing a ContextMenu below API 14.
+     * @param activity DeckPicker instance that we can run callbacks on
+     */
+    public void supportAddContentMenu(final DeckPicker activity) {
+        Resources res = activity.getResources();
+        new MaterialDialog.Builder(activity)
+                .items(new String[]{res.getString(R.string.menu_add_note),
+                        res.getString(R.string.menu_get_shared_decks),
+                        res.getString(R.string.new_deck)})
+                .itemsCallback(new MaterialDialog.ListCallback() {
+                    @Override
+                    public void onSelection(MaterialDialog materialDialog, View view, int i,
+                                            CharSequence charSequence) {
+                        switch (i) {
+                            case 0:
+                                activity.addNote();
+                                break;
+                            case 1:
+                                activity.addSharedDeck();
+                                break;
+                            case 2:
+                                final EditText mDialogEditText = new EditText(activity);
+                                mDialogEditText.setSingleLine(true);
+                                new MaterialDialog.Builder(activity)
+                                        .title(R.string.new_deck)
+                                        .positiveText(R.string.dialog_ok)
+                                        .customView(mDialogEditText, true)
+                                        .onPositive(new MaterialDialog.SingleButtonCallback() {
+                                            @Override
+                                            public void onClick(@NonNull MaterialDialog d, @NonNull DialogAction w) {
+                                                Timber.i("DeckPicker:: Creating new deck...");
+                                                String deckName = mDialogEditText.getText().toString();
+                                                activity.getCol().getDecks().id(deckName, true);
+                                                CardBrowser.clearSelectedDeck();
+                                                activity.onRequireDeckListUpdate();
+                                            }
+                                        })
+                                        .negativeText(R.string.dialog_cancel)
+                                        .show();
+                        }
+                    }
+                })
+                .build().show();
     }
 }

--- a/AnkiDroid/src/main/res/layout-v14/floating_add_button.xml
+++ b/AnkiDroid/src/main/res/layout-v14/floating_add_button.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Floating action button -->
+<merge xmlns:android="http://schemas.android.com/apk/res/android">
+    <com.getbase.floatingactionbutton.FloatingActionsMenu
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:fab="http://schemas.android.com/apk/res-auto"
+        android:id="@+id/add_content_menu"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="end|bottom"
+        android:layout_margin="16dp"
+        fab:fab_addButtonColorNormal="@color/fab_normal"
+        fab:fab_addButtonColorPressed="@color/fab_pressed"
+        fab:fab_icon="@drawable/ic_add_white_24dp"
+        fab:fab_labelStyle="@style/menu_labels_style"
+        fab:layout_behavior="com.ichi2.anki.widgets.FabBehavior">
+        <com.getbase.floatingactionbutton.FloatingActionButton
+            android:id="@+id/add_deck_action"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            fab:fab_colorNormal="@color/fab_normal"
+            fab:fab_icon="@drawable/ic_folder_white_24dp"
+            fab:fab_title="@string/new_deck"
+            fab:fab_size="mini"
+            fab:fab_colorPressed="@color/fab_pressed"/>
+        <com.getbase.floatingactionbutton.FloatingActionButton
+            android:id="@+id/add_shared_action"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            fab:fab_colorNormal="@color/fab_normal"
+            fab:fab_icon="@drawable/ic_file_download_white_24dp"
+            fab:fab_title="@string/menu_get_shared_decks"
+            fab:fab_size="mini"
+            fab:fab_colorPressed="@color/fab_pressed"/>
+        <com.getbase.floatingactionbutton.FloatingActionButton
+            android:id="@+id/add_note_action"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            fab:fab_colorNormal="@color/fab_normal"
+            fab:fab_icon="@drawable/ic_add_white_24dp"
+            fab:fab_title="@string/menu_add_note"
+            fab:fab_size="mini"
+            fab:fab_colorPressed="@color/fab_pressed"/>
+    </com.getbase.floatingactionbutton.FloatingActionsMenu>
+</merge>

--- a/AnkiDroid/src/main/res/layout/floating_add_button.xml
+++ b/AnkiDroid/src/main/res/layout/floating_add_button.xml
@@ -1,45 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Floating action button -->
-<merge xmlns:android="http://schemas.android.com/apk/res/android">
-    <net.i2p.android.ext.floatingactionbutton.FloatingActionsMenu
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:fab="http://schemas.android.com/apk/res-auto"
-        android:id="@+id/add_content_menu"
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+       xmlns:app="http://schemas.android.com/apk/res-auto">
+    <android.support.design.widget.FloatingActionButton
+        android:id="@+id/add_note_action"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="end|bottom"
+        android:src="@drawable/ic_add_white_24dp"
+        android:layout_gravity="bottom|end"
         android:layout_margin="16dp"
-        fab:fab_addButtonColorNormal="@color/fab_normal"
-        fab:fab_addButtonColorPressed="@color/fab_pressed"
-        fab:fab_icon="@drawable/ic_add_white_24dp"
-        fab:fab_labelStyle="@style/menu_labels_style"
-        fab:layout_behavior="com.ichi2.anki.widgets.FabBehavior">
-        <net.i2p.android.ext.floatingactionbutton.FloatingActionButton
-            android:id="@+id/add_deck_action"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            fab:fab_colorNormal="@color/fab_normal"
-            fab:fab_icon="@drawable/ic_folder_white_24dp"
-            fab:fab_title="@string/new_deck"
-            fab:fab_size="mini"
-            fab:fab_colorPressed="@color/fab_pressed"/>
-        <net.i2p.android.ext.floatingactionbutton.FloatingActionButton
-            android:id="@+id/add_shared_action"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            fab:fab_colorNormal="@color/fab_normal"
-            fab:fab_icon="@drawable/ic_file_download_white_24dp"
-            fab:fab_title="@string/menu_get_shared_decks"
-            fab:fab_size="mini"
-            fab:fab_colorPressed="@color/fab_pressed"/>
-        <net.i2p.android.ext.floatingactionbutton.FloatingActionButton
-            android:id="@+id/add_note_action"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            fab:fab_colorNormal="@color/fab_normal"
-            fab:fab_icon="@drawable/ic_add_white_24dp"
-            fab:fab_title="@string/menu_add_note"
-            fab:fab_size="mini"
-            fab:fab_colorPressed="@color/fab_pressed"/>
-    </net.i2p.android.ext.floatingactionbutton.FloatingActionsMenu>
+        app:elevation="6dp"
+        app:backgroundTint="@color/fab_normal"
+        app:pressedTranslationZ="12dp"/>
 </merge>


### PR DESCRIPTION
The items in the FloatingActionsMenu were still clickable even when the menu was collapsed, probably due to a bug in the animation done by the NineOldAndroids library that is used in the version of the floatingactionbutton library that we were using (in order to support Gingerbread).

In this PR I've made it so that we revert to the standard design support library button implementation + context menu below API 14, and use the official floatingactionbutton library on API 14+.

One thing that we need to watch out for in this implementation is that `mActionsMenu` will be null below API 14.