### PR TITLE
Fix activity with back icon not going back

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
@@ -45,6 +45,7 @@ public class NavigationDrawerActivity extends AnkiActivity implements Navigation
     /** Navigation Drawer */
     protected CharSequence mTitle;
     protected Boolean mFragmented = false;
+    private boolean mNavButtonGoesBack = false;
     // Other members
     private String mOldColPath;
     private int mOldTheme;
@@ -72,13 +73,15 @@ public class NavigationDrawerActivity extends AnkiActivity implements Navigation
             getSupportActionBar().setDisplayHomeAsUpEnabled(true);
             getSupportActionBar().setHomeButtonEnabled(true);
 
-            // Open the nav drawer when the navigation button is tapped. We need to explicitly
-            // define this because locking the nav drawer (when gestures are enabled) prevents
-            // the nav drawer from opening even when tapping the navigation button.
+            // Decide which action to take when the navigation button is tapped.
             toolbar.setNavigationOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
-                    mDrawerLayout.openDrawer(Gravity.LEFT);
+                    if (mNavButtonGoesBack) {
+                        finishWithAnimation(ActivityTransitionAnimation.RIGHT);
+                    } else {
+                        mDrawerLayout.openDrawer(Gravity.LEFT);
+                    }
                 }
             });
         }
@@ -302,6 +305,7 @@ public class NavigationDrawerActivity extends AnkiActivity implements Navigation
         if (getSupportActionBar() != null) {
             getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         }
+        mNavButtonGoesBack = true;
     }
 
     public boolean isDrawerOpen() {


### PR DESCRIPTION
A NavigationDrawerActivity that opts to have a back button as the
navigation button will also override the button behaviour to go back.

Fixes https://github.com/ankidroid/Anki-Android/issues/4136