### PR TITLE
fix manual link

### DIFF
--- a/CONTRIBUTING.asc
+++ b/CONTRIBUTING.asc
@@ -6,7 +6,7 @@ https://ankidroid.org/docs/help-ja.html[日本語]
 
 == Before Asking
 
-Before asking for help, please try searching through the link:manual.html[AnkiDroid Manual], the list of https://github.com/ankidroid/Anki-Android/wiki/FAQ[Frequently Asked Questions], and also the main http://ankisrs.net/docs/manual.html[Anki Manual] for general help with the Anki system and features, and any issues not limited to Android.
+Before asking for help, please try searching through the https://ankidroid.org/docs/manual.html[AnkiDroid Manual], the list of https://github.com/ankidroid/Anki-Android/wiki/FAQ[Frequently Asked Questions], and also the main http://ankisrs.net/docs/manual.html[Anki Manual] for general help with the Anki system and features, and any issues not limited to Android.
 
 == Support
 If you were unable to find what you needed in the documentation above, please visit the relevant site below:


### PR DESCRIPTION
previous link resolved to https://github.com/ankidroid/Anki-Android/blob/develop/manual.html, which 404-ed