### PR TITLE
Quote the replacement string when using Matcher#appendReplacement

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -2186,7 +2186,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
         Matcher m = Pattern.compile("([^\u0000-\uFFFF])").matcher(text);
         while (m.find()) {
             String a = "&#x" + Integer.toHexString(m.group(1).codePointAt(0)) + ";";
-            m.appendReplacement(sb, a);
+            m.appendReplacement(sb, Matcher.quoteReplacement(a));
         }
         m.appendTail(sb);
         return sb.toString();

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/LaTeX.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/LaTeX.java
@@ -56,6 +56,7 @@ public class LaTeX {
      * in AnkiDroid. The omitted parameters are used to generate LaTeX images. AnkiDroid does not
      * support the generation of LaTeX media and the provided parameters are sufficient for all
      * other cases.
+     * NOTE: _imgLink produces an alphanumeric filename so there is no need to escape the replacement string.
      */
     public static String mungeQA(String html, Collection col) {
         StringBuffer sb = new StringBuffer();

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
@@ -653,7 +653,7 @@ public class Anki2Importer extends Importer {
                 BufferedInputStream dstData = _dstMediaData(fname);
                 if (srcData == null) {
                     // file was not in source, ignore
-                    m.appendReplacement(sb, m.group(0));
+                    m.appendReplacement(sb, Matcher.quoteReplacement(m.group(0)));
                     continue;
                 }
                 // if model-local file exists from a previous import, use that
@@ -663,19 +663,19 @@ public class Anki2Importer extends Importer {
 
                 String lname = String.format(Locale.US, "%s_%s%s", name, mid, ext);
                 if (mDst.getMedia().have(lname)) {
-                    m.appendReplacement(sb, m.group(0).replace(fname, lname));
+                    m.appendReplacement(sb, Matcher.quoteReplacement(m.group(0).replace(fname, lname)));
                     continue;
                 } else if (dstData == null || compareMedia(srcData, dstData)) { // if missing or the same, pass unmodified
                     // need to copy?
                     if (dstData == null) {
                         _writeDstMedia(fname, srcData);
                     }
-                    m.appendReplacement(sb, m.group(0));
+                    m.appendReplacement(sb, Matcher.quoteReplacement(m.group(0)));
                     continue;
                 }
                 // exists but does not match, so we need to dedupe
                 _writeDstMedia(lname, srcData);
-                m.appendReplacement(sb, m.group(0).replace(fname, lname));
+                m.appendReplacement(sb, Matcher.quoteReplacement(m.group(0).replace(fname, lname)));
             }
             m.appendTail(sb);
             fields = sb.toString();


### PR DESCRIPTION
This fixes #4466.

Don't merge this yet, I want to investigate the impact of this bug with all our other uses of `appendReplacement` when I have time tomorrow.

[This method](https://developer.android.com/reference/java/util/regex/Matcher.html#appendReplacement(java.lang.StringBuffer,%20java.lang.String)) eats up `$` and `\` characters since it treats them as special substitution characters. For whatever reason, the javadocs that show up inside the IDE omit most of the information which shows up in the web link. Would have been nice to have that info!