### PR TITLE
Set max-width of images to 99%

### DIFF
--- a/AnkiDroid/src/main/assets/flashcard.css
+++ b/AnkiDroid/src/main/assets/flashcard.css
@@ -65,7 +65,7 @@ zoom into images correctly even with max dimensions specified, so this way is
 preferred over using JavaScript.
 */
 .chrome img {
-  max-width: 90%;
+  max-width: 99%;
   max-height: 90%;
 }
 

--- a/AnkiDroid/src/main/assets/scripts/card.js
+++ b/AnkiDroid/src/main/assets/scripts/card.js
@@ -28,7 +28,7 @@ var resizeImages = function() {
         if (window.innerWidth === 0 || window.innerHeight === 0) {
             return;
         }
-        var maxWidth = window.innerWidth * 0.90;
+        var maxWidth = window.innerWidth * 0.99;
         var maxHeight = window.innerHeight * 0.90;
         var ratio = 0;
         var images = document.getElementsByTagName('img');


### PR DESCRIPTION
Fixes https://github.com/ankidroid/Anki-Android/issues/4343

--

Since card content scrolls vertically it makes sense to still use 90%
for max-height in order to keep some of the card visible (like text
above or below an image).