### PR TITLE
Fix an issue that data in Cookies may be lost

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -176,6 +176,9 @@ public class AnkiDroidApp extends Application {
         // Configure WebView to allow file scheme pages to access cookies.
         CompatHelper.getCompat().enableCookiesForFileSchemePages();
 
+        // Prepare Cookies to be synchronized between RAM and permanent storage.
+        CompatHelper.getCompat().prepareWebViewCookies(this.getApplicationContext());
+
         // Set good default values for swipe detection
         final ViewConfiguration vc = ViewConfiguration.get(this);
         DEFAULT_SWIPE_MIN_DISTANCE = vc.getScaledPagingTouchSlop();

--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
@@ -60,5 +60,7 @@ public interface Compat {
     void openUrl(AnkiActivity activity, Uri uri);
     void supportAddContentMenu(final DeckPicker a);
     Intent getPreferenceSubscreenIntent(Context context, String subscreen);
+    void prepareWebViewCookies(Context context);
+    void flushWebViewCookies();
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV10.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV10.java
@@ -14,6 +14,7 @@ import android.support.annotation.NonNull;
 import android.support.v4.content.ContextCompat;
 import android.view.View;
 import android.view.WindowManager;
+import android.webkit.CookieSyncManager;
 import android.widget.EditText;
 import android.widget.LinearLayout;
 import android.widget.RemoteViews;
@@ -73,6 +74,18 @@ public class CompatV10 implements Compat {
         Timber.w("Cookies not supported in API version %d", CompatHelper.getSdkVersion());
     }
 
+    // CookieSyncManager is need to be initialized before use.
+    // Note: CookieSyncManager is deprecated since API level 21, but still need to be used here.
+    public void prepareWebViewCookies(Context context) {
+        CookieSyncManager.createInstance(context);
+    }
+
+    // A data of cookies may be lost when an application exists just after it was written.
+    // Below API level 21, this problem can be solved by using CookieSyncManager.sync().
+    // Note: CookieSyncManager is deprecated since API level 21, but still need to be used here.
+    public void flushWebViewCookies() {
+        CookieSyncManager.getInstance().sync();
+    }
 
     // Below API level 16, widget dimensions cannot be adjusted
     public void updateWidgetDimensions(Context context, RemoteViews updateViews, Class<?> cls) {

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.java
@@ -2,11 +2,13 @@
 package com.ichi2.compat;
 
 import android.annotation.TargetApi;
+import android.content.Context;
 import android.content.res.TypedArray;
 import android.view.View;
+import android.webkit.CookieManager;
 
-/** Implementation of {@link Compat} for SDK level 19 */
-@TargetApi(19)
+/** Implementation of {@link Compat} for SDK level 21 */
+@TargetApi(21)
 public class CompatV21 extends CompatV19 implements Compat {
     @Override
     public void setSelectableBackground(View view) {
@@ -15,5 +17,18 @@ public class CompatV21 extends CompatV19 implements Compat {
         TypedArray ta = view.getContext().obtainStyledAttributes(attrs);
         view.setBackgroundResource(ta.getResourceId(0, 0));
         ta.recycle();
+    }
+
+    // On API level 21 and higher, CookieManager will be set automatically, so there is nothing to do here.
+    @Override
+    public void prepareWebViewCookies(Context context) {
+
+    }
+
+    // A data of cookies may be lost when an application exists just after it was written.
+    // On API level 21 and higher, this problem can be solved by using CookieManager.flush().
+    @Override
+    public void flushWebViewCookies() {
+        CookieManager.getInstance().flush();
     }
 }


### PR DESCRIPTION
I encountered a problem that a data saved to Cookies by JavaScript was sometimes to be lost only in the last one. I tried and found out that [CookieManager](http://developer.android.com/reference/android/webkit/CookieManager.html) managed Cookies asynchronously and because of that the changes applied to Cookies after the last synchronization process was lost. Therefore, it is necessary to specify the timings when it to sync Cookies manifestly. I guess calling [`CookieManager.flush()`](http://developer.android.com/reference/android/webkit/CookieManager.html#flush()) in [`onPause()`](https://github.com/ankidroid/Anki-Android/blob/develop/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java#L905) and [`onDestroy()`](https://github.com/ankidroid/Anki-Android/blob/develop/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java#L933)  in [AbstractFlashcardViewer.java](https://github.com/ankidroid/Anki-Android/blob/develop/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java) will be sufficient.

And I also found a little bit of a problem that [WebView](http://developer.android.com/reference/android/webkit/WebView.html) instances were not released on [`onDestroy()`](https://github.com/ankidroid/Anki-Android/blob/develop/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java#L933) in [AbstractFlashcardViewer.java](https://github.com/ankidroid/Anki-Android/blob/develop/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java). [`WebView.destroy()`](http://developer.android.com/reference/android/webkit/WebView.html#destroy()) should be called after use as described in the document. This may cause a memory leak, though the effects due to it were highly unlikely.