### PR TITLE
Decrease targetSdkVersion to pre-26 / 8.0, avoids background limits

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -8,7 +8,7 @@ android {
     defaultConfig {
         applicationId "com.ichi2.anki"
         minSdkVersion 14
-        targetSdkVersion 26
+        targetSdkVersion 25
         testApplicationId "com.ichi2.anki.tests"
         vectorDrawables.useSupportLibrary = true
     }


### PR DESCRIPTION
From the [docs](https://developer.android.com/about/versions/oreo/android-8.0-changes.html): "By default, these restrictions only apply to apps that target O"

That seemed like an easy temporary fix for Issue https://github.com/ankidroid/Anki-Android/issues/4786, so I just tested it, and if we move targetSdkVersion to 25 (vs 26 in upstream/master) this no longer crashes on reboots on my 8.1 emulator where I was able to reproduce this before.

It is obviously not a proper fix but it definitively avoids the problem for now. I will still work on a definitive fix for this and submit a PR but killing a crash bug with a one-digit change is nice if it is acceptable