### PR TITLE
Don't prevent rendering in browser when scroll at 0

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1141,8 +1141,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
         public void onScroll(AbsListView view, int firstVisibleItem, int visibleItemCount, int totalItemCount) {
             // Show the progress bar if scrolling to given position requires rendering of the question / answer
             int lastVisibleItem = firstVisibleItem + visibleItemCount;
-            // Don't try to start rendering before scrolling has begun (firstVisibleItem == 0)
-            if (firstVisibleItem > 0 && lastVisibleItem > 0 && getCards().size() > lastVisibleItem) {
+            int size = getCards().size();
+            if (size > 0 && firstVisibleItem < size && lastVisibleItem - 1 < size) {
                 String firstAns = getCards().get(firstVisibleItem).get("answer");
                 // Note: max value of lastVisibleItem is totalItemCount, so need to subtract 1
                 String lastAns = getCards().get(lastVisibleItem - 1).get("answer");


### PR DESCRIPTION
@timrae Do you remember exactly why this condition was included? I couldn't understand why it was there and there appear to be no adverse effects of removing it as far as I can tell. It fixes https://github.com/ankidroid/Anki-Android/issues/4339.