### PR TITLE
Remove unrequired colleciton reopen in import-replace

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
@@ -821,7 +821,6 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
         }
         int addedCount = -1;
         try {
-            col.reopen();
             CollectionHelper.getInstance().unlockCollection();
 
             // because users don't have a backup of media, it's safer to import new


### PR DESCRIPTION
Fixes https://github.com/ankidroid/Anki-Android/issues/4395.

I couldn't pinpoint the exact cause of the problem, but removing this method call fixed it. Calling it is completely unnecessary as the rest of the method only copies media files and doesn't require an open collection, so removing it is not a problem.