### PR TITLE
Use SVG images of LaTeX formulas, when required

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Media.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Media.java
@@ -300,7 +300,7 @@ public class Media {
 
         for (String s : strings) {
             // handle latex
-            s =  LaTeX.mungeQA(s, mCol);
+            s =  LaTeX.mungeQA(s, mCol, model);
             // extract filenames
             Matcher m;
             for (Pattern p : mRegexps) {


### PR DESCRIPTION
As this [pull request](https://github.com/dae/anki/pull/112) was merged into Anki 2.1, LaTeX can now be exported to SVG instead of PNG, by enabling an option in the note type (see [this commit](https://github.com/dae/anki/commit/8cd20f335272e7471a861afc530665591ebab181)).

This works the same way as the current Anki 2.1 code:
- if the note type specifies it, look for an svg file
- otherwise, look for a png one

I'm not sure if it should be done this way or if AnkiDroid should check for both files, ignoring the note type.