### PR TITLE
pass certain multitouch events through the whiteboard to the card behind it

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -229,7 +229,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
     private View mMainLayout;
     private View mLookUpIcon;
     private FrameLayout mCardContainer;
-    protected WebView mCard;
+    private WebView mCard;
     private WebView mNextCard;
     private FrameLayout mCardFrame;
     private FrameLayout mTouchLayer;
@@ -2072,6 +2072,37 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
                 mTimeoutHandler.postDelayed(mShowQuestionTask, delay);
             }
         }
+    }
+
+
+    /** Scroll the currently shown flashcard vertically
+     *
+     * @param dy amount to be scrolled
+     */
+    public void scrollCurrentCardBy(int dy) {
+        boolean beforeIceCreamSandwich = CompatHelper.getSdkVersion() < 14;
+        if (dy != 0 && (beforeIceCreamSandwich ? true : mCard.canScrollVertically(dy))) {
+            mCard.scrollBy(0, dy);
+        }
+    }
+
+
+    /** Tap onto the currently shown flashcard at position x and y
+     *
+     * @param x horizontal position of the event
+     * @param y vertical position of the event
+     */
+    public void tapOnCurrentCard(int x, int y) {
+        // assemble suitable ACTION_DOWN and ACTION_UP events and forward them to the card's handler
+        MotionEvent eDown = MotionEvent.obtain(SystemClock.uptimeMillis(),
+                SystemClock.uptimeMillis(), MotionEvent.ACTION_DOWN, x, y,
+                1, 1, 0, 1, 1, 0, 0);
+        mCard.dispatchTouchEvent(eDown);
+
+        MotionEvent eUp = MotionEvent.obtain(eDown.getDownTime(),
+                SystemClock.uptimeMillis(), MotionEvent.ACTION_UP, x, y,
+                1, 1, 0, 1, 1, 0, 0);
+        mCard.dispatchTouchEvent(eUp);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -2080,8 +2080,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
      * @param dy amount to be scrolled
      */
     public void scrollCurrentCardBy(int dy) {
-        boolean beforeIceCreamSandwich = CompatHelper.getSdkVersion() < 14;
-        if (dy != 0 && (beforeIceCreamSandwich ? true : mCard.canScrollVertically(dy))) {
+        if (dy != 0 && mCard.canScrollVertically(dy)) {
             mCard.scrollBy(0, dy);
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -229,7 +229,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
     private View mMainLayout;
     private View mLookUpIcon;
     private FrameLayout mCardContainer;
-    private WebView mCard;
+    protected WebView mCard;
     private WebView mNextCard;
     private FrameLayout mCardFrame;
     private FrameLayout mTouchLayer;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -27,6 +27,7 @@ import android.content.res.Resources;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.SystemClock;
 import android.support.v4.content.ContextCompat;
 import android.support.v4.view.ActionProvider;
 import android.support.v4.view.MenuItemCompat;
@@ -63,6 +64,7 @@ public class Reviewer extends AbstractFlashcardViewer {
     private boolean mPrefFullscreenReview = false;
     private static final int ADD_NOTE = 12;
     private Long mLastSelectedBrowserDid = null;
+    private MultiTouchBehindWhiteBoard mMultiTouchBehindWhiteBoard = new MultiTouchBehindWhiteBoard();
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -502,7 +504,10 @@ public class Reviewer extends AbstractFlashcardViewer {
                     // Bypass whiteboard listener when it's hidden or fullscreen immersive mode is temporarily suspended
                     return getGestureDetector().onTouchEvent(event);
                 }
-                return mWhiteboard.handleTouchEvent(event);
+                if (mWhiteboard.handleDrawEvent(event)) {
+                    return true;
+                }
+                return handleEventBehindWhiteBoard(event);
             }
         });
         mWhiteboard.setEnabled(true);
@@ -519,6 +524,32 @@ public class Reviewer extends AbstractFlashcardViewer {
             if (!mHasDrawerSwipeConflicts) {
                 enableDrawerSwipe();
             }
+        }
+    }
+
+    // Parse multitouch input to scroll the card behind the whiteboard or click on elements
+    private boolean handleEventBehindWhiteBoard(MotionEvent event) {
+        int pointerCount = event.getPointerCount();
+
+        switch (event.getActionMasked()) {
+            case MotionEvent.ACTION_POINTER_DOWN:
+                if (pointerCount == 2) {
+                    mMultiTouchBehindWhiteBoard.reinitialize(event);
+                    return true;
+                }
+                return false;
+            case MotionEvent.ACTION_MOVE:
+                if (pointerCount == 2) {
+                    return mMultiTouchBehindWhiteBoard.tryScroll(event);
+                }
+                return false;
+            case MotionEvent.ACTION_POINTER_UP:
+                if (pointerCount == 2) {
+                    return mMultiTouchBehindWhiteBoard.tryClick(event);
+                }
+                return false;
+            default:
+                return false;
         }
     }
 
@@ -687,6 +718,87 @@ public class Reviewer extends AbstractFlashcardViewer {
                 default:
                     return false;
             }
+        }
+    }
+
+    /**
+     * Keeps track of coordinates from MotionEvents in order to pass two finger scrolling or a tap
+     * with a second finger through the WhiteBoard to the Card displayed behind it
+     */
+    private class MultiTouchBehindWhiteBoard {
+        private final static float TAP_TOLERANCE = 5.0f;
+        private float x0;
+        private float y0;
+        private float x;
+        private float y;
+        private int pointerId;
+        private boolean withinTapTolerance;
+
+        // call this with an ACTION_POINTER_DOWN event to start a new round of detecting drag or tap
+        private void reinitialize(MotionEvent event) {
+            withinTapTolerance = true;
+            pointerId = event.getPointerId(event.getActionIndex());
+            x0 = event.getX(event.findPointerIndex(pointerId));
+            y0 = event.getY(event.findPointerIndex(pointerId));
+        }
+
+        private boolean update(MotionEvent event) {
+            int pointerIndex = event.findPointerIndex(pointerId);
+            if (pointerIndex > -1) {
+                x = event.getX(pointerIndex);
+                y = event.getY(pointerIndex);
+                float dx = Math.abs(x0 - x);
+                float dy = Math.abs(y0 - y);
+                if (dx >= TAP_TOLERANCE || dy >= TAP_TOLERANCE) {
+                    withinTapTolerance = false;
+                }
+                return true;
+            }
+            return false;
+        }
+
+        // call this with an ACTION_POINTER_UP event to check whether it matches a tap
+        // if so, forward a click action and return true
+        private boolean tryClick(MotionEvent event) {
+            if (pointerId == event.getPointerId(event.getActionIndex())) {
+                update(event);
+                if (withinTapTolerance) {
+                    // assemble suitable ACTION_DOWN and ACTION_UP events based on the current event
+                    // and forward them to the WebView's handler
+                    MotionEvent eDown = MotionEvent.obtain(SystemClock.uptimeMillis(),
+                            SystemClock.uptimeMillis(), MotionEvent.ACTION_DOWN, x, y,
+                            event.getPressure(), event.getSize(), event.getMetaState(),
+                            event.getXPrecision(), event.getYPrecision(), 0,
+                            event.getEdgeFlags());
+                    mCard.dispatchTouchEvent(eDown);
+
+                    MotionEvent eUp = MotionEvent.obtain(eDown.getDownTime(),
+                            SystemClock.uptimeMillis(), MotionEvent.ACTION_UP, x, y,
+                            event.getPressure(), event.getSize(), event.getMetaState(),
+                            event.getXPrecision(), event.getYPrecision(), 0,
+                            event.getEdgeFlags());
+                    mCard.dispatchTouchEvent(eUp);
+
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        // call this with an ACTION_MOVE event to check whether it exceeds the threshold for a tap
+        // in this case perform a scroll action
+        private boolean tryScroll(MotionEvent event) {
+            if (update(event) && !withinTapTolerance) {
+                int dy = (int) (y0 - y);
+                boolean beforeIceCreamSandwich = CompatHelper.getSdkVersion() < 14;
+                if (dy != 0 && (beforeIceCreamSandwich ? true : mCard.canScrollVertically(dy))) {
+                    mCard.scrollBy(0, dy);
+                    x0 = x;
+                    y0 = y;
+                }
+                return true;
+            }
+            return false;
         }
     }
 }


### PR DESCRIPTION
This makes the whiteboard more ergonomic (in my subjective opinion). [Related issue](https://github.com/ankidroid/Anki-Android/issues/4522). Summing up, when keeping one finger on the whiteboard while it is activated, it is now possible to use a second finger to scroll the card behind the whiteboard or tap onto one of its elements.

With respect to documentation in the code files I modified, I have tried to follow the style and extent I found in there. Feel free to criticize or ask for more if anything is unclear!

To make the whiteboard sensitive to multitouch-events, I changed its call to MotionEvent.getAction() into MotionEvent.getActionMasked() and included a check for a second finger being placed on the touch screen. In that case, the current stroke is aborted and the whiteboard goes into a no-drawing state until all fingers have been removed and a new, single finger touches the screen again.
To abort the stroke, I added a new function abortDraw() (and while being at it, gave the touchXX functions somewhat more descriptive names) which finishes the current stroke and pops it off the undo stack right after.
The check for a second finger being placed on the screen is done by evaluating ACTION_POINTER_DOWN in WhiteBoard.handleTouchEvent(). When such an event is received for the first time in a stroke, the function will return false (and keep doing so until the last finger has been removed again), which in turn can be evaluated in the event handler of the Reviewer class. Whenever false is returned, this is taken as indication, that a multitouchevent needs to be handled.
I have added a nested helper class to the Reviewer, which keeps track of MotionEvents with two fingers on the screen. Essentially it is designed to tell apart a tap of the second finger from a drag by analyzing the MotionEvents, but it also stores the starting position to compute the distance to be scrolled. Finally, it also takes the appropriate action depending on what is to be the outcome of the event, clicking or scrolling.

Changing the WebView mCard in AbsractFlashCardviewer from private into protected makes it possible to access it in Reviewer in order to forward the tap or drag to the card below the whiteboard.
However, I am not yet happy about the implementation of forwarding these two:

- passing a click to the card is done by recycling the ACTION_POINTER_UP event of the second finger. An ACTION_DOWN event is derived from it and passed to the card's webview by calling its dispatchTouchEvent(). The same is then followed by a matching ACTION_UP counterpart.
To me this looks like an ugly hack, but so far I was unable to figure out any better way to do it.

- scrolling the card is done by calling View.scrollBy(). When this function is called, there is no check in place a priori to prevent scrolling beyond the boundaries. This leads to weird behaviour of the side scrollbars when left unchecked. Leaving it like that would not severely impact the functionality, but I think it's kind of ugly.
Checking View.canScrollVertically() prior to executing the scroll command fixes this, but this method requires API Level 14, while Ankidroid seeks for backward compatibility with level 10. I have tried explicitly computing the distance left for scrolling in both directions myself via mCard.getContentHeight() and mCard.getScrollY(), but I failed to find a place from which the size of the card's visible pane can be read. Hence I have tried to take care of the function call using the CompatHelper class, but I have no idea whether or not the app will blow into the face of a user of such an old device, because I don't have one to test on. Please have a look at this!

In particular, based on the changes here it should be straightforward to process other actions as well (horizontal scrolling, using yet another finger to zoom, etc.)