### PR TITLE
Add a v2 provider which is active for Android M and above

### DIFF
--- a/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/ContentProviderTest.java
+++ b/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/ContentProviderTest.java
@@ -46,12 +46,12 @@ import java.util.Arrays;
 import java.util.List;
 
 /**
- * Test cases for {@link com.ichi2.anki.provider.CardContentProvider}.
+ * Test cases for {@link com.ichi2.anki.provider.CardContentProvider2}.
  * <p/>
  * These tests should cover all supported operations for each URI.
  */
 public class ContentProviderTest extends AndroidTestCase {
-
+    private static final int PROVIDER_VERSION = 2;      // Version of the provider to use for testing
     private static final String BASIC_MODEL_NAME = "com.ichi2.anki.provider.test.basic.x94oa3F";
     private static final String TEST_FIELD_VALUE = "test field value";
     private static final String TEST_TAG = "aldskfhewjklhfczmxkjshf";
@@ -109,7 +109,7 @@ public class ContentProviderTest extends AndroidTestCase {
             c.setDid(did);
             c.flush();
         }
-        return Uri.withAppendedPath(FlashCardsContract.Note.CONTENT_URI, Long.toString(newNote.getId()));
+        return Uri.withAppendedPath(FlashCardsContract.Note.getUri(PROVIDER_VERSION), Long.toString(newNote.getId()));
     }
 
     /**
@@ -155,7 +155,7 @@ public class ContentProviderTest extends AndroidTestCase {
         values.put(FlashCardsContract.Note.MID, mModelId);
         values.put(FlashCardsContract.Note.FLDS, Utils.joinFields(TEST_NOTE_FIELDS));
         values.put(FlashCardsContract.Note.TAGS, TEST_TAG);
-        Uri newNoteUri = cr.insert(FlashCardsContract.Note.CONTENT_URI, values);
+        Uri newNoteUri = cr.insert(FlashCardsContract.Note.getUri(PROVIDER_VERSION), values);
         assertNotNull("Check that URI returned from addNewNote is not null", newNoteUri);
         // Check that it looks as expected
         Note addedNote = new Note(col, Long.parseLong(newNoteUri.getLastPathSegment()));
@@ -181,7 +181,7 @@ public class ContentProviderTest extends AndroidTestCase {
         // search for correct mid
         final ContentResolver cr = getContext().getContentResolver();
         String[] selectionArgs = {String.format("mid=%d", mModelId)};
-        Cursor cursor = cr.query(FlashCardsContract.Note.CONTENT_URI, null, null, selectionArgs, null);
+        Cursor cursor = cr.query(FlashCardsContract.Note.getUri(PROVIDER_VERSION), null, null, selectionArgs, null);
         assertNotNull(cursor);
         try {
             assertEquals("Check number of results", mCreatedNotes.size(), cursor.getCount());
@@ -189,7 +189,7 @@ public class ContentProviderTest extends AndroidTestCase {
             cursor.close();
         }
         // search for correct mid and also correct tag
-        cursor = cr.query(FlashCardsContract.Note.CONTENT_URI, null, "tag:" + TEST_TAG, selectionArgs, null);
+        cursor = cr.query(FlashCardsContract.Note.getUri(PROVIDER_VERSION), null, "tag:" + TEST_TAG, selectionArgs, null);
         assertNotNull(cursor);
         try {
             assertEquals("Check number of results", mCreatedNotes.size(), cursor.getCount());
@@ -198,7 +198,7 @@ public class ContentProviderTest extends AndroidTestCase {
         }
         // search for bogus mid
         selectionArgs[0] = String.format("mid=%d", 0);
-        cursor = cr.query(FlashCardsContract.Note.CONTENT_URI, null, null, selectionArgs, null);
+        cursor = cr.query(FlashCardsContract.Note.getUri(PROVIDER_VERSION), null, null, selectionArgs, null);
         assertNotNull(cursor);
         try {
             assertEquals("Check number of results", 0, cursor.getCount());
@@ -213,7 +213,7 @@ public class ContentProviderTest extends AndroidTestCase {
     public void testQueryNoteIds() {
         final ContentResolver cr = getContext().getContentResolver();
         // Query all available notes
-        final Cursor allNotesCursor = cr.query(FlashCardsContract.Note.CONTENT_URI, null, "tag:" + TEST_TAG, null, null);
+        final Cursor allNotesCursor = cr.query(FlashCardsContract.Note.getUri(PROVIDER_VERSION), null, "tag:" + TEST_TAG, null, null);
         assertNotNull(allNotesCursor);
         try {
             assertEquals("Check number of results", mCreatedNotes.size(), allNotesCursor.getCount());
@@ -222,7 +222,7 @@ public class ContentProviderTest extends AndroidTestCase {
                 for (int i = 0; i < FlashCardsContract.Note.DEFAULT_PROJECTION.length; i++) {
                     String[] projection = removeFromProjection(FlashCardsContract.Note.DEFAULT_PROJECTION, i);
                     String noteId = allNotesCursor.getString(allNotesCursor.getColumnIndex(FlashCardsContract.Note._ID));
-                    Uri noteUri = Uri.withAppendedPath(FlashCardsContract.Note.CONTENT_URI, noteId);
+                    Uri noteUri = Uri.withAppendedPath(FlashCardsContract.Note.getUri(PROVIDER_VERSION), noteId);
                     final Cursor singleNoteCursor = cr.query(noteUri, projection, null, null, null);
                     assertNotNull("Check that there is a valid cursor for detail data", singleNoteCursor);
                     try {
@@ -251,7 +251,7 @@ public class ContentProviderTest extends AndroidTestCase {
         // Query all available notes
         for (int i = 0; i < FlashCardsContract.Note.DEFAULT_PROJECTION.length; i++) {
             String[] projection = removeFromProjection(FlashCardsContract.Note.DEFAULT_PROJECTION, i);
-            final Cursor allNotesCursor = cr.query(FlashCardsContract.Note.CONTENT_URI, projection, "tag:" + TEST_TAG, null, null);
+            final Cursor allNotesCursor = cr.query(FlashCardsContract.Note.getUri(PROVIDER_VERSION), projection, "tag:" + TEST_TAG, null, null);
             assertNotNull("Check that there is a valid cursor", allNotesCursor);
             try {
                 assertEquals("Check number of results", mCreatedNotes.size(), allNotesCursor.getCount());
@@ -318,7 +318,7 @@ public class ContentProviderTest extends AndroidTestCase {
         cv.put(FlashCardsContract.Model.FIELD_NAMES, Utils.joinFields(TEST_MODEL_FIELDS));
         cv.put(FlashCardsContract.Model.NUM_CARDS, TEST_MODEL_CARDS.length);
         cv.put(FlashCardsContract.Model.CSS, TEST_MODEL_CSS);
-        Uri modelUri = cr.insert(FlashCardsContract.Model.CONTENT_URI, cv);
+        Uri modelUri = cr.insert(FlashCardsContract.Model.getUri(PROVIDER_VERSION), cv);
         assertNotNull("Check inserted model isn't null", modelUri);
         long mid = Long.parseLong(modelUri.getLastPathSegment());
         final Collection col = CollectionHelper.getInstance().getCol(getContext());
@@ -367,13 +367,13 @@ public class ContentProviderTest extends AndroidTestCase {
     public void testQueryAllModels() {
         final ContentResolver cr = getContext().getContentResolver();
         // Query all available models
-        final Cursor allModels = cr.query(FlashCardsContract.Model.CONTENT_URI, null, null, null, null);
+        final Cursor allModels = cr.query(FlashCardsContract.Model.getUri(PROVIDER_VERSION), null, null, null, null);
         assertNotNull(allModels);
         try {
             assertTrue("Check that there is at least one result", allModels.getCount() > 0);
             while (allModels.moveToNext()) {
                 long modelId = allModels.getLong(allModels.getColumnIndex(FlashCardsContract.Model._ID));
-                Uri modelUri = Uri.withAppendedPath(FlashCardsContract.Model.CONTENT_URI, Long.toString(modelId));
+                Uri modelUri = Uri.withAppendedPath(FlashCardsContract.Model.getUri(PROVIDER_VERSION), Long.toString(modelId));
                 final Cursor singleModel = cr.query(modelUri, null, null, null, null);
                 assertNotNull(singleModel);
                 try {
@@ -401,13 +401,13 @@ public class ContentProviderTest extends AndroidTestCase {
     public void testMoveCardsToOtherDeck() {
         final ContentResolver cr = getContext().getContentResolver();
         // Query all available notes
-        final Cursor allNotesCursor = cr.query(FlashCardsContract.Note.CONTENT_URI, null, "tag:" + TEST_TAG, null, null);
+        final Cursor allNotesCursor = cr.query(FlashCardsContract.Note.getUri(PROVIDER_VERSION), null, "tag:" + TEST_TAG, null, null);
         assertNotNull(allNotesCursor);
         try {
             assertEquals("Check number of results", mCreatedNotes.size(), allNotesCursor.getCount());
             while (allNotesCursor.moveToNext()) {
                 // Now iterate over all cursors
-                Uri cardsUri = Uri.withAppendedPath(Uri.withAppendedPath(FlashCardsContract.Note.CONTENT_URI,
+                Uri cardsUri = Uri.withAppendedPath(Uri.withAppendedPath(FlashCardsContract.Note.getUri(PROVIDER_VERSION),
                         allNotesCursor.getString(allNotesCursor.getColumnIndex(FlashCardsContract.Note._ID))), "cards");
                 final Cursor cardsCursor = cr.query(cardsUri, null, null, null, null);
                 assertNotNull("Check that there is a valid cursor after query for cards", cardsCursor);
@@ -441,7 +441,7 @@ public class ContentProviderTest extends AndroidTestCase {
      */
     public void testQueryCurrentModel() {
         final ContentResolver cr = getContext().getContentResolver();
-        Uri uri = Uri.withAppendedPath(FlashCardsContract.Model.CONTENT_URI, FlashCardsContract.Model.CURRENT_MODEL_ID);
+        Uri uri = Uri.withAppendedPath(FlashCardsContract.Model.getUri(PROVIDER_VERSION), FlashCardsContract.Model.CURRENT_MODEL_ID);
         final Cursor modelCursor = cr.query(uri, null, null, null, null);
         assertNotNull(modelCursor);
         try {
@@ -464,10 +464,10 @@ public class ContentProviderTest extends AndroidTestCase {
         ContentValues dummyValues = new ContentValues();
         Uri[] updateUris = {
                 // Can't update most tables in bulk -- only via ID
-                FlashCardsContract.Note.CONTENT_URI,
-                FlashCardsContract.Model.CONTENT_URI,
-                FlashCardsContract.Deck.CONTENT_ALL_URI,
-                FlashCardsContract.Note.CONTENT_URI.buildUpon()
+                FlashCardsContract.Note.getUri(PROVIDER_VERSION),
+                FlashCardsContract.Model.getUri(PROVIDER_VERSION),
+                FlashCardsContract.Deck.getUri(PROVIDER_VERSION),
+                FlashCardsContract.Note.getUri(PROVIDER_VERSION).buildUpon()
                         .appendPath("1234")
                         .appendPath("cards")
                         .build(),
@@ -483,19 +483,19 @@ public class ContentProviderTest extends AndroidTestCase {
             }
         }
         Uri[] deleteUris = {
-                FlashCardsContract.Note.CONTENT_URI,
+                FlashCardsContract.Note.getUri(PROVIDER_VERSION),
                 // Only note/<id> is supported
-                FlashCardsContract.Note.CONTENT_URI.buildUpon()
+                FlashCardsContract.Note.getUri(PROVIDER_VERSION).buildUpon()
                         .appendPath("1234")
                         .appendPath("cards")
                         .build(),
-                FlashCardsContract.Note.CONTENT_URI.buildUpon()
+                FlashCardsContract.Note.getUri(PROVIDER_VERSION).buildUpon()
                         .appendPath("1234")
                         .appendPath("cards")
                         .appendPath("2345")
                         .build(),
-                FlashCardsContract.Model.CONTENT_URI,
-                FlashCardsContract.Model.CONTENT_URI.buildUpon()
+                FlashCardsContract.Model.getUri(PROVIDER_VERSION),
+                FlashCardsContract.Model.getUri(PROVIDER_VERSION).buildUpon()
                         .appendPath("1234")
                         .build(),
         };
@@ -509,19 +509,19 @@ public class ContentProviderTest extends AndroidTestCase {
         }
         Uri[] insertUris = {
                 // Can't do an insert with specific ID on the following tables
-                FlashCardsContract.Note.CONTENT_URI.buildUpon()
+                FlashCardsContract.Note.getUri(PROVIDER_VERSION).buildUpon()
                         .appendPath("1234")
                         .build(),
-                FlashCardsContract.Note.CONTENT_URI.buildUpon()
+                FlashCardsContract.Note.getUri(PROVIDER_VERSION).buildUpon()
                         .appendPath("1234")
                         .appendPath("cards")
                         .build(),
-                FlashCardsContract.Note.CONTENT_URI.buildUpon()
+                FlashCardsContract.Note.getUri(PROVIDER_VERSION).buildUpon()
                         .appendPath("1234")
                         .appendPath("cards")
                         .appendPath("2345")
                         .build(),
-                FlashCardsContract.Model.CONTENT_URI.buildUpon()
+                FlashCardsContract.Model.getUri(PROVIDER_VERSION).buildUpon()
                         .appendPath("1234")
                         .build(),
         };
@@ -547,7 +547,7 @@ public class ContentProviderTest extends AndroidTestCase {
         Decks decks = col.getDecks();
 
         Cursor decksCursor = getContext().getContentResolver()
-                .query(FlashCardsContract.Deck.CONTENT_ALL_URI, FlashCardsContract.Deck.DEFAULT_PROJECTION, null, null, null);
+                .query(FlashCardsContract.Deck.getUri(PROVIDER_VERSION), FlashCardsContract.Deck.DEFAULT_PROJECTION, null, null, null);
 
         assertNotNull(decksCursor);
         try {
@@ -574,7 +574,7 @@ public class ContentProviderTest extends AndroidTestCase {
         col = CollectionHelper.getInstance().getCol(getContext());
 
         long deckId = mTestDeckIds[0];
-        Uri deckUri = Uri.withAppendedPath(FlashCardsContract.Deck.CONTENT_ALL_URI, Long.toString(deckId));
+        Uri deckUri = Uri.withAppendedPath(FlashCardsContract.Deck.getUri(PROVIDER_VERSION), Long.toString(deckId));
         Cursor decksCursor = getContext().getContentResolver().query(deckUri, null, null, null, null);
         try {
             if (decksCursor == null || !decksCursor.moveToFirst()) {
@@ -601,7 +601,7 @@ public class ContentProviderTest extends AndroidTestCase {
         Sched sched = col.getSched();
 
         Cursor reviewInfoCursor = getContext().getContentResolver().query(
-                FlashCardsContract.ReviewInfo.CONTENT_URI, null, null, null, null);
+                FlashCardsContract.ReviewInfo.getUri(PROVIDER_VERSION), null, null, null, null);
         assertNotNull(reviewInfoCursor);
         assertEquals("Check that we actually received one card", 1, reviewInfoCursor.getCount());
 
@@ -636,7 +636,7 @@ public class ContentProviderTest extends AndroidTestCase {
         col.getDecks().select(1); //select Default deck
 
         Cursor reviewInfoCursor = getContext().getContentResolver().query(
-                FlashCardsContract.ReviewInfo.CONTENT_URI, null, deckSelector, deckArguments, null);
+                FlashCardsContract.ReviewInfo.getUri(PROVIDER_VERSION), null, deckSelector, deckArguments, null);
         assertNotNull(reviewInfoCursor);
         assertEquals("Check that we actually received one card", 1, reviewInfoCursor.getCount());
         try {
@@ -668,7 +668,7 @@ public class ContentProviderTest extends AndroidTestCase {
     public void testSetSelectedDeck(){
         long deckId = mTestDeckIds[0];
         ContentResolver cr = getContext().getContentResolver();
-        Uri selectDeckUri = FlashCardsContract.Deck.CONTENT_SELECTED_URI;
+        Uri selectDeckUri = FlashCardsContract.Deck.getSelectedUri(PROVIDER_VERSION);
         ContentValues values = new ContentValues();
         values.put(FlashCardsContract.Deck.DECK_ID, deckId);
         cr.update(selectDeckUri, values, null, null);
@@ -690,7 +690,7 @@ public class ContentProviderTest extends AndroidTestCase {
         Card card = sched.getCard();
 
         ContentResolver cr = getContext().getContentResolver();
-        Uri reviewInfoUri = FlashCardsContract.ReviewInfo.CONTENT_URI;
+        Uri reviewInfoUri = FlashCardsContract.ReviewInfo.getUri(PROVIDER_VERSION);
         ContentValues values = new ContentValues();
         long noteId = card.note().getId();
         int cardOrd = card.getOrd();

--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -306,8 +306,18 @@
             android:name="com.sec.minimode.icon.landscape.normal"
             android:resource="@drawable/anki" />
 
+        <!-- ContentProvider for external applications to access the AnkiDroid DB (SDK 23+ version) -->
         <provider
-            android:name=".provider.CardContentProvider"
+            android:name=".provider.CardContentProvider2"
+            android:authorities="com.ichi2.anki.flashcards.v2"
+            android:enabled="true"
+            android:exported="true"
+            android:permission="com.ichi2.anki.permission.READ_WRITE_DATABASE">
+            <meta-data android:name="com.ichi2.anki.provider.spec" android:value="2" />
+        </provider>
+        <!-- Legacy version of provider with dynamic permissions. Disabled on Android M and above -->
+        <provider
+            android:name=".provider.legacy.CardContentProvider"
             android:authorities="com.ichi2.anki.flashcards"
             android:enabled="true"
             android:exported="true" >

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -35,6 +35,7 @@ import android.content.res.Resources;
 import android.database.SQLException;
 import android.graphics.PixelFormat;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Message;
 import android.provider.Settings;
@@ -77,6 +78,7 @@ import com.ichi2.anki.dialogs.MediaCheckDialog;
 import com.ichi2.anki.dialogs.SyncErrorDialog;
 import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.anki.exception.DeckRenameException;
+import com.ichi2.anki.provider.legacy.CardContentProvider;
 import com.ichi2.anki.receiver.SdCardReceiver;
 import com.ichi2.anki.stats.AnkiStatsTaskHandler;
 import com.ichi2.anki.widgets.DeckAdapter;
@@ -854,6 +856,10 @@ public class DeckPicker extends NavigationDrawerActivity implements
         } else if (preferences.getString("lastVersion", "").equals("")) {
             // Fresh install
             preferences.edit().putString("lastVersion", VersionUtils.getPkgVersionName()).commit();
+            // Disable the legacy ContentProvider on Android M and above
+            if (CompatHelper.getSdkVersion() >= Build.VERSION_CODES.M) {
+                CardContentProvider.setEnabledState(this, false);
+            }
             onFinishedStartup();
         } else if (skip < 2 && !preferences.getString("lastVersion", "").equals(VersionUtils.getPkgVersionName())) {
             // AnkiDroid is being updated and a collection already exists. We check if we are upgrading
@@ -894,6 +900,10 @@ public class DeckPicker extends NavigationDrawerActivity implements
             // Recommend the user to do a full-sync if they're upgrading from before 2.3.1beta8
             if (previous < 20301208) {
                 mRecommendFullSync = true;
+            }
+            // Make sure the legacy ContentProvider is disabled on Android M and above
+            if (CompatHelper.getSdkVersion() >= Build.VERSION_CODES.M) {
+                CardContentProvider.setEnabledState(this, false);
             }
             // Check if preference upgrade or database check required, otherwise go to new feature screen
             int upgradePrefsVersion = AnkiDroidApp.CHECK_PREFERENCES_AT_VERSION;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -48,6 +48,7 @@ import android.view.WindowManager.BadTokenException;
 import android.widget.Toast;
 
 import com.afollestad.materialdialogs.MaterialDialog;
+import com.ichi2.anki.provider.legacy.CardContentProvider;
 import com.ichi2.libanki.hooks.AdvancedStatistics;
 import com.ichi2.themes.Themes;
 import com.ichi2.ui.AppCompatPreferenceActivity;
@@ -512,17 +513,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                     break;
                 }
                 case "providerEnabled": {
-                    ComponentName providerName = new ComponentName(this, "com.ichi2.anki.provider.CardContentProvider");
-                    PackageManager pm = getPackageManager();
-                    int state;
-                    if (((CheckBoxPreference) pref).isChecked()) {
-                         state = PackageManager.COMPONENT_ENABLED_STATE_ENABLED;
-                        Timber.i("AnkiDroid ContentProvider enabled by user");
-                    } else {
-                        state = PackageManager.COMPONENT_ENABLED_STATE_DISABLED;
-                        Timber.i("AnkiDroid ContentProvider disabled by user");
-                    }
-                    pm.setComponentEnabledSetting(providerName, state, PackageManager.DONT_KILL_APP);
+                    CardContentProvider.setEnabledState(this, ((CheckBoxPreference) pref).isChecked());
                     break;
                 }
             }
@@ -659,7 +650,13 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                 plugins.removePreference(doubleScrolling);
             }
         }
-
+        // Disable the API switch on Android M as this SDK handles permissions correctly
+        if (CompatHelper.getSdkVersion() >= Build.VERSION_CODES.M) {
+            CheckBoxPreference providerEnabled = (CheckBoxPreference) screen.findPreference("providerEnabled");
+            if (providerEnabled != null && plugins != null) {
+                plugins.removePreference(providerEnabled);
+            }
+        }
         PreferenceCategory workarounds = (PreferenceCategory) screen.findPreference("category_workarounds");
         if (workarounds != null) {
             CheckBoxPreference writeAnswersDisable = (CheckBoxPreference) screen.findPreference("writeAnswersDisable");

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider2.java
@@ -1,0 +1,25 @@
+package com.ichi2.anki.provider;
+
+import com.ichi2.anki.FlashCardsContract;
+
+/**
+ * Content Provider designed for Android SDK 23 and above
+ */
+public final class CardContentProvider2 extends BaseCardContentProvider {
+    private static final int VER = 2;
+    static {
+        // Here you can see all the URIs at a glance
+        sUriMatcher.addURI(FlashCardsContract.getAuthority(VER), "notes", NOTES);
+        sUriMatcher.addURI(FlashCardsContract.getAuthority(VER), "notes/#", NOTES_ID);
+        sUriMatcher.addURI(FlashCardsContract.getAuthority(VER), "notes/#/cards", NOTES_ID_CARDS);
+        sUriMatcher.addURI(FlashCardsContract.getAuthority(VER), "notes/#/cards/#", NOTES_ID_CARDS_ORD);
+        sUriMatcher.addURI(FlashCardsContract.getAuthority(VER), "models", MODELS);
+        sUriMatcher.addURI(FlashCardsContract.getAuthority(VER), "models/*", MODELS_ID);
+        sUriMatcher.addURI(FlashCardsContract.getAuthority(VER), "models/*/templates", MODELS_ID_TEMPLATES);
+        sUriMatcher.addURI(FlashCardsContract.getAuthority(VER), "models/*/templates/#", MODELS_ID_TEMPLATES_ID);
+        sUriMatcher.addURI(FlashCardsContract.getAuthority(VER), "schedule/", SCHEDULE);
+        sUriMatcher.addURI(FlashCardsContract.getAuthority(VER), "decks/", DECKS);
+        sUriMatcher.addURI(FlashCardsContract.getAuthority(VER), "decks/#", DECKS_ID);
+        sUriMatcher.addURI(FlashCardsContract.getAuthority(VER), "selected_deck/", DECK_SELECTED);
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/legacy/CardContentProvider.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/legacy/CardContentProvider.java
@@ -1,0 +1,92 @@
+/***************************************************************************************
+ *                                                                                      *
+ * Copyright (c) 2015 Frank Oltmanns <frank.oltmanns@gmail.com>                         *
+ * Copyright (c) 2015 Timothy Rae <timothy.rae@gmail.com>                               *
+ * Copyright (c) 2016 Mark Carter <mark@marcardar.com>                                  *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+
+package com.ichi2.anki.provider.legacy;
+
+import android.content.ComponentName;
+import android.content.ContentValues;
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.net.Uri;
+
+import com.ichi2.anki.FlashCardsContract;
+import com.ichi2.anki.provider.BaseCardContentProvider;
+
+import timber.log.Timber;
+
+/**
+ * Legacy ContentProvider that is designed to use a more relaxed permissions scheme than the newer provider in order to
+ * work around the following design flaw in the Android framework on Android SDK 22 and below:
+ * <a href="https://code.google.com/p/android/issues/detail?id=25906">Issue 25906:	Permissions Are Install-Order Dependent</a>
+ * This provider is disabled on Android Marshmallow and above.
+ */
+@Deprecated
+public final class CardContentProvider extends BaseCardContentProvider {
+    private static final int VER = 1;
+    static {
+        // Here you can see all the URIs at a glance
+        sUriMatcher.addURI(FlashCardsContract.getAuthority(VER), "notes", NOTES);
+        sUriMatcher.addURI(FlashCardsContract.getAuthority(VER), "notes/#", NOTES_ID);
+        sUriMatcher.addURI(FlashCardsContract.getAuthority(VER), "notes/#/cards", NOTES_ID_CARDS);
+        sUriMatcher.addURI(FlashCardsContract.getAuthority(VER), "notes/#/cards/#", NOTES_ID_CARDS_ORD);
+        sUriMatcher.addURI(FlashCardsContract.getAuthority(VER), "models", MODELS);
+        sUriMatcher.addURI(FlashCardsContract.getAuthority(VER), "models/*", MODELS_ID);
+        sUriMatcher.addURI(FlashCardsContract.getAuthority(VER), "models/*/templates", MODELS_ID_TEMPLATES);
+        sUriMatcher.addURI(FlashCardsContract.getAuthority(VER), "models/*/templates/#", MODELS_ID_TEMPLATES_ID);
+        sUriMatcher.addURI(FlashCardsContract.getAuthority(VER), "schedule/", SCHEDULE);
+        sUriMatcher.addURI(FlashCardsContract.getAuthority(VER), "decks/", DECKS);
+        sUriMatcher.addURI(FlashCardsContract.getAuthority(VER), "decks/#", DECKS_ID);
+        sUriMatcher.addURI(FlashCardsContract.getAuthority(VER), "selected_deck/", DECK_SELECTED);
+    }
+
+    @Override
+    public int update(Uri uri, ContentValues values, String selection, String[] selectionArgs) {
+        Context c = getContext();
+        if (c == null) {
+            return 0;
+        }
+        if (c.checkCallingPermission(FlashCardsContract.READ_WRITE_PERMISSION) != PackageManager.PERMISSION_GRANTED) {
+            throw new SecurityException("Update permission not granted for: " + uri);
+        }
+        return super.update(uri, values, selection, selectionArgs);
+    }
+
+    @Override
+    public int delete(Uri uri, String selection, String[] selectionArgs) {
+        Context c = getContext();
+        if (c == null) {
+            return 0;
+        }
+        if (c.checkCallingPermission(FlashCardsContract.READ_WRITE_PERMISSION) != PackageManager.PERMISSION_GRANTED) {
+            throw new SecurityException("Delete permission not granted for: " + uri);
+        }
+        return super.delete(uri, selection, selectionArgs);
+    }
+
+    /**
+     * Enable or disable the ContentProvider
+     */
+    public static void setEnabledState(Context context, boolean enabled) {
+        ComponentName providerName = new ComponentName(context, "com.ichi2.anki.provider.legacy.CardContentProvider");
+        PackageManager pm = context.getPackageManager();
+        int state = (enabled) ? PackageManager.COMPONENT_ENABLED_STATE_ENABLED:
+                PackageManager.COMPONENT_ENABLED_STATE_DISABLED;
+        pm.setComponentEnabledSetting(providerName, state, PackageManager.DONT_KILL_APP);
+    }
+}

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -144,5 +144,5 @@
     <string name="card_template_editor_would_delete_note">Removing this card type would cause one or more notes to be deleted. Please create a new card type first.</string>
     <!-- Permissions -->
     <string name="read_write_permission_label">Read and write to the AnkiDroid database</string>
-    <string name="read_write_permission_description">Allow the application to access existing notes, cards, note types, and decks, as well as create new ones</string>
+    <string name="read_write_permission_description">Allow the application full access to your AnkiDroid collection. It may insert, edit, and delete notes, cards, note types, and decks</string>
 </resources>

--- a/api/src/main/java/com/ichi2/anki/FlashCardsContract.java
+++ b/api/src/main/java/com/ichi2/anki/FlashCardsContract.java
@@ -107,16 +107,37 @@ import android.net.Uri;
  * </table>
  */
 public class FlashCardsContract {
-    public static final String AUTHORITY = "com.ichi2.anki.flashcards";
+    private static final String AUTHORITY_V2 =  "com.ichi2.anki.flashcards.v2";
+    private static final String AUTHORITY_LEGACY =  "com.ichi2.anki.flashcards";
     public static final String READ_WRITE_PERMISSION = "com.ichi2.anki.permission.READ_WRITE_DATABASE";
 
-    /**
-     * A content:// style uri to the authority for the flash card provider
-     */
-    public static final Uri AUTHORITY_URI = Uri.parse("content://" + AUTHORITY);
+    /** Legacy fields that used to be public **/
+    private static final String URI_FORMAT = "content://%s";
+    private static final Uri AUTHORITY_URI_LEGACY = Uri.parse(String.format(URI_FORMAT, AUTHORITY_LEGACY));
+    /** Deprecated since API v2. Use getAuthority() instead **/
+    @Deprecated
+    public static final String AUTHORITY = AUTHORITY_LEGACY;
+
+    /** Deprecated since API v2. Use getAuthority() instead **/
+    @Deprecated
+    public static final Uri AUTHORITY_URI = AUTHORITY_URI_LEGACY;
+
 
     /* Don't create instances of this class. */
     private FlashCardsContract() {
+    }
+
+    /**
+     * A content:// style uri to the authority for the flash card provider
+     * @param version The version of the provider to use. Currently 2 or higher gives the current provider,
+     *                while 1 gives the legacy provider for use with Android SDK 22 and below.
+     */
+    public static String getAuthority(int version) {
+        if (version > 1) {
+            return AUTHORITY_V2;
+        } else {
+            return AUTHORITY_LEGACY;
+        }
     }
 
 
@@ -250,6 +271,8 @@ public class FlashCardsContract {
      * </table>
      */
     public static class Note {
+        private static final String URI_SUBPATH = "notes";
+
         /**
          * The content:// style URI for notes. If the it is appended by the note's ID, this
          * note can be directly accessed, e.g.
@@ -272,7 +295,13 @@ public class FlashCardsContract {
          *
          * For examples on how to use the URI for queries see class description.
          */
-        public static final Uri CONTENT_URI = Uri.withAppendedPath(AUTHORITY_URI, "notes");
+        public static Uri getUri(int version) {
+            return Uri.withAppendedPath(Uri.parse(String.format(URI_FORMAT, getAuthority(version))), URI_SUBPATH);
+        }
+
+        /** Deprecated from v2: Use getUri() instead **/
+        @Deprecated
+        public static final Uri CONTENT_URI = Uri.withAppendedPath(AUTHORITY_URI_LEGACY, URI_SUBPATH);
 
         /**
          * This is the ID of the note. It is the same as the note ID in Anki. This ID can be
@@ -402,11 +431,20 @@ public class FlashCardsContract {
      * </p>
      */
     public static class Model {
+        private static final String URI_SUBPATH = "models";
+
         /**
          * The content:// style URI for model. If the it is appended by the model's ID, this
          * note can be directly accessed. See class description above for further details.
          */
-        public static final Uri CONTENT_URI = Uri.withAppendedPath(AUTHORITY_URI, "models");
+        public static Uri getUri(int version) {
+            return Uri.withAppendedPath(Uri.parse(String.format(URI_FORMAT, getAuthority(version))), URI_SUBPATH);
+        }
+
+        /** Deprecated from v2: Use getUri() instead **/
+        @Deprecated
+        public static final Uri CONTENT_URI = Uri.withAppendedPath(AUTHORITY_URI_LEGACY, URI_SUBPATH);
+
         public static final String CURRENT_MODEL_ID = "current";
 
         /**
@@ -453,6 +491,8 @@ public class FlashCardsContract {
      * be generated for each active CardTemplate which is defined.
      */
     public static class CardTemplate {
+        public static final String URI_SUBPATH = "templates";
+
 
         /**
          * MIME type used for data.
@@ -659,6 +699,8 @@ public class FlashCardsContract {
      * </pre>
      */
     public static class Card {
+        public static final String URI_SUBPATH = "cards";
+
         /**
          * This is the ID of the note that this card belongs to (i.e. {@link Note#_ID}).
          */
@@ -850,8 +892,15 @@ public class FlashCardsContract {
      * </pre>
      */
     public static class ReviewInfo {
+        private static final String URI_SUBPATH = "schedule";
 
-        public static final Uri CONTENT_URI = Uri.withAppendedPath(AUTHORITY_URI, "schedule");
+        public static Uri getUri(int version) {
+            return Uri.withAppendedPath(Uri.parse(String.format(URI_FORMAT, getAuthority(version))), URI_SUBPATH);
+        }
+
+        /** Deprecated from v2: Use getUri() instead **/
+        @Deprecated
+        public static Uri CONTENT_URI = Uri.withAppendedPath(AUTHORITY_URI_LEGACY, URI_SUBPATH);
 
         /**
          * This is the ID of the note that this card belongs to (i.e. {@link Note#_ID}).
@@ -1019,9 +1068,23 @@ public class FlashCardsContract {
      */
 
     public static class Deck {
+        private static final String URI_SUBPATH = "decks";
 
-        public static final Uri CONTENT_ALL_URI = Uri.withAppendedPath(AUTHORITY_URI, "decks");
-        public static final Uri CONTENT_SELECTED_URI = Uri.withAppendedPath(AUTHORITY_URI, "selected_deck");
+        public static Uri getUri(int version) {
+            return Uri.withAppendedPath(Uri.parse(String.format(URI_FORMAT, getAuthority(version))), URI_SUBPATH);
+        }
+
+        /** Deprecated from v2: Use getUri() instead **/
+        @Deprecated
+        public static final Uri CONTENT_ALL_URI = Uri.withAppendedPath(AUTHORITY_URI_LEGACY, URI_SUBPATH);
+
+        public static Uri getSelectedUri(int version) {
+            return Uri.withAppendedPath(Uri.parse(String.format(URI_FORMAT, getAuthority(version))), "selected_deck");
+        }
+
+        /** Deprecated from v2: Use getSelectedUri() instead **/
+        @Deprecated
+        public static final Uri CONTENT_SELECTED_URI = Uri.withAppendedPath(AUTHORITY_URI_LEGACY, "selected_deck");
         /**
          * The name of the Deck
          */


### PR DESCRIPTION
This PR is designed to solve two problems:

1) Improve security of the ContentProvider when the user has an Android M device or higher, as we don't need to worry about the install order dependency design flaw in the Android framework.

This is achieved by refactoring the ContentProvider code into an abstract class, and then splitting into two implementations: `CardContentProvider` (a legacy version using the previous permissions structure), and `CardContentProvider2` (a new provider that uses properly enforced static permissions, but with the same implementation as before).

On Android M and above, the legacy provider is completely disabled, and the setting in advanced preferences is removed as the Android operating system does a better job of handling access, by way of our custom permission.

2) Fix the failing unit tests

This is achieved by switching the unit tests over to `CardContentProvider2`, which makes the tests pass due to the use of static permissions.