### PR TITLE
Add ability to use custom sync server

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -439,8 +439,8 @@ public class DeckPicker extends NavigationDrawerActivity implements
                 onSdCardNotMounted();
             } else if (!CollectionHelper.isCurrentAnkiDroidDirAccessible(this)) {
                 // AnkiDroid directory inaccessible
-                Intent prefIntent = CompatHelper.getCompat().getAdvancedPreferencesIntent(this);
-                startActivityForResultWithoutAnimation(prefIntent, REQUEST_PATH_UPDATE);
+                Intent i = CompatHelper.getCompat().getPreferenceSubscreenIntent(this, "com.ichi2.anki.prefs.advanced");
+                startActivityForResultWithoutAnimation(i, REQUEST_PATH_UPDATE);
                 Toast.makeText(this, R.string.directory_inaccessible, Toast.LENGTH_LONG).show();
             } else {
                 showDatabaseErrorDialog(DatabaseErrorDialog.DIALOG_LOAD_FAILED);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -181,6 +181,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
             // syncAccount's summary can change while preferences are still open (user logs
             // in from preferences screen), so we need to update it here.
             updatePreference(prefs, "syncAccount", this);
+            updatePreference(prefs, "custom_sync_server_link", this);
         }
     }
 
@@ -282,6 +283,16 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                         }
                     }
                 });
+                // Custom sync server option
+                Preference customSyncServerPreference = screen.findPreference("custom_sync_server_link");
+                customSyncServerPreference.setOnPreferenceClickListener(new OnPreferenceClickListener() {
+                    public boolean onPreferenceClick(Preference preference) {
+                        Intent i = CompatHelper.getCompat().getPreferenceSubscreenIntent(Preferences.this,
+                                "com.ichi2.anki.prefs.custom_sync_server");
+                        startActivity(i);
+                        return true;
+                    }
+                });
                 // Force full sync option
                 Preference fullSyncPreference = screen.findPreference("force_full_sync");
                 fullSyncPreference.setOnPreferenceClickListener(new OnPreferenceClickListener() {
@@ -295,6 +306,10 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                 });
                 // Workaround preferences
                 removeUnnecessaryAdvancedPrefs(screen);
+                break;
+            case "com.ichi2.anki.prefs.custom_sync_server":
+                getSupportActionBar().setTitle(R.string.custom_sync_server_title);
+                listener.addPreferencesFromResource(R.xml.preferences_custom_sync_server);
                 break;
         }
     }
@@ -374,7 +389,6 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
         CharSequence s = pref.getSummary();
         mOriginalSumarries.put(pref.getKey(), (s != null) ? s.toString() : "");
         // Update summary
-
         updateSummary(pref);
     }
 
@@ -515,8 +529,15 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
         if (pref == null || pref.getKey() == null) {
             return;
         }
+        // Handle special cases
         if (pref.getKey().equals("about_dialog_preference")) {
             pref.setSummary(getResources().getString(R.string.about_version) + " " + VersionUtils.getPkgVersionName());
+        } else if (pref.getKey().equals("custom_sync_server_link")) {
+            if (!AnkiDroidApp.getSharedPrefs(this).getBoolean("useCustomSyncServer", false)) {
+                pref.setSummary(R.string.disabled);
+            } else {
+                pref.setSummary(AnkiDroidApp.getSharedPrefs(this).getString("syncBaseUrl", ""));
+            }
         }
         // Get value text
         String value;
@@ -709,6 +730,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
             // syncAccount's summary can change while preferences are still open (user logs
             // in from preferences screen), so we need to update it here.
             ((Preferences) getActivity()).updatePreference(prefs, "syncAccount", this);
+            ((Preferences) getActivity()).updatePreference(prefs, "custom_sync_server_link", this);
         }
 
         @Override

