### PR TITLE
Stop timers on answer reveal

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -2064,6 +2064,10 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
         mIsSelecting = false;
         updateCard(enrichWithQADiv(answer, true));
         showEaseButtons();
+
+        // Stop review timer and answer timer
+        pauseTimer();
+
         // If the user wants to show the next question automatically
         if (mPrefUseTimer) {
             long delay = mWaitQuestionSecond * 1000 + mUseTimerDynamicMS;


### PR DESCRIPTION
I want to be able to see how quickly I answer questions since I'm trying to improve my recall speeds.

I've made the answer timer stop when the answer is revealed.

Note, this will also call mCurrentCard.stopTimer() and thus may affect card stats - I could change to something like the below if that would cause unintended side effects.

```
        // Stop answer timer
        if (mCardTimer != null) {
            mCardTimer.stop();
        }
```