### PR TITLE
Use long type when intervals are handled in seconds

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sched.java
@@ -1982,7 +1982,7 @@ public class Sched {
      * @return A string like “1 min” or “1.7 mo”
      */
     public String nextIvlStr(Context context, Card card, int ease) {
-        int ivl = nextIvl(card, ease);
+        long ivl = nextIvl(card, ease);
         if (ivl == 0) {
             return context.getString(R.string.sched_end);
         }
@@ -2001,7 +2001,7 @@ public class Sched {
     /**
      * Return the next interval for CARD, in seconds.
      */
-    public int nextIvl(Card card, int ease) {
+    public long nextIvl(Card card, int ease) {
         try {
             if (card.getQueue() == 0 || card.getQueue() == 1 || card.getQueue() == 3) {
                 return _nextLrnIvl(card, ease);
@@ -2009,12 +2009,12 @@ public class Sched {
                 // lapsed
                 JSONObject conf = _lapseConf(card);
                 if (conf.getJSONArray("delays").length() > 0) {
-                    return (int) (conf.getJSONArray("delays").getDouble(0) * 60.0);
+                    return (long) (conf.getJSONArray("delays").getDouble(0) * 60.0);
                 }
-                return _nextLapseIvl(card, conf) * 86400;
+                return _nextLapseIvl(card, conf) * 86400L;
             } else {
                 // review
-                return _nextRevIvl(card, ease) * 86400;
+                return _nextRevIvl(card, ease) * 86400L;
             }
         } catch (JSONException e) {
             throw new RuntimeException(e);
@@ -2022,7 +2022,7 @@ public class Sched {
     }
 
 
-    private int _nextLrnIvl(Card card, int ease) {
+    private long _nextLrnIvl(Card card, int ease) {
         // this isn't easily extracted from the learn code
         if (card.getQueue() == 0) {
             card.setLeft(_startingLeft(card));
@@ -2037,7 +2037,7 @@ public class Sched {
                 if (!_resched(card)) {
                     return 0;
                 }
-                return _graduatingIvl(card, conf, true, false) * 86400;
+                return _graduatingIvl(card, conf, true, false) * 86400L;
             } else {
                 int left = card.getLeft() % 1000 - 1;
                 if (left <= 0) {
@@ -2045,7 +2045,7 @@ public class Sched {
                     if (!_resched(card)) {
                         return 0;
                     }
-                    return _graduatingIvl(card, conf, false, false) * 86400;
+                    return _graduatingIvl(card, conf, false, false) * 86400L;
                 } else {
                     return _delayForGrade(conf, left);
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Stats.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Stats.java
@@ -764,8 +764,8 @@ public class Stats {
         }
         mFirstElement = 0;
         mMaxElements = list.size() - 1;
-        mAverage = Utils.timeSpan(context, (int) Math.round(avg * SECONDS_PER_DAY));
-        mLongest = Utils.timeSpan(context, (int) Math.round(max_ * SECONDS_PER_DAY));
+        mAverage = Utils.timeSpan(context, (long) Math.round(avg * SECONDS_PER_DAY));
+        mLongest = Utils.timeSpan(context, (long) Math.round(max_ * SECONDS_PER_DAY));
 
         //some adjustments to not crash the chartbuilding with emtpy data
         if (mMaxElements == 0) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
@@ -136,7 +136,7 @@ public class Utils {
      * @param time_s The time to format, in seconds
      * @return The time quantity string. Something like "3 s" or "1.7 yr".
      */
-    public static String timeQuantity(Context context, int time_s) {
+    public static String timeQuantity(Context context, long time_s) {
         Resources res = context.getResources();
         // N.B.: the integer s, min, h, d and (one decimal, rounded by format) double for month, year is
         // hard-coded. See also 01-core.xml

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
@@ -163,11 +163,12 @@ public class Utils {
      * @param time_s The time to format, in seconds
      * @return The formatted, localized time string. The time is always an integer.
      */
-    public static String timeSpan(Context context, int time_s) {
+    public static String timeSpan(Context context, long time_s) {
         int time_x;  // Time in unit x
         Resources res = context.getResources();
         if (Math.abs(time_s) < TIME_MINUTE ) {
-            return res.getQuantityString(R.plurals.time_span_seconds, time_s, time_s);
+            time_x = (int) time_s;
+            return res.getQuantityString(R.plurals.time_span_seconds, time_x, time_x);
         } else if (Math.abs(time_s) < TIME_HOUR) {
             time_x = (int) Math.round(time_s/TIME_MINUTE);
             return res.getQuantityString(R.plurals.time_span_minutes, time_x, time_x);
@@ -193,7 +194,7 @@ public class Utils {
      * @param time_s The time to format, in seconds
      * @return The formatted, localized time string. The time is always a float.
      */
-    public static String roundedTimeSpan(Context context, int time_s) {
+    public static String roundedTimeSpan(Context context, long time_s) {
         if (Math.abs(time_s) < TIME_DAY) {
             return context.getResources().getString(R.string.stats_overview_hours, time_s/TIME_HOUR);
         } else if (Math.abs(time_s) < TIME_MONTH) {


### PR DESCRIPTION
The libanki/sched functions such as nextIvl and the libanki/utils function timeQuantity work with intervals in seconds. For intervals longer than 68 years this can't be expressed in a signed 32 bit int, causing an integer overflow and buggy display of interval times under the review ease buttons.

Edit: Also updated timeSpan and roundedTimeSpan which used int seconds as well, used in showing deck statistics.

Recently I started seeing this come up for cards in my decks. When I looked it had been reported by another user last year under issue #4674 (fixed by this patch).