### PR TITLE
Add forecast to the overview statistics

### DIFF
--- a/AnkiDroid/src/main/res/values/06-statistics.xml
+++ b/AnkiDroid/src/main/res/values/06-statistics.xml
@@ -54,18 +54,20 @@
     <string name="stats_today_mature_cards">Correct answers on mature cards: %1$d/%2$d (%3$.1f%%)</string>
     <string name="stats_today_no_mature_cards">No mature cards were studied today</string>
 
-
+    <string name="stats_overview_forecast_total">Total: &lt;b&gt;%1$d&lt;/b&gt; reviews</string>
+    <string name="stats_overview_forecast_average">Average: &lt;b&gt;%1$.1f&lt;/b&gt; reviews/day</string>
+    <string name="stats_overview_forecast_due_tomorrow">Due tomorrow: &lt;b&gt;%1$d&lt;/b&gt;</string>
 
     <string name="stats_overview_days_studied">Days studied: &lt;b&gt;%1$d%%&lt;/b&gt; (%2$d of %3$d)</string>
-    <string name="stats_overview_total_reviews">Total: &lt;b&gt;%1$d&lt;/b&gt;  reviews</string>
+    <string name="stats_overview_total_reviews">Total: &lt;b&gt;%1$d&lt;/b&gt; reviews</string>
     <string name="stats_overview_reviews_per_day_studydays">Average for days studied: &lt;b&gt;%1$.1f&lt;/b&gt; reviews/day</string>
     <string name="stats_overview_reviews_per_day_all">If you studied every day: &lt;b&gt;%1$.1f&lt;/b&gt; reviews/day</string>
 
     <string name="stats_overview_time_per_day_studydays">Average for days studied: &lt;b&gt;%1$.1f&lt;/b&gt; minutes/day</string>
     <string name="stats_overview_time_per_day_all">If you studied every day:  &lt;b&gt;%1$.1f&lt;/b&gt; minutes/day</string>
 
-    <string name="stats_overview_new_cards_per_day">Average: &lt;b&gt;%1$.1f&lt;/b&gt; new cards/day</string>
-    <string name="stats_overview_total_new_cards">Total: &lt;b&gt;%1$d&lt;/b&gt;  new cards</string>
+    <string name="stats_overview_new_cards_per_day">Average: &lt;b&gt;%1$.1f&lt;/b&gt; cards/day</string>
+    <string name="stats_overview_total_new_cards">Total: &lt;b&gt;%1$d&lt;/b&gt; cards</string>
 
     <string name="stats_overview_average_interval">"Average interval: "</string>
     <string name="stats_overview_longest_interval">"Longest interval: "</string>
@@ -87,7 +89,7 @@
     <string name="stats_forecast">Forecast</string>
     <string name="stats_review_count">Review count</string>
     <string name="stats_review_time">Review time</string>
-    <string name="stats_progress">Progress</string>
+    <string name="stats_added">Added</string>
     <string name="stats_review_intervals">Intervals</string>
     <string name="stats_breakdown">Hourly breakdown</string>
     <string name="stats_weekly_breakdown">Weekly breakdown</string>


### PR DESCRIPTION
@timrae 
Remind me again which merge strategy you prefer for the releases. Should PRs target `release-2.6` and rely on the merge script to port everything back to `develop`, or do we just target `develop` and cherry-pick anything we think should go to 2.6 manually? Not really sure what's easier.

--

This commit adds more of the missing stats from https://github.com/ankidroid/Anki-Android/issues/3623, namely the *Forecast* block. I also renamed the "Progress" block to "Added" to match the desktop version which I somehow missed earlier.

There are still a couple of values missing and I've started porting them over but the changes are too big to move into the beta at this point. It might end up as a major re-work of the stats code for the next release instead (the non-charting portion, that is).