--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
@@ -59,6 +59,6 @@ public interface Compat {
     void setSelectableBackground(View view);
     void openUrl(AnkiActivity activity, Uri uri);
     void supportAddContentMenu(final DeckPicker a);
-    Intent getAdvancedPreferencesIntent(Context context);
+    Intent getPreferenceSubscreenIntent(Context context, String subscreen);
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV10.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV10.java
@@ -161,10 +161,10 @@ public class CompatV10 implements Compat {
     }
 
     @Override
-    public Intent getAdvancedPreferencesIntent(Context context) {
+    public Intent getPreferenceSubscreenIntent(Context context, String subscreen) {
         // We're using "legacy preference headers" below API 11
         Intent i = new Intent(context, Preferences.class);
-        i.setAction("com.ichi2.anki.prefs.advanced");
+        i.setAction(subscreen);
         return i;
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV11.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV11.java
@@ -38,12 +38,13 @@ public class CompatV11 extends CompatV10 implements Compat {
     }
 
     @Override
-    public Intent getAdvancedPreferencesIntent(Context context) {
+    public Intent getPreferenceSubscreenIntent(Context context, String subscreen) {
         Intent i = new Intent(context, Preferences.class);
         i.putExtra(PreferenceActivity.EXTRA_SHOW_FRAGMENT, "com.ichi2.anki.Preferences$SettingsFragment");
         Bundle extras = new Bundle();
-        extras.putString("subscreen", "com.ichi2.anki.prefs.advanced");
+        extras.putString("subscreen", subscreen);
         i.putExtra(PreferenceActivity.EXTRA_SHOW_FRAGMENT_ARGUMENTS, extras);
+        i.putExtra(PreferenceActivity.EXTRA_NO_HEADERS, true);
         return i;
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/FullSyncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/FullSyncer.java
@@ -16,11 +16,13 @@
 
 package com.ichi2.libanki.sync;
 
+import android.content.SharedPreferences;
 import android.database.sqlite.SQLiteDatabaseCorruptException;
 
 
 import com.ichi2.anki.AnkiDatabaseManager;
 import com.ichi2.anki.AnkiDb;
+import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.R;
 import com.ichi2.anki.exception.UnknownHttpResponseException;
 import com.ichi2.async.Connection;
@@ -60,6 +62,13 @@ public class FullSyncer extends HttpSyncer {
 
     @Override
     public String syncURL() {
+        // Allow user to specify custom sync server
+        SharedPreferences userPreferences = AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance());
+        if (userPreferences!= null && userPreferences.getBoolean("useCustomSyncServer", false)) {
+            File syncBase = new File(userPreferences.getString("syncBaseUrl", Consts.SYNC_BASE));
+            return new File(syncBase, "/sync").toString() + "/";
+        }
+        // Usual case
         return Consts.SYNC_BASE + "sync/";
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HttpSyncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HttpSyncer.java
@@ -20,6 +20,8 @@ package com.ichi2.libanki.sync;
 
 
 
+import android.content.SharedPreferences;
+
 import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.exception.UnknownHttpResponseException;
 import com.ichi2.async.Connection;
@@ -448,6 +450,13 @@ public class HttpSyncer {
 
 
     public String syncURL() {
+        // Allow user to specify custom sync server
+        SharedPreferences userPreferences = AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance());
+        if (userPreferences!= null && userPreferences.getBoolean("useCustomSyncServer", false)) {
+            File syncBase = new File(userPreferences.getString("syncBaseUrl", Consts.SYNC_BASE));
+            return new File(syncBase, "/sync").toString() + "/";
+        }
+        // Usual case
         return Consts.SYNC_BASE + "sync/";
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteMediaServer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteMediaServer.java
@@ -17,8 +17,10 @@
 
 package com.ichi2.libanki.sync;
 
+import android.content.SharedPreferences;
 import android.text.TextUtils;
 
+import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.exception.MediaSyncException;
 import com.ichi2.anki.exception.UnknownHttpResponseException;
 import com.ichi2.async.Connection;
@@ -55,6 +57,13 @@ public class RemoteMediaServer extends HttpSyncer {
 
     @Override
     public String syncURL() {
+        // Allow user to specify custom sync server
+        SharedPreferences userPreferences = AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance());
+        if (userPreferences!= null && userPreferences.getBoolean("useCustomSyncServer", false)) {
+            File mediaSyncBase = new File(userPreferences.getString("syncMediaUrl", Consts.SYNC_MEDIA_BASE));
+            return mediaSyncBase.toString() + "/";
+        }
+        // Usual case
         return Consts.SYNC_MEDIA_BASE;
     }
 

--- a/AnkiDroid/src/main/res/layout/my_account.xml
+++ b/AnkiDroid/src/main/res/layout/my_account.xml
@@ -108,8 +108,15 @@
                 android:text="@string/sign_up_description"
                 android:layout_gravity="center"
                 android:textSize="@dimen/abc_text_size_button_material"
-                android:textStyle="bold"
-                />
+                android:textStyle="bold"/>
+            <TextView
+                android:id="@+id/no_account_not_affiliated"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/sign_up_not_affiliated"
+                android:layout_gravity="center"
+                android:textSize="@dimen/abc_text_size_button_material"
+                android:textStyle="italic"/>
 
             <Button
                 android:id="@+id/sign_up_button"

--- a/AnkiDroid/src/main/res/values/04-network.xml
+++ b/AnkiDroid/src/main/res/values/04-network.xml
@@ -31,7 +31,7 @@
     <string name="menu_get_shared_decks">Get shared decks</string>
     <string name="connection_error_message">A network error has occurred</string>
     <string name="not_logged_in_title">Log in to AnkiWeb</string>
-    <string name="login_create_account_message">You must log in to an AnkiWeb account. You can create one in the next step.</string>
+    <string name="login_create_account_message">You must log in to a third party account to use the cloud sync service. You can create one in the next step.</string>
     <string name="no_email_client">No email client available</string>
 
     <!-- MyAccount.java -->
@@ -41,6 +41,7 @@
     <string name="password_repeat">Repeat password</string>
     <string name="log_in">Log in</string>
     <string name="sign_up_description">Don’t have an AnkiWeb account? It’s free!</string>
+    <string name="sign_up_not_affiliated">Note: AnkiWeb is not affiliated with AnkiDroid</string>
     <string name="sign_up">Sign up</string>
     <string name="logged_as">Logged in as</string>
     <string name="log_out">Log out</string>

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -18,7 +18,8 @@
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 --><resources>
-
+    <!-- generic strings -->
+    <string name="disabled">Disabled</string>
     <!-- preferences.xml categories-->
     <string name="pref_cat_general">AnkiDroid</string>
     <string name="pref_cat_general_summ">General settings</string>
@@ -139,6 +140,12 @@
     <string name="convert_fen_text_summ">Draw chessboard from Forsyth–Edwards Notation. The notation must be enclosed in [fen][/fen] tags.</string>
     <string name="enable_api_title">Enable AnkiDroid API</string>
     <string name="enable_api_summary">Let other apps connect to AnkiDroid and read / write data without your intervention</string>
+    <!-- Custom sync server settings -->
+    <string name="custom_sync_server_title">Custom sync server</string>
+    <string name="custom_sync_server_enable_title">Use custom sync server</string>
+    <string name="custom_sync_server_enable_summary">If you don\'t want to use the proprietary AnkiWeb service you can specify an alternative server here</string>
+    <string name="custom_sync_server_base_url_title">Sync url</string>
+    <string name="custom_sync_server_media_url_title">Media sync url</string>
 
     <!-- studyoptions -->
     <string name="studyoptions_limit_select_tags">Select tags</string>

--- a/AnkiDroid/src/main/res/xml/preferences_advanced.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_advanced.xml
@@ -35,6 +35,9 @@
             android:key="force_full_sync"
             android:title="@string/force_full_sync_title"
             android:summary="@string/force_full_sync_summary" />
+        <Preference
+            android:key="custom_sync_server_link"
+            android:title="@string/custom_sync_server_title"/>
         <PreferenceCategory android:title="@string/pref_cat_performance" >
             <com.ichi2.ui.SeekBarPreference
                 android:defaultValue="8"

--- a/AnkiDroid/src/main/res/xml/preferences_custom_sync_server.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_custom_sync_server.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+
+<!-- Advanced Preferences -->
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+    <CheckBoxPreference
+        android:key="useCustomSyncServer"
+        android:title="Use custom sync server"
+        android:summary="@string/custom_sync_server_enable_summary"
+        android:defaultValue="false"/>
+    <EditTextPreference
+        android:key="syncBaseUrl"
+        android:dependency="useCustomSyncServer"
+        android:title="@string/custom_sync_server_base_url_title"
+        android:defaultValue="https://ankiweb.net/"/>
+    <EditTextPreference
+        android:key="syncMediaUrl"
+        android:dependency="useCustomSyncServer"
+        android:title="@string/custom_sync_server_media_url_title"
+        android:defaultValue="https://msync.ankiweb.net/"/>
+</PreferenceScreen>


### PR DESCRIPTION
It looks like they're finally making some progress with https://github.com/dsnopek/anki-sync-server/pull/28, so I've gone ahead and added support for a custom sync server.

Fixes #1057 and supersedes #680

This also makes it clear that AnkiWeb is not affiliated with AnkiDroid in response to the results of the [recent survey](https://docs.google.com/forms/d/1LkA0jw4zb-ye889gzcz8gRBWJqGPfbUpu-QUppbPgHM/viewanalytics).