### PR TITLE
Don't immediately switch to normal undo on empty whiteboard undo queue

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -258,8 +258,13 @@ public class Reviewer extends AbstractFlashcardViewer {
         }
 
         if (mShowWhiteboard && mWhiteboard != null && mWhiteboard.undoSize() > 0) {
+            // Whiteboard undo queue non-empty. Switch the undo icon to a whiteboard specific one.
             menu.findItem(R.id.action_undo).setIcon(R.drawable.ic_eraser_variant_white_24dp);
             menu.findItem(R.id.action_undo).setEnabled(true).getIcon().setAlpha(Themes.ALPHA_ICON_ENABLED_LIGHT);
+        } else if (mShowWhiteboard && mWhiteboard != null && mWhiteboard.isUndoModeActive()) {
+            // Whiteboard undo queue empty, but user has added strokes to it for current card. Disable undo button.
+            menu.findItem(R.id.action_undo).setIcon(R.drawable.ic_eraser_variant_white_24dp);
+            menu.findItem(R.id.action_undo).setEnabled(false).getIcon().setAlpha(Themes.ALPHA_ICON_DISABLED_LIGHT);
         } else if (colIsOpen() && getCol().undoAvailable()) {
             menu.findItem(R.id.action_undo).setIcon(R.drawable.ic_undo_white_24dp);
             menu.findItem(R.id.action_undo).setEnabled(true).getIcon().setAlpha(Themes.ALPHA_ICON_ENABLED_LIGHT);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.java
@@ -55,6 +55,7 @@ public class Whiteboard extends View {
 
     private boolean mInvertedColors = false;
     private boolean mMonochrome = true;
+    private boolean mUndoModeActive = false;
 
 
     public Whiteboard(AnkiActivity context, boolean inverted, boolean monochrome) {
@@ -138,6 +139,7 @@ public class Whiteboard extends View {
      * Clear the whiteboard.
      */
     public void clear() {
+        mUndoModeActive = false;
         mBitmap.eraseColor(0);
         mUndo.clear();
         invalidate();
@@ -158,8 +160,18 @@ public class Whiteboard extends View {
         }
     }
 
+    /**
+     * @return the number of strokes currently on the undo queue
+     */
     public int undoSize() {
         return mUndo.size();
+    }
+
+    /**
+     * @return true if the undo queue has had any strokes added to it since the last clear
+     */
+    public boolean isUndoModeActive() {
+        return mUndoModeActive;
     }
 
     private void createBitmap(int w, int h, Bitmap.Config conf) {
@@ -209,6 +221,7 @@ public class Whiteboard extends View {
             mCanvas.drawPoint(mX, mY, mPaint);
             mUndo.add(mX, mY);
         }
+        mUndoModeActive = true;
         // kill the path so we don't double draw
         mPath.reset();
         if (mUndo.size() == 1 && mActivity.get() != null) {


### PR DESCRIPTION
As identified on the forum, it's annoying when you are undoing whiteboard strokes quickly and accidentally undo the last review.

This changes the behavior slightly so that the undo button becomes disabled when the queue is empty, until the whiteboard is cleared.