### PR TITLE
Don't crash when attempting to select non-existent decks

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -42,6 +42,8 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.regex.Pattern;
 
+import timber.log.Timber;
+
 // fixmes:
 // - make sure users can't set grad interval < 1
 
@@ -895,6 +897,10 @@ public class Decks {
      */
     public void select(long did) {
         try {
+            if (mDecks.get(did) == null) {
+                Timber.i("Requested to select non-existent deck %d", did);
+                return;
+            }
             String name = mDecks.get(did).getString("name");
 
             // current deck


### PR DESCRIPTION
I found a crash today:
1. Delete the currently selected deck
1. Restart AnkiDroid, check that no decks are currently selected
1. Long-tap on any deck
1. Crash

```
java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.String org.json.JSONObject.getString(java.lang.String)' on a null object reference
    at com.ichi2.libanki.Decks$override.select(Decks.java:900)
    at com.ichi2.libanki.Decks$override.access$dispatch(Decks.java)
    at com.ichi2.libanki.Decks.select(Decks.java:0)
    at com.ichi2.libanki.Sched.haveBuried(Sched.java:2321)
    at com.ichi2.anki.dialogs.DeckPickerContextMenu.getListIds(DeckPickerContextMenu.java:110)
    at com.ichi2.anki.dialogs.DeckPickerContextMenu.onCreateDialog(DeckPickerContextMenu.java:65)
```

@dae 
It seems that libanki also has the [same issue](https://github.com/dae/anki/blob/master/anki/decks.py#L458). Is this patch something you'd want to add to libanki? Obviously it's better not to call the `select()` function on a non-existent deck in the first place, but since it's library code I think it's better to not crash in such situations.

In AnkiDroid we have introduced several hacks to get around limitations in libanki, in that we sometimes want to get some information about a specific deck that's not currently selected (e.g. in this case, whether it has buried cards or not). In such cases we will store the currently selected deck id, select the deck of interest, call the library function, and then reselect the original deck.

See [here](https://github.com/ankidroid/Anki-Android/blob/master/AnkiDroid/src/main/java/com/ichi2/libanki/Sched.java#L2321) for the code in question this time. 