### PR TITLE
Upgrade test dependencies and migrate tests to new APIs

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -64,11 +64,11 @@ dependencies {
     implementation 'org.jsoup:jsoup:1.10.3'
     api project(":api")
 
-    testImplementation 'junit:junit:4.12'
-    testImplementation 'org.mockito:mockito-core:1.10.19' // v1 while PowerMock does not fully support v2.
-    testImplementation 'org.powermock:powermock-core:1.6.5'
-    testImplementation 'org.powermock:powermock-module-junit4:1.6.5'
-    testImplementation 'org.powermock:powermock-api-mockito:1.6.5'
+    testImplementation 'org.junit.vintage:junit-vintage-engine:5.2.0'
+    testImplementation 'org.mockito:mockito-core:2.18.3'
+    testImplementation 'org.powermock:powermock-core:2.0.0-beta.5'
+    testImplementation 'org.powermock:powermock-module-junit4:2.0.0-beta.5'
+    testImplementation 'org.powermock:powermock-api-mockito2:2.0.0-beta.5'
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
 
 }

--- a/AnkiDroid/src/test/java/com/wildplot/android/rendering/FloatMatcher.java
+++ b/AnkiDroid/src/test/java/com/wildplot/android/rendering/FloatMatcher.java
@@ -1,9 +1,8 @@
 package com.wildplot.android.rendering;
 
-import org.hamcrest.Description;
-import org.hamcrest.TypeSafeMatcher;
+import org.mockito.ArgumentMatcher;
 
-class FloatMatcher extends TypeSafeMatcher<Float> {
+class FloatMatcher implements ArgumentMatcher<Float> {
     private final double expected;
     private final double precision;
 
@@ -17,13 +16,7 @@ class FloatMatcher extends TypeSafeMatcher<Float> {
     }
 
     @Override
-    protected boolean matchesSafely(Float actualValue) {
+    public boolean matches(Float actualValue) {
         return Math.abs(((double) actualValue) - expected) <= precision;
-    }
-
-
-    @Override
-    public void describeTo(Description description) {
-        description.appendText(expected + " ± " + precision);
     }
 }

--- a/AnkiDroid/src/test/java/com/wildplot/android/rendering/PieChartParameterizedTest.java
+++ b/AnkiDroid/src/test/java/com/wildplot/android/rendering/PieChartParameterizedTest.java
@@ -24,19 +24,19 @@ import java.util.Collection;
 
 import static com.wildplot.android.rendering.PieChartTest.createRectangleMock;
 import static java.util.Arrays.asList;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyFloat;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.floatThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyFloat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.floatThat;
 import static org.mockito.Mockito.inOrder;
 import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
 
 @RunWith(PowerMockRunner.class)
-@PowerMockRunnerDelegate(value = Parameterized.class)
-@PrepareForTest({RectangleWrap.class, GraphicsWrap.class, ColorWrap.class,
-        android.graphics.Color.class})
+@PowerMockRunnerDelegate(Parameterized.class)
+@PrepareForTest({RectangleWrap.class, GraphicsWrap.class, ColorWrap.class, PlotSheet.class,
+        Color.class})
 @SuppressWarnings("WeakerAccess")
 public class PieChartParameterizedTest {
     private static final double PRECISION = 2 * 1E-3F;

--- a/AnkiDroid/src/test/java/com/wildplot/android/rendering/PieChartTest.java
+++ b/AnkiDroid/src/test/java/com/wildplot/android/rendering/PieChartTest.java
@@ -14,10 +14,10 @@ import org.mockito.Mock;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyFloat;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.floatThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyFloat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.floatThat;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.mock;
@@ -25,8 +25,8 @@ import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({RectangleWrap.class, GraphicsWrap.class, ColorWrap.class,
-        android.graphics.Color.class})
+@PrepareForTest({RectangleWrap.class, GraphicsWrap.class, ColorWrap.class, PlotSheet.class,
+        Color.class})
 public class PieChartTest {
     private static final double PRECISION = 1E-3F;
     @Mock


### PR DESCRIPTION
    - Junit 4 -> Junit 5 using Vintage Engine
    - Mockito -> 1.10.x -> 2.18.x
    - Powermock 1.6.x -> Powermock 2.0.x

## Purpose / Description
I think in general if you can upgrade dependencies without too much pain, you should and this wasn't that bad - I implemented this while working on #4873 

## Fixes
This change causes no change in behavior that I can detect, all tests (unit or connected) continue to work after the change

## Approach


## How Has This Been Tested?

I ran unit tests and connected tests, and my travis context ran things on my local branch and passed

## Learning (optional, can help others)

I looked at the project pages and maven repositories for all of our test infrastructure dependencies as well as their getting started pages, and moved everything up to the most current possible stable versions with the exception of powermock - have to use the 2.0 beta there in order to have compatibility with modern mockito

_Links to blog posts, patterns, libraries or addons used to solve this problem_

Reason for Powermock 2.0-beta: https://github.com/powermock/powermock/issues/726