### PR TITLE
Set journal_mode=delete when closing collection

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -308,6 +308,9 @@ public class Collection {
             } catch (RuntimeException e) {
                 AnkiDroidApp.sendExceptionReport(e, "closeDB");
             }
+            if (!mServer) {
+                mDb.getDatabase().rawQuery("pragma journal_mode = delete", null);
+            }
             mDb.close();
             mDb = null;
             mMedia.close();


### PR DESCRIPTION
From https://github.com/ankidroid/Anki-Android/issues/4213

For devices that force use of WAL mode. This will let them do a full sync upload. Should have no effect for everyone else. The desktop client has the same line of code for this.