### PR TITLE
Fix glosbe

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/web/HttpFetcher.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/web/HttpFetcher.java
@@ -61,7 +61,7 @@ public class HttpFetcher {
             HttpContext localContext = new BasicHttpContext();
             HttpGet httpGet = new HttpGet(address);
             HttpResponse response = httpClient.execute(httpGet, localContext);
-            if (!response.getStatusLine().toString().contains("OK")) {
+            if (response.getStatusLine().getStatusCode() != 200) {
                 return "FAILED";
             }
 


### PR DESCRIPTION
Glosbe are returning "HTTP/1.1 200" which does not contain "OK" in the status line, so the request was getting caught by this if statement. I think checking on the status code should be less fragile. There's also a bunch of deprecated HttpClient stuff in this file, but I'll leave it for now!

Fixes https://github.com/ankidroid/Anki-Android/issues/4502
