### PR TITLE
Don't mix up JSON `null` and missing last parameters on full media sync

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/MediaSyncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/MediaSyncer.java
@@ -121,7 +121,12 @@ public class MediaSyncer {
                 for (int i = 0; i < data.length(); i++) {
                     String fname = data.getJSONArray(i).getString(0);
                     int rusn = data.getJSONArray(i).getInt(1);
-                    String rsum = data.getJSONArray(i).optString(2);
+                    String rsum = null;
+                    if (!data.getJSONArray(i).isNull(2)) {
+                        // If `rsum` is a JSON `null` value, `.optString(2)` will
+                        // return `"null"` as a string
+                        rsum = data.getJSONArray(i).optString(2);
+                    }
                     Pair<String, Integer> info = mCol.getMedia().syncInfo(fname);
                     String lsum = info.first;
                     int ldirty = info.second;


### PR DESCRIPTION
Steps to reproduce:

  * Use [`anki-sync-server`-based server software](https://github.com/dsnopek/anki-sync-server) (not tested with AnkiWeb)
  * Add a bunch of media files in desktop Anki and sync
  * Delete some of the media files on desktop Anki and sync again
  * Reset AnkiDroid and try doing a full sync to your sync server

Expected Result:

 * Sync succeeds, just like in desktop Anki

Actual Result:

 * AnkiDroid will abort media sync (but succeed in database sync), stating an "Internal Server Error" has occurred.

What actually happened:

 * Server returned list of media files (including deleted ones), but has set their checksums to `null` (JSON value)
 * AnkiDroid parses this JSON string using https://developer.android.com/reference/org/json/JSONArray.html → JSON `null` values become, [`JSONObject.NULL`](https://developer.android.com/reference/org/json/JSONObject.html#NULL)s (which have a `.toString()` value of `"null"`)
 * AnkiDroid retrieves the value of the third column using [`JSONArray.optString`](https://developer.android.com/reference/org/json/JSONArray.html#optString(int)), which "Returns the value at index if it exists, **coercing it if necessary**" – where *coercing* means calling `.toString()`
   - Therefor all JSON `null`s will be converted to this string: `"null"`
 * Since `"null"` is obviously not [TextUtils.isEmpty](https://developer.android.com/reference/android/text/TextUtils.html#isEmpty(java.lang.CharSequence)), AnkiDroid will consider this values to be changed (not deleted) and will try to download them again
 * Server software crashes when invalid filename is requested and returns "500 Internal Server Error"
 * Unhappiness :crying_cat_face: 