### PR TITLE
Permanently remember last deck in CardBrowser when coming from DeckPicker

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
@@ -54,9 +54,6 @@ public class NavigationDrawerActivity extends AnkiActivity implements Navigation
     public static final int REQUEST_PREFERENCES_UPDATE = 100;
     public static final int REQUEST_BROWSE_CARDS = 101;
     public static final int REQUEST_STATISTICS = 102;
-
-    private long mCurrentCardId = -1L;
-
     // Navigation drawer initialisation
     protected void initNavigationDrawer(View mainView){
         // Create inherited navigation drawer layout here so that it can be used by parent class
@@ -119,11 +116,17 @@ public class NavigationDrawerActivity extends AnkiActivity implements Navigation
             return;
         }
         Menu menu = mNavigationView.getMenu();
-        MenuItem item = menu.findItem(itemId);
-        if (item != null) {
-            item.setChecked(true);
+        if (itemId == -1) {
+            for (int i = 0; i < menu.size(); i++) {
+                menu.getItem(i).setChecked(false);
+            }
         } else {
-            Timber.e("Could not find item %d", itemId);
+            MenuItem item = menu.findItem(itemId);
+            if (item != null) {
+                item.setChecked(true);
+            } else {
+                Timber.e("Could not find item %d", itemId);
+            }
         }
     }
 
@@ -233,10 +236,6 @@ public class NavigationDrawerActivity extends AnkiActivity implements Navigation
         }
     }
 
-    protected void setCurrentCardId(long id) {
-        mCurrentCardId = id;
-    }
-
     @Override
     public boolean onNavigationItemSelected(MenuItem item) {
         // Don't do anything if user selects already selected position
@@ -251,12 +250,7 @@ public class NavigationDrawerActivity extends AnkiActivity implements Navigation
                 startActivityWithAnimation(deckPicker, ActivityTransitionAnimation.RIGHT);
                 break;
             case R.id.nav_browser:
-                Intent cardBrowser = new Intent(this, CardBrowser.class);
-                cardBrowser.putExtra("selectedDeck", getCol().getDecks().selected());
-                if (mCurrentCardId >= 0) {
-                    cardBrowser.putExtra("currentCard", mCurrentCardId);
-                }                
-                startActivityForResultWithAnimation(cardBrowser, REQUEST_BROWSE_CARDS, ActivityTransitionAnimation.LEFT);
+                openCardBrowser();
                 break;
             case R.id.nav_stats:
                 Intent intent = new Intent(this, Statistics.class);
@@ -283,6 +277,15 @@ public class NavigationDrawerActivity extends AnkiActivity implements Navigation
         }
         mDrawerLayout.closeDrawers();
         return true;
+    }
+
+    /**
+     * Open the card browser. Override this method to pass it custom arguments
+     */
+    protected void openCardBrowser() {
+        Intent cardBrowser = new Intent(this, CardBrowser.class);
+        cardBrowser.putExtra("selectedDeck", getCol().getDecks().selected());
+        startActivityForResultWithAnimation(cardBrowser, REQUEST_BROWSE_CARDS, ActivityTransitionAnimation.LEFT);
     }
 
     protected void showBackIcon() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -53,6 +53,7 @@ public class Reviewer extends AbstractFlashcardViewer {
     private boolean mShowWhiteboard = true;
     private boolean mBlackWhiteboard = true;
     private boolean mPrefFullscreenReview = false;
+    private Long mLastSelectedBrowserDid = null;
 
     @Override
     protected void setTitle() {
@@ -432,14 +433,20 @@ public class Reviewer extends AbstractFlashcardViewer {
         }
     }
 
+
     @Override
-    public boolean onNavigationItemSelected(MenuItem item) {
-        // Tell the browser the current card ID so that it can tell us when we need to reload
-        if (mCurrentCard != null) {
-            setCurrentCardId(mCurrentCard.getId());
+    protected void openCardBrowser() {
+        Intent cardBrowser = new Intent(this, CardBrowser.class);
+        cardBrowser.putExtra("selectedDeck", getCol().getDecks().selected());
+        if (mLastSelectedBrowserDid != null) {
+            cardBrowser.putExtra("defaultDeckId", mLastSelectedBrowserDid);
+        } else {
+            cardBrowser.putExtra("defaultDeckId", getCol().getDecks().selected());
         }
-        return super.onNavigationItemSelected(item);
+        cardBrowser.putExtra("currentCard", mCurrentCard.getId());
+        startActivityForResultWithAnimation(cardBrowser, REQUEST_BROWSE_CARDS, ActivityTransitionAnimation.LEFT);
     }
+
 
     @Override
     public void onWindowFocusChanged(boolean hasFocus) {
@@ -455,8 +462,13 @@ public class Reviewer extends AbstractFlashcardViewer {
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         if (requestCode == REQUEST_STATISTICS || requestCode == REQUEST_BROWSE_CARDS) {
-            // select original deck if the statistics or card browser were opened,
-            // which can change the selected deck
+            // Store the selected deck
+            if (data != null && data.getBooleanExtra("allDecksSelected", false)) {
+                mLastSelectedBrowserDid = -1L;
+            } else {
+                mLastSelectedBrowserDid = getCol().getDecks().selected();
+            }
+            // select original deck if the statistics or card browser were opened, which can change the selected deck
             if (data != null && data.hasExtra("originalDeck")) {
                 getCol().getDecks().select(data.getLongExtra("originalDeck", 0L));
             }

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV10.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV10.java
@@ -148,7 +148,6 @@ public class CompatV10 implements Compat {
                                                 Timber.i("DeckPicker:: Creating new deck...");
                                                 String deckName = mDialogEditText.getText().toString();
                                                 activity.getCol().getDecks().id(deckName, true);
-                                                CardBrowser.clearSelectedDeck();
                                                 activity.onRequireDeckListUpdate();
                                             }
                                         })


### PR DESCRIPTION
As mentioned in #4069. 

The old way of remembering the last selected deck was pretty sloppy to be honest (using a static variable, poor encapsulation, etc.), so I've changed it so that we pass in the default deck ID as an extra, where a value of -1 corresponds to "All Decks". I also pass whether or not all decks was selected as a boolean extra in the result intent, and it's up to the calling Activity to handle that how they want.

I made a new method `openCardBrowser()` which is overridden in DeckPicker and Reviewer to allow the passing in of Activity dependent custom parameters. This is a lot cleaner than the setter method I was using to pass in the current card ID.

Unrelated to the above changes, I also got rid of all the warnings in the Browser class while I was at it, which is in a separate commit.