### PR TITLE
Undo buried card #4312

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -1018,7 +1018,6 @@ public class DeckPicker extends NavigationDrawerActivity implements
                 if (isReview || isBury || isSuspend) {
                     openReviewer();
                 }
-
             }
 
             @Override

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -996,6 +996,11 @@ public class DeckPicker extends NavigationDrawerActivity implements
     private void undo() {
         String undoReviewString = getResources().getString(R.string.undo_action_review);
         final boolean isReview = undoReviewString.equals(getCol().undoName(getResources()));
+        String undoBuryString = getResources().getString(R.string.undo_action_bury_card);
+        final boolean isBury = undoBuryString.equals(getCol().undoName(getResources()));
+        String undoSuspendString = getResources().getString(R.string.undo_action_suspend_card);
+        final boolean isSuspend = undoSuspendString.equals(getCol().undoName(getResources()));
+
         DeckTask.launchDeckTask(DeckTask.TASK_TYPE_UNDO, new DeckTask.TaskListener() {
             @Override
             public void onCancelled() {
@@ -1010,9 +1015,10 @@ public class DeckPicker extends NavigationDrawerActivity implements
             @Override
             public void onPostExecute(TaskData result) {
                 hideProgressBar();
-                if (isReview) {
+                if (isReview || isBury || isSuspend) {
                     openReviewer();
                 }
+
             }
 
             @Override


### PR DESCRIPTION
Changed undo to return to the review screen when undoing buried and suspended cards. The bug report said that the card counter should be updated, but I thought it would be more consistent if it behaved the same way as undoing a review.