### PR TITLE
Increase swipe-to-sync trigger distance

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -138,6 +138,8 @@ public class DeckPicker extends NavigationDrawerActivity implements
     // 10 minutes in milliseconds.
     public static final long AUTOMATIC_SYNC_MIN_INTERVAL = 600000;
 
+    private static final int SWIPE_TO_SYNC_TRIGGER_DISTANCE = 400;
+
     private MaterialDialog mProgressDialog;
     private View mStudyoptionsFrame;
     private RecyclerView mRecyclerView;
@@ -391,6 +393,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
         mRecyclerView.setAdapter(mDeckListAdapter);
 
         mPullToSyncWrapper = (SwipeRefreshLayout) findViewById(R.id.pull_to_sync_wrapper);
+        mPullToSyncWrapper.setDistanceToTriggerSync(SWIPE_TO_SYNC_TRIGGER_DISTANCE);
         mPullToSyncWrapper.setOnRefreshListener(new SwipeRefreshLayout.OnRefreshListener() {
             @Override
             public void onRefresh() {
@@ -1527,7 +1530,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
                                     break;
                             }
                         } else if (result[0] instanceof String) {
-                            dialogMessage = res.getString(R.string.sync_log_error_specific, -1, result[0]);
+                            dialogMessage = res.getString(R.string.sync_log_error_specific, Integer.toString(-1), result[0]);
                         } else {
                             dialogMessage = res.getString(R.string.sync_generic_error);
                         }


### PR DESCRIPTION
@madhead 

I want to increase the threshold for triggering a sync by swiping. I like this feature and have been using it myself but there are still occasions where I trigger it accidentally when I just wanted to scroll up the deck list (this is maybe 95% my own bad habit).

Unlike, say, Gmail, the cost of accidentally starting and cancelling a sync in AnkiDroid is pretty high, so I want to try to decrease the chances of it happening. 

Also a quick fix to a warning in DeckPicker.