### PR TITLE
Fix some bugs with fullscreen mode on old APIs

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -2723,7 +2723,8 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
 
         @Override
         public boolean onSingleTapConfirmed(MotionEvent e) {
-            if (mPrefFullscreenReview > 0 && CompatHelper.getCompat().isSystemUiVisible(AbstractFlashcardViewer.this)) {
+            if (mPrefFullscreenReview > 0 &&
+                    CompatHelper.getCompat().isImmersiveSystemUiVisible(AbstractFlashcardViewer.this)) {
                 delayedHide(INITIAL_HIDE_DELAY);
                 return true;
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -25,6 +25,7 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.res.Resources;
 import android.graphics.drawable.Drawable;
+import android.os.Build;
 import android.support.v4.content.ContextCompat;
 import android.support.v4.view.ActionProvider;
 import android.support.v4.view.MenuItemCompat;
@@ -78,6 +79,9 @@ public class Reviewer extends AbstractFlashcardViewer {
 
     @Override
     protected int getContentViewAttr(int fullscreenMode) {
+        if (CompatHelper.getSdkVersion() < Build.VERSION_CODES.KITKAT) {
+            fullscreenMode = 0;     // The specific fullscreen layouts are only applicable for immersive mode
+        }
         switch (fullscreenMode) {
             case 1:
                 return R.layout.reviewer_fullscreen_1;
@@ -450,9 +454,9 @@ public class Reviewer extends AbstractFlashcardViewer {
         mWhiteboard.setOnTouchListener(new View.OnTouchListener() {
             @Override
             public boolean onTouch(View v, MotionEvent event) {
-                if (!mShowWhiteboard ||
-                        mPrefFullscreenReview && CompatHelper.getCompat().isSystemUiVisible(Reviewer.this)) {
-                    // TODO: (timrae). Tidy this logic up and confirm working on all API levels
+                if (!mShowWhiteboard || (mPrefFullscreenReview
+                        && CompatHelper.getCompat().isImmersiveSystemUiVisible(Reviewer.this))) {
+                    // Bypass whiteboard listener when it's hidden or fullscreen immersive mode is temporarily suspended
                     return getGestureDetector().onTouchEvent(event);
                 }
                 return mWhiteboard.handleTouchEvent(event);

--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
@@ -66,7 +66,7 @@ public interface Compat {
     void flushWebViewCookies();
     void setHTML5MediaAutoPlay(WebSettings settings, Boolean allow);
     void setStatusBarColor(Window window, int color);
-    /** Returns true if the system UI currently visible */
-    boolean isSystemUiVisible(AnkiActivity activity);
+    /** Returns true if the system UI currently visible during immersive mode */
+    boolean isImmersiveSystemUiVisible(AnkiActivity activity);
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV10.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV10.java
@@ -193,7 +193,7 @@ public class CompatV10 implements Compat {
     }
 
     @Override
-    public boolean isSystemUiVisible(AnkiActivity activity) {
+    public boolean isImmersiveSystemUiVisible(AnkiActivity activity) {
         return false;   // Immersive mode introduced in KitKat
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV19.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV19.java
@@ -88,7 +88,7 @@ public class CompatV19 extends CompatV17 implements Compat {
     }
 
     @Override
-    public boolean isSystemUiVisible(AnkiActivity activity) {
+    public boolean isImmersiveSystemUiVisible(AnkiActivity activity) {
         return (activity.getWindow().getDecorView().getSystemUiVisibility() & View.SYSTEM_UI_FLAG_HIDE_NAVIGATION) == 0;
     }
 }

--- a/AnkiDroid/src/main/res/layout/reviewer_flashcard.xml
+++ b/AnkiDroid/src/main/res/layout/reviewer_flashcard.xml
@@ -23,23 +23,26 @@
 
 <FrameLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_gravity="center"
     android:id="@+id/flashcard_frame"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
     android:layout_margin="0dip">
 
-    <!-- TODO: Can we change the child FrameLayouts to just Views??? -->
     <FrameLayout
+        android:layout_gravity="center"
         android:id="@+id/flashcard"
         android:layout_width="fill_parent"
         android:layout_height="fill_parent" />
     <FrameLayout
+        android:layout_gravity="center"
         android:id="@+id/touch_layer"
         android:layout_width="fill_parent"
         android:layout_height="fill_parent"
         android:layout_margin="20dip"
         android:longClickable="true" />
     <FrameLayout
+        android:layout_gravity="center"
         android:id="@+id/whiteboard"
         android:layout_margin="20dip"
         android:layout_width="fill_parent"


### PR DESCRIPTION
* The immersive mode layouts should not be used below KitKat
* The layout margins are ignored in Gingerbread without layout_gravity set
* Renamed `isSystemUiVisible()` to make the meaning a bit more clear