### PR TITLE
Remove "note" from "Add note" on floating add button

### DIFF
--- a/AnkiDroid/src/main/res/layout-v14/floating_add_button.xml
+++ b/AnkiDroid/src/main/res/layout-v14/floating_add_button.xml
@@ -38,7 +38,7 @@
             android:layout_height="wrap_content"
             fab:fab_colorNormal="@color/fab_normal"
             fab:fab_icon="@drawable/ic_add_white_24dp"
-            fab:fab_title="@string/menu_add_note"
+            fab:fab_title="@string/menu_add"
             fab:fab_size="mini"
             fab:fab_colorPressed="@color/fab_pressed"/>
     </com.getbase.floatingactionbutton.FloatingActionsMenu>


### PR DESCRIPTION
Judging from the comments in the multiple reports saying they can't find the + button over the last week, new users are clearly failing to associate adding a flashcard with the term "Add note" right off the bat, which is kind of obvious really. Anki desktop just uses "Add", so I think we should too.