### PR TITLE
Note that there was an error on exception during media sync

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
@@ -407,7 +407,7 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
                     } else {
                         AnkiDroidApp.sendExceptionReport(e, "doInBackgroundSync-mediaSync");
                     }
-                    mediaError = e.getLocalizedMessage();
+                    mediaError = AnkiDroidApp.getAppResources().getString(R.string.sync_media_error) + "\n\n" + e.getLocalizedMessage();
                 }
             }
             if (noChanges && (!media || noMediaChanges)) {


### PR DESCRIPTION
Following on from #4718.

Note that we already have `mediaError = AnkiDroidApp.getAppResources().getString(R.string.sync_media_error);` in the case where the media syncer returns null.