### PR TITLE
round days in the weekly breakdown down to whole weeks

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Stats.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Stats.java
@@ -940,6 +940,7 @@ public class Stats {
 
         int pd = _periodDays();
         if (pd > 0) {
+            pd = Math.round( pd / 7 ) * 7;
             lim += " and id > " + ((mCol.getSched().getDayCutoff() - (SECONDS_PER_DAY * pd)) * 1000);
         }
 


### PR DESCRIPTION
Otherwise this supposedly weekly statistic is skewed by adding 1-2 extra days,
making it somewhat pointless.