### PR TITLE
Don't report duplicate caught crashes

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
@@ -530,7 +530,7 @@ public class AnkiActivity extends AppCompatActivity implements LoaderManager.Loa
 
     // Restart the activity
     @SuppressLint("NewApi")
-    protected void restartActivity() {
+    public void restartActivity() {
         Timber.i("AnkiActivity -- restartActivity()");
         Intent intent = new Intent();
         intent.setClass(this, this.getClass());

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
@@ -115,6 +115,21 @@ public class CollectionHelper {
         return getCol(path);
     }
 
+    /**
+     * Call getCol(context) inside try / catch statement.
+     * Send exception report and return null if there was an exception.
+     * @param context
+     * @return
+     */
+    public synchronized Collection getColSafe(Context context) {
+        try {
+            return getCol(context);
+        } catch (Exception e) {
+            AnkiDroidApp.sendExceptionReport(e, "CollectionHelper.getColSafe");
+            return null;
+        }
+    }
+
 
     /**
      * Reopen the {@link Collection} after it's been opened at least once, and subsequently closed. If the

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -458,6 +458,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                 case "reportErrorMode": {
                     String value = prefs.getString("reportErrorMode", "");
                     AnkiDroidApp.getInstance().setAcraReportingMode(value);
+                    AnkiDroidApp.getSharedPrefs(this).edit().remove("sentExceptionReports").apply();    // clear cache
                     break;
                 }
                 case "syncAccount": {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.java
@@ -2,7 +2,6 @@
 package com.ichi2.anki.dialogs;
 
 import android.content.res.Resources;
-import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.os.Message;
 import android.view.View;
@@ -13,8 +12,8 @@ import com.ichi2.anki.AnkiActivity;
 import com.ichi2.anki.AnkiDatabaseManager;
 import com.ichi2.anki.BackupManager;
 import com.ichi2.anki.CollectionHelper;
+import com.ichi2.anki.DeckPicker;
 import com.ichi2.anki.R;
-import com.ichi2.themes.Themes;
 import com.ichi2.compat.CompatHelper;
 
 import java.io.File;
@@ -38,37 +37,6 @@ public class DatabaseErrorDialog extends AsyncDialogFragment {
 
     // public flag which lets us distinguish between inaccessible and corrupt database
     public static boolean databaseCorruptFlag = false;
-
-    public interface DatabaseErrorDialogListener {
-        public void showDatabaseErrorDialog(int dialogType);
-
-
-        public void sendErrorReport();
-
-
-        public boolean hasErrorFiles();
-
-
-        public void startLoadingCollection();
-
-
-        public void repairDeck();
-
-
-        public void restoreFromBackup(String backupPath);
-
-
-        public void integrityCheck();
-
-
-        public void sync(String conflict);
-
-
-        public void exit();
-
-
-        public void dismissAllDialogFragments();
-    }
 
 
     /**
@@ -115,13 +83,13 @@ public class DatabaseErrorDialog extends AsyncDialogFragment {
                         .callback(new MaterialDialog.ButtonCallback() {
                             @Override
                             public void onPositive(MaterialDialog dialog) {
-                                ((DatabaseErrorDialogListener) getActivity())
+                                ((DeckPicker) getActivity())
                                         .showDatabaseErrorDialog(DIALOG_ERROR_HANDLING);
                             }
 
                             @Override
                             public void onNegative(MaterialDialog dialog) {
-                                ((DatabaseErrorDialogListener) getActivity()).exit();
+                                ((DeckPicker) getActivity()).exit();
                             }
                         })
                         .show();
@@ -139,24 +107,24 @@ public class DatabaseErrorDialog extends AsyncDialogFragment {
                         .callback(new MaterialDialog.ButtonCallback() {
                             @Override
                             public void onPositive(MaterialDialog dialog) {
-                                ((DatabaseErrorDialogListener) getActivity())
+                                ((DeckPicker) getActivity())
                                         .showDatabaseErrorDialog(DIALOG_ERROR_HANDLING);
                             }
 
                             @Override
                             public void onNegative(MaterialDialog dialog) {
-                                ((DatabaseErrorDialogListener) getActivity()).sendErrorReport();
+                                ((DeckPicker) getActivity()).sendErrorReport();
                                 dismissAllDialogFragments();
                             }
 
                             @Override
                             public void onNeutral(MaterialDialog dialog) {
-                                ((DatabaseErrorDialogListener) getActivity()).exit();
+                                ((DeckPicker) getActivity()).exit();
                             }
                         })
                         .show();
                 dialog.getCustomView().findViewById(R.id.buttonDefaultNegative).setEnabled(
-                        ((DatabaseErrorDialogListener) getActivity()).hasErrorFiles());
+                        ((DeckPicker) getActivity()).hasErrorFiles());
                 return dialog;
 
             case DIALOG_ERROR_HANDLING:
@@ -204,26 +172,26 @@ public class DatabaseErrorDialog extends AsyncDialogFragment {
                                     CharSequence charSequence) {
                                 switch (mRepairValues[which]) {
                                     case 0:
-                                        ((DatabaseErrorDialogListener) getActivity()).startLoadingCollection();
+                                        ((DeckPicker) getActivity()).restartActivity();
                                         return;
                                     case 1:
-                                        ((DatabaseErrorDialogListener) getActivity())
+                                        ((DeckPicker) getActivity())
                                                 .showDatabaseErrorDialog(DIALOG_CONFIRM_DATABASE_CHECK);
                                         return;
                                     case 2:
-                                        ((DatabaseErrorDialogListener) getActivity())
+                                        ((DeckPicker) getActivity())
                                                 .showDatabaseErrorDialog(DIALOG_REPAIR_COLLECTION);
                                         return;
                                     case 3:
-                                        ((DatabaseErrorDialogListener) getActivity())
+                                        ((DeckPicker) getActivity())
                                                 .showDatabaseErrorDialog(DIALOG_RESTORE_BACKUP);
                                         return;
                                     case 4:
-                                        ((DatabaseErrorDialogListener) getActivity())
+                                        ((DeckPicker) getActivity())
                                                 .showDatabaseErrorDialog(DIALOG_FULL_SYNC_FROM_SERVER);
                                         return;
                                     case 5:
-                                        ((DatabaseErrorDialogListener) getActivity())
+                                        ((DeckPicker) getActivity())
                                                 .showDatabaseErrorDialog(DIALOG_NEW_COLLECTION);
                                 }
                             }
@@ -240,7 +208,7 @@ public class DatabaseErrorDialog extends AsyncDialogFragment {
                         .callback(new MaterialDialog.ButtonCallback() {
                             @Override
                             public void onPositive(MaterialDialog dialog) {
-                                ((DatabaseErrorDialogListener) getActivity()).repairDeck();
+                                ((DeckPicker) getActivity()).repairDeck();
                                 dismissAllDialogFragments();
                             }
                         })
@@ -261,7 +229,7 @@ public class DatabaseErrorDialog extends AsyncDialogFragment {
                             .callback(new MaterialDialog.ButtonCallback() {
                                 @Override
                                 public void onPositive(MaterialDialog dialog) {
-                                    ((DatabaseErrorDialogListener) getActivity())
+                                    ((DeckPicker) getActivity())
                                             .showDatabaseErrorDialog(DIALOG_ERROR_HANDLING);
                                 }
                             });
@@ -287,7 +255,7 @@ public class DatabaseErrorDialog extends AsyncDialogFragment {
                                         int which, CharSequence charSequence) {
                                     if (mBackups[which].length() > 0) {
                                         // restore the backup if it's valid
-                                        ((DatabaseErrorDialogListener) getActivity())
+                                        ((DeckPicker) getActivity())
                                                 .restoreFromBackup(mBackups[which]
                                                         .getPath());
                                         dismissAllDialogFragments();
@@ -317,12 +285,10 @@ public class DatabaseErrorDialog extends AsyncDialogFragment {
                                 String path = CollectionHelper.getInstance().getCollectionPath(getActivity());
                                 AnkiDatabaseManager.closeDatabase(path);
                                 if (BackupManager.moveDatabaseToBrokenFolder(path, false)) {
-                                    ((DatabaseErrorDialogListener) getActivity()).startLoadingCollection();
+                                    ((DeckPicker) getActivity()).restartActivity();
                                 } else {
-                                    ((DatabaseErrorDialogListener) getActivity())
-                                            .showDatabaseErrorDialog(DIALOG_ERROR_HANDLING);
+                                    ((DeckPicker) getActivity()).showDatabaseErrorDialog(DIALOG_LOAD_FAILED);
                                 }
-                                dismissAllDialogFragments();
                             }
                         })
                         .show();
@@ -335,7 +301,7 @@ public class DatabaseErrorDialog extends AsyncDialogFragment {
                         .callback(new MaterialDialog.ButtonCallback() {
                             @Override
                             public void onPositive(MaterialDialog dialog) {
-                                ((DatabaseErrorDialogListener) getActivity()).integrityCheck();
+                                ((DeckPicker) getActivity()).integrityCheck();
                                 dismissAllDialogFragments();
                             }
                         })
@@ -349,7 +315,7 @@ public class DatabaseErrorDialog extends AsyncDialogFragment {
                         .callback(new MaterialDialog.ButtonCallback() {
                             @Override
                             public void onPositive(MaterialDialog dialog) {
-                                ((DatabaseErrorDialogListener) getActivity())
+                                ((DeckPicker) getActivity())
                                         .showDatabaseErrorDialog(DIALOG_RESTORE_BACKUP);
                             }
                         })
@@ -363,8 +329,7 @@ public class DatabaseErrorDialog extends AsyncDialogFragment {
                         .callback(new MaterialDialog.ButtonCallback() {
                             @Override
                             public void onPositive(MaterialDialog dialog) {
-                                DatabaseErrorDialogListener activity = (DatabaseErrorDialogListener) getActivity();
-                                activity.sync("download");
+                                ((DeckPicker) getActivity()).sync("download");
                                 dismissAllDialogFragments();
                             }
                         })
@@ -468,6 +433,6 @@ public class DatabaseErrorDialog extends AsyncDialogFragment {
     
     
     public void dismissAllDialogFragments() {
-        ((DatabaseErrorDialogListener) getActivity()).dismissAllDialogFragments();
+        ((DeckPicker) getActivity()).dismissAllDialogFragments();
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
@@ -225,7 +225,7 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
         mContext = AnkiDroidApp.getInstance().getApplicationContext();
 
         // Skip the task if the collection cannot be opened
-        if (mType != TASK_TYPE_REPAIR_DECK && CollectionHelper.getInstance().getCol(mContext) == null) {
+        if (mType != TASK_TYPE_REPAIR_DECK && CollectionHelper.getInstance().getColSafe(mContext) == null) {
             Timber.e("Aborting DeckTask %d as Collection could not be opened", mType);
             return null;
         }


### PR DESCRIPTION
I've noticed that some users continually spam our crash database with thousands of identical crash reports, so here I've added a cache to the shared preferences, which contains the hash of the stack trace of each exception that has been reported for the current version. 

Each time a caught exception is up for reporting, we check if the hash already exists, and if it does we skip sending it to our server. If not, it's added to the cache. Uncaught exceptions are unaffected as that would require modifications to Acra, and it's probably OK to prioritize those crashes anyway.

This should make it easier for us to find crashes, and reduce the frequency that we have to purge crashes before the database becomes unusable.

I've also tightened up the error handling surrounding the opening of the collection while I was testing these changes.