### PR TITLE
Remove latency for long-tap to work in Browser

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
@@ -616,10 +616,16 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
     private TaskData doInBackgroundSearchCards(TaskData... params) {
         Timber.d("doInBackgroundSearchCards");
         Collection col = CollectionHelper.getInstance().getCol(mContext);
-        HashMap<String, String> deckNames = (HashMap<String, String>) params[0].getObjArray()[0];
+        Map<String, String> deckNames = (HashMap<String, String>) params[0].getObjArray()[0];
         String query = (String) params[0].getObjArray()[1];
         Boolean order = (Boolean) params[0].getObjArray()[2];
-        ArrayList<HashMap<String,String>> searchResult = col.findCardsForCardBrowser(query, order, deckNames);
+        List<Map<String,String>> searchResult = col.findCardsForCardBrowser(query, order, deckNames);
+        // Render the first few items
+        for (int i = 0; i < Math.min(CardBrowser.MIN_CARDS_TO_RENDER, searchResult.size()); i++) {
+            Card c = col.getCard(Long.parseLong(searchResult.get(i).get("id"), 10));
+            CardBrowser.updateSearchItemQA(searchResult.get(i), c);
+        }
+        // Finish off the task
         if (isCancelled()) {
             Timber.d("doInBackgroundSearchCards was cancelled so return null");
             return null;
@@ -633,7 +639,7 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
     private TaskData doInBackgroundRenderBrowserQA(TaskData... params) {
         Timber.d("doInBackgroundRenderBrowserQA");
         Collection col = CollectionHelper.getInstance().getCol(mContext);
-        ArrayList<HashMap<String, String>> items = (ArrayList<HashMap<String, String>>) params[0].getObjArray()[0];
+        List<Map<String, String>> items = (List<Map<String, String>>) params[0].getObjArray()[0];
         Integer startPos = (Integer) params[0].getObjArray()[1];
         Integer n = (Integer) params[0].getObjArray()[2];
 
@@ -1342,7 +1348,7 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
         private int mInteger;
         private String mMsg;
         private boolean mBool = false;
-        private ArrayList<HashMap<String, String>> mCards;
+        private List<Map<String, String>> mCards;
         private long mLong;
         private Context mContext;
         private int mType;
@@ -1399,12 +1405,12 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
         }
 
 
-        public TaskData(ArrayList<HashMap<String, String>> cards) {
+        public TaskData(List<Map<String, String>> cards) {
             mCards = cards;
         }
 
 
-        public TaskData(ArrayList<HashMap<String, String>> cards, Comparator comparator) {
+        public TaskData(List<Map<String, String>> cards, Comparator comparator) {
             mCards = cards;
             mComparator = comparator;
         }
@@ -1472,12 +1478,12 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
         }
 
 
-        public ArrayList<HashMap<String, String>> getCards() {
+        public List<Map<String, String>> getCards() {
             return mCards;
         }
 
 
-        public void setCards(ArrayList<HashMap<String, String>> cards) {
+        public void setCards(List<Map<String, String>> cards) {
             mCards = cards;
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1058,7 +1058,7 @@ public class Collection {
     }
 
 
-    public ArrayList<HashMap<String, String>> findCardsForCardBrowser(String search, boolean order, HashMap<String, String> deckNames) {
+    public List<Map<String, String>> findCardsForCardBrowser(String search, boolean order, Map<String, String> deckNames) {
         return new Finder(this).findCardsForCardBrowser(search, order, deckNames);
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
@@ -1010,26 +1010,23 @@ public class Finder {
      * ***********************************************************
      */
 
-    public ArrayList<HashMap<String, String>> findCardsForCardBrowser(String query, boolean _order,
-            HashMap<String, String> deckNames) {
+    public List<Map<String, String>> findCardsForCardBrowser(String query, boolean _order, Map<String, String> deckNames) {
         return _findCardsForCardBrowser(query, _order, deckNames);
     }
 
 
-    public ArrayList<HashMap<String, String>> findCardsForCardBrowser(String query, String _order,
-            HashMap<String, String> deckNames) {
+    public List<Map<String, String>> findCardsForCardBrowser(String query, String _order, Map<String, String> deckNames) {
         return _findCardsForCardBrowser(query, _order, deckNames);
     }
 
 
     /** Return a list of card ids for QUERY */
-    private ArrayList<HashMap<String, String>> _findCardsForCardBrowser(String query, Object _order,
-            HashMap<String, String> deckNames) {
+    private List<Map<String, String>> _findCardsForCardBrowser(String query, Object _order, Map<String, String> deckNames) {
         String[] tokens = _tokenize(query);
         Pair<String, String[]> res1 = _where(tokens);
         String preds = res1.first;
         String[] args = res1.second;
-        ArrayList<HashMap<String, String>> res = new ArrayList<>();
+        List<Map<String, String>> res = new ArrayList<>();
         if (preds == null) {
             return res;
         }
@@ -1047,7 +1044,7 @@ public class Finder {
                     Timber.i("_findCardsForCardBrowser() cancelled...");
                     return null;
                 }                
-                HashMap<String, String> map = new HashMap<>();
+                Map<String, String> map = new HashMap<>();
                 map.put("id", cur.getString(0));
                 map.put("sfld", cur.getString(1));
                 map.put("deck", deckNames.get(cur.getString(2)));


### PR DESCRIPTION
Previously we were calling `TASK_TYPE_RENDER_BROWSER_QA` with the first 1000 cards in the result from `mSearchCardsHandler.onPostExecute()`.

Since the `mRenderQAHandler` does a `notifyDataSetChanged()` for EVERY card in the list as they're updated, this was effectively blocking the long-click listener for the cards, so I moved that initial card rendering code into the first DeckTask and dropped MIN_CARDS_TO_RENDER from 1000 to 500.

I also did a little bit of tidying up like using the List and Map interfaces polymorphically instead of the ArrayList and HashMap implementations.

Fixes #4191