### PR TITLE
Fix CUSTOM_STUDY_TAGS reschedule setting

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
@@ -173,7 +173,7 @@ public class CustomStudyDialog extends DialogFragment {
                                             sb.append("(").append(TextUtils.join(" or ", arr)).append(")");
                                         }
                                         createCustomStudySession(new JSONArray(), new Object[]{sb.toString(),
-                                                Consts.DYN_MAX_SIZE, Consts.DYN_RANDOM}, false);
+                                                Consts.DYN_MAX_SIZE, Consts.DYN_RANDOM}, true);
                                     }
                                 });
                                 activity.showDialogFragment(dialogFragment);


### PR DESCRIPTION
On Desktop, when creating a Custom Study session "by tag", the cards are rescheduled by default. This configuration is inconsistent in AnkiDroid. This patch aims to solve it, by setting the reschedule option to true on CUSTOM_STUDY_TAGS deck creation.

Fixes Google Code Issue 2043 reported in #2940.