### PR TITLE
Simplify themes and make them more consistent

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.java
@@ -110,10 +110,10 @@ public class DeckAdapter extends RecyclerView.Adapter<DeckAdapter.ViewHolder> {
                 R.attr.collapseRef };
         TypedArray ta = context.obtainStyledAttributes(attrs);
         Resources res = context.getResources();
-        mZeroCountColor = ta.getColor(0, res.getColor(R.color.theme_light_zero_count));
-        mNewCountColor = ta.getColor(1, res.getColor(R.color.theme_light_new_count));
-        mLearnCountColor = ta.getColor(2, res.getColor(R.color.theme_light_learn_count));
-        mReviewCountColor = ta.getColor(3, res.getColor(R.color.theme_light_review_count));
+        mZeroCountColor = ta.getColor(0, res.getColor(R.color.black));
+        mNewCountColor = ta.getColor(1, res.getColor(R.color.black));
+        mLearnCountColor = ta.getColor(2, res.getColor(R.color.black));
+        mReviewCountColor = ta.getColor(3, res.getColor(R.color.black));
         mRowCurrentDrawable = ta.getResourceId(4, 0);
         mDeckNameDefaultColor = ta.getColor(5, res.getColor(R.color.black));
         mDeckNameDynColor = ta.getColor(6, res.getColor(R.color.material_blue_A700));

--- a/AnkiDroid/src/main/res/drawable/footer_button_again.xml
+++ b/AnkiDroid/src/main/res/drawable/footer_button_again.xml
@@ -4,12 +4,12 @@
     <selector>
         <item android:state_pressed="true">
             <shape android:shape="rectangle" >
-                <solid android:color="@color/material_red_600" />
+                <solid android:color="@color/material_red_800" />
             </shape>
         </item>
         <item android:state_focused="true">
             <shape android:shape="rectangle" >
-                <solid android:color="@color/material_red_700" />
+                <solid android:color="@color/material_red_900" />
             </shape>
         </item>
         <item>

--- a/AnkiDroid/src/main/res/drawable/footer_button_all_black.xml
+++ b/AnkiDroid/src/main/res/drawable/footer_button_all_black.xml
@@ -4,12 +4,12 @@
     <selector>
         <item android:state_pressed="true">
             <shape android:shape="rectangle" >
-                <solid android:color="#050505" />
+                <solid android:color="#101010" />
             </shape>
         </item>
         <item android:state_focused="true">
             <shape android:shape="rectangle" >
-                <solid android:color="#0a0a0a" />
+                <solid android:color="#101010" />
             </shape>
         </item>
         <item>

--- a/AnkiDroid/src/main/res/drawable/footer_button_all_plain.xml
+++ b/AnkiDroid/src/main/res/drawable/footer_button_all_plain.xml
@@ -15,7 +15,7 @@
         <item>
             <shape android:shape="rectangle" >
                 <solid android:color="#9E9E9E" />
-                <stroke android:width="1dp" android:color="#F5F5F5"/>
+                <stroke android:width=".2dp" android:color="#F5F5F5"/>
             </shape>
         </item>
     </selector>

--- a/AnkiDroid/src/main/res/drawable/item_background_selected_pre21_black.xml
+++ b/AnkiDroid/src/main/res/drawable/item_background_selected_pre21_black.xml
@@ -22,5 +22,5 @@
     <item android:state_focused="true"                                android:state_pressed="true" android:drawable="@drawable/list_selector_background_transition_holo_dark" />
     <item android:state_focused="false"                               android:state_pressed="true" android:drawable="@drawable/list_selector_background_transition_holo_dark" />
     <item android:state_focused="true"                                                             android:drawable="@drawable/list_focused_holo" />-->
-    <item android:drawable="@color/theme_black_currentDeckBackground" />
+    <item android:drawable="@color/theme_black_row_current" />
 </selector>

--- a/AnkiDroid/src/main/res/layout/card_browser.xml
+++ b/AnkiDroid/src/main/res/layout/card_browser.xml
@@ -27,14 +27,14 @@
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    app:popupTheme="?attr/actionBarPopupThemeRef"/>
+                    app:popupTheme="@style/ActionBar.Popup"/>
 
                 <Spinner
                     android:id="@+id/browser_column2_spinner"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    app:popupTheme="?attr/actionBarPopupThemeRef"/>
+                    app:popupTheme="@style/ActionBar.Popup"/>
             </LinearLayout>
 
             <ListView

--- a/AnkiDroid/src/main/res/layout/note_editor.xml
+++ b/AnkiDroid/src/main/res/layout/note_editor.xml
@@ -46,7 +46,7 @@
                         android:id="@+id/note_type_spinner"
                         android:layout_width="fill_parent"
                         android:layout_height="@dimen/touch_target"
-                        app:popupTheme="?attr/actionBarPopupThemeRef"/>
+                        app:popupTheme="@style/ActionBar.Popup"/>
                 </LinearLayout>
 
                 <!-- Deck selector -->
@@ -69,7 +69,7 @@
                         android:id="@+id/note_deck_spinner"
                         android:layout_width="fill_parent"
                         android:layout_height="@dimen/touch_target"
-                        app:popupTheme="?attr/actionBarPopupThemeRef"/>
+                        app:popupTheme="@style/ActionBar.Popup"/>
                 </LinearLayout>
 
                 <LinearLayout

--- a/AnkiDroid/src/main/res/layout/studyoptions_fragment.xml
+++ b/AnkiDroid/src/main/res/layout/studyoptions_fragment.xml
@@ -18,9 +18,10 @@
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
             android:minHeight="?attr/actionBarSize"
-            android:theme="?attr/actionBarThemeRef"
+            android:theme="@style/ActionBarStyle"
             android:layout_alignParentTop="true"
-            app:popupTheme="?attr/actionBarPopupThemeRef"/>
+            android:background="?attr/colorPrimary"
+            app:popupTheme="@style/ActionBar.Popup"/>
         <LinearLayout
             android:layout_below="@id/studyOptionsToolbar"
             android:layout_width="fill_parent"

--- a/AnkiDroid/src/main/res/layout/tags_dialog_title.xml
+++ b/AnkiDroid/src/main/res/layout/tags_dialog_title.xml
@@ -6,8 +6,7 @@
     android:layout_height="wrap_content"
     android:minHeight="?attr/actionBarSize"
     android:layout_alignParentTop="true"
-    android:theme="?attr/actionBarThemeRef"
-    app:popupTheme="?attr/actionBarPopupThemeRef">
-
-
+    android:theme="@style/ActionBarStyle"
+    android:background="?attr/colorPrimary"
+    app:popupTheme="@style/ActionBar.Popup">
 </android.support.v7.widget.Toolbar>

--- a/AnkiDroid/src/main/res/layout/toolbar.xml
+++ b/AnkiDroid/src/main/res/layout/toolbar.xml
@@ -9,14 +9,14 @@
         android:layout_alignParentTop="true"
         app:navigationContentDescription="@string/abc_action_bar_up_description"
         app:navigationIcon="?attr/homeAsUpIndicator"
-        android:theme="?attr/actionBarThemeRef"
-        app:popupTheme="?attr/actionBarPopupThemeRef">
+        android:background="?attr/colorPrimary"
+        android:theme="@style/ActionBarStyle">
         <Spinner
             android:id="@+id/toolbar_spinner"
             android:background="?attr/selectableItemBackground"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:visibility="gone"
-            app:popupTheme="?attr/actionBarPopupThemeRef"/>
+            app:popupTheme="@style/ActionBar.Popup"/>
     </android.support.v7.widget.Toolbar>
 </merge>

--- a/AnkiDroid/src/main/res/menu/model_browser.xml
+++ b/AnkiDroid/src/main/res/menu/model_browser.xml
@@ -14,5 +14,5 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:visibility="gone" 
-        app:popupTheme="?attr/actionBarPopupThemeRef"/>
+        app:popupTheme="@style/ActionBar.Popup"/>
 </menu>

--- a/AnkiDroid/src/main/res/values/attrs.xml
+++ b/AnkiDroid/src/main/res/values/attrs.xml
@@ -21,8 +21,8 @@
      specifically for action bar text color isn't necessary, but it simplifies the color setting
      while making it accessible everywhere and eases the use of themes -->
     <attr name="actionBarTextColor" format="color"/> <!-- For title and subtitle, and any other text that may appear in action bar-->
-    <attr name="actionBarThemeRef" format="reference"/>
-    <attr name="actionBarPopupThemeRef" format="reference"/>
+    <attr name="actionBarPopupBackgroundColor" format="color"/>
+    <attr name="actionBarPopupTextColor" format="color"/>
 
     <!-- Custom preferences -->
     <attr name="min" format="integer" />

--- a/AnkiDroid/src/main/res/values/styles.xml
+++ b/AnkiDroid/src/main/res/values/styles.xml
@@ -91,4 +91,27 @@
         <item name="android:background">?attr/fab_item_background</item>
         <item name="android:textColor">?attr/fab_labelsTextColor</item>
     </style>
+
+    <!-- Action bar. Currently all action bar text is white in every theme. -->
+    <style name="ActionBarStyle" parent="Base.ThemeOverlay.AppCompat.ActionBar">
+        <!-- Colors: hamburger, title text, overflow icon -->
+        <item name="android:textColorPrimary">@color/white</item>
+        <!-- Colors: subtitle text -->
+        <item name="android:textColorSecondary">@color/white</item>
+        <!-- Overflow menu style -->
+        <item name="popupTheme">@style/ActionBar.Popup</item>
+    </style>
+
+    <!-- For all other action bar popups like overflow menu (except spinner dropdown in Lollipop). -->
+    <style name="ActionBar.Popup" parent="Base.ThemeOverlay.AppCompat.ActionBar">
+        <item name="android:drawSelectorOnTop">true</item>
+        <item name="android:background">?attr/actionBarPopupBackgroundColor</item>
+        <item name="android:textColorPrimary">?attr/actionBarPopupTextColor</item>
+        <item name="android:textColorSecondary">?attr/actionBarPopupTextColor</item>
+    </style>
+
+    <style name="Theme_Light_Statistics" parent="Theme_Light_Compat">
+        <item name="android:radioButtonStyle">@android:style/Widget.CompoundButton.RadioButton
+        </item>
+    </style>
 </resources>

--- a/AnkiDroid/src/main/res/values/theme_black.xml
+++ b/AnkiDroid/src/main/res/values/theme_black.xml
@@ -3,39 +3,44 @@
     <color name="theme_black_primary">#070707</color>
     <color name="theme_black_primary_dark">#000000</color>
     <color name="theme_black_primary_light">#151515</color>
-    <color name="theme_black_accent">#303030</color>
+    <color name="theme_black_accent">#808080</color>
     <color name="theme_black_primary_text">#fff</color> <!-- Alternative: #808080 -->
     <color name="theme_black_secondary_text">#a0a0a0</color>
-    <color name="theme_black_dynDeck">#305683</color>
-    <color name="theme_black_currentDeckBackground">#0c0c0c</color>
-    <color name="theme_black_browser_suspended">#3ce6e181</color>
-    <color name="theme_black_browser_marked">#230b2e</color>
+    <color name="theme_black_row_current">#0c0c0c</color>
 
     <style name="Theme_Dark.Black">
         <!-- Android colors -->
-        <item name="colorPrimary">@color/theme_black_primary</item>
+        <item name="colorPrimary">@color/theme_black_primary_dark</item>
         <item name="colorPrimaryDark">@color/black</item>
         <item name="colorAccent">@color/theme_black_accent</item>
         <item name="android:textColor">@color/theme_black_primary_text</item>
+        <item name="android:textColorPrimary">@color/theme_black_primary_text</item>
+        <item name="android:textColorSecondary">@color/theme_black_secondary_text</item>
+        <item name="android:colorBackground">@color/theme_black_primary</item>
+        <item name="android:windowBackground">@color/theme_black_primary</item>
         <!-- Action bar styles -->
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
         <item name="windowActionModeOverlay">true</item>
         <item name="actionBarTextColor">@color/white</item>
-        <item name="actionBarThemeRef">@style/ActionBarBlack</item>
-        <item name="actionBarPopupThemeRef">@style/ActionBar.Popup.Black</item>
+        <item name="actionBarPopupBackgroundColor">@color/theme_black_primary_light</item>
+        <item name="actionBarPopupTextColor">@color/theme_black_primary_text</item>
+        <item name="actionModeBackground">@color/theme_black_primary_dark</item>
         <!-- Deck list colors and divider -->
         <item name="currentDeckBackground">@drawable/item_background_selected_pre21_black</item>
-        <item name="currentDeckBackgroundColor">@color/theme_black_currentDeckBackground</item>
-        <item name="dynDeckColor">@color/theme_black_dynDeck</item>
+        <item name="currentDeckBackgroundColor">@color/theme_black_row_current</item>
+        <item name="dynDeckColor">#305683</item>
         <item name="deckDivider">@drawable/divider_black</item>
         <item name="expandRef">@drawable/ic_chevron_right_white_24dp</item>
         <item name="collapseRef">@drawable/ic_expand_more_white_24dp</item>
-        <!-- Reviewer colors -->
-        <item name="topBarColor">@color/theme_black_primary</item>
+        <!-- Count colors -->
         <item name="newCountColor">@color/material_blue_700</item>
         <item name="learnCountColor">@color/material_red_400</item>
         <item name="reviewCountColor">@color/material_green_400</item>
+        <item name="zeroCountColor">#202020</item>
+        <!-- Reviewer colors -->
+        <item name="topBarColor">@color/theme_black_primary</item>
+        <item name="maxTimerColor">@color/material_red_300</item>
         <item name="answerButtonTextColor">@color/theme_black_primary_text</item>
         <item name="againButtonTextColor">@color/material_red_400</item>
         <item name="hardButtonTextColor">@color/white</item>
@@ -47,40 +52,20 @@
         <item name="goodButtonRef">@drawable/footer_button_all_black</item>
         <item name="easyButtonRef">@drawable/footer_button_all_black</item>
         <!-- Browser colors -->
-        <item name="suspendedColor">@color/theme_black_browser_suspended</item>
-        <item name="markedColor">@color/theme_black_browser_marked</item>
+        <item name="suspendedColor">#A8A634</item>
+        <item name="markedColor">#391080</item>
         <!-- FAB -->
-        <item name="fab_normal">@color/theme_black_accent</item>
-        <item name="fab_pressed">#c8333333</item> <!-- 55 less opacity than fab_normal -->
+        <item name="fab_normal">#ff303030</item>
+        <item name="fab_pressed">#c8303030</item> <!-- 55 less opacity than fab_normal -->
         <item name="fab_labelsTextColor">@color/theme_black_primary_text</item>
         <item name="fab_background">@color/theme_black_primary_light</item>
         <item name="fab_item_background">@drawable/fab_label_background_black_pre21</item>
         <!-- StudyOptions fragment -->
         <item name="study_start_textColor">@color/theme_black_primary_text</item>
-
-        <!--Below are additions to the base theme -->
-
-        <!-- textColorPrimary changes: navdraw text, edittext text -->
-        <item name="android:textColorPrimary">@color/theme_black_primary_text</item>
-        <!-- textColorSecondary changes: navdraw icon shading, edittext underline, scroll bar -->
-        <item name="android:textColorSecondary">@color/theme_black_secondary_text</item>
-        <item name="android:colorBackground">@color/theme_black_primary</item>
-        <!-- windowBackground seems to do what colorBackground does, but on older APIs-->
-        <item name="android:windowBackground">@color/theme_black_primary</item>
-        <item name="colorButtonNormal">@color/theme_black_primary_light</item>
-        <!-- Dialogs -->
+        <!-- Dialog styles -->
+        <item name="android:listPreferredItemHeight">56dip</item>
         <item name="md_dark_theme">true</item>
-        <item name="md_positive_color">@color/theme_black_primary_text</item>
         <item name="md_background_color">@color/theme_black_primary_light</item>
-    </style>
-
-    <!-- ActionBar -->
-    <style name="ActionBarBlack" parent="Base.ThemeOverlay.AppCompat.Dark.ActionBar">
-        <!-- Determines color of text and system icons (overflow etc.) in the action bar -->
-        <item name="android:textColorPrimary">@color/white</item>
-        <item name="android:textColorSecondary">@color/white</item>
-        <item name="android:background">@color/black</item>
-        <item name="popupMenuStyle">@style/ActionBar.Popup.Black</item>
     </style>
 
     <!-- Preferences screens -->
@@ -89,13 +74,5 @@
         <item name="windowNoTitle">false</item>
         <item name="android:background">@color/theme_black_primary_dark</item>
         <item name="android:colorBackground">@color/theme_black_primary_dark</item>
-        <item name="popupMenuStyle">@style/ActionBar.Popup.Black</item>
-    </style>
-
-    <style name="ActionBar.Popup.Black" parent="Base.ThemeOverlay.AppCompat.Dark.ActionBar">
-        <item name="android:drawSelectorOnTop">true</item>
-        <item name="android:background">@color/theme_black_primary_light</item>
-        <item name="android:textColorPrimary">@color/theme_black_primary_text</item>
-        <item name="android:textColorSecondary">@color/theme_black_secondary_text</item>
     </style>
 </resources>

--- a/AnkiDroid/src/main/res/values/theme_dark.xml
+++ b/AnkiDroid/src/main/res/values/theme_dark.xml
@@ -1,59 +1,67 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <color name="theme_dark_primary">#3d3d3d</color>
+    <color name="theme_dark_primary_dark">@color/black</color>
+    <color name="theme_dark_primary_light">@color/material_grey_800</color>
     <color name="theme_dark_accent">@color/material_light_blue_700</color>
+    <color name="theme_dark_primary_text">@color/white</color>
+    <color name="theme_dark_secondary_text">#b2ffffff</color>
     <color name="theme_dark_row_current">#393939</color>
-    <color name="theme_dark_dynDeck">#6699d6</color>
-    <color name="theme_dark_browser_marked">@color/material_deep_purple_400</color>
-    <color name="theme_dark_browser_suspended">@color/material_grey_700</color>
-    <color name="theme_dark_new_count">@color/material_indigo_200</color>
-    <color name="theme_dark_learn_count">@color/material_red_200</color>
-    <color name="theme_dark_review_count">@color/material_green_200</color>
-    <color name="theme_dark_zero_count">#202020</color>
-    <color name="theme_dark_max_timer">@color/material_red_300</color>
 
     <style name="Theme_Dark" parent="@style/Theme.AppCompat">
+        <!-- Android colors -->
         <item name="colorPrimary">@color/theme_dark_primary</item>
-        <item name="colorPrimaryDark">@color/black</item>
+        <item name="colorPrimaryDark">@color/theme_dark_primary_dark</item>
         <item name="colorAccent">@color/theme_dark_accent</item>
-        <item name="android:textColor">@color/white</item>
+        <item name="android:textColor">@color/theme_dark_primary_text</item>
+        <item name="android:textColorPrimary">@color/theme_dark_primary_text</item>
+        <item name="android:textColorSecondary">@color/theme_dark_secondary_text</item>
+        <item name="android:colorBackground">@color/material_theme_grey</item>
+        <item name="android:windowBackground">@color/material_theme_grey</item>
         <!-- Action bar styles -->
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
         <item name="windowActionModeOverlay">true</item>
         <item name="actionBarTextColor">@color/white</item>
-        <item name="actionBarThemeRef">@style/ActionBarDark</item>
-        <item name="actionBarPopupThemeRef">@style/ActionBar.Popup.Dark</item>
+        <item name="actionBarPopupBackgroundColor">@color/theme_dark_primary</item>
+        <item name="actionBarPopupTextColor">@color/theme_dark_primary_text</item>
+        <item name="actionModeBackground">@color/theme_dark_primary</item>
         <!-- Deck list colors and divider -->
         <item name="currentDeckBackground">@drawable/item_background_selected_pre21_dark</item>
         <item name="currentDeckBackgroundColor">@color/theme_dark_row_current</item>
-        <item name="dynDeckColor">@color/theme_dark_dynDeck</item>
+        <item name="dynDeckColor">#6699d6</item>
         <item name="deckDivider">@drawable/divider_dark</item>
         <item name="expandRef">@drawable/ic_chevron_right_white_24dp</item>
         <item name="collapseRef">@drawable/ic_expand_more_white_24dp</item>
+        <!-- Count colors -->
+        <item name="newCountColor">@color/material_indigo_200</item>
+        <item name="learnCountColor">@color/material_red_200</item>
+        <item name="reviewCountColor">@color/material_green_200</item>
+        <item name="zeroCountColor">#202020</item>
         <!-- Reviewer colors -->
-        <item name="topBarColor">@color/material_grey_800</item>
-        <item name="maxTimerColor">@color/theme_dark_max_timer</item>
-        <item name="newCountColor">@color/theme_dark_new_count</item>
-        <item name="learnCountColor">@color/theme_dark_learn_count</item>
-        <item name="reviewCountColor">@color/theme_dark_review_count</item>
-        <item name="zeroCountColor">@color/theme_dark_zero_count</item>
+        <item name="topBarColor">@color/theme_dark_primary_light</item>
+        <item name="maxTimerColor">@color/material_red_300</item>
         <item name="answerButtonTextColor">@color/white</item>
         <item name="againButtonTextColor">@color/white</item>
         <item name="hardButtonTextColor">@color/white</item>
         <item name="goodButtonTextColor">@color/white</item>
         <item name="easyButtonTextColor">@color/white</item>
-        <!-- Reviewer button drawables
-            Note: We can't use attributes inside a drawable, so necessary to have separate drawable for
-            each theme. See Android bug https://code.google.com/p/android/issues/detail?id=26251 -->
-        <!-- Hard button also serves as the style for the Show Answer button -->
+        <!-- Reviewer button drawables -->
         <item name="againButtonRef">@drawable/footer_button_again_dark</item>
         <item name="hardButtonRef">@drawable/footer_button_hard_dark</item>
         <item name="goodButtonRef">@drawable/footer_button_good_dark</item>
         <item name="easyButtonRef">@drawable/footer_button_easy_dark</item>
         <!-- Browser colors -->
-        <item name="suspendedColor">@color/theme_dark_browser_suspended</item>
-        <item name="markedColor">@color/theme_dark_browser_marked</item>
+        <item name="suspendedColor">@color/material_grey_700</item>
+        <item name="markedColor">@color/material_deep_purple_400</item>
+        <!-- FAB -->
+        <item name="fab_normal">@color/material_light_blue_700</item>
+        <item name="fab_pressed">@color/material_light_blue_900</item>
+        <item name="fab_labelsTextColor">@color/white</item>
+        <item name="fab_background">@color/material_grey_700</item>
+        <item name="fab_item_background">@drawable/fab_label_background_pre21</item>
+        <!-- StudyOptions fragment -->
+        <item name="study_start_textColor">@color/white</item>
         <!-- Images -->
         <item name="navDrawerImage">@drawable/nav_drawer_logo_dark_theme</item>
         <item name="attachFileImage">@drawable/ic_attachment_white_24dp</item>
@@ -61,32 +69,15 @@
         <item name="dialogErrorIcon">@drawable/ic_warning_white_36dp</item>
         <item name="dialogSyncErrorIcon">@drawable/ic_sync_problem_white_36dp</item>
         <item name="dialogSendIcon">@drawable/ic_send_white_36dp</item>
-        <!-- FAB -->
-        <item name="fab_normal">@color/material_light_blue_500</item>
-        <item name="fab_pressed">@color/material_light_blue_700</item>
-        <item name="fab_labelsTextColor">@color/white</item>
-        <item name="fab_background">@color/material_grey_700</item>
-        <item name="fab_item_background">@drawable/fab_label_background_pre21</item>
-        <!-- StudyOptions fragment -->
-        <item name="study_start_textColor">@color/white</item>
+        <!-- Dialog styles -->
+        <item name="android:listPreferredItemHeight">56dip</item>
+        <item name="md_dark_theme">true</item>
     </style>
 
+    <!-- Preferences screens -->
     <!-- Legacy action bar  (used in Preferences with no explicit Toolbar) -->
     <style name="LegacyActionBarDark" parent="Theme_Dark">
         <item name="windowActionBar">true</item>
         <item name="windowNoTitle">false</item>
-    </style>
-
-    <!-- ActionBar -->
-    <style name="ActionBarDark" parent="Base.ThemeOverlay.AppCompat.Dark.ActionBar">
-        <!-- Determines color of text and system icons (overflow etc.) in the action bar -->
-        <item name="android:textColorPrimary">@color/white</item>
-        <item name="android:textColorSecondary">@color/white</item>
-        <item name="android:background">@color/theme_dark_primary</item>
-    </style>
-
-    <!-- For all other action bar popups (except spinner dropdown in Lollipop) -->
-    <style name="ActionBar.Popup.Dark" parent="Base.ThemeOverlay.AppCompat.Dark.ActionBar">
-        <item name="android:drawSelectorOnTop">true</item>
     </style>
 </resources>

--- a/AnkiDroid/src/main/res/values/theme_light.xml
+++ b/AnkiDroid/src/main/res/values/theme_light.xml
@@ -1,65 +1,79 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+Notes about themes:
+
+- We can't use attributes inside a drawable, so it is necessary to have separate drawables
+(where themed colors are defined inside) for each theme.
+See Android bug https://code.google.com/p/android/issues/detail?id=26251
+- Reviewer hard button also serves as the style for the Show Answer button
+- textColorPrimary changes: navdraw text, edittext text
+- textColorSecondary changes: navdraw icon shading, edittext underline, scroll bar
+- windowBackground colors the area under the decklist (and possibly other things) on older
+APIs. It's visible when there aren't enough decks to fill the screen.
+-->
 <resources>
     <color name="theme_light_primary">@color/material_light_blue_500</color>
+    <color name="theme_light_primary_dark">@color/material_light_blue_700</color>
+    <color name="theme_light_primary_light">@color/material_light_blue_100</color>
     <color name="theme_light_accent">@color/material_blue_grey_700</color>
+    <color name="theme_light_primary_text">@color/black</color>
+    <color name="theme_light_secondary_text">#de000000</color>  <!-- 87% black -->
     <color name="theme_light_row_current">#ececec</color>
-    <color name="theme_light_dynDeck">#2222bb</color>
-    <color name="theme_light_browser_marked">#D9B2E9</color>
-    <color name="theme_light_browser_suspended">#FFFFB2</color>
-    <color name="theme_light_new_count">@color/material_indigo_700</color>
-    <color name="theme_light_learn_count">@color/material_red_700</color>
-    <color name="theme_light_review_count">@color/material_green_700</color>
-    <color name="theme_light_zero_count">#1f000000</color>
-    <color name="theme_light_max_timer">@color/material_red_500</color>
-    <color name="theme_light_popup_text">#de000000</color> <!-- 87% black -->
 
-    <style name="Theme_Light" parent="@style/Theme.AppCompat.Light.DarkActionBar">
+    <style name="Theme_Light" parent="@style/Theme.AppCompat.Light">
+        <!-- Android colors -->
         <item name="colorPrimary">@color/theme_light_primary</item>
-        <item name="colorPrimaryDark">@color/material_light_blue_700</item>
+        <item name="colorPrimaryDark">@color/theme_light_primary_dark</item>
         <item name="colorAccent">@color/theme_light_accent</item>
-        <item name="android:colorBackground">@android:color/white</item>
-        <!-- Use black on white text for higher contrast than standard light theme -->
         <item name="android:textColor">@color/black</item>
+        <item name="android:textColorPrimary">@color/theme_light_primary_text</item>
+        <item name="android:textColorSecondary">@color/theme_light_secondary_text</item>
+        <item name="android:colorBackground">@android:color/white</item>
+        <item name="android:windowBackground">@android:color/white</item>
         <!-- Action bar styles -->
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
         <item name="windowActionModeOverlay">true</item>
         <item name="actionBarTextColor">@color/white</item>
-        <item name="actionModeBackground">@color/theme_light_accent</item>
-        <item name="actionBarThemeRef">@style/ActionBarLight</item>
-        <item name="popupTheme">@style/ActionBar.Popup.Light</item>
-        <item name="actionBarPopupThemeRef">@style/ActionBar.Popup.Light</item>
-        <!-- Dialog styles -->
-        <item name="android:listPreferredItemHeight">56dip</item>
+        <item name="actionBarPopupBackgroundColor">@color/white</item>
+        <item name="actionBarPopupTextColor">@color/theme_light_primary_text</item>
+        <item name="actionModeBackground">@color/theme_light_primary</item>
         <!-- Deck list colors and divider -->
         <item name="currentDeckBackground">@drawable/item_background_selected_pre21</item>
         <item name="currentDeckBackgroundColor">@color/theme_light_row_current</item>
-        <item name="dynDeckColor">@color/theme_light_dynDeck</item>
+        <item name="dynDeckColor">#2222bb</item>
         <item name="deckDivider">@drawable/divider</item>
         <item name="expandRef">@drawable/ic_chevron_right_black_24dp</item>
         <item name="collapseRef">@drawable/ic_expand_more_black_24dp</item>
+        <!-- Count colors -->
+        <item name="newCountColor">@color/material_indigo_700</item>
+        <item name="learnCountColor">@color/material_red_700</item>
+        <item name="reviewCountColor">@color/material_green_700</item>
+        <item name="zeroCountColor">#1f000000</item>
         <!-- Reviewer colors -->
-        <item name="topBarColor">@color/material_light_blue_100</item>
-        <item name="maxTimerColor">@color/theme_light_max_timer</item>
-        <item name="newCountColor">@color/theme_light_new_count</item>
-        <item name="learnCountColor">@color/theme_light_learn_count</item>
-        <item name="reviewCountColor">@color/theme_light_review_count</item>
-        <item name="zeroCountColor">@color/theme_light_zero_count</item>
+        <item name="topBarColor">@color/theme_light_primary_light</item>
+        <item name="maxTimerColor">@color/material_red_500</item>
         <item name="answerButtonTextColor">@color/white</item>
         <item name="againButtonTextColor">@color/white</item>
         <item name="hardButtonTextColor">@color/white</item>
         <item name="goodButtonTextColor">@color/white</item>
         <item name="easyButtonTextColor">@color/white</item>
-        <!-- Reviewer button drawables
-            Note: We can't use attributes inside a drawable, so necessary to have separate drawable for
-            each theme. See Android bug https://code.google.com/p/android/issues/detail?id=26251 -->
+        <!-- Reviewer button drawables -->
         <item name="againButtonRef">@drawable/footer_button_again</item>
         <item name="hardButtonRef">@drawable/footer_button_hard</item>
         <item name="goodButtonRef">@drawable/footer_button_good</item>
         <item name="easyButtonRef">@drawable/footer_button_easy</item>
         <!-- Browser colors -->
-        <item name="suspendedColor">@color/theme_light_browser_suspended</item>
-        <item name="markedColor">@color/theme_light_browser_marked</item>
+        <item name="suspendedColor">#FFFFB2</item>
+        <item name="markedColor">#D9B2E9</item>
+        <!-- FAB -->
+        <item name="fab_normal">@color/material_light_blue_700</item>
+        <item name="fab_pressed">@color/material_light_blue_900</item>
+        <item name="fab_labelsTextColor">@color/white</item>
+        <item name="fab_background">@color/material_grey_700</item>
+        <item name="fab_item_background">@drawable/fab_label_background_pre21</item>
+        <!-- StudyOptions fragment -->
+        <item name="study_start_textColor">@color/white</item>
         <!-- Images -->
         <item name="navDrawerImage">@drawable/nav_drawer_logo</item>
         <item name="attachFileImage">@drawable/ic_attachment_black_24dp</item>
@@ -67,40 +81,15 @@
         <item name="dialogErrorIcon">@drawable/ic_warning_black_36dp</item>
         <item name="dialogSyncErrorIcon">@drawable/ic_sync_problem_black_36dp</item>
         <item name="dialogSendIcon">@drawable/ic_send_black_36dp</item>
-        <!-- FAB -->
-        <item name="fab_normal">@color/material_light_blue_500</item>
-        <item name="fab_pressed">@color/material_light_blue_700</item>
-        <item name="fab_labelsTextColor">@color/white</item>
-        <item name="fab_background">@color/material_grey_700</item>
-        <item name="fab_item_background">@drawable/fab_label_background_pre21</item>
-        <!-- StudyOptions fragment -->
-        <item name="study_start_textColor">@color/white</item>
+        <!-- Dialog styles -->
+        <item name="android:listPreferredItemHeight">56dip</item>
+        <item name="md_dark_theme">false</item>
     </style>
 
-    <style name="Theme_Light_Statistics" parent="Theme_Light_Compat">
-        <item name="android:radioButtonStyle">@android:style/Widget.CompoundButton.RadioButton
-        </item>
-    </style>
-
+    <!-- Preferences screens -->
     <!-- Theme for showing legacy ActionBar without explicitly including a toolbar -->
     <style name="LegacyActionBarLight" parent="Theme_Light">
         <item name="windowActionBar">true</item>
         <item name="windowNoTitle">false</item>
-    </style>
-
-    <!-- ActionBar -->
-    <!-- Inheriting from light theme necessary to get light spinner dropdown background in Lollipop -->
-    <style name="ActionBarLight" parent="Base.ThemeOverlay.AppCompat.ActionBar">
-        <!-- Determines color of text and system icons (overflow etc.) in the action bar -->
-        <item name="android:textColorPrimary">@color/white</item>
-        <item name="android:textColorSecondary">@color/white</item>
-        <item name="android:background">@color/theme_light_primary</item>
-    </style>
-
-    <!-- For all other action bar popups (except spinner dropdown in Lollipop) -->
-    <style name="ActionBar.Popup.Light" parent="Base.ThemeOverlay.AppCompat.ActionBar">
-        <item name="android:drawSelectorOnTop">true</item>
-        <item name="android:textColorPrimary">@color/theme_light_popup_text</item>
-        <item name="android:background">@color/white</item>
     </style>
 </resources>

--- a/AnkiDroid/src/main/res/values/theme_plain.xml
+++ b/AnkiDroid/src/main/res/values/theme_plain.xml
@@ -8,24 +8,19 @@
     <color name="theme_plain_secondary_text">#727272</color>
 
     <style name="Theme_Light.Plain">
+        <!-- Android colors -->
         <item name="colorPrimary">@color/theme_plain_primary</item>
         <item name="colorPrimaryDark">@color/theme_plain_primary_dark</item>
         <item name="colorAccent">@color/theme_plain_accent</item>
         <item name="android:textColor">@color/theme_plain_primary_text</item>
         <item name="android:textColorPrimary">@color/theme_plain_primary_text</item>
         <item name="android:textColorSecondary">@color/theme_plain_secondary_text</item>
-        <item name="android:colorBackground">@color/theme_plain_primary_light</item>
         <!-- Action bar styles -->
-        <item name="actionBarThemeRef">@style/ActionBarPlain</item>
-        <item name="popupTheme">@style/ActionBar.Popup.Plain</item>
-        <item name="actionBarPopupThemeRef">@style/ActionBar.Popup.Plain</item>
+        <item name="actionBarPopupBackgroundColor">@color/theme_plain_primary_light</item>
+        <item name="actionBarPopupTextColor">@color/theme_plain_primary_text</item>
+        <item name="actionModeBackground">@color/theme_plain_primary</item>
         <!-- Reviewer colors -->
         <item name="topBarColor">@color/theme_plain_primary_light</item>
-        <item name="answerButtonTextColor">@color/theme_plain_primary_light</item>
-        <item name="againButtonTextColor">@color/theme_plain_primary_light</item>
-        <item name="hardButtonTextColor">@color/theme_plain_primary_light</item>
-        <item name="goodButtonTextColor">@color/theme_plain_primary_light</item>
-        <item name="easyButtonTextColor">@color/theme_plain_primary_light</item>
         <!-- Reviewer button drawables -->
         <item name="againButtonRef">@drawable/footer_button_all_plain</item>
         <item name="hardButtonRef">@drawable/footer_button_all_plain</item>
@@ -34,30 +29,13 @@
         <!-- FAB -->
         <item name="fab_normal">@color/theme_plain_accent</item>
         <item name="fab_pressed">#c8607d8b</item> <!-- 55 less opacity than fab_normal -->
-        <item name="fab_labelsTextColor">@color/theme_plain_primary_light</item>
         <item name="fab_background">@color/theme_plain_primary_dark</item>
-        <item name="fab_item_background">@drawable/fab_label_background_pre21</item>
     </style>
 
+    <!-- Preferences screens -->
     <!-- Theme for showing legacy ActionBar without explicitly including a toolbar -->
     <style name="LegacyActionBarPlain" parent="Theme_Light.Plain">
         <item name="windowActionBar">true</item>
         <item name="windowNoTitle">false</item>
-    </style>
-
-    <!-- ActionBar -->
-    <style name="ActionBarPlain" parent="Base.ThemeOverlay.AppCompat.ActionBar">
-        <!-- Determines color of text and system icons (overflow etc.) in the action bar -->
-        <item name="android:textColorPrimary">@color/white</item>
-        <item name="android:textColorSecondary">@color/white</item>
-        <item name="android:background">@color/theme_plain_primary</item>
-    </style>
-
-    <!-- For all other action bar popups (except spinner dropdown in Lollipop) -->
-    <style name="ActionBar.Popup.Plain" parent="Base.ThemeOverlay.AppCompat.ActionBar">
-        <item name="android:drawSelectorOnTop">true</item>
-        <item name="android:background">@color/theme_plain_primary_light</item>
-        <item name="android:textColorPrimary">@color/theme_plain_primary_text</item>
-        <item name="android:textColorSecondary">@color/theme_plain_secondary_text</item>
     </style>
 </resources>


### PR DESCRIPTION
Some more work on themes and minor color tweaks. The base themes should be identical in their definitions (except for light theme inheriting from light base) and their order which should make them easier to maintain.

- I've factored out the action bar styles so there is only one now. The colors can be grabbed from theme attributes.
- Fixed a bug I introduced with action bar colors (like the long-tap toast)
- Black theme answer button touch feedback is brighter
- Black theme has a brighter accent
- Plain theme anwer button border is thin again. I really didn't like the larger one.
- CAB background colors now use the same color as the action bar
- The default light theme has a darker FAB. I noticed Google apps used the darker primary color, so I copied them.