### PR TITLE
Upgrade gradle and gradle plugin, with appropriate migrations, and Travis speedups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,15 @@ android:
   components:
     - tools
     - platform-tools
-    - build-tools-24.0.3
-    - build-tools-26.0.3
-    - android-22
+    - build-tools-27.0.3
+    # Android API-16 is required to use the emulator with API 16
+    - android-16
+    # Our current build target
     - android-26
-    - extra-android-support
     - extra-android-m2repository
-    - sys-img-armeabi-v7a-android-22
+    # Android Emulator API 16 benchmarks as fastest:
+    #   https://medium.com/zendesk-engineering/speeding-up-android-builds-on-travis-ci-1bb4cdbd9c62
+    - sys-img-armeabi-v7a-android-16
 
 licenses:
     - 'android-sdk-preview-license-.+'
@@ -26,8 +28,8 @@ jdk:
 
 # Emulator Management: Create, Start and Wait
 before_script:
-  - echo no | android create avd --force -n test -t android-22 --sdcard 10M --abi armeabi-v7a
-  - emulator -avd test -no-skin -no-audio -no-window &
+  - echo no | android create avd --force -n test -t android-16 --sdcard 10M --abi armeabi-v7a
+  - emulator -avd test -no-audio -no-window &
   - android-wait-for-emulator
   - adb shell input keyevent 82 &
 

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -3,7 +3,6 @@ apply plugin: 'com.github.triplet.play'
 def homePath = System.properties['user.home']
 android {
     compileSdkVersion 26
-    buildToolsVersion '26.0.3'
 
     defaultConfig {
         applicationId "com.ichi2.anki"
@@ -47,29 +46,29 @@ play {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:26.1.0'
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation 'com.android.support:appcompat-v7:26.1.0'
     // Note: the design support library can be quite buggy, so test everything thoroughly before updating it
-    compile 'com.android.support:design:26.1.0'
-    compile 'com.android.support:customtabs:26.1.0'
-    compile 'com.android.support:recyclerview-v7:26.1.0'
-    compile 'io.requery:sqlite-android:3.16.0'
-    compile('com.afollestad.material-dialogs:core:0.8.6.2@aar') {
+    implementation 'com.android.support:design:26.1.0'
+    implementation 'com.android.support:customtabs:26.1.0'
+    implementation 'com.android.support:recyclerview-v7:26.1.0'
+    implementation 'io.requery:sqlite-android:3.16.0'
+    implementation('com.afollestad.material-dialogs:core:0.8.6.2@aar') {
         //exclude group: 'com.android.support'  // uncomment to force our local support lib version
         transitive = true
     }
-    compile 'com.getbase:floatingactionbutton:1.10.1'
-    compile 'ch.acra:acra:4.6.2'
-    compile 'com.jakewharton.timber:timber:2.7.1'
-    compile 'com.google.code.gson:gson:2.8.2'
-    compile 'org.jsoup:jsoup:1.10.3'
-    compile project(":api")
+    implementation 'com.getbase:floatingactionbutton:1.10.1'
+    implementation 'ch.acra:acra:4.6.2'
+    implementation 'com.jakewharton.timber:timber:2.7.1'
+    implementation 'com.google.code.gson:gson:2.8.2'
+    implementation 'org.jsoup:jsoup:1.10.3'
+    api project(":api")
 
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.mockito:mockito-core:1.10.19' // v1 while PowerMock does not fully support v2.
-    testCompile 'org.powermock:powermock-core:1.6.5'
-    testCompile 'org.powermock:powermock-module-junit4:1.6.5'
-    testCompile 'org.powermock:powermock-api-mockito:1.6.5'
-    testCompile 'org.hamcrest:hamcrest-all:1.3'
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.mockito:mockito-core:1.10.19' // v1 while PowerMock does not fully support v2.
+    testImplementation 'org.powermock:powermock-core:1.6.5'
+    testImplementation 'org.powermock:powermock-module-junit4:1.6.5'
+    testImplementation 'org.powermock:powermock-api-mockito:1.6.5'
+    testImplementation 'org.hamcrest:hamcrest-all:1.3'
 
 }

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -6,11 +6,10 @@ def version = "1.1.0alpha5"
 
 android {
     compileSdkVersion 26
-    buildToolsVersion '26.0.3'
 
     defaultConfig {
         minSdkVersion 8
-        targetSdkVersion 26
+        targetSdkVersion 25
         versionCode 11015   // 4th digit: 1=alpha, 2=beta, 3=official
         versionName version
     }
@@ -23,7 +22,7 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
+    api fileTree(dir: 'libs', include: ['*.jar'])
 }
 
 // Borrowed from here:
@@ -64,9 +63,11 @@ task zipRelease(type: Zip) {
     archiveName "release-${version}.zip"
 }
 
-task generateRelease << {
-    println "Release ${version} can be found at ${localReleaseDest}/"
-    println "Release ${version} zipped can be found ${buildDir}/release-${version}.zip"
+task generateRelease {
+    doLast {
+        println "Release ${version} can be found at ${localReleaseDest}/"
+        println "Release ${version} zipped can be found ${buildDir}/release-${version}.zip"
+    }
 }
 
 generateRelease.dependsOn(uploadArchives)

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.1.2'
         classpath 'com.github.triplet.gradle:play-publisher:1.1.5'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,6 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+# Gradle now auto-selects build tools versions based on gradle version
+# If you change this, it may select a new version of build tools, reflected in .travis.yml
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.5.1-all.zip


### PR DESCRIPTION
- upgrade gradle plugin to current stable
- upgrade gradle to 4.5.1 (most current that works seamlessly with gradle plugin)
- new gradle plugin ignores buildtools specification, remove it
- new gradle exposes dependencies with [more granularity](https://developer.android.com/studio/build/gradle-plugin-3-0-0-migration#new_configurations), convert ours
- api module still had a targetSdk of 26 but we backed down to 25 for main module, I don't think these should diverge?
- remove obsolete buildtools from travis, add the current ones (hope this works)