### PR TITLE
Updating versions for buildtools and gson dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ android:
     - tools
     - platform-tools
     - build-tools-24.0.3
-    - build-tools-26.0.2
+    - build-tools-26.0.3
     - android-22
     - android-26
     - extra-android-support

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.github.triplet.play'
 def homePath = System.properties['user.home']
 android {
     compileSdkVersion 26
-    buildToolsVersion '26.0.2'
+    buildToolsVersion '26.0.3'
 
     defaultConfig {
         applicationId "com.ichi2.anki"
@@ -61,7 +61,7 @@ dependencies {
     compile 'com.getbase:floatingactionbutton:1.10.1'
     compile 'ch.acra:acra:4.6.2'
     compile 'com.jakewharton.timber:timber:2.7.1'
-    compile 'com.google.code.gson:gson:2.4'
+    compile 'com.google.code.gson:gson:2.8.2'
     compile 'org.jsoup:jsoup:1.10.3'
     compile project(":api")
 

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -6,7 +6,7 @@ def version = "1.1.0alpha5"
 
 android {
     compileSdkVersion 26
-    buildToolsVersion '26.0.2'
+    buildToolsVersion '26.0.3'
 
     defaultConfig {
         minSdkVersion 8


### PR DESCRIPTION
buildtools update from 26.0.2 to 26.0.3 (shouldn't affect anything?) and gson from 2.4 to 2.8.2 - a bigger change but seems to work fine for me?