### PR TITLE
Added set TTS lanuage in context reviewer menu

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -188,7 +188,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
     private boolean mScrollingButtons;
     private boolean mGesturesEnabled;
     // Android WebView
-    private boolean mSpeakText;
+    protected boolean mSpeakText;
     protected boolean mDisableClipboard = false;
     protected boolean mNightMode = false;
     private boolean mPrefSafeDisplay;
@@ -2125,6 +2125,23 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
         } else if (Sound.SOUNDS_ANSWER == cardSide) {
             ReadText.textToSpeech(Utils.stripHTML(card.getPureAnswer()), getDeckIdForCard(card),
                     card.getOrd(), Sound.SOUNDS_ANSWER);
+        }
+    }
+
+
+    /**
+     * Shows the dialogue for selecting TTS for the current card and cardside.
+     */
+    protected void showSelectTtsDialogue() {
+        if (mTtsInitialized) {
+            if (!sDisplayAnswer) {
+                ReadText.selectTts(Utils.stripHTML(mCurrentCard.q(true)), getDeckIdForCard(mCurrentCard), mCurrentCard.getOrd(),
+                        Sound.SOUNDS_QUESTION);
+            }
+            else {
+                ReadText.selectTts(Utils.stripHTML(mCurrentCard.getPureAnswer()), getDeckIdForCard(mCurrentCard),
+                        mCurrentCard.getOrd(), Sound.SOUNDS_ANSWER);
+            }
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/MetaDB.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MetaDB.java
@@ -202,6 +202,24 @@ public class MetaDB {
         }
     }
 
+    /**
+     * Associates a language to a deck, model, and card model for a given type.
+     *
+     * @param qa the part of the card for which to store the association, {@link #LANGUAGES_QA_QUESTION},
+     *            {@link #LANGUAGES_QA_ANSWER}, or {@link #LANGUAGES_QA_UNDEFINED}
+     * @param language the language to associate, as a two-characters, lowercase string
+     */
+    public static void updateLanguage(Context context, long did, int ord, int qa, String language) {
+        openDBIfClosed(context);
+        try {
+            mMetaDb.execSQL("UPDATE languages SET language = ? WHERE did = ? AND ord = ? AND qa = ?;", new Object[] {
+                    language, did, ord, qa});
+            Timber.v("Update language for deck %d", did);
+        } catch (Exception e) {
+            Timber.e(e,"Error updating language in MetaDB ");
+        }
+    }
+
 
     /**
      * Returns the language associated with the given deck, model and card model, for the given type.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.java
@@ -74,6 +74,76 @@ public class ReadText {
     }
 
 
+    /**
+     * Ask the user what language they want.
+     *
+     * @param text The text to be read
+     * @param did The deck id
+     * @param ord The card template ordinal
+     * @param qa The card question or card answer
+     */
+    public static void selectTts(String text, long did, int ord, int qa) {
+        mTextToSpeak = text;
+        mQuestionAnswer = qa;
+        mDid = did;
+        mOrd = ord;
+        Resources res = mReviewer.get().getResources();
+        final MaterialDialog.Builder builder = new MaterialDialog.Builder(mReviewer.get());
+        // Build the language list if it's empty
+        if (availableTtsLocales.isEmpty()) {
+            buildAvailableLanguages();
+        }
+        if (availableTtsLocales.size() == 0) {
+            Timber.w("ReadText.textToSpeech() no TTS languages available");
+            builder.content(res.getString(R.string.no_tts_available_message))
+                    .iconAttr(R.attr.dialogErrorIcon)
+                    .positiveText(res.getString(R.string.dialog_ok));
+        } else {
+            ArrayList<CharSequence> dialogItems = new ArrayList<CharSequence>();
+            final ArrayList<String> dialogIds = new ArrayList<String>();
+            // Add option: "no tts"
+            dialogItems.add(res.getString(R.string.tts_no_tts));
+            dialogIds.add(NO_TTS);
+            for (int i = 0; i < availableTtsLocales.size(); i++) {
+                dialogItems.add(availableTtsLocales.get(i).getDisplayName());
+                dialogIds.add(availableTtsLocales.get(i).getISO3Language());
+            }
+            String[] items = new String[dialogItems.size()];
+            dialogItems.toArray(items);
+
+            builder.title(res.getString(R.string.select_locale_title))
+                    .items(items)
+                    .itemsCallback(new MaterialDialog.ListCallback() {
+                        @Override
+                        public void onSelection(MaterialDialog materialDialog, View view, int which,
+                                                CharSequence charSequence) {
+                            String locale = dialogIds.get(which);
+                            Timber.d("ReadText.selectTts() user chose locale '%s'", locale);
+                            if (!locale.equals(NO_TTS)) {
+                                speak(mTextToSpeak, locale);
+                            }
+                            String language = getLanguage(mDid, mOrd, mQuestionAnswer);
+                            if (language.equals("")) { // No language stored
+                                MetaDB.storeLanguage(mReviewer.get(), mDid, mOrd, mQuestionAnswer, locale);
+                            } else {
+                                MetaDB.updateLanguage(mReviewer.get(), mDid, mOrd, mQuestionAnswer, locale);
+                            }
+
+                        }
+                    });
+        }
+        // Show the dialog after short delay so that user gets a chance to preview the card
+        final Handler handler = new Handler();
+        final int delay = 500;
+        handler.postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                builder.build().show();
+            }
+        }, delay);
+    }
+
+
     public static void textToSpeech(String text, long did, int ord, int qa) {
         mTextToSpeak = text;
         mQuestionAnswer = qa;
@@ -99,50 +169,7 @@ public class ReadText {
         }
 
         // Otherwise ask the user what language they want to use
-        Resources res = mReviewer.get().getResources();
-        final MaterialDialog.Builder builder = new MaterialDialog.Builder(mReviewer.get());
-        if (availableTtsLocales.size() == 0) {
-            Timber.w("ReadText.textToSpeech() no TTS languages available");
-            builder.content(res.getString(R.string.no_tts_available_message))
-                    .iconAttr(R.attr.dialogErrorIcon)
-                    .positiveText(res.getString(R.string.dialog_ok));
-        } else {
-            ArrayList<CharSequence> dialogItems = new ArrayList<CharSequence>();
-            final ArrayList<String> dialogIds = new ArrayList<String>();
-            // Add option: "no tts"
-            dialogItems.add(res.getString(R.string.tts_no_tts));
-            dialogIds.add(NO_TTS);
-            for (int i = 0; i < availableTtsLocales.size(); i++) {
-                dialogItems.add(availableTtsLocales.get(i).getDisplayName());
-                dialogIds.add(availableTtsLocales.get(i).getISO3Language());
-            }
-            String[] items = new String[dialogItems.size()];
-            dialogItems.toArray(items);
-
-            builder.title(res.getString(R.string.select_locale_title))
-                    .items(items)
-                    .itemsCallback(new MaterialDialog.ListCallback() {
-                        @Override
-                        public void onSelection(MaterialDialog materialDialog, View view, int which,
-                                CharSequence charSequence) {
-                            String locale = dialogIds.get(which);
-                            Timber.d("ReadText.textToSpeech() user chose locale '%s'", locale);
-                            if (!locale.equals(NO_TTS)) {
-                                speak(mTextToSpeak, locale);
-                            }
-                            MetaDB.storeLanguage(mReviewer.get(), mDid, mOrd, mQuestionAnswer, locale);
-                        }
-                    });
-        }
-        // Show the dialog after short delay so that user gets a chance to preview the card
-        final Handler handler = new Handler();
-        final int delay = 500;
-        handler.postDelayed(new Runnable() {
-            @Override
-            public void run() {
-                builder.build().show();
-            }
-        }, delay);
+        selectTts(mTextToSpeak, mDid, mOrd, mQuestionAnswer);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -189,6 +189,11 @@ public class Reviewer extends AbstractFlashcardViewer {
                 startActivityForResultWithAnimation(i, DECK_OPTIONS, ActivityTransitionAnimation.FADE);
                 break;
 
+            case R.id.action_select_tts:
+                Timber.i("Reviewer:: Select TTS button pressed");
+                showSelectTtsDialogue();
+                break;
+
             default:
                 return super.onOptionsItemSelected(item);
         }
@@ -253,6 +258,9 @@ public class Reviewer extends AbstractFlashcardViewer {
         }
         if (getCol().getDecks().isDyn(getParentDid())) {
             menu.findItem(R.id.action_open_deck_options).setVisible(false);
+        }
+        if(mSpeakText){
+            menu.findItem(R.id.action_select_tts).setVisible(true);
         }
         return super.onCreateOptionsMenu(menu);
     }

