### PR TITLE
Add canQuery() to api

### DIFF
--- a/api/src/main/java/com/ichi2/anki/api/AddContentApi.java
+++ b/api/src/main/java/com/ichi2/anki/api/AddContentApi.java
@@ -66,6 +66,27 @@ public final class AddContentApi {
     }
 
     /**
+     * Check whether we have permission to call query methods such as #findNotes
+     *
+     * @param modelId model ID. Use -1 for queries not specific to a model
+     * @return true iff permission granted (if modelId does not exist then result is unspecified)
+     */
+    public boolean canQuery(long modelId) {
+        // for future-proof compatibility, we should do a real check
+        try {
+            if (modelId < 0L) {
+                return getModelList() != null;
+            }
+            else {
+                return getNoteCount(modelId) >= 0;
+            }
+        }
+        catch (SecurityException e) {
+            return false;
+        }
+    }
+
+    /**
      * Create a new note with specified fields, tags, and model and place it in the specified deck.
      * No duplicate checking is performed - so the note should be checked beforehand using #findNotesByKeys
      * @param modelId ID for the model used to add the notes


### PR DESCRIPTION
This is for the client to check whether they have permission to query the API. It does a real check on the provider so should be compatible with future versions (when you start to enforce permission checking on pre-M).

I can't add a canInsert() method because (in the case where the client has insert permission, but not delete permission) it could leave "temporary" notes/model etc used for the check.