### PR TITLE
Statistics: right y-axis disappeared on "BREAKDOWN"

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/stats/ChartBuilder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/stats/ChartBuilder.java
@@ -156,7 +156,10 @@ public class ChartBuilder {
         double yTicks = ticksCalcY(desiredPixelDistanceBetweenTicks, rect, 0, mMaxCards * Y_AXIS_STRETCH_FACTOR);
         setupYaxis(plotSheet, hiddenPlotSheet, yTicks, mAxisTitles[1], false, true);
 
-        if(mCumulative != null) {
+        //0 = X-axis title
+        //1 = Y-axis title left
+        //2 = Y-axis title right (optional)
+        if(mAxisTitles.length == 3) {
             double rightYtics = ticsCalc(desiredPixelDistanceBetweenTicks, rect, mMcount * Y_AXIS_STRETCH_FACTOR);
             setupYaxis(plotSheet, hiddenPlotSheet, rightYtics, mAxisTitles[2], true, true);
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/hooks/AdvancedStatistics.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/hooks/AdvancedStatistics.java
@@ -852,10 +852,10 @@ public class AdvancedStatistics extends Hook  {
 
             try {
                 cur = db.rawQuery(query, null);
-                cur.moveToFirst();
 
-                nLearnedPerDeckId.put(cur.getLong(0), cur.getInt(1));
-
+                while(cur.moveToNext()) {
+                    nLearnedPerDeckId.put(cur.getLong(0), cur.getInt(1));
+                }
             } finally {
                 if (cur != null && !cur.isClosed()) {
                     cur.close();


### PR DESCRIPTION
Solves: https://github.com/ankidroid/Anki-Android/issues/4317
Also fixed bug in AdvancedStatistics which:
- Made it crash if no cards were studied today
- Made it only take into account cards studied today in 1 deck