### PR TITLE
Use more API levels in CI, move to sdkmanager/avdmanager

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,37 +1,70 @@
 language: android
+
 sudo: false
+
+jdk:
+  - oraclejdk8
+
 env:
   global:
     - ADB_INSTALL_TIMEOUT=8
+    - ABI=armeabi-v7a
+    - EMU_FLAVOR=default # use google_apis flavor if no default flavor emulator
+    # PATH order is incredibly important. e.g. the 'emulator' script exists in more than one place!
+    - ANDROID_HOME=/usr/local/android-sdk
+    - TOOLS=${ANDROID_HOME}/tools
+    - PATH=${ANDROID_HOME}:${ANDROID_HOME}/emulator:${TOOLS}:${TOOLS}/bin:${ANDROID_HOME}/platform-tools:${PATH}
+  matrix:
+   - API=15
+   - API=16 AUDIO=-no-audio
+   - API=17
+   - API=18
+   - API=19
+   # API 20 doesn't have an emulator
+   - API=21
+   - API=22
+   - API=23 EMU_FLAVOR=google_apis
+   - API=24
+   - API=25 EMU_FLAVOR=google_apis
+   # API >= 26 don't have arm emulators, and Travis doesn't support x86
+
+matrix:
+  fast_finish: true # We can report success without waiting for these
+  allow_failures:
+    - env: API=15  # sometimes emulator hangs, sometimes not - possibly fixable
+    - env: API=23 EMU_FLAVOR=google_apis # has permission errors
+    - env: API=24                        # has permission errors
+    - env: API=25 EMU_FLAVOR=google_apis # has permission errors
 
 android:
   components:
+    # installing things this way vs 'sdkmanager' is deprecated, should move to sdkmanager over time
     - tools
     - platform-tools
-    - build-tools-27.0.3
-    # Android API-16 is required to use the emulator with API 16
-    - android-16
-    # Our current build target
-    - android-26
+    - tools              # a second time per Travis official docs, necessary for newest versions
+    - build-tools-27.0.3 # Automated dependency from gradle - gradle will drive the changes
+    - android-$API       # We need the API of the emulator we will run
+    - android-26         # We need the API of the current build target
     - extra-android-m2repository
-    # Android Emulator API 16 benchmarks as fastest:
-    #   https://medium.com/zendesk-engineering/speeding-up-android-builds-on-travis-ci-1bb4cdbd9c62
-    - sys-img-armeabi-v7a-android-16
 
 licenses:
     - 'android-sdk-preview-license-.+'
     - 'android-sdk-license-.+'
     - 'google-gdk-license-.+'
 
-jdk:
-  - oraclejdk8
-
 # Emulator Management: Create, Start and Wait
+install:
+  - echo 'count=0' > /home/travis/.android/repositories.cfg # Avoid harmless sdkmanager warning
+  - echo yes | sdkmanager tools # 'emulator' is deprecated, 'avdmanager' is current, this installs it
+  - echo yes | sdkmanager "system-images;android-$API;$EMU_FLAVOR;$ABI" # install our emulator
+  - echo no | avdmanager create avd --force -n test -k "system-images;android-$API;$EMU_FLAVOR;$ABI" -c 10M
+  - emulator -avd test -engine classic -no-window $AUDIO -camera-back none -camera-front none -selinux permissive -qemu -m 512 &
+
 before_script:
-  - echo no | android create avd --force -n test -t android-16 --sdcard 10M --abi armeabi-v7a
-  - emulator -avd test -no-audio -no-window &
   - android-wait-for-emulator
   - adb shell input keyevent 82 &
+
+script: ./gradlew test :AnkiDroid:connectedCheck
 
 before_cache:
   - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
@@ -40,8 +73,6 @@ cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
-
-script: ./gradlew :AnkiDroid:connectedCheck
 
 notifications:
   email:


### PR DESCRIPTION
## Purpose / Description

1- We support Android API >= 15, but we're only CI testing API 16 at the moment.
2- I did a PR for us from Gradle 3.1.1 to 3.1.2, and Travis CI passed but it turns out Gradle 3.1.2 ***could have caused the app to fail on install*** on API 21 and API 22! The exact sort of thing running Travis might help with

Now, Gradle 3.1.3 (which we moved to just now) fixed this specific gradle issue, but I do not want any of my PRs to be responsible for install failures on releases if I can help it, and doing CI on all possible levels seems sensible

So this does as full of an API matrix on Travis as I was able to implement, while also moving us towards the current-recommended "sdkmanager" and "avdmanager" tools, vs the deprecated "android" tool

This takes our CI success report time from 6 minutes (after previous changes) up to around 20, but as mentioned on those changes - time taken isn't everything. API 16 is still there and shows up in 6 minutes if people are watching closely.

## Fixes
We got lucky and I didn't see install failures, so I did not log an issue

## Approach
I use a combo of an env-based matrix and fast-failure in Travis

There are a few APIs that we may be able to get working in Travis, but I thought it was important to simply go with what we have working now instead of waiting for perfect, so I allow failures on 4 API levels, with notes.

## How Has This Been Tested?
[Endless iterations of change/test with Travis
](https://travis-ci.com/mikehardy/Anki-Android/builds)
## Learning (optional, can help others)
These are the issues that prompted my concern:
https://issuetracker.google.com/issues/78072750
https://www.google.com/search?q=INSTALL_FAILED_DEXOPT+D8
https://developer.android.com/s/results/?q=INSTALL_FAILED_DEXOPT

_Links to blog posts, patterns, libraries or addons used to solve this problem_
This .travis.yml from another project was the most informative:
https://github.com/albodelu/android-maps-utils/blob/8ab3efe962cfe59da6db748c176108d7e142e4e7/.travis.yml