--- a/AnkiDroid/src/main/res/menu/reviewer.xml
+++ b/AnkiDroid/src/main/res/menu/reviewer.xml
@@ -65,4 +65,8 @@
     <item
         android:id="@+id/action_open_deck_options"
         android:title="@string/study_options" />
+    <item
+        android:id="@+id/action_select_tts"
+        android:title="@string/select_tts"
+        android:visible="false" />
 </menu>

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -156,6 +156,7 @@
     <string name="import_hint">Place the apkg file in directory “%s” and touch “OK” to import cards</string>
     <string name="upgrade_import_no_file_found">No importable %1$s file found</string>
     <string name="study_options">Deck options</string>
+    <string name="select_tts">Set TTS language</string>
     <string name="custom_study">Custom study</string>
     <string name="more_options">More</string>
     <string name="dyn_deck_desc">This is a special deck for studying outside of the normal schedule. Cards will be automatically returned to their original decks after you review them. Deleting this deck from the deck list will return all remaining cards to their original deck.</string>

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -54,7 +54,7 @@
     <string name="text_selection_click_summ">Enable this if you are not able to select text with a long press</string>
     <string name="dictionary">Lookup dictionary</string>
     <string name="reset_languages">Reset languages</string>
-    <string name="reset_languages_summ">Reset language assignments (for text to speech and dictionaries) for all decks. Reset specific deck assignments on deck picker.</string>
+    <string name="reset_languages_summ">Reset language assignments (for text to speech and dictionaries) for all decks.</string>
     <string name="reset_languages_question">Reset all language assignments?</string>
     <string name="reset_confirmation">All states reset</string>
     <string name="card_zoom">Card zoom</string>


### PR DESCRIPTION
I hope everything is fine, at least it works when I tried it. Would be good if someone could take a look at my sql query in MetaDb.. wouldn't wanna mess up the database ;)

This will ask the user to select language for the current cardside.


Also I suggest we change:
"Reset language assignments (for text to speech and dictionaries) for all decks. Reset specific deck assignments on deck picker."

To
"Reset language assignments (for text to speech and dictionaries) for all decks. Reset specific deck assignments in reviewer."