### PR TITLE
Move "Cram" bar to top in Review Count/Review Time & fix legend order

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/stats/ChartBuilder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/stats/ChartBuilder.java
@@ -47,6 +47,7 @@ public class ChartBuilder {
     private Collection mCollectionData;
 
     int mMaxCards = 0;
+    private boolean mBackwards;
     private int[] mValueLabels;
     private int[] mColors;
     private int[] mAxisTitles;
@@ -96,7 +97,7 @@ public class ChartBuilder {
         mCumulative = stats.getCumulative();
         mSeriesList = stats.getSeriesList();
         Object[] metaData = stats.getMetaInfo();
-        //backwards = (Boolean) metaData[2];
+        mBackwards = (Boolean) metaData[2];
         mValueLabels = (int[]) metaData[3];
         mColors = (int[]) metaData[4];
         mAxisTitles = (int[]) metaData[5];
@@ -137,6 +138,7 @@ public class ChartBuilder {
         plotSheet.setBackgroundColor(new ColorWrap(backgroundColor));
         int textColor = Themes.getColorFromAttr(mChartView.getContext(), android.R.attr.textColor);
         plotSheet.setTextColor(new ColorWrap(textColor));
+        plotSheet.setIsBackwards(mBackwards);
 
         if (mChartType == Stats.ChartType.CARDS_TYPES) {
             return createPieChart(plotSheet);
@@ -145,8 +147,8 @@ public class ChartBuilder {
         PlotSheet hiddenPlotSheet = new PlotSheet(mFirstElement - 0.5, mLastElement + 0.5, 0, mMcount * Y_AXIS_STRETCH_FACTOR);     //for second y-axis
         hiddenPlotSheet.setFrameThickness(frameThickness * 0.66f, frameThickness * 0.66f, frameThickness, frameThickness * 0.9f);
 
-        setupBarGraphs(plotSheet, hiddenPlotSheet);
         setupCumulative(plotSheet, hiddenPlotSheet);
+        setupBarGraphs(plotSheet, hiddenPlotSheet);
 
         double xTicks = ticksCalcX(desiredPixelDistanceBetweenTicks, rect, mFirstElement, mLastElement);
         setupXaxis(plotSheet, xTicks, true);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Stats.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Stats.java
@@ -340,7 +340,7 @@ public class Stats {
         mHasColoredCumulative = false;
         mType = type;
         mDynamicAxis = true;
-        mBackwards = false;
+        mBackwards = true;
         mTitle = R.string.stats_forecast;
         mValueLabels = new int[] { R.string.statistics_young, R.string.statistics_mature };
         mColors = new int[] { R.attr.stats_young, R.attr.stats_mature };
@@ -479,10 +479,10 @@ public class Stats {
         } else if(charType == ChartType.REVIEW_TIME) {
             mTitle = R.string.stats_review_time;
         }
-        mValueLabels = new int[] { R.string.statistics_learn, R.string.statistics_relearn, R.string.statistics_young,
-                R.string.statistics_mature, R.string.statistics_cram };
-        mColors = new int[] { R.attr.stats_learn, R.attr.stats_relearn, R.attr.stats_young, R.attr.stats_mature,
-                R.attr.stats_cram };
+        mValueLabels = new int[] { R.string.statistics_cram, R.string.statistics_learn, R.string.statistics_relearn, R.string.statistics_young,
+                R.string.statistics_mature };
+        mColors = new int[] { R.attr.stats_cram, R.attr.stats_learn, R.attr.stats_relearn, R.attr.stats_young,
+                R.attr.stats_mature };
         int num = 0;
         int chunk = 0;
         switch (type) {
@@ -554,8 +554,8 @@ public class Stats {
                     .rawQuery(
                             query, null);
             while (cur.moveToNext()) {
-                list.add(new double[] { cur.getDouble(0), cur.getDouble(1), cur.getDouble(4), cur.getDouble(2),
-                        cur.getDouble(3), cur.getDouble(5) });
+                list.add(new double[] { cur.getDouble(0), cur.getDouble(5), cur.getDouble(1), cur.getDouble(4),
+                        cur.getDouble(2), cur.getDouble(3)});
             }
         } finally {
             if (cur != null && !cur.isClosed()) {
@@ -578,11 +578,12 @@ public class Stats {
         for (int i = 0; i < list.size(); i++) {
             double[] data = list.get(i);
             mSeriesList[0][i] = data[0]; // day
-            mSeriesList[1][i] = data[1] + data[2] + data[3] + data[4] + data[5]; // lrn
-            mSeriesList[2][i] = data[2] + data[3] + data[4] + data[5]; // relearn
-            mSeriesList[3][i] = data[3] + data[4] + data[5]; // young
-            mSeriesList[4][i] = data[4] + data[5]; // mature
-            mSeriesList[5][i] = data[5]; // cram
+            mSeriesList[1][i] = data[1] + data[2] + data[3] + data[4] + data[5]; // cram
+            mSeriesList[2][i] = data[2] + data[3] + data[4] + data[5]; // learn
+            mSeriesList[3][i] = data[3] + data[4] + data[5]; // relearn
+            mSeriesList[4][i] = data[4] + data[5]; // young
+            mSeriesList[5][i] = data[5]; // mature
+
             if (mSeriesList[1][i] > mMaxCards) {
                 mMaxCards = (int) Math.round(data[1] + data[2] + data[3] + data[4] + data[5]);
             }
@@ -788,6 +789,7 @@ public class Stats {
      */
     public boolean calculateBreakdown(AxisType type) {
         mTitle = R.string.stats_breakdown;
+        mBackwards = false;
         mAxisTitles = new int[] { R.string.stats_time_of_day, R.string.stats_percentage_correct, R.string.stats_reviews };
         mValueLabels = new int[] { R.string.stats_percentage_correct, R.string.stats_answers};
         mColors = new int[] { R.attr.stats_counts, R.attr.stats_hours};
@@ -922,6 +924,7 @@ public class Stats {
      */
     public boolean calculateWeeklyBreakdown(AxisType type) {
         mTitle = R.string.stats_weekly_breakdown;
+        mBackwards = false;
         mAxisTitles = new int[] { R.string.stats_day_of_week, R.string.stats_percentage_correct, R.string.stats_reviews };
         mValueLabels = new int[] { R.string.stats_percentage_correct, R.string.stats_answers};
         mColors = new int[] { R.attr.stats_counts, R.attr.stats_hours};
@@ -1040,6 +1043,7 @@ public class Stats {
     public boolean calculateAnswerButtons(AxisType type) {
         mHasColoredCumulative = true;
         mTitle = R.string.stats_answer_buttons;
+        mBackwards = false;
         mAxisTitles = new int[] { R.string.stats_answer_type, R.string.stats_answers, R.string.stats_cumulative_correct_percentage };
         mValueLabels = new int[] { R.string.statistics_learn, R.string.statistics_young, R.string.statistics_mature};
         mColors = new int[] { R.attr.stats_learn, R.attr.stats_young, R.attr.stats_mature};
@@ -1166,6 +1170,7 @@ public class Stats {
      */
     public boolean calculateCardTypes(AxisType type) {
         mTitle = R.string.stats_cards_types;
+        mBackwards = false;
         mAxisTitles = new int[] { R.string.stats_answer_type, R.string.stats_answers, R.string.stats_cumulative_correct_percentage };
         mValueLabels = new int[] {R.string.statistics_mature, R.string.statistics_young_and_learn, R.string.statistics_unlearned, R.string.statistics_suspended_and_buried};
         mColors = new int[] { R.attr.stats_mature, R.attr.stats_young, R.attr.stats_unseen, R.attr.stats_suspended_and_buried };

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/hooks/AdvancedStatistics.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/hooks/AdvancedStatistics.java
@@ -271,7 +271,7 @@ public class AdvancedStatistics extends Hook  {
         metaInfo.setmHasColoredCumulative(true);
         metaInfo.setmType(type);
         metaInfo.setmTitle(R.string.stats_forecast);
-        metaInfo.setmBackwards(false);
+        metaInfo.setmBackwards(true);
         metaInfo.setmValueLabels(mValueLabels);
         metaInfo.setmColors(mColors);
         metaInfo.setmAxisTitles(mAxisTitles);

--- a/AnkiDroid/src/main/java/com/wildplot/android/rendering/PlotSheet.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/rendering/PlotSheet.java
@@ -22,7 +22,9 @@ import com.wildplot.android.rendering.graphics.wrapper.*;
 import com.wildplot.android.rendering.interfaces.Drawable;
 import com.wildplot.android.rendering.interfaces.Legendable;
 
+import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.Vector;
@@ -56,7 +58,9 @@ public class PlotSheet implements Drawable {
      * not yet implemented
      */
     protected boolean isMultiMode = false;
-    
+
+    protected boolean isBackwards = false;
+
     /**
      * thickness of frame in pixel
      */
@@ -419,7 +423,11 @@ public class PlotSheet implements Drawable {
                 g.setFontSize(oldFontSize);
             }
 
-            Set<String> keySet = mLegendMap.keySet();
+            List<String> keyList = new Vector<>(mLegendMap.keySet());
+
+            if(isBackwards) {
+                Collections.reverse(keyList);
+            }
 
             float oldFontSize = g.getFontSize();
             g.setFontSize(oldFontSize* 0.9f);
@@ -434,7 +442,8 @@ public class PlotSheet implements Drawable {
 
             int legendCnt = 0;
             Timber.d("should draw legend now, number of legend entries: %d", mLegendMap.size());
-            for(String legendName : keySet){
+
+            for(String legendName : keyList){
 
                 float stringWidth = fm.stringWidth(" : "+legendName);
 
@@ -721,6 +730,14 @@ public class PlotSheet implements Drawable {
     public void unsetFontSize() {
         fontSizeSet = false;
 
+    }
+
+    /**
+     * Show the legend items in reverse order of the order in which they were added.
+     * @param isBackwards If true, the legend items are shown in reverse order.
+     */
+    public void setIsBackwards(boolean isBackwards) {
+        this.isBackwards = isBackwards;
     }
 
     public void setFontSize(float fontSize) {


### PR DESCRIPTION
- Move "Cram" bar to top in Review Count/Review Time (solves https://github.com/ankidroid/Anki-Android/issues/4277)

- Make order in which legend items are shown consistent with Anki Desktop (reverse order for done & due charts, but keep cumulative as last item)