### PR TITLE
add a workaround option allowJSMediaAutoPlay

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -2207,6 +2207,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
         Timber.d("fillFlashcard()");
         Timber.d("base url = %s", mBaseUrl);
         if (!mUseQuickUpdate && mCard != null && mNextCard != null) {
+            CompatHelper.getCompat().setHTML5MediaAutoPlay(mNextCard.getSettings(), getConfigForCurrentCard().optBoolean("autoplay"));
             mNextCard.loadDataWithBaseURL(mBaseUrl + "__viewer__.html", mCardContent.toString(), "text/html", "utf-8", null);
             mNextCard.setVisibility(View.VISIBLE);
             mCardFrame.removeView(mCard);
@@ -2216,6 +2217,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
             mNextCard.setVisibility(View.GONE);
             mCardFrame.addView(mNextCard, 0);
         } else if (mCard != null) {
+            CompatHelper.getCompat().setHTML5MediaAutoPlay(mCard.getSettings(), getConfigForCurrentCard().optBoolean("autoplay"));
             mCard.loadDataWithBaseURL(mBaseUrl + "__viewer__.html", mCardContent.toString(), "text/html", "utf-8", null);
         }
         if (mShowTimer && mCardTimer.getVisibility() == View.INVISIBLE) {

--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
@@ -22,6 +22,7 @@ import android.database.sqlite.SQLiteDatabase;
 import android.net.Uri;
 import android.speech.tts.TextToSpeech;
 import android.view.View;
+import android.webkit.WebSettings;
 import android.widget.RemoteViews;
 
 import com.ichi2.anki.AbstractFlashcardViewer;
@@ -62,5 +63,6 @@ public interface Compat {
     Intent getPreferenceSubscreenIntent(Context context, String subscreen);
     void prepareWebViewCookies(Context context);
     void flushWebViewCookies();
+    void setHTML5MediaAutoPlay(WebSettings settings, Boolean allow);
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatHelper.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatHelper.java
@@ -36,6 +36,8 @@ public class CompatHelper {
             mCompat = new CompatV21();
         } else if (getSdkVersion() >= 19) {
             mCompat = new CompatV19();
+        } else if (getSdkVersion() >= 17) {
+            mCompat = new CompatV17();
         } else if (getSdkVersion() >= 16) {
             mCompat = new CompatV16();
         } else if (getSdkVersion() >= 15) {

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV10.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV10.java
@@ -15,6 +15,7 @@ import android.support.v4.content.ContextCompat;
 import android.view.View;
 import android.view.WindowManager;
 import android.webkit.CookieSyncManager;
+import android.webkit.WebSettings;
 import android.widget.EditText;
 import android.widget.LinearLayout;
 import android.widget.RemoteViews;
@@ -85,6 +86,11 @@ public class CompatV10 implements Compat {
     // Note: CookieSyncManager is deprecated since API level 21, but still need to be used here.
     public void flushWebViewCookies() {
         CookieSyncManager.getInstance().sync();
+    }
+
+    // Below API level 17, there is no simple way to enable the auto play feature of HTML media elements.
+    public void setHTML5MediaAutoPlay(WebSettings webSettings, Boolean allow) {
+
     }
 
     // Below API level 16, widget dimensions cannot be adjusted

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV17.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV17.java
@@ -1,0 +1,17 @@
+
+package com.ichi2.compat;
+
+import android.annotation.TargetApi;
+import android.webkit.WebSettings;
+
+import timber.log.Timber;
+
+/** Implementation of {@link Compat} for SDK level 17 */
+@TargetApi(17)
+public class CompatV17 extends CompatV16 implements Compat {
+
+    @Override
+    public void setHTML5MediaAutoPlay(WebSettings webSettings, Boolean allow) {
+        webSettings.setMediaPlaybackRequiresUserGesture(!allow);
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV19.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV19.java
@@ -16,7 +16,7 @@ import com.ichi2.anki.R;
 
 /** Implementation of {@link Compat} for SDK level 19 */
 @TargetApi(19)
-public class CompatV19 extends CompatV16 implements Compat {
+public class CompatV19 extends CompatV17 implements Compat {
     private static final int ANIMATION_DURATION = 200;
 
     @Override


### PR DESCRIPTION
This PR adds a option whether or not permit autoplay on HTML5 media element without a user gesture.
Anki, AnkiMobile and AnkiDroid supports audio/video elements as the special tag. It is very useful for normal use, but the specification of it lacks flexibility. 
For example, there is someone learning something with a large card, containing media elements sparsely, and he want to play a media when it appeared into the screen without a touch. He can not do it with the build-in feature, but can with JavaScript and this option.