### PR TITLE
Adjust max-width image resizing

### DIFF
--- a/AnkiDroid/src/main/assets/flashcard.css
+++ b/AnkiDroid/src/main/assets/flashcard.css
@@ -65,7 +65,7 @@ zoom into images correctly even with max dimensions specified, so this way is
 preferred over using JavaScript.
 */
 .chrome img {
-  max-width: 99%;
+  max-width: 100%;
   max-height: 90%;
 }
 

--- a/AnkiDroid/src/main/assets/scripts/card.js
+++ b/AnkiDroid/src/main/assets/scripts/card.js
@@ -28,7 +28,7 @@ var resizeImages = function() {
         if (window.innerWidth === 0 || window.innerHeight === 0) {
             return;
         }
-        var maxWidth = window.innerWidth * 0.99;
+        var maxWidth = window.innerWidth * 0.90;
         var maxHeight = window.innerHeight * 0.90;
         var ratio = 0;
         var images = document.getElementsByTagName('img');


### PR DESCRIPTION
The pre-Chrome engine (Android 4.3 and below) uses the screen's
dimensions to determine the width, so we need to keep that at the
original 90% to avoid horizontal overflow. The Chrome engine uses the
dimensions of the parent element so we safely use 100% without causing
overflow.