### PR TITLE
Tweaks for the inline replay button

### DIFF
--- a/AnkiDroid/src/main/assets/flashcard.css
+++ b/AnkiDroid/src/main/assets/flashcard.css
@@ -80,12 +80,33 @@ preferred over using JavaScript.
 }
 
 
-/* Make sure the replay buttons look black or white unless explicitly changed. */
-.replaybutton svg {
-    stroke: none;
-    fill: black;
+/* Make sure the replay buttons look black or white unless explicitly
+changed. Use some fancy CSS to make the button align vertically, and
+scale up, but not down.  */
+
+.replaybutton span {
+  display: inline-block;
+  vertical-align: middle;
+  padding: 5px;
 }
 
+.replaybutton span svg {
+  stroke: none;
+  fill: black;
+  display: inline;
+  height: 1em;
+  width: 1em;
+  min-width: 32px;
+  min-height: 32px;
+}
+
+.replaybutton span img {
+  display: inline;
+  height: 1em;
+  width: 1em;
+  min-width: 32px;
+  min-height: 32px;
+}
 .night_mode .replaybutton svg {
-    fill: white;
+  fill: white;
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.java
@@ -209,15 +209,16 @@ public class Sound {
             // and then appending the html code to add the play button
             String button;
             if (CompatHelper.getSdkVersion() >= Build.VERSION_CODES.HONEYCOMB) {
-                button = "<svg width=\"32\" height=\"32\"><polygon points=\"11,25 25,16 11,7\"/>Replay</svg>";
+                button = "<svg viewBox=\"0 0 32 32\"><polygon points=\"11,25 25,16 11,7\"/>Replay</svg>";
             } else {
                 button = "<img src='file:///android_asset/inline_play_button.png' />";
             }
             String soundMarker = matcher.group();
             int markerStart = contentLeft.indexOf(soundMarker);
             stringBuilder.append(contentLeft.substring(0, markerStart));
+            // The <span> around the button (SVG or PNG image) is needed to make the vertical alignment work.
             stringBuilder.append("<a class='replaybutton' href=\"playsound:" + soundPath + "\">"
-                    + "<span style='padding:5px;'>"+ button
+                    + "<span>"+ button
                     + "</span></a>");
             contentLeft = contentLeft.substring(markerStart + soundMarker.length());
             Timber.d("Content left = %s", contentLeft);


### PR DESCRIPTION
Make the replay button scale up for large text, but use a minimum size for small text, and make the button vertically align.

Fixes #4162 
Although i am not sure about the shape of the touch feedback. I couldn’t reproduce that, it looks good on the several devices where it tested it.

Images (See #4162 for “before”):

![screenshot_2016-03-23-12-10-22](https://cloud.githubusercontent.com/assets/1690429/13984225/2d36a286-f0f5-11e5-9597-7d14f96b0f63.png)
![screenshot_2016-03-23-12-11-03](https://cloud.githubusercontent.com/assets/1690429/13984231/30d03b82-f0f5-11e5-8508-4a59304cd4ec.png)
 
Also tested with Gingerbread, there the PNG naturally gets blurry when you scale it up, but otherwise it looks basically the same.