### PR TITLE
remove unnecessary buildToolsVersion from gradle scripts

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -3,7 +3,6 @@ apply plugin: 'com.github.triplet.play'
 def homePath = System.properties['user.home']
 android {
     compileSdkVersion 26
-    buildToolsVersion '26.0.3'
 
     defaultConfig {
         applicationId "com.ichi2.anki"

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -6,7 +6,6 @@ def version = "1.1.0alpha5"
 
 android {
     compileSdkVersion 26
-    buildToolsVersion '26.0.3'
 
     defaultConfig {
         minSdkVersion 8


### PR DESCRIPTION
removed buildToolsVersion from gradle scripts since this is no longer needed (as of gradle 3.0)