### PR TITLE
Fix sync cancellation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ android:
     - tools
     - platform-tools
     - build-tools-24.0.3
+    - build-tools-25.0.1
     - android-25
     - extra-android-support
     - extra-android-m2repository

--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -23,7 +23,7 @@
           package="com.ichi2.anki"
           android:installLocation="auto"
           android:versionCode="20800102"
-          android:versionName="">
+          android:versionName="2.8alpha2">
 
     <!--
         The version number is of the form:

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HttpSyncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HttpSyncer.java
@@ -348,6 +348,9 @@ public class HttpSyncer {
         return 0;
     }
 
+    public void abort() throws UnknownHttpResponseException {
+    }
+
 
     public HttpResponse meta() throws UnknownHttpResponseException {
         return null;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/MediaSyncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/MediaSyncer.java
@@ -101,13 +101,9 @@ public class MediaSyncer {
             mCol.log("last local usn is " + lastUsn);
             mDownloadCount = 0;
             while (true) {
-                // Allow cancellation
+                // Allow cancellation (note: media sync has no finish command, so just throw)
                 if (Connection.getIsCancelled()) {
                     Timber.i("Sync was cancelled");
-                    try {
-                        mServer.finish();
-                    } catch (UnknownHttpResponseException e) {
-                    }
                     throw new RuntimeException("UserAbortedSync");
                 }
                 JSONArray data = mServer.mediaChanges(lastUsn);
@@ -119,6 +115,11 @@ public class MediaSyncer {
                 List<String> need = new ArrayList<>();
                 lastUsn = data.getJSONArray(data.length()-1).getInt(1);
                 for (int i = 0; i < data.length(); i++) {
+                    // Allow cancellation (note: media sync has no finish command, so just throw)
+                    if (Connection.getIsCancelled()) {
+                        Timber.i("Sync was cancelled");
+                        throw new RuntimeException("UserAbortedSync");
+                    }
                     String fname = data.getJSONArray(i).getString(0);
                     int rusn = data.getJSONArray(i).getInt(1);
                     String rsum = null;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.java
@@ -906,7 +906,7 @@ public class Syncer {
             Timber.i("Sync was cancelled");
             publishProgress(con, R.string.sync_cancelled);
             try {
-                mServer.finish();
+                mServer.abort();
             } catch (UnknownHttpResponseException e) {
             }
             throw new RuntimeException("UserAbortedSync");


### PR DESCRIPTION
Previously we were calling sync/finish during abort, which is not supported by the protocol, as discussed in issue #4512. Instead we must use the new abort command. I also removed unnecessary calls to finish() during media sync, and added another check during the main file fetching loop to improve the cancellation speed during media sync.

Closes #4512 

@dae