### PR TITLE
Update to newer support libraries and build tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ language: android
 sudo: false
 android:
   components:
+    - tools
     - platform-tools
-    - build-tools-23.0.1
+    - build-tools-23.0.2
     - android-23
     - extra-android-support
     - extra-android-m2repository

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -3,13 +3,20 @@ apply plugin: 'com.github.triplet.play'
 def homePath = System.properties['user.home']
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    buildToolsVersion "23.0.2"
 
     defaultConfig {
         applicationId "com.ichi2.anki"
         minSdkVersion 10
         targetSdkVersion 23
         testApplicationId "com.ichi2.anki.tests"
+        // Stops the Gradle’s automatic rasterization of vectors
+        generatedDensities = [] // remove when moving to gradle 2.0
+    }
+    // Flag that tells aapt to keep the attribute ids
+    aaptOptions {
+        // replace with vectorDrawables.useSupportLibrary = true when moving to gradle 2.0
+        additionalParameters "--no-version-vectors"
     }
     lintOptions {
         abortOnError false
@@ -41,12 +48,12 @@ play {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:23.1.1'
+    compile 'com.android.support:appcompat-v7:23.2.0'
     // Note: the design support library can be quite buggy, so test everything thoroughly before updating it
-    compile 'com.android.support:design:23.1.1'
-    compile 'com.android.support:customtabs:23.1.1'
-    compile 'com.android.support:recyclerview-v7:23.1.1'
-    compile('com.afollestad.material-dialogs:core:0.8.5.1@aar') {
+    compile 'com.android.support:design:23.2.0'
+    compile 'com.android.support:customtabs:23.2.0'
+    compile 'com.android.support:recyclerview-v7:23.2.0'
+    compile('com.afollestad.material-dialogs:core:0.8.5.5@aar') {
         //exclude group: 'com.android.support'  // uncomment to force our local support lib version
         transitive = true
     }

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -6,7 +6,7 @@ def version = "1.0.0alpha2"
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    buildToolsVersion '23.0.2'
 
     defaultConfig {
         minSdkVersion 8

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.1'
+        classpath 'com.android.tools.build:gradle:1.5.0'
         classpath 'com.github.triplet.gradle:play-publisher:1.1.4'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
There's a [new batch](http://developer.android.com/tools/support-library/index.html) of support libraries so we might as well start testing them now.

One of the new libraries was causing us to crash at runtime on API <20 so I turned it off according to the instructions in the release notes. There's a simpler way with Gradle 2.0 which I'll update to when it's out of beta (I'm using it locally for the instant run feature and it seems to work well).

I've tested our main activities on 7 different APIs and all seems to be working well so far.