### PR TITLE
Add ability to insert clozes from the notes editor

### DIFF
--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -227,6 +227,19 @@
                 <data android:mimeType="text/plain" />
             </intent-filter>
         </activity>
+        <activity android:name="com.ichi2.anki.ClozeInserter"
+            android:label="@string/insert_cloze_intent_title">
+            <!--Cannot yet add android:exported="false" here because of this android issue: -->
+            <!--https://code.google.com/p/android/issues/detail?id=199161-->
+            <!--The issue means that our insert cloze option will be visible in every app whichever -->
+            <!--"exported" option we pick, but if we add android:exported="false" then other apps -->
+            <!--where users click this option will crash.-->
+            <intent-filter>
+                <action android:name="android.intent.action.PROCESS_TEXT" />
+                <category android:name="android.intent.category.DEFAULT"/>
+                <data android:mimeType="text/plain"/>
+            </intent-filter>
+        </activity>
         <activity android:name="com.ichi2.anki.dialogs.AnkiDroidCrashReportDialog"
             android:theme="@style/Theme.CrashReportDialog"
             android:launchMode="singleInstance"

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ClozeInserter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ClozeInserter.java
@@ -1,0 +1,20 @@
+package com.ichi2.anki;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Build;
+import android.os.Bundle;
+import android.support.annotation.RequiresApi;
+
+public class ClozeInserter extends Activity {
+    @RequiresApi(api = Build.VERSION_CODES.M)
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        CharSequence text = getIntent().getCharSequenceExtra(Intent.EXTRA_PROCESS_TEXT);
+        Intent intent = new Intent();
+        intent.putExtra(Intent.EXTRA_PROCESS_TEXT, "{{c1::" + text + "}}");
+        setResult(RESULT_OK, intent);
+        finish();
+    }
+}

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -101,6 +101,9 @@
     <string name="field_remapping">%1$s (from “%2$s”)</string>
     <string name="confirm_map_cards_to_nothing">Any cards mapped to nothing will be deleted. If a note has no remaining cards, it will be lost. Are you sure you want to continue?</string>
 
+    <!--Short title visible alongside Copy, Paste, Cut etc. in floating text selection toolbar-->
+    <string name="insert_cloze_intent_title">Insert cloze</string>
+
     <plurals name="timebox_reached">
         <item quantity="one">%1$d card studied in %2$s</item>
         <item quantity="other">%1$d cards studied in %2$s</item>


### PR DESCRIPTION
This is an attempt to add the feature requested in https://github.com/ankidroid/Anki-Android/issues/2520

By selecting text anywhere in the app, there is now an option for "Insert Cloze" alongside copy, cut, select all.

## Limitations

- Unfortunately it does not seem to be possible to limit this action to only be visible in the edit notes screen, or even to limit it to only be available within Anki. (see [the feature request to fix this ](https://code.google.com/p/android/issues/detail?id=199161) and [an article which alerted me to this problem](https://medium.com/google-developers/custom-text-selection-actions-with-action-process-text-191f792d2999#.d4z3fa5zb) )

- This functionality is only available to Android Marshmallow users onwards.

- The cloze pattern inserted is always `{{c1::` so users will need to edit this by hand if that's not what they wanted.

![cloze_02](https://cloud.githubusercontent.com/assets/8859100/23464063/8e957530-fe8b-11e6-8778-7628d4bd6e49.png)