### PR TITLE
Explicitly supply locale in string formatting calls

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -568,10 +568,10 @@ public class DeckPicker extends NavigationDrawerActivity implements
                 mDialogEditText = new EditText(DeckPicker.this);
                 ArrayList<String> names = getCol().getDecks().allNames();
                 int n = 1;
-                String name = String.format("%s %d", res.getString(R.string.filtered_deck_name), n);
+                String name = String.format(Locale.getDefault(), "%s %d", res.getString(R.string.filtered_deck_name), n);
                 while (names.contains(name)) {
                     n++;
-                    name = String.format("%s %d", res.getString(R.string.filtered_deck_name), n);
+                    name = String.format(Locale.getDefault(), "%s %d", res.getString(R.string.filtered_deck_name), n);
                 }
                 mDialogEditText.setText(name);
                 // mDialogEditText.setFilters(new InputFilter[] { mDeckNameFilter });

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
@@ -57,6 +57,7 @@ import org.json.JSONObject;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -743,7 +744,7 @@ public class CardContentProvider extends ContentProvider {
         if (col.getDecks().isDyn(deckId)) {
             throw new IllegalArgumentException("A filtered deck cannot be specified as the deck in bulkInsertNotes");
         }
-        col.log(String.format("bulkInsertNotes: %d items.\n%s", valuesArr.length, getLogMessage("bulkInsert", null)));
+        col.log(String.format(Locale.US, "bulkInsertNotes: %d items.\n%s", valuesArr.length, getLogMessage("bulkInsert", null)));
 
         // for caching model information (so we don't have to query for each note)
         long modelId = -1L;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Media.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Media.java
@@ -259,7 +259,7 @@ public class Media {
                 root = root + " (1)";
             } else {
                 int n = Integer.parseInt(m.group(1));
-                root = String.format(" (%d)", n + 1);
+                root = String.format(Locale.US, " (%d)", n + 1);
             }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sched.java
@@ -2552,7 +2552,7 @@ public class Sched {
 
         @Override
         public String toString() {
-            return String.format("%s, %d, %d, %d, %d, %d, %s",
+            return String.format(Locale.US, "%s, %d, %d, %d, %d, %d, %s",
                     Arrays.toString(names), did, depth, revCount, lrnCount, newCount, children);
         }
     }

--- a/api/src/main/java/com/ichi2/anki/api/AddContentApi.java
+++ b/api/src/main/java/com/ichi2/anki/api/AddContentApi.java
@@ -42,6 +42,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -687,7 +688,8 @@ public final class AddContentApi {
     private class CompatV2 extends CompatV1 {
         @Override
         public Cursor queryNotes(long modelId) {
-            return mResolver.query(Note.CONTENT_URI_V2, PROJECTION, String.format("%s=%d", Note.MID, modelId), null, null);
+            return mResolver.query(Note.CONTENT_URI_V2, PROJECTION,
+                    String.format(Locale.US, "%s=%d", Note.MID, modelId), null, null);
         }
 
         @Override
@@ -711,7 +713,8 @@ public final class AddContentApi {
                 keyToIndexesMap.get(key).add(i);
             }
             // Query for notes that have specified model and checksum of first field matches
-            String sel = String.format("%s=%d and %s in (%s)", Note.MID, modelId, Note.CSUM, TextUtils.join(",", csums));
+            String sel = String.format(Locale.US, "%s=%d and %s in (%s)", Note.MID, modelId, Note.CSUM,
+                    TextUtils.join(",", csums));
             Cursor notesTableCursor = mResolver.query(Note.CONTENT_URI_V2, PROJECTION, sel, null, null);
             if (notesTableCursor == null) {
                 return null;


### PR DESCRIPTION
The `String.format` calls in the API code would fail if someone is using a language with a different set of symbols for numbers (e.g., Arabic). The rest are mostly cosmetic fixes.