### PR TITLE
support pictures in subfolders

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Media.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Media.java
@@ -388,7 +388,7 @@ public class Media {
                     if (unescape) {
                         string = string.replace(tag,tag.replace(fname, Uri.decode(fname)));
                     } else {
-                        string = string.replace(tag,tag.replace(fname, Uri.encode(fname)));
+                        string = string.replace(tag,tag.replace(fname, Uri.encode(fname, "/")));
                     }
                 }
             }


### PR DESCRIPTION
Hello,

the reviewer didn't show pictures if they are located in subfolders (e.g., /sdcard/.../collection.media/japanese/hand.jpg). The reviewer activity shows a missing picture symbol. However, when opening the card editor, the image shows without problems.

Ankidroid replaced the "/" with %2F, using japanese%2Fhand.jpg as path. Excluding "/" from URI encoding fixes this problem.

All the best,
Thomas