### PR TITLE
Don't flash white when stats are first opened, change black on black …

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.java
@@ -16,6 +16,7 @@
 package com.ichi2.anki;
 
 import android.content.Intent;
+import android.graphics.Color;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
@@ -613,8 +614,11 @@ public class Statistics extends NavigationDrawerActivity implements
             mWebView = (WebView) rootView.findViewById(R.id.web_view_stats);
             if(mWebView == null)
                 Timber.d("mChart null!!!");
-            else
+            else {
                 Timber.d("mChart is not null!");
+                // Set transparent color to prevent flashing white when night mode enabled
+                mWebView.setBackgroundColor(Color.argb(1, 0, 0, 0));
+            }
 
             //mChart.setLayerType(View.LAYER_TYPE_SOFTWARE, null);
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/stats/ChartBuilder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/stats/ChartBuilder.java
@@ -244,7 +244,7 @@ public class ChartBuilder {
         for(int i = 1; i< mCumulative.length; i++){
             double[][] cumulative = {mCumulative[0], mCumulative[i]};
 
-            ColorWrap usedColor = ColorWrap.BLACK;
+            ColorWrap usedColor = new ColorWrap(Themes.getColorFromAttr(mChartView.getContext(), R.attr.stats_cumulative));
             String name = mChartView.getResources().getString(R.string.stats_cumulative);
             if(mHasColoredCumulative){      //also non colored Cumulatives have names!
                 usedColor = new ColorWrap(Themes.getColorFromAttr(mChartView.getContext(), mColors[i - 1]));

--- a/AnkiDroid/src/main/res/values/attrs.xml
+++ b/AnkiDroid/src/main/res/values/attrs.xml
@@ -68,6 +68,7 @@
     <attr name="stats_counts" format="color"/>
     <attr name="stats_unseen" format="color"/>
     <attr name="stats_suspended" format="color"/>
+    <attr name="stats_cumulative" format="color"/>
     <!-- Reviewer other colors -->
     <attr name="topBarColor" format="color"/>
     <attr name="maxTimerColor" format="color"/>

--- a/AnkiDroid/src/main/res/values/colors.xml
+++ b/AnkiDroid/src/main/res/values/colors.xml
@@ -26,6 +26,7 @@
     <color name="stats_counts">#E6000000</color>
     <color name="stats_unseen">#000</color>
     <color name="stats_suspended">#ff0</color>
+    <color name="stats_cumulative">#000000</color>
     <color name="transparent">#00000000</color>
     <color name="white">#ffffff</color>
     <color name="black">#000000</color>

--- a/AnkiDroid/src/main/res/values/theme_black.xml
+++ b/AnkiDroid/src/main/res/values/theme_black.xml
@@ -61,10 +61,11 @@
         <item name="stats_relearn">#c00</item>
         <item name="stats_cram">#ff0</item>
         <item name="stats_interval">#077</item>
-        <item name="stats_hours">#ccc</item>
-        <item name="stats_counts">#E6000000</item>
-        <item name="stats_unseen">#000</item>
+        <item name="stats_hours">@color/material_grey_500</item>
+        <item name="stats_counts">@color/material_grey_800</item>
+        <item name="stats_unseen">@color/material_grey_800</item>
         <item name="stats_suspended">#ff0</item>
+        <item name="stats_cumulative">@color/material_grey_800</item>
         <!-- Browser colors -->
         <item name="suspendedColor">#A8A634</item>
         <item name="markedColor">#391080</item>

--- a/AnkiDroid/src/main/res/values/theme_dark.xml
+++ b/AnkiDroid/src/main/res/values/theme_dark.xml
@@ -65,6 +65,7 @@
         <item name="stats_counts">#E6000000</item>
         <item name="stats_unseen">#000</item>
         <item name="stats_suspended">#ff0</item>
+        <item name="stats_cumulative">@color/stats_cumulative</item>
         <!-- Browser colors -->
         <item name="suspendedColor">@color/material_grey_700</item>
         <item name="markedColor">@color/material_deep_purple_400</item>

--- a/AnkiDroid/src/main/res/values/theme_light.xml
+++ b/AnkiDroid/src/main/res/values/theme_light.xml
@@ -78,6 +78,7 @@ APIs. It's visible when there aren't enough decks to fill the screen.
         <item name="stats_counts">#E6000000</item>
         <item name="stats_unseen">#000</item>
         <item name="stats_suspended">#ff0</item>
+        <item name="stats_cumulative">@color/stats_cumulative</item>
         <!-- Browser colors -->
         <item name="suspendedColor">#FFFFB2</item>
         <item name="markedColor">#D9B2E9</item>


### PR DESCRIPTION
…to grey on black in statistics charts

- When you first open the stats, it now doesn't flashes white anymore
for a fraction of a second. Fixed by changing the background to
transparent like is done in the Reviewer.
- When using the black theme, the unseen cards are now shown as grey on
black in the pie chart instead of black
- When using the black theme, the cumulative line in the intervals chart
are now shown as grey on black instead of black on black
- When using the black theme, the counts bars in the hourly and weekly
breakdown chart are now shown as grey on black instead of black on black

See https://github.com/ankidroid/Anki-Android/pull/4089#issuecomment-186711708