### PR TITLE
Remove % sign escape in constants file for AAPTv2, Fixes issue #4801

### DIFF
--- a/AnkiDroid/src/main/res/values/constants.xml
+++ b/AnkiDroid/src/main/res/values/constants.xml
@@ -148,7 +148,7 @@
         <item>0</item>
         <item>1</item>
     </string-array>
-    <string name="deck_conf_percent">XXX \%%</string>
+    <string name="deck_conf_percent">XXX %</string>
 
     <string-array name="cram_deck_conf_order_values">
         <item>0</item>


### PR DESCRIPTION
The gradle plugin moved from the AAPT (Android Asset Packaging Tool) v1 to v2 as it went from gradle plugin 2.3+ to 3+

The difference between the two is that AAPTv1 doesn't display duplicated percent signs in the UI from our resources XML strings that have '%%' in them in an attempt to escape the % with a %.

From my reading it may be that when we move to AAPTv2 we will have to update all strings to remove the %% escaping (and just leave %) or we will have to find a workaround, or ?

It appears that AAPTv1 will be around through the end of 2018 and it's a problem either way, no need to make it an urgent problem, right?

I'd say this temporarily fixes the issue so it's not a blocker, but should not *close* Issue #4801 