### PR TITLE
drawArc/fillArc: Avoid drawing full arcs when arcAngle is 0

### DIFF
--- a/AnkiDroid/src/main/java/com/wildplot/android/rendering/graphics/wrapper/GraphicsWrap.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/rendering/graphics/wrapper/GraphicsWrap.java
@@ -92,6 +92,9 @@ public class GraphicsWrap {
     }
     
     public void drawArc(float x, float y, float width, float height, float startAngle, float arcAngle){
+        if (arcAngle == 0) {
+            return;
+        }
         Style oldStyle = paint.getStyle();
         paint.setStyle(Style.STROKE);
         RectF rectF = new RectF(x,y,x+width,y+height);
@@ -99,6 +102,9 @@ public class GraphicsWrap {
         paint.setStyle(oldStyle);
     }
     public void fillArc(float x, float y, float width, float height, float startAngle, float arcAngle){
+        if (arcAngle == 0) {
+            return;
+        }
         Style oldStyle = paint.getStyle();
         paint.setStyle(Style.FILL);
         RectF rectF = new RectF(x,y,x+width,y+height);


### PR DESCRIPTION
This fixes issues with the card types graph showing almost everything as black when unseen is 0, except the yellow part for suspended which is drawn afterwards.

The documentation for [Canvas.drawArc][1] says:

> If the sweep angle is >= 360, then the oval is drawn completely.
> Note that this differs slightly from SkPath::arcTo, which treats the
> sweep angle modulo 360. If the sweep angle is negative, the sweep
> angle is treated as sweep angle modulo 360

There's no explicit mention of what happens if the sweep angle is 0, but it looks like in practice it's the same as if it was 360.

Since the operation is going to be a no-op either way, it doesn't hurt to skip it.

[1]: https://developer.android.com/reference/android/graphics/Canvas.html#drawArc(android.graphics.RectF,%20float,%20float,%20boolean,%20android.graphics.Paint)

------

It looks like PR #4463 was intended to fix issue #4319, but it didn't help for me.

As I posted in https://github.com/ankidroid/Anki-Android/issues/4319#issuecomment-289647053, ankidroid 2.8.2 still showed similar graphs (and so did the latest alphas), and after a few months of being bothered by this bug I decided to finally handle it myself.

First time doing android app development, I expected this to suck much more but it's actually pretty okay. Android studio held my hands the entire time and the debugging experience is completely smooth 10/10, took me less than an hour to isolate this bug.