### PR TITLE
Fix boot crash

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.java
@@ -7,6 +7,7 @@ import android.content.Intent;
 
 import com.ichi2.anki.CollectionHelper;
 import com.ichi2.anki.receiver.ReminderReceiver;
+import com.ichi2.libanki.Collection;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -24,9 +25,12 @@ public class BootService extends IntentService {
 
         try {
             for (JSONObject deck : CollectionHelper.getInstance().getCol(this).getDecks().all()) {
+                Collection col = CollectionHelper.getInstance().getCol(this);
+                if (col.getDecks().isDyn(deck.getLong("id"))) {
+                    continue;
+                }
                 final long deckConfigurationId = deck.getLong("conf");
-                final JSONObject deckConfiguration = CollectionHelper.getInstance().getCol(this).getDecks()
-                        .getConf(deckConfigurationId);
+                final JSONObject deckConfiguration = col.getDecks().getConf(deckConfigurationId);
 
                 if (deckConfiguration.has("reminder")) {
                     final JSONObject reminder = deckConfiguration.getJSONObject("reminder");

--- a/AnkiDroid/src/main/res/values/17-model-manager.xml
+++ b/AnkiDroid/src/main/res/values/17-model-manager.xml
@@ -50,7 +50,7 @@
     <string name="model_field_editor_options">Field options</string>
     <string name="model_field_editor_rename">Rename field</string>
     <string name="model_field_editor_reposition_menu">Reposition field</string>
-    <string name="model_field_editor_reposition" formatted="false">Reposition field (enter a value %1$d–%2$d)</string>
+    <string name="model_field_editor_reposition">Reposition field (enter a value %1$d–%2$d)</string>
     <string name="model_field_editor_changing">Updating fields</string>
     <string name="model_field_editor_sort_field">Sort by this field</string>
     <string name="model_clone_suffix">copy</string>


### PR DESCRIPTION
Couple of small fixes.

The first one was causing a crash on device startup if you have dynamic decks.
The second is producing a confusing lint warning which would otherwise be useful for finding broken translation strings that would crash at runtime.