### PR TITLE
Don't center saved searches list

### DIFF
--- a/AnkiDroid/src/main/res/layout/card_browser_item_my_searches_dialog.xml
+++ b/AnkiDroid/src/main/res/layout/card_browser_item_my_searches_dialog.xml
@@ -8,11 +8,10 @@
     android:paddingBottom="5dp">
 
     <LinearLayout
-        android:layout_width="fill_parent"
-        android:layout_height="fill_parent"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
         android:orientation="vertical"
         android:gravity="left|center_vertical"
-        android:layout_centerVertical="true"
         android:layout_toLeftOf="@+id/card_browser_my_search_remove_button">
         <TextView android:id="@+id/card_browser_my_search_name_textview"
             android:layout_width="wrap_content"


### PR DESCRIPTION
Fixes https://github.com/ankidroid/Anki-Android/issues/4252

Don't think `layout_centerVertical` was doing anything useful. Before-after:
![savedsearches](https://cloud.githubusercontent.com/assets/789082/15042760/0f2f8d3e-130a-11e6-88b8-612672c7f8e4.png)
