### PR TITLE
Disable default "swipe to refresh" animation in favor of custom sync dialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -393,6 +393,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
         mPullToSyncWrapper.setOnRefreshListener(new SwipeRefreshLayout.OnRefreshListener() {
             @Override
             public void onRefresh() {
+                mPullToSyncWrapper.setRefreshing(false);
                 sync();
             }
         });


### PR DESCRIPTION
Check the demo: https://youtu.be/dfrWr1FcIfs

As you see, `RecyclerView` works correctly when nested in `SwipeRefreshLayout`.