### PR TITLE
Remove unnecessary whiteboard margins when fullscreen disabled

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -853,8 +853,19 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
         restorePreferences();
         super.onCreate(savedInstanceState);
         setContentView(getContentViewAttr(mPrefFullscreenReview));
-        View mainView = findViewById(android.R.id.content);
-        initNavigationDrawer(mainView);
+        // If not using fullscreen mode then set whiteboard/gesture margins to zero
+        View whiteboard = findViewById(R.id.whiteboard);
+        View touchLayer = findViewById(R.id.touch_layer);
+        if (mPrefFullscreenReview == 0 && whiteboard != null && touchLayer != null) {
+            FrameLayout.LayoutParams pwb  = (FrameLayout.LayoutParams) whiteboard.getLayoutParams();
+            FrameLayout.LayoutParams ptl  = (FrameLayout.LayoutParams) touchLayer.getLayoutParams();
+            pwb.setMargins(pwb.leftMargin, 0, 0 , 0);
+            ptl.setMargins(ptl.leftMargin, 0, 0 , 0);
+            whiteboard.setLayoutParams(pwb);
+            touchLayer.setLayoutParams(ptl);
+        }
+        // Setup navigation drawer
+        initNavigationDrawer(findViewById(android.R.id.content));
         // Open collection asynchronously
         startLoadingCollection();
     }


### PR DESCRIPTION
(Not ready for merging)

This removes the top/bottom/right whiteboard and gesture margins when fullscreen mode is not enabled, after [a user complaint on the forum](https://groups.google.com/forum/#!topic/anki-android/rAojEmqGYJU). It's not as obvious how we should deal with the left margin.

To address the left margin / drawer swipe issue highlighted in that thread, I guess we could either:

A) Set the left margin to zero as well and go back to the old behavior of automatically disabling "swipe to open" on the navigation drawer when gestures or whiteboard are enabled.

B) Make a new setting that allows users to disable "swipe to open" of the navigation drawer if they want to. In the case where the swipe is disabled we set the left margin to zero, otherwise we keep it at 20dp.

What do others think?