### PR TITLE
Remove nook safeDisplay workaround, nook is api 8

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -683,12 +683,8 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
         PreferenceCategory workarounds = (PreferenceCategory) screen.findPreference("category_workarounds");
         if (workarounds != null) {
             CheckBoxPreference fixHebrewText = (CheckBoxPreference) screen.findPreference("fixHebrewText");
-            CheckBoxPreference safeDisplayMode = (CheckBoxPreference) screen.findPreference("safeDisplay");
             CompatHelper.removeHiddenPreferences(this.getApplicationContext());
 
-            if (!CompatHelper.isNook()) {
-                workarounds.removePreference(safeDisplayMode);
-            }
             if (CompatHelper.getSdkVersion() >= 16) {
                 workarounds.removePreference(fixHebrewText);
             }

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatHelper.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatHelper.java
@@ -88,10 +88,6 @@ public class CompatHelper {
         return android.os.Build.MODEL.equalsIgnoreCase("bntv400") && android.os.Build.BRAND.equals("NOOK");
     }
 
-    public static boolean isNook() {
-        return android.os.Build.MODEL.equalsIgnoreCase("nook") || android.os.Build.DEVICE.equalsIgnoreCase("nook");
-    }
-
     public static boolean isChromebook() {
         return android.os.Build.BRAND.equalsIgnoreCase("chromium") || android.os.Build.MANUFACTURER.equalsIgnoreCase("chromium");
     }
@@ -110,10 +106,6 @@ public class CompatHelper {
 
     public static void removeHiddenPreferences(Context context) {
         SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
-
-        if (getSdkVersion() >= 15 && !isNook()) {
-            preferences.edit().remove("safeDisplay").commit();
-        }
         if (getSdkVersion() >= 16) {
             preferences.edit().remove("fixHebrewText").commit();
         }


### PR DESCRIPTION
I verified nook is api 8, and while nook HD/HD+ are >= API 15, the "isNook()" boolean was targeted exclusively at the api 8 nook, so removing this is safe while we move to api >= 15