### PR TITLE
Make parallel builds work on current code, add parallel build release tool 

### DIFF
--- a/tools/parallel-package-name.sh
+++ b/tools/parallel-package-name.sh
@@ -12,9 +12,8 @@ CONSTANTS="res/values/constants.xml"
 
 OLD_ID=`grep applicationId AnkiDroid/build.gradle | sed "s/.*applicationId \"//" | sed "s/\"//"`
 OLD_NAME=`grep "name=\"app_name\"" $ROOT$CONSTANTS | sed "s/.*name=\"app_name\">//" | sed "s/<\/string>//"`
-sed -i -e "s/name=\"app_name\">$OLD_NAME/name=\"app_name\">$NEW_NAME/g" $ROOT$CONSTANTS
-sed -i -e "s/applicationId \"$OLD_ID/applicationId \"$NEW_ID/g" AnkiDroid/build.gradle
-sed -i -e "s/android:authorities=\"$OLD_ID/android:authorities=\"$NEW_ID/g" $ROOT$MANIFEST
-sed -i -e "s/permission android:name=\"$OLD_ID.permission/permission android:name=\"$NEW_ID.permission/g" $ROOT$MANIFEST
-find $ROOT/res/xml -type f -exec sed -i -e "s/android:targetPackage=\"$OLD_ID\"/android:targetPackage=\"$NEW_ID\"/g"  {} \;
-
+sed -i '' "s/name=\"app_name\">$OLD_NAME/name=\"app_name\">$NEW_NAME/g" $ROOT$CONSTANTS
+sed -i '' "s/applicationId \"$OLD_ID/applicationId \"$NEW_ID/g" AnkiDroid/build.gradle
+sed -i '' "s/android:authorities=\"$OLD_ID/android:authorities=\"$NEW_ID/g" $ROOT$MANIFEST
+sed -i '' "s/permission android:name=\"$OLD_ID.permission/permission android:name=\"$NEW_ID.permission/g" $ROOT$MANIFEST
+find $ROOT/res/xml -type f -exec sed -i '' "s/android:targetPackage=\"$OLD_ID\"/android:targetPackage=\"$NEW_ID\"/g"  {} \;

--- a/tools/parallel-package-release.sh
+++ b/tools/parallel-package-release.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+#
+# This script assumes a few things -
+#
+# 1) you are in the main directory of the Anki source code (e.g. 'Anki-Android' is the current working directory)
+# 2) you have a Java keystore at the file path $home/src/android-keystore
+# 3) In that java keystore you have the key alias 'nrkeystorealias'
+# 4) you have no local changes in your working directory (e.g. "git reset --hard && git clean -f")
+# If those assumptions are met, this script will generate 3 parallel builds that should be the same as your current checkout
+# They will be placed in the parent directory ('..') as 'AnkiDroid-<version>.parallel.<A B or C>.apk'
+
+# It takes 1 argument - the tag name to use for the build (e.g. '2.9alpha16')
+# It will ask you for your keystore and key password
+
+TAG=$1
+
+# Read the key passwords
+read -sp "Enter keystore password: " KSTOREPWD; echo
+read -sp "Enter key password: " KEYPWD; echo
+export KSTOREPWD
+export KEYPWD
+
+# Get on to the tag requested
+#git checkout $TAG
+
+BUILDNAMES='A B C'
+for BUILD in $BUILDNAMES; do
+    git reset --hard
+    git clean -f
+    LCBUILD=`tr '[:upper:]' '[:lower:]' <<< $BUILD`
+    ./tools/parallel-package-name.sh com.ici2.anki.$LCBUILD AnkiDroid.$BUILD
+    ./gradlew assembleRelease
+    cp AnkiDroid/build/outputs/apk/AnkiDroid-release.apk ../AnkiDroid-$TAG.parallel.$BUILD.apk
+done


### PR DESCRIPTION
Hi there - I made one set of small non-functional changes to the parallel build, and one functional change -

I updated sed commands so they were "sed -i ''" vs "sed -i -e", this means the in-line edited files are no longer backed up, but the current combo of MacOS and AndroidStudio was failing to build when there were ".xml-e" (backup) files in the resources directory. Since we have version control for real backups and these builds will never be committed, it seemed an easy decision to remove the backup functionality to proceed with the build

The functional change is the addition of a 'parallel-package-release.sh' tool, that iteratively builds 3 parallel packages (A, B and C, like before) in a way that should make for compatible upgrades to previous users.

This appears to work for me now - installs and upgrades both work correctly although you need to change the storage directory in advanced preferences still (like previous parallel builds) 