### PR TITLE
Fix IllegalStateException crashes with ConfirmationDialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
@@ -618,16 +618,18 @@ public class CardTemplateEditor extends AnkiActivity {
          * @param numAffectedCards number of cards which will be affected
          */
         private void confirmDeleteCards(final JSONObject tmpl, final JSONObject model,  int numAffectedCards) {
-            ConfirmationDialog d = new ConfirmationDialog() {
-                @Override
-                public void confirm() {
-                    deleteTemplateWithCheck(tmpl, model);
-                }
-            };
+            ConfirmationDialog d = new ConfirmationDialog();
             Resources res = getResources();
             String msg = String.format(res.getQuantityString(R.plurals.card_template_editor_confirm_delete,
                             numAffectedCards), numAffectedCards, tmpl.optString("name"));
             d.setArgs(msg);
+            Runnable confirm = new Runnable() {
+                @Override
+                public void run() {
+                    deleteTemplateWithCheck(tmpl, model);
+                }
+            };
+            d.setConfirm(confirm);
             ((AnkiActivity) getActivity()).showDialogFragment(d);
         }
 
@@ -642,13 +644,15 @@ public class CardTemplateEditor extends AnkiActivity {
                 ((CardTemplateEditor) getActivity()).getCol().modSchema(true);
                 deleteTemplate(tmpl, model);
             } catch (ConfirmModSchemaException e) {
-                ConfirmationDialog d = new ConfirmationDialog() {
+                ConfirmationDialog d = new ConfirmationDialog();
+                d.setArgs(getResources().getString(R.string.full_sync_confirmation));
+                Runnable confirm = new Runnable() {
                     @Override
-                    public void confirm() {
+                    public void run() {
                         deleteTemplate(tmpl, model);
                     }
                 };
-                d.setArgs(getResources().getString(R.string.full_sync_confirmation));
+                d.setConfirm(confirm);
                 ((AnkiActivity) getActivity()).showDialogFragment(d);
             }
         }
@@ -677,13 +681,15 @@ public class CardTemplateEditor extends AnkiActivity {
                 ((CardTemplateEditor) getActivity()).getCol().modSchema(true);
                 addNewTemplate(model);
             } catch (ConfirmModSchemaException e) {
-                ConfirmationDialog d = new ConfirmationDialog() {
+                ConfirmationDialog d = new ConfirmationDialog();
+                d.setArgs(getResources().getString(R.string.full_sync_confirmation));
+                Runnable confirm = new Runnable() {
                     @Override
-                    public void confirm() {
+                    public void run() {
                         addNewTemplate(model);
                     }
                 };
-                d.setArgs(getResources().getString(R.string.full_sync_confirmation));
+                d.setConfirm(confirm);
                 ((AnkiActivity) getActivity()).showDialogFragment(d);
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -2222,15 +2222,17 @@ public class DeckPicker extends NavigationDrawerActivity implements
                     showSimpleMessageDialog(getResources().getString(R.string.empty_cards_none));
                 } else {
                     String msg = String.format(getResources().getString(R.string.empty_cards_count), cids.size());
-                    ConfirmationDialog dialog = new ConfirmationDialog() {
+                    ConfirmationDialog dialog = new ConfirmationDialog();
+                    dialog.setArgs(msg);
+                    Runnable confirm = new Runnable() {
                         @Override
-                        public void confirm() {
+                        public void run() {
                             getCol().remCards(Utils.arrayList2array(cids));
                             UIUtils.showSimpleSnackbar(DeckPicker.this, String.format(
                                     getResources().getString(R.string.empty_cards_deleted), cids.size()), false);
                         }
                     };
-                    dialog.setArgs(msg);
+                    dialog.setConfirm(confirm);
                     showDialogFragment(dialog);
                 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -683,14 +683,16 @@ public class NoteEditor extends AnkiActivity {
                 mReloadRequired = true;
                 if (mModelChangeCardMap.size() < mEditorNote.cards().size() || mModelChangeCardMap.containsKey(null)) {
                     // If cards will be lost via the new mapping then show a confirmation dialog before proceeding with the change
-                    ConfirmationDialog dialog = new ConfirmationDialog () {
+                    ConfirmationDialog dialog = new ConfirmationDialog ();
+                    dialog.setArgs(res.getString(R.string.confirm_map_cards_to_nothing));
+                    Runnable confirm = new Runnable() {
                         @Override
-                        public void confirm() {
+                        public void run() {
                             // Bypass the check once the user confirms
                             changeNoteTypeWithErrorHandling(oldModel, newModel);
                         }
                     };
-                    dialog.setArgs(res.getString(R.string.confirm_map_cards_to_nothing));
+                    dialog.setConfirm(confirm);
                     showDialogFragment(dialog);
                 } else {
                     // Otherwise go straight to changing note type
@@ -744,9 +746,11 @@ public class NoteEditor extends AnkiActivity {
             changeNoteType(oldModel, newModel);
         } catch (ConfirmModSchemaException e) {
             // Libanki has determined we should ask the user to confirm first
-            ConfirmationDialog dialog = new ConfirmationDialog() {
+            ConfirmationDialog dialog = new ConfirmationDialog();
+            dialog.setArgs(res.getString(R.string.full_sync_confirmation));
+            Runnable confirm = new Runnable() {
                 @Override
-                public void confirm() {
+                public void run() {
                     // Bypass the check once the user confirms
                     getCol().modSchemaNoCheck();
                     try {
@@ -757,7 +761,7 @@ public class NoteEditor extends AnkiActivity {
                     }
                 }
             };
-            dialog.setArgs(res.getString(R.string.full_sync_confirmation));
+            dialog.setConfirm(confirm);
             showDialogFragment(dialog);
         }
     }
@@ -844,26 +848,28 @@ public class NoteEditor extends AnkiActivity {
                 startActivityForResultWithAnimation(intent, REQUEST_ADD, ActivityTransitionAnimation.LEFT);
                 return true;
 
-            case R.id.action_reset_card_progress:
+            case R.id.action_reset_card_progress: {
                 Timber.i("NoteEditor:: Reset progress button pressed");
                 // Show confirmation dialog before resetting card progress
-                ConfirmationDialog dialog = new ConfirmationDialog () {
+                ConfirmationDialog dialog = new ConfirmationDialog();
+                String title = res.getString(R.string.reset_card_dialog_title);
+                String message = res.getString(R.string.reset_card_dialog_message);
+                dialog.setArgs(title, message);
+                Runnable confirm = new Runnable() {
                     @Override
-                    public void confirm() {
+                    public void run() {
                         Timber.i("NoteEditor:: OK button pressed");
-                        getCol().getSched().forgetCards(new long[] { mCurrentEditedCard.getId() });
+                        getCol().getSched().forgetCards(new long[]{mCurrentEditedCard.getId()});
                         getCol().reset();
                         mReloadRequired = true;
                         UIUtils.showThemedToast(NoteEditor.this,
                                 getResources().getString(R.string.reset_card_dialog_acknowledge), true);
                     }
                 };
-                String title = res.getString(R.string.reset_card_dialog_title);
-                String message = res.getString(R.string.reset_card_dialog_message);
-                dialog.setArgs(title, message);
+                dialog.setConfirm(confirm);
                 showDialogFragment(dialog);
                 return true;
-
+            }
             case R.id.action_reschedule_card:
                 Timber.i("NoteEditor:: Reschedule button pressed");
                 showDialogFragment(NoteEditorRescheduleCard.newInstance());

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ConfirmationDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ConfirmationDialog.java
@@ -8,59 +8,63 @@ import android.support.v4.app.DialogFragment;
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.ichi2.anki.R;
 
-/**
- * This is a reusable convenience class which makes it easy to show a confirmation dialog as a DialogFragment.
- * To use, create a new instance which overrides the confirm() method, call setArgs(...), and then show
- * the DialogFragment via the fragment manager as usual.
- */
-public abstract class ConfirmationDialog extends DialogFragment {
-
-    public void setArgs(String message) {
-        setArgs("" , message);
-    }
-
-    public void setArgs(String title, String message) {
-        Bundle args = new Bundle();
-        args.putString("message", message);
-        args.putString("title", title);
-        setArguments(args);
-    }
-
-
-    @Override
-    public MaterialDialog onCreateDialog(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        Resources res = getActivity().getResources();
-        String title = getArguments().getString("title");
-        return new MaterialDialog.Builder(getActivity())
-                .title(title.equals("") ? res.getString(R.string.app_name) : title)
-                .content(getArguments().getString("message"))
-                .positiveText(res.getString(R.string.dialog_ok))
-                .negativeText(res.getString(R.string.dialog_cancel))
-                .callback(new MaterialDialog.ButtonCallback() {
-                    @Override
-                    public void onPositive(MaterialDialog dialog) {
-                        confirm();
-                    }
-
-                    @Override
-                    public void onNegative(MaterialDialog dialog) {
-                        cancel();
-                    }
-                })
-                .show();
-    }
-
-
     /**
-     * Must override this method to handle confirmation event
+     * This is a reusable convenience class which makes it easy to show a confirmation dialog as a DialogFragment.
+     * Create a new instance, call setArgs(...), setConfirm(), and setCancel() then show it via the fragment manager as usual.
      */
-    public abstract void confirm();
+    public class ConfirmationDialog extends DialogFragment {
+        // TODO: Replace these with lambdas
+        private Runnable mConfirm = new Runnable() {
+            @Override
+            public void run() { // Do nothing by default
+            }
+        };
+        private Runnable mCancel = new Runnable() {
+            @Override
+            public void run() { // Do nothing by default
+            }
+        };
 
+        public void setArgs(String message) {
+            setArgs("" , message);
+        }
 
-    /**
-     * Optionally override this method to do something special when operation cancelled
-     */
-    public void cancel() {
+        public void setArgs(String title, String message) {
+            Bundle args = new Bundle();
+            args.putString("message", message);
+            args.putString("title", title);
+            setArguments(args);
+        }
+
+        public void setConfirm(Runnable confirm) {
+            mConfirm = confirm;
+        }
+
+        public void setCancel(Runnable cancel) {
+            mCancel = cancel;
+        }
+
+        @Override
+        public MaterialDialog onCreateDialog(Bundle savedInstanceState) {
+            super.onCreate(savedInstanceState);
+            Resources res = getActivity().getResources();
+            String title = getArguments().getString("title");
+            return new MaterialDialog.Builder(getActivity())
+                    .title(title.equals("") ? res.getString(R.string.app_name) : title)
+                    .content(getArguments().getString("message"))
+                    .positiveText(res.getString(R.string.dialog_ok))
+                    .negativeText(res.getString(R.string.dialog_cancel))
+                    .callback(new MaterialDialog.ButtonCallback() {
+                        @Override
+                        public void onPositive(MaterialDialog dialog) {
+                            mConfirm.run();
+                        }
+
+                        @Override
+                        public void onNegative(MaterialDialog dialog) {
+                            mCancel.run();
+                        }
+                    })
+                    .show();
+        }
     }
-}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DialogHandler.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DialogHandler.java
@@ -8,6 +8,7 @@ import android.os.Message;
 
 import com.ichi2.anki.AnkiActivity;
 import com.ichi2.anki.AnkiDroidApp;
+import com.ichi2.anki.CollectionHelper;
 import com.ichi2.anki.DeckPicker;
 import com.ichi2.anki.R;
 import com.ichi2.async.Connection;
@@ -87,13 +88,15 @@ public class DialogHandler extends Handler {
             ((DeckPicker) mActivity.get()).showDatabaseErrorDialog(msgData.getInt("dialogType"));
         } else if (msg.what == MSG_SHOW_FORCE_FULL_SYNC_DIALOG) {
             // Confirmation dialog for forcing full sync
-            ConfirmationDialog dialog = new ConfirmationDialog () {
+            ConfirmationDialog dialog = new ConfirmationDialog ();
+            Runnable confirm = new Runnable() {
                 @Override
-                public void confirm() {
+                public void run() {
                     // Bypass the check once the user confirms
-                    ((AnkiActivity) getActivity()).getCol().modSchemaNoCheck();
+                    CollectionHelper.getInstance().getCol(AnkiDroidApp.getInstance()).modSchemaNoCheck();
                 }
             };
+            dialog.setConfirm(confirm);
             dialog.setArgs(msgData.getString("message"));
             (mActivity.get()).showDialogFragment(dialog);
         } else if (msg.what == MSG_DO_SYNC) {


### PR DESCRIPTION
Android can't instantiate fragments that are anonymous classes. It was somehow working fine until they updated the support library. Here we use Runnables instead. Once we move to Java8 we can make the code much less verbose by using lambdas.

Fixes #4587 
Fixes #4571