### PR TITLE
Move snackbar methods so they are globally accessible

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -362,7 +362,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
             // Show hint about lookup function if dictionary available and Webview version supports text selection
             if (!mDisableClipboard && Lookup.isAvailable() && CompatHelper.isHoneycomb()) {
                 String lookupHint = getResources().getString(R.string.lookup_hint);
-                Themes.showThemedToast(AbstractFlashcardViewer.this, lookupHint, false);
+                UIUtils.showThemedToast(AbstractFlashcardViewer.this, lookupHint, false);
             }
             Vibrator vibratorManager = (Vibrator) getSystemService(Context.VIBRATOR_SERVICE);
             vibratorManager.vibrate(50);
@@ -620,7 +620,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
                 int nMins = elapsed[0].intValue() / 60;
                 String mins = res.getQuantityString(R.plurals.timebox_reached_minutes, nMins, nMins);
                 String timeboxMessage = res.getQuantityString(R.plurals.timebox_reached, nCards, nCards, mins);
-                Themes.showThemedToast(AbstractFlashcardViewer.this, timeboxMessage, true);
+                UIUtils.showThemedToast(AbstractFlashcardViewer.this, timeboxMessage, true);
                 getCol().startTimebox();
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
@@ -11,7 +11,6 @@ import android.graphics.Color;
 import android.media.AudioManager;
 import android.net.Uri;
 import android.os.Bundle;
-import android.support.design.widget.Snackbar;
 import android.support.v4.app.DialogFragment;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
@@ -21,14 +20,12 @@ import android.support.v4.app.NotificationCompat;
 import android.support.v4.content.ContextCompat;
 import android.support.v4.content.IntentCompat;
 import android.support.v4.content.Loader;
-
 import android.support.v7.app.AppCompatActivity;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup.LayoutParams;
 import android.view.animation.Animation;
 import android.widget.ProgressBar;
-import android.widget.TextView;
 
 import com.ichi2.anim.ActivityTransitionAnimation;
 import com.ichi2.anki.dialogs.AsyncDialogFragment;
@@ -389,66 +386,6 @@ public class AnkiActivity extends AppCompatActivity implements LoaderManager.Loa
         showSimpleMessageDialog(title, message, false);
     }
 
-    /**
-     * Show a simple Toast-like Snackbar with no actions. 
-     * To enable swipe-to-dismiss, the Activity layout should include a CoordinatorLayout with id "root_layout"
-     * @param mainTextResource
-     * @param shortLength
-     */
-    protected void showSimpleSnackbar(int mainTextResource, boolean shortLength) {
-        View root = findViewById(R.id.root_layout);
-        showSnackbar(mainTextResource, shortLength, -1, null, root);
-    }
-    protected void showSimpleSnackbar(String mainText, boolean shortLength) {
-        View root = findViewById(R.id.root_layout);
-        showSnackbar(mainText, shortLength, -1, null, root, null);
-    }
-
-    /**
-     * Show a snackbar with an action
-     * @param mainTextResource resource for the main text string
-     * @param shortLength whether or not to use long length
-     * @param actionTextResource resource for the text string shown as the action
-     * @param listener listener for the action (if null no action shown)
-     * @oaram root View Snackbar will attach to. Should be CoordinatorLayout for swipe-to-dismiss to work.
-     */
-    protected void showSnackbar(int mainTextResource, boolean shortLength, int actionTextResource,
-                                View.OnClickListener listener, View root) {
-        showSnackbar(mainTextResource,shortLength,actionTextResource,listener,root, null);
-    }
-    protected void showSnackbar(int mainTextResource, boolean shortLength, int actionTextResource,
-                                View.OnClickListener listener, View root, Snackbar.Callback callback) {
-        String mainText = getResources().getString(mainTextResource);
-        showSnackbar(mainText, shortLength, actionTextResource, listener, root, callback);
-    }
-    protected void showSnackbar(String mainText, boolean shortLength, int actionTextResource,
-                                View.OnClickListener listener, View root, Snackbar.Callback callback) {
-        if (root == null) {
-            root = findViewById(android.R.id.content);
-            if (root == null) {
-                Timber.e("Could not show Snackbar due to null View");
-                return;
-            }
-        }
-        int length = shortLength ? Snackbar.LENGTH_SHORT : Snackbar.LENGTH_LONG;
-        Snackbar sb = Snackbar.make(root, mainText, length);
-        if (listener != null) {
-            sb.setAction(actionTextResource, listener);
-        }
-        if (callback != null) {
-            sb.setCallback(callback);
-        }
-        // Make the text white to avoid interference from our theme colors.
-        View view = sb.getView();
-        TextView tv = (TextView) view.findViewById(android.support.design.R.id.snackbar_text);
-        TextView action = (TextView) view.findViewById(android.support.design.R.id.snackbar_action);
-        if (tv != null && action != null) {
-            tv.setTextColor(Color.WHITE);
-            action.setTextColor(ContextCompat.getColor(this, R.color.material_light_blue_500));
-            tv.setMaxLines(2);  // prevent tablets from truncating to 1 line
-        }
-        sb.show();
-    }
 
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -290,7 +290,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
         @Override
         public void OnSaveSearch(String searchName, String searchTerms) {
             if (TextUtils.isEmpty(searchName)) {
-                Themes.showThemedToast(CardBrowser.this,
+                UIUtils.showThemedToast(CardBrowser.this,
                         getString(R.string.card_browser_list_my_searches_new_search_error_empty_name), true);
                 return;
             }
@@ -305,7 +305,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
                     savedFiltersObj.put(searchName, searchTerms);
                     should_save = true;
                 } else {
-                    Themes.showThemedToast(CardBrowser.this,
+                    UIUtils.showThemedToast(CardBrowser.this,
                             getString(R.string.card_browser_list_my_searches_new_search_error_dup), true);
                 }
                 if (should_save) {
@@ -1070,7 +1070,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 Timber.i("CardBrowser:: Completed doInBackgroundSearchCards Successfuly");
                 updateList();
                 if (!mSearchView.isIconified()) {
-                    showSimpleSnackbar(getSubtitleText(), false);
+                    UIUtils.showSimpleSnackbar(CardBrowser.this, getSubtitleText(), false);
                 }
             }
             hideProgressBar();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
@@ -104,7 +104,7 @@ public class CardTemplateEditor extends AnkiActivity {
             } else if (result.getString() != null && result.getString().equals("removeTemplateFailed")) {
                 // Failed to remove template
                 String message = getResources().getString(R.string.card_template_editor_would_delete_note);
-                Themes.showThemedToast(CardTemplateEditor.this, message, false);
+                UIUtils.showThemedToast(CardTemplateEditor.this, message, false);
             } else {
                 // RuntimeException occurred
                 setResult(RESULT_CANCELED);
@@ -464,7 +464,7 @@ public class CardTemplateEditor extends AnkiActivity {
                         final JSONObject template = tmpls.getJSONObject(position);
                         // Don't do anything if only one template
                         if (tmpls.length() < 2) {
-                            Themes.showThemedToast(getActivity(), res.getString(R.string.card_template_editor_cant_delete), false);
+                            UIUtils.showThemedToast(getActivity(), res.getString(R.string.card_template_editor_cant_delete), false);
                             return true;
                         }
                         // Show confirmation dialog
@@ -495,7 +495,7 @@ public class CardTemplateEditor extends AnkiActivity {
                         if (dummyCard != null) {
                             cid = dummyCard.getId();
                         } else {
-                            ((AnkiActivity) getActivity()).showSimpleSnackbar(R.string.invalid_template, false);
+                            UIUtils.showSimpleSnackbar(getActivity(), R.string.invalid_template, false);
                             return true;
                         }
                     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
@@ -245,7 +245,7 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
                         } else if (key.equals("confRemove")) {
                             if (mOptions.getLong("id") == 1) {
                                 // Don't remove the options group if it's the default group
-                                Themes.showThemedToast(DeckOptions.this,
+                                UIUtils.showThemedToast(DeckOptions.this,
                                         getResources().getString(R.string.default_conf_delete_error), false);
                             } else {
                                 // Remove options group, handling the case where the user needs to confirm full sync

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -327,7 +327,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
             if (exportPath != null) {
                 showAsyncDialogFragment(DeckPickerExportCompleteDialog.newInstance(exportPath));
             } else {
-                Themes.showThemedToast(DeckPicker.this, getResources().getString(R.string.export_unsuccessful), true);
+                UIUtils.showThemedToast(DeckPicker.this, getResources().getString(R.string.export_unsuccessful), true);
             }
         }
 
@@ -658,9 +658,9 @@ public class DeckPicker extends NavigationDrawerActivity implements
             // Show a message when reviewing has finished
             int[] studyOptionsCounts = getCol().getSched().counts();
             if (studyOptionsCounts[0] + studyOptionsCounts[1] + studyOptionsCounts[2] == 0) {
-                showSimpleSnackbar(R.string.studyoptions_congrats_finished, false);
+                UIUtils.showSimpleSnackbar(this, R.string.studyoptions_congrats_finished, false);
             } else {
-                showSimpleSnackbar(R.string.studyoptions_no_cards_due, false);
+                UIUtils.showSimpleSnackbar(this, R.string.studyoptions_no_cards_due, false);
             }
         } else if (requestCode == REQUEST_BROWSE_CARDS) {
             // Store the selected deck after opening browser
@@ -949,7 +949,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
                     // Don't show new features dialog for development builds
                     preferences.edit().putString("lastVersion", VersionUtils.getPkgVersionName()).apply();
                     String ver = getResources().getString(R.string.updated_version, VersionUtils.getPkgVersionName());
-                    showSnackbar(ver, true, -1, null, findViewById(R.id.root_layout), null);
+                    UIUtils.showSnackbar(this, ver, true, -1, null, findViewById(R.id.root_layout), null);
                     showStartupScreensAndDialogs(preferences, 2);
                 }
             }
@@ -1079,7 +1079,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
             Resources res = AnkiDroidApp.getAppResources();
             showSimpleNotification(res.getString(R.string.app_name), res.getString(messageResource));
         } else {
-            showSimpleSnackbar(messageResource, false);
+            UIUtils.showSimpleSnackbar(this, messageResource, false);
         }
     }
 
@@ -1097,7 +1097,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
     }
 
     public void onSdCardNotMounted() {
-        Themes.showThemedToast(this, getResources().getString(R.string.sd_card_not_mounted), false);
+        UIUtils.showThemedToast(this, getResources().getString(R.string.sd_card_not_mounted), false);
         finishWithoutAnimation();
     }
 
@@ -1124,7 +1124,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
                     mProgressDialog.dismiss();
                 }
                 if (result == null || !result.getBoolean()) {
-                    Themes.showThemedToast(DeckPicker.this, getResources().getString(R.string.deck_repair_error), true);
+                    UIUtils.showThemedToast(DeckPicker.this, getResources().getString(R.string.deck_repair_error), true);
                     onCollectionLoadError();
                 }
             }
@@ -1636,7 +1636,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
         try {
             startActivityWithoutAnimation(intent);
         } catch (ActivityNotFoundException e) {
-            Themes.showThemedToast(this, getResources().getString(R.string.no_email_client), false);
+            UIUtils.showThemedToast(this, getResources().getString(R.string.no_email_client), false);
         }
     }
 
@@ -1743,7 +1743,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
             openStudyOptions(false);
         } else if (getCol().getSched().newDue() || getCol().getSched().revDue()) {
             // If there are no cards to review because of the daily study limit then give "Study more" option
-            showSnackbar(R.string.studyoptions_limit_reached, false, R.string.study_more, new OnClickListener() {
+            UIUtils.showSnackbar(this, R.string.studyoptions_limit_reached, false, R.string.study_more, new OnClickListener() {
                 @Override
                 public void onClick(View v) {
                     CustomStudyDialog d = CustomStudyDialog.newInstance(
@@ -1759,7 +1759,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
             // If the deck is empty and has no children then show a message saying it's empty
             final Uri helpUrl = Uri.parse(getResources().getString(R.string.link_manual_getting_started));
             mayOpenUrl(helpUrl);
-            showSnackbar(R.string.empty_deck, false, R.string.help, new OnClickListener() {
+            UIUtils.showSnackbar(this, R.string.empty_deck, false, R.string.help, new OnClickListener() {
                 @Override
                 public void onClick(View v) {
                     openUrl(helpUrl);
@@ -1767,7 +1767,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
             }, findViewById(R.id.root_layout), mSnackbarShowHideCallback);
         } else {
             // Otherwise say there are no cards scheduled to study, and give option to do custom study
-            showSnackbar(R.string.studyoptions_empty_schedule, false, R.string.custom_study, new OnClickListener() {
+            UIUtils.showSnackbar(this, R.string.studyoptions_empty_schedule, false, R.string.custom_study, new OnClickListener() {
                 @Override
                 public void onClick(View v) {
                     CustomStudyDialog d = CustomStudyDialog.newInstance(
@@ -1923,7 +1923,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
                                 col.getDecks().rename(col.getDecks().get(did), newName);
                             } catch (DeckRenameException e) {
                                 // We get a localized string from libanki to explain the error
-                                Themes.showThemedToast(DeckPicker.this, e.getLocalizedMessage(res), false);
+                                UIUtils.showThemedToast(DeckPicker.this, e.getLocalizedMessage(res), false);
                             }
                         }
                         dismissAllDialogFragments();
@@ -1954,7 +1954,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
             return;
         }
         if (did == 1) {
-            showSimpleSnackbar(R.string.delete_deck_default_deck, true);
+            UIUtils.showSimpleSnackbar(this, R.string.delete_deck_default_deck, true);
             dismissAllDialogFragments();
             return;
         }
@@ -2166,7 +2166,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
                         @Override
                         public void confirm() {
                             getCol().remCards(Utils.arrayList2array(cids));
-                            showSimpleSnackbar(String.format(
+                            UIUtils.showSimpleSnackbar(DeckPicker.this, String.format(
                                     getResources().getString(R.string.empty_cards_deleted), cids.size()), false);
                         }
                     };

--- a/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.java
@@ -139,7 +139,7 @@ public class MyAccount extends AnkiActivity {
         if (!"".equalsIgnoreCase(username) && !"".equalsIgnoreCase(password)) {
             Connection.login(loginListener, new Connection.Payload(new Object[]{username, password}));
         } else {
-            showSimpleSnackbar(R.string.invalid_username_password, true);
+            UIUtils.showSimpleSnackbar(this, R.string.invalid_username_password, true);
         }
     }
 
@@ -258,9 +258,9 @@ public class MyAccount extends AnkiActivity {
             } else {
                 Timber.e("Login failed, error code %d",data.returnType);
                 if (data.returnType == 403) {
-                    showSimpleSnackbar(R.string.invalid_username_password, true);
+                    UIUtils.showSimpleSnackbar(MyAccount.this, R.string.invalid_username_password, true);
                 } else {
-                    showSimpleSnackbar(R.string.connection_error_message, true);
+                    UIUtils.showSimpleSnackbar(MyAccount.this, R.string.connection_error_message, true);
                 }
             }
         }
@@ -268,7 +268,7 @@ public class MyAccount extends AnkiActivity {
 
         @Override
         public void onDisconnected() {
-            showSimpleSnackbar(R.string.youre_offline, true);
+            UIUtils.showSimpleSnackbar(MyAccount.this, R.string.youre_offline, true);
         }
     };
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -216,10 +216,10 @@ public class NoteEditor extends AnkiActivity {
                 } catch (JSONException e) {
                     throw new RuntimeException();
                 }
-                Themes.showThemedToast(NoteEditor.this,
+                UIUtils.showThemedToast(NoteEditor.this,
                         getResources().getQuantityString(R.plurals.factadder_cards_added, count, count), true);
             } else {
-                Themes.showThemedToast(NoteEditor.this, getResources().getString(R.string.factadder_saving_error), true);
+                UIUtils.showThemedToast(NoteEditor.this, getResources().getString(R.string.factadder_saving_error), true);
             }
             if (!mAddNote || mCaller == CALLER_CARDEDITOR || mAedictIntent) {
                 mChanged = true;
@@ -597,12 +597,12 @@ public class NoteEditor extends AnkiActivity {
                             mSourceText[1] = entry_lines[0];
                             mAedictIntent = true;
                         } else {
-                            Themes.showThemedToast(NoteEditor.this,
+                            UIUtils.showThemedToast(NoteEditor.this,
                                     getResources().getString(R.string.intent_aedict_empty), false);
                             return true;
                         }
                     } else {
-                        Themes.showThemedToast(NoteEditor.this, getResources().getString(R.string.intent_aedict_empty),
+                        UIUtils.showThemedToast(NoteEditor.this, getResources().getString(R.string.intent_aedict_empty),
                                 false);
                         return true;
                     }
@@ -610,7 +610,7 @@ public class NoteEditor extends AnkiActivity {
                 }
             }
         }
-        Themes.showThemedToast(NoteEditor.this, getResources().getString(R.string.intent_aedict_category), false);
+        UIUtils.showThemedToast(NoteEditor.this, getResources().getString(R.string.intent_aedict_category), false);
         return true;
     }
 
@@ -858,7 +858,7 @@ public class NoteEditor extends AnkiActivity {
                         getCol().getSched().forgetCards(new long[] { mCurrentEditedCard.getId() });
                         getCol().reset();
                         mReloadRequired = true;
-                        Themes.showThemedToast(NoteEditor.this,
+                        UIUtils.showThemedToast(NoteEditor.this,
                                 getResources().getString(R.string.reset_card_dialog_acknowledge), true);
                     }
                 };
@@ -975,7 +975,7 @@ public class NoteEditor extends AnkiActivity {
         getCol().getSched().reschedCards(new long[] { mCurrentEditedCard.getId() }, days, days);
         getCol().reset();
         mReloadRequired = true;
-        Themes.showThemedToast(NoteEditor.this,
+        UIUtils.showThemedToast(NoteEditor.this,
                 getResources().getString(R.string.reschedule_card_dialog_acknowledge), true);
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
@@ -436,8 +436,7 @@ public class StudyOptionsFragment extends Fragment implements Toolbar.OnMenuItem
                 int[] counts = getCol().getSched().counts();
                 if ((counts[0]+counts[1]+counts[2])>0 && mStudyOptionsView != null) {
                     View rootLayout = mStudyOptionsView.findViewById(R.id.studyoptions_main);
-                    AnkiActivity activity = (AnkiActivity) getActivity();
-                    activity.showSnackbar(R.string.studyoptions_no_cards_due, false, 0, null, rootLayout);
+                    UIUtils.showSnackbar(getActivity(), R.string.studyoptions_no_cards_due, false, 0, null, rootLayout);
                 }
             }
         } else if (requestCode == STATISTICS && mCurrentContentView == CONTENT_CONGRATS) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/UIUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/UIUtils.java
@@ -1,7 +1,14 @@
 
 package com.ichi2.anki;
 
+import android.app.Activity;
 import android.content.Context;
+import android.graphics.Color;
+import android.support.design.widget.Snackbar;
+import android.support.v4.content.ContextCompat;
+import android.view.View;
+import android.widget.TextView;
+import android.widget.Toast;
 
 import com.ichi2.async.DeckTask;
 import com.ichi2.async.DeckTask.TaskData;
@@ -11,6 +18,79 @@ import java.util.Calendar;
 import timber.log.Timber;
 
 public class UIUtils {
+
+    public static void showThemedToast(Context context, String text, boolean shortLength) {
+        Toast.makeText(context, text, shortLength ? Toast.LENGTH_SHORT : Toast.LENGTH_LONG).show();
+    }
+
+
+    /**
+     * Show a simple Toast-like Snackbar with no actions.
+     * To enable swipe-to-dismiss, the Activity layout should include a CoordinatorLayout with id "root_layout"
+     * @param mainTextResource
+     * @param shortLength
+     */
+    public static void showSimpleSnackbar(Activity activity, int mainTextResource, boolean shortLength) {
+        View root = activity.findViewById(R.id.root_layout);
+        showSnackbar(activity, mainTextResource, shortLength, -1, null, root);
+    }
+    public static void showSimpleSnackbar(Activity activity, String mainText, boolean shortLength) {
+        View root = activity.findViewById(R.id.root_layout);
+        showSnackbar(activity, mainText, shortLength, -1, null, root, null);
+    }
+
+    /**
+     * Show a snackbar with an action
+     * @param mainTextResource resource for the main text string
+     * @param shortLength whether or not to use long length
+     * @param actionTextResource resource for the text string shown as the action
+     * @param listener listener for the action (if null no action shown)
+     * @oaram root View Snackbar will attach to. Should be CoordinatorLayout for swipe-to-dismiss to work.
+     */
+    public static void showSnackbar(Activity activity, int mainTextResource, boolean shortLength,
+                                int actionTextResource, View.OnClickListener listener, View root) {
+        showSnackbar(activity, mainTextResource,shortLength,actionTextResource,listener,root, null);
+    }
+
+
+    public static void showSnackbar(Activity activity, int mainTextResource, boolean shortLength,
+                                int actionTextResource, View.OnClickListener listener, View root,
+                                Snackbar.Callback callback) {
+        String mainText = activity.getResources().getString(mainTextResource);
+        showSnackbar(activity, mainText, shortLength, actionTextResource, listener, root, callback);
+    }
+
+
+    public static void showSnackbar(Activity activity, String mainText, boolean shortLength,
+                                int actionTextResource, View.OnClickListener listener, View root,
+                                Snackbar.Callback callback) {
+        if (root == null) {
+            root = activity.findViewById(android.R.id.content);
+            if (root == null) {
+                Timber.e("Could not show Snackbar due to null View");
+                return;
+            }
+        }
+        int length = shortLength ? Snackbar.LENGTH_SHORT : Snackbar.LENGTH_LONG;
+        Snackbar sb = Snackbar.make(root, mainText, length);
+        if (listener != null) {
+            sb.setAction(actionTextResource, listener);
+        }
+        if (callback != null) {
+            sb.setCallback(callback);
+        }
+        // Make the text white to avoid interference from our theme colors.
+        View view = sb.getView();
+        TextView tv = (TextView) view.findViewById(android.support.design.R.id.snackbar_text);
+        TextView action = (TextView) view.findViewById(android.support.design.R.id.snackbar_action);
+        if (tv != null && action != null) {
+            tv.setTextColor(Color.WHITE);
+            action.setTextColor(ContextCompat.getColor(activity, R.color.material_light_blue_500));
+            tv.setMaxLines(2);  // prevent tablets from truncating to 1 line
+        }
+        sb.show();
+    }
+
 
     public static float getDensityAdjustedValue(Context context, float value) {
         return context.getResources().getDisplayMetrics().density * value;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportDialog.java
@@ -10,6 +10,7 @@ import android.view.View;
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.ichi2.anki.CollectionHelper;
 import com.ichi2.anki.R;
+import com.ichi2.anki.UIUtils;
 import com.ichi2.libanki.Utils;
 import com.ichi2.themes.Themes;
 
@@ -86,7 +87,7 @@ public class ImportDialog extends DialogFragment {
                 // Allow user to choose from the list of available APKG files
                 List<File> fileList = Utils.getImportableDecks(getActivity());
                 if (fileList.size() == 0) {
-                    Themes.showThemedToast(getActivity(),
+                    UIUtils.showThemedToast(getActivity(),
                             getResources().getString(R.string.upgrade_import_no_file_found, "'.apkg'"), false);
                     return builder.showListener(new DialogInterface.OnShowListener() {
                         @Override

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TagsDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TagsDialog.java
@@ -28,6 +28,7 @@ import android.widget.TextView;
 
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.ichi2.anki.R;
+import com.ichi2.anki.UIUtils;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -292,8 +293,8 @@ public class TagsDialog extends DialogFragment {
             }
             mTagsArrayAdapter.notifyDataSetChanged();
             // Show a snackbar to let the user know the tag was added successfully
-            Snackbar.make(mDialog.getView().findViewById(R.id.tags_dialog_snackbar),
-                    feedbackText, Snackbar.LENGTH_LONG).show();
+            UIUtils.showSnackbar(getActivity(), feedbackText, false, -1, null,
+                    mDialog.getView().findViewById(R.id.tags_dialog_snackbar), null);
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV19.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV19.java
@@ -32,7 +32,8 @@ public class CompatV19 extends CompatV17 implements Compat {
                         | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
                         | View.SYSTEM_UI_FLAG_FULLSCREEN
                         | View.SYSTEM_UI_FLAG_LOW_PROFILE
-                        | View.SYSTEM_UI_FLAG_IMMERSIVE);
+                        | View.SYSTEM_UI_FLAG_IMMERSIVE
+        );
         // Show / hide the Action bar together with the status bar
         SharedPreferences prefs = AnkiDroidApp.getSharedPrefs(a);
         final int fullscreenMode = Integer.parseInt(prefs.getString("fullscreenMode", "0"));

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/StepsPreference.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/StepsPreference.java
@@ -24,7 +24,7 @@ import android.util.AttributeSet;
 
 import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.R;
-import com.ichi2.themes.Themes;
+import com.ichi2.anki.UIUtils;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -71,9 +71,9 @@ public class StepsPreference extends EditTextPreference {
         if (positiveResult) {
             String validated = getValidatedStepsInput(getEditText().getText().toString());
             if (validated == null) {
-                Themes.showThemedToast(getContext(), getContext().getResources().getString(R.string.steps_error), false);
+                UIUtils.showThemedToast(getContext(), getContext().getResources().getString(R.string.steps_error), false);
             } else if (TextUtils.isEmpty(validated) && !mAllowEmpty) {
-                Themes.showThemedToast(getContext(), getContext().getResources().getString(R.string.steps_min_error),
+                UIUtils.showThemedToast(getContext(), getContext().getResources().getString(R.string.steps_min_error),
                         false);
             } else {
                 setText(validated);

--- a/AnkiDroid/src/main/java/com/ichi2/themes/Themes.java
+++ b/AnkiDroid/src/main/java/com/ichi2/themes/Themes.java
@@ -40,10 +40,6 @@ public class Themes {
     private final static int THEME_NIGHT_DARK = 1;
 
 
-    public static void showThemedToast(Context context, String text, boolean shortLength) {
-        Toast.makeText(context, text, shortLength ? Toast.LENGTH_SHORT : Toast.LENGTH_LONG).show();
-    }
-
     public static void setTheme(Context context) {
         SharedPreferences prefs = AnkiDroidApp.getSharedPrefs(context.getApplicationContext());
         if (prefs.getBoolean("invertedColors", false)) {


### PR DESCRIPTION
Fixes https://github.com/ankidroid/Anki-Android/issues/4251

We manually apply a color in our snackbar methods but they are buried inside AnkiActivity so they can't be used anywhere else. I don't think there is a very strong tie between those activities and showing snackbars so I moved it out to the UIUtils class.