### PR TITLE
Parsing a "send_to" intent data to prepopulate card insert dialog

### DIFF
--- a/AnkiDroid/src/main/res/values-ru/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-ru/10-preferences.xml
@@ -171,6 +171,21 @@
   <string name="custom_buttons_setting_if_room">Show if room</string>
   <string name="custom_buttons_setting_menu_only">Menu only</string>
   <string name="reset_custom_buttons">Reset to default</string>
+
+  <!-- Card creation preferences -->
+  <string name="pref_cat_card_creation">Создание карточек при отправке из других приложений</string>
+
+  <string name="card_front_or_back_position">Заполнять изучаемое слово в:</string>
+
+  <string name="ignore_intents_subject">Автоматически определять изучаемое слово</string>
+  <string name="ignore_intents_subject_summary">Игнорировать изучаемое слово, предоставленное внешним приложением, вместо него использовать первое в тексте</string>
+
+  <string name="parse_clipboard">Автоматически заполнять карточку</string>
+  <string name="parse_clipboard_summary">Автоматически разбирать карточку на изучаемое слово и перевод</string>
+
+  <string name="card_obfuscation">Прятать изучаемое слово в примерах</string>
+  <string name="card_obfuscation_summary"></string>
+
   <!-- Advanced statistics settings -->
   <string name="advanced_statistics_title">Advanced statistics</string>
   <string name="enable_advanced_statistics_title">Enable advanced statistics</string>

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -39,6 +39,7 @@
     <string name="pref_cat_actions">Actions</string>
     <string name="pref_cat_advanced">Advanced</string>
     <string name="pref_cat_advanced_summ">Optimization and experimental features</string>
+    <string name="pref_cat_card_creation">Adding cards via "send to" dialog</string>
     <string name="pref_cat_performance">Performance</string>
     <string name="pref_cat_workarounds">Workarounds</string>
     <string name="pref_cat_plugins">Plugins</string>
@@ -158,6 +159,19 @@
     <string name="custom_buttons_setting_if_room">Show if room</string>
     <string name="custom_buttons_setting_menu_only">Menu only</string>
     <string name="reset_custom_buttons">Reset to default</string>
+
+    <!-- Card creation preferences -->
+    <string name="card_front_or_back_position">Subject word goes to:</string>
+
+    <string name="ignore_intents_subject">Derive the word from article text</string>
+    <string name="ignore_intents_subject_summary">Ignore the word provided from another app and instead retrieve it with transcription</string>
+
+    <string name="parse_clipboard">Parse clipboard for translation</string>
+    <string name="parse_clipboard_summary">Try to derive translated words while creating cards from other apps</string>
+
+    <string name="card_obfuscation">Hide original word in examples</string>
+    <string name="card_obfuscation_summary">At receiving card from another app original word will be hidden in transaltion examples</string>
+
 
     <!-- Advanced statistics settings -->
     <string name="advanced_statistics_title">Advanced statistics</string>

--- a/AnkiDroid/src/main/res/values/11-arrays.xml
+++ b/AnkiDroid/src/main/res/values/11-arrays.xml
@@ -80,4 +80,12 @@
         <item>Black</item>
         <item>Dark</item>
     </string-array>
+    <string-array name="card_position">
+        <item>front</item>
+        <item>back</item>
+    </string-array>
+    <string-array name="card_position_value">
+        <item>front</item>
+        <item>back</item>
+    </string-array>
 </resources>

--- a/AnkiDroid/src/main/res/xml/preferences_advanced.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_advanced.xml
@@ -38,6 +38,36 @@
         <Preference
             android:key="custom_sync_server_link"
             android:title="@string/custom_sync_server_title"/>
+        <PreferenceCategory android:title="@string/pref_cat_card_creation" >
+            <ListPreference
+                android:key="card_front_or_back_position"
+                android:title="@string/card_front_or_back_position"
+                android:defaultValue="front"
+                android:entries="@array/card_position"
+                android:entryValues="@array/card_position_value"/>
+            <!-- some dictionaries provide in intent "Subject" field the search text, that was used to find current trnaslation,
+            i.e. subject "diction" may have been used for finding "dictionary" article.
+            Meanwhile, in case this dictionary includes translated word at the beginning of its article, and this word can be detected
+            being divided by transription from the translation text - then subject can be ignored and the word can be parsed from intent
+            "text" field. For example, the intent.text may be the following:
+            DICTIONARY [дикшэнери] some translation text-->
+            <CheckBoxPreference
+                android:key="ignore_subject_from_the_app"
+                android:defaultValue="false"
+                android:title="@string/ignore_intents_subject"
+                android:summary="@string/ignore_intents_subject_summary"/>
+            <CheckBoxPreference
+                android:key="parse_clipboard_for_translation"
+                android:defaultValue="false"
+                android:title="@string/parse_clipboard"
+                android:summary="@string/parse_clipboard_summary"/>
+            <!-- usually the following setting makes sense only in case translation is on front (i.e. card_front_or_back_position=back)-->
+            <CheckBoxPreference
+                android:key="hide_subject_word_in_translation_examples"
+                android:defaultValue="false"
+                android:summary="@string/card_obfuscation_summary"
+                android:title="@string/card_obfuscation"/>
+        </PreferenceCategory>
         <PreferenceCategory android:title="@string/pref_cat_performance" >
             <com.ichi2.ui.SeekBarPreference
                 android:defaultValue="8"


### PR DESCRIPTION
A new feature set is added. Everything added are advanced features, that may be switched on/off if necessary.
It is all aimed at fast creating of new cards from send_to intents:
1.clipboard send all the information in a single field. Now it will be parsed and in case [transcription] in square brackets is found - text before it is considered to be the original word and text after it is considered to be the translation
2.to create cards quicker - translation will be automatically parsed for examples. and the translated word will be hidden in examples (swaped for ______)
3.for send_to intents form other apps a bug is found - form there an incomplete word may be send. For example, user may search word "contribution" and type just "contribu" in search dialog in his dictionary unitl he got the translation. At this moment the "send_to" intent may send a word "contibu" with the dictionary card. Meanwhile in the dictionary itself there is a necessary word that can be retrieved automatically in case it is demarked from the translation with [transciption].

All those new features were tested by myslef for a month with "abby lingvo" dictionary (I create words from clipboard) and by my wife with "offline dictionaries" by www.nghs.fr (here the send_to feature is build into the dictionary itself).