### PR TITLE
Fix broken custom sync server media server url generation

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteMediaServer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteMediaServer.java
@@ -61,7 +61,7 @@ public class RemoteMediaServer extends HttpSyncer {
         // Allow user to specify custom sync server
         SharedPreferences userPreferences = AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance());
         if (userPreferences!= null && userPreferences.getBoolean("useCustomSyncServer", false)) {
-            Uri mediaSyncBase = Uri.parse(userPreferences.getString("syncBaseUrl", Consts.SYNC_BASE));
+            Uri mediaSyncBase = Uri.parse(userPreferences.getString("syncMediaUrl", Consts.SYNC_MEDIA_BASE));
             return mediaSyncBase.toString() + "/";
         }
         // Usual case


### PR DESCRIPTION
Commit 8273eb8e2cb0006af8a37208c08b2b9a5e168c68 fixed a mistake in
the way custom sync server URLs are assembled, but at the same time it
broke the generation of the media server URL.