### PR TITLE
Always set locale when returning to Activity

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -286,18 +286,12 @@ public class AnkiDroidApp extends Application {
      * Sets the user language.
      *
      * @param localeCode The locale code of the language to set
-     * @return True if the language has changed, else false
      */
-    public static boolean setLanguage(String localeCode) {
-        boolean languageChanged = false;
+    public static void setLanguage(String localeCode) {
         Configuration config = getInstance().getResources().getConfiguration();
         Locale newLocale = LanguageUtil.getLocale(localeCode);
-        if (!config.locale.equals(newLocale)) {
-            languageChanged = true;
-            config.locale = newLocale;
-            getInstance().getResources().updateConfiguration(config, getInstance().getResources().getDisplayMetrics());
-        }
-        return languageChanged;
+        config.locale = newLocale;
+        getInstance().getResources().updateConfiguration(config, getInstance().getResources().getDisplayMetrics());
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.java
@@ -83,11 +83,6 @@ public class StudyOptionsActivity extends NavigationDrawerActivity implements St
     public void onActivityResult(int requestCode, int resultCode, Intent intent) {
         super.onActivityResult(requestCode, resultCode, intent);
         Timber.d("onActivityResult (requestCode = %d, resultCode = %d)", requestCode, resultCode);
-
-        String newLanguage = AnkiDroidApp.getSharedPrefs(this).getString(Preferences.LANGUAGE, "");
-        if (AnkiDroidApp.setLanguage(newLanguage)) {
-            supportInvalidateOptionsMenu();
-        }
         getCurrentFragment().restorePreferences();
     }
 


### PR DESCRIPTION
Fixes https://github.com/ankidroid/Anki-Android/issues/4341

Even if the locale in the `Configuration` is set correctly, it refuses to use it unless explicitly updated. No idea why that is  (Android :camel:), but our condition to skip it was preventing us from re-applying it when returning to an Activity. Someone had actually solved this problem before.