### PR TITLE
Feature 4863/timber upgrade

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -59,7 +59,7 @@ dependencies {
     }
     implementation 'com.getbase:floatingactionbutton:1.10.1'
     implementation 'ch.acra:acra:4.6.2'
-    implementation 'com.jakewharton.timber:timber:2.7.1'
+    implementation 'com.jakewharton.timber:timber:4.7.0'
     implementation 'com.google.code.gson:gson:2.8.2'
     implementation 'org.jsoup:jsoup:1.10.3'
     api project(":api")
@@ -70,5 +70,5 @@ dependencies {
     testImplementation 'org.powermock:powermock-module-junit4:2.0.0-beta.5'
     testImplementation 'org.powermock:powermock-api-mockito2:2.0.0-beta.5'
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
-
+    testImplementation 'net.lachlanmckee:timber-junit-rule:1.0.1'
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ProductionCrashReportingTreeTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ProductionCrashReportingTreeTest.java
@@ -1,0 +1,77 @@
+package com.ichi2.anki;
+
+import android.util.Log;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import timber.log.Timber;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeast;
+import static org.powermock.api.mockito.PowerMockito.verifyStatic;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(Log.class)
+public class ProductionCrashReportingTreeTest {
+
+
+    @Before
+    public void setUp() {
+
+        // setup - simply instrument the class and do same log init as production
+        PowerMockito.mockStatic(Log.class);
+        Timber.plant(new AnkiDroidApp.ProductionCrashReportingTree());
+    }
+
+
+    /**
+     * The Production logger ignores verbose and debug logs on purpose
+     * Make sure these ignored log levels are not passed to the platform logger
+     */
+    @Test
+    public void testProductionDebugVerboseIgnored() {
+
+        // set up the platform log so that if anyone calls these 2 methods at all, it throws
+        Mockito.when(Log.v(anyString(), anyString(), (Throwable) any()))
+                .thenThrow(new RuntimeException("Verbose logging should have been ignored"));
+        Mockito.when(Log.d(anyString(), anyString(), (Throwable) any()))
+                .thenThrow(new RuntimeException("Debug logging should be ignored"));
+
+        // now call our wrapper - if it hits the platform logger it will throw
+        Timber.v("verbose");
+        Timber.d("debug");
+    }
+
+
+    /**
+     * The levels that are fully logged have special "tag" behavior per-level
+     *
+     * Info: always {@link AnkiDroidApp#TAG} as the logging tag
+     * Warn/Error: tag is LoggingClass.className()'s most specific dot-separated String subsection
+     */
+    @Test
+    public void testProductionLogTag() {
+
+        // setUp() instrumented the static, now exercise it
+        Timber.i("info level message");
+        Timber.w("warn level message");
+        Timber.e("error level message");
+
+        // verify that info level had the constant tag
+        verifyStatic(Log.class, atLeast(1));
+        Log.i(AnkiDroidApp.TAG, "info level message", null);
+
+        // verify Warn/Error has final part of calling class name to start the message
+        verifyStatic(Log.class, atLeast(1));
+        Log.w(AnkiDroidApp.TAG, this.getClass().getSimpleName() + "/ " + "warn level message", null);
+        verifyStatic(Log.class, atLeast(1));
+        Log.e(AnkiDroidApp.TAG, this.getClass().getSimpleName() + "/ " + "error level message", null);
+    }
+}


### PR DESCRIPTION
## Purpose / Description

Our Timber dependency was very old, and newer ones allow support for logging during Unit tests, which would be useful

## Fixes
#4863 

## Approach
Between direct observation and conversation here, assumed three requirements for the production logger 
- verbose and debug should be ignored
- info gets a fixed log tag
- warn+error get fixed tag + logging classname prepended to message

I then took the default implementation proposed by the current Timber release documentation, as well as the DebugTree classname discovery implementation, and implemented it here to match the three requirements

## How Has This Been Tested?

I looked at live logcat snippets of production releases and debug releases, then made sure with visual inspection they looked similar.

I also implemented a unit test to exercise the new production logger and verify the three requirements were met

## Learning (optional, can help others)

PowerMockito for static classes is pretty interesting. Here's how to mock statics and verify:
https://automationrhapsody.com/verify-static-method-called-powermock/

Here's the example Timber implementation:
https://github.com/JakeWharton/timber/blob/master/timber-sample/src/main/java/com/example/timber/ExampleApp.java

Looking at our logging implementation prior to any changes is useful 
https://github.com/ankidroid/Anki-Android/blob/v2.5.4/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java#L351