### PR TITLE
Added bulkInsert() support to API and ContentProvider for 2000% faster Note inserts

### DIFF
--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -311,6 +311,7 @@
             android:authorities="com.ichi2.anki.flashcards"
             android:enabled="true"
             android:exported="true" >
+            <meta-data android:name="com.ichi2.anki.provider.spec" android:value="2" />
         </provider>
     </application>
 


### PR DESCRIPTION
Two parts to this:

1.

Speed Improvements: when inserting many notes (2000% faster!) - added support for bulkInsert() to the content provider as well as the API. Also improved inserting single notes (39% faster) by calling provider once (and passing in deckId) rather than the old way of calling it 3 times.

I've added a meta-data key to the provider (in manifest) so that the API can query whether the provider supports these new features.

Here are the stats from my testing on a Nexus 6P (6.0.1):

Insert 2122 notes (same model (three fields), same deck, single card)

Ankidroid v.20600116 (3 provider calls per note): 191secs
Single provider call per note: 138secs
Single provider call in total (bulk insert): 119secs

This PR: single provider call in total (bulk insert, single transaction):
Ignore duplicates (empty deck): 44secs
Ignore duplicates (deck already contains 2122 notes, so none added): 34secs
No duplicate check (empty deck): 8.5secs

2.

On Android 6.0, AnkiDroid needs to be run BEFORE the AddContentAPI can be used. This is so that the user has the chance to grant the storage permission.  This new method should be called by the user before using the API's read/write methods. If it returns a non-null value, then the caller should launch the activity for that intent. When the user returns to the calling app, the calling app should again call this method to check whether the API can indeed be used (because maybe the user ran AnkiDroid but did not grant the permission).