### PR TITLE
Fix audio recording not saving and cases where recorder stops

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/AudioView.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/AudioView.java
@@ -195,6 +195,19 @@ public class AudioView extends LinearLayout {
         if (mRecord != null) {
             mRecord.update();
         }
+        if (mRecorder != null && mStatus == Status.RECORDING) {
+            mRecorder.stop();
+            mStatus = Status.IDLE;
+            if (mOnRecordingFinishEventListener != null) {
+                mOnRecordingFinishEventListener.onRecordingFinish(AudioView.this);
+            }
+        }
+    }
+
+    public void notifyReleaseRecorder() {
+        if (mRecorder != null) {
+            mRecorder.release();
+        }
     }
 
     protected class PlayPauseButton extends ImageButton {
@@ -396,13 +409,7 @@ public class AudioView extends LinearLayout {
 
                     case RECORDING:
                         setImageResource(mResRecordStopImage);
-                        mRecorder.stop();
-                        mStatus = Status.IDLE; // Back to idle, so if play
-                                               // pressed, initialize player
                         notifyStopRecord();
-                        if (mOnRecordingFinishEventListener != null) {
-                            mOnRecordingFinishEventListener.onRecordingFinish(AudioView.this);
-                        }
                         break;
 
                     default:

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
@@ -162,18 +162,21 @@ public class MultimediaEditFieldActivity extends AnkiActivity
         switch (item.getItemId()) {
             case R.id.multimedia_edit_field_to_text:
                 Timber.i("To text field button pressed");
+                mFieldController.onFocusLost();
                 toTextField();
                 supportInvalidateOptionsMenu();
                 return true;
 
             case R.id.multimedia_edit_field_to_image:
                 Timber.i("To image button pressed");
+                mFieldController.onFocusLost();
                 toImageField();
                 supportInvalidateOptionsMenu();
                 return true;
 
             case R.id.multimedia_edit_field_to_audio:
                 Timber.i("To audio button pressed");
+                mFieldController.onFocusLost();
                 toAudioField();
                 supportInvalidateOptionsMenu();
                 return true;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicAudioFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicAudioFieldController.java
@@ -44,6 +44,7 @@ public class BasicAudioFieldController extends FieldControllerBase implements IF
      */
     private String tempAudioPath;
     private String origAudioPath;
+    private AudioView mAudioView;
 
 
     @Override
@@ -74,10 +75,9 @@ public class BasicAudioFieldController extends FieldControllerBase implements IF
             }
         }
 
-        AudioView audioView = AudioView.createRecorderInstance(mActivity, R.drawable.av_play, R.drawable.av_pause,
+        mAudioView = AudioView.createRecorderInstance(mActivity, R.drawable.av_play, R.drawable.av_pause,
                 R.drawable.av_stop, R.drawable.av_rec, R.drawable.av_rec_stop, tempAudioPath);
-
-        audioView.setOnRecordingFinishEventListener(new AudioView.OnRecordingFinishEventListener() {
+        mAudioView.setOnRecordingFinishEventListener(new AudioView.OnRecordingFinishEventListener() {
             @Override
             public void onRecordingFinish(View v) {
                 // currentFilePath.setText("Recording done, you can preview it. Hit save after finish");
@@ -85,22 +85,27 @@ public class BasicAudioFieldController extends FieldControllerBase implements IF
                 mField.setHasTemporaryMedia(true);
             }
         });
-        layout.addView(audioView, LinearLayout.LayoutParams.FILL_PARENT);
+        layout.addView(mAudioView, LinearLayout.LayoutParams.FILL_PARENT);
     }
 
 
     @Override
     public void onDone() {
+        mAudioView.notifyStopRecord();
     }
-
 
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
     }
 
+    @Override
+    public void onFocusLost() {
+        mAudioView.notifyReleaseRecorder();
+    }
+
 
     @Override
     public void onDestroy() {
+        mAudioView.notifyReleaseRecorder();
     }
-
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
@@ -178,6 +178,11 @@ public class BasicImageFieldController extends FieldControllerBase implements IF
         setPreviewImage(mField.getImagePath(), getMaxImageSize());
     }
 
+    @Override
+    public void onFocusLost() {
+
+    }
+
 
     @Override
     public void onDone() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicTextFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicTextFieldController.java
@@ -317,6 +317,11 @@ public class BasicTextFieldController extends FieldControllerBase implements IFi
         }
     }
 
+    @Override
+    public void onFocusLost() {
+
+    }
+
 
     /**
      * @param context

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/IFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/IFieldController.java
@@ -62,6 +62,8 @@ public interface IFieldController {
     // called back on result.
     void onActivityResult(int requestCode, int resultCode, Intent data);
 
+    // Called when the controller has stopped showing the field in favor of another one
+    void onFocusLost();
 
     // Is called to apply in the field new data from UI.
     void onDone();


### PR DESCRIPTION
- Fixed audio not saving if recording is terminated with the "Save"
action icon.
- Fixed many cases where the recorder would become unusable after the
first use.

---

Fixes https://github.com/ankidroid/Anki-Android/issues/4254
Also want to close https://github.com/ankidroid/Anki-Android/issues/2669. I've at least fixed the cases where AnkiDroid itself puts it into that state.