### PR TITLE
Fix random factor in lrn card scheduling

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sched.java
@@ -942,9 +942,8 @@ public class Sched {
             int delay = _delayForGrade(conf, card.getLeft());
             if (card.getDue() < Utils.now()) {
                 // not collapsed; add some randomness
-                delay *= (1 + (new Random().nextInt(25) / 100));
+                delay *= Utils.randomFloatInRange(1f, 1.25f);
             }
-            // TODO: check, if type for second due is correct
             card.setDue((int) (Utils.now() + delay));
 
             // due today?

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
@@ -1015,4 +1015,13 @@ public class Utils {
     public static String unescape(String htmlText) {
         return Html.fromHtml(htmlText).toString();
     }
+
+
+    /**
+     * Return a random float within the range of min and max.
+     */
+    public static float randomFloatInRange(float min, float max) {
+        Random rand = new Random();
+        return rand.nextFloat() * (max - min) + min;
+    }
 }


### PR DESCRIPTION
The previous calculation always truncated to 1.

--

Fixes https://github.com/ankidroid/Anki-Android/issues/4390. Fairly low impact scheduling bug. Learning cards are meant to be randomized within the learn queue, and this bug meant that they were always scheduled in the order that they were introduced.