### PR TITLE
Add 3rd party app support for showing Delete Empty Cards dialog using intent

### DIFF
--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -128,6 +128,10 @@
                 <action android:name="com.ichi2.anki.DO_SYNC" />
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="com.ichi2.anki.DELETE_EMPTY_CARDS" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
         </activity>
         <activity
             android:theme="@style/Theme_Dark_Compat.Launcher"

--- a/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.java
@@ -124,11 +124,11 @@ public class IntentHandler extends Activity {
                         .build().show();
             }
         } else if ("com.ichi2.anki.DO_SYNC".equals(action)) {
-            sendDoSyncMsg();
             reloadIntent.setAction(action);
-            reloadIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-            startActivity(reloadIntent);
-            finishWithFade();
+            handleDialogHandlerMsg(DialogHandler.MSG_DO_SYNC, reloadIntent);
+        } else if ("com.ichi2.anki.DELETE_EMPTY_CARDS".equals(action)) {
+            reloadIntent.setAction(action);
+            handleDialogHandlerMsg(DialogHandler.MSG_DELETE_EMPTY_CARDS, reloadIntent);
         } else {
             // Launcher intents should start DeckPicker if no other task exists,
             // otherwise go to previous task
@@ -167,14 +167,17 @@ public class IntentHandler extends Activity {
     }
 
     /**
-     * Send a Message to AnkiDroidApp so that the DialogMessageHandler forces a sync
+     * Send a Message to AnkiDroidApp so that the DialogHandler triggers the action
      */
-    private void sendDoSyncMsg() {
+    private void handleDialogHandlerMsg(int msg, Intent reloadIntent) {
         // Create a new message for DialogHandler
         Message handlerMessage = Message.obtain();
-        handlerMessage.what = DialogHandler.MSG_DO_SYNC;
+        handlerMessage.what = msg;
         // Store the message in AnkiDroidApp message holder, which is loaded later in AnkiActivity.onResume
         DialogHandler.storeMessage(handlerMessage);
+        reloadIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_FORWARD_RESULT);
+        startActivity(reloadIntent);
+        finishWithFade();
     }
 
     /** Finish Activity using FADE animation **/

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DialogHandler.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DialogHandler.java
@@ -41,6 +41,7 @@ public class DialogHandler extends Handler {
     public static final int MSG_SHOW_DATABASE_ERROR_DIALOG = 6;
     public static final int MSG_SHOW_FORCE_FULL_SYNC_DIALOG = 7;
     public static final int MSG_DO_SYNC = 8;
+    public static final int MSG_DELETE_EMPTY_CARDS = 9;
 
 
     WeakReference<AnkiActivity> mActivity;
@@ -112,6 +113,9 @@ public class DialogHandler extends Handler {
                 }
             }
             mActivity.get().finishWithoutAnimation();
+        } else if (msg.what == MSG_DELETE_EMPTY_CARDS) {
+            ((DeckPicker) mActivity.get()).handleEmptyCards(true);
+            // don't finish the activity now - because waiting for user response to dialog
         }
     }
 


### PR DESCRIPTION
The activity is auto-finished in any of the following instances:

1. There are no empty cards to delete
2. The user presses back or cancel on confirmation dialog
3. The user confirms deletion of the empty cards