### PR TITLE
Fix duplicate checking bug

### DIFF
--- a/api/src/main/java/com/ichi2/anki/api/Utils.java
+++ b/api/src/main/java/com/ichi2/anki/api/Utils.java
@@ -71,7 +71,14 @@ class Utils {
             byte[] digest = md.digest(data.getBytes("UTF-8"));
             BigInteger biginteger = new BigInteger(1, digest);
             String result = biginteger.toString(16);
-            return Long.valueOf(result.substring(0, 8), 16);
+            
+            // pad checksum to 40 bytes, as is done in the main AnkiDroid code
+            if (result.length() < 40) {
+                String zeroes = "0000000000000000000000000000000000000000";
+                result = zeroes.substring(0, zeroes.length() - result.length()) + result;
+            }
+            
+            return Long.valueOf(result.substring(0, 8), 16);            
         } catch (Exception e) {
             // This is guaranteed to never happen
             throw new IllegalStateException("Error making field checksum with SHA1 algorithm and UTF-8 encoding", e);


### PR DESCRIPTION
Duplicate checking code does not pad checksum with leading zeroes as main AnkiDroid code does, causing fields with checksums starting with 0 to fail to match correctly.