### PR TITLE
updated translation status tool to correctly scrape current format of crowdin.com

### DIFF
--- a/tools/translation-rates.sh
+++ b/tools/translation-rates.sh
@@ -4,20 +4,26 @@
 #
 wget -O tmp-translations-page.html https://crowdin.net/project/ankidroid --no-check-certificate
 cat tmp-translations-page.html |
- tr "\n" " " |
- sed -e "s/project-language-name\">/\n/g" |
- sed -e "s/.*project-language-name//g" |
- sed -e "s/<\/div>//g" |
- grep "translated:" |
- sed -e "s/<\/strong>.*translated://g" |
- sed -e "s/<\/ins>.*//g" |
- sed -e 's/[[:space:]]*$//g' |
- grep -v " 0%" > tmp-list.txt
+egrep 'project-language-name|[approved|translated]: \d+%'|
+sed -e "s/<strong.*unselectable\">//g"|
+sed -e "s/<\/strong>//g" |
+sed -e "s/\w*<\/div>//g" |
+sed -e "s/[[:space:]]*//g"|
+tr "\n" " " |
+tr '%' '\n' |
+sed -e "s/^ //g" |
+sed -e "s/\:/\: /g" |
+grep -v "^\s+$" |
+sed -e "s/$/%/g" |
+grep -v " 0" > tmp-list.txt
 
 echo "By country:"
 cat tmp-list.txt |  sort
 
-echo "\nBy rate:"
-cat tmp-list.txt | sed -e "s/\(.*\) \([0-9]*\)%/\2% \1/g" | sort -nr
+echo "\nBy rate approved (implies 100% translated):"
+cat tmp-list.txt | grep approved | sed -e "s/\(.*\) \([0-9]*\)%/\2% \1/g" | sort -nr
+
+echo "\nBy rate translated:"
+cat tmp-list.txt | grep translated | sed -e "s/\(.*\) \([0-9]*\)%/\2% \1/g" | sort -nr
 
 rm -f tmp-translations-page.html tmp-list.txt


### PR DESCRIPTION
I was curious of the status of the Spanish language translation, and noticed the translation status tool did not seem to function - it appears crowdin.com altered their generated status page and the tool had not been updated to match? I reworked the string of greps and seds until it appeared to work for me, perhaps this is useful for others? Now to figure out how to get Spanish to 100% translated + approved using crowdin.com...