### PR TITLE
Allow unit tests to work on SDK23 from command line

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -61,3 +61,5 @@ dependencies {
     compile 'com.google.code.gson:gson:2.4'
     compile project(":api")
 }
+
+apply from: "testconfig.gradle"

--- a/AnkiDroid/testconfig.gradle
+++ b/AnkiDroid/testconfig.gradle
@@ -1,0 +1,12 @@
+def adb = android.getAdbExe().toString()
+
+// hack that pre-installs the app with necessary permissions before connectedDebugAndroidTest re-installs
+task preInstallApp(type: Exec, dependsOn: 'assembleDebugAndroidTest') {
+    commandLine "$adb install -g ./build/outputs/apk/AnkiDroid-debug.apk".split(' ')
+}
+
+tasks.whenTaskAdded { task ->
+    if (task.name.startsWith('connectedDebugAndroidTest')) {
+        task.dependsOn preInstallApp
+    }
+}


### PR DESCRIPTION
This allows unit tests to run properly on an Android M device when calling the tests manually from the command line (i.e. `./gradlew connectedCheck`), and in the future should enable Travis to run the tests. 

I only have access to Android Studio 1.5 on the laptop I'm stuck with at the moment, but it seems that when it internally runs unit tests it doesn't call the gradle task (just builds and runs via adb), so this hack doesn't work in the IDE unfortunately.

The workaround there is to install and grant storage permissions manually before running tests.