### PR TITLE
Color entire text box for dupes in note editor

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.java
@@ -2,9 +2,13 @@
 package com.ichi2.anki;
 
 import android.content.Context;
+import android.graphics.drawable.Drawable;
 import android.util.AttributeSet;
 import android.widget.EditText;
 import android.widget.TextView;
+
+import com.ichi2.themes.Themes;
+
 
 public class FieldEditText extends EditText {
 
@@ -13,6 +17,7 @@ public class FieldEditText extends EditText {
 
     private String mName;
     private int mOrd;
+    private Drawable mOrigBackground;
 
 
     public FieldEditText(Context context) {
@@ -64,13 +69,24 @@ public class FieldEditText extends EditText {
         }
         setText(content);
         setMinimumWidth(400);
+        mOrigBackground = getBackground();
+        // Fixes bug where new instances of this object have wrong colors, probably
+        // from some reuse mechanic in Android.
+        setDefaultStyle();
+    }
+
+    /**
+     * Modify the style of this view to represent a duplicate field.
+     */
+    public void setDupeStyle() {
+        setBackgroundColor(Themes.getColorFromAttr(getContext(), R.attr.duplicateColor));
     }
 
 
-    public String cleanText(String text) {
-        text = text.replaceAll("\\s*(" + NL_MARK + "\\s*)+", NEW_LINE);
-        text = text.replaceAll("^[,;:\\s\\)\\]" + NEW_LINE + "]*", "");
-        text = text.replaceAll("[,;:\\s\\(\\[" + NEW_LINE + "]*$", "");
-        return text;
+    /**
+     * Restore the default style of this view.
+     */
+    public void setDefaultStyle() {
+        setBackgroundDrawable(mOrigBackground);
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1303,11 +1303,10 @@ public class NoteEditor extends AnkiActivity {
         Integer dupeCode = mEditorNote.dupeOrEmpty();
         // Change bottom line color of text field
         if (dupeCode != null && dupeCode == 2) {
-            field.getBackground().setColorFilter(ContextCompat.getColor(this, R.color.material_red_500),
-                    PorterDuff.Mode.SRC_ATOP);
+            field.setDupeStyle();
             isDupe = true;
         } else {
-            field.getBackground().clearColorFilter();
+            field.setDefaultStyle();
             isDupe = false;
         }
         // Put back the old value so we don't interfere with modification detection

--- a/AnkiDroid/src/main/res/values/attrs.xml
+++ b/AnkiDroid/src/main/res/values/attrs.xml
@@ -78,6 +78,8 @@
     <!-- Browser colors -->
     <attr name="suspendedColor" format="color"/>
     <attr name="markedColor" format="color"/>
+    <!-- Note editor colors -->
+    <attr name="duplicateColor" format="color"/>
     <!-- Images -->
     <attr name="navDrawerImage" format="integer"/>
     <attr name="attachFileImage" format="integer"/>

--- a/AnkiDroid/src/main/res/values/theme_black.xml
+++ b/AnkiDroid/src/main/res/values/theme_black.xml
@@ -69,6 +69,8 @@
         <!-- Browser colors -->
         <item name="suspendedColor">#A8A634</item>
         <item name="markedColor">#391080</item>
+        <!-- Note editor colors -->
+        <item name="duplicateColor">#855</item>
         <!-- FAB -->
         <item name="fab_normal">#ff303030</item>
         <item name="fab_pressed">#c8303030</item> <!-- 55 less opacity than fab_normal -->

--- a/AnkiDroid/src/main/res/values/theme_dark.xml
+++ b/AnkiDroid/src/main/res/values/theme_dark.xml
@@ -74,6 +74,8 @@
         <!-- Browser colors -->
         <item name="suspendedColor">@color/material_grey_700</item>
         <item name="markedColor">@color/material_deep_purple_400</item>
+        <!-- Note editor colors -->
+        <item name="duplicateColor">#855</item>
         <!-- FAB -->
         <item name="fab_normal">@color/material_light_blue_700</item>
         <item name="fab_pressed">@color/material_light_blue_900</item>

--- a/AnkiDroid/src/main/res/values/theme_light.xml
+++ b/AnkiDroid/src/main/res/values/theme_light.xml
@@ -87,6 +87,8 @@ APIs. It's visible when there aren't enough decks to fill the screen.
         <!-- Browser colors -->
         <item name="suspendedColor">#FFFFB2</item>
         <item name="markedColor">#D9B2E9</item>
+        <!-- Note editor colors -->
+        <item name="duplicateColor">#fcc</item>
         <!-- FAB -->
         <item name="fab_normal">@color/material_light_blue_700</item>
         <item name="fab_pressed">@color/material_light_blue_900</item>


### PR DESCRIPTION
Fixes #4333 and #3943.

This commit changes the way our duplicates look in the note editor. We lose the underline thing on dupes but this is the quickest and easiest way that works on all APIs. I vastly prefer this look over the highlighted underline and it at least looks like the desktop version which is more familiar to our users.

![screenshot_20160621-154827](https://cloud.githubusercontent.com/assets/789082/16219204/fc30c468-37c7-11e6-8049-411b9ac2a666.png)
![screenshot_20160621-154849](https://cloud.githubusercontent.com/assets/789082/16219205/fc34cf0e-37c7-11e6-8312-8311f91b3a99.png)
![screenshot_20160621-154942](https://cloud.githubusercontent.com/assets/789082/16219206/fc3a3da4-37c7-11e6-8337-66981aa4c3ef.png)
