### PR TITLE
Fix query not using selectionArgs

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DB.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DB.java
@@ -133,10 +133,15 @@ public class DB {
      * @return The integer result of the query.
      */
     public int queryScalar(String query) {
+        return queryScalar(query, null);
+    }
+
+
+    public int queryScalar(String query, String[] selectionArgs) {
         Cursor cursor = null;
         int scalar;
         try {
-            cursor = mDatabase.rawQuery(query, null);
+            cursor = mDatabase.rawQuery(query, selectionArgs);
             if (!cursor.moveToNext()) {
                 return 0;
             }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Note.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Note.java
@@ -134,9 +134,9 @@ public class Note implements Cloneable {
         String sfld = Utils.stripHTMLMedia(mFields[mCol.getModels().sortIdx(mModel)]);
         String tags = stringTags();
         String fields = joinedFields();
-        if (mod == null && mCol.getDb().queryScalar(String.format(Locale.US,
+        if (mod == null && mCol.getDb().queryScalar(
                 "select 1 from notes where id = ? and tags = ? and flds = ?",
-                mId, tags, fields)) > 0) {
+                new String[]{Long.toString(mId), tags, fields}) > 0) {
             return;
         }
         long csum = Utils.fieldChecksum(mFields[0]);


### PR DESCRIPTION
Fixed a query that would never work because the string formatting had no tokens to replace.

Seems to be low-impact from what I understand, making us save data a little more frequently than necessary.