### PR TITLE
gradle plugin 3.1.3 update / google repo usage via shortcut

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
+        classpath 'com.android.tools.build:gradle:3.1.3'
         classpath 'com.github.triplet.gradle:play-publisher:1.1.5'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/build.gradle
+++ b/build.gradle
@@ -2,10 +2,7 @@
 
 buildscript {
     repositories {
-        maven {
-            url 'https://maven.google.com/'
-            name 'Google'
-        }
+        google()
         jcenter()
     }
     dependencies {
@@ -18,10 +15,7 @@ buildscript {
 
 allprojects {
     repositories {
-        maven {
-            url 'https://maven.google.com/'
-            name 'Google'
-        }
+        google()
         jcenter()
     }
 }


### PR DESCRIPTION
Two changes, both tiny, as separate commits (ideally following your preference):

1- using google repo before jcenter is still necessary but [my previous fix](https://github.com/ankidroid/Anki-Android/commit/a42492795ae88b833d4f241a35a1a20e36edd159#diff-c197962302397baf3a4cc36463dce5ea) was unnecessarily verbose, this implementation is the current way

2- Android Studio updated and that brings a gradle plugin update
