### PR TITLE
Safely use HTML 5 for Java10; use google repos first

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -35,6 +35,12 @@ def localReleaseDest = "${buildDir}/release/${version}"
 task androidJavadocs(type: Javadoc) {
     source = android.sourceSets.main.java.srcDirs
     classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+
+    // Java 10 wants you to choose between html4 and html5. We are html5 clean and should use it.
+    // But in JDK < 10 the option isn't there and it breaks the build. This handles both.
+    if(JavaVersion.current() >= JavaVersion.VERSION_1_10){
+        options.addBooleanOption('html5', true)
+    }
 }
 
 task androidJavadocsJar(type: Jar, dependsOn: androidJavadocs) {

--- a/build.gradle
+++ b/build.gradle
@@ -2,11 +2,11 @@
 
 buildscript {
     repositories {
-        jcenter()
         maven {
             url 'https://maven.google.com/'
             name 'Google'
         }
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.2'
@@ -18,11 +18,11 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
         maven {
             url 'https://maven.google.com/'
             name 'Google'
         }
+        jcenter()
     }
 }
 


### PR DESCRIPTION
- Adding the flag that chooses HTML5 for Java10 while protecting the build in Java < 10

- Semi-unrelated, but the jcenter repositories went 404 on android.arch.common-1.0.0.jar which blew up the Travis build, and the whole internet said put the google repositories before jcenter, so I did that and it works