### PR TITLE
Update support libraries

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -46,12 +46,12 @@ play {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:23.3.0'
+    compile 'com.android.support:appcompat-v7:23.4.0'
     // Note: the design support library can be quite buggy, so test everything thoroughly before updating it
-    compile 'com.android.support:design:23.3.0'
-    compile 'com.android.support:customtabs:23.3.0'
-    compile 'com.android.support:recyclerview-v7:23.3.0'
-    compile('com.afollestad.material-dialogs:core:0.8.5.8@aar') {
+    compile 'com.android.support:design:23.4.0'
+    compile 'com.android.support:customtabs:23.4.0'
+    compile 'com.android.support:recyclerview-v7:23.4.0'
+    compile('com.afollestad.material-dialogs:core:0.8.5.9@aar') {
         //exclude group: 'com.android.support'  // uncomment to force our local support lib version
         transitive = true
     }

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,6 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
-        maven { url "https://jitpack.io" }
     }
 }
 


### PR DESCRIPTION
I tried downgrading the support libraries to get around https://github.com/ankidroid/Anki-Android/issues/4217 but the problem seemed to remain even with older versions. I'm thinking that my method to reproduce the problem is a different problem entirely and has always been there. So maybe Google's fix does actually work for the cases we have reported.

I want to try updating the support libs and see if @snowtimeglass can still reproduce it in the next beta.

Also, the Material Dialogs library has [moved back to jCenter](https://github.com/afollestad/material-dialogs/releases/tag/0.8.5.9) so I removed the jitpack repo while I was at it.