### PR TITLE
Navigation drawer: lag on older devices

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
@@ -20,6 +20,7 @@ import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.net.Uri;
 import android.os.Bundle;
+import android.os.Handler;
 import android.support.design.widget.NavigationView;
 import android.support.v4.view.GravityCompat;
 import android.support.v4.view.MenuItemCompat;
@@ -58,6 +59,12 @@ public class NavigationDrawerActivity extends AnkiActivity implements Navigation
     public static final int REQUEST_PREFERENCES_UPDATE = 100;
     public static final int REQUEST_BROWSE_CARDS = 101;
     public static final int REQUEST_STATISTICS = 102;
+
+    /**
+     * runnable that will be executed after the drawer has been closed.
+     */
+    private Runnable pendingRunnable;
+
     // Navigation drawer initialisation
     protected void initNavigationDrawer(View mainView){
         // Create inherited navigation drawer layout here so that it can be used by parent class
@@ -110,6 +117,11 @@ public class NavigationDrawerActivity extends AnkiActivity implements Navigation
             public void onDrawerClosed(View drawerView) {
                 super.onDrawerClosed(drawerView);
                 supportInvalidateOptionsMenu();
+
+                if(pendingRunnable != null) {
+                    new Handler().post(pendingRunnable);
+                    pendingRunnable = null;
+                }
             }
 
 
@@ -247,44 +259,55 @@ public class NavigationDrawerActivity extends AnkiActivity implements Navigation
     }
 
     @Override
-    public boolean onNavigationItemSelected(MenuItem item) {
+    public boolean onNavigationItemSelected(final MenuItem item) {
         // Don't do anything if user selects already selected position
         if (item.isChecked()) {
             return true;
         }
-        // Take action if a different item selected
-        switch (item.getItemId()) {
-            case R.id.nav_decks:
-                Intent deckPicker = new Intent(this, DeckPicker.class);
-                deckPicker.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);    // opening DeckPicker should clear back history
-                startActivityWithAnimation(deckPicker, ActivityTransitionAnimation.RIGHT);
-                break;
-            case R.id.nav_browser:
-                openCardBrowser();
-                break;
-            case R.id.nav_stats:
-                Intent intent = new Intent(this, Statistics.class);
-                intent.putExtra("selectedDeck", getCol().getDecks().selected());
-                startActivityForResultWithAnimation(intent, REQUEST_STATISTICS, ActivityTransitionAnimation.LEFT);
-                break;
-            case R.id.nav_night_mode:
-                mNightModeSwitch.performClick();
-                return true;
-            case R.id.nav_settings:
-                mOldColPath = CollectionHelper.getCurrentAnkiDroidDirectory(this);
-                // Remember the theme we started with so we can restart the Activity if it changes
-                mOldTheme = Themes.getCurrentTheme(getApplicationContext());
-                startActivityForResultWithAnimation(new Intent(this, Preferences.class), REQUEST_PREFERENCES_UPDATE, ActivityTransitionAnimation.FADE);
-                break;
-            case R.id.nav_help:
-                openUrl(Uri.parse(AnkiDroidApp.getManualUrl()));
-                break;
-            case R.id.nav_feedback:
-                openUrl(Uri.parse(AnkiDroidApp.getFeedbackUrl()));
-                break;
-            default:
-                return false;
-        }
+
+        /*
+         * This runnable will be executed in onDrawerClosed(...)
+         * to make the animation more fluid on older devices.
+         */
+        pendingRunnable = new Runnable() {
+            @Override
+            public void run() {
+                // Take action if a different item selected
+                switch (item.getItemId()) {
+                    case R.id.nav_decks:
+                        Intent deckPicker = new Intent(NavigationDrawerActivity.this, DeckPicker.class);
+                        deckPicker.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);    // opening DeckPicker should clear back history
+                        startActivityWithAnimation(deckPicker, ActivityTransitionAnimation.RIGHT);
+                        break;
+                    case R.id.nav_browser:
+                        openCardBrowser();
+                        break;
+                    case R.id.nav_stats:
+                        Intent intent = new Intent(NavigationDrawerActivity.this, Statistics.class);
+                        intent.putExtra("selectedDeck", getCol().getDecks().selected());
+                        startActivityForResultWithAnimation(intent, REQUEST_STATISTICS, ActivityTransitionAnimation.LEFT);
+                        break;
+                    case R.id.nav_night_mode:
+                        mNightModeSwitch.performClick();
+                        break;
+                    case R.id.nav_settings:
+                        mOldColPath = CollectionHelper.getCurrentAnkiDroidDirectory(NavigationDrawerActivity.this);
+                        // Remember the theme we started with so we can restart the Activity if it changes
+                        mOldTheme = Themes.getCurrentTheme(getApplicationContext());
+                        startActivityForResultWithAnimation(new Intent(NavigationDrawerActivity.this, Preferences.class), REQUEST_PREFERENCES_UPDATE, ActivityTransitionAnimation.FADE);
+                        break;
+                    case R.id.nav_help:
+                        openUrl(Uri.parse(AnkiDroidApp.getManualUrl()));
+                        break;
+                    case R.id.nav_feedback:
+                        openUrl(Uri.parse(AnkiDroidApp.getFeedbackUrl()));
+                        break;
+                    default:
+                        break;
+                }
+            }
+        };
+
         mDrawerLayout.closeDrawers();
         return true;
     }


### PR DESCRIPTION
Lag especially noticeable when starting another activity, e.g. startActivity(settingsIntent).
Solution: A pending runnable will be executed after the drawer has been closed.