### PR TITLE
Change notifications to setRepeating, may fix issue #4525

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
@@ -323,7 +323,7 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
                                 calendar.set(Calendar.MINUTE, reminder.getJSONArray("time").getInt(1));
                                 calendar.set(Calendar.SECOND, 0);
 
-                                alarmManager.setInexactRepeating(
+                                alarmManager.setRepeating(
                                         AlarmManager.RTC_WAKEUP,
                                         calendar.getTimeInMillis(),
                                         AlarmManager.INTERVAL_DAY,
@@ -356,7 +356,7 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
                             calendar.set(Calendar.MINUTE, reminder.getJSONArray("time").getInt(1));
                             calendar.set(Calendar.SECOND, 0);
 
-                            alarmManager.setInexactRepeating(
+                            alarmManager.setRepeating(
                                     AlarmManager.RTC_WAKEUP,
                                     calendar.getTimeInMillis(),
                                     AlarmManager.INTERVAL_DAY,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.java
@@ -72,7 +72,7 @@ public class BootService extends IntentService {
                         calendar.set(Calendar.MINUTE, reminder.getJSONArray("time").getInt(1));
                         calendar.set(Calendar.SECOND, 0);
 
-                        alarmManager.setInexactRepeating(
+                        alarmManager.setRepeating(
                                 AlarmManager.RTC_WAKEUP,
                                 calendar.getTimeInMillis(),
                                 AlarmManager.INTERVAL_DAY,
@@ -99,7 +99,7 @@ public class BootService extends IntentService {
         calendar.set(Calendar.SECOND, 0);
         final PendingIntent notificationIntent =
                 PendingIntent.getBroadcast(context, 0, new Intent(context, NotificationReceiver.class), 0);
-        alarmManager.setInexactRepeating(
+        alarmManager.setRepeating(
                 AlarmManager.RTC_WAKEUP,
                 calendar.getTimeInMillis(),
                 AlarmManager.INTERVAL_DAY,


### PR DESCRIPTION
simple change from setInexactRepeating to setRepeating

I say it "may" fix issue #4525 because I am able to see notifications correctly firing at the expected time with and without the fix (on Nexus 5 API 23 stock emulator), but I it is obviously an issue for some

This will obviously need testing from the affected parties, and if it isn't sufficient the only alternative I see in AlarmManager is to implement recurrence in our code and call setWindow() to get closer to exact alarms