### PR TITLE
Whiteboard gesture fix

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -454,7 +454,8 @@ public class Reviewer extends AbstractFlashcardViewer {
             public boolean onTouch(View v, MotionEvent event) {
                 if (!mShowWhiteboard ||
                         mPrefFullscreenReview && CompatHelper.getCompat().isSystemUiVisible(Reviewer.this)) {
-                    return false;
+                    // TODO: (timrae). Tidy this logic up and confirm working on all API levels
+                    return getGestureDetector().onTouchEvent(event);
                 }
                 return mWhiteboard.handleTouchEvent(event);
             }

--- a/AnkiDroid/src/main/res/layout/reviewer.xml
+++ b/AnkiDroid/src/main/res/layout/reviewer.xml
@@ -29,10 +29,6 @@
                 android:layout_above="@+id/bottom_area_layout"
                 android:layout_below="@+id/top_bar">
                 <include layout="@layout/reviewer_flashcard"/>
-                <FrameLayout
-                    android:id="@+id/whiteboard"
-                    android:layout_width="fill_parent"
-                    android:layout_height="fill_parent" />
             </FrameLayout>
             <include layout="@layout/reviewer_answer_buttons"/>
         </RelativeLayout>

--- a/AnkiDroid/src/main/res/layout/reviewer_flashcard.xml
+++ b/AnkiDroid/src/main/res/layout/reviewer_flashcard.xml
@@ -37,9 +37,13 @@
         android:id="@+id/touch_layer"
         android:layout_width="fill_parent"
         android:layout_height="fill_parent"
-        android:layout_marginBottom="20dip"
-        android:layout_marginTop="20dip"
+        android:layout_margin="20dip"
         android:longClickable="true" />
+    <FrameLayout
+        android:id="@+id/whiteboard"
+        android:layout_margin="20dip"
+        android:layout_width="fill_parent"
+        android:layout_height="fill_parent" />
     <ImageView
         android:id="@+id/lookup_button"
         android:layout_width="wrap_content"

--- a/AnkiDroid/src/main/res/layout/reviewer_fullscreen_1.xml
+++ b/AnkiDroid/src/main/res/layout/reviewer_fullscreen_1.xml
@@ -29,10 +29,6 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:fitsSystemWindows="true">
-            <FrameLayout
-                android:id="@+id/whiteboard"
-                android:layout_width="fill_parent"
-                android:layout_height="fill_parent" />
             <include layout="@layout/toolbar"
                      android:layout_width="fill_parent"
                      android:layout_height="wrap_content"

--- a/AnkiDroid/src/main/res/layout/reviewer_fullscreen_2.xml
+++ b/AnkiDroid/src/main/res/layout/reviewer_fullscreen_2.xml
@@ -15,10 +15,6 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:fitsSystemWindows="true">
-            <FrameLayout
-                android:id="@+id/whiteboard"
-                android:layout_width="fill_parent"
-                android:layout_height="fill_parent" />
             <RelativeLayout
                 android:id="@+id/front_frame"
                 android:layout_width="match_parent"

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0'
+        classpath 'com.android.tools.build:gradle:2.1.0'
         classpath 'com.github.triplet.gradle:play-publisher:1.1.4'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
I think this fixes #4259. Hopefully it hasn't introduced other errors elsewhere. I'm looking to get some feedback on how well it works and a few points below before merging.

The PR adds a 20dp margin to all edges of the whiteboard and gesture detector layers. The gesture detector layer already had this margin in the top and bottom, so I just kept the same number arbitrarily. The number seems to basically work, but according to my testing it may need to be slightly increased in some cases. 

0. I'm not sure if there's any standard for how many dp are taken up by these "system swipe zones"...? If there is an official number then we should use it, if not then I guess we could either dig into the source code, use trial and error, or change to a different and more reliable approach (not sure what that might be).

0. Obviously the PR reduces the drawable area of the whiteboard. See the screenshot below; it's probably much more noticeable on a smaller screen. Maybe we should disable the margin when fullscreen is disabled?

0. Perhaps with this change to the gesture touch layer, we could also re-enable swipe to open the navigation drawer, as this PR also effectively deals with the same issue. Again, 20dp might be too small for 100% reliable results.

![whiteboard_gesture_limits](https://cloud.githubusercontent.com/assets/2818274/15049055/5f3e9992-1327-11e6-8555-d3400bc92290.png)