### PR TITLE
Added support for bulk insert of Notes: 2000% faster

### DIFF
--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -311,6 +311,7 @@
             android:authorities="com.ichi2.anki.flashcards"
             android:enabled="true"
             android:exported="true" >
+            <meta-data android:name="com.ichi2.anki.provider.spec" android:value="2" />
         </provider>
     </application>
 

--- a/api/src/main/java/com/ichi2/anki/FlashCardsContract.java
+++ b/api/src/main/java/com/ichi2/anki/FlashCardsContract.java
@@ -311,6 +311,11 @@ public class FlashCardsContract {
          * MIME type used for notes.
          */
         public static final String CONTENT_TYPE = "vnd.android.cursor.dir/vnd.com.ichi2.anki.note";
+
+        /**
+         * Used only by bulkInsert() to specify which deck the notes should be placed in
+         */
+        public static final String DECK_ID_QUERY_PARAM = "deckId";
     }
 
 


### PR DESCRIPTION
This is a major performance improvement for inserting large numbers (hundreds or thousands) of Notes.

Added support for bulkInsert() to the content provider as well as the API (addNewNotes). This will work with existing provider but new provider implementation is much faster.

Added support for inserting a new note into a deck with one provider call (instead of three in existing API implementation) to the provider's insert() method. Again, this will work with existing provider, but new provider implementation is about 39% faster.

Added API support for updating an existing note: updateNote() and updateNoteTags(). (This is already supported by existing provider).

Added API support for counting number of notes (with a certain model id) in a deck: countNotes(). I couldn't see a way to count notes in a deck while ignoring model id. (This is already supported by existing provider).

Added provider support for "count(*)" column in projection.

Added a meta-data key to the provider (in manifest) so that the API can query whether the provider supports these new features.

Here are the stats from my testing on a Nexus 6P (6.0.1):

Insert 2122 notes (same model (three fields), same deck, single card)

Ankidroid v.20600116 (3 provider calls per note): **191secs**
Rewrote as single provider call per note: 138secs
Rewrote as single provider call in total (bulk insert): 119secs

This PR: single provider call in total (bulk insert, single transaction):
Ignore duplicates (empty deck): 44secs
Ignore duplicates (deck already contains 2122 notes, so none added): 34secs
No duplicate check (empty deck): **8.5secs**