### PR TITLE
switch over to per-day sibling burying

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -154,9 +154,12 @@ public class Collection {
         mStartTime = 0;
         mSched = new Sched(this);
         if (!mConf.optBoolean("newBury", false)) {
-            boolean mod = mDb.getMod();
-            mSched.unburyCards();
-            mDb.setMod(mod);
+            try {
+                mConf.put("newBury", true);
+            } catch (JSONException e) {
+                throw new RuntimeException(e);
+            }
+            setMod();
         }
     }
 
@@ -294,11 +297,6 @@ public class Collection {
 
     public synchronized void close(boolean save) {
         if (mDb != null) {
-            if (!mConf.optBoolean("newBury", false)) {
-                boolean mod = mDb.getMod();
-                mSched.unburyCards();
-                mDb.setMod(mod);
-            }
             try {
                 SQLiteDatabase db = getDb().getDatabase();
                 if (save) {
@@ -313,7 +311,6 @@ public class Collection {
                     if (db.inTransaction()) {
                         db.endTransaction();
                     }
-                    lock();
                 }
             } catch (RuntimeException e) {
                 AnkiDroidApp.sendExceptionReport(e, "closeDB");


### PR DESCRIPTION
From https://github.com/dae/anki/commit/44b83d9bd80a1966842698ea2546216d98db30df

While working on some other stuff I noticed this ancient commit was never ported over. In practice it means those using a somewhat older collection who *also* don't use the desktop client would be seeing the older sibling burying behaviour. It's likely not very many people.

There was also a random call to lock() in the same method which the desktop client doesn't have so I removed it. No idea what the impact of this will be though.