### PR TITLE
Delay automatic card advance by auto play audio time

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.java
@@ -22,6 +22,7 @@ import android.app.Activity;
 import android.content.Context;
 import android.media.AudioManager;
 import android.media.MediaPlayer;
+import android.media.MediaMetadataRetriever;
 import android.media.MediaPlayer.OnCompletionListener;
 import android.media.ThumbnailUtils;
 import android.net.Uri;
@@ -42,6 +43,7 @@ import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -246,6 +248,23 @@ public class Sound {
                 playSound(mSoundPaths.get(qa).get(0), new PlayAllCompletionListener(qa));
             }
         }
+    }
+
+    /**
+     * Returns length in milliseconds.
+     * @param qa -- One of Sound.SOUNDS_QUESTION, Sound.SOUNDS_ANSWER, or Sound.SOUNDS_QUESTION_AND_ANSWER
+     */
+    public long getSoundsLength(int qa) {
+        long length = 0;
+        if (mSoundPaths != null && (qa == Sound.SOUNDS_QUESTION_AND_ANSWER && makeQuestionAnswerList() || mSoundPaths.containsKey(qa))) {
+            MediaMetadataRetriever metaRetriever = new MediaMetadataRetriever();
+            for (String uri_string : mSoundPaths.get(qa)) {
+                Uri soundUri = Uri.parse(uri_string);
+                metaRetriever.setDataSource(AnkiDroidApp.getInstance().getApplicationContext(), soundUri);
+                length += Long.parseLong(metaRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION));
+            }
+        }
+        return length;
     }
 
     /**

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -119,7 +119,7 @@
     <string name="notification_minimum_cards_due_vibrate">Vibrate</string>
     <string name="notification_minimum_cards_due_blink">Blink light</string>
     <string name="timeout_answer_text">Automatic display answer</string>
-    <string name="timeout_answer_summ">Show answer automatically without user input</string>
+    <string name="timeout_answer_summ">Show answer automatically without user input. Delay includes time for automatically played audio files.</string>
     <string name="timeout_answer_seconds">Time to show answer</string>
     <string name="timeout_answer_seconds_summ">XXX s</string>
     <string name="timeout_question_seconds">Time to show next question</string>


### PR DESCRIPTION
For front card, delay by the time for audio on the front and back, so
the user could hear the audio, then have time to say or think the
answer.

Required changing min api level to 14 for media file length call. This
loses compatibility with 1.6% of devices according to
https://developer.android.com/about/dashboards/index.html The other
option would be to figure out some older api, or make it conditional on
a newer version if there is none. I don't care, get a newer os,
wikipedia says 4.0 was released in 2011.
