### PR TITLE
Theme fixes

### DIFF
--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -224,7 +224,6 @@
             android:finishOnTaskLaunch="true" />
         <activity
             android:name="com.ichi2.anki.Statistics"
-            android:theme="@style/Theme_Light_Statistics"
             android:configChanges="keyboardHidden|orientation|locale|screenSize"
             android:parentActivityName=".DeckPicker">
             <!-- The meta-data element is needed for versions lower than 4.1 -->

--- a/AnkiDroid/src/main/res/drawable/footer_button_all_black.xml
+++ b/AnkiDroid/src/main/res/drawable/footer_button_all_black.xml
@@ -15,7 +15,7 @@
         <item>
             <shape android:shape="rectangle" >
                 <solid android:color="#000000" />
-                <stroke android:width="1dp" android:color="#0a0a0a"/>
+                <stroke android:width=".5dp" android:color="#101010"/>
             </shape>
         </item>
     </selector>

--- a/AnkiDroid/src/main/res/layout/my_account.xml
+++ b/AnkiDroid/src/main/res/layout/my_account.xml
@@ -61,7 +61,7 @@
                     android:id="@+id/login_button"
                     android:layout_width="fill_parent"
                     android:layout_height="wrap_content"
-                    android:textColor="@color/white"
+                    android:theme="@style/LargeButtonStyle"
                     android:singleLine="true"
                     android:textSize="@dimen/md_title_textsize"
                     android:layout_gravity="center"

--- a/AnkiDroid/src/main/res/layout/my_account_logged_in.xml
+++ b/AnkiDroid/src/main/res/layout/my_account_logged_in.xml
@@ -43,7 +43,7 @@
                 android:id="@+id/logout_button"
                 android:layout_width="fill_parent"
                 android:layout_height="wrap_content"
-                android:textColor="@color/white"
+                android:theme="@style/LargeButtonStyle"
                 android:singleLine="true"
                 android:textSize="@dimen/md_title_textsize"
                 android:layout_gravity="center"

--- a/AnkiDroid/src/main/res/layout/studyoptions_fragment.xml
+++ b/AnkiDroid/src/main/res/layout/studyoptions_fragment.xml
@@ -202,7 +202,7 @@
                         android:paddingBottom="8dp"/>
                     <Button
                         android:id="@+id/studyoptions_start"
-                        android:textColor="?attr/study_start_textColor"
+                        android:theme="@style/LargeButtonStyle"
                         android:layout_width="200dip"
                         android:layout_height="wrap_content"
                         android:lines="2"

--- a/AnkiDroid/src/main/res/values/attrs.xml
+++ b/AnkiDroid/src/main/res/values/attrs.xml
@@ -32,6 +32,9 @@
     <declare-styleable name="SeekBarPreference">
         <attr name="interval" format="integer" />
     </declare-styleable>
+    <!-- App buttons -->
+    <attr name="largeButtonBackgroundColor" format="color"/>
+    <attr name="largeButtonTextColor" format="color"/>
     <!-- Deck list colors, divider, and expander -->
     <attr name="currentDeckBackground" format="reference"/>
     <attr name="currentDeckBackgroundColor" format="color"/>
@@ -84,6 +87,4 @@
     <attr name="fab_labelsTextColor" format="color"/>
     <attr name="fab_background" format="color"/>
     <attr name="fab_item_background" format="reference"/>
-    <!-- StudyOptions fragment -->
-    <attr name="study_start_textColor" format="color"/>
 </resources>

--- a/AnkiDroid/src/main/res/values/styles.xml
+++ b/AnkiDroid/src/main/res/values/styles.xml
@@ -110,8 +110,8 @@
         <item name="android:textColorSecondary">?attr/actionBarPopupTextColor</item>
     </style>
 
-    <style name="Theme_Light_Statistics" parent="Theme_Light_Compat">
-        <item name="android:radioButtonStyle">@android:style/Widget.CompoundButton.RadioButton
-        </item>
+    <style name="LargeButtonStyle">
+        <item name="colorButtonNormal">?attr/largeButtonBackgroundColor</item>
+        <item name="android:textColor">?attr/largeButtonTextColor</item>
     </style>
 </resources>

--- a/AnkiDroid/src/main/res/values/theme_black.xml
+++ b/AnkiDroid/src/main/res/values/theme_black.xml
@@ -18,7 +18,9 @@
         <item name="android:textColorSecondary">@color/theme_black_secondary_text</item>
         <item name="android:colorBackground">@color/theme_black_primary</item>
         <item name="android:windowBackground">@color/theme_black_primary</item>
-        <item name="colorButtonNormal">#ff303030</item>
+        <!-- App buttons -->
+        <item name="largeButtonBackgroundColor">#ff303030</item>
+        <item name="largeButtonTextColor">@color/theme_black_primary_text</item>
         <!-- Action bar styles -->
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
@@ -72,8 +74,6 @@
         <item name="fab_labelsTextColor">@color/theme_black_primary_text</item>
         <item name="fab_background">@color/theme_black_primary_light</item>
         <item name="fab_item_background">@drawable/fab_label_background_black_pre21</item>
-        <!-- StudyOptions fragment -->
-        <item name="study_start_textColor">@color/theme_black_primary_text</item>
         <!-- Dialog styles -->
         <item name="android:listPreferredItemHeight">56dip</item>
         <item name="md_dark_theme">true</item>

--- a/AnkiDroid/src/main/res/values/theme_dark.xml
+++ b/AnkiDroid/src/main/res/values/theme_dark.xml
@@ -18,7 +18,9 @@
         <item name="android:textColorSecondary">@color/theme_dark_secondary_text</item>
         <item name="android:colorBackground">@color/material_theme_grey</item>
         <item name="android:windowBackground">@color/material_theme_grey</item>
-        <item name="colorButtonNormal">@color/material_light_blue_700</item>
+        <!-- App buttons -->
+        <item name="largeButtonBackgroundColor">@color/material_light_blue_700</item>
+        <item name="largeButtonTextColor">@color/white</item>
         <!-- Action bar styles -->
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
@@ -72,8 +74,6 @@
         <item name="fab_labelsTextColor">@color/white</item>
         <item name="fab_background">@color/material_grey_700</item>
         <item name="fab_item_background">@drawable/fab_label_background_pre21</item>
-        <!-- StudyOptions fragment -->
-        <item name="study_start_textColor">@color/white</item>
         <!-- Images -->
         <item name="navDrawerImage">@drawable/nav_drawer_logo_dark_theme</item>
         <item name="attachFileImage">@drawable/ic_attachment_white_24dp</item>

--- a/AnkiDroid/src/main/res/values/theme_light.xml
+++ b/AnkiDroid/src/main/res/values/theme_light.xml
@@ -20,7 +20,8 @@ APIs. It's visible when there aren't enough decks to fill the screen.
     <color name="theme_light_secondary_text">#de000000</color>  <!-- 87% black -->
     <color name="theme_light_row_current">#ececec</color>
 
-    <style name="Theme_Light" parent="@style/Theme.AppCompat.Light">
+    <!-- DarkActionBar needed for readable text in the menu opened by the hardware menu button -->
+    <style name="Theme_Light" parent="@style/Theme.AppCompat.Light.DarkActionBar">
         <!-- Android colors -->
         <item name="colorPrimary">@color/theme_light_primary</item>
         <item name="colorPrimaryDark">@color/theme_light_primary_dark</item>
@@ -30,7 +31,9 @@ APIs. It's visible when there aren't enough decks to fill the screen.
         <item name="android:textColorSecondary">@color/theme_light_secondary_text</item>
         <item name="android:colorBackground">@android:color/white</item>
         <item name="android:windowBackground">@android:color/white</item>
-        <item name="colorButtonNormal">@color/material_light_blue_700</item>
+        <!-- App buttons -->
+        <item name="largeButtonBackgroundColor">@color/material_light_blue_700</item>
+        <item name="largeButtonTextColor">@color/white</item>
         <!-- Action bar styles -->
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
@@ -84,8 +87,6 @@ APIs. It's visible when there aren't enough decks to fill the screen.
         <item name="fab_labelsTextColor">@color/white</item>
         <item name="fab_background">@color/material_grey_700</item>
         <item name="fab_item_background">@drawable/fab_label_background_pre21</item>
-        <!-- StudyOptions fragment -->
-        <item name="study_start_textColor">@color/white</item>
         <!-- Images -->
         <item name="navDrawerImage">@drawable/nav_drawer_logo</item>
         <item name="attachFileImage">@drawable/ic_attachment_black_24dp</item>

--- a/AnkiDroid/src/main/res/values/theme_plain.xml
+++ b/AnkiDroid/src/main/res/values/theme_plain.xml
@@ -15,7 +15,8 @@
         <item name="android:textColor">@color/theme_plain_primary_text</item>
         <item name="android:textColorPrimary">@color/theme_plain_primary_text</item>
         <item name="android:textColorSecondary">@color/theme_plain_secondary_text</item>
-        <item name="colorButtonNormal">@color/theme_plain_accent</item>
+        <!-- App buttons -->
+        <item name="largeButtonBackgroundColor">@color/theme_plain_accent</item>
         <!-- Action bar styles -->
         <item name="actionBarPopupBackgroundColor">@color/theme_plain_primary_light</item>
         <item name="actionBarPopupTextColor">@color/theme_plain_primary_text</item>
@@ -27,17 +28,6 @@
         <item name="hardButtonRef">@drawable/footer_button_all_plain</item>
         <item name="goodButtonRef">@drawable/footer_button_all_plain</item>
         <item name="easyButtonRef">@drawable/footer_button_all_plain</item>
-        <!-- Stats colors -->
-        <item name="stats_young">#7c7</item>
-        <item name="stats_mature">#070</item>
-        <item name="stats_learn">#00F</item>
-        <item name="stats_relearn">#c00</item>
-        <item name="stats_cram">#ff0</item>
-        <item name="stats_interval">#077</item>
-        <item name="stats_hours">#ccc</item>
-        <item name="stats_counts">#E6000000</item>
-        <item name="stats_unseen">#000</item>
-        <item name="stats_suspended">#ff0</item>
         <!-- FAB -->
         <item name="fab_normal">@color/theme_plain_accent</item>
         <item name="fab_pressed">#c8607d8b</item> <!-- 55 less opacity than fab_normal -->


### PR DESCRIPTION
- Fixes https://github.com/ankidroid/Anki-Android/issues/4091. I added a comment to explain why that particular base theme is needed so it doesn't get removed again.

- Made black theme button border brighter (should resolve the third point in https://github.com/ankidroid/Anki-Android/issues/4090).

- I removed `Theme_Light_Statistics` which I'm pretty sure is doing nothing (the theme is overridden at runtime, and we have no radio buttons anyway...)

- Created a new style for large buttons. My previous fix to the touch feedback made it so the buttons in the note editor (Tags and Cards) also got given a color which isn't desirable.