### PR TITLE
Fix #3400: Use the locale’s first day of the week in statistics

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/stats/ChartBuilder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/stats/ChartBuilder.java
@@ -17,6 +17,7 @@ package com.ichi2.anki.stats;
 
 import android.graphics.Paint;
 
+import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.R;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Stats;
@@ -32,6 +33,8 @@ import com.wildplot.android.rendering.YAxis;
 import com.wildplot.android.rendering.YGrid;
 import com.wildplot.android.rendering.graphics.wrapper.ColorWrap;
 import com.wildplot.android.rendering.graphics.wrapper.RectangleWrap;
+
+import java.util.Calendar;
 
 import timber.log.Timber;
 
@@ -298,7 +301,16 @@ public class ChartBuilder {
                 xAxis.setExplicitTicks(timePositions, mChartView.getResources().getStringArray(R.array.stats_day_time_strings));
                 break;
             case WEEKLY_BREAKDOWN:
-                timePositions = new double[]{0, 1, 2, 3, 4, 5, 6};
+                int startOfWeek = Integer.parseInt(AnkiDroidApp.getSharedPrefs(mChartView.getContext()).getString(
+                        mChartView.getContext().getString(R.string.start_of_week_preference),
+                        mChartView.getContext().getString(R.string.start_of_week_sunday)
+                ));
+
+                if (Calendar.MONDAY == startOfWeek) {
+                    timePositions = new double[]{6, 0, 1, 2, 3, 4, 5};
+                } else {
+                    timePositions = new double[]{0, 1, 2, 3, 4, 5, 6};
+                }
                 xAxis.setExplicitTicks(timePositions, mChartView.getResources().getStringArray(R.array.stats_week_days));
                 break;
         }

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -137,6 +137,11 @@
     <string name="time_limit_summ">XXX min</string>
     <string name="day_offset">Start of next day</string>
     <string name="day_offset_summ">XXX hours past midnight</string>
+    <string name="start_of_week">Start of week</string>
+    <string-array name="start_of_week_labels">
+        <item>Sunday</item>
+        <item>Monday</item>
+    </string-array>
     <string name="input_workaround">Input workaround</string>
     <string name="input_workaround_summ">Workaround for focusing problems on HTML input boxes. Causes problems on several devices.</string>
     <string name="pref_keep_screen_on">Keep screen on</string>

--- a/AnkiDroid/src/main/res/values/constants.xml
+++ b/AnkiDroid/src/main/res/values/constants.xml
@@ -201,4 +201,13 @@
         <item>0</item>
         <item>1</item>
     </string-array>
+
+    <string name="start_of_week_preference" translatable="false">startOfWeek</string>
+    <string name="start_of_week_sunday" translatable="false">1</string>
+    <string name="start_of_week_monday" translatable="false">2</string>
+    <string name="start_of_week_default" translatable="false">@string/start_of_week_sunday</string>
+    <string-array name="start_of_week">
+        <item>@string/start_of_week_sunday</item>
+        <item>@string/start_of_week_monday</item>
+    </string-array>
 </resources>

--- a/AnkiDroid/src/main/res/xml/preferences_advanced_statistics.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_advanced_statistics.xml
@@ -4,7 +4,12 @@
 <!-- Advanced Statistics Preferences -->
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://arbitrary.app.namespace/com.ichi2.anki">
-
+    <ListPreference
+        android:defaultValue="@string/start_of_week_default"
+        android:entries="@array/start_of_week_labels"
+        android:entryValues="@array/start_of_week"
+        android:key="@string/start_of_week_preference"
+        android:title="@string/start_of_week" />
     <CheckBoxPreference
         android:defaultValue="false"
         android:key="advanced_statistics_enabled"


### PR DESCRIPTION
Actually, the locale is not used, but extra setting is added to the app