### PR TITLE
in-place sed editing not cross-platform, convert to perl, fixes #4777

### DIFF
--- a/tools/parallel-package-name.sh
+++ b/tools/parallel-package-name.sh
@@ -12,8 +12,8 @@ CONSTANTS="res/values/constants.xml"
 
 OLD_ID=`grep applicationId AnkiDroid/build.gradle | sed "s/.*applicationId \"//" | sed "s/\"//"`
 OLD_NAME=`grep "name=\"app_name\"" $ROOT$CONSTANTS | sed "s/.*name=\"app_name\">//" | sed "s/<\/string>//"`
-sed -i '' "s/name=\"app_name\">$OLD_NAME/name=\"app_name\">$NEW_NAME/g" $ROOT$CONSTANTS
-sed -i '' "s/applicationId \"$OLD_ID/applicationId \"$NEW_ID/g" AnkiDroid/build.gradle
-sed -i '' "s/android:authorities=\"$OLD_ID/android:authorities=\"$NEW_ID/g" $ROOT$MANIFEST
-sed -i '' "s/permission android:name=\"$OLD_ID.permission/permission android:name=\"$NEW_ID.permission/g" $ROOT$MANIFEST
-find $ROOT/res/xml -type f -exec sed -i '' "s/android:targetPackage=\"$OLD_ID\"/android:targetPackage=\"$NEW_ID\"/g"  {} \;
+perl -pi -e "s/name=\"app_name\">$OLD_NAME/name=\"app_name\">$NEW_NAME/g" $ROOT$CONSTANTS
+perl -pi -e "s/applicationId \"$OLD_ID/applicationId \"$NEW_ID/g" AnkiDroid/build.gradle
+perl -pi -e "s/android:authorities=\"$OLD_ID/android:authorities=\"$NEW_ID/g" $ROOT$MANIFEST
+perl -pi -e "s/permission android:name=\"$OLD_ID.permission/permission android:name=\"$NEW_ID.permission/g" $ROOT$MANIFEST
+find $ROOT/res/xml -type f -exec perl -pi -e "s/android:targetPackage=\"$OLD_ID\"/android:targetPackage=\"$NEW_ID\"/g" {} \;


### PR DESCRIPTION
@ju-w logged bug #4777 indicating my changes to the renaming script failed on Ubuntu.

Root cause is that the '-i' flag for sed is not POSIX, so is not cross-platform and my change made it work on OS X but is unworkable on Linux (and vice-versa)

The solution I picked was to convert to 'perl -pi -e "s///g"' style from 'sed -i "s///g"' style, and this pull request is the implementation of that simple conversion.

Tested on OS X and the reported Ubuntu version

I also did a full sweep in tools/* and it is worth noting the 'release.sh' script still uses 'sed -i' but that's obviously separate so I will leave it at the mention.