### PR TITLE
Fix nav drawer not opening with gestures enabled

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -48,11 +48,11 @@ play {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:23.2.0'
+    compile 'com.android.support:appcompat-v7:23.2.1'
     // Note: the design support library can be quite buggy, so test everything thoroughly before updating it
-    compile 'com.android.support:design:23.2.0'
-    compile 'com.android.support:customtabs:23.2.0'
-    compile 'com.android.support:recyclerview-v7:23.2.0'
+    compile 'com.android.support:design:23.2.1'
+    compile 'com.android.support:customtabs:23.2.1'
+    compile 'com.android.support:recyclerview-v7:23.2.1'
     compile('com.afollestad.material-dialogs:core:0.8.5.5@aar') {
         //exclude group: 'com.android.support'  // uncomment to force our local support lib version
         transitive = true

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
@@ -27,6 +27,7 @@ import android.support.v4.widget.DrawerLayout;
 import android.support.v7.app.ActionBarDrawerToggle;
 import android.support.v7.widget.SwitchCompat;
 import android.support.v7.widget.Toolbar;
+import android.view.Gravity;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -70,6 +71,16 @@ public class NavigationDrawerActivity extends AnkiActivity implements Navigation
             // enable ActionBar app icon to behave as action to toggle nav drawer
             getSupportActionBar().setDisplayHomeAsUpEnabled(true);
             getSupportActionBar().setHomeButtonEnabled(true);
+
+            // Open the nav drawer when the navigation button is tapped. We need to explicitly
+            // define this because locking the nav drawer (when gestures are enabled) prevents
+            // the nav drawer from opening even when tapping the navigation button.
+            toolbar.setNavigationOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    mDrawerLayout.openDrawer(Gravity.LEFT);
+                }
+            });
         }
         // Configure night-mode switch
         final SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(NavigationDrawerActivity.this);
@@ -106,7 +117,7 @@ public class NavigationDrawerActivity extends AnkiActivity implements Navigation
             }
         };
 
-        mDrawerLayout.setDrawerListener(mDrawerToggle);
+        mDrawerLayout.addDrawerListener(mDrawerToggle);
     }
 
 


### PR DESCRIPTION
Fix or workaround for https://github.com/ankidroid/Anki-Android/issues/4108

The support libraries were updated again and the problem is still there so I tried to fix it manually. I'll open a bug report for it on google just to see what's up but I have a feeling the change was intended.

As far as I can tell this works and the "up" behaviour isn't broken in things like the studyoptions so I think it's okay.