### PR TITLE
Api docs and deprecation

### DIFF
--- a/api/src/main/java/com/ichi2/anki/api/AddContentApi.java
+++ b/api/src/main/java/com/ichi2/anki/api/AddContentApi.java
@@ -180,7 +180,7 @@ public final class AddContentApi {
     /**
      * Get the number of notes that exist for the specified model ID
      * @param mid id of the model to be used
-     * @return number of notes that exist with that model ID
+     * @return number of notes that exist with that model ID or -1 if there was a problem
      */
     public int getNoteCount(long mid) {
         Cursor cursor = getCompat().queryNotes(mid);
@@ -219,7 +219,7 @@ public final class AddContentApi {
     /**
      * Get the contents of a note with known ID
      * @param noteId the ID of the note to find
-     * @return object containing the contents of note with noteID
+     * @return object containing the contents of note with noteID or null if there was a problem
      */
     public NoteInfo getNote(long noteId) {
         Uri noteUri = Uri.withAppendedPath(Note.CONTENT_URI, Long.toString(noteId));

--- a/api/src/main/java/com/ichi2/anki/api/Utils.java
+++ b/api/src/main/java/com/ichi2/anki/api/Utils.java
@@ -111,6 +111,7 @@ class Utils {
      * @param html The HTML escaped text
      * @return The text with its HTML entities unescaped.
      */
+    @SuppressWarnings("deprecation")
     private static String entsToTxt(String html) {
         // entitydefs defines nbsp as \xa0 instead of a standard space, so we
         // replace it first
@@ -118,6 +119,7 @@ class Utils {
         Matcher htmlEntities = htmlEntitiesPattern.matcher(html);
         StringBuffer sb = new StringBuffer();
         while (htmlEntities.find()) {
+            // Html.fromHtml(String) is deprecated but it's replacement isn't available till API24
             htmlEntities.appendReplacement(sb, Html.fromHtml(htmlEntities.group()).toString());
         }
         htmlEntities.appendTail(sb);

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,11 @@ allprojects {
         google()
         jcenter()
     }
+    gradle.projectsEvaluated {
+        tasks.withType(JavaCompile) {
+            options.compilerArgs << "-Xlint:deprecation"
+        }
+    }
 }
 
 ext {


### PR DESCRIPTION
## Purpose / Description

I've been working on the API to stop users from crashing - part of it is the API being clear about error return values and that's implemented here

Also the compiler kept warning me about deprecation and I figured out how to expose that, then investigated the source, noted the problem and suppressed the warning since it isn't important to fix now

## Fixes
#4617 

## Approach
Better docs should help in conjunction with a more defensive sample app

## How Has This Been Tested?

purely javadoc updates and comments

## Learning (optional, can help others)
Finding deprecation is actually difficult. IDEA-FindBugs and IDEA-Checkstyle both failed to do it for me, even with API levels moved up past the deprecation tag showing up. Adding compiler options was the only way to do it that I found

_Links to blog posts, patterns, libraries or addons used to solve this problem_
