### PR TITLE
#1463 Recognize TTS elements in questions and answers.

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -62,6 +62,7 @@ dependencies {
     compile 'ch.acra:acra:4.6.2'
     compile 'com.jakewharton.timber:timber:2.7.1'
     compile 'com.google.code.gson:gson:2.4'
+    compile 'org.jsoup:jsoup:1.10.3'
     compile project(":api")
 
     testCompile 'junit:junit:4.12'

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -39,7 +39,6 @@ import android.os.Handler;
 import android.os.Message;
 import android.os.SystemClock;
 import android.os.Vibrator;
-import android.speech.tts.TextToSpeech;
 import android.support.v4.content.ContextCompat;
 import android.support.v4.view.GestureDetectorCompat;
 import android.support.v7.app.ActionBar;
@@ -99,19 +98,14 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.lang.ref.WeakReference;
 import java.net.URLDecoder;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import timber.log.Timber;
-
-import org.jsoup.Jsoup;
-import org.jsoup.nodes.Element;
 
 public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
 
@@ -2261,48 +2255,13 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
     }
 
     /**
-     * Snippet of text accompanied by its locale code (if known).
-     */
-    private static final class LocalisedText {
-        private String mText;
-        private String mLocaleCode;
-
-        /**
-         * Construct an object representing a snippet of text in an unknown locale.
-         */
-        public LocalisedText(String text) {
-            mText = text;
-            mLocaleCode = "";
-        }
-
-        /**
-         * Construct an object representing a snippet of text in a particular locale.
-         *
-         * @param localeCode A string representation of a locale in the format returned by
-         *                    Locale.toString().
-         */
-        public LocalisedText(String text, String localeCode) {
-            mText = text;
-            mLocaleCode = localeCode;
-        }
-
-        public String getText() {
-            return mText;
-        }
-
-        public String getLocaleCode() {
-            return mLocaleCode;
-        }
-    }
-
-    /**
      * Reads the text (using TTS) for the given side of a card.
      *
      * @param card     The card to play TTS for
      * @param cardSide The side of the current card to play TTS for
      */
     private static void readCardText(final Card card, final int cardSide) {
-        String cardSideContent;
+        final String cardSideContent;
         if (Sound.SOUNDS_QUESTION == cardSide) {
             cardSideContent = card.q(true);
         } else if (Sound.SOUNDS_ANSWER == cardSide) {
@@ -2312,53 +2271,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
             return;
         }
 
-        long deckId = getDeckIdForCard(card);
-        int ord = card.getOrd();
-        boolean isFirstText = true;
-        for (LocalisedText textToRead : getTextsToRead(cardSideContent)) {
-            if (!textToRead.getText().isEmpty()) {
-                ReadText.textToSpeech(textToRead.getText(), deckId, ord, cardSide,
-                        textToRead.getLocaleCode(),
-                        isFirstText ? TextToSpeech.QUEUE_FLUSH : TextToSpeech.QUEUE_ADD);
-                isFirstText = false;
-            }
-        }
-    }
-
-    /**
-     * Returns the list of text snippets contained in the given HTML fragment that should be read
-     * using the Android text-to-speech engine, together with the languages they are in.
-     * <p>
-     * Each returned LocalisedText object contains the text extracted from a &lt;tts&gt; element
-     * whose 'service' attribute is set to 'android', and the localeCode taken from the 'voice'
-     * attribute of that element. This holds unless the HTML fragment contains no such &lt;tts&gt;
-     * elements; in that case the function returns a single LocalisedText object containing the
-     * text extracted from the whole HTML fragment, with the localeCode set to an empty string.
-     */
-    private static List<LocalisedText> getTextsToRead(String html) {
-        List<LocalisedText> textsToRead = new ArrayList<>();
-
-        Element elem = Jsoup.parseBodyFragment(html).body();
-        parseTtsElements(elem, textsToRead);
-        if (textsToRead.size() == 0) {
-            // No <tts service="android"> elements found: return the text of the whole HTML fragment
-            textsToRead.add(new LocalisedText(elem.text()));
-        }
-
-        return textsToRead;
-    }
-
-    private static void parseTtsElements(Element element, List<LocalisedText> textsToRead) {
-        if (element.tagName().equalsIgnoreCase("tts")) {
-            if (element.attr("service").equalsIgnoreCase("android")) {
-                textsToRead.add(new LocalisedText(element.text(), element.attr("voice")));
-                return; // ignore any children
-            }
-        }
-
-        for (Element child : element.children()) {
-            parseTtsElements(child, textsToRead);
-        }
+        ReadText.readCardSide(cardSide, cardSideContent, getDeckIdForCard(card), card.getOrd());
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -2262,18 +2262,20 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
     /**
      * Snippet of text accompanied by its locale code (if known).
      */
-    private static class LocalisedText
-    {
+    private static class LocalisedText {
         private String text;
         private String localeCode;
 
-        /** Construct an object representing a snippet of text in an unknown locale. */
+        /**
+         * Construct an object representing a snippet of text in an unknown locale.
+         */
         public LocalisedText(String text_) {
             text = text_;
             localeCode = "";
         }
 
-        /** Construct an object representing a snippet of text in a particular locale.
+        /**
+         * Construct an object representing a snippet of text in a particular locale.
          *
          * @param localeCode_ A string representation of a locale in the format returned by
          *                    Locale.toString().
@@ -2283,13 +2285,11 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
             localeCode = localeCode_;
         }
 
-        public String getText()
-        {
+        public String getText() {
             return text;
         }
 
-        public String getLocaleCode()
-        {
+        public String getLocaleCode() {
             return localeCode;
         }
     }
@@ -2297,7 +2297,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
     /**
      * Reads the text (using TTS) for the given side of a card.
      *
-     * @param card The card to play TTS for
+     * @param card     The card to play TTS for
      * @param cardSide The side of the current card to play TTS for
      */
     private static void readCardText(final Card card, final int cardSide) {
@@ -2317,8 +2317,8 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
         for (LocalisedText textToRead : getTextsToRead(cardSideContent)) {
             if (!textToRead.getText().isEmpty()) {
                 ReadText.textToSpeech(textToRead.getText(), deckId, ord, cardSide,
-                                      textToRead.getLocaleCode(),
-                                      isFirstText ? TextToSpeech.QUEUE_FLUSH : TextToSpeech.QUEUE_ADD);
+                        textToRead.getLocaleCode(),
+                        isFirstText ? TextToSpeech.QUEUE_FLUSH : TextToSpeech.QUEUE_ADD);
                 isFirstText = false;
             }
         }
@@ -2327,7 +2327,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
     /**
      * Returns the list of text snippets contained in the given HTML fragment that should be read
      * using the Android text-to-speech engine, together with the languages they are in.
-     *
+     * <p>
      * Each returned LocalisedText object contains the text extracted from a &lt;tts&gt; element
      * whose 'service' attribute is set to 'android', and the localeCode taken from the 'voice'
      * attribute of that element. This holds unless the HTML fragment contains no such &lt;tts&gt;
@@ -2368,8 +2368,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
             if (!sDisplayAnswer) {
                 ReadText.selectTts(Utils.stripHTML(mCurrentCard.q(true)), getDeckIdForCard(mCurrentCard), mCurrentCard.getOrd(),
                         Sound.SOUNDS_QUESTION);
-            }
-            else {
+            } else {
                 ReadText.selectTts(Utils.stripHTML(mCurrentCard.getPureAnswer()), getDeckIdForCard(mCurrentCard),
                         mCurrentCard.getOrd(), Sound.SOUNDS_ANSWER);
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -102,6 +102,7 @@ import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -2262,35 +2263,35 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
     /**
      * Snippet of text accompanied by its locale code (if known).
      */
-    private static class LocalisedText {
-        private String text;
-        private String localeCode;
+    private static final class LocalisedText {
+        private String mText;
+        private String mLocaleCode;
 
         /**
          * Construct an object representing a snippet of text in an unknown locale.
          */
-        public LocalisedText(String text_) {
-            text = text_;
-            localeCode = "";
+        public LocalisedText(String text) {
+            mText = text;
+            mLocaleCode = "";
         }
 
         /**
          * Construct an object representing a snippet of text in a particular locale.
          *
-         * @param localeCode_ A string representation of a locale in the format returned by
+         * @param localeCode A string representation of a locale in the format returned by
          *                    Locale.toString().
          */
-        public LocalisedText(String text_, String localeCode_) {
-            text = text_;
-            localeCode = localeCode_;
+        public LocalisedText(String text, String localeCode) {
+            mText = text;
+            mLocaleCode = localeCode;
         }
 
         public String getText() {
-            return text;
+            return mText;
         }
 
         public String getLocaleCode() {
-            return localeCode;
+            return mLocaleCode;
         }
     }
 
@@ -2334,8 +2335,8 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
      * elements; in that case the function returns a single LocalisedText object containing the
      * text extracted from the whole HTML fragment, with the localeCode set to an empty string.
      */
-    private static ArrayList<LocalisedText> getTextsToRead(String html) {
-        ArrayList<LocalisedText> textsToRead = new ArrayList<LocalisedText>();
+    private static List<LocalisedText> getTextsToRead(String html) {
+        List<LocalisedText> textsToRead = new ArrayList<>();
 
         Element elem = Jsoup.parseBodyFragment(html).body();
         parseTtsElements(elem, textsToRead);
@@ -2347,7 +2348,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
         return textsToRead;
     }
 
-    private static void parseTtsElements(Element element, ArrayList<LocalisedText> textsToRead) {
+    private static void parseTtsElements(Element element, List<LocalisedText> textsToRead) {
         if (element.tagName().equalsIgnoreCase("tts")) {
             if (element.attr("service").equalsIgnoreCase("android")) {
                 textsToRead.add(new LocalisedText(element.text(), element.attr("voice")));

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -2301,14 +2301,11 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
      * @param cardSide The side of the current card to play TTS for
      */
     private static void readCardText(final Card card, final int cardSide) {
-        int qa;
-        String html;
+        String cardSideContent;
         if (Sound.SOUNDS_QUESTION == cardSide) {
-            html = card.q(true);
-            qa = Sound.SOUNDS_QUESTION;
+            cardSideContent = card.q(true);
         } else if (Sound.SOUNDS_ANSWER == cardSide) {
-            html = card.getPureAnswer();
-            qa = Sound.SOUNDS_ANSWER;
+            cardSideContent = card.getPureAnswer();
         } else {
             Timber.w("Unrecognised cardSide");
             return;
@@ -2317,9 +2314,9 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
         long deckId = getDeckIdForCard(card);
         int ord = card.getOrd();
         boolean isFirstText = true;
-        for (LocalisedText textToRead : getTextsToRead(html)) {
+        for (LocalisedText textToRead : getTextsToRead(cardSideContent)) {
             if (!textToRead.getText().isEmpty()) {
-                ReadText.textToSpeech(textToRead.getText(), deckId, ord, qa,
+                ReadText.textToSpeech(textToRead.getText(), deckId, ord, cardSide,
                                       textToRead.getLocaleCode(),
                                       isFirstText ? TextToSpeech.QUEUE_FLUSH : TextToSpeech.QUEUE_ADD);
                 isFirstText = false;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.java
@@ -141,6 +141,27 @@ public class ReadText {
         }, delay);
     }
 
+    /**
+     * Read a card side using a TTS service.
+     *
+     * @param cardSide         Card side to be read; Sound.SOUNDS_QUESTION or Sound.SOUNDS_ANSWER.
+     * @param cardSideContents Contents of the card side to be read, in HTML format. If it contains
+     *                         any &lt;tts service="android"&gt; elements, only their contents is
+     *                         read; otherwise, all text is read. See TtsParser for more details.
+     * @param did              Index of the deck containing the card.
+     * @param ord              The card template ordinal.
+     */
+    public static void readCardSide(int cardSide, String cardSideContents, long did, int ord) {
+        boolean isFirstText = true;
+        for (TtsParser.LocalisedText textToRead : TtsParser.getTextsToRead(cardSideContents)) {
+            if (!textToRead.getText().isEmpty()) {
+                textToSpeech(textToRead.getText(), did, ord, cardSide,
+                        textToRead.getLocaleCode(),
+                        isFirstText ? TextToSpeech.QUEUE_FLUSH : TextToSpeech.QUEUE_ADD);
+                isFirstText = false;
+            }
+        }
+    }
 
     /**
      * Read the given text using an appropriate TTS voice.
@@ -159,8 +180,8 @@ public class ReadText {
      *
      * @param queueMode TextToSpeech.QUEUE_ADD or TextToSpeech.QUEUE_FLUSH.
      */
-    public static void textToSpeech(String text, long did, int ord, int qa, String localeCode,
-                                    int queueMode) {
+    private static void textToSpeech(String text, long did, int ord, int qa, String localeCode,
+                                     int queueMode) {
         mTextToSpeak = text;
         mQuestionAnswer = qa;
         mDid = did;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.java
@@ -76,9 +76,9 @@ public class ReadText {
      * Ask the user what language they want.
      *
      * @param text The text to be read
-     * @param did The deck id
-     * @param ord The card template ordinal
-     * @param qa The card question or card answer
+     * @param did  The deck id
+     * @param ord  The card template ordinal
+     * @param qa   The card question or card answer
      */
     public static void selectTts(String text, long did, int ord, int qa) {
         mTextToSpeak = text;
@@ -144,9 +144,9 @@ public class ReadText {
 
     /**
      * Read the given text using an appropriate TTS voice.
-     *
+     * <p>
      * The voice is chosen as follows:
-     *
+     * <p>
      * 1. If localeCode is a non-empty string representing a locale in the format returned
      *    by Locale.toString(), and a voice matching the language of this locale (and ideally,
      *    but not necessarily, also the country and variant of the locale) is available, then this
@@ -203,12 +203,11 @@ public class ReadText {
      * Convert a string representation of a locale, in the format returned by Locale.toString(),
      * into a Locale object, disregarding any script and extensions fields (i.e. using solely the
      * language, country and variant fields).
-     *
+     * <p>
      * Returns a Locale object constructed from an empty string if the input string is null, empty
      * or contains more than 3 fields separated by underscores.
      */
-    private static Locale localeFromStringIgnoringScriptAndExtensions(String localeCode)
-    {
+    private static Locale localeFromStringIgnoringScriptAndExtensions(String localeCode) {
         if (localeCode == null) {
             return new Locale("");
         }
@@ -228,8 +227,7 @@ public class ReadText {
         }
     }
 
-    private static String stripScriptAndExtensions(String localeCode)
-    {
+    private static String stripScriptAndExtensions(String localeCode) {
         int hashPos = localeCode.indexOf('#');
         if (hashPos >= 0) {
             localeCode = localeCode.substring(0, hashPos);
@@ -241,8 +239,7 @@ public class ReadText {
      * Returns true if the TTS engine supports the language of the locale represented by localeCode
      * (which should be in the format returned by Locale.toString()), false otherwise.
      */
-    private static boolean isLanguageAvailable(String localeCode)
-    {
+    private static boolean isLanguageAvailable(String localeCode) {
         return mTts.isLanguageAvailable(localeFromStringIgnoringScriptAndExtensions(localeCode)) >=
                 TextToSpeech.LANG_AVAILABLE;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/TtsParser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/TtsParser.java
@@ -1,0 +1,86 @@
+package com.ichi2.anki;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Element;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Parse card sides, extracting text snippets that should be read using a text-to-speech engine.
+ */
+public final class TtsParser {
+    /**
+     * Returns the list of text snippets contained in the given HTML fragment that should be read
+     * using the Android text-to-speech engine, together with the languages they are in.
+     * <p>
+     * Each returned LocalisedText object contains the text extracted from a &lt;tts&gt; element
+     * whose 'service' attribute is set to 'android', and the localeCode taken from the 'voice'
+     * attribute of that element. This holds unless the HTML fragment contains no such &lt;tts&gt;
+     * elements; in that case the function returns a single LocalisedText object containing the
+     * text extracted from the whole HTML fragment, with the localeCode set to an empty string.
+     */
+    public static List<LocalisedText> getTextsToRead(String html) {
+        List<LocalisedText> textsToRead = new ArrayList<>();
+
+        Element elem = Jsoup.parseBodyFragment(html).body();
+        parseTtsElements(elem, textsToRead);
+        if (textsToRead.size() == 0) {
+            // No <tts service="android"> elements found: return the text of the whole HTML fragment
+            textsToRead.add(new LocalisedText(elem.text()));
+        }
+
+        return textsToRead;
+    }
+
+    private static void parseTtsElements(Element element, List<LocalisedText> textsToRead) {
+        if (element.tagName().equalsIgnoreCase("tts") &&
+                element.attr("service").equalsIgnoreCase("android")) {
+            textsToRead.add(new LocalisedText(element.text(), element.attr("voice")));
+            return; // ignore any children
+        }
+
+        for (Element child : element.children()) {
+            parseTtsElements(child, textsToRead);
+        }
+    }
+
+    // ----------------------------------------------------------------------------
+    // INNER CLASSES
+    // ----------------------------------------------------------------------------
+
+    /**
+     * Snippet of text accompanied by its locale code (if known).
+     */
+    public static final class LocalisedText {
+        private String mText;
+        private String mLocaleCode;
+
+        /**
+         * Construct an object representing a snippet of text in an unknown locale.
+         */
+        public LocalisedText(String text) {
+            mText = text;
+            mLocaleCode = "";
+        }
+
+        /**
+         * Construct an object representing a snippet of text in a particular locale.
+         *
+         * @param localeCode A string representation of a locale in the format returned by
+         *                   Locale.toString().
+         */
+        public LocalisedText(String text, String localeCode) {
+            mText = text;
+            mLocaleCode = localeCode;
+        }
+
+        public String getText() {
+            return mText;
+        }
+
+        public String getLocaleCode() {
+            return mLocaleCode;
+        }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV10.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV10.java
@@ -63,7 +63,7 @@ public class CompatV10 implements Compat {
             public void onUtteranceCompleted(String utteranceId) {
                 if (ReadText.sTextQueue.size() > 0) {
                     String[] text = ReadText.sTextQueue.remove(0);
-                    ReadText.speak(text[0], text[1]);
+                    ReadText.speak(text[0], text[1], TextToSpeech.QUEUE_FLUSH);
                 }
             }
         });

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV15.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV15.java
@@ -17,7 +17,7 @@ public class CompatV15 extends CompatV12 implements Compat {
             public void onDone(String arg0) {
                 if (ReadText.sTextQueue.size() > 0) {
                     String[] text = ReadText.sTextQueue.remove(0);
-                    ReadText.speak(text[0], text[1]);
+                    ReadText.speak(text[0], text[1], TextToSpeech.QUEUE_FLUSH);
                 }
             }
             @Override


### PR DESCRIPTION
Although a number of workarounds have been proposed in #1463 to make AnkiDroid read only parts of questions and answers using a TTS engine, I think the originally proposed solution, i.e. recognition of `<tts>` elements embedded in the card template, is simpler and more convenient for the user. This is also the approach taken by the AwesomeTTS plugin to the desktop app. This commit makes AnkiDroid recognise `<tts>` elements similar to those accepted by AwesomeTTS.

If the front or back template contains any `<tts>` elements with the `service` attribute set to `android`, then only the text enclosed in these elements is read aloud using the TTS engine. The `voice` attribute can be used to specify the language of the text (details below). If no `<tts service='android'>` elements are present in the template, the user is asked to select a language from a list, and a voice for this language is used to read aloud the whole front or back side -- as has been the case so far. `<tts>` elements with other values of the `service` attribute are ignored, which makes it possible to use the same card format with AnkiDroid and with the AwesomeTTS add-on to the desktop app (each ignoring services it doesn't recognise).

`voice` attributes should be given in the format used by the `Locale.toString()` function, i.e.

    language_code + "_" + country_code [+ "_" + variant_code]

(the second underscore and the variant code are optional and typically unnecessary). Typical examples: `en_US`, `en_GB`, `fr_FR`.

Full example:

    <tts service="android" voice="de_DE">{{Back}}</tts> (pl. {{Plural}})

Here only the contents of the _Back_ field are read aloud (in German); the contents of the _Plural_ field are only displayed, not read.

The Jsoup library is used to find and parse `<tts>` fields. This introduces a new dependency; I don't know if it is a problem or not. There are other parts of AnkiDroid that need to parse HTML and currently do it with regexes, which don't always cover the full range of valid HTML constructs; perhaps it would be simpler and more robust to do it using Jsoup or a similar library.