### PR TITLE
Add Audio Clips from from local file

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -58,6 +58,7 @@ import com.ichi2.anki.dialogs.TagsDialog.TagsDialogListener;
 import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.anki.multimediacard.IMultimediaEditableNote;
 import com.ichi2.anki.multimediacard.activity.MultimediaEditFieldActivity;
+import com.ichi2.anki.multimediacard.fields.AudioClipField;
 import com.ichi2.anki.multimediacard.fields.AudioField;
 import com.ichi2.anki.multimediacard.fields.EFieldType;
 import com.ichi2.anki.multimediacard.fields.IField;
@@ -1187,6 +1188,12 @@ public class NoteEditor extends AnkiActivity {
                                 mNote.setField(index, field);
                                 startMultimediaFieldEditor(index, mNote, field);
                                 return true;
+                            }
+                            case R.id.menu_multimedia_audio_clip: {
+                                Timber.i("NoteEditor:: Add audio clip button pressed");
+                                field = new AudioClipField();
+                                mNote.setField(index, field);
+                                startMultimediaFieldEditor(index, mNote, field);
                             }
                             case R.id.menu_multimedia_photo: {
                                 Timber.i("NoteEditor:: Add image button pressed");

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1194,6 +1194,7 @@ public class NoteEditor extends AnkiActivity {
                                 field = new AudioClipField();
                                 mNote.setField(index, field);
                                 startMultimediaFieldEditor(index, mNote, field);
+                                return true;
                             }
                             case R.id.menu_multimedia_photo: {
                                 Timber.i("NoteEditor:: Add image button pressed");

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -59,7 +59,7 @@ import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.anki.multimediacard.IMultimediaEditableNote;
 import com.ichi2.anki.multimediacard.activity.MultimediaEditFieldActivity;
 import com.ichi2.anki.multimediacard.fields.AudioClipField;
-import com.ichi2.anki.multimediacard.fields.AudioField;
+import com.ichi2.anki.multimediacard.fields.AudioRecordingField;
 import com.ichi2.anki.multimediacard.fields.EFieldType;
 import com.ichi2.anki.multimediacard.fields.IField;
 import com.ichi2.anki.multimediacard.fields.ImageField;
@@ -1184,7 +1184,7 @@ public class NoteEditor extends AnkiActivity {
                         switch (item.getItemId()) {
                             case R.id.menu_multimedia_audio: {
                                 Timber.i("NoteEditor:: Record audio button pressed");
-                                field = new AudioField();
+                                field = new AudioRecordingField();
                                 mNote.setField(index, field);
                                 startMultimediaFieldEditor(index, mNote, field);
                                 return true;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
@@ -24,6 +24,7 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
 
+import androidx.annotation.NonNull;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 import androidx.appcompat.widget.Toolbar;
@@ -186,6 +187,7 @@ public class MultimediaEditFieldActivity extends AnkiActivity
 
             case R.id.multimedia_edit_field_to_audio_clip:
                 Timber.i("To audio clip button pressed");
+                mFieldController.onFocusLost();
                 toAudioClipField();
                 supportInvalidateOptionsMenu();
                 return true;
@@ -290,7 +292,7 @@ public class MultimediaEditFieldActivity extends AnkiActivity
     }
 
 
-    public void onRequestPermissionsResult (int requestCode, String[] permissions, int[] grantResults) {
+    public void onRequestPermissionsResult (int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
         if (requestCode == REQUEST_AUDIO_PERMISSION && permissions.length == 1) {
             // TODO:  Disable the record button / show some feedback to the user
             recreateEditingUi();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
@@ -35,6 +35,7 @@ import android.widget.LinearLayout;
 import com.ichi2.anki.AnkiActivity;
 import com.ichi2.anki.R;
 import com.ichi2.anki.multimediacard.IMultimediaEditableNote;
+import com.ichi2.anki.multimediacard.fields.AudioClipField;
 import com.ichi2.anki.multimediacard.fields.AudioField;
 import com.ichi2.anki.multimediacard.fields.BasicControllerFactory;
 import com.ichi2.anki.multimediacard.fields.EFieldType;
@@ -153,6 +154,7 @@ public class MultimediaEditFieldActivity extends AnkiActivity
         getMenuInflater().inflate(R.menu.activity_edit_text, menu);
         menu.findItem(R.id.multimedia_edit_field_to_text).setVisible(mField.getType() != EFieldType.TEXT);
         menu.findItem(R.id.multimedia_edit_field_to_audio).setVisible(mField.getType() != EFieldType.AUDIO);
+        menu.findItem(R.id.multimedia_edit_field_to_audio_clip).setVisible(mField.getType() != EFieldType.AUDIO_CLIP);
         menu.findItem(R.id.multimedia_edit_field_to_image).setVisible(mField.getType() != EFieldType.IMAGE);
         return true;
     }
@@ -179,6 +181,12 @@ public class MultimediaEditFieldActivity extends AnkiActivity
                 Timber.i("To audio button pressed");
                 mFieldController.onFocusLost();
                 toAudioField();
+                supportInvalidateOptionsMenu();
+                return true;
+
+            case R.id.multimedia_edit_field_to_audio_clip:
+                Timber.i("To audio clip button pressed");
+                toAudioClipField();
                 supportInvalidateOptionsMenu();
                 return true;
 
@@ -241,6 +249,13 @@ public class MultimediaEditFieldActivity extends AnkiActivity
     protected void toAudioField() {
         if (mField.getType() != EFieldType.AUDIO) {
             mField = new AudioField();
+            recreateEditingUi();
+        }
+    }
+
+    protected void toAudioClipField() {
+        if (mField.getType() != EFieldType.AUDIO_CLIP) {
+            mField = new AudioClipField();
             recreateEditingUi();
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
@@ -36,7 +36,7 @@ import com.ichi2.anki.AnkiActivity;
 import com.ichi2.anki.R;
 import com.ichi2.anki.multimediacard.IMultimediaEditableNote;
 import com.ichi2.anki.multimediacard.fields.AudioClipField;
-import com.ichi2.anki.multimediacard.fields.AudioField;
+import com.ichi2.anki.multimediacard.fields.AudioRecordingField;
 import com.ichi2.anki.multimediacard.fields.BasicControllerFactory;
 import com.ichi2.anki.multimediacard.fields.EFieldType;
 import com.ichi2.anki.multimediacard.fields.IControllerFactory;
@@ -119,7 +119,7 @@ public class MultimediaEditFieldActivity extends AnkiActivity
         }
 
         // Request permission to record if audio field
-        if (mField instanceof AudioField && ContextCompat.checkSelfPermission(this, Manifest.permission.RECORD_AUDIO) !=
+        if (mField instanceof AudioRecordingField && ContextCompat.checkSelfPermission(this, Manifest.permission.RECORD_AUDIO) !=
                 PackageManager.PERMISSION_GRANTED) {
             ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.RECORD_AUDIO},
                     REQUEST_AUDIO_PERMISSION);
@@ -153,7 +153,7 @@ public class MultimediaEditFieldActivity extends AnkiActivity
         // Inflate the menu; this adds items to the action bar if it is present.
         getMenuInflater().inflate(R.menu.activity_edit_text, menu);
         menu.findItem(R.id.multimedia_edit_field_to_text).setVisible(mField.getType() != EFieldType.TEXT);
-        menu.findItem(R.id.multimedia_edit_field_to_audio).setVisible(mField.getType() != EFieldType.AUDIO);
+        menu.findItem(R.id.multimedia_edit_field_to_audio).setVisible(mField.getType() != EFieldType.AUDIO_RECORDING);
         menu.findItem(R.id.multimedia_edit_field_to_audio_clip).setVisible(mField.getType() != EFieldType.AUDIO_CLIP);
         menu.findItem(R.id.multimedia_edit_field_to_image).setVisible(mField.getType() != EFieldType.IMAGE);
         return true;
@@ -178,9 +178,9 @@ public class MultimediaEditFieldActivity extends AnkiActivity
                 return true;
 
             case R.id.multimedia_edit_field_to_audio:
-                Timber.i("To audio button pressed");
+                Timber.i("To audio recording button pressed");
                 mFieldController.onFocusLost();
-                toAudioField();
+                toAudioRecordingField();
                 supportInvalidateOptionsMenu();
                 return true;
 
@@ -220,7 +220,7 @@ public class MultimediaEditFieldActivity extends AnkiActivity
                     bChangeToText = true;
                 }
             }
-        } else if (mField.getType() == EFieldType.AUDIO) {
+        } else if (mField.getType() == EFieldType.AUDIO_RECORDING) {
             if (mField.getAudioPath() == null) {
                 bChangeToText = true;
             }
@@ -246,9 +246,9 @@ public class MultimediaEditFieldActivity extends AnkiActivity
     }
 
 
-    protected void toAudioField() {
-        if (mField.getType() != EFieldType.AUDIO) {
-            mField = new AudioField();
+    protected void toAudioRecordingField() {
+        if (mField.getType() != EFieldType.AUDIO_RECORDING) {
+            mField = new AudioRecordingField();
             recreateEditingUi();
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/AudioClipField.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/AudioClipField.java
@@ -1,0 +1,117 @@
+package com.ichi2.anki.multimediacard.fields;
+
+import com.ichi2.anki.AnkiDroidApp;
+import com.ichi2.libanki.Collection;
+
+import java.io.File;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class AudioClipField extends FieldBase implements IField {
+
+    private static final long serialVersionUID = 2937641017832762987L;
+    private String mAudioPath;
+    private String mName;
+    private boolean mHasTemporaryMedia = false;
+
+    private static final String PATH_REGEX = "\\[sound:(.*)\\]";
+
+    @Override
+    public EFieldType getType() {
+        return EFieldType.AUDIO_CLIP;
+    }
+
+    @Override
+    public boolean setType(EFieldType type) {
+        return false;
+    }
+
+    @Override
+    public boolean isModified() {
+        return false;
+    }
+
+    @Override
+    public String getHtml() {
+        return null;
+    }
+
+    @Override
+    public boolean setHtml(String html) {
+        return false;
+    }
+
+    @Override
+    public boolean setImagePath(String pathToImage) {
+        return false;
+    }
+
+    @Override
+    public String getImagePath() {
+        return null;
+    }
+
+    @Override
+    public boolean setAudioPath(String pathToAudio) {
+        mAudioPath = pathToAudio;
+        setThisModified();
+        return true;
+    }
+
+    @Override
+    public String getAudioPath() {
+        return mAudioPath;
+    }
+
+    @Override
+    public String getText() {
+        return null;
+    }
+
+    @Override
+    public boolean setText(String text) {
+        return false;
+    }
+
+    @Override
+    public void setHasTemporaryMedia(boolean hasTemporaryMedia) {
+
+    }
+
+    @Override
+    public boolean hasTemporaryMedia() {
+        return false;
+    }
+
+    @Override
+    public String getName() {
+        return null;
+    }
+
+    @Override
+    public void setName(String name) {
+
+    }
+
+    @Override
+    public String getFormattedValue() {
+        File file = new File(getAudioPath());
+        if (file.exists()) {
+            return String.format("[sound:%s]", file.getName());
+        } else {
+            return "";
+        }
+    }
+
+    @Override
+    public void setFormattedString(Collection col, String value) {
+        Pattern p = Pattern.compile(PATH_REGEX);
+        Matcher m = p.matcher(value);
+        String res = "";
+        if (m.find()) {
+            res = m.group(1);
+        }
+        String mediaDir = col.getMedia().dir() + "/";
+        setAudioPath(mediaDir + res);
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/AudioClipField.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/AudioClipField.java
@@ -1,12 +1,5 @@
 package com.ichi2.anki.multimediacard.fields;
 
-import com.ichi2.anki.AnkiDroidApp;
-import com.ichi2.libanki.Collection;
-
-import java.io.File;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 /**
  * Implementation of Audio Clip field type
  */
@@ -19,113 +12,28 @@ public class AudioClipField extends AudioField {
         return EFieldType.AUDIO_CLIP;
     }
 
-
-//    @Override
-//    public boolean setType(EFieldType type) {
-//        return false;
-//    }
-
-
     @Override
     public boolean isModified() {
         return false;
     }
 
-
-//    @Override
-//    public String getHtml() {
-//        return null;
-//    }
-//
-//
-//    @Override
-//    public boolean setHtml(String html) {
-//        return false;
-//    }
-//
-//
-//    @Override
-//    public boolean setImagePath(String pathToImage) {
-//        return false;
-//    }
-//
-//
-//    @Override
-//    public String getImagePath() {
-//        return null;
-//    }
-//
-//
-//    @Override
-//    public boolean setAudioPath(String pathToAudio) {
-//        mAudioPath = pathToAudio;
-//        setThisModified();
-//        return true;
-//    }
-//
-//
-//    @Override
-//    public String getAudioPath() {
-//        return mAudioPath;
-//    }
-
-
-//    @Override
-//    public String getText() {
-//        return null;
-//    }
-//
-//
-//    @Override
-//    public boolean setText(String text) {
-//        return false;
-//    }
-
-
     @Override
     public void setHasTemporaryMedia(boolean hasTemporaryMedia) {
-
+        mHasTemporaryMedia = hasTemporaryMedia;
     }
-
 
     @Override
     public boolean hasTemporaryMedia() {
         return false;
     }
 
-
     @Override
     public String getName() {
         return null;
     }
 
-
     @Override
     public void setName(String name) {
-
+        // does nothing? FIXME investigate this
     }
-
-
-//    @Override
-//    public String getFormattedValue() {
-//        File file = new File(getAudioPath());
-//        if (file.exists()) {
-//            return String.format("[sound:%s]", file.getName());
-//        } else {
-//            return "";
-//        }
-//    }
-//
-//
-//    @Override
-//    public void setFormattedString(Collection col, String value) {
-//        Pattern p = Pattern.compile(PATH_REGEX);
-//        Matcher m = p.matcher(value);
-//        String res = "";
-//        if (m.find()) {
-//            res = m.group(1);
-//        }
-//        String mediaDir = col.getMedia().dir() + "/";
-//        setAudioPath(mediaDir + res);
-//    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/AudioField.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/AudioField.java
@@ -26,21 +26,18 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * Implementation of Audio field type
+ * Implementation of Audio field types
  */
-public class AudioField extends FieldBase implements IField {
-    private static final long serialVersionUID = 5033819217738174719L;
-    private String mAudioPath;
-    private String mName;
-    private boolean mHasTemporaryMedia = false;
+public abstract class AudioField extends FieldBase implements IField {
+    protected String mAudioPath;
+    protected String mName;
+    protected boolean mHasTemporaryMedia = false;
 
-    private static final String PATH_REGEX = "\\[sound:(.*)\\]";
+    protected static final String PATH_REGEX = "\\[sound:(.*)\\]";
 
 
     @Override
-    public EFieldType getType() {
-        return EFieldType.AUDIO;
-    }
+    public abstract EFieldType getType();
 
 
     @Override
@@ -50,9 +47,7 @@ public class AudioField extends FieldBase implements IField {
 
 
     @Override
-    public boolean isModified() {
-        return getThisModified();
-    }
+    public abstract boolean isModified();
 
 
     @Override
@@ -106,27 +101,19 @@ public class AudioField extends FieldBase implements IField {
 
 
     @Override
-    public void setHasTemporaryMedia(boolean hasTemporaryMedia) {
-        mHasTemporaryMedia = hasTemporaryMedia;
-    }
+    public abstract void setHasTemporaryMedia(boolean hasTemporaryMedia);
 
 
     @Override
-    public boolean hasTemporaryMedia() {
-        return mHasTemporaryMedia;
-    }
+    public abstract boolean hasTemporaryMedia();
 
 
     @Override
-    public String getName() {
-        return mName;
-    }
+    public abstract String getName();
 
 
     @Override
-    public void setName(String name) {
-        mName = name;
-    }
+    public abstract void setName(String name);
 
 
     @Override

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/AudioRecordingField.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/AudioRecordingField.java
@@ -8,15 +8,15 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * Implementation of Audio Clip field type
+ * Implementation of Audio Recording field type
  */
-public class AudioClipField extends AudioField {
-    private static final long serialVersionUID = 2937641017832762987L;
+public class AudioRecordingField extends AudioField {
+    private static final long serialVersionUID = 5033819217738174719L;
 
 
     @Override
     public EFieldType getType() {
-        return EFieldType.AUDIO_CLIP;
+        return EFieldType.AUDIO_RECORDING;
     }
 
 
@@ -28,7 +28,7 @@ public class AudioClipField extends AudioField {
 
     @Override
     public boolean isModified() {
-        return false;
+        return getThisModified();
     }
 
 
@@ -84,25 +84,25 @@ public class AudioClipField extends AudioField {
 
     @Override
     public void setHasTemporaryMedia(boolean hasTemporaryMedia) {
-
+        mHasTemporaryMedia = hasTemporaryMedia;
     }
 
 
     @Override
     public boolean hasTemporaryMedia() {
-        return false;
+        return mHasTemporaryMedia;
     }
 
 
     @Override
     public String getName() {
-        return null;
+        return mName;
     }
 
 
     @Override
     public void setName(String name) {
-
+        mName = name;
     }
 
 
@@ -129,3 +129,4 @@ public class AudioClipField extends AudioField {
 //        setAudioPath(mediaDir + res);
 //    }
 }
+

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/AudioRecordingField.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/AudioRecordingField.java
@@ -1,12 +1,5 @@
 package com.ichi2.anki.multimediacard.fields;
 
-import com.ichi2.anki.AnkiDroidApp;
-import com.ichi2.libanki.Collection;
-
-import java.io.File;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 /**
  * Implementation of Audio Recording field type
  */
@@ -20,66 +13,10 @@ public class AudioRecordingField extends AudioField {
     }
 
 
-//    @Override
-//    public boolean setType(EFieldType type) {
-//        return false;
-//    }
-
-
     @Override
     public boolean isModified() {
         return getThisModified();
     }
-
-
-//    @Override
-//    public String getHtml() {
-//        return null;
-//    }
-//
-//
-//    @Override
-//    public boolean setHtml(String html) {
-//        return false;
-//    }
-//
-//
-//    @Override
-//    public boolean setImagePath(String pathToImage) {
-//        return false;
-//    }
-//
-//
-//    @Override
-//    public String getImagePath() {
-//        return null;
-//    }
-//
-//
-//    @Override
-//    public boolean setAudioPath(String pathToAudio) {
-//        mAudioPath = pathToAudio;
-//        setThisModified();
-//        return true;
-//    }
-//
-//
-//    @Override
-//    public String getAudioPath() {
-//        return mAudioPath;
-//    }
-
-
-//    @Override
-//    public String getText() {
-//        return null;
-//    }
-//
-//
-//    @Override
-//    public boolean setText(String text) {
-//        return false;
-//    }
 
 
     @Override
@@ -105,28 +42,5 @@ public class AudioRecordingField extends AudioField {
         mName = name;
     }
 
-
-//    @Override
-//    public String getFormattedValue() {
-//        File file = new File(getAudioPath());
-//        if (file.exists()) {
-//            return String.format("[sound:%s]", file.getName());
-//        } else {
-//            return "";
-//        }
-//    }
-//
-//
-//    @Override
-//    public void setFormattedString(Collection col, String value) {
-//        Pattern p = Pattern.compile(PATH_REGEX);
-//        Matcher m = p.matcher(value);
-//        String res = "";
-//        if (m.find()) {
-//            res = m.group(1);
-//        }
-//        String mediaDir = col.getMedia().dir() + "/";
-//        setAudioPath(mediaDir + res);
-//    }
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicAudioClipFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicAudioClipFieldController.java
@@ -1,0 +1,105 @@
+package com.ichi2.anki.multimediacard.fields;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+
+import android.database.Cursor;
+import android.net.Uri;
+import android.provider.MediaStore;
+import android.util.DisplayMetrics;
+import android.view.View;
+import android.widget.LinearLayout;
+import android.widget.Button;
+import android.widget.LinearLayout.LayoutParams;
+import android.widget.TextView;
+
+import com.ichi2.anki.CollectionHelper;
+import com.ichi2.anki.R;
+import com.ichi2.anki.multimediacard.AudioView;
+import com.ichi2.libanki.Collection;
+
+import com.ichi2.anki.R;
+import com.ichi2.compat.CompatHelper;
+import com.ichi2.utils.ExifUtil;
+
+import java.io.File;
+import java.io.IOException;
+
+import timber.log.Timber;
+
+public class BasicAudioClipFieldController extends FieldControllerBase implements IFieldController {
+
+    protected static final int ACTIVITY_SELECT_AUDIO_CLIP = 1;
+
+    protected Button mBtnLibrary;
+    protected TextView mTvAudioClip;
+
+
+    @Override
+    public void createUI(Context context, LinearLayout layout) {
+        mBtnLibrary = new Button(mActivity);
+        mBtnLibrary.setText(gtxt(R.string.multimedia_editor_image_field_editing_library));
+        mBtnLibrary.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                Intent i = new Intent(Intent.ACTION_PICK, MediaStore.Audio.Media.EXTERNAL_CONTENT_URI);
+                mActivity.startActivityForResult(i, ACTIVITY_SELECT_AUDIO_CLIP);
+            }
+        });
+
+        layout.addView(mBtnLibrary, android.view.ViewGroup.LayoutParams.FILL_PARENT);
+
+        mTvAudioClip = new TextView(mActivity);
+        if (mField.getAudioPath() == null) {
+            mTvAudioClip.setVisibility(View.GONE);
+        }
+        else {
+            mTvAudioClip.setText(mField.getAudioPath());
+            mTvAudioClip.setVisibility(View.VISIBLE);
+        }
+
+        layout.addView(mTvAudioClip, android.view.ViewGroup.LayoutParams.FILL_PARENT);
+    }
+
+    private String gtxt(int id) {
+        return mActivity.getText(id).toString();
+    }
+
+
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        if (resultCode == Activity.RESULT_CANCELED) {
+            // Do Nothing.
+        } else if (requestCode == ACTIVITY_SELECT_AUDIO_CLIP) {
+
+            Uri selectedClip = data.getData();
+            // Timber.d(selectedImage.toString());
+            String[] filePathColumn = { MediaStore.MediaColumns.DATA };
+
+            Cursor cursor = mActivity.getContentResolver().query(selectedClip, filePathColumn, null, null, null);
+            cursor.moveToFirst();
+
+            int columnIndex = cursor.getColumnIndex(filePathColumn[0]);
+            String filePath = cursor.getString(columnIndex);
+            cursor.close();
+
+            Timber.d(filePath);
+            mField.setAudioPath(filePath);
+
+            mTvAudioClip.setText(mField.getFormattedValue());
+            mTvAudioClip.setVisibility(View.VISIBLE);
+        }
+        //setPreviewImage(mField.getImagePath(), getMaxImageSize());
+    }
+
+    @Override
+    public void onDone() {
+
+    }
+
+    @Override
+    public void onDestroy() {
+
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicAudioClipFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicAudioClipFieldController.java
@@ -7,99 +7,151 @@ import android.content.Intent;
 import android.database.Cursor;
 import android.net.Uri;
 import android.provider.MediaStore;
-import android.util.DisplayMetrics;
 import android.view.View;
+import android.view.ViewGroup;
 import android.widget.LinearLayout;
 import android.widget.Button;
-import android.widget.LinearLayout.LayoutParams;
 import android.widget.TextView;
 
 import com.ichi2.anki.CollectionHelper;
 import com.ichi2.anki.R;
-import com.ichi2.anki.multimediacard.AudioView;
 import com.ichi2.libanki.Collection;
 
-import com.ichi2.anki.R;
-import com.ichi2.compat.CompatHelper;
-import com.ichi2.utils.ExifUtil;
-
 import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 
 import timber.log.Timber;
 
 public class BasicAudioClipFieldController extends FieldControllerBase implements IFieldController {
 
-    protected static final int ACTIVITY_SELECT_AUDIO_CLIP = 1;
+    private static final int ACTIVITY_SELECT_AUDIO_CLIP = 1;
 
-    protected Button mBtnLibrary;
-    protected TextView mTvAudioClip;
+    private File storingDirectory;
+
+    private TextView mTvAudioClip;
 
 
     @Override
     public void createUI(Context context, LinearLayout layout) {
-        mBtnLibrary = new Button(mActivity);
-        mBtnLibrary.setText(gtxt(R.string.multimedia_editor_image_field_editing_library));
-        mBtnLibrary.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                Intent i = new Intent(Intent.ACTION_PICK, MediaStore.Audio.Media.EXTERNAL_CONTENT_URI);
-                mActivity.startActivityForResult(i, ACTIVITY_SELECT_AUDIO_CLIP);
-            }
+
+        Collection col = CollectionHelper.getInstance().getCol(context);
+        storingDirectory = new File(col.getMedia().dir());
+
+        Button mBtnLibrary = new Button(mActivity);
+        mBtnLibrary.setText(mActivity.getText(R.string.multimedia_editor_image_field_editing_library));
+        mBtnLibrary.setOnClickListener(v -> {
+            Intent i = new Intent();
+            i.setType("audio/*");
+            i.setAction(Intent.ACTION_GET_CONTENT);
+            // Only get openable files, to avoid virtual files issues with Android 7+
+            i.addCategory(Intent.CATEGORY_OPENABLE);
+            String chooserPrompt = mActivity.getResources().getString(R.string.multimedia_editor_popup_audio_clip);
+            mActivity.startActivityForResultWithoutAnimation(Intent.createChooser(i, chooserPrompt), ACTIVITY_SELECT_AUDIO_CLIP);
         });
 
-        layout.addView(mBtnLibrary, android.view.ViewGroup.LayoutParams.FILL_PARENT);
+        layout.addView(mBtnLibrary, ViewGroup.LayoutParams.MATCH_PARENT);
 
         mTvAudioClip = new TextView(mActivity);
         if (mField.getAudioPath() == null) {
             mTvAudioClip.setVisibility(View.GONE);
-        }
-        else {
+        } else {
             mTvAudioClip.setText(mField.getAudioPath());
             mTvAudioClip.setVisibility(View.VISIBLE);
         }
 
-        layout.addView(mTvAudioClip, android.view.ViewGroup.LayoutParams.FILL_PARENT);
-    }
-
-    private String gtxt(int id) {
-        return mActivity.getText(id).toString();
+        layout.addView(mTvAudioClip, ViewGroup.LayoutParams.MATCH_PARENT);
     }
 
 
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
-        if (resultCode == Activity.RESULT_CANCELED) {
-            // Do Nothing.
-        } else if (requestCode == ACTIVITY_SELECT_AUDIO_CLIP) {
+        if ((resultCode != Activity.RESULT_CANCELED) && (requestCode == ACTIVITY_SELECT_AUDIO_CLIP)) {
 
             Uri selectedClip = data.getData();
-            // Timber.d(selectedImage.toString());
-            String[] filePathColumn = { MediaStore.MediaColumns.DATA };
+            Timber.d(selectedClip.toString());
 
-            Cursor cursor = mActivity.getContentResolver().query(selectedClip, filePathColumn, null, null, null);
+            // Get information about the selected document
+            String[] queryColumns = { MediaStore.MediaColumns.DISPLAY_NAME, MediaStore.MediaColumns.SIZE };
+            Cursor cursor = mActivity.getContentResolver().query(selectedClip, queryColumns, null, null, null);
             cursor.moveToFirst();
-
-            int columnIndex = cursor.getColumnIndex(filePathColumn[0]);
-            String filePath = cursor.getString(columnIndex);
+            String audioClipFullName = cursor.getString(0);
+            // Note this could be unsafe, null name, or name without standard extension etc, go off mime types instead?
+            String[] audioClipFullNameParts = audioClipFullName.split("\\.");
             cursor.close();
 
-            Timber.d(filePath);
-            mField.setAudioPath(filePath);
+            // We may receive documents we can't access directly, we have to copy to a temp file
+            File clipCopy = null;
+            try {
+                clipCopy = File.createTempFile("ankidroid_audioclip_" + audioClipFullNameParts[0],
+                        "." + audioClipFullNameParts[1],
+                        storingDirectory);
+            } catch (IOException e) {
+                Timber.e(e, "Could not create temporary audio file. ");
+            }
+
+            // Copy file contents into new temp file. Possibly check file size first and warn if large?
+            InputStream inputStream = null;
+            try {
+                inputStream = mActivity.getContentResolver().openInputStream(selectedClip);
+
+                // copy the picked file contents to internal media iteratively using Buffered Streams?
+                OutputStream outputStream = null;
+                try {
+                    // FIXME no no no no
+                    clipCopy.setWritable(true, false);
+                    outputStream = new FileOutputStream(clipCopy);
+                    byte buffer[] = new byte[1024];
+                    int length = 0;
+
+                    while((length = inputStream.read(buffer)) > 0) {
+                        outputStream.write(buffer,0,length);
+                    }
+                }
+                catch (IOException e) {
+                    Timber.e(e, "error in creating a file");
+                }
+                finally {
+                    try {
+                        outputStream.close();
+                    }
+                    catch (IOException ioe) {
+                        // nothing?
+                    }
+                }
+
+                mField.setHasTemporaryMedia(true);
+            }
+            catch (FileNotFoundException fnfe) {
+                Timber.e(fnfe, "Unable to open selected audio clip");
+            }
+            finally {
+                // close the file descriptor here?
+                try {
+                    inputStream.close();
+                }
+                catch (IOException ioe) {
+                    // nothing
+                }
+            }
+
+            Timber.d("audio clip picker file path is: %s", clipCopy.getAbsolutePath());
+            mField.setAudioPath(clipCopy.getAbsolutePath());
 
             mTvAudioClip.setText(mField.getFormattedValue());
             mTvAudioClip.setVisibility(View.VISIBLE);
         }
-        //setPreviewImage(mField.getImagePath(), getMaxImageSize());
     }
 
     @Override
-    public void onDone() {
-
-    }
+    public void onDone() { /* nothing */ }
 
     @Override
-    public void onDestroy() {
+    public void onFocusLost() { /* nothing */ }
 
-    }
+    @Override
+    public void onDestroy() { /* nothing */ }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicAudioRecordingFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicAudioRecordingFieldController.java
@@ -62,8 +62,7 @@ public class BasicAudioRecordingFieldController extends FieldControllerBase impl
             try {
                 Collection col = CollectionHelper.getInstance().getCol(context);
                 File storingDirectory = new File(col.getMedia().dir());
-                File file = File.createTempFile("ankidroid_audiorec", ".3gp", storingDirectory);
-                tempAudioPath = file.getAbsolutePath();
+                tempAudioPath = File.createTempFile("ankidroid_audiorec", ".3gp", storingDirectory).getAbsolutePath();
             } catch (IOException e) {
                 Timber.e(e, "Could not create temporary audio file.");
                 tempAudioPath = null;
@@ -74,6 +73,7 @@ public class BasicAudioRecordingFieldController extends FieldControllerBase impl
                 R.drawable.av_stop, R.drawable.av_rec, R.drawable.av_rec_stop, tempAudioPath);
         mAudioView.setOnRecordingFinishEventListener(v -> {
             // currentFilePath.setText("Recording done, you can preview it. Hit save after finish");
+            // FIXME is this okay if it is still null?
             mField.setAudioPath(tempAudioPath);
             mField.setHasTemporaryMedia(true);
         });

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicAudioRecordingFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicAudioRecordingFieldController.java
@@ -34,7 +34,7 @@ import java.io.IOException;
 
 import timber.log.Timber;
 
-public class BasicAudioFieldController extends FieldControllerBase implements IFieldController {
+public class BasicAudioRecordingFieldController extends FieldControllerBase implements IFieldController {
 
     /**
      * This controller always return a temporary path where it writes the audio

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicControllerFactory.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicControllerFactory.java
@@ -41,8 +41,8 @@ public class BasicControllerFactory implements IControllerFactory {
             case IMAGE:
                 return new BasicImageFieldController();
 
-            case AUDIO:
-                return new BasicAudioFieldController();
+            case AUDIO_RECORDING:
+                return new BasicAudioRecordingFieldController();
 
             case AUDIO_CLIP:
                 return new BasicAudioClipFieldController();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicControllerFactory.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicControllerFactory.java
@@ -44,6 +44,9 @@ public class BasicControllerFactory implements IControllerFactory {
             case AUDIO:
                 return new BasicAudioFieldController();
 
+            case AUDIO_CLIP:
+                return new BasicAudioClipFieldController();
+
             default:
 
                 break;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicTextFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicTextFieldController.java
@@ -275,7 +275,7 @@ public class BasicTextFieldController extends FieldControllerBase implements IFi
                     showToast(gtxt(R.string.multimedia_editor_pron_pronunciation_failed));
                 }
 
-                AudioField af = new AudioField();
+                AudioField af = new AudioRecordingField();
                 af.setAudioPath(pronuncPath);
                 // This is done to delete the file later.
                 af.setHasTemporaryMedia(true);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/EFieldType.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/EFieldType.java
@@ -26,4 +26,5 @@ public enum EFieldType {
     TEXT, // Just text
     IMAGE, // Just image
     AUDIO, // Just audio
+    AUDIO_CLIP, // Just audio clip
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/EFieldType.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/EFieldType.java
@@ -25,6 +25,6 @@ package com.ichi2.anki.multimediacard.fields;
 public enum EFieldType {
     TEXT, // Just text
     IMAGE, // Just image
-    AUDIO, // Just audio
+    AUDIO_RECORDING, // Just audio
     AUDIO_CLIP, // Just audio clip
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.java
@@ -21,7 +21,7 @@ package com.ichi2.anki.servicelayer;
 
 import com.ichi2.anki.multimediacard.IMultimediaEditableNote;
 import com.ichi2.anki.multimediacard.fields.AudioClipField;
-import com.ichi2.anki.multimediacard.fields.AudioField;
+import com.ichi2.anki.multimediacard.fields.AudioRecordingField;
 import com.ichi2.anki.multimediacard.fields.IField;
 import com.ichi2.anki.multimediacard.fields.ImageField;
 import com.ichi2.anki.multimediacard.fields.TextField;
@@ -79,7 +79,7 @@ public class NoteService {
                 if (value.startsWith("<img")) {
                     field = new ImageField();
                 } else if (value.startsWith("[sound:") && value.contains("rec")) {
-                    field = new AudioField();
+                    field = new AudioRecordingField();
                 } else if (value.startsWith("[sound:")) {
                     field = new AudioClipField();
                 } else {
@@ -159,16 +159,13 @@ public class NoteService {
     private static void importMediaToDirectory(Collection col, IField field) {
         String tmpMediaPath = null;
         switch (field.getType()) {
-            case AUDIO:
+            case AUDIO_RECORDING:
+            case AUDIO_CLIP:
                 tmpMediaPath = field.getAudioPath();
                 break;
 
             case IMAGE:
                 tmpMediaPath = field.getImagePath();
-                break;
-
-            case AUDIO_CLIP:
-                tmpMediaPath = field.getAudioPath();
                 break;
 
             case TEXT:
@@ -186,7 +183,8 @@ public class NoteService {
                         inFile.delete();
                     }
                     switch (field.getType()) {
-                        case AUDIO:
+                        case AUDIO_RECORDING:
+                        case AUDIO_CLIP:
                             field.setAudioPath(outFile.getAbsolutePath());
                             break;
                         case IMAGE:

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.java
@@ -20,6 +20,7 @@
 package com.ichi2.anki.servicelayer;
 
 import com.ichi2.anki.multimediacard.IMultimediaEditableNote;
+import com.ichi2.anki.multimediacard.fields.AudioClipField;
 import com.ichi2.anki.multimediacard.fields.AudioField;
 import com.ichi2.anki.multimediacard.fields.IField;
 import com.ichi2.anki.multimediacard.fields.ImageField;
@@ -77,8 +78,10 @@ public class NoteService {
                 IField field = null;
                 if (value.startsWith("<img")) {
                     field = new ImageField();
-                } else if (value.startsWith("[sound:")) {
+                } else if (value.startsWith("[sound:") && value.contains("rec")) {
                     field = new AudioField();
+                } else if (value.startsWith("[sound:")) {
+                    field = new AudioClipField();
                 } else {
                     field = new TextField();
                 }
@@ -162,6 +165,10 @@ public class NoteService {
 
             case IMAGE:
                 tmpMediaPath = field.getImagePath();
+                break;
+
+            case AUDIO_CLIP:
+                tmpMediaPath = field.getAudioPath();
                 break;
 
             case TEXT:

--- a/AnkiDroid/src/main/res/menu/activity_edit_text.xml
+++ b/AnkiDroid/src/main/res/menu/activity_edit_text.xml
@@ -20,6 +20,12 @@
         android:title="@string/multimedia_editor_field_editing_audio"
         ankidroid:showAsAction="ifRoom|withText" />
     <item
+        android:id="@+id/multimedia_edit_field_to_audio_clip"
+        android:icon="@drawable/ic_mic_white_24dp"
+        android:orderInCategory="100"
+        android:title="@string/multimedia_editor_field_editing_audio_clip"
+        ankidroid:showAsAction="ifRoom|withText" />
+    <item
         android:id="@+id/multimedia_edit_field_done"
         android:icon="@drawable/ic_done_white_24dp"
         android:orderInCategory="100"

--- a/AnkiDroid/src/main/res/menu/popupmenu_multimedia_options.xml
+++ b/AnkiDroid/src/main/res/menu/popupmenu_multimedia_options.xml
@@ -7,6 +7,9 @@
             android:id="@+id/menu_multimedia_photo"
             android:title="@string/multimedia_editor_popup_image"/>
         <item
+            android:id="@+id/menu_multimedia_audio_clip"
+            android:title="@string/multimedia_editor_popup_audio_clip"/>
+        <item
             android:id="@+id/menu_multimedia_audio"
             android:title="@string/multimedia_editor_popup_audio"/>
         <item

--- a/AnkiDroid/src/main/res/values/16-multimedia-editor.xml
+++ b/AnkiDroid/src/main/res/values/16-multimedia-editor.xml
@@ -15,6 +15,7 @@
 --><resources>
     <!-- Main editor popup menu items -->
     <string name="multimedia_editor_popup_image">Add image</string>
+    <string name="multimedia_editor_popup_audio_clip">Add audio clip</string>
     <string name="multimedia_editor_popup_audio">Record audio</string>
     <string name="multimedia_editor_popup_text">Advanced editor</string>
     <string name="multimedia_editor_popup_cloze">Cloze deletion</string>
@@ -51,6 +52,7 @@
     <string name="multimedia_editor_field_editing_text">Text</string>
     <string name="multimedia_editor_field_editing_image">Image</string>
     <string name="multimedia_editor_field_editing_audio">Audio</string>
+    <string name="multimedia_editor_field_editing_audio_clip">Audio Clip</string>
     <string name="multimedia_editor_field_editing_done">Done</string>
 
     <!-- Text field editing -->
@@ -74,6 +76,7 @@
     <!-- for buttons -->
     <string name="multimedia_editor_image_field_editing_galery">Gallery</string>
     <string name="multimedia_editor_image_field_editing_photo">Camera</string>
+    <string name="multimedia_editor_image_field_editing_library">Library</string>
 
     <!-- General -->
     <!-- message on the progress dialog for the user to wait, means process -->

--- a/AnkiDroid/src/main/res/values/16-multimedia-editor.xml
+++ b/AnkiDroid/src/main/res/values/16-multimedia-editor.xml
@@ -51,7 +51,7 @@
     <!-- these are button names to convert field type -->
     <string name="multimedia_editor_field_editing_text">Text</string>
     <string name="multimedia_editor_field_editing_image">Image</string>
-    <string name="multimedia_editor_field_editing_audio">Audio</string>
+    <string name="multimedia_editor_field_editing_audio">Audio recording</string>
     <string name="multimedia_editor_field_editing_audio_clip">Audio Clip</string>
     <string name="multimedia_editor_field_editing_done">Done</string>
 


### PR DESCRIPTION
This is based entirely on the work from @johndem as seen in [his pull request](https://github.com/ankidroid/Anki-Android/pull/4079)

- I rebased his work to current master, and did minimum fixups to get it to build
- I removed commented out code per suggestion on previous pull request
- I altered it to be a ACTION_GET_CONTENT per suggestion on previous pull request
- I filtered it by CATEGORY_OPENABLE so we don't get ensnared in virtual document stuff

The most important change I did was to implement the audio add using a data copy as it became clear to me that  documents from ACTION_GET_CONTENT may not be directly accessible (you can't get their file name, only a descriptor or an input stream).

This currently builds correctly and generates notes with audio files based on mp3s I have stored on an sdcard, and they sync correctly and are viewable on other devices.