### PR TITLE
Use HTTPS to connect to Beolingus now, fixes #4789

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/beolingus/parsing/BeolingusParser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/beolingus/parsing/BeolingusParser.java
@@ -22,6 +22,8 @@ package com.ichi2.anki.multimediacard.beolingus.parsing;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import timber.log.Timber;
+
 /**
  * This class parses beolingus pages
  */
@@ -40,7 +42,8 @@ public class BeolingusParser {
         Matcher m = PRONUNC_PATTERN.matcher(html);
         while (m.find()) {
             if (m.group(2).equals(wordToSearchFor)) {
-                return "http://dict.tu-chemnitz.de" + m.group(1);
+                Timber.d("pronunciation URL is https://dict.tu-chemnitz.de" + m.group(1));
+                return "https://dict.tu-chemnitz.de" + m.group(1);
             }
         }
         return "no";
@@ -51,9 +54,12 @@ public class BeolingusParser {
      * @return {@code "no"}, or the http address of the mp3 file
      */
     public static String getMp3AddressFromPronounciation(String pronunciationPageHtml) {
+        // Only log the page if you need to work with the regex
+        // Timber.d("pronunciationPageHtml is " + pronunciationPageHtml);
         Matcher m = MP3_PATTERN.matcher(pronunciationPageHtml);
         if (m.find()) {
-            return "http://dict.tu-chemnitz.de" + m.group(1);
+            Timber.d("MP3 address is https://dict.tu-chemnitz.de" + m.group(1));
+            return "https://dict.tu-chemnitz.de" + m.group(1);
         }
         return "no";
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/beolingus/parsing/BeolingusParserTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/beolingus/parsing/BeolingusParserTest.java
@@ -15,7 +15,7 @@ public class BeolingusParserTest {
                 + "alt=\"[anhören]\" title=\"Wasser\" border=\"0\" align=\"top\" /></a>";
 
         String pronunciationUrl = BeolingusParser.getPronunciationAddressFromTranslation(html, "Wasser");
-        assertEquals("http://dict.tu-chemnitz.de/dings.cgi?speak=de/0/7/52qA5FttGIU;text=Wasser", pronunciationUrl);
+        assertEquals("https://dict.tu-chemnitz.de/dings.cgi?speak=de/0/7/52qA5FttGIU;text=Wasser", pronunciationUrl);
     }
 
     @Test
@@ -23,6 +23,6 @@ public class BeolingusParserTest {
         String html = "<td><a href=\"/speak-de/0/7/52qA5FttGIU.mp3\">Mit Ihrem";
 
         String mp3 = BeolingusParser.getMp3AddressFromPronounciation(html);
-        assertEquals("http://dict.tu-chemnitz.de/speak-de/0/7/52qA5FttGIU.mp3", mp3);
+        assertEquals("https://dict.tu-chemnitz.de/speak-de/0/7/52qA5FttGIU.mp3", mp3);
     }
 }


### PR DESCRIPTION
Beolingus has switched to HTTPS and they enforce it by sending a 302 / Moved Permanently redirect HTTP response when you try them without TLS. Everything else about the integration appears to be working as originally coded so this was a trivial fix.