### PR TITLE
make front field of card initial focus when editing/adding

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -195,7 +195,6 @@ public class NoteEditor extends AnkiActivity {
                     .show(NoteEditor.this, "", res.getString(R.string.saving_facts), false);
         }
 
-
         @Override
         public void onProgressUpdate(DeckTask.TaskData... values) {
             int count = values[0].getInt();
@@ -536,6 +535,12 @@ public class NoteEditor extends AnkiActivity {
 
         if (!mAddNote && mCurrentEditedCard != null) {
             Timber.i("NoteEditor:: Edit note activity successfully started with card id %d", mCurrentEditedCard.getId());
+        }
+
+        //set focus to FieldEditText 'front' on startup like Anki desktop
+        if (mEditFields != null) {
+            FieldEditText front = mEditFields.getFirst();
+            front.requestFocus();
         }
     }
 

--- a/AnkiDroid/src/main/res/layout/note_editor.xml
+++ b/AnkiDroid/src/main/res/layout/note_editor.xml
@@ -72,11 +72,13 @@
                         app:popupTheme="@style/ActionBar.Popup"/>
                 </LinearLayout>
 
+                <!-- Front/Back/Attach views added in NoteEditor.populateEditFields(..) -->
                 <LinearLayout
                     android:id="@+id/CardEditorEditFieldsLayout"
                     android:layout_width="fill_parent"
                     android:layout_height="wrap_content"
                     android:orientation="vertical"
+                    android:focusable="true"
                     android:padding="@dimen/keyline_1" />
 
                 <LinearLayout


### PR DESCRIPTION
Small productivity change that makes the front FieldEditText the initial focus when editing a card.  Allows users with keyboards to start typing without having to click the front card field like on Anki desktop.