### PR TITLE
Fix media sync comparison and a consequent DB error

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.java
@@ -151,12 +151,7 @@ public class MyAccount extends AnkiActivity {
         editor.putString("hkey", "");
         editor.commit();
         //  force media resync on deauth
-        try {
-            getCol().getMedia().forceResync();
-        } catch (SQLiteException e) {
-            Timber.e("MyAccount.logout()  reinitializing media db due to sqlite error");
-            getCol().getMedia()._initDB();
-        }
+        getCol().getMedia().forceResync();
         switchToState(STATE_LOG_IN);
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Media.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Media.java
@@ -770,7 +770,8 @@ public class Media {
     public void forceResync() {
         mDb.execute("delete from media");
         mDb.execute("update meta set lastUsn=0,dirMod=0");
-        mDb.execute("vacuum analyze");
+        mDb.execute("vacuum");
+        mDb.execute("analyze");
         mDb.commit();
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/MediaSyncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/MediaSyncer.java
@@ -151,7 +151,7 @@ public class MediaSyncer {
                         
                     } else if (!TextUtils.isEmpty(lsum)) {
                         // deleted remotely
-                        if (ldirty != 0) {
+                        if (ldirty == 0) {
                             mCol.log("delete local");
                             mCol.getMedia().syncDelete(fname);
                         } else {


### PR DESCRIPTION
Fixes https://github.com/ankidroid/Anki-Android/issues/4507

This was technically a self-correcting issue, so it's not a big deal, but it is really annoying when triggered because it's slow and resulted in an error. Basically, the sanity check fails because of the differing counts so it wipes the media DB in order to rebuild it on the next sync, which meant scanning every media file once again (thus fixing the discrepancy).

I uncovered a bug in the part that wipes the DB. The `vacuum analyze` command is failing. It's probably because the Android SQLite method it uses can only execute one statement per call, so I split them up onto two lines ([the importer](https://github.com/ankidroid/Anki-Android/blob/develop/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java#L135) does this too). This was also the cause of [this](https://github.com/ankidroid/Anki-Android/commit/ddfd0e65b25bcf79bb60a220c19583f66df1caab) error, so I removed the workaround for it.