### PR TITLE
Fix NaN in overview stats calculations

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/stats/OverviewStatsBuilder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/stats/OverviewStatsBuilder.java
@@ -238,7 +238,7 @@ public class OverviewStatsBuilder {
 
         // Fill in the overview stats
         oStats.forecastTotalReviews = tot;
-        oStats.forecastAverageReviews = (double) tot / (totd.size() * chunk);
+        oStats.forecastAverageReviews = totd.size() == 0 ? 0 : (double) tot / (totd.size() * chunk);
         oStats.forecastDueTomorrow = mCol.getDb().queryScalar(String.format(Locale.US,
                 "select count() from cards where did in %s and queue in (2,3) " +
                         "and due = ?", _limit()), new String[]{Integer.toString(mCol.getSched().getToday() + 1)});

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Stats.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Stats.java
@@ -296,10 +296,10 @@ public class Stats {
             }
         }
         oStats.reviewsPerDayOnAll = (double) oStats.totalReviews / oStats.allDays;
-        oStats.reviewsPerDayOnStudyDays = (double) oStats.totalReviews / oStats.daysStudied;
+        oStats.reviewsPerDayOnStudyDays = oStats.daysStudied == 0 ? 0 : (double) oStats.totalReviews / oStats.daysStudied;
 
         oStats.timePerDayOnAll = oStats.totalTime / oStats.allDays;
-        oStats.timePerDayOnStudyDays = oStats.totalTime / oStats.daysStudied;
+        oStats.timePerDayOnStudyDays = oStats.daysStudied == 0 ? 0 : oStats.totalTime / oStats.daysStudied;
 
         oStats.totalNewCards = getNewCards(timespan);
         oStats.newCardsPerDay = (double) oStats.totalNewCards / (double) oStats.allDays;

--- a/AnkiDroid/src/main/res/values/06-statistics.xml
+++ b/AnkiDroid/src/main/res/values/06-statistics.xml
@@ -20,7 +20,7 @@
 --><resources>
     <string name="statistics_young">Young</string>
     <string name="statistics_mature">Mature</string>
-    <string name="statistics_young_and_learn">Young and learn</string>
+    <string name="statistics_young_and_learn">Young+Learn</string>
     <string name="statistics_unlearned">Unseen</string>
     <string name="statistics_suspended_and_buried">Suspended+Buried</string>
     <string name="statistics_relearn">Relearn</string>


### PR DESCRIPTION
A quick fix to NaN appearing in average calculations in the stats overview.

Also updated a string for consistency.