### PR TITLE
Lint warnings with automated fixes

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -783,7 +783,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
     private String contentForCloze(String txt, int idx) {
         Pattern re = Pattern.compile("\\{\\{c" + idx + "::(.+?)\\}\\}");
         Matcher m = re.matcher(txt);
-        Set<String> matches = new LinkedHashSet<String>();
+        Set<String> matches = new LinkedHashSet<>();
         // LinkedHashSet: make entries appear only once, like Anki desktop (see also issue #2208), and keep the order
         // they appear in.
         String groupOne = new String();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -21,8 +21,6 @@ package com.ichi2.anki;
 import android.app.Application;
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.content.pm.PackageInfo;
-import android.content.pm.PackageManager;
 import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.os.Environment;
@@ -380,7 +378,7 @@ public class AnkiDroidApp extends Application {
 
     /** A tree which logs necessary data for crash reporting. */
     public static class ProductionCrashReportingTree extends Timber.HollowTree {
-        private static final ThreadLocal<String> NEXT_TAG = new ThreadLocal<String>();
+        private static final ThreadLocal<String> NEXT_TAG = new ThreadLocal<>();
         private static final Pattern ANONYMOUS_CLASS = Pattern.compile("\\$\\d+$");
 
         @Override public void e(String message, Object... args) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiFont.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiFont.java
@@ -27,7 +27,7 @@ public class AnkiFont {
     private Boolean mIsDefault;
     private Boolean mIsOverride;
     private static final String fAssetPathPrefix = "/android_asset/fonts/";
-    private static Set<String> corruptFonts = new HashSet<String>();
+    private static Set<String> corruptFonts = new HashSet<>();
 
 
     private AnkiFont(String name, String family, List<String> attributes, String path) {
@@ -52,7 +52,7 @@ public class AnkiFont {
         File fontfile = new File(path);
         String name = Utils.removeFileExtension(fontfile.getName());
         String family = name;
-        List<String> attributes = new ArrayList<String>();
+        List<String> attributes = new ArrayList<>();
 
         if (fromAssets) {
             path = fAssetPathPrefix.concat(fontfile.getName());

--- a/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.java
@@ -195,8 +195,6 @@ public class BackupManager {
                     // set timestamp of file in order to avoid creating a new backup unless its changed
                     backupFile.setLastModified(colFile.lastModified());
                     Timber.i("Backup created succesfully");
-                } catch (FileNotFoundException e1) {
-                    e1.printStackTrace();
                 } catch (IOException e) {
                     e.printStackTrace();
                 }
@@ -268,10 +266,8 @@ public class BackupManager {
             Timber.i("repairCollection - moved corrupt file to broken folder");
             File repairedFile = new File(deckPath + ".tmp");
             return repairedFile.renameTo(deckFile);
-        } catch (IOException e) {
+        } catch (IOException | InterruptedException e) {
             Timber.e("repairCollection - error: " + e.getMessage());
-        } catch (InterruptedException e) {
-            Timber.e("repairCollection - error: " +  e.getMessage());
         }
         return false;
     }
@@ -318,7 +314,7 @@ public class BackupManager {
         if (files == null) {
             files = new File[0];
         }
-        ArrayList<File> deckBackups = new ArrayList<File>();
+        ArrayList<File> deckBackups = new ArrayList<>();
         for (File aktFile : files) {
             if (aktFile.getName().replaceAll("^(.*)-\\d{4}-\\d{2}-\\d{2}-\\d{2}-\\d{2}.apkg$", "$1.apkg")
                     .equals(colFile.getName().replace(".anki2",".apkg"))) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
@@ -27,7 +27,6 @@ import android.support.v4.content.ContextCompat;
 import com.ichi2.anki.exception.StorageAccessException;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Storage;
-import com.ichi2.libanki.hooks.Hooks;
 
 import java.io.File;
 import java.io.IOException;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CustomExceptionHandler.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CustomExceptionHandler.java
@@ -42,7 +42,7 @@ public class CustomExceptionHandler implements Thread.UncaughtExceptionHandler {
     private Context mCurContext;
     // private Random randomGenerator = new Random();
 
-    private HashMap<String, String> mInformation = new HashMap<String, String>(20);
+    private HashMap<String, String> mInformation = new HashMap<>(20);
 
 
     static CustomExceptionHandler getInstance() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
@@ -79,8 +79,8 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
 
     public class DeckPreferenceHack implements SharedPreferences {
 
-        private Map<String, String> mValues = new HashMap<String, String>();
-        private Map<String, String> mSummaries = new HashMap<String, String>();
+        private Map<String, String> mValues = new HashMap<>();
+        private Map<String, String> mSummaries = new HashMap<>();
         private MaterialDialog mProgressDialog;
 
 
@@ -158,7 +158,7 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
                         Timber.i("Change value for key '" + key + "': " + value);
 
                         if (key.equals("maxAnswerTime")) {
-                            mOptions.put("maxTaken", (Integer) value);
+                            mOptions.put("maxTaken", value);
                         } else if (key.equals("newFactor")) {
                             mOptions.getJSONObject("new").put("initialFactor", (Integer) value * 10);
                         } else if (key.equals("newOrder")) {
@@ -172,33 +172,33 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
                             }
                             mOptions.getJSONObject("new").put("order", Integer.parseInt((String) value));
                         } else if (key.equals("newPerDay")) {
-                            mOptions.getJSONObject("new").put("perDay", (Integer) value);
+                            mOptions.getJSONObject("new").put("perDay", value);
                         } else if (key.equals("newGradIvl")) {
                             JSONArray ja = new JSONArray(); // [graduating, easy]
-                            ja.put((Integer) value);
+                            ja.put(value);
                             ja.put(mOptions.getJSONObject("new").getJSONArray("ints").get(1));
                             mOptions.getJSONObject("new").put("ints", ja);
                         } else if (key.equals("newEasy")) {
                             JSONArray ja = new JSONArray(); // [graduating, easy]
                             ja.put(mOptions.getJSONObject("new").getJSONArray("ints").get(0));
-                            ja.put((Integer) value);
+                            ja.put(value);
                             mOptions.getJSONObject("new").put("ints", ja);
                         } else if (key.equals("newBury")) {
-                            mOptions.getJSONObject("new").put("bury", (Boolean) value);
+                            mOptions.getJSONObject("new").put("bury", value);
                         } else if (key.equals("revPerDay")) {
-                            mOptions.getJSONObject("rev").put("perDay", (Integer) value);
+                            mOptions.getJSONObject("rev").put("perDay", value);
                         } else if (key.equals("easyBonus")) {
                             mOptions.getJSONObject("rev").put("ease4", (Integer) value / 100.0f);
                         } else if (key.equals("revIvlFct")) {
                             mOptions.getJSONObject("rev").put("ivlFct", (Integer) value / 100.0f);
                         } else if (key.equals("revMaxIvl")) {
-                            mOptions.getJSONObject("rev").put("maxIvl", (Integer) value);
+                            mOptions.getJSONObject("rev").put("maxIvl", value);
                         } else if (key.equals("revBury")) {
-                            mOptions.getJSONObject("rev").put("bury", (Boolean) value);
+                            mOptions.getJSONObject("rev").put("bury", value);
                         } else if (key.equals("lapMinIvl")) {
-                            mOptions.getJSONObject("lapse").put("minInt", (Integer) value);
+                            mOptions.getJSONObject("lapse").put("minInt", value);
                         } else if (key.equals("lapLeechThres")) {
-                            mOptions.getJSONObject("lapse").put("leechFails", (Integer) value);
+                            mOptions.getJSONObject("lapse").put("leechFails", value);
                         } else if (key.equals("lapLeechAct")) {
                             mOptions.getJSONObject("lapse").put("leechAction", Integer.parseInt((String) value));
                         } else if (key.equals("lapNewIvl")) {
@@ -206,11 +206,11 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
                         } else if (key.equals("showAnswerTimer")) {
                             mOptions.put("timer", (Boolean) value ? 1 : 0);
                         } else if (key.equals("autoPlayAudio")) {
-                            mOptions.put("autoplay", (Boolean) value);
+                            mOptions.put("autoplay", value);
                         } else if (key.equals("replayQuestion")) {
-                            mOptions.put("replayq", (Boolean) value);
+                            mOptions.put("replayq", value);
                         } else if (key.equals("desc")) {
-                            mDeck.put("desc", (String) value);
+                            mDeck.put("desc", value);
                             mCol.getDecks().save(mDeck);
                         } else if (key.equals("newSteps")) {
                             mOptions.getJSONObject("new").put("delays", StepsPreference.convertToJSON((String) value));
@@ -462,7 +462,7 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
             return mValues.get(key);
         }
 
-        public List<OnSharedPreferenceChangeListener> listeners = new LinkedList<OnSharedPreferenceChangeListener>();
+        public List<OnSharedPreferenceChangeListener> listeners = new LinkedList<>();
 
 
         @Override

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FilteredDeckOptions.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FilteredDeckOptions.java
@@ -77,8 +77,8 @@ public class FilteredDeckOptions extends AppCompatPreferenceActivity implements 
 
     public class DeckPreferenceHack implements SharedPreferences {
 
-        private Map<String, String> mValues = new HashMap<String, String>();
-        private Map<String, String> mSummaries = new HashMap<String, String>();
+        private Map<String, String> mValues = new HashMap<>();
+        private Map<String, String> mSummaries = new HashMap<>();
 
 
         public DeckPreferenceHack() {
@@ -130,22 +130,22 @@ public class FilteredDeckOptions extends AppCompatPreferenceActivity implements 
                         Timber.i("Change value for key '" + entry.getKey() + "': " + entry.getValue());
                         if (entry.getKey().equals("search")) {
                             JSONArray ar = mDeck.getJSONArray("terms");
-                            ar.getJSONArray(0).put(0, (String) entry.getValue());
+                            ar.getJSONArray(0).put(0, entry.getValue());
                             mDeck.put("terms", ar);
                         } else if (entry.getKey().equals("limit")) {
                             JSONArray ar = mDeck.getJSONArray("terms");
-                            ar.getJSONArray(0).put(1, (Integer) entry.getValue());
+                            ar.getJSONArray(0).put(1, entry.getValue());
                             mDeck.put("terms", ar);
                         } else if (entry.getKey().equals("order")) {
                             JSONArray ar = mDeck.getJSONArray("terms");
                             ar.getJSONArray(0).put(2, Integer.parseInt((String) entry.getValue()));
                             mDeck.put("terms", ar);
                         } else if (entry.getKey().equals("resched")) {
-                            mDeck.put("resched", (Boolean) entry.getValue());
+                            mDeck.put("resched", entry.getValue());
                         } else if (entry.getKey().equals("stepsOn")) {
                             boolean on = (Boolean) entry.getValue();
                             if (on) {
-                                JSONArray steps =  StepsPreference.convertToJSON((String) mValues.get("steps"));
+                                JSONArray steps =  StepsPreference.convertToJSON(mValues.get("steps"));
                                 if (steps.length() > 0) {
                                     mDeck.put("delays", steps);
                                 }
@@ -314,7 +314,7 @@ public class FilteredDeckOptions extends AppCompatPreferenceActivity implements 
             return mValues.get(key);
         }
 
-        public List<OnSharedPreferenceChangeListener> listeners = new LinkedList<OnSharedPreferenceChangeListener>();
+        public List<OnSharedPreferenceChangeListener> listeners = new LinkedList<>();
 
 
         @Override

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Info.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Info.java
@@ -26,7 +26,6 @@ import android.os.Build;
 import android.os.Bundle;
 import android.support.v7.widget.Toolbar;
 import android.text.ClipboardManager;
-import android.text.method.LinkMovementMethod;
 import android.util.TypedValue;
 import android.view.KeyEvent;
 import android.view.View;
@@ -34,7 +33,6 @@ import android.view.View.OnClickListener;
 import android.webkit.WebChromeClient;
 import android.webkit.WebView;
 import android.widget.Button;
-import android.widget.TextView;
 
 import com.ichi2.anim.ActivityTransitionAnimation;
 import com.ichi2.compat.CompatHelper;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Lookup.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Lookup.java
@@ -98,8 +98,8 @@ public class Lookup {
                 final CharSequence[] itemValues = { "en", "fr", "es", "it", "ch", "ru" };
                 String language = getLanguage(MetaDB.LANGUAGES_QA_UNDEFINED);
                 if (language.length() > 0) {
-                    for (int i = 0; i < itemValues.length; i++) {
-                        if (language.equals(itemValues[i])) {
+                    for (CharSequence itemValue : itemValues) {
+                        if (language.equals(itemValue)) {
                             lookupLeo(language, mLookupText);
                             mLookupText = "";
                             return true;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.java
@@ -22,7 +22,6 @@ import android.database.sqlite.SQLiteException;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.v7.widget.Toolbar;
-import android.text.method.LinkMovementMethod;
 import android.view.KeyEvent;
 import android.view.View;
 import android.view.View.OnClickListener;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
@@ -18,7 +18,6 @@ package com.ichi2.anki;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.res.Configuration;
-import android.content.res.Resources;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.design.widget.NavigationView;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -415,8 +415,8 @@ public class NoteEditor extends AnkiActivity {
 
         // Note type Selector
         mNoteTypeSpinner = (Spinner) findViewById(R.id.note_type_spinner);
-        mAllModelIds = new ArrayList<Long>();
-        final ArrayList<String> modelNames = new ArrayList<String>();
+        mAllModelIds = new ArrayList<>();
+        final ArrayList<String> modelNames = new ArrayList<>();
         ArrayList<JSONObject> models = getCol().getModels().all();
         Collections.sort(models, new JSONNameComparator());
         for (JSONObject m : models) {
@@ -428,7 +428,7 @@ public class NoteEditor extends AnkiActivity {
             }
         }
 
-        ArrayAdapter<String> noteTypeAdapter = new ArrayAdapter<String>(this,android.R.layout.simple_spinner_item, modelNames);
+        ArrayAdapter<String> noteTypeAdapter = new ArrayAdapter<>(this, android.R.layout.simple_spinner_item, modelNames);
         mNoteTypeSpinner.setAdapter(noteTypeAdapter);
         noteTypeAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
 
@@ -444,8 +444,8 @@ public class NoteEditor extends AnkiActivity {
             throw new RuntimeException();
         }
         mNoteDeckSpinner = (Spinner) findViewById(R.id.note_deck_spinner);
-        mAllDeckIds = new ArrayList<Long>();
-        final ArrayList<String> deckNames = new ArrayList<String>();
+        mAllDeckIds = new ArrayList<>();
+        final ArrayList<String> deckNames = new ArrayList<>();
 
         ArrayList<JSONObject> decks = getCol().getDecks().all();
         Collections.sort(decks, new JSONNameComparator());
@@ -463,7 +463,7 @@ public class NoteEditor extends AnkiActivity {
             }
         }
 
-        ArrayAdapter<String> noteDeckAdapter = new ArrayAdapter<String>(this,android.R.layout.simple_spinner_item, deckNames);
+        ArrayAdapter<String> noteDeckAdapter = new ArrayAdapter<>(this, android.R.layout.simple_spinner_item, deckNames);
         mNoteDeckSpinner.setAdapter(noteDeckAdapter);
         noteDeckAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
         mNoteDeckSpinner.setOnItemSelectedListener(new OnItemSelectedListener() {
@@ -521,7 +521,7 @@ public class NoteEditor extends AnkiActivity {
         }
 
 
-        ((LinearLayout) findViewById(R.id.CardEditorTagButton)).setOnClickListener(new View.OnClickListener() {
+        findViewById(R.id.CardEditorTagButton).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
                 Timber.i("NoteEditor:: Tags button pressed... opening tags editor");
@@ -572,7 +572,7 @@ public class NoteEditor extends AnkiActivity {
                 first = second;
                 second = "";
             }
-            Pair<String, String> messages = new Pair<String, String>(first, second);
+            Pair<String, String> messages = new Pair<>(first, second);
 
             mSourceText = new String[2];
             mSourceText[0] = messages.first;
@@ -654,7 +654,7 @@ public class NoteEditor extends AnkiActivity {
     private void saveNote() {
         final Resources res = getResources();
         if (mSelectedTags == null) {
-            mSelectedTags = new ArrayList<String>();
+            mSelectedTags = new ArrayList<>();
         }
         // treat add new note and edit existing note independently
         if (mAddNote) {
@@ -980,10 +980,10 @@ public class NoteEditor extends AnkiActivity {
 
     private void showTagsDialog() {
         if (mSelectedTags == null) {
-            mSelectedTags = new ArrayList<String>();
+            mSelectedTags = new ArrayList<>();
         }
-        ArrayList<String> tags = new ArrayList<String>(getCol().getTags().all());
-        ArrayList<String> selTags = new ArrayList<String>(mSelectedTags);
+        ArrayList<String> tags = new ArrayList<>(getCol().getTags().all());
+        ArrayList<String> selTags = new ArrayList<>(mSelectedTags);
         TagsDialog dialog = com.ichi2.anki.dialogs.TagsDialog.newInstance(TagsDialog.TYPE_ADD_TAG, selTags,
                 tags);
         dialog.setTagsDialogListener(new TagsDialogListener() {
@@ -1083,7 +1083,7 @@ public class NoteEditor extends AnkiActivity {
 
     private void populateEditFields(String[][] fields, boolean editModelMode) {
         mFieldsLayoutContainer.removeAllViews();
-        mEditFields = new LinkedList<FieldEditText>();
+        mEditFields = new LinkedList<>();
 
         // Use custom font if selected from preferences
         Typeface mCustomTypeface = null;
@@ -1391,7 +1391,7 @@ public class NoteEditor extends AnkiActivity {
 
     private void updateTags() {
         if (mSelectedTags == null) {
-            mSelectedTags = new ArrayList<String>();
+            mSelectedTags = new ArrayList<>();
         }
         mTagsButton.setText(getResources().getString(R.string.CardEditorTags,
                 getCol().getTags().join(getCol().getTags().canonify(mSelectedTags)).trim().replace(" ", ", ")));
@@ -1602,12 +1602,12 @@ public class NoteEditor extends AnkiActivity {
             // Configure the interface according to whether note type is getting changed or not
             if (mAllModelIds.get(pos) != noteModelId) {
                 // Initialize mapping between fields of old model -> new model
-                mModelChangeFieldMap = new HashMap<Integer, Integer>();
+                mModelChangeFieldMap = new HashMap<>();
                 for (int i=0; i < mEditorNote.items().length; i++) {
                     mModelChangeFieldMap.put(i, i);
                 }
                 // Initialize mapping between cards new model -> old model
-                mModelChangeCardMap = new HashMap<Integer, Integer>();
+                mModelChangeCardMap = new HashMap<>();
                 try {
                     for (int i=0; i < newModel.getJSONArray("tmpls").length() ; i++) {
                         if (i < mEditorNote.cards().size()) {
@@ -1624,7 +1624,7 @@ public class NoteEditor extends AnkiActivity {
                 // Don't let the user change any other values at the same time as changing note type
                 mSelectedTags = mEditorNote.getTags();
                 updateTags();
-                ((LinearLayout) findViewById(R.id.CardEditorTagButton)).setEnabled(false);
+                findViewById(R.id.CardEditorTagButton).setEnabled(false);
                 //((LinearLayout) findViewById(R.id.CardEditorCardsButton)).setEnabled(false);
                 mNoteDeckSpinner.setEnabled(false);
                 int position = mAllDeckIds.indexOf(mCurrentEditedCard.getDid());
@@ -1634,7 +1634,7 @@ public class NoteEditor extends AnkiActivity {
             } else {
                 populateEditFields();
                 updateCards(mCurrentEditedCard.model());
-                ((LinearLayout) findViewById(R.id.CardEditorTagButton)).setEnabled(true);
+                findViewById(R.id.CardEditorTagButton).setEnabled(true);
                 //((LinearLayout) findViewById(R.id.CardEditorCardsButton)).setEnabled(false);
                 mNoteDeckSpinner.setEnabled(true);
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.java
@@ -18,7 +18,6 @@ package com.ichi2.anki;
 
 import android.content.Context;
 import android.content.res.Resources;
-import android.graphics.drawable.Drawable;
 import android.os.Handler;
 import android.speech.tts.TextToSpeech;
 import android.view.View;
@@ -26,7 +25,6 @@ import android.view.View;
 import android.widget.Toast;
 
 import com.afollestad.materialdialogs.MaterialDialog;
-import com.ichi2.themes.Themes;
 import com.ichi2.compat.CompatHelper;
 
 import java.lang.ref.WeakReference;
@@ -38,14 +36,14 @@ import timber.log.Timber;
 
 public class ReadText {
     private static TextToSpeech mTts;
-    private static ArrayList<Locale> availableTtsLocales = new ArrayList<Locale>();
+    private static ArrayList<Locale> availableTtsLocales = new ArrayList<>();
     private static String mTextToSpeak;
     private static WeakReference<Context> mReviewer;
     private static long mDid;
     private static int mOrd;
     private static int mQuestionAnswer;
     public static final String NO_TTS = "0";
-    public static ArrayList<String[]> sTextQueue = new ArrayList<String[]>();
+    public static ArrayList<String[]> sTextQueue = new ArrayList<>();
     public static HashMap<String, String> mTtsParams;
 
 
@@ -99,8 +97,8 @@ public class ReadText {
                     .iconAttr(R.attr.dialogErrorIcon)
                     .positiveText(res.getString(R.string.dialog_ok));
         } else {
-            ArrayList<CharSequence> dialogItems = new ArrayList<CharSequence>();
-            final ArrayList<String> dialogIds = new ArrayList<String>();
+            ArrayList<CharSequence> dialogItems = new ArrayList<>();
+            final ArrayList<String> dialogIds = new ArrayList<>();
             // Add option: "no tts"
             dialogItems.add(res.getString(R.string.tts_no_tts));
             dialogIds.add(NO_TTS);
@@ -175,7 +173,7 @@ public class ReadText {
 
     public static void initializeTts(Context context) {
         // Store weak reference to Activity to prevent memory leak
-        mReviewer = new WeakReference<Context>(context);
+        mReviewer = new WeakReference<>(context);
         // Create new TTS object and setup its onInit Listener
         mTts = new TextToSpeech(context, new TextToSpeech.OnInitListener() {
             @Override
@@ -197,7 +195,7 @@ public class ReadText {
                 CompatHelper.getCompat().setTtsOnUtteranceProgressListener(mTts);
             }
         });
-        mTtsParams = new HashMap<String, String>();
+        mTtsParams = new HashMap<>();
         mTtsParams.put(TextToSpeech.Engine.KEY_PARAM_UTTERANCE_ID, "stringId");
         // Show toast that it's getting initialized, as it can take a while before the sound plays the first time
         Toast.makeText(context, context.getString(R.string.initializing_tts), Toast.LENGTH_LONG).show();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.java
@@ -24,7 +24,6 @@ import android.support.v4.app.FragmentPagerAdapter;
 import android.support.v4.view.ViewPager;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
-import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.java
@@ -18,18 +18,13 @@ package com.ichi2.anki;
 
 import android.content.Intent;
 import android.os.Bundle;
-import android.view.KeyEvent;
-import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 
 import com.ichi2.anim.ActivityTransitionAnimation;
 import com.ichi2.anki.StudyOptionsFragment.StudyOptionsListener;
 import com.ichi2.anki.dialogs.CustomStudyDialog;
-import com.ichi2.themes.Themes;
 import com.ichi2.widget.WidgetStatus;
-
-import org.json.JSONArray;
 
 import timber.log.Timber;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/UIUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/UIUtils.java
@@ -2,9 +2,6 @@
 package com.ichi2.anki;
 
 import android.content.Context;
-import android.os.Build;
-import android.view.View;
-import android.view.WindowManager;
 
 import com.ichi2.async.DeckTask;
 import com.ichi2.async.DeckTask.TaskData;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CardBrowserContextMenu.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CardBrowserContextMenu.java
@@ -3,11 +3,9 @@ package com.ichi2.anki.dialogs;
 
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.ichi2.anki.R;
-import com.ichi2.themes.Themes;
 
 import android.app.Dialog;
 import android.content.res.Resources;
-import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.support.v4.app.DialogFragment;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CardBrowserMySearchesDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CardBrowserMySearchesDialog.java
@@ -61,7 +61,7 @@ public class CardBrowserMySearchesDialog extends DialogFragment {
         int type = getArguments().getInt("type");
         if (type == CARD_BROWSER_MY_SEARCHES_TYPE_LIST) {
             mSavedFilters = (HashMap<String, String>) getArguments().getSerializable("savedFilters");
-            mSearchesAdapter = new MySearchesArrayAdapter(getActivity(), new ArrayList<String>(mSavedFilters.keySet()));
+            mSearchesAdapter = new MySearchesArrayAdapter(getActivity(), new ArrayList<>(mSavedFilters.keySet()));
             mSearchesAdapter.notifyDataSetChanged(); //so the values are sorted.
             builder.title(res.getString(R.string.card_browser_list_my_searches_title))
                     .adapter(mSearchesAdapter, new MaterialDialog.ListCallback() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CardBrowserOrderDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CardBrowserOrderDialog.java
@@ -4,11 +4,9 @@ package com.ichi2.anki.dialogs;
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.ichi2.anki.CardBrowser;
 import com.ichi2.anki.R;
-import com.ichi2.themes.Themes;
 
 import android.app.Dialog;
 import android.content.res.Resources;
-import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.support.v4.app.DialogFragment;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.java
@@ -65,9 +65,7 @@ public class DatabaseErrorDialog extends AsyncDialogFragment {
         boolean sqliteInstalled = false;
         try {
             sqliteInstalled = Runtime.getRuntime().exec("sqlite3 --version").waitFor() == 0;
-        } catch (IOException e) {
-            e.printStackTrace();
-        } catch (InterruptedException e) {
+        } catch (IOException | InterruptedException e) {
             e.printStackTrace();
         }
 
@@ -131,8 +129,8 @@ public class DatabaseErrorDialog extends AsyncDialogFragment {
             case DIALOG_ERROR_HANDLING:
                 // The user has asked to see repair options; allow them to choose one of the repair options or go back
                 // to the previous dialog
-                ArrayList<String> options = new ArrayList<String>();
-                ArrayList<Integer> values = new ArrayList<Integer>();
+                ArrayList<String> options = new ArrayList<>();
+                ArrayList<Integer> values = new ArrayList<>();
                 if (!((AnkiActivity)getActivity()).colIsOpen()) {
                     // retry
                     options.add(res.getString(R.string.backup_retry_opening));

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.java
@@ -27,7 +27,6 @@ import com.ichi2.anki.CollectionHelper;
 import com.ichi2.anki.DeckPicker;
 import com.ichi2.anki.R;
 import com.ichi2.anki.StudyOptionsFragment;
-import com.ichi2.async.DeckTask;
 import com.ichi2.libanki.Collection;
 
 import java.util.ArrayList;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerExportCompleteDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerExportCompleteDialog.java
@@ -1,15 +1,12 @@
 
 package com.ichi2.anki.dialogs;
 
-import android.content.res.Resources;
-import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.os.Message;
 
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.ichi2.anki.DeckPicker;
 import com.ichi2.anki.R;
-import com.ichi2.themes.Themes;
 
 public class DeckPickerExportCompleteDialog extends AsyncDialogFragment {
     

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DialogHandler.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DialogHandler.java
@@ -76,7 +76,7 @@ public class DialogHandler extends Handler {
             // Media check results
             int id = msgData.getInt("dialogType");
             if (id!=MediaCheckDialog.DIALOG_CONFIRM_MEDIA_CHECK) {
-                List<List<String>> checkList = new ArrayList<List<String>>();
+                List<List<String>> checkList = new ArrayList<>();
                 checkList.add(msgData.getStringArrayList("nohave"));
                 checkList.add(msgData.getStringArrayList("unused"));
                 checkList.add(msgData.getStringArrayList("invalid"));

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ExportDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ExportDialog.java
@@ -80,8 +80,8 @@ public class ExportDialog extends DialogFragment {
                                                        Integer[] integers, CharSequence[] charSequences) {
                                 mIncludeMedia = false;
                                 mIncludeSched = false;
-                                for (int i = 0; i < integers.length; i++) {
-                                    switch (integers[i]) {
+                                for (Integer integer : integers) {
+                                    switch (integer) {
                                         case INCLUDE_SCHED:
                                             mIncludeSched = true;
                                             break;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/MediaCheckDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/MediaCheckDialog.java
@@ -43,9 +43,9 @@ public class MediaCheckDialog extends AsyncDialogFragment {
     public static MediaCheckDialog newInstance(int dialogType, List<List<String>> checkList) {
         MediaCheckDialog f = new MediaCheckDialog();
         Bundle args = new Bundle();
-        args.putStringArrayList("nohave", new ArrayList<String>(checkList.get(0)));
-        args.putStringArrayList("unused", new ArrayList<String>(checkList.get(1)));
-        args.putStringArrayList("invalid", new ArrayList<String>(checkList.get(2)));
+        args.putStringArrayList("nohave", new ArrayList<>(checkList.get(0)));
+        args.putStringArrayList("unused", new ArrayList<>(checkList.get(1)));
+        args.putStringArrayList("invalid", new ArrayList<>(checkList.get(2)));
         args.putInt("dialogType", dialogType);
         f.setArguments(args);
         return f;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ModelBrowserContextMenu.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ModelBrowserContextMenu.java
@@ -1,14 +1,11 @@
 package com.ichi2.anki.dialogs;
 
 import android.app.Dialog;
-import android.content.res.Resources;
-import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.support.v4.app.DialogFragment;
 
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.ichi2.anki.R;
-import com.ichi2.themes.Themes;
 
 public class ModelBrowserContextMenu extends DialogFragment {
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ModelEditorContextMenu.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ModelEditorContextMenu.java
@@ -1,14 +1,11 @@
 package com.ichi2.anki.dialogs;
 
 import android.app.Dialog;
-import android.content.res.Resources;
-import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.support.v4.app.DialogFragment;
 
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.ichi2.anki.R;
-import com.ichi2.themes.Themes;
 
 public class ModelEditorContextMenu extends DialogFragment {
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SyncErrorDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SyncErrorDialog.java
@@ -1,14 +1,12 @@
 
 package com.ichi2.anki.dialogs;
 
-import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.os.Message;
 
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.ichi2.anki.R;
 import com.ichi2.libanki.Collection;
-import com.ichi2.themes.Themes;
 
 public class SyncErrorDialog extends AsyncDialogFragment {
     public static final int DIALOG_USER_NOT_LOGGED_IN_SYNC = 0;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TagsDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TagsDialog.java
@@ -10,12 +10,10 @@ import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.SearchView;
 import android.support.v7.widget.Toolbar;
-import android.text.Editable;
 import android.text.InputFilter;
 import android.text.InputType;
 import android.text.Spanned;
 import android.text.TextUtils;
-import android.text.TextWatcher;
 import android.view.LayoutInflater;
 import android.view.MenuItem;
 import android.view.View;
@@ -27,11 +25,8 @@ import android.widget.Filter;
 import android.widget.Filterable;
 import android.widget.RadioGroup;
 import android.widget.TextView;
-import android.widget.Toast;
 
-import com.afollestad.materialdialogs.DialogAction;
 import com.afollestad.materialdialogs.MaterialDialog;
-import com.ichi2.anki.AnkiActivity;
 import com.ichi2.anki.R;
 
 import java.util.ArrayList;
@@ -96,10 +91,10 @@ public class TagsDialog extends DialogFragment {
 
         mType = getArguments().getInt(DIALOG_TYPE_KEY);
 
-        mCurrentTags = new TreeSet<String>(String.CASE_INSENSITIVE_ORDER);
+        mCurrentTags = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
         mCurrentTags.addAll(getArguments().getStringArrayList(CHECKED_TAGS_KEY));
 
-        mAllTags = new ArrayList<String>();
+        mAllTags = new ArrayList<>();
         mAllTags.addAll(getArguments().getStringArrayList(ALL_TAGS_KEY));
 
         for (String tag : mCurrentTags) {
@@ -167,7 +162,7 @@ public class TagsDialog extends DialogFragment {
                     @Override
                     public void onPositive(MaterialDialog dialog) {
                         mTagsDialogListener
-                                .onPositive(new ArrayList<String>(mCurrentTags), mSelectedOption);
+                                .onPositive(new ArrayList<>(mCurrentTags), mSelectedOption);
                     }
                 });
         mDialog = builder.build();
@@ -318,7 +313,7 @@ public class TagsDialog extends DialogFragment {
         public ArrayList<String> mTagsList;
 
         public  TagsArrayAdapter() {
-            mTagsList = new ArrayList<String>();
+            mTagsList = new ArrayList<>();
             mTagsList.addAll(mAllTags);
             sortData();
         }
@@ -380,7 +375,7 @@ public class TagsDialog extends DialogFragment {
             private ArrayList<String> mFilteredTags;
             private TagsFilter() {
                 super();
-                mFilteredTags = new ArrayList<String>();
+                mFilteredTags = new ArrayList<>();
             }
 
             @Override

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/LoadPronounciationActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/LoadPronounciationActivity.java
@@ -107,7 +107,7 @@ public class LoadPronounciationActivity extends Activity implements OnCancelList
         mLanguageLister = new LanguageListerBeolingus(this);
 
         mSpinnerFrom = new Spinner(this);
-        ArrayAdapter<String> adapter = new ArrayAdapter<String>(this, android.R.layout.simple_spinner_item,
+        ArrayAdapter<String> adapter = new ArrayAdapter<>(this, android.R.layout.simple_spinner_item,
                 mLanguageLister.getLanguages());
         adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
         mSpinnerFrom.setAdapter(adapter);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/PickStringDialogFragment.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/PickStringDialogFragment.java
@@ -43,7 +43,7 @@ public class PickStringDialogFragment extends DialogFragment {
         AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
         builder.setTitle(mTitle);
 
-        ArrayAdapter<String> adapter = new ArrayAdapter<String>(this.getActivity(),
+        ArrayAdapter<String> adapter = new ArrayAdapter<>(this.getActivity(),
                 android.R.layout.simple_list_item_1, mPossibleChoices);
 
         builder.setAdapter(adapter, mListener);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/TranslationActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/TranslationActivity.java
@@ -123,7 +123,7 @@ public class TranslationActivity extends FragmentActivity implements DialogInter
         mLanguageLister = new LanguagesListerGlosbe(this);
 
         mSpinnerFrom = new Spinner(this);
-        ArrayAdapter<String> adapter = new ArrayAdapter<String>(this, android.R.layout.simple_spinner_item,
+        ArrayAdapter<String> adapter = new ArrayAdapter<>(this, android.R.layout.simple_spinner_item,
                 mLanguageLister.getLanguages());
         adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
         mSpinnerFrom.setAdapter(adapter);
@@ -134,7 +134,7 @@ public class TranslationActivity extends FragmentActivity implements DialogInter
         linearLayout.addView(tvTo);
 
         mSpinnerTo = new Spinner(this);
-        ArrayAdapter<String> adapterTo = new ArrayAdapter<String>(this, android.R.layout.simple_spinner_item,
+        ArrayAdapter<String> adapterTo = new ArrayAdapter<>(this, android.R.layout.simple_spinner_item,
                 mLanguageLister.getLanguages());
         adapterTo.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
         mSpinnerTo.setAdapter(adapterTo);
@@ -300,7 +300,7 @@ public class TranslationActivity extends FragmentActivity implements DialogInter
 
 
     private static ArrayList<String> parseJson(Response resp, String languageCodeTo) {
-        ArrayList<String> res = new ArrayList<String>();
+        ArrayList<String> res = new ArrayList<>();
 
         /*
          * The algorithm below includes the parsing of glosbe results. Glosbe.com returns a list of different phrases in

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/AudioField.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/AudioField.java
@@ -19,7 +19,6 @@
 
 package com.ichi2.anki.multimediacard.fields;
 
-import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.libanki.Collection;
 
 import java.io.File;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicTextFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicTextFieldController.java
@@ -165,7 +165,7 @@ public class BasicTextFieldController extends FieldControllerBase implements IFi
                 // Pick from two translation sources
                 PickStringDialogFragment fragment = new PickStringDialogFragment();
 
-                final ArrayList<String> translationSources = new ArrayList<String>();
+                final ArrayList<String> translationSources = new ArrayList<>();
                 translationSources.add("Glosbe.com");
                 // Chromebooks do not support dependent apps yet.
                 if (!CompatHelper.isChromebook()) {
@@ -210,7 +210,7 @@ public class BasicTextFieldController extends FieldControllerBase implements IFi
             // Should be more than one text not empty fields for clone to make
             // sense
 
-            mPossibleClones = new ArrayList<String>();
+            mPossibleClones = new ArrayList<>();
 
             int numTextFields = 0;
             for (int i = 0; i < mNote.getNumberOfFields(); ++i) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/impl/MultimediaEditableNote.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/impl/MultimediaEditableNote.java
@@ -47,7 +47,7 @@ public class MultimediaEditableNote implements IMultimediaEditableNote {
             return;
         }
 
-        ArrayList<IField> newFields = new ArrayList<IField>();
+        ArrayList<IField> newFields = new ArrayList<>();
         newFields.add(mFields.get(mFields.size() - 1));
         newFields.addAll(mFields);
         newFields.remove(mFields.size());
@@ -78,7 +78,7 @@ public class MultimediaEditableNote implements IMultimediaEditableNote {
 
     private ArrayList<IField> getFieldsPrivate() {
         if (mFields == null) {
-            mFields = new ArrayList<IField>();
+            mFields = new ArrayList<>();
         }
 
         return mFields;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/language/LanguageListerBase.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/language/LanguageListerBase.java
@@ -36,7 +36,7 @@ public class LanguageListerBase {
 
 
     public LanguageListerBase() {
-        mLanguageMap = new HashMap<String, String>();
+        mLanguageMap = new HashMap<>();
     }
 
 
@@ -59,7 +59,7 @@ public class LanguageListerBase {
 
 
     public ArrayList<String> getLanguages() {
-        ArrayList<String> res = new ArrayList<String>();
+        ArrayList<String> res = new ArrayList<>();
         res.addAll(mLanguageMap.keySet());
         Collections.sort(res, new Comparator<String>() {
             @Override

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/language/LanguageListerBeolingus.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/language/LanguageListerBeolingus.java
@@ -21,7 +21,6 @@ package com.ichi2.anki.multimediacard.language;
 
 import android.content.Context;
 
-import com.ichi2.anki.R;
 import java.util.Locale;
 
 /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/language/LanguagesLister.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/language/LanguagesLister.java
@@ -29,7 +29,7 @@ public class LanguagesLister {
 
 
     LanguagesLister() {
-        mLanguageMap = new HashMap<String, String>();
+        mLanguageMap = new HashMap<>();
 
         mLanguageMap.put("Mandarin", "cmn");
         mLanguageMap.put("Spanish", "spa");
@@ -52,7 +52,7 @@ public class LanguagesLister {
 
 
     public ArrayList<String> getLanguages() {
-        ArrayList<String> res = new ArrayList<String>();
+        ArrayList<String> res = new ArrayList<>();
         res.addAll(mLanguageMap.keySet());
         Collections.sort(res, new Comparator<String>() {
             @Override

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/language/LanguagesListerGlosbe.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/language/LanguagesListerGlosbe.java
@@ -25,8 +25,6 @@ import java.util.Locale;
 
 import android.content.Context;
 
-import com.ichi2.anki.R;
-
 /**
  * This language lister is used to call glosbe.com translation services.
  * <p>
@@ -57,7 +55,7 @@ public class LanguagesListerGlosbe extends LanguageListerBase {
     public static String requestToResponseLangCode(String req) {
         if (locale_map == null) {
             String[] languages = Locale.getISOLanguages();
-            locale_map = new HashMap<String, Locale>(languages.length);
+            locale_map = new HashMap<>(languages.length);
             for (String language : languages) {
                 Locale locale = new Locale(language);
                 locale_map.put(locale.getISO3Language(), locale);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/CustomFontsReviewerExt.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/CustomFontsReviewerExt.java
@@ -23,7 +23,6 @@ import android.text.TextUtils;
 import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.AnkiFont;
 import com.ichi2.libanki.Utils;
-import com.ichi2.themes.Themes;
 
 import java.util.HashMap;
 import java.util.List;
@@ -164,7 +163,7 @@ public class CustomFontsReviewerExt implements ReviewerExt {
      */
     private static Map<String, AnkiFont> getCustomFontsMap(Context context) {
         List<AnkiFont> fonts = Utils.getCustomFonts(context);
-        Map<String, AnkiFont> customFontsMap = new HashMap<String, AnkiFont>();
+        Map<String, AnkiFont> customFontsMap = new HashMap<>();
         for (AnkiFont f : fonts) {
             customFontsMap.put(f.getName(), f);
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/stats/ChartBuilder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/stats/ChartBuilder.java
@@ -15,11 +15,6 @@
  ****************************************************************************************/
 package com.ichi2.anki.stats;
 
-import android.content.Context;
-import android.content.res.ColorStateList;
-import android.content.res.Resources;
-import android.content.res.TypedArray;
-import android.graphics.Color;
 import android.graphics.Paint;
 
 import android.widget.TextView;
@@ -418,9 +413,9 @@ public class ChartBuilder {
     }
     private double maxValue(double[] array){
         double max = Double.NEGATIVE_INFINITY;
-        for(int i = 0; i<array.length; i++){
-            if(array[i]>max)
-                max = array[i];
+        for (double anArray : array) {
+            if (anArray > max)
+                max = anArray;
         }
 
         return max;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/stats/ChartView.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/stats/ChartView.java
@@ -23,7 +23,7 @@ import android.graphics.Rect;
 import android.util.AttributeSet;
 
 import android.view.View;
-import com.ichi2.anki.AnkiDroidApp;
+
 import com.ichi2.anki.Statistics;
 import com.wildplot.android.rendering.PlotSheet;
 import com.wildplot.android.rendering.graphics.wrapper.GraphicsWrap;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckDropDownAdapter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckDropDownAdapter.java
@@ -73,8 +73,8 @@ public final class DeckDropDownAdapter extends BaseAdapter {
             convertView.setTag(viewHolder);
         } else {
             viewHolder = (DeckDropDownViewHolder) convertView.getTag();
-            deckNameView = (TextView) viewHolder.deckNameView;
-            deckCountsView = (TextView) viewHolder.deckCountsView;
+            deckNameView = viewHolder.deckNameView;
+            deckCountsView = viewHolder.deckCountsView;
         }
         if (position == 0) {
             deckNameView.setText(context.getResources().getString(R.string.deck_summary_all_decks));

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionLoader.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionLoader.java
@@ -3,7 +3,6 @@ package com.ichi2.async;
 import android.content.Context;
 import android.support.v4.content.AsyncTaskLoader;
 
-import com.ichi2.anki.AnkiActivity;
 import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.CollectionHelper;
 import com.ichi2.libanki.Collection;

--- a/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
@@ -225,9 +225,7 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
                     valid = (hostkey != null) && (hostkey.length() > 0);
                 } catch (JSONException e) {
                     valid = false;
-                } catch (IllegalStateException e) {
-                    throw new RuntimeException(e);
-                } catch (IOException e) {
+                } catch (IllegalStateException | IOException e) {
                     throw new RuntimeException(e);
                 }
             }
@@ -553,7 +551,7 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
 
 
         public void setConnectionManager(ThreadSafeClientConnManager connectionManager) {
-            mConnectionManager = new WeakReference<ThreadSafeClientConnManager>(connectionManager);
+            mConnectionManager = new WeakReference<>(connectionManager);
         }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
@@ -824,8 +824,8 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
             // data and rely on them running a media db check to get rid of any
             // unwanted media. in the future we might also want to duplicate this step
             // import media
-            HashMap<String, String> nameToNum = new HashMap<String, String>();
-            HashMap<String, String> numToName = new HashMap<String, String>();
+            HashMap<String, String> nameToNum = new HashMap<>();
+            HashMap<String, String> numToName = new HashMap<>();
             File mediaMapFile = new File(dir.getAbsolutePath(), "media");
             if (mediaMapFile.exists()) {
                 JsonReader jr = new JsonReader(new FileReader(mediaMapFile));
@@ -1080,8 +1080,8 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
         Timber.d("doInBackgroundLoadModels");
         Collection col = CollectionHelper.getInstance().getCol(mContext);
 
-        ArrayList<JSONObject> models = (ArrayList<JSONObject>) col.getModels().all();
-        ArrayList<Integer> cardCount = new ArrayList<Integer>();
+        ArrayList<JSONObject> models = col.getModels().all();
+        ArrayList<Integer> cardCount = new ArrayList<>();
         Collections.sort(models, new Comparator<JSONObject>() {
             @Override
             public int compare(JSONObject a, JSONObject b) {

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV10.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV10.java
@@ -22,7 +22,6 @@ import com.afollestad.materialdialogs.MaterialDialog;
 import com.ichi2.anki.AbstractFlashcardViewer;
 import com.ichi2.anki.AnkiActivity;
 import com.ichi2.anki.AnkiDroidApp;
-import com.ichi2.anki.CardBrowser;
 import com.ichi2.anki.DeckPicker;
 import com.ichi2.anki.Preferences;
 import com.ichi2.anki.R;

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV19.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV19.java
@@ -5,7 +5,6 @@ import android.animation.Animator;
 import android.animation.AnimatorListenerAdapter;
 import android.annotation.TargetApi;
 import android.content.SharedPreferences;
-import android.content.res.Resources;
 import android.support.v7.widget.Toolbar;
 import android.view.View;
 import android.widget.LinearLayout;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.java
@@ -64,7 +64,7 @@ class AnkiExporter extends Exporter {
     Collection mSrc;
     String mMediaDir;
     int mCount;
-    ArrayList<String> mMediaFiles = new ArrayList<String>();
+    ArrayList<String> mMediaFiles = new ArrayList<>();
 
 
     public AnkiExporter(Collection col) {
@@ -105,11 +105,11 @@ class AnkiExporter extends Exporter {
         Timber.d("Copy cards");
         mSrc.getDb().getDatabase()
                 .execSQL("INSERT INTO DST_DB.cards select * from cards where id in " + Utils.ids2str(cids));
-        Set<Long> nids = new HashSet<Long>(mSrc.getDb().queryColumn(Long.class,
+        Set<Long> nids = new HashSet<>(mSrc.getDb().queryColumn(Long.class,
                 "select nid from cards where id in " + Utils.ids2str(cids), 0));
         // notes
         Timber.d("Copy notes");
-        ArrayList<Long> uniqueNids = new ArrayList<Long>(nids);
+        ArrayList<Long> uniqueNids = new ArrayList<>(nids);
         String strnids = Utils.ids2str(uniqueNids);
         mSrc.getDb().getDatabase().execSQL("INSERT INTO DST_DB.notes select * from notes where id in " + strnids);
         // remove system tags if not exporting scheduling info
@@ -117,7 +117,7 @@ class AnkiExporter extends Exporter {
             Timber.d("Stripping system tags from list");
             ArrayList<String> srcTags = mSrc.getDb().queryColumn(String.class,
                     "select tags from notes where id in " + strnids, 0);
-            ArrayList<Object[]> args = new ArrayList<Object[]>(srcTags.size());
+            ArrayList<Object[]> args = new ArrayList<>(srcTags.size());
             Object [] arg = new Object[2];
             for (int row = 0; row < srcTags.size(); row++) {
                 arg[0]=removeSystemTags(srcTags.get(row));
@@ -156,7 +156,7 @@ class AnkiExporter extends Exporter {
         }
         // decks
         Timber.d("Copy decks");
-        ArrayList<Long> dids = new ArrayList<Long>();
+        ArrayList<Long> dids = new ArrayList<>();
         if (mDid != null) {
             dids.add(mDid);
             for (Long x : mSrc.getDecks().children(mDid).values()) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.java
@@ -287,7 +287,7 @@ public class Card implements Cloneable {
             JSONObject t = template();
             Object[] data;
             try {
-                data = new Object[] { mId, f.getId(), m.getLong("id"), mODid != 0l ? mODid : mDid, mOrd,
+                data = new Object[] { mId, f.getId(), m.getLong("id"), mODid != 0L ? mODid : mDid, mOrd,
                         f.stringTags(), f.joinedFields() };
             } catch (JSONException e) {
                 throw new RuntimeException(e);
@@ -625,11 +625,11 @@ public class Card implements Cloneable {
 
 
     // A list of class members to skip in the toString() representation
-    public static final Set<String> SKIP_PRINT = new HashSet<String>(Arrays.asList("SKIP_PRINT", "$assertionsDisabled", "TYPE_LRN",
+    public static final Set<String> SKIP_PRINT = new HashSet<>(Arrays.asList("SKIP_PRINT", "$assertionsDisabled", "TYPE_LRN",
             "TYPE_NEW", "TYPE_REV", "mNote", "mQA", "mCol", "mTimerStarted", "mTimerStopped"));
 
     public String toString() {
-        List<String> members = new ArrayList<String>();
+        List<String> members = new ArrayList<>();
         for (Field f : this.getClass().getDeclaredFields()) {
             try {
                 // skip non-useful elements
@@ -637,9 +637,7 @@ public class Card implements Cloneable {
                     continue;
                 }
                 members.add(String.format("'%s': %s", f.getName(), f.get(this)));
-            } catch (IllegalAccessException e) {
-                members.add(String.format("'%s': %s", f.getName(), "N/A"));
-            } catch (IllegalArgumentException e) {
+            } catch (IllegalAccessException | IllegalArgumentException e) {
                 members.add(String.format("'%s': %s", f.getName(), "N/A"));
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -473,7 +473,7 @@ public class Collection {
      */
 
     public int noteCount() {
-        return (int) mDb.queryScalar("SELECT count() FROM notes");
+        return mDb.queryScalar("SELECT count() FROM notes");
     }
 
     /**
@@ -568,7 +568,7 @@ public class Collection {
 
 
     private ArrayList<JSONObject> _tmplsFromOrds(JSONObject model, ArrayList<Integer> avail) {
-        ArrayList<JSONObject> ok = new ArrayList<JSONObject>();
+        ArrayList<JSONObject> ok = new ArrayList<>();
         JSONArray tmpls;
         try {
             if (model.getInt("type") == Consts.MODEL_STD) {
@@ -603,8 +603,8 @@ public class Collection {
     public ArrayList<Long> genCards(long[] nids) {
         // build map of (nid,ord) so we don't create dupes
         String snids = Utils.ids2str(nids);
-        HashMap<Long, HashMap<Integer, Long>> have = new HashMap<Long, HashMap<Integer, Long>>();
-        HashMap<Long, Long> dids = new HashMap<Long, Long>();
+        HashMap<Long, HashMap<Integer, Long>> have = new HashMap<>();
+        HashMap<Long, Long> dids = new HashMap<>();
         Cursor cur = null;
         try {
             cur = mDb.getDatabase().rawQuery("SELECT id, nid, ord, did FROM cards WHERE nid IN " + snids, null);
@@ -620,7 +620,7 @@ public class Collection {
                 if (dids.containsKey(nid)) {
                     if (dids.get(nid) != 0 && dids.get(nid) != did) {
                         // cards are in two or more different decks; revert to model default
-                        dids.put(nid, 0l);
+                        dids.put(nid, 0L);
                     }
                 } else {
                     // first card or multiple cards in same deck
@@ -633,10 +633,10 @@ public class Collection {
             }
         }
         // build cards for each note
-        ArrayList<Object[]> data = new ArrayList<Object[]>();
+        ArrayList<Object[]> data = new ArrayList<>();
         long ts = Utils.maxID(mDb);
         long now = Utils.intNow();
-        ArrayList<Long> rem = new ArrayList<Long>();
+        ArrayList<Long> rem = new ArrayList<>();
         int usn = usn();
         cur = null;
         try {
@@ -710,12 +710,12 @@ public class Collection {
 	    if (type == 0) {
 	        cms = findTemplates(note);
 	    } else if (type == 1) {
-	        cms = new ArrayList<JSONObject>();
+	        cms = new ArrayList<>();
 	        for (Card c : note.cards()) {
 	            cms.add(c.template());
 	        }
 	    } else {
-	        cms = new ArrayList<JSONObject>();
+	        cms = new ArrayList<>();
 	        try {
                 JSONArray ja = note.model().getJSONArray("tmpls");
                 for (int i = 0; i < ja.length(); ++i) {
@@ -726,9 +726,9 @@ public class Collection {
             }
 	    }
 	    if (cms.isEmpty()) {
-	        return new ArrayList<Card>();
+	        return new ArrayList<>();
 	    }
-	    List<Card> cards = new ArrayList<Card>();
+	    List<Card> cards = new ArrayList<>();
 	    for (JSONObject template : cms) {
 	        cards.add(_newCard(note, template, 1, false));
 	    }
@@ -882,7 +882,7 @@ public class Collection {
      */
 
     private ArrayList<Object[]> _fieldData(String snids) {
-        ArrayList<Object[]> result = new ArrayList<Object[]>();
+        ArrayList<Object[]> result = new ArrayList<>();
         Cursor cur = null;
         try {
             cur = mDb.getDatabase().rawQuery("SELECT id, mid, flds FROM notes WHERE id IN " + snids, null);
@@ -901,7 +901,7 @@ public class Collection {
     /** Update field checksums and sort cache, after find&replace, etc. */
     public void updateFieldCache(long[] nids) {
         String snids = Utils.ids2str(nids);
-        ArrayList<Object[]> r = new ArrayList<Object[]>();
+        ArrayList<Object[]> r = new ArrayList<>();
         for (Object[] o : _fieldData(snids)) {
             String[] fields = Utils.splitFields((String) o[2]);
             JSONObject model = mModels.get((Long) o[1]);
@@ -938,7 +938,7 @@ public class Collection {
         } else {
             throw new RuntimeException();
         }
-        ArrayList<HashMap<String, String>> result = new ArrayList<HashMap<String, String>>();
+        ArrayList<HashMap<String, String>> result = new ArrayList<>();
         for (Object[] row : _qaData(where)) {
             result.add(_renderQA(row));
         }
@@ -958,7 +958,7 @@ public class Collection {
         // data is [cid, nid, mid, did, ord, tags, flds]
         // unpack fields and create dict
         String[] flist = Utils.splitFields((String) data[6]);
-        Map<String, String> fields = new HashMap<String, String>();
+        Map<String, String> fields = new HashMap<>();
         JSONObject model = mModels.get((Long) data[2]);
         Map<String, Pair<Integer, JSONObject>> fmap = mModels.fieldMap(model);
         for (String name : fmap.keySet()) {
@@ -980,11 +980,11 @@ public class Collection {
             fields.put("Card", template.getString("name"));
             fields.put(String.format(Locale.US, "c%d", cardNum), "1");
             // render q & a
-            HashMap<String, String> d = new HashMap<String, String>();
+            HashMap<String, String> d = new HashMap<>();
             d.put("id", Long.toString((Long) data[0]));
             qfmt = TextUtils.isEmpty(qfmt) ? template.getString("qfmt") : qfmt;
             afmt = TextUtils.isEmpty(afmt) ? template.getString("afmt") : afmt;
-            for (Pair<String, String> p : new Pair[]{new Pair<String, String>("q", qfmt), new Pair<String, String>("a", afmt)}) {
+            for (Pair<String, String> p : new Pair[]{new Pair<>("q", qfmt), new Pair<>("a", afmt)}) {
                 String type = p.first;
                 String format = p.second;
                 if (type.equals("q")) {
@@ -1023,7 +1023,7 @@ public class Collection {
 
 
     public ArrayList<Object[]> _qaData(String where) {
-        ArrayList<Object[]> data = new ArrayList<Object[]>();
+        ArrayList<Object[]> data = new ArrayList<>();
         Cursor cur = null;
         try {
             cur = mDb.getDatabase().rawQuery(
@@ -1162,7 +1162,7 @@ public class Collection {
      * [type, undoName, data] type 1 = review; type 2 =
      */
     public void clearUndo() {
-        mUndo = new LinkedList<Object[]>();
+        mUndo = new LinkedList<>();
     }
 
 
@@ -1227,7 +1227,7 @@ public class Collection {
     		return (Long) data[2];
 
     	case UNDO_DELETE_NOTE:
-    		ArrayList<Long> ids = new ArrayList<Long>();
+    		ArrayList<Long> ids = new ArrayList<>();
     		Note note2 = (Note)data[1];
     		note2.flush(note2.getMod(), false);
     		ids.add(note2.getId());
@@ -1332,7 +1332,7 @@ public class Collection {
     /** Fix possible problems and rebuild caches. */
     public long fixIntegrity() {
         File file = new File(mPath);
-        ArrayList<String> problems = new ArrayList<String>();
+        ArrayList<String> problems = new ArrayList<>();
         long oldSize = file.length();
         try {
             mDb.getDatabase().beginTransaction();
@@ -1352,7 +1352,7 @@ public class Collection {
                 for (JSONObject m : mModels.all()) {
                     // cards with invalid ordinal
                     if (m.getInt("type") == Consts.MODEL_STD) {
-                        ArrayList<Integer> ords = new ArrayList<Integer>();
+                        ArrayList<Integer> ords = new ArrayList<>();
                         JSONArray tmpls = m.getJSONArray("tmpls");
                         for (int t = 0; t < tmpls.length(); t++) {
                             ords.add(tmpls.getJSONObject(t).getInt("ord"));
@@ -1366,7 +1366,7 @@ public class Collection {
                         }
                     }
                     // notes with invalid field counts
-                    ids = new ArrayList<Long>();
+                    ids = new ArrayList<>();
                     Cursor cur = null;
                     try {
                         cur = mDb.getDatabase().rawQuery("select id, flds from notes where mid = " + m.getLong("id"), null);
@@ -1415,7 +1415,7 @@ public class Collection {
                     mDb.execute("update cards set odue=0 where id in " + Utils.ids2str(ids));
                 }
                 // cards with odid set when not in a dyn deck
-                ArrayList<Long> dids = new ArrayList<Long>();
+                ArrayList<Long> dids = new ArrayList<>();
                 for (long id : mDecks.allIds()) {
                     if (!mDecks.isDyn(id)) {
                         dids.add(id);
@@ -1471,7 +1471,7 @@ public class Collection {
             modSchemaNoCheck();
         }
         // TODO: report problems
-        return (long) ((oldSize - newSize) / 1024);
+        return (oldSize - newSize) / 1024;
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DB.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DB.java
@@ -197,7 +197,7 @@ public class DB {
     public <T> ArrayList<T> queryColumn(Class<T> type, String query, int column) {
         int nullExceptionCount = 0;
         InvocationTargetException nullException = null; // to catch the null exception for reporting
-        ArrayList<T> results = new ArrayList<T>();
+        ArrayList<T> results = new ArrayList<>();
         Cursor cursor = null;
 
         try {
@@ -221,13 +221,7 @@ public class DB {
                     }
                 }
             }
-        } catch (NoSuchMethodException e) {
-            // This is really coding error, so it should be revealed if it ever happens
-            throw new RuntimeException(e);
-        } catch (IllegalArgumentException e) {
-            // This is really coding error, so it should be revealed if it ever happens
-            throw new RuntimeException(e);
-        } catch (IllegalAccessException e) {
+        } catch (NoSuchMethodException | IllegalAccessException | IllegalArgumentException e) {
             // This is really coding error, so it should be revealed if it ever happens
             throw new RuntimeException(e);
         } finally {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -446,7 +446,7 @@ public class Decks {
         if (mDecks.containsKey(did)) {
             return mDecks.get(did);
         } else if (_default) {
-            return mDecks.get(1l);
+            return mDecks.get(1L);
         } else {
             return null;
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
@@ -24,8 +24,6 @@ import android.text.TextUtils;
 
 import android.util.Pair;
 
-import com.ichi2.anki.AnkiDroidApp;
-import com.ichi2.anki.CardBrowser;
 import com.ichi2.async.DeckTask;
 
 import org.json.JSONArray;
@@ -89,7 +87,7 @@ public class Finder {
         Pair<String, String[]> res1 = _where(tokens);
         String preds = res1.first;
         String[] args = res1.second;
-        List<Long> res = new ArrayList<Long>();
+        List<Long> res = new ArrayList<>();
         if (preds == null) {
             return res;
         }
@@ -105,7 +103,7 @@ public class Finder {
             }
         } catch (SQLException e) {
             // invalid grouping
-            return new ArrayList<Long>();
+            return new ArrayList<>();
         } finally {
             if (cur != null) {
                 cur.close();
@@ -123,7 +121,7 @@ public class Finder {
         Pair<String, String[]> res1 = _where(tokens);
         String preds = res1.first;
         String[] args = res1.second;
-        List<Long> res = new ArrayList<Long>();
+        List<Long> res = new ArrayList<>();
         if (preds == null) {
             return res;
         }
@@ -141,7 +139,7 @@ public class Finder {
             }
         } catch (SQLException e) {
             // invalid grouping
-            return new ArrayList<Long>();
+            return new ArrayList<>();
         } finally {
             if (cur != null) {
                 cur.close();
@@ -158,7 +156,7 @@ public class Finder {
 
     public String[] _tokenize(String query) {
         char inQuote = 0;
-        List<String> tokens = new ArrayList<String>();
+        List<String> tokens = new ArrayList<>();
         String token = "";
         for (int i = 0; i < query.length(); ++i) {
             // quoted text
@@ -279,10 +277,10 @@ public class Finder {
     public Pair<String, String[]> _where(String[] tokens) {
         // state and query
         SearchState s = new SearchState();
-        List<String> args = new ArrayList<String>();
+        List<String> args = new ArrayList<>();
         for (String token : tokens) {
             if (s.bad) {
-                return new Pair<String, String[]>(null, null);
+                return new Pair<>(null, null);
             }
             // special tokens
             if (token.equals("-")) {
@@ -333,9 +331,9 @@ public class Finder {
             }
         }
         if (s.bad) {
-            return new Pair<String, String[]>(null, null);
+            return new Pair<>(null, null);
         }
-        return new Pair<String, String[]>(s.q, args.toArray(new String[args.size()]));
+        return new Pair<>(s.q, args.toArray(new String[args.size()]));
     }
 
 
@@ -381,13 +379,13 @@ public class Finder {
             return _order(false);
         } else {
             // custom order string provided
-            return new Pair<String, Boolean>(" order by " + order, false);
+            return new Pair<>(" order by " + order, false);
         }
     }
     
     private Pair<String, Boolean> _order(Boolean order) {
         if (!order) {
-            return new Pair<String, Boolean>("", false);
+            return new Pair<>("", false);
         }
         try {
             // use deck default
@@ -421,7 +419,7 @@ public class Finder {
             	sort = "n.id, c.ord";
             }
             boolean sortBackwards = mCol.getConf().getBoolean("sortBackwards");
-            return new Pair<String, Boolean>(" ORDER BY " + sort, sortBackwards);
+            return new Pair<>(" ORDER BY " + sort, sortBackwards);
         } catch (JSONException e) {
             throw new RuntimeException(e);
         }
@@ -581,7 +579,7 @@ public class Finder {
 
 
     private String _findModel(String val) {
-        LinkedList<Long> ids = new LinkedList<Long>();
+        LinkedList<Long> ids = new LinkedList<>();
         try {
             for (JSONObject m : mCol.getModels().all()) {
                 if (m.getString("name").equalsIgnoreCase(val)) {
@@ -600,7 +598,7 @@ public class Finder {
             return null;
         }
         TreeMap<String, Long> children = mCol.getDecks().children(did);
-        List<Long> res = new ArrayList<Long>();
+        List<Long> res = new ArrayList<>();
         res.add(did);
         res.addAll(children.values());
         return res;
@@ -625,7 +623,7 @@ public class Finder {
                 ids = dids(mCol.getDecks().id(val, false));
             } else {
                 // wildcard
-                ids = new ArrayList<Long>();
+                ids = new ArrayList<>();
                 val = val.replace("*", ".*");
                 val = val.replace("+", "\\+");
                 for (JSONObject d : mCol.getDecks().all()) {
@@ -661,7 +659,7 @@ public class Finder {
             return "c.ord = " + num;
         }
         // search for template names
-        List<String> lims = new ArrayList<String>();
+        List<String> lims = new ArrayList<>();
         try {
             for (JSONObject m : mCol.getModels().all()) {
                 JSONArray tmpls = m.getJSONArray("tmpls");
@@ -710,7 +708,7 @@ public class Finder {
         Pattern pattern = Pattern.compile("\\Q" + javaVal + "\\E", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
 
         // find models that have that field
-        Map<Long, Object[]> mods = new HashMap<Long, Object[]>();
+        Map<Long, Object[]> mods = new HashMap<>();
         try {
             for (JSONObject m : mCol.getModels().all()) {
                 JSONArray flds = m.getJSONArray("flds");
@@ -728,7 +726,7 @@ public class Finder {
             // nothing has that field
             return null;
         }
-        LinkedList<Long> nids = new LinkedList<Long>();
+        LinkedList<Long> nids = new LinkedList<>();
         Cursor cur = null;
         try {
             /*
@@ -738,7 +736,7 @@ public class Finder {
              */
             cur = mCol.getDb().getDatabase().rawQuery(
                     "select id, mid, flds from notes where mid in " +
-                            Utils.ids2str(new LinkedList<Long>(mods.keySet())) +
+                            Utils.ids2str(new LinkedList<>(mods.keySet())) +
                             " and flds like ? escape '\\'", new String[] { "%" + sqlVal + "%" });
 
             while (cur.moveToNext()) {
@@ -770,7 +768,7 @@ public class Finder {
         String mid = split[0];
         val = split[1];
         String csum = Long.toString(Utils.fieldChecksum(val));
-        List<Long> nids = new ArrayList<Long>();
+        List<Long> nids = new ArrayList<>();
         Cursor cur = null;
         try {
             cur = mCol.getDb().getDatabase().rawQuery(
@@ -824,7 +822,7 @@ public class Finder {
 
     public static int findReplace(Collection col, List<Long> nids, String src, String dst, boolean isRegex,
             String field, boolean fold) {
-        Map<Long, Integer> mmap = new HashMap<Long, Integer>();
+        Map<Long, Integer> mmap = new HashMap<>();
         if (field != null) {
             try {
                 for (JSONObject m : col.getModels().all()) {
@@ -852,9 +850,9 @@ public class Finder {
         }
         Pattern regex = Pattern.compile(src);
 
-        ArrayList<Object[]> d = new ArrayList<Object[]>();
+        ArrayList<Object[]> d = new ArrayList<>();
         String snids = Utils.ids2str(nids);
-        nids = new ArrayList<Long>();
+        nids = new ArrayList<>();
         Cursor cur = null;
         try {
             cur = col.getDb().getDatabase().rawQuery(
@@ -906,8 +904,8 @@ public class Finder {
     }
 
     public List<String> fieldNames(Collection col, boolean downcase) {
-        Set<String> fields = new HashSet<String>();
-        List<String> names = new ArrayList<String>();
+        Set<String> fields = new HashSet<>();
+        List<String> names = new ArrayList<>();
         try {
             for (JSONObject m : col.getModels().all()) {
                 JSONArray flds = m.getJSONArray("flds");
@@ -923,7 +921,7 @@ public class Finder {
             throw new RuntimeException(e);
         }
         if (downcase) {
-            return new ArrayList<String>(fields);
+            return new ArrayList<>(fields);
         }
         return names;
     }
@@ -969,9 +967,9 @@ public class Finder {
     	}
         search += "'" + fieldName + ":*'";
         // go through notes
-        Map<String, List<Long>> vals = new HashMap<String, List<Long>>();
-        List<Pair<String, List<Long>>> dupes = new ArrayList<Pair<String, List<Long>>>();
-        Map<Long, Integer> fields = new HashMap<Long, Integer>();
+        Map<String, List<Long>> vals = new HashMap<>();
+        List<Pair<String, List<Long>>> dupes = new ArrayList<>();
+        Map<Long, Integer> fields = new HashMap<>();
         Cursor cur = null;
         try {
             cur = col.getDb().getDatabase().rawQuery(
@@ -995,7 +993,7 @@ public class Finder {
                 }
                 vals.get(val).add(nid);
                 if (vals.get(val).size() == 2) {
-                    dupes.add(new Pair<String, List<Long>>(val, vals.get(val)));
+                    dupes.add(new Pair<>(val, vals.get(val)));
                 }
             }
         } finally {
@@ -1031,7 +1029,7 @@ public class Finder {
         Pair<String, String[]> res1 = _where(tokens);
         String preds = res1.first;
         String[] args = res1.second;
-        ArrayList<HashMap<String, String>> res = new ArrayList<HashMap<String, String>>();
+        ArrayList<HashMap<String, String>> res = new ArrayList<>();
         if (preds == null) {
             return res;
         }
@@ -1049,7 +1047,7 @@ public class Finder {
                     Timber.i("_findCardsForCardBrowser() cancelled...");
                     return null;
                 }                
-                HashMap<String, String> map = new HashMap<String, String>();
+                HashMap<String, String> map = new HashMap<>();
                 map.put("id", cur.getString(0));
                 map.put("sfld", cur.getString(1));
                 map.put("deck", deckNames.get(cur.getString(2)));
@@ -1065,7 +1063,7 @@ public class Finder {
         } catch (SQLException e) {
             // invalid grouping
             Timber.e("Invalid grouping, sql: " + sql);
-            return new ArrayList<HashMap<String, String>>();
+            return new ArrayList<>();
         } finally {
             if (cur != null) {
                 cur.close();

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Media.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Media.java
@@ -283,9 +283,9 @@ public class Media {
      * @return A list containing all the sound and image filenames found in the input string.
      */
     public List<String> filesInStr(Long mid, String string, boolean includeRemote) {
-        List<String> l = new ArrayList<String>();
+        List<String> l = new ArrayList<>();
         JSONObject model = mCol.getModels().get(mid);
-        List<String> strings = new ArrayList<String>();
+        List<String> strings = new ArrayList<>();
         try {
             if (model.getInt("type") == Consts.MODEL_CLOZE && string.contains("{{c")) {
                 // if the field has clozes in it, we'll need to expand the
@@ -322,12 +322,12 @@ public class Media {
 
 
     private List<String> _expandClozes(String string) {
-        Set<String> ords = new TreeSet<String>();
+        Set<String> ords = new TreeSet<>();
         Matcher m = Pattern.compile("\\{\\{c(\\d+)::.+?\\}\\}").matcher(string);
         while (m.find()) {
             ords.add(m.group(1));
         }
-        ArrayList<String> strings = new ArrayList<String>();
+        ArrayList<String> strings = new ArrayList<>();
         String clozeReg = Template.clozeReg;
         
         for (String ord : ords) {
@@ -415,7 +415,7 @@ public class Media {
     private List<List<String>> check(File[] local) {
         File mdir = new File(dir());
         // gather all media references in NFC form
-        Set<String> allRefs = new HashSet<String>();
+        Set<String> allRefs = new HashSet<>();
         Cursor cur = null;
         try {
             cur = mCol.getDb().getDatabase().rawQuery("select id, mid, flds from notes", null);
@@ -441,8 +441,8 @@ public class Media {
             }
         }
         // loop through media folder
-        List<String> unused = new ArrayList<String>();
-        List<String> invalid = new ArrayList<String>();
+        List<String> unused = new ArrayList<>();
+        List<String> invalid = new ArrayList<>();
         File[] files;
         if (local == null) {
             files = mdir.listFiles();
@@ -488,13 +488,13 @@ public class Media {
         if (renamedFiles) {
             return check(local);
         }
-        List<String> nohave = new ArrayList<String>();
+        List<String> nohave = new ArrayList<>();
         for (String x : allRefs) {
             if (!x.startsWith("_")) {
                 nohave.add(x);
             }
         }
-        List<List<String>> result = new ArrayList<List<String>>();
+        List<List<String>> result = new ArrayList<>();
         result.add(nohave);
         result.add(unused);
         result.add(invalid);
@@ -610,7 +610,7 @@ public class Media {
         Pair<List<String>, List<String>> result = _changes();
         List<String> added = result.first;
         List<String> removed = result.second;
-        ArrayList<Object[]> media = new ArrayList<Object[]>();
+        ArrayList<Object[]> media = new ArrayList<>();
         for (String f : added) {
             String path = new File(dir(), f).getAbsolutePath();
             long mt = _mtime(path);
@@ -627,7 +627,7 @@ public class Media {
 
 
     private Pair<List<String>, List<String>> _changes() {
-        Map<String, Object[]> cache = new HashMap<String, Object[]>();
+        Map<String, Object[]> cache = new HashMap<>();
         Cursor cur = null;
         try {
             cur = mDb.getDatabase().rawQuery("select fname, csum, mtime from media where csum is not null", null);
@@ -644,8 +644,8 @@ public class Media {
                 cur.close();
             }
         }
-        List<String> added = new ArrayList<String>();
-        List<String> removed = new ArrayList<String>();
+        List<String> added = new ArrayList<>();
+        List<String> removed = new ArrayList<>();
         // loop through on-disk files
         for (File f : new File(dir()).listFiles()) {
             // ignore folders and thumbs.db
@@ -702,7 +702,7 @@ public class Media {
                 removed.add(fname);
             }
         }
-        return new Pair<List<String>, List<String>>(added, removed);
+        return new Pair<>(added, removed);
     }
 
 
@@ -729,9 +729,9 @@ public class Media {
             if (cur.moveToNext()) {
                 String csum = cur.getString(0);
                 int dirty = cur.getInt(1);
-                return new Pair<String, Integer>(csum, dirty);
+                return new Pair<>(csum, dirty);
             } else {
-                return new Pair<String, Integer>(null, 0);
+                return new Pair<>(null, 0);
             }
         } finally {
             if (cur != null) {
@@ -804,7 +804,7 @@ public class Media {
             ZipOutputStream z = new ZipOutputStream(new BufferedOutputStream(new FileOutputStream(f)));
             z.setMethod(ZipOutputStream.DEFLATED);
 
-            List<String> fnames = new ArrayList<String>();
+            List<String> fnames = new ArrayList<>();
             // meta is a list of (fname, zipname), where zipname of null is a deleted file
             // NOTE: In python, meta is a list of tuples that then gets serialized into json and added
             // to the zip as a string. In our version, we use JSON objects from the start to avoid the
@@ -855,7 +855,7 @@ public class Media {
             z.close();
             // Don't leave lingering temp files if the VM terminates.
             f.deleteOnExit();
-            return new Pair<File, List<String>>(f, fnames);
+            return new Pair<>(f, fnames);
         } catch (IOException e) {
             Timber.e("Failed to create media changes zip", e);
             throw new RuntimeException(e);
@@ -876,7 +876,7 @@ public class Media {
      */
     public int addFilesFromZip(ZipFile z) throws IOException {
         try {
-            List<Object[]> media = new ArrayList<Object[]>();
+            List<Object[]> media = new ArrayList<>();
             // get meta info first
             JSONObject meta = new JSONObject(Utils.convertStreamToString(z.getInputStream(z.getEntry("_meta"))));
             // then loop through all files

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -109,7 +109,7 @@ public class Models {
     // private DB mDb;
     //
     /** Map for compiled Mustache Templates */
-    private Map<String, Template> mCmpldTemplateMap = new HashMap<String, Template>();
+    private Map<String, Template> mCmpldTemplateMap = new HashMap<>();
 
 
     //
@@ -145,7 +145,7 @@ public class Models {
      */
     public void load(String json) {
         mChanged = false;
-        mModels = new HashMap<Long, JSONObject>();
+        mModels = new HashMap<>();
         try {
             JSONObject modelarray = new JSONObject(json);
             JSONArray ids = modelarray.names();
@@ -280,10 +280,9 @@ public class Models {
 
     /** get all models */
     public ArrayList<JSONObject> all() {
-        ArrayList<JSONObject> models = new ArrayList<JSONObject>();
-        Iterator<JSONObject> it = mModels.values().iterator();
-        while (it.hasNext()) {
-            models.add(it.next());
+        ArrayList<JSONObject> models = new ArrayList<>();
+        for (JSONObject jsonObject : mModels.values()) {
+            models.add(jsonObject);
         }
         return models;
     }
@@ -476,10 +475,10 @@ public class Models {
         try {
             ja = m.getJSONArray("flds");
             // TreeMap<Integer, String> map = new TreeMap<Integer, String>();
-            Map<String, Pair<Integer, JSONObject>> result = new HashMap<String, Pair<Integer, JSONObject>>();
+            Map<String, Pair<Integer, JSONObject>> result = new HashMap<>();
             for (int i = 0; i < ja.length(); i++) {
                 JSONObject f = ja.getJSONObject(i);
-                result.put(f.getString("name"), new Pair<Integer, JSONObject>(f.getInt("ord"), f));
+                result.put(f.getString("name"), new Pair<>(f.getInt("ord"), f));
             }
             return result;
         } catch (JSONException e) {
@@ -492,7 +491,7 @@ public class Models {
         JSONArray ja;
         try {
             ja = m.getJSONArray("flds");
-            ArrayList<String> names = new ArrayList<String>();
+            ArrayList<String> names = new ArrayList<>();
             for (int i = 0; i < ja.length(); i++) {
                 names.add(ja.getJSONObject(i).getString("name"));
             }
@@ -596,7 +595,7 @@ public class Models {
 
         @Override
         public String[] transform(String[] fields) {
-            ArrayList<String> fl = new ArrayList<String>(Arrays.asList(fields));
+            ArrayList<String> fl = new ArrayList<>(Arrays.asList(fields));
             fl.remove(idx);
             return fl.toArray(new String[fl.size()]);
         }
@@ -607,7 +606,7 @@ public class Models {
         mCol.modSchema(true);
         try {
             JSONArray ja = m.getJSONArray("flds");
-            ArrayList<JSONObject> l = new ArrayList<JSONObject>();
+            ArrayList<JSONObject> l = new ArrayList<>();
             int oldidx = -1;
             for (int i = 0; i < ja.length(); ++i) {
                 l.add(ja.getJSONObject(i));
@@ -655,7 +654,7 @@ public class Models {
         @Override
         public String[] transform(String[] fields) {
             String val = fields[oldidx];
-            ArrayList<String> fl = new ArrayList<String>(Arrays.asList(fields));
+            ArrayList<String> fl = new ArrayList<>(Arrays.asList(fields));
             fl.remove(oldidx);
             fl.add(idx, val);
             return fl.toArray(new String[fl.size()]);
@@ -716,7 +715,7 @@ public class Models {
             if (m.getLong("id") == 0) {
                 return;
             }
-            ArrayList<Object[]> r = new ArrayList<Object[]>();
+            ArrayList<Object[]> r = new ArrayList<>();
             Cursor cur = null;
 
             try {
@@ -724,7 +723,7 @@ public class Models {
                         .rawQuery("select id, flds from notes where mid = " + m.getLong("id"), null);
                 while (cur.moveToNext()) {
                     r.add(new Object[] {
-                            Utils.joinFields((String[]) fn.transform(Utils.splitFields(cur.getString(1)))),
+                            Utils.joinFields(fn.transform(Utils.splitFields(cur.getString(1)))),
                             Utils.intNow(), mCol.usn(), cur.getLong(0) });
                 }
             } finally {
@@ -844,8 +843,8 @@ public class Models {
         try {
             JSONArray ja = m.getJSONArray("tmpls");
             int oldidx = -1;
-            ArrayList<JSONObject> l = new ArrayList<JSONObject>();
-            HashMap<Integer, Integer> oldidxs = new HashMap<Integer, Integer>();
+            ArrayList<JSONObject> l = new ArrayList<>();
+            HashMap<Integer, Integer> oldidxs = new HashMap<>();
             for (int i = 0; i < ja.length(); ++i) {
                 if (ja.get(i).equals(template)) {
                     oldidx = i;
@@ -917,7 +916,7 @@ public class Models {
     }
 
     private void _changeNotes(long[] nids, JSONObject newModel, Map<Integer, Integer> map) {
-        List<Object[]> d = new ArrayList<Object[]>();
+        List<Object[]> d = new ArrayList<>();
         int nfields;
         long mid;
         try {
@@ -933,12 +932,12 @@ public class Models {
             while (cur.moveToNext()) {
                 long nid = cur.getLong(0);
                 String[] flds = Utils.splitFields(cur.getString(1));
-                Map<Integer, String> newflds = new HashMap<Integer, String>();
+                Map<Integer, String> newflds = new HashMap<>();
 
                 for (Integer old : map.keySet()) {
                     newflds.put(map.get(old), flds[old]);
                 }
-                List<String> flds2 = new ArrayList<String>();
+                List<String> flds2 = new ArrayList<>();
                 for (int c = 0; c < nfields; ++c) {
                     if (newflds.containsKey(c)) {
                         flds2.add(newflds.get(c));
@@ -959,8 +958,8 @@ public class Models {
     }
 
     private void _changeCards(long[] nids, JSONObject oldModel, JSONObject newModel, Map<Integer, Integer> map) {
-        List<Object[]> d = new ArrayList<Object[]>();
-        List<Long> deleted = new ArrayList<Long>();
+        List<Object[]> d = new ArrayList<>();
+        List<Long> deleted = new ArrayList<>();
         Cursor cur = null;
         int omType;
         int nmType;
@@ -1045,7 +1044,7 @@ public class Models {
                 return;
             }
             JSONArray req = new JSONArray();
-            ArrayList<String> flds = new ArrayList<String>();
+            ArrayList<String> flds = new ArrayList<>();
             JSONArray fields;
             fields = m.getJSONArray("flds");
             for (int i = 0; i < fields.length(); i++) {
@@ -1070,17 +1069,17 @@ public class Models {
 
     private Object[] _reqForTemplate(JSONObject m, ArrayList<String> flds, JSONObject t) {
         try {
-            ArrayList<String> a = new ArrayList<String>();
-            ArrayList<String> b = new ArrayList<String>();
+            ArrayList<String> a = new ArrayList<>();
+            ArrayList<String> b = new ArrayList<>();
             for (String f : flds) {
                 a.add("ankiflag");
                 b.add("");
             }
             Object[] data;
-            data = new Object[] { 1l, 1l, m.getLong("id"), 1l, t.getInt("ord"), "",
+            data = new Object[] {1L, 1L, m.getLong("id"), 1L, t.getInt("ord"), "",
                     Utils.joinFields(a.toArray(new String[a.size()])) };
             String full = mCol._renderQA(data).get("q");
-            data = new Object[] { 1l, 1l, m.getLong("id"), 1l, t.getInt("ord"), "",
+            data = new Object[] {1L, 1L, m.getLong("id"), 1L, t.getInt("ord"), "",
                     Utils.joinFields(b.toArray(new String[b.size()])) };
             String empty = mCol._renderQA(data).get("q");
             // if full and empty are the same, the template is invalid and there is no way to satisfy it
@@ -1089,7 +1088,7 @@ public class Models {
             }
             String type = "all";
             JSONArray req = new JSONArray();
-            ArrayList<String> tmp = new ArrayList<String>();
+            ArrayList<String> tmp = new ArrayList<>();
             for (int i = 0; i < flds.size(); i++) {
                 tmp.clear();
                 tmp.addAll(a);
@@ -1133,7 +1132,7 @@ public class Models {
             for (String f : fields) {
                 f = f.trim();
             }
-            ArrayList<Integer> avail = new ArrayList<Integer>();
+            ArrayList<Integer> avail = new ArrayList<>();
             JSONArray reqArray = m.getJSONArray("req");
             for (int i = 0; i < reqArray.length(); i++) {
                 JSONArray sr = reqArray.getJSONArray(i);
@@ -1191,8 +1190,8 @@ public class Models {
     public ArrayList<Integer> _availClozeOrds(JSONObject m, String flds, boolean allowEmpty) {
         String[] sflds = Utils.splitFields(flds);
         Map<String, Pair<Integer, JSONObject>> map = fieldMap(m);
-        Set<Integer> ords = new HashSet<Integer>();
-        List<String> matches = new ArrayList<String>();
+        Set<Integer> ords = new HashSet<>();
+        List<String> matches = new ArrayList<>();
         Matcher mm;
         try {
             mm = fClozePattern1.matcher(m.getJSONArray("tmpls").getJSONObject(0).getString("qfmt"));
@@ -1221,9 +1220,9 @@ public class Models {
         }
         if (ords.isEmpty() && allowEmpty) {
             // empty clozes use first ord
-            return new ArrayList<Integer>(Arrays.asList(new Integer[] { 0 }));
+            return new ArrayList<>(Arrays.asList(new Integer[]{0}));
         }
-        return new ArrayList<Integer>(ords);
+        return new ArrayList<>(ords);
     }
 
 
@@ -1348,12 +1347,12 @@ public class Models {
 
 
     public HashMap<Long, HashMap<Integer, String>> getTemplateNames() {
-        HashMap<Long, HashMap<Integer, String>> result = new HashMap<Long, HashMap<Integer, String>>();
+        HashMap<Long, HashMap<Integer, String>> result = new HashMap<>();
         for (JSONObject m : mModels.values()) {
             JSONArray templates;
             try {
                 templates = m.getJSONArray("tmpls");
-                HashMap<Integer, String> names = new HashMap<Integer, String>();
+                HashMap<Integer, String> names = new HashMap<>();
                 for (int i = 0; i < templates.length(); i++) {
                     JSONObject t = templates.getJSONObject(i);
                     names.put(t.getInt("ord"), t.getString("name"));
@@ -1389,12 +1388,11 @@ public class Models {
 
     /** Validate model entries. */
 	public boolean validateModel() {
-		Iterator<Entry<Long, JSONObject>> iterator = mModels.entrySet().iterator();
-		while (iterator.hasNext()) {
-			if (!validateBrackets(iterator.next().getValue())) {
-				return false;
-			}
-		}
+        for (Entry<Long, JSONObject> longJSONObjectEntry : mModels.entrySet()) {
+            if (!validateBrackets(longJSONObjectEntry.getValue())) {
+                return false;
+            }
+        }
 		return true;
 	}
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Note.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Note.java
@@ -73,7 +73,7 @@ public class Note implements Cloneable {
             mModel = model;
             try {
                 mMid = model.getLong("id");
-                mTags = new ArrayList<String>();
+                mTags = new ArrayList<>();
                 mFields = new String[model.getJSONArray("flds").length()];
                 Arrays.fill(mFields, "");
             } catch (JSONException e) {
@@ -154,7 +154,7 @@ public class Note implements Cloneable {
 
 
     public ArrayList<Card> cards() {
-        ArrayList<Card> cards = new ArrayList<Card>();
+        ArrayList<Card> cards = new ArrayList<>();
         Cursor cur = null;
         try {
             cur = mCol.getDb().getDatabase()
@@ -244,7 +244,7 @@ public class Note implements Cloneable {
 
 
     public void delTag(String tag) {
-        List<String> rem = new LinkedList<String>();
+        List<String> rem = new LinkedList<>();
         for (String t : mTags) {
             if (t.equalsIgnoreCase(tag)) {
                 rem.add(t);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sched.java
@@ -81,10 +81,10 @@ public class Sched {
     private double[] mEtaCache = new double[] { -1, -1, -1, -1 };
 
     // Queues
-    private final LinkedList<Long> mNewQueue = new LinkedList<Long>();
-    private final LinkedList<long[]> mLrnQueue = new LinkedList<long[]>();
-    private final LinkedList<Long> mLrnDayQueue = new LinkedList<Long>();
-    private final LinkedList<Long> mRevQueue = new LinkedList<Long>();
+    private final LinkedList<Long> mNewQueue = new LinkedList<>();
+    private final LinkedList<long[]> mLrnQueue = new LinkedList<>();
+    private final LinkedList<Long> mLrnDayQueue = new LinkedList<>();
+    private final LinkedList<Long> mRevQueue = new LinkedList<>();
 
     private LinkedList<Long> mNewDids;
     private LinkedList<Long> mLrnDids;
@@ -304,7 +304,7 @@ public class Sched {
 
     public void extendLimits(int newc, int rev) {
         JSONObject cur = mCol.getDecks().current();
-        ArrayList<JSONObject> decks = new ArrayList<JSONObject>();
+        ArrayList<JSONObject> decks = new ArrayList<>();
         decks.add(cur);
         try {
             decks.addAll(mCol.getDecks().parents(cur.getLong("id")));
@@ -329,7 +329,7 @@ public class Sched {
 
     private int _walkingCount(Method limFn, Method cntFn) {
         int tot = 0;
-        HashMap<Long, Integer> pcounts = new HashMap<Long, Integer>();
+        HashMap<Long, Integer> pcounts = new HashMap<>();
         // for each of the active decks
         try {
             for (long did : mCol.getDecks().active()) {
@@ -361,11 +361,7 @@ public class Sched {
                 // and add to running total
                 tot += cnt;
             }
-        } catch (JSONException e) {
-            throw new RuntimeException(e);
-        } catch (InvocationTargetException e) {
-            throw new RuntimeException(e);
-        } catch (IllegalAccessException e) {
+        } catch (JSONException | IllegalAccessException | InvocationTargetException e) {
             throw new RuntimeException(e);
         }
         return tot;
@@ -384,8 +380,8 @@ public class Sched {
         _checkDay();
         mCol.getDecks().recoverOrphans();
         ArrayList<JSONObject> decks = mCol.getDecks().allSorted();
-        HashMap<String, Integer[]> lims = new HashMap<String, Integer[]>();
-        ArrayList<DeckDueTreeNode> data = new ArrayList<DeckDueTreeNode>();
+        HashMap<String, Integer[]> lims = new HashMap<>();
+        ArrayList<DeckDueTreeNode> data = new ArrayList<>();
         try {
             for (JSONObject deck : decks) {
                 // if we've already seen the exact same deck name, remove the
@@ -451,7 +447,7 @@ public class Sched {
 
 
     private List<DeckDueTreeNode> _groupChildrenMain(List<DeckDueTreeNode> grps) {
-        List<DeckDueTreeNode> tree = new ArrayList<DeckDueTreeNode>();
+        List<DeckDueTreeNode> tree = new ArrayList<>();
         // group and recurse
         ListIterator<DeckDueTreeNode> it = grps.listIterator();
         while (it.hasNext()) {
@@ -460,7 +456,7 @@ public class Sched {
             // Compose the "tail" node list. The tail is a list of all the nodes that proceed
             // the current one that contain the same name[0]. I.e., they are subdecks that stem
             // from this node. This is our version of python's itertools.groupby.
-            List<DeckDueTreeNode> tail  = new ArrayList<DeckDueTreeNode>();
+            List<DeckDueTreeNode> tail  = new ArrayList<>();
             tail.add(node);
             while (it.hasNext()) {
                 DeckDueTreeNode next = it.next();
@@ -478,7 +474,7 @@ public class Sched {
             int rev = 0;
             int _new = 0;
             int lrn = 0;
-            List<DeckDueTreeNode> children = new ArrayList<DeckDueTreeNode>();
+            List<DeckDueTreeNode> children = new ArrayList<>();
             for (DeckDueTreeNode c : tail) {
                 if (c.names.length == 1) {
                     // current node
@@ -583,7 +579,7 @@ public class Sched {
 
     private void _resetNew() {
         _resetNewCount();
-        mNewDids = new LinkedList<Long>(mCol.getDecks().active());
+        mNewDids = new LinkedList<>(mCol.getDecks().active());
         mNewQueue.clear();
         _updateNewCardRatio();
     }
@@ -715,13 +711,7 @@ public class Sched {
                 }
             }
             return lim;
-        } catch (IllegalArgumentException e) {
-            throw new RuntimeException(e);
-        } catch (IllegalAccessException e) {
-            throw new RuntimeException(e);
-        } catch (InvocationTargetException e) {
-            throw new RuntimeException(e);
-        } catch (NoSuchMethodException e) {
+        } catch (IllegalArgumentException | NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
             throw new RuntimeException(e);
         }
     }
@@ -1192,9 +1182,7 @@ public class Sched {
                     "SELECT count() FROM (SELECT 1 FROM cards WHERE did = " + did
                             + " AND queue = 3 AND due <= " + mToday
                             + " LIMIT " + mReportLimit + ")");
-        } catch (SQLException e) {
-            throw new RuntimeException(e);
-        } catch (JSONException e) {
+        } catch (SQLException | JSONException e) {
             throw new RuntimeException(e);
         }
     }
@@ -1664,7 +1652,7 @@ public class Sched {
 
 
     private void _moveToDyn(long did, List<Long> ids) {
-        ArrayList<Object[]> data = new ArrayList<Object[]>();
+        ArrayList<Object[]> data = new ArrayList<>();
         long t = Utils.intNow();
         int u = mCol.usn();
         for (long c = 0; c < ids.size(); c++) {
@@ -2113,7 +2101,7 @@ public class Sched {
      */
 
     private void _burySiblings(Card card) {
-        LinkedList<Long> toBury = new LinkedList<Long>();
+        LinkedList<Long> toBury = new LinkedList<>();
         JSONObject nconf = _newConf(card);
         boolean buryNew = nconf.optBoolean("bury", true);
         JSONObject rconf = _revConf(card);
@@ -2179,7 +2167,7 @@ public class Sched {
      * @param imax The maximum interval (inclusive)
      */
     public void reschedCards(long[] ids, int imin, int imax) {
-        ArrayList<Object[]> d = new ArrayList<Object[]>();
+        ArrayList<Object[]> d = new ArrayList<>();
         int t = mToday;
         long mod = Utils.intNow();
         Random rnd = new Random();
@@ -2220,7 +2208,7 @@ public class Sched {
     public void sortCards(long[] cids, int start, int step, boolean shuffle, boolean shift) {
         String scids = Utils.ids2str(cids);
         long now = Utils.intNow();
-        ArrayList<Long> nids = new ArrayList<Long>();
+        ArrayList<Long> nids = new ArrayList<>();
         for (long id : cids) {
         	long nid = mCol.getDb().queryLongScalar("SELECT nid FROM cards WHERE id = " + id);
         	if (!nids.contains(nid)) {
@@ -2232,7 +2220,7 @@ public class Sched {
             return;
         }
         // determine nid ordering
-        HashMap<Long, Long> due = new HashMap<Long, Long>();
+        HashMap<Long, Long> due = new HashMap<>();
         if (shuffle) {
             Collections.shuffle(nids);
         }
@@ -2252,7 +2240,7 @@ public class Sched {
             }
         }
         // reorder cards
-        ArrayList<Object[]> d = new ArrayList<Object[]>();
+        ArrayList<Object[]> d = new ArrayList<>();
         Cursor cur = null;
         try {
             cur = mCol.getDb().getDatabase()
@@ -2524,7 +2512,7 @@ public class Sched {
         public int revCount;
         public int lrnCount;
         public int newCount;
-        public List<DeckDueTreeNode> children = new ArrayList<DeckDueTreeNode>();
+        public List<DeckDueTreeNode> children = new ArrayList<>();
 
         public DeckDueTreeNode(String[] names, long did, int revCount, int lrnCount, int newCount) {
             this.names = names;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.java
@@ -92,7 +92,7 @@ public class Sound {
     /**
      * Stores sounds for the current card, key is one of the subset flags. It is intended that it not contain empty lists, and code assumes this will be true.
      */
-    private HashMap<Integer, ArrayList<String>> mSoundPaths = new HashMap<Integer, ArrayList<String>>();
+    private HashMap<Integer, ArrayList<String>> mSoundPaths = new HashMap<>();
 
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Stats.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Stats.java
@@ -242,7 +242,7 @@ public class Stats {
             lim += " AND day <= " + end;
         }
 
-        ArrayList<int[]> dues = new ArrayList<int[]>();
+        ArrayList<int[]> dues = new ArrayList<>();
         Cursor cur = null;
         try {
             String query;
@@ -327,7 +327,7 @@ public class Stats {
 
     /* only needed for studyoptions small chart */
     public static double[][] getSmallDueStats(Collection col) {
-        ArrayList<int[]> dues = new ArrayList<int[]>();
+        ArrayList<int[]> dues = new ArrayList<>();
         Cursor cur = null;
         try {
             cur = col
@@ -396,7 +396,7 @@ public class Stats {
                 chunk = 30;
                 break;
         }
-        ArrayList<String> lims = new ArrayList<String>();
+        ArrayList<String> lims = new ArrayList<>();
         if (num != -1) {
             lims.add("id > " + ((mCol.getSched().getDayCutoff() - ((num + 1) * chunk * 86400)) * 1000));
         }
@@ -428,7 +428,7 @@ public class Stats {
             ti = "1";
             tf = "";
         }
-        ArrayList<double[]> list = new ArrayList<double[]>();
+        ArrayList<double[]> list = new ArrayList<>();
         Cursor cur = null;
         String query = "SELECT (cast((id/1000 - " + mCol.getSched().getDayCutoff() + ") / 86400.0 AS INT))/"
                 + chunk + " AS day, " + "sum(CASE WHEN type = 0 THEN " + ti + " ELSE 0 END)"
@@ -588,7 +588,7 @@ public class Stats {
                 break;
         }
 
-        ArrayList<double[]> list = new ArrayList<double[]>();
+        ArrayList<double[]> list = new ArrayList<>();
         Cursor cur = null;
         try {
             cur = mCol
@@ -711,7 +711,7 @@ public class Stats {
         long cutoff = mCol.getSched().getDayCutoff();
         long cut = cutoff  - sd.get(Calendar.HOUR_OF_DAY)*3600;
 
-        ArrayList<double[]> list = new ArrayList<double[]>();
+        ArrayList<double[]> list = new ArrayList<>();
         Cursor cur = null;
         String query = "select " +
                 "23 - ((cast((" + cut + " - id/1000) / 3600.0 as int)) % 24) as hour, " +
@@ -853,7 +853,7 @@ public class Stats {
 
 
 
-        ArrayList<double[]> list = new ArrayList<double[]>();
+        ArrayList<double[]> list = new ArrayList<>();
         Cursor cur = null;
         String query = "SELECT strftime('%w',datetime( cast(id/ 1000  -" + sd.get(Calendar.HOUR_OF_DAY)*3600 +
                 " as int), 'unixepoch')) as wd, " +
@@ -963,7 +963,7 @@ public class Stats {
         mType = type;
         String lim = _revlogLimit().replaceAll("[\\[\\]]", "");
 
-        Vector<String> lims = new Vector<String>();
+        Vector<String> lims = new Vector<>();
         int days = 0;
 
         if (lim.length() > 0)
@@ -986,7 +986,7 @@ public class Stats {
         else
             lim = "";
 
-        ArrayList<double[]> list = new ArrayList<double[]>();
+        ArrayList<double[]> list = new ArrayList<>();
         Cursor cur = null;
         String query = "select (case " +
                 "                when type in (0,2) then 0 " +
@@ -1096,7 +1096,7 @@ public class Stats {
         mType = type;
 
 
-        ArrayList<double[]> list = new ArrayList<double[]>();
+        ArrayList<double[]> list = new ArrayList<>();
         double[] pieData;
         Cursor cur = null;
         String query = "select " +
@@ -1154,7 +1154,7 @@ public class Stats {
 
     private String _limit() {
         if (mWholeCollection) {
-            ArrayList<Long> ids = new ArrayList<Long>();
+            ArrayList<Long> ids = new ArrayList<>();
             for (JSONObject d : mCol.getDecks().all()) {
                 try {
                     ids.add(d.getLong("id"));

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Storage.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Storage.java
@@ -124,7 +124,7 @@ public class Storage {
             }
             if (ver < 4) {
                 col.modSchemaNoCheck();
-                ArrayList<JSONObject> clozes = new ArrayList<JSONObject>();
+                ArrayList<JSONObject> clozes = new ArrayList<>();
                 for (JSONObject m : col.getModels().all()) {
                     if (!m.getJSONArray("tmpls").getJSONObject(0).getString("qfmt").contains("{{cloze:")) {
                         m.put("type", Consts.MODEL_STD);
@@ -245,7 +245,7 @@ public class Storage {
             t.put("name", "Cloze");
             // delete non-cloze cards for the model
             JSONArray ja = m.getJSONArray("tmpls");
-            ArrayList<JSONObject> rem = new ArrayList<JSONObject>();
+            ArrayList<JSONObject> rem = new ArrayList<>();
             for (int i = 1; i < ja.length(); i++) {
                 JSONObject ta = ja.getJSONObject(i);
                 if (!ta.getString("afmt").contains("{{cloze:")) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Tags.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Tags.java
@@ -53,7 +53,7 @@ public class Tags {
     private static final Pattern sCanonify = Pattern.compile("[\"']");
 
     private Collection mCol;
-    private TreeMap<String, Integer> mTags = new TreeMap<String, Integer>();
+    private TreeMap<String, Integer> mTags = new TreeMap<>();
     private boolean mChanged;
 
 
@@ -127,7 +127,7 @@ public class Tags {
 
 
     public List<String> all() {
-        List<String> list = new ArrayList<String>();
+        List<String> list = new ArrayList<>();
         list.addAll(mTags.keySet());
         return list;
     }
@@ -149,7 +149,7 @@ public class Tags {
             mTags.clear();
             mChanged = true;
         }
-        List<String> tags = new ArrayList<String>();
+        List<String> tags = new ArrayList<>();
         Cursor cursor = null;
         try {
             cursor = mCol.getDb().getDatabase().rawQuery("SELECT DISTINCT tags FROM notes"+lim, null);
@@ -161,7 +161,7 @@ public class Tags {
                 cursor.close();
             }
         }
-        HashSet<String> tagSet = new HashSet<String>();
+        HashSet<String> tagSet = new HashSet<>();
         for (String s : split(TextUtils.join(" ", tags))) {
             tagSet.add(s);
         }
@@ -188,7 +188,7 @@ public class Tags {
     public ArrayList<String> byDeck(long did, boolean children) {
         String sql;
         if (children) {
-            ArrayList<Long> dids = new ArrayList<Long>();
+            ArrayList<Long> dids = new ArrayList<>();
             dids.add(did);
             for (long id : mCol.getDecks().children(did).values()) {
                 dids.add(id);
@@ -200,7 +200,7 @@ public class Tags {
         List<String> tags = mCol.getDb().queryColumn(String.class, sql, 0);
         // Cast to set to remove duplicates
         // Use methods used to get all tags to parse tags here as well.
-        return new ArrayList<String>(new HashSet<String>(split(TextUtils.join(" ", tags))));
+        return new ArrayList<>(new HashSet<>(split(TextUtils.join(" ", tags))));
     }
 
 
@@ -248,8 +248,8 @@ public class Tags {
             lim.append(l).append("like '% ").append(t).append(" %'");
         }
         Cursor cur = null;
-        List<Long> nids = new ArrayList<Long>();
-        ArrayList<Object[]> res = new ArrayList<Object[]>();
+        List<Long> nids = new ArrayList<>();
+        ArrayList<Object[]> res = new ArrayList<>();
         try {
             cur = mCol
                     .getDb()
@@ -290,7 +290,7 @@ public class Tags {
 
     /** Parse a string and return a list of tags. */
     public List<String> split(String tags) {
-        ArrayList<String> list = new ArrayList<String>();
+        ArrayList<String> list = new ArrayList<>();
         for (String s : tags.replace('\u3000', ' ').split("\\s")) {
             if (s.length() > 0) {
                 list.add(s);
@@ -327,7 +327,7 @@ public class Tags {
     public String remFromStr(String deltags, String tags) {
         List<String> currentTags = split(tags);
         for (String tag : split(deltags)) {
-            List<String> remove = new ArrayList<String>();
+            List<String> remove = new ArrayList<>();
             for (String tx: currentTags) {
                 if (tag.equalsIgnoreCase(tx)) {
                     remove.add(tx);
@@ -351,7 +351,7 @@ public class Tags {
     public TreeSet<String> canonify(List<String> tagList) {
         // NOTE: The python version creates a list of tags, puts them into a set, then sorts them. The TreeSet
         // used here already guarantees uniqueness and sort order, so we return it as-is without those steps.
-        TreeSet<String> strippedTags = new TreeSet<String>(String.CASE_INSENSITIVE_ORDER);
+        TreeSet<String> strippedTags = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
         for (String t : tagList) {
             String s = sCanonify.matcher(t).replaceAll("");
             for (String existingTag : mTags.keySet()) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
@@ -818,16 +818,13 @@ public class Utils {
 
     private static void printJSONObject(JSONObject jsonObject, String indentation, BufferedWriter buff) {
         try {
-            @SuppressWarnings("unchecked") Iterator<String> keys = (Iterator<String>) jsonObject.keys();
-            TreeSet<String> orderedKeysSet = new TreeSet<String>();
+            @SuppressWarnings("unchecked") Iterator<String> keys = jsonObject.keys();
+            TreeSet<String> orderedKeysSet = new TreeSet<>();
             while (keys.hasNext()) {
                 orderedKeysSet.add(keys.next());
             }
 
-            Iterator<String> orderedKeys = orderedKeysSet.iterator();
-            while (orderedKeys.hasNext()) {
-                String key = orderedKeys.next();
-
+            for (String key : orderedKeysSet) {
                 try {
                     Object value = jsonObject.get(key);
                     if (value instanceof JSONObject) {
@@ -890,7 +887,7 @@ public class Utils {
         SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd");
         df.setTimeZone(TimeZone.getTimeZone("GMT"));
         Calendar cal = new GregorianCalendar(TimeZone.getTimeZone("GMT"));
-        cal.setTimeInMillis(System.currentTimeMillis() - (long) utcOffset * 1000l);
+        cal.setTimeInMillis(System.currentTimeMillis() - (long) utcOffset * 1000L);
         return Date.valueOf(df.format(cal.getTime()));
     }
 
@@ -1047,7 +1044,7 @@ public class Utils {
         } catch (IOException e) {
             Timber.e(e, "Error on retrieving ankidroid fonts");
         }
-        List<AnkiFont> fonts = new ArrayList<AnkiFont>();
+        List<AnkiFont> fonts = new ArrayList<>();
         for (int i = 0; i < fontsCount; i++) {
             String filePath = fontsList[i].getAbsolutePath();
             String filePathExtension = getFileExtension(filePath);
@@ -1064,9 +1061,9 @@ public class Utils {
             }
         }
         if (ankiDroidFonts != null) {
-            for (int i = 0; i < ankiDroidFonts.length; i++) {
+            for (String ankiDroidFont : ankiDroidFonts) {
                 // Assume all files in the assets directory are actually fonts.
-                AnkiFont font = AnkiFont.createAnkiFont(context, ankiDroidFonts[i], true);
+                AnkiFont font = AnkiFont.createAnkiFont(context, ankiDroidFont, true);
                 if (font != null) {
                     fonts.add(font);
                 }
@@ -1092,7 +1089,7 @@ public class Utils {
             });
             deckCount = deckList.length;
         }
-        List<File> decks = new ArrayList<File>();
+        List<File> decks = new ArrayList<>();
         decks.addAll(Arrays.asList(deckList).subList(0, deckCount));
         return decks;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/hooks/AdvancedStatistics.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/hooks/AdvancedStatistics.java
@@ -934,7 +934,7 @@ public class AdvancedStatistics extends Hook  {
             Timber.d("today: " + today);
 
             Stack<Review> reviews = new Stack<>();
-            ArrayList<Review> reviewList = new ArrayList<Review>();
+            ArrayList<Review> reviewList = new ArrayList<>();
 
             //By having simulateReview add future reviews depending on which simulation of this card this is (the nth) we can:
             //1. Do monte carlo simulation if we add nIterations future reviews if n = 1
@@ -1186,9 +1186,9 @@ public class AdvancedStatistics extends Hook  {
             s.append(":");
             s.append(System.getProperty("line.separator"));
 
-            for(int i=0; i<matrix.length; i++) {
-                for(int j=0; j<matrix[i].length; j++) {
-                    s.append(String.format(format, matrix[i][j]));
+            for (int[] aMatrix : matrix) {
+                for (int j = 0; j < aMatrix.length; j++) {
+                    s.append(String.format(format, aMatrix[j]));
                 }
                 s.append(System.getProperty("line.separator"));
             }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/hooks/ChessFilter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/hooks/ChessFilter.java
@@ -18,8 +18,6 @@ package com.ichi2.libanki.hooks;
 
 
 
-import com.ichi2.anki.AnkiDroidApp;
-
 import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/hooks/Hooks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/hooks/Hooks.java
@@ -44,7 +44,7 @@ public class Hooks {
 
     private Hooks(Context context) {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context.getApplicationContext());
-        hooks = new HashMap<String, List<Hook>>();
+        hooks = new HashMap<>();
         // Always-ON hooks
         new FuriganaFilters().install(this);
         new HintFilter().install(this);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/hooks/Leech.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/hooks/Leech.java
@@ -21,7 +21,6 @@ import android.content.res.Resources;
 
 import android.widget.Toast;
 
-import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.R;
 import com.ichi2.libanki.Card;
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Importer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Importer.java
@@ -20,7 +20,6 @@ package com.ichi2.libanki.importer;
 import android.content.Context;
 import android.content.res.Resources;
 
-import com.ichi2.anki.R;
 import com.ichi2.async.DeckTask;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Utils;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/FullSyncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/FullSyncer.java
@@ -51,7 +51,7 @@ public class FullSyncer extends HttpSyncer {
 
     public FullSyncer(Collection col, String hkey, Connection con) {
         super(hkey, con);
-        mPostVars = new HashMap<String, Object>();
+        mPostVars = new HashMap<>();
         mPostVars.put("k", hkey);
         mPostVars.put("v",
                 String.format(Locale.US, "ankidroid,%s,%s", VersionUtils.getPkgVersionName(), Utils.platDesc()));
@@ -167,11 +167,7 @@ public class FullSyncer extends HttpSyncer {
             } else {
                 return new Object[] { super.stream2String(ret.getEntity().getContent()) };
             }
-        } catch (FileNotFoundException e) {
-            throw new RuntimeException(e);
-        } catch (IllegalStateException e) {
-            throw new RuntimeException(e);
-        } catch (IOException e) {
+        } catch (IllegalStateException | IOException e) {
             throw new RuntimeException(e);
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HttpSyncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HttpSyncer.java
@@ -107,7 +107,7 @@ public class HttpSyncer {
         mHKey = hkey;
         mSKey = Utils.checksum(Float.toString(new Random().nextFloat())).substring(0, 8);
         mCon = con;
-        mPostVars = new HashMap<String, Object>();
+        mPostVars = new HashMap<>();
     }
 
 
@@ -242,12 +242,10 @@ public class HttpSyncer {
                 Timber.e(e, "SSLException while building HttpClient");
                 throw new RuntimeException("SSLException while building HttpClient");
             }
-        } catch (UnsupportedEncodingException e) {
+        } catch (UnsupportedEncodingException | JSONException e) {
             throw new RuntimeException(e);
         } catch (IOException e) {
             Timber.e(e, "BasicHttpSyncer.sync: IOException");
-            throw new RuntimeException(e);
-        } catch (JSONException e) {
             throw new RuntimeException(e);
         } finally {
             if (tmpFileBuffer != null && tmpFileBuffer.exists()) {
@@ -304,8 +302,6 @@ public class HttpSyncer {
             }
             rd.close();
             return sb.toString();
-        } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(e);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/MediaSyncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/MediaSyncer.java
@@ -114,7 +114,7 @@ public class MediaSyncer {
                     break;
                 }
 
-                List<String> need = new ArrayList<String>();
+                List<String> need = new ArrayList<>();
                 lastUsn = data.getJSONArray(data.length()-1).getInt(1);
                 for (int i = 0; i < data.length(); i++) {
                     String fname = data.getJSONArray(i).getString(0);
@@ -241,10 +241,7 @@ public class MediaSyncer {
                 }
                 mCon.publishProgress(String.format(
                         AnkiDroidApp.getAppResources().getString(R.string.sync_media_downloaded_count), mDownloadCount));
-            } catch (IOException e) {
-                Timber.e(e, "Error downloading media files");
-                throw new RuntimeException(e);
-            } catch (UnknownHttpResponseException e) {
+            } catch (IOException | UnknownHttpResponseException e) {
                 Timber.e(e, "Error downloading media files");
                 throw new RuntimeException(e);
             }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteMediaServer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteMediaServer.java
@@ -71,7 +71,7 @@ public class RemoteMediaServer extends HttpSyncer {
 
     public JSONObject begin() throws UnknownHttpResponseException, MediaSyncException {
         try {
-            mPostVars = new HashMap<String, Object>();
+            mPostVars = new HashMap<>();
             mPostVars.put("k", mHKey);
             mPostVars.put("v",
                     String.format(Locale.US, "ankidroid,%s,%s", VersionUtils.getPkgVersionName(), Utils.platDesc()));
@@ -81,9 +81,7 @@ public class RemoteMediaServer extends HttpSyncer {
             JSONObject ret = _dataOnly(jresp, JSONObject.class);
             mSKey = ret.getString("sk");
             return ret;
-        } catch (JSONException e) {
-            throw new RuntimeException(e);
-        } catch (IOException e) {
+        } catch (JSONException | IOException e) {
             throw new RuntimeException(e);
         }
     }
@@ -92,16 +90,14 @@ public class RemoteMediaServer extends HttpSyncer {
     // args: lastUsn
     public JSONArray mediaChanges(int lastUsn) throws UnknownHttpResponseException, MediaSyncException {
         try {
-            mPostVars = new HashMap<String, Object>();
+            mPostVars = new HashMap<>();
             mPostVars.put("sk", mSKey);
 
             HttpResponse resp = super.req("mediaChanges",
                     super.getInputStream(Utils.jsonToString(new JSONObject().put("lastUsn", lastUsn))));
             JSONObject jresp = new JSONObject(super.stream2String(resp.getEntity().getContent()));
             return _dataOnly(jresp, JSONArray.class);
-        } catch (JSONException e) {
-            throw new RuntimeException(e);
-        } catch (IOException e) {
+        } catch (JSONException | IOException e) {
             throw new RuntimeException(e);
         }
     }
@@ -137,9 +133,7 @@ public class RemoteMediaServer extends HttpSyncer {
             HttpResponse resp = super.req("uploadChanges", new FileInputStream(zip), 0);
             JSONObject jresp = new JSONObject(super.stream2String(resp.getEntity().getContent()));
             return _dataOnly(jresp, JSONArray.class);
-        } catch (JSONException e) {
-            throw new RuntimeException(e);
-        } catch (IOException e) {
+        } catch (JSONException | IOException e) {
             throw new RuntimeException(e);
         }
     }
@@ -152,9 +146,7 @@ public class RemoteMediaServer extends HttpSyncer {
                     super.getInputStream(Utils.jsonToString(new JSONObject().put("local", lcnt))));
             JSONObject jresp = new JSONObject(super.stream2String(resp.getEntity().getContent()));
             return _dataOnly(jresp, String.class);
-        } catch (JSONException e) {
-            throw new RuntimeException(e);
-        } catch (IOException e) {
+        } catch (JSONException | IOException e) {
             throw new RuntimeException(e);
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteServer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteServer.java
@@ -28,8 +28,6 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
 import java.util.HashMap;
 import java.util.Locale;
 
@@ -45,7 +43,7 @@ public class RemoteServer extends HttpSyncer {
     @Override
     public HttpResponse hostKey(String user, String pw) throws UnknownHttpResponseException {
         try {
-            mPostVars = new HashMap<String, Object>();
+            mPostVars = new HashMap<>();
             JSONObject jo = new JSONObject();
             jo.put("u", user);
             jo.put("p", pw);
@@ -59,7 +57,7 @@ public class RemoteServer extends HttpSyncer {
     @Override
     public HttpResponse meta() throws UnknownHttpResponseException {
         try {
-            mPostVars = new HashMap<String, Object>();
+            mPostVars = new HashMap<>();
             mPostVars.put("k", mHKey);
             mPostVars.put("s", mSKey);
             JSONObject jo = new JSONObject();
@@ -112,9 +110,7 @@ public class RemoteServer extends HttpSyncer {
             return Long.parseLong(s);
         } catch (NumberFormatException e) {
             return 0;
-        } catch (IllegalStateException e) {
-            throw new RuntimeException(e);
-        } catch (IOException e) {
+        } catch (IllegalStateException | IOException e) {
             throw new RuntimeException(e);
         }
     }
@@ -129,11 +125,7 @@ public class RemoteServer extends HttpSyncer {
             } else {
                 return new JSONObject();
             }
-        } catch (IllegalStateException e) {
-            throw new RuntimeException(e);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        } catch (JSONException e) {
+        } catch (IllegalStateException | JSONException | IOException e) {
             throw new RuntimeException(e);
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.java
@@ -222,9 +222,7 @@ public class Syncer {
             } finally {
                 mCol.getDb().getDatabase().endTransaction();
             }
-        } catch (JSONException e) {
-            throw new RuntimeException(e);
-        } catch (IllegalStateException e) {
+        } catch (JSONException | IllegalStateException e) {
             throw new RuntimeException(e);
         } catch (OutOfMemoryError e) {
             AnkiDroidApp.sendExceptionReport(e, "Syncer-sync");
@@ -442,7 +440,7 @@ public class Syncer {
      */
 
     private void prepareToChunk() {
-        mTablesLeft = new LinkedList<String>();
+        mTablesLeft = new LinkedList<>();
         mTablesLeft.add("revlog");
         mTablesLeft.add("cards");
         mTablesLeft.add("notes");
@@ -800,7 +798,7 @@ public class Syncer {
 
 
     private void mergeTags(JSONArray tags) {
-        ArrayList<String> list = new ArrayList<String>();
+        ArrayList<String> list = new ArrayList<>();
         for (int i = 0; i < tags.length(); i++) {
             try {
                 list.add(tags.getString(i));
@@ -821,9 +819,7 @@ public class Syncer {
             try {
                 mCol.getDb().execute("INSERT OR IGNORE INTO revlog VALUES (?,?,?,?,?,?,?,?,?)",
                         ConvUtils.jsonArray2Objects(logs.getJSONArray(i)));
-            } catch (SQLException e) {
-                throw new RuntimeException(e);
-            } catch (JSONException e) {
+            } catch (SQLException | JSONException e) {
                 throw new RuntimeException(e);
             }
         }
@@ -837,7 +833,7 @@ public class Syncer {
             for (int i = 0; i < data.length(); i++) {
                 ids[i] = data.getJSONArray(i).getLong(0);
             }
-            HashMap<Long, Long> lmods = new HashMap<Long, Long>();
+            HashMap<Long, Long> lmods = new HashMap<>();
             Cursor cur = null;
             try {
                 cur = mCol
@@ -854,7 +850,7 @@ public class Syncer {
                     cur.close();
                 }
             }
-            ArrayList<Object[]> update = new ArrayList<Object[]>();
+            ArrayList<Object[]> update = new ArrayList<>();
             for (int i = 0; i < data.length(); i++) {
                 JSONArray r = data.getJSONArray(i);
                 if (!lmods.containsKey(r.getLong(0)) || lmods.get(r.getLong(0)) < r.getLong(modIdx)) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/template/Template.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/template/Template.java
@@ -18,7 +18,6 @@ package com.ichi2.libanki.template;
 
 import android.text.TextUtils;
 
-import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.libanki.Utils;
 import com.ichi2.libanki.hooks.Hooks;
 
@@ -31,8 +30,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import timber.log.Timber;
 
 /**
  * This class renders the card content by parsing the card template and replacing all marked sections

--- a/AnkiDroid/src/main/java/com/ichi2/themes/HtmlColors.java
+++ b/AnkiDroid/src/main/java/com/ichi2/themes/HtmlColors.java
@@ -17,7 +17,7 @@ public class HtmlColors {
 
     public static String nameToHex(String name) {
         if (sColorsMap == null) {
-            sColorsMap = new HashMap<String, String>();
+            sColorsMap = new HashMap<>();
             for (int i = 0; i < fColorsRawList.length; i+=2) {
                 sColorsMap.put(fColorsRawList[i].toLowerCase(Locale.US), fColorsRawList[i+1].toLowerCase(Locale.US));
             }

--- a/AnkiDroid/src/main/java/com/ichi2/themes/StyledProgressDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/themes/StyledProgressDialog.java
@@ -25,7 +25,6 @@ import android.view.WindowManager.BadTokenException;
 
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.ichi2.anki.AnkiActivity;
-import com.ichi2.anki.R;
 
 import timber.log.Timber;
 

--- a/AnkiDroid/src/main/java/com/ichi2/utils/Base64.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/Base64.java
@@ -1197,12 +1197,10 @@ public class Base64 extends Object {
 
             obj = ois.readObject();
         } // end try
-        catch (java.io.IOException e) {
+        catch (java.io.IOException | ClassNotFoundException e) {
             throw e; // Catch and throw in order to execute finally{}
         } // end catch
-        catch (java.lang.ClassNotFoundException e) {
-            throw e; // Catch and throw in order to execute finally{}
-        } // end catch
+        // end catch
         finally {
             try {
                 bais.close();

--- a/AnkiDroid/src/main/java/com/ichi2/utils/DiffEngine.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/DiffEngine.java
@@ -114,7 +114,7 @@ public class DiffEngine {
         // Check for equality (speedup)
         LinkedList<DiffAction> diffs;
         if (text1.equals(text2)) {
-            diffs = new LinkedList<DiffAction>();
+            diffs = new LinkedList<>();
             diffs.add(new DiffAction(Operation.EQUAL, text1));
             return diffs;
         }
@@ -157,7 +157,7 @@ public class DiffEngine {
      * @return Linked List of Diff objects.
      */
     protected LinkedList<DiffAction> diff_compute(String text1, String text2, boolean checklines) {
-        LinkedList<DiffAction> diffs = new LinkedList<DiffAction>();
+        LinkedList<DiffAction> diffs = new LinkedList<>();
 
         if (text1.length() == 0) {
             // Just add some text (speedup)
@@ -219,7 +219,7 @@ public class DiffEngine {
         diffs = diff_map(text1, text2);
         if (diffs == null) {
             // No acceptable result.
-            diffs = new LinkedList<DiffAction>();
+            diffs = new LinkedList<>();
             diffs.add(new DiffAction(Operation.DELETE, text1));
             diffs.add(new DiffAction(Operation.INSERT, text2));
         }
@@ -286,8 +286,8 @@ public class DiffEngine {
      *         element of the List of unique strings is intentionally blank.
      */
     protected LinesToCharsResult diff_linesToChars(String text1, String text2) {
-        List<String> lineArray = new ArrayList<String>();
-        Map<String, Integer> lineHash = new HashMap<String, Integer>();
+        List<String> lineArray = new ArrayList<>();
+        Map<String, Integer> lineHash = new HashMap<>();
         // e.g. linearray[4] == "Hello\n"
         // e.g. linehash.get("Hello\n") == 4
 
@@ -370,15 +370,15 @@ public class DiffEngine {
         int text2_length = text2.length();
         int max_d = text1_length + text2_length - 1;
         boolean doubleEnd = Diff_DualThreshold * 2 < max_d;
-        List<Set<Long>> v_map1 = new ArrayList<Set<Long>>();
-        List<Set<Long>> v_map2 = new ArrayList<Set<Long>>();
-        Map<Integer, Integer> v1 = new HashMap<Integer, Integer>();
-        Map<Integer, Integer> v2 = new HashMap<Integer, Integer>();
+        List<Set<Long>> v_map1 = new ArrayList<>();
+        List<Set<Long>> v_map2 = new ArrayList<>();
+        Map<Integer, Integer> v1 = new HashMap<>();
+        Map<Integer, Integer> v2 = new HashMap<>();
         v1.put(1, 0);
         v2.put(1, 0);
         int x, y;
         Long footstep = 0L; // Used to track overlapping paths.
-        Map<Long, Integer> footsteps = new HashMap<Long, Integer>();
+        Map<Long, Integer> footsteps = new HashMap<>();
         boolean done = false;
         // If the total number of characters is odd, then the front path will
         // collide with the reverse path.
@@ -491,7 +491,7 @@ public class DiffEngine {
      * @return LinkedList of Diff objects.
      */
     protected LinkedList<DiffAction> diff_path1(List<Set<Long>> v_map, String text1, String text2) {
-        LinkedList<DiffAction> path = new LinkedList<DiffAction>();
+        LinkedList<DiffAction> path = new LinkedList<>();
         int x = text1.length();
         int y = text2.length();
         Operation last_op = null;
@@ -541,7 +541,7 @@ public class DiffEngine {
      * @return LinkedList of Diff objects.
      */
     protected LinkedList<DiffAction> diff_path2(List<Set<Long>> v_map, String text1, String text2) {
-        LinkedList<DiffAction> path = new LinkedList<DiffAction>();
+        LinkedList<DiffAction> path = new LinkedList<>();
         int x = text1.length();
         int y = text2.length();
         Operation last_op = null;
@@ -730,7 +730,7 @@ public class DiffEngine {
             return;
         }
         boolean changes = false;
-        Stack<DiffAction> equalities = new Stack<DiffAction>(); // Stack of qualities.
+        Stack<DiffAction> equalities = new Stack<>(); // Stack of qualities.
         String lastequality = null; // Always equal to equalities.lastElement().text
         ListIterator<DiffAction> pointer = diffs.listIterator();
         // Number of characters that changed prior to the equality.

--- a/AnkiDroid/src/main/java/com/ichi2/utils/HttpUtility.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/HttpUtility.java
@@ -35,8 +35,6 @@ public class HttpUtility {
                     Timber.e("%d: %s", response.getStatusLine().getStatusCode(), response.getStatusLine().getReasonPhrase());
                     break;
             }
-        } catch (ClientProtocolException ex) {
-            Timber.e(ex.toString());
         } catch (IOException ex) {
             Timber.e(ex.toString());
         }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/MethodLogger.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/MethodLogger.java
@@ -19,8 +19,6 @@ package com.ichi2.utils;
 import android.text.TextUtils;
 
 
-import com.ichi2.anki.AnkiDroidApp;
-
 import timber.log.Timber;
 
 /**

--- a/AnkiDroid/src/main/java/com/wildplot/android/parsing/TopLevelParser.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/parsing/TopLevelParser.java
@@ -25,7 +25,7 @@ import java.util.regex.Pattern;
 public class TopLevelParser implements Function2D, Function3D, Cloneable{
     Random random = new Random();
     private HashMap<String, TopLevelParser> parserRegister;
-    private HashMap<String, Double> varMap = new HashMap<String, Double>();
+    private HashMap<String, Double> varMap = new HashMap<>();
     private double x = 0.0, y = 0.0;
     private Expression expression = null;
     private boolean isValid = false;
@@ -153,7 +153,7 @@ public class TopLevelParser implements Function2D, Function3D, Cloneable{
 
 
     public TopLevelParser createCopy(){
-		HashMap<String, TopLevelParser> newParserRegister = new HashMap<String, TopLevelParser>();
+		HashMap<String, TopLevelParser> newParserRegister = new HashMap<>();
 		for(String key : parserRegister.keySet()){
 			newParserRegister.put(key, parserRegister.get(key).createCopy(newParserRegister));
 		}

--- a/AnkiDroid/src/main/java/com/wildplot/android/rendering/DrawableContainer.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/rendering/DrawableContainer.java
@@ -22,7 +22,7 @@ import java.util.Vector;
 
 
 public class DrawableContainer implements Drawable {
-    Vector<Drawable> drawableVector = new Vector<Drawable>();
+    Vector<Drawable> drawableVector = new Vector<>();
     private boolean isOnFrame = false;
     private boolean isOnAbort = false;
     private boolean isCritical = false;

--- a/AnkiDroid/src/main/java/com/wildplot/android/rendering/MultiScreenPart.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/rendering/MultiScreenPart.java
@@ -27,7 +27,7 @@ import java.util.Vector;
 public class MultiScreenPart {
 	private double[] xRange = {-15,15};
 	private double[] yRange = {-10,10};
-	private Vector<Drawable> drawables = new Vector<Drawable>();
+	private Vector<Drawable> drawables = new Vector<>();
 	
 	
 	

--- a/AnkiDroid/src/main/java/com/wildplot/android/rendering/PlotSheet.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/rendering/PlotSheet.java
@@ -18,7 +18,6 @@ package com.wildplot.android.rendering;
 
 import android.graphics.Typeface;
 
-import com.ichi2.anki.AnkiDroidApp;
 import com.wildplot.android.rendering.graphics.wrapper.*;
 import com.wildplot.android.rendering.interfaces.Drawable;
 import com.wildplot.android.rendering.interfaces.Legendable;
@@ -90,8 +89,8 @@ public class PlotSheet implements Drawable {
     /**
      * the ploting screens, screen 0 is the only one in single mode
      */
-    Vector<MultiScreenPart> screenParts = new Vector<MultiScreenPart>();
-    private HashMap<String, ColorWrap> mLegendMap = new HashMap<String, ColorWrap>();
+    Vector<MultiScreenPart> screenParts = new Vector<>();
+    private HashMap<String, ColorWrap> mLegendMap = new HashMap<>();
     private boolean mDrawablesPrepared = false;
 
     /**
@@ -329,8 +328,8 @@ public class PlotSheet implements Drawable {
         RectangleWrap field = g.getClipBounds();
         this.currentScreen = screenNr;
         prepareDrawables();
-        Vector<Drawable> offFrameDrawables = new Vector<Drawable>();
-        Vector<Drawable> onFrameDrawables = new Vector<Drawable>();
+        Vector<Drawable> offFrameDrawables = new Vector<>();
+        Vector<Drawable> onFrameDrawables = new Vector<>();
 
 
         g.setTypeface(typeface);
@@ -472,8 +471,8 @@ public class PlotSheet implements Drawable {
         if(!mDrawablesPrepared) {
             mDrawablesPrepared = true;
             Vector<Drawable> drawables = this.screenParts.get(0).getDrawables();
-            Vector<Drawable> onFrameDrawables = new Vector<Drawable>();
-            Vector<Drawable> offFrameDrawables = new Vector<Drawable>();
+            Vector<Drawable> onFrameDrawables = new Vector<>();
+            Vector<Drawable> offFrameDrawables = new Vector<>();
 
             DrawableContainer onFrameContainer = new DrawableContainer(true, false);
 

--- a/AnkiDroid/src/main/java/com/wildplot/android/rendering/RelativeColorGradient.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/rendering/RelativeColorGradient.java
@@ -24,7 +24,7 @@ import java.util.Vector;
 public class RelativeColorGradient {
 	public static ColorWrap[] makeGradient(Vector<ColorWrap> colorVector, int numberOfColorsInGradient) {
 		if(colorVector == null) {
-			colorVector = new Vector<ColorWrap>();
+			colorVector = new Vector<>();
 		}
 		
 		if(colorVector.size() < 2) {

--- a/AnkiDroid/src/main/java/com/wildplot/android/rendering/ReliefDrawer.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/rendering/ReliefDrawer.java
@@ -128,7 +128,7 @@ public class ReliefDrawer implements Drawable {
 			if(this.gradientColors.length >= heightRegionCount){
 				this.heightRegionCount = this.gradientColors.length;
 			} else {
-				Vector<ColorWrap> colorVector = new Vector<ColorWrap>(Arrays.asList(this.gradientColors));
+				Vector<ColorWrap> colorVector = new Vector<>(Arrays.asList(this.gradientColors));
 				this.gradientColors = RelativeColorGradient.makeGradient(colorVector, this.heightRegionCount);
 				this.heightRegionCount = this.gradientColors.length;
 			}
@@ -175,7 +175,7 @@ public class ReliefDrawer implements Drawable {
 			if(this.gradientColors.length >= heightRegionCount){
 				this.heightRegionCount = this.gradientColors.length;
 			} else {
-				Vector<ColorWrap> colorVector = new Vector<ColorWrap>(Arrays.asList(this.gradientColors));
+				Vector<ColorWrap> colorVector = new Vector<>(Arrays.asList(this.gradientColors));
 				this.gradientColors = RelativeColorGradient.makeGradient(colorVector, this.heightRegionCount);
 				this.heightRegionCount = this.gradientColors.length;
 			}

--- a/AnkiDroid/src/main/java/com/wildplot/android/rendering/YGrid.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/rendering/YGrid.java
@@ -192,10 +192,9 @@ public class YGrid implements Drawable {
     private void drawExplicitLines(GraphicsWrap g){
         RectangleWrap field = g.getClipBounds();
 
-        for(int i = 0; i< mTickPositions.length; i++) {
-            double currentX = mTickPositions[i];
-            drawGridLine(currentX, g, field);
-        }
+		for (double currentX : mTickPositions) {
+			drawGridLine(currentX, g, field);
+		}
     }
 	
 	/**

--- a/AnkiDroid/src/main/res/menu/activity_load_pronounciation.xml
+++ b/AnkiDroid/src/main/res/menu/activity_load_pronounciation.xml
@@ -1,3 +1,3 @@
-<menu xmlns:android="http://schemas.android.com/apk/res/android" >
+<menu>
 
 </menu>

--- a/AnkiDroid/src/main/res/menu/activity_search_image.xml
+++ b/AnkiDroid/src/main/res/menu/activity_search_image.xml
@@ -1,3 +1,3 @@
-<menu xmlns:android="http://schemas.android.com/apk/res/android" >
+<menu>
 
 </menu>

--- a/AnkiDroid/src/main/res/menu/activity_translation.xml
+++ b/AnkiDroid/src/main/res/menu/activity_translation.xml
@@ -1,3 +1,3 @@
-<menu xmlns:android="http://schemas.android.com/apk/res/android" >
+<menu>
 
 </menu>

--- a/AnkiDroid/src/main/res/values-ar/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-ar/02-strings.xml
@@ -38,7 +38,7 @@
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <string name="preference_summary_percentage">XXX%</string>
   <string name="drawer_open">Open drawer</string>
   <string name="drawer_close">Close drawer</string>

--- a/AnkiDroid/src/main/res/values-bg/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-bg/02-strings.xml
@@ -38,7 +38,7 @@
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <string name="preference_summary_percentage">XXX%</string>
   <string name="drawer_open">Отвори чекмеджето</string>
   <string name="drawer_close">Затвори чекмеджето</string>

--- a/AnkiDroid/src/main/res/values-ca/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-ca/02-strings.xml
@@ -38,7 +38,7 @@
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <string name="preference_summary_percentage">XXX%</string>
   <string name="drawer_open">Obrir el calaix</string>
   <string name="drawer_close">Tancar el calaix</string>

--- a/AnkiDroid/src/main/res/values-cs/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-cs/02-strings.xml
@@ -38,7 +38,7 @@
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <string name="preference_summary_percentage">XXX%</string>
   <string name="drawer_open">Otevřít zásuvku</string>
   <string name="drawer_close">Zavřít zásuvku</string>

--- a/AnkiDroid/src/main/res/values-de/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-de/02-strings.xml
@@ -38,7 +38,7 @@
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <string name="preference_summary_percentage">XXX %</string>
   <string name="drawer_open">Navigationsleiste öffnen</string>
   <string name="drawer_close">Navigationsleiste schließen</string>

--- a/AnkiDroid/src/main/res/values-el/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-el/02-strings.xml
@@ -38,7 +38,7 @@
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <string name="preference_summary_percentage">XXX%</string>
   <string name="drawer_open">Open drawer</string>
   <string name="drawer_close">Close drawer</string>

--- a/AnkiDroid/src/main/res/values-es-rAR/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-es-rAR/02-strings.xml
@@ -38,7 +38,7 @@
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <string name="preference_summary_percentage">XXX%</string>
   <string name="drawer_open">Abrir cajón</string>
   <string name="drawer_close">Cerrar cajón</string>

--- a/AnkiDroid/src/main/res/values-es-rES/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-es-rES/02-strings.xml
@@ -38,7 +38,7 @@
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <string name="preference_summary_percentage">XXX%</string>
   <string name="drawer_open">Abrir cajón</string>
   <string name="drawer_close">Cerrar cajón</string>

--- a/AnkiDroid/src/main/res/values-et/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-et/02-strings.xml
@@ -38,7 +38,7 @@
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <string name="preference_summary_percentage">XXX%</string>
   <string name="drawer_open">Open drawer</string>
   <string name="drawer_close">Close drawer</string>

--- a/AnkiDroid/src/main/res/values-fa/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-fa/02-strings.xml
@@ -38,7 +38,7 @@
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <string name="preference_summary_percentage">XXX%</string>
   <string name="drawer_open">Open drawer</string>
   <string name="drawer_close">Close drawer</string>

--- a/AnkiDroid/src/main/res/values-fi/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-fi/02-strings.xml
@@ -38,7 +38,7 @@
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <string name="preference_summary_percentage">XXX%</string>
   <string name="drawer_open">Avaa laatikosto</string>
   <string name="drawer_close">Sulje laatikosto</string>

--- a/AnkiDroid/src/main/res/values-fr/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-fr/02-strings.xml
@@ -38,7 +38,7 @@
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <string name="preference_summary_percentage">XXX %</string>
   <string name="drawer_open">Ouvrir la barre de navigation</string>
   <string name="drawer_close">Fermer la barre de navigation</string>

--- a/AnkiDroid/src/main/res/values-gl/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-gl/02-strings.xml
@@ -38,7 +38,7 @@
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <string name="preference_summary_percentage">XXX%</string>
   <string name="drawer_open">Abrir a gabeta</string>
   <string name="drawer_close">Pechar a gabeta</string>

--- a/AnkiDroid/src/main/res/values-go/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-go/02-strings.xml
@@ -38,7 +38,7 @@
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <string name="preference_summary_percentage">XXX%</string>
   <string name="drawer_open">Open drawer</string>
   <string name="drawer_close">Close drawer</string>

--- a/AnkiDroid/src/main/res/values-he/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-he/02-strings.xml
@@ -38,7 +38,7 @@
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <string name="preference_summary_percentage">XXX%</string>
   <string name="drawer_open">פתח מגירה</string>
   <string name="drawer_close">סגור מגירה</string>

--- a/AnkiDroid/src/main/res/values-hi/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-hi/02-strings.xml
@@ -38,7 +38,7 @@
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <string name="preference_summary_percentage">XXX%</string>
   <string name="drawer_open">Open drawer</string>
   <string name="drawer_close">Close drawer</string>

--- a/AnkiDroid/src/main/res/values-hu/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-hu/02-strings.xml
@@ -38,7 +38,7 @@
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <string name="preference_summary_percentage">XXX%</string>
   <string name="drawer_open">Fiók megnyitása</string>
   <string name="drawer_close">Fiók bezárása</string>

--- a/AnkiDroid/src/main/res/values-id/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-id/02-strings.xml
@@ -38,7 +38,7 @@
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <string name="preference_summary_percentage">XXX%</string>
   <string name="drawer_open">Buka laci</string>
   <string name="drawer_close">Tutup laci</string>

--- a/AnkiDroid/src/main/res/values-it/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-it/02-strings.xml
@@ -38,7 +38,7 @@
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <string name="preference_summary_percentage">XXX%</string>
   <string name="drawer_open">Apri barra di navigazione</string>
   <string name="drawer_close">Chiudi barra di navigazione</string>

--- a/AnkiDroid/src/main/res/values-ja/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-ja/02-strings.xml
@@ -38,7 +38,7 @@
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <string name="preference_summary_percentage">XXX%</string>
   <string name="drawer_open">ドロワーを開く</string>
   <string name="drawer_close">ドロワーを閉じる</string>

--- a/AnkiDroid/src/main/res/values-ko/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-ko/02-strings.xml
@@ -38,7 +38,7 @@
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <string name="preference_summary_percentage">XXX %</string>
   <string name="drawer_open">서랍 열기</string>
   <string name="drawer_close">서랍 닫기</string>

--- a/AnkiDroid/src/main/res/values-lt/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-lt/02-strings.xml
@@ -38,7 +38,7 @@
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <string name="preference_summary_percentage">XXX%</string>
   <string name="drawer_open">Open drawer</string>
   <string name="drawer_close">Close drawer</string>

--- a/AnkiDroid/src/main/res/values-lv/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-lv/02-strings.xml
@@ -38,7 +38,7 @@
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <string name="preference_summary_percentage">XXX%</string>
   <string name="drawer_open">Open drawer</string>
   <string name="drawer_close">Close drawer</string>

--- a/AnkiDroid/src/main/res/values-nl/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-nl/02-strings.xml
@@ -38,7 +38,7 @@
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <string name="preference_summary_percentage">XXX%</string>
   <string name="drawer_open">Open drawer</string>
   <string name="drawer_close">Sluit drawer</string>

--- a/AnkiDroid/src/main/res/values-no/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-no/02-strings.xml
@@ -38,7 +38,7 @@
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <string name="preference_summary_percentage">XXX%</string>
   <string name="drawer_open">Åpne navigasjonspanelet</string>
   <string name="drawer_close">Lukk navigasjonspanelet</string>

--- a/AnkiDroid/src/main/res/values-pl/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-pl/02-strings.xml
@@ -38,7 +38,7 @@
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <string name="preference_summary_percentage">XXX%</string>
   <string name="drawer_open">Otwórz menu boczne</string>
   <string name="drawer_close">Zamknij menu boczne</string>

--- a/AnkiDroid/src/main/res/values-pt-rBR/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-pt-rBR/02-strings.xml
@@ -38,7 +38,7 @@
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <string name="preference_summary_percentage">XXX%</string>
   <string name="drawer_open">Abrir gaveta</string>
   <string name="drawer_close">Fechar gaveta</string>

--- a/AnkiDroid/src/main/res/values-pt-rPT/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-pt-rPT/02-strings.xml
@@ -38,7 +38,7 @@
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <string name="preference_summary_percentage">XXX%</string>
   <string name="drawer_open">Abrir painel</string>
   <string name="drawer_close">Fechar painel</string>

--- a/AnkiDroid/src/main/res/values-ro/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-ro/02-strings.xml
@@ -38,7 +38,7 @@
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <string name="preference_summary_percentage">XXX%</string>
   <string name="drawer_open">Open drawer</string>
   <string name="drawer_close">Close drawer</string>

--- a/AnkiDroid/src/main/res/values-ru/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-ru/02-strings.xml
@@ -38,7 +38,7 @@
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <string name="preference_summary_percentage">XXX%</string>
   <string name="drawer_open">Открыть панель</string>
   <string name="drawer_close">Закрыть панель</string>

--- a/AnkiDroid/src/main/res/values-sk/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-sk/02-strings.xml
@@ -38,7 +38,7 @@
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <string name="preference_summary_percentage">XXX%</string>
   <string name="drawer_open">Otvoriť zoznam</string>
   <string name="drawer_close">Zavrieť lištu</string>

--- a/AnkiDroid/src/main/res/values-sl/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-sl/02-strings.xml
@@ -38,7 +38,7 @@
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <string name="preference_summary_percentage">XXX %</string>
   <string name="drawer_open">Odpri predal</string>
   <string name="drawer_close">Zapri predal</string>

--- a/AnkiDroid/src/main/res/values-sr/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-sr/02-strings.xml
@@ -38,7 +38,7 @@
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <string name="preference_summary_percentage">XXX %</string>
   <string name="drawer_open">Отвори фиоку</string>
   <string name="drawer_close">Затвори фиоку</string>

--- a/AnkiDroid/src/main/res/values-sv/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-sv/02-strings.xml
@@ -38,7 +38,7 @@
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <string name="preference_summary_percentage">XXX%</string>
   <string name="drawer_open">Öppna panel</string>
   <string name="drawer_close">Stäng panel</string>

--- a/AnkiDroid/src/main/res/values-th/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-th/02-strings.xml
@@ -38,7 +38,7 @@
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <string name="preference_summary_percentage">XXX%</string>
   <string name="drawer_open">Open drawer</string>
   <string name="drawer_close">Close drawer</string>

--- a/AnkiDroid/src/main/res/values-tr/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-tr/02-strings.xml
@@ -38,7 +38,7 @@
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <string name="preference_summary_percentage">XXX%</string>
   <string name="drawer_open">Çekmeceyi Aç</string>
   <string name="drawer_close">Çekmeceyi Kapat</string>

--- a/AnkiDroid/src/main/res/values-uk/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-uk/02-strings.xml
@@ -38,7 +38,7 @@
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <string name="preference_summary_percentage">XXX%</string>
   <string name="drawer_open">Відкрити шухляду</string>
   <string name="drawer_close">Закрити шухляду</string>

--- a/AnkiDroid/src/main/res/values-vi/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-vi/02-strings.xml
@@ -38,7 +38,7 @@
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <string name="preference_summary_percentage">XXX%</string>
   <string name="drawer_open">Mở ngăn kéo</string>
   <string name="drawer_close">Đóng ngăn kéo</string>

--- a/AnkiDroid/src/main/res/values-zh-rCN/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-zh-rCN/02-strings.xml
@@ -38,7 +38,7 @@
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <string name="preference_summary_percentage">XXX%</string>
   <string name="drawer_open">打开侧栏</string>
   <string name="drawer_close">关闭侧栏</string>

--- a/AnkiDroid/src/main/res/values-zh-rTW/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-zh-rTW/02-strings.xml
@@ -38,7 +38,7 @@
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
   <string name="preference_summary_percentage">XXX%</string>
   <string name="drawer_open">開啟側欄</string>
   <string name="drawer_close">關閉側欄</string>

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -17,7 +17,8 @@
 ~
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
---><resources xmlns:tools="http://schemas.android.com/tools">
+-->
+<resources>
     <!-- How to format a percentage shown in the summary field of a preference -->
     <string name="preference_summary_percentage">XXX%</string>
 

--- a/AnkiDroid/src/main/res/xml/preference_headers_legacy.xml
+++ b/AnkiDroid/src/main/res/xml/preference_headers_legacy.xml
@@ -16,8 +16,7 @@
 -->
 
 <!--  General Preferences -->
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://arbitrary.app.namespace/com.ichi2.anki" >
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
     <PreferenceScreen android:title="@string/pref_cat_general"
         android:summary="@string/pref_cat_general_summ">
           <intent 


### PR DESCRIPTION
Some of the lint warnings have automated fixes. Here is a batch that fixes these:

```
unused imports
redundant typecasts
unused resource imports in xml
long literal ending with 'l' instead of 'L'
Explicit type can be replaced with <>
'for' loop replaceable with 'foreach'
identical 'catch' branches in 'try' statement
'while' loop replaceable with 'foreach'```