### PR TITLE
Colored answer buttons in black theme.

### DIFF
--- a/AnkiDroid/src/main/res/values/theme_black.xml
+++ b/AnkiDroid/src/main/res/values/theme_black.xml
@@ -40,10 +40,10 @@
         <item name="learnCountColor">@color/theme_black_learn_count</item>
         <item name="reviewCountColor">@color/theme_black_review_count</item>
         <item name="answerButtonTextColor">@color/theme_black_primary_text</item>
-        <item name="againButtonTextColor">@color/theme_black_primary_text</item>
-        <item name="hardButtonTextColor">@color/theme_black_primary_text</item>
-        <item name="goodButtonTextColor">@color/theme_black_primary_text</item>
-        <item name="easyButtonTextColor">@color/theme_black_primary_text</item>
+        <item name="againButtonTextColor">@color/material_red_400</item>
+        <item name="hardButtonTextColor">@color/white</item>
+        <item name="goodButtonTextColor">@color/material_green_400</item>
+        <item name="easyButtonTextColor">@color/material_light_blue_400</item>
         <!-- Reviewer button drawables -->
         <item name="againButtonRef">@drawable/footer_button_all_black</item>
         <item name="hardButtonRef">@drawable/footer_button_all_black</item>


### PR DESCRIPTION
Here are colored buttons for the black theme. I used darker colors than the original screenshot. What do you think? For comparison:

![screenshot_20160131-214218](https://cloud.githubusercontent.com/assets/789082/12701645/b2fb2e06-c863-11e5-98bc-535187ec0a0d.png)
![screenshot_20160124-113411](https://cloud.githubusercontent.com/assets/789082/12701647/b6f183ac-c863-11e5-8257-3f3c05c93c5a.png)
