### PR TITLE
Proposed fix for #4624 - fix scrolling when showing answer

### DIFF
--- a/AnkiDroid/src/main/assets/scripts/card.js
+++ b/AnkiDroid/src/main/assets/scripts/card.js
@@ -88,6 +88,23 @@ function taKey(itag, e) {
     }
 }
 
+// from https://plainjs.com/javascript/styles/get-the-position-of-an-element-relative-to-the-document-24/
+function offset(el) {
+    var rect = el.getBoundingClientRect();
+    var scrollLeft = window.pageXOffset || document.documentElement.scrollLeft;
+    var scrollTop = window.pageYOffset || document.documentElement.scrollTop;
+
+    return { top: rect.top + scrollTop, left: rect.left + scrollLeft };
+}
+
+function scrollToAnswer(){
+    var answer = document.getElementById('answer');
+
+    if (answer) {
+       window.scrollTo(0, offset(answer).top);
+    }
+}
+
 window.onload = function() {
     /* If the WebView loads too early on Android <= 4.3 (which happens
        on the first card or regularly with WebView switching enabled),
@@ -98,13 +115,13 @@ window.onload = function() {
        correctly. */
     window.scrollTo(0,0);
     resizeImages();
-    window.location.href = "#answer";
+    scrollToAnswer();
 };
 
 var onPageFinished = function() {
     if (!resizeDone) {
         resizeImages();
         /* Re-anchor to answer after image resize since the point changes */
-        window.location.href = "#answer";
+        scrollToAnswer();
     }
 }


### PR DESCRIPTION
It looks like card.js's current approach of scrolling to the answer by using `window.location.href = "#answer";` is no longer working in newer versions of the WebView for whatever reason. However, it seems that `window.scrollTo()` still works correctly.

So I have come up with a proposed fix that:
- Locates the answer divider element, and if it is present:
  - Determines the distance between the answer divider and the top of the HTML page
  - Scrolls the window to that Y location using `window.scrollTo()`

This is working on my Nexus 5X with the following specs:
Android 8.0.0
Chrome 62.0.3202.84