### PR TITLE
Fix failing provider tests

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -68,3 +68,5 @@ dependencies {
     compile 'com.google.code.gson:gson:2.4'
     compile project(":api")
 }
+
+apply from: "travis.gradle"

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
@@ -419,7 +419,7 @@ public class CardContentProvider extends ContentProvider {
             return 0;
         }
 
-        if (getContext().checkCallingPermission(FlashCardsContract.READ_WRITE_PERMISSION) != PackageManager.PERMISSION_GRANTED) {
+        if (getContext().checkCallingOrSelfPermission(FlashCardsContract.READ_WRITE_PERMISSION) != PackageManager.PERMISSION_GRANTED) {
             throw new IllegalStateException("Update permission not granted for: " + uri);
         }
 
@@ -646,7 +646,7 @@ public class CardContentProvider extends ContentProvider {
         if (col == null) {
             return 0;
         }
-        if (getContext().checkCallingPermission(FlashCardsContract.READ_WRITE_PERMISSION) != PackageManager.PERMISSION_GRANTED) {
+        if (getContext().checkCallingOrSelfPermission(FlashCardsContract.READ_WRITE_PERMISSION) != PackageManager.PERMISSION_GRANTED) {
             throw new IllegalStateException("Delete permission not granted for: " + uri);
         }
 

--- a/AnkiDroid/travis.gradle
+++ b/AnkiDroid/travis.gradle
@@ -1,0 +1,15 @@
+def adb = android.getAdbExe().toString()
+
+task setStoragePermission(type: Exec, dependsOn: 'installDebug') {
+    commandLine "$adb shell pm grant com.ichi2.anki android.permission.WRITE_EXTERNAL_STORAGE".split(' ')
+}
+task setProviderPermission(type: Exec, dependsOn: 'installDebug') {
+    commandLine "$adb shell pm grant com.ichi2.anki com.ichi2.anki.permission.READ_WRITE_DATABASE".split(' ')
+}
+
+tasks.whenTaskAdded { task ->
+    if (task.name.startsWith('connectedDebugAndroidTest')) {
+        task.dependsOn setStoragePermission
+        task.dependsOn setProviderPermission
+    }
+}


### PR DESCRIPTION
The provider was using checkCallingPermission() which only checks if another process has the permission. Since the unit tests originate from the same process as AnkiDroid, it needs to be checkCallingOrSelfPermission(). I also added a task that automatically grants permission to the emulator over adb for the two permissions that we need to run the tests. The adb calls will be rejected below API 23 (our tests currently run on an API22 emulator), so they are mainly for when we eventually upgrade.

@marcardar
FYI