### PR TITLE
Init mocks prior to using them to avoid NPEs, Fixes #4873

### DIFF
--- a/AnkiDroid/src/test/java/com/wildplot/android/rendering/PieChartParameterizedTest.java
+++ b/AnkiDroid/src/test/java/com/wildplot/android/rendering/PieChartParameterizedTest.java
@@ -14,6 +14,7 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.mockito.InOrder;
 import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.modules.junit4.PowerMockRunnerDelegate;
@@ -61,6 +62,7 @@ public class PieChartParameterizedTest {
     @Before
     public void setUp() throws Exception {
         mockStatic(android.graphics.Color.class);
+        MockitoAnnotations.initMocks(this);
         when(Color.argb(anyInt(), anyInt(), anyInt(), anyInt())).thenReturn(0);
         when(plot.getFrameThickness()).thenReturn(new float[]{0, 0, 0, 0});
 

--- a/AnkiDroid/src/test/java/com/wildplot/android/rendering/PieChartTest.java
+++ b/AnkiDroid/src/test/java/com/wildplot/android/rendering/PieChartTest.java
@@ -11,6 +11,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -40,6 +41,7 @@ public class PieChartTest {
     @Before
     public void setUp() throws Exception {
         mockStatic(android.graphics.Color.class);
+        MockitoAnnotations.initMocks(this);
         when(Color.argb(anyInt(), anyInt(), anyInt(), anyInt())).thenReturn(0);
         when(plot.getFrameThickness()).thenReturn(new float[]{0, 0, 0, 0});
 


### PR DESCRIPTION

## Purpose / Description
I rely on unit tests heavily when I code, and the PieChartParameterizedTest was throwing NPEs fairly frequently

## Fixes
#4873 

## Approach
After research I think the problem was just that the class wasn't initializing correctly

## How Has This Been Tested?
The previous behavior (NPEs) was observable with AndroidStudio current (as of now) on MacOS current, with repeated executions of "tests in com." to trigger unit test execution. I got an NPE in the PieChart test about 50% of the time, now I never get it

## Learning (optional, can help others)
I learned that our unit test infrastructure is very out of date!
