### PR TITLE
Remove unused totals from deck overview

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
@@ -519,7 +519,7 @@ public class StudyOptionsFragment extends Fragment implements Toolbar.OnMenuItem
                     int revCards = (Integer) obj[2];
                     int totalNew = (Integer) obj[3];
                     int totalCards = (Integer) obj[4];
-                    int eta = (Integer) obj[7];
+                    int eta = (Integer) obj[5];
 
                     // Don't do anything if the fragment is no longer attached to it's Activity or col has been closed
                     if (getActivity() == null) {

--- a/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
@@ -701,10 +701,8 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
             int[] counts = sched.counts();
             int totalNewCount = sched.totalNewForCurrentDeck();
             int totalCount = sched.cardCount();
-            double progressMature = ((double) sched.matureCount()) / ((double) totalCount);
-            double progressAll = 1 - (((double) (totalNewCount + counts[1])) / ((double) totalCount));
-            return new TaskData(new Object[] { counts[0], counts[1], counts[2], totalNewCount, totalCount,
-                    progressMature, progressAll, sched.eta(counts)});
+            return new TaskData(new Object[]{counts[0], counts[1], counts[2], totalNewCount,
+                    totalCount, sched.eta(counts)});
         } catch (RuntimeException e) {
             Timber.e(e, "doInBackgroundUpdateValuesFromDeck - an error occurred");
             return null;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sched.java
@@ -2371,12 +2371,6 @@ public class Sched {
     }
 
 
-    public int matureCount() {
-        String dids = _deckLimit();
-        return mCol.getDb().queryScalar("SELECT count() FROM cards WHERE type = 2 AND ivl >= 21 AND did IN " + dids);
-    }
-
-
     public int eta(int[] counts) {
         return eta(counts, true);
     }


### PR DESCRIPTION
The old deck overview screen had a progress bar thing that is no longer used. This commit cuts a whole SQL query from building that view so it should speed things up a little.