### PR TITLE
Fix sending of exported files on Android 6+

### DIFF
--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -358,6 +358,16 @@
             android:exported="true" >
             <meta-data android:name="com.ichi2.anki.provider.spec" android:value="2" />
         </provider>
+
+        <provider
+            android:name="android.support.v4.content.FileProvider"
+            android:authorities="com.ichi2.anki.apkgfileprovider"
+            android:grantUriPermissions="true"
+            android:exported="false">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/filepaths" />
+        </provider>
     </application>
 
 </manifest>

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -22,7 +22,6 @@
 package com.ichi2.anki;
 
 import android.Manifest;
-import android.content.ActivityNotFoundException;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -43,10 +42,11 @@ import android.support.v4.app.ActivityCompat;
 import android.support.v4.app.DialogFragment;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentTransaction;
+import android.support.v4.app.ShareCompat;
+import android.support.v4.content.FileProvider;
 import android.support.v4.widget.SwipeRefreshLayout;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
-import android.text.Html;
 import android.text.TextUtils;
 import android.view.KeyEvent;
 import android.view.Menu;
@@ -1608,9 +1608,9 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
     @Override
     public void exportApkg(String filename, Long did, boolean includeSched, boolean includeMedia) {
-        // get export path
+        // get export path from internal storage
         File colPath = new File(getCol().getPath());
-        File exportDir = new File(colPath.getParentFile(), "export");
+        File exportDir = new File(getFilesDir(), "export");
         exportDir.mkdirs();
         File exportPath;
         if (filename != null) {
@@ -1642,19 +1642,34 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
 
     public void emailFile(String path) {
-        Intent intent = new Intent(Intent.ACTION_SEND);
-        intent.setType("message/rfc822");
-        intent.putExtra(Intent.EXTRA_SUBJECT, getString(R.string.export_email_subject));
-        intent.putExtra(Intent.EXTRA_TEXT, Html.fromHtml(getString(R.string.export_email_text)));
+        // Make sure the file actually exists
         File attachment = new File(path);
-        if (attachment.exists()) {
-            Uri uri = Uri.fromFile(attachment);
-            intent.putExtra(Intent.EXTRA_STREAM, uri);
+        if (!attachment.exists()) {
+            Timber.e("Specified apkg file %s does not exist", path);
+            UIUtils.showThemedToast(this, getResources().getString(R.string.apk_share_error), false);
+            return;
         }
+        // Get a URI for the file to be shared via the FileProvider API
+        Uri uri;
         try {
-            startActivityWithoutAnimation(intent);
-        } catch (ActivityNotFoundException e) {
-            UIUtils.showThemedToast(this, getResources().getString(R.string.no_email_client), false);
+            uri = FileProvider.getUriForFile(DeckPicker.this, "com.ichi2.anki.apkgfileprovider", attachment);
+        } catch (IllegalArgumentException e) {
+            Timber.e("Could not generate a valid URI for the apkg file");
+            UIUtils.showThemedToast(this, getResources().getString(R.string.apk_share_error), false);
+            return;
+        }
+        Intent shareIntent = ShareCompat.IntentBuilder.from(DeckPicker.this)
+                .setType("text/html")
+                .setStream(uri)
+                .setSubject(getString(R.string.export_email_subject))
+                .setHtmlText(getString(R.string.export_email_text))
+                .getIntent();
+        shareIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+        if (shareIntent.resolveActivity(getPackageManager()) != null) {
+            startActivityWithoutAnimation(shareIntent);
+        } else {
+            Timber.e("Could not find appropriate application to share apkg with");
+            UIUtils.showThemedToast(this, getResources().getString(R.string.apk_share_error), false);
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/utils/Files.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/Files.java
@@ -1,0 +1,56 @@
+package com.ichi2.utils;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+
+import timber.log.Timber;
+
+public class Files {
+    public static boolean copy(File file, File outfile) {
+        Timber.d("Copying file %s to %s", file.getAbsolutePath(), outfile.getAbsolutePath());
+        if (!file.isFile()) {
+            Timber.e("%s is not a file", file.getAbsolutePath());
+            return false;
+        }
+        if (!outfile.isFile()) {
+            Timber.e("%s is not a file", outfile.getAbsolutePath());
+            return false;
+        }
+
+        FileInputStream inStream = null;
+        FileOutputStream outStream = null;
+        try {
+            inStream = new FileInputStream(file);
+            outStream = new FileOutputStream(outfile);
+            FileChannel inChannel = inStream.getChannel();
+            FileChannel outChannel = outStream.getChannel();
+            inChannel.transferTo(0, inChannel.size(), outChannel);
+        } catch (Exception e) {
+            Timber.e("Exception copying file %s to %s\n %s", file.getAbsolutePath(), outfile.getAbsolutePath(), e.getMessage());
+            return false;
+        } finally {
+            closeQuietly(inStream);
+            closeQuietly(outStream);
+        }
+        return true;
+    }
+
+    public static boolean move(File file, File outfile) {
+        boolean result = copy(file, outfile);
+        file.delete();
+        return result;
+    }
+
+    private static void closeQuietly(Closeable closeable) {
+        if (closeable != null) {
+            try {
+                closeable.close();
+            } catch (IOException e) {
+            }
+        }
+    }
+}

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -152,9 +152,9 @@
     <string name="confirm_apkg_export">Export collection as apkg file?</string>
     <string name="confirm_apkg_export_deck">Export “%s” as apkg file?</string>
     <string name="export_in_progress">Exporting apkg file…</string>
-    <string name="export_successful_title">Email apkg?</string>
-    <string name="export_successful">File “%s” was exported. Do you want to email it?</string>
-    <string name="export_email_subject">AnkiDroid exported collection</string>
+    <string name="export_successful_title">Send apkg?</string>
+    <string name="export_successful">File “%s” was exported. Do you want to send it with another app?</string>
+    <string name="export_email_subject">AnkiDroid exported flashcards</string>
     <string name="export_email_text">
         <![CDATA[
         Hi!
@@ -218,4 +218,6 @@
         <item quantity="one">%2$d new card to review in %1$s</item>
         <item quantity="other">%2$d new cards to review in %1$s</item>
     </plurals>
+    <!-- Currently only used if exporting APKG fails -->
+    <string name="apk_share_error">Error sharing apkg file</string>
 </resources>

--- a/AnkiDroid/src/main/res/values/04-network.xml
+++ b/AnkiDroid/src/main/res/values/04-network.xml
@@ -31,7 +31,6 @@
     <string name="connection_error_message">A network error has occurred</string>
     <string name="not_logged_in_title">Log in to AnkiWeb</string>
     <string name="login_create_account_message">You must log in to a third party account to use the cloud sync service. You can create one in the next step.</string>
-    <string name="no_email_client">No email client available</string>
 
     <!-- MyAccount.java -->
     <string name="username">Email address</string>

--- a/AnkiDroid/src/main/res/xml/filepaths.xml
+++ b/AnkiDroid/src/main/res/xml/filepaths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <files-path path="export/" name="export-internal-storage" />
+</paths>


### PR DESCRIPTION
I just noticed today on my Nexus 5x that the app crashes with a `android.os.FileUriExposedException` on export->email send. The Android documentation says:

> Don’t use Uri.fromFile(). It forces receiving apps to have the READ_EXTERNAL_STORAGE permission, won’t work at all if you are trying to share across users, and in versions of Android lower than 4.4 (API level 19), would require your app to have WRITE_EXTERNAL_STORAGE. And really important share targets, such as the Gmail app, don't have the READ_EXTERNAL_STORAGE, causing this call to fail.

So I set up a FileProvider to send the file in a way that doesn't require the receiving app to have external storage read permission. For this to work, we have to hardcode the list of paths that the FileProvider has access to, which makes it a bit tricky to keep using External Storage to store the exported APKG (since the collection path is user-customizable). To get around this I export to internal storage instead, and then only move it to external if the user chooses not to send it via email.

This also fixes #4535 by not artificially limiting the receiving app to an email client.

Could someone please give this a quick review?