### PR TITLE
Use non-zero layout width for xlarge layouts

### DIFF
--- a/AnkiDroid/src/main/res/layout-xlarge/homescreen.xml
+++ b/AnkiDroid/src/main/res/layout-xlarge/homescreen.xml
@@ -12,13 +12,13 @@
             android:background="?android:attr/colorBackground"
             android:orientation="horizontal">
         <include layout="@layout/deck_picker"
-                     android:layout_width="0dip"
+                     android:layout_width="1dip"
                      android:layout_weight="3"
                      android:layout_height="match_parent"/>
         <FrameLayout
                      android:id="@+id/studyoptions_fragment"
                      android:layout_weight="2"
-                     android:layout_width="0dip"
+                     android:layout_width="1dip"
                      android:layout_height="fill_parent"/>
     </LinearLayout>
     <include layout="@layout/navigation_drawer" />


### PR DESCRIPTION
With the new support libraries, the tablet layout's decklist always anchors to the top on any update or tap. This fixes that.

The changelog for the recyclerview library said something about layout values no longer being ignored, and:
>Note: These lifted restrictions may cause unexpected behavior in your layouts. Make sure you specify the correct layout parameters. 

So I think 0 width counts as an "incorrect" value. Honestly I just guessed stuff until it worked.