### PR TITLE
Update connected test deps and fix permissions errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ jdk:
 
 env:
   global:
-    - ADB_INSTALL_TIMEOUT=8
+    - export QEMU_AUDIO_DRV=none # Avoid emulator hangs. Anyway, if an emulator makes a sound does anyone hear it?
+    - ADB_INSTALL_TIMEOUT=20  # Emulator timeout in minutes. Gradle files have equivalent setting.
     - ABI=armeabi-v7a
     - EMU_FLAVOR=default # use google_apis flavor if no default flavor emulator
     # PATH order is incredibly important. e.g. the 'emulator' script exists in more than one place!
@@ -16,7 +17,7 @@ env:
     - PATH=${ANDROID_HOME}:${ANDROID_HOME}/emulator:${TOOLS}:${TOOLS}/bin:${ANDROID_HOME}/platform-tools:${PATH}
   matrix:
    - API=15
-   - API=16 AUDIO=-no-audio
+   - API=16
    - API=17
    - API=18
    - API=19
@@ -31,10 +32,9 @@ env:
 matrix:
   fast_finish: true # We can report success without waiting for these
   allow_failures:
-    - env: API=15  # sometimes emulator hangs, sometimes not - possibly fixable
-    - env: API=23 EMU_FLAVOR=google_apis # has permission errors
-    - env: API=24                        # has permission errors
-    - env: API=25 EMU_FLAVOR=google_apis # has permission errors
+    - env: API=15                        # sometimes emulator hangs, possibly fixable
+    - env: API=23 EMU_FLAVOR=google_apis # Flaky: 'Skipping device 'test(AVD)' for 'AnkiDroid:': Unknown API Level'
+    - env: API=25 EMU_FLAVOR=google_apis # emulator startup timeout - possibly fixable
 
 android:
   components:
@@ -58,13 +58,21 @@ install:
   - echo yes | sdkmanager tools # 'emulator' is deprecated, 'avdmanager' is current, this installs it
   - echo yes | sdkmanager "system-images;android-$API;$EMU_FLAVOR;$ABI" # install our emulator
   - echo no | avdmanager create avd --force -n test -k "system-images;android-$API;$EMU_FLAVOR;$ABI" -c 10M
-  - emulator -avd test -engine classic -no-window $AUDIO -camera-back none -camera-front none -selinux permissive -qemu -m 512 &
+  - emulator -avd test -no-skin -no-window -camera-back none -camera-front none -selinux permissive -qemu -m 512 &
 
 before_script:
-  - android-wait-for-emulator
+  # Try once with a huge timeout, it will succeed fast or just wait trying
+  # Note "travis_wait" generates an ugly log line when it stops waiting, but it can be ignored
+  # Reference: https://github.com/travis-ci/travis-ci/issues/5441
+  # Example: '/home/travis/build.sh: line NNN:  NNN Terminated              travis_jigger $! $timeout $cmd
+  - travis_wait 20 android-wait-for-emulator || yes
+  # Try one more time, succeeding fast while maybe allowing success if first fixed 360s in emulator was hit
+  - travis_wait 20 android-wait-for-emulator
   - adb shell input keyevent 82 &
 
-script: ./gradlew test :AnkiDroid:connectedCheck
+script:
+  # We need a travis_wait here also, or some emulators timeout during the package install (!)
+  - travis_wait ./gradlew test :AnkiDroid:connectedCheck --stacktrace
 
 before_cache:
   - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,14 +65,14 @@ before_script:
   # Note "travis_wait" generates an ugly log line when it stops waiting, but it can be ignored
   # Reference: https://github.com/travis-ci/travis-ci/issues/5441
   # Example: '/home/travis/build.sh: line NNN:  NNN Terminated              travis_jigger $! $timeout $cmd
-  - travis_wait 20 android-wait-for-emulator || yes
+  - android-wait-for-emulator || yes
   # Try one more time, succeeding fast while maybe allowing success if first fixed 360s in emulator was hit
   - travis_wait 20 android-wait-for-emulator
   - adb shell input keyevent 82 &
 
 script:
   # We need a travis_wait here also, or some emulators timeout during the package install (!)
-  - travis_wait ./gradlew test :AnkiDroid:connectedCheck --stacktrace
+  - ./gradlew test :AnkiDroid:connectedCheck --stacktrace
 
 before_cache:
   - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -10,6 +10,7 @@ android {
         targetSdkVersion 25
         testApplicationId "com.ichi2.anki.tests"
         vectorDrawables.useSupportLibrary = true
+        testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
     }
     lintOptions {
         abortOnError false
@@ -35,6 +36,11 @@ android {
     dexOptions {
         // Skip pre-dexing when running on Travis CI or when disabled via -Dpre-dex=false.
         preDexLibraries = preDexEnabled && !travisBuild
+    }
+
+    // This enables long timeouts required on slow environments, e.g. Travis
+    adbOptions {
+        timeOutInMs 20 * 60 * 1000  // 20 minutes
     }
 }
 
@@ -70,5 +76,18 @@ dependencies {
     testImplementation 'org.powermock:powermock-module-junit4:2.0.0-beta.5'
     testImplementation 'org.powermock:powermock-api-mockito2:2.0.0-beta.5'
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
-    testImplementation 'net.lachlanmckee:timber-junit-rule:1.0.1'
+    testImplementation 'net.lachlanmckee:timber-junit-rule:1.0.1'  // test logging rule
+
+    // 3 excludes, to avoid dependency resolve clash between our 26.0.1 and 27.1.1
+    // This will be solved if we move all the android stuff to 27.1.1
+    androidTestImplementation('com.android.support.test.espresso:espresso-core:3.0.2') {
+        exclude group: 'com.android.support', module: 'support-annotations'
+    }
+    androidTestImplementation('com.android.support.test:runner:1.0.2') {
+        exclude group: 'com.android.support', module: 'support-annotations'
+    }
+    androidTestImplementation('com.android.support.test:rules:1.0.2') {
+        exclude group: 'com.android.support', module: 'support-annotations'
+    }
+    androidTestUtil 'com.android.support.test:orchestrator:1.0.2'
 }

--- a/AnkiDroid/proguard-rules.pro
+++ b/AnkiDroid/proguard-rules.pro
@@ -1,14 +1,9 @@
 # Add project specific ProGuard rules here.
-# By default, the flags in this file are appended to flags specified
-# in C:\Program Files (x86)\Android\android-sdk/tools/proguard/proguard-android.txt
-# You can edit the include path and order by changing the proguardFiles
-# directive in build.gradle.
+# By default
 #
 # For more details, see
 #   http://developer.android.com/guide/developing/tools/proguard.html
-
-# Add any project specific keep options here:
-
+#
 # If your project uses WebView with JS, uncomment the following
 # and specify the fully qualified class name to the JavaScript interface
 # class:
@@ -20,8 +15,19 @@
 # https://code.google.com/p/android/issues/detail?id=78377
 -keepattributes **
 -keep class !android.support.v7.view.menu.**,!android.support.design.internal.NavigationMenu,!android.support.design.internal.NavigationMenuPresenter,!android.support.design.internal.NavigationSubMenu,** {*;}
+
+# AnkiDroid specific settings
 -dontpreverify
 -dontoptimize
 -dontshrink
 -dontwarn **
 -dontnote **
+
+# JUnit problems with new Gradle? https://github.com/googlesamples/android-testing/issues/179
+-keep @org.junit.runner.RunWith public class *
+
+# Other testing related settings
+-keep class android.support.test.**
+-keep class android.support.multidex.**
+-keep class org.junit.**
+-ignorewarnings

--- a/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/CollectionTest.java
+++ b/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/CollectionTest.java
@@ -1,16 +1,49 @@
+/***************************************************************************************
+ *                                                                                      *
+ * Copyright (c) 2015 Frank Oltmanns <frank.oltmanns@gmail.com>                         *
+ * Copyright (c) 2015 Timothy Rae <timothy.rae@gmail.com>                               *
+ * Copyright (c) 2016 Mark Carter <mark@marcardar.com>                                  *
+ * Copyright (c) 2018 Mike Hardy <mike@mikehardy.net>                                   *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+
 package com.ichi2.anki.tests;
 
-import android.test.AndroidTestCase;
+import android.Manifest;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.rule.GrantPermissionRule;
+import android.support.test.runner.AndroidJUnit4;
 
 import com.ichi2.anki.CollectionHelper;
 
-import java.io.IOException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.Assert;
+import org.junit.runner.RunWith;
 
 /**
  * This test case verifies that the directory initialization works even if the app is not yet fully initialized.
  */
-public class CollectionTest extends AndroidTestCase{
-    public void testOpenCollection() throws IOException {
-        assertNotNull("Collection could not be opened", CollectionHelper.getInstance().getCol(getContext()));
+@RunWith(AndroidJUnit4.class)
+public class CollectionTest {
+
+    @Rule public GrantPermissionRule mRuntimePermissionRule =
+            GrantPermissionRule.grant(Manifest.permission.WRITE_EXTERNAL_STORAGE);
+
+    @Test
+    public void testOpenCollection() {
+        Assert.assertNotNull("Collection could not be opened",
+                CollectionHelper.getInstance().getCol(InstrumentationRegistry.getTargetContext()));
     }
 }

--- a/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/ContentProviderTest.java
+++ b/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/ContentProviderTest.java
@@ -3,6 +3,7 @@
  * Copyright (c) 2015 Frank Oltmanns <frank.oltmanns@gmail.com>                         *
  * Copyright (c) 2015 Timothy Rae <timothy.rae@gmail.com>                               *
  * Copyright (c) 2016 Mark Carter <mark@marcardar.com>                                  *
+ * Copyright (c) 2018 Mike Hardy <mike@mikehardy.net>                                   *
  *                                                                                      *
  * This program is free software; you can redistribute it and/or modify it under        *
  * the terms of the GNU General Public License as published by the Free Software        *
@@ -19,12 +20,19 @@
 
 package com.ichi2.anki.tests;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import android.Manifest;
 import android.content.ContentResolver;
 import android.content.ContentUris;
 import android.content.ContentValues;
 import android.database.Cursor;
 import android.net.Uri;
-import android.test.AndroidTestCase;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.rule.GrantPermissionRule;
+import android.support.test.runner.AndroidJUnit4;
 import android.util.Log;
 
 import com.ichi2.anki.AbstractFlashcardViewer;
@@ -42,17 +50,25 @@ import com.ichi2.libanki.Utils;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 
 /**
  * Test cases for {@link com.ichi2.anki.provider.CardContentProvider}.
  * <p/>
  * These tests should cover all supported operations for each URI.
  */
-public class ContentProviderTest extends AndroidTestCase {
+@RunWith(AndroidJUnit4.class)
+public class ContentProviderTest {
 
     private static final String BASIC_MODEL_NAME = "com.ichi2.anki.provider.test.basic.x94oa3F";
     private static final String TEST_FIELD_NAME = "TestFieldName";
@@ -70,20 +86,26 @@ public class ContentProviderTest extends AndroidTestCase {
     private static final String[] TEST_NOTE_FIELDS = {"dis is za Fr0nt", "Te$t"};
     private static final String TEST_MODEL_CSS = "styleeeee";
 
-    private int mNumDecksBeforeTest;
-    private long[] mTestDeckIds = new long[TEST_DECKS.length];
-    private ArrayList<Uri> mCreatedNotes;
-    private long mModelId = 0;
-    private String[] mDummyFields = new String[1];
+    private static int mNumDecksBeforeTest;
+    private static long[] mTestDeckIds = new long[TEST_DECKS.length];
+    private static ArrayList<Uri> mCreatedNotes;
+    private static long mModelId;
+    private static String[] mDummyFields;
+
+    @Rule
+    public GrantPermissionRule mRuntimePermissionRule =
+            GrantPermissionRule.grant(Manifest.permission.WRITE_EXTERNAL_STORAGE,
+                    com.ichi2.anki.Manifest.permission.READ_WRITE_DATABASE);
+
     /**
      * Initially create one note for each model.
      */
-    @Override
-    protected void setUp() throws Exception {
-        super.setUp();
+    @BeforeClass
+    public static void setUp() throws Exception {
+
         Log.i(AnkiDroidApp.TAG, "setUp()");
         mCreatedNotes = new ArrayList<>();
-        final Collection col = CollectionHelper.getInstance().getCol(getContext());
+        final Collection col = CollectionHelper.getInstance().getCol(InstrumentationRegistry.getTargetContext());
         // Add a new basic model that we use for testing purposes (existing models could potentially be corrupted)
         JSONObject model = Models.addBasicModel(col, BASIC_MODEL_NAME);
         mModelId = model.getLong("id");
@@ -118,10 +140,10 @@ public class ContentProviderTest extends AndroidTestCase {
     /**
      * Remove the notes and decks created in setUp().
      */
-    @Override
-    protected void tearDown() throws Exception {
+    @AfterClass
+    public static void tearDown() throws Exception {
         Log.i(AnkiDroidApp.TAG, "tearDown()");
-        final Collection col = CollectionHelper.getInstance().getCol(getContext());
+        final Collection col = CollectionHelper.getInstance().getCol(InstrumentationRegistry.getTargetContext());
         // Delete all notes
         List<Long> remnantNotes = col.findNotes("tag:" + TEST_TAG);
         if (remnantNotes.size() > 0) {
@@ -142,16 +164,16 @@ public class ContentProviderTest extends AndroidTestCase {
         // Delete test model
         col.modSchema(false);
         col.getModels().rem(col.getModels().get(mModelId));
-        super.tearDown();
     }
 
 
     /**
      * Check that inserting and removing a note into default deck works as expected
      */
+    @Test
     public void testInsertAndRemoveNote() throws Exception {
         // Get required objects for test
-        final ContentResolver cr = getContext().getContentResolver();
+        final ContentResolver cr = InstrumentationRegistry.getTargetContext().getContentResolver();
         // Add the note
         ContentValues values = new ContentValues();
         values.put(FlashCardsContract.Note.MID, mModelId);
@@ -180,10 +202,11 @@ public class ContentProviderTest extends AndroidTestCase {
     /**
      * Check that inserting and removing a note into default deck works as expected
      */
+    @Test
     public void testInsertTemplate() throws Exception {
         // Get required objects for test
-        final ContentResolver cr = getContext().getContentResolver();
-        Collection col = CollectionHelper.getInstance().getCol(getContext());
+        final ContentResolver cr = InstrumentationRegistry.getTargetContext().getContentResolver();
+        Collection col = CollectionHelper.getInstance().getCol(InstrumentationRegistry.getTargetContext());
         // Add a new basic model that we use for testing purposes (existing models could potentially be corrupted)
         JSONObject model = Models.addBasicModel(col, BASIC_MODEL_NAME);
         long modelId = model.getLong("id");
@@ -215,10 +238,11 @@ public class ContentProviderTest extends AndroidTestCase {
     /**
      * Check that inserting and removing a note into default deck works as expected
      */
+    @Test
     public void testInsertField() throws Exception {
         // Get required objects for test
-        final ContentResolver cr = getContext().getContentResolver();
-        Collection col = CollectionHelper.getInstance().getCol(getContext());
+        final ContentResolver cr = InstrumentationRegistry.getTargetContext().getContentResolver();
+        Collection col = CollectionHelper.getInstance().getCol(InstrumentationRegistry.getTargetContext());
         JSONObject model = Models.addBasicModel(col, BASIC_MODEL_NAME);
         long modelId = model.getLong("id");
         JSONArray initialFldsArr = model.getJSONArray("flds");
@@ -243,9 +267,10 @@ public class ContentProviderTest extends AndroidTestCase {
     /**
      * Test queries to notes table using direct SQL URI
      */
+    @Test
     public void testQueryDirectSqlQuery() {
         // search for correct mid
-        final ContentResolver cr = getContext().getContentResolver();
+        final ContentResolver cr = InstrumentationRegistry.getTargetContext().getContentResolver();
         Cursor cursor = cr.query(FlashCardsContract.Note.CONTENT_URI_V2, null, String.format("mid=%d", mModelId), null, null);
         assertNotNull(cursor);
         try {
@@ -269,8 +294,9 @@ public class ContentProviderTest extends AndroidTestCase {
     /**
      * Test that a query for all the notes added in setup() looks correct
      */
+    @Test
     public void testQueryNoteIds() {
-        final ContentResolver cr = getContext().getContentResolver();
+        final ContentResolver cr = InstrumentationRegistry.getTargetContext().getContentResolver();
         // Query all available notes
         final Cursor allNotesCursor = cr.query(FlashCardsContract.Note.CONTENT_URI, null, "tag:" + TEST_TAG, null, null);
         assertNotNull(allNotesCursor);
@@ -305,8 +331,9 @@ public class ContentProviderTest extends AndroidTestCase {
     /**
      * Check that a valid Cursor is returned when querying notes table with non-default projections
      */
+    @Test
     public void testQueryNotesProjection() {
-        final ContentResolver cr = getContext().getContentResolver();
+        final ContentResolver cr = InstrumentationRegistry.getTargetContext().getContentResolver();
         // Query all available notes
         for (int i = 0; i < FlashCardsContract.Note.DEFAULT_PROJECTION.length; i++) {
             String[] projection = removeFromProjection(FlashCardsContract.Note.DEFAULT_PROJECTION, i);
@@ -327,12 +354,10 @@ public class ContentProviderTest extends AndroidTestCase {
 
     private String[] removeFromProjection(String[] inputProjection, int idx) {
         String[] outputProjection = new String[inputProjection.length - 1];
-        for (int i = 0; i < idx; i++) {
-            outputProjection[i] = inputProjection[i];
-        }
-        for (int i = idx + 1; i < inputProjection.length; i++) {
-            outputProjection[i - 1] = inputProjection[i];
-        }
+        System.arraycopy(inputProjection, 0,
+                outputProjection, 0, idx);
+        System.arraycopy(inputProjection, idx + 1,
+                outputProjection, idx + 1 - 1, inputProjection.length - (idx + 1));
         return outputProjection;
     }
 
@@ -340,8 +365,9 @@ public class ContentProviderTest extends AndroidTestCase {
     /**
      * Check that updating the flds column works as expected
      */
+    @Test
     public void testUpdateNoteFields() {
-        final ContentResolver cr = getContext().getContentResolver();
+        final ContentResolver cr = InstrumentationRegistry.getTargetContext().getContentResolver();
         ContentValues cv = new ContentValues();
         // Change the fields so that the first field is now "newTestValue"
         String[] dummyFields2 = mDummyFields.clone();
@@ -360,7 +386,9 @@ public class ContentProviderTest extends AndroidTestCase {
                         noteCursor.getString(noteCursor.getColumnIndex(FlashCardsContract.Note.FLDS)));
                 assertTrue("Check that the flds have been updated correctly", Arrays.equals(newFlds, dummyFields2));
             } finally {
-                noteCursor.close();
+                if (noteCursor != null) {
+                    noteCursor.close();
+                }
             }
         }
     }
@@ -369,8 +397,9 @@ public class ContentProviderTest extends AndroidTestCase {
     /**
      * Check that inserting a new model works as expected
      */
+    @Test
     public void testInsertAndUpdateModel() throws Exception {
-        final ContentResolver cr = getContext().getContentResolver();
+        final ContentResolver cr = InstrumentationRegistry.getTargetContext().getContentResolver();
         ContentValues cv = new ContentValues();
         // Insert a new model
         cv.put(FlashCardsContract.Model.NAME, TEST_MODEL_NAME);
@@ -420,7 +449,7 @@ public class ContentProviderTest extends AndroidTestCase {
                 col.getModels().rem(col.getModels().get(mid));
             } catch (ConfirmModSchemaException e) {
                 // This will never happen
-                throw new IllegalStateException("Unexpected ConfirmModSchemaException trying to remove model");
+                fail("Unexpected ConfirmModSchemaException trying to remove model");
             }
         }
     }
@@ -428,8 +457,9 @@ public class ContentProviderTest extends AndroidTestCase {
     /**
      * Query .../models URI
      */
+    @Test
     public void testQueryAllModels() {
-        final ContentResolver cr = getContext().getContentResolver();
+        final ContentResolver cr = InstrumentationRegistry.getTargetContext().getContentResolver();
         // Query all available models
         final Cursor allModels = cr.query(FlashCardsContract.Model.CONTENT_URI, null, null, null, null);
         assertNotNull(allModels);
@@ -462,8 +492,9 @@ public class ContentProviderTest extends AndroidTestCase {
     /**
      * Move all the cards from their old decks to the first deck that was added in setup()
      */
+    @Test
     public void testMoveCardsToOtherDeck() {
-        final ContentResolver cr = getContext().getContentResolver();
+        final ContentResolver cr = InstrumentationRegistry.getTargetContext().getContentResolver();
         // Query all available notes
         final Cursor allNotesCursor = cr.query(FlashCardsContract.Note.CONTENT_URI, null, "tag:" + TEST_TAG, null, null);
         assertNotNull(allNotesCursor);
@@ -504,8 +535,9 @@ public class ContentProviderTest extends AndroidTestCase {
     /**
      * Check that querying the current model gives a valid result
      */
+    @Test
     public void testQueryCurrentModel() {
-        final ContentResolver cr = getContext().getContentResolver();
+        final ContentResolver cr = InstrumentationRegistry.getTargetContext().getContentResolver();
         Uri uri = Uri.withAppendedPath(FlashCardsContract.Model.CONTENT_URI, FlashCardsContract.Model.CURRENT_MODEL_ID);
         final Cursor modelCursor = cr.query(uri, null, null, null, null);
         assertNotNull(modelCursor);
@@ -524,8 +556,9 @@ public class ContentProviderTest extends AndroidTestCase {
     /**
      * Check that an Exception is thrown when unsupported operations are performed
      */
+    @Test
     public void testUnsupportedOperations() {
-        final ContentResolver cr = getContext().getContentResolver();
+        final ContentResolver cr = InstrumentationRegistry.getTargetContext().getContentResolver();
         ContentValues dummyValues = new ContentValues();
         Uri[] updateUris = {
                 // Can't update most tables in bulk -- only via ID
@@ -604,14 +637,14 @@ public class ContentProviderTest extends AndroidTestCase {
 
     /**
      * Test query to decks table
-     * @throws Exception
      */
+    @Test
     public void testQueryAllDecks() throws Exception{
         Collection col;
-        col = CollectionHelper.getInstance().getCol(getContext());
+        col = CollectionHelper.getInstance().getCol(InstrumentationRegistry.getTargetContext());
         Decks decks = col.getDecks();
 
-        Cursor decksCursor = getContext().getContentResolver()
+        Cursor decksCursor = InstrumentationRegistry.getTargetContext().getContentResolver()
                 .query(FlashCardsContract.Deck.CONTENT_ALL_URI, FlashCardsContract.Deck.DEFAULT_PROJECTION, null, null, null);
 
         assertNotNull(decksCursor);
@@ -632,15 +665,15 @@ public class ContentProviderTest extends AndroidTestCase {
 
     /**
      * Test query to specific deck ID
-     * @throws Exception
      */
+    @Test
     public void testQueryCertainDeck() throws Exception {
         Collection col;
-        col = CollectionHelper.getInstance().getCol(getContext());
+        col = CollectionHelper.getInstance().getCol(InstrumentationRegistry.getTargetContext());
 
         long deckId = mTestDeckIds[0];
         Uri deckUri = Uri.withAppendedPath(FlashCardsContract.Deck.CONTENT_ALL_URI, Long.toString(deckId));
-        Cursor decksCursor = getContext().getContentResolver().query(deckUri, null, null, null, null);
+        Cursor decksCursor = InstrumentationRegistry.getTargetContext().getContentResolver().query(deckUri, null, null, null, null);
         try {
             if (decksCursor == null || !decksCursor.moveToFirst()) {
                 fail("No deck received. Should have delivered deck with id " + deckId);
@@ -653,19 +686,22 @@ public class ContentProviderTest extends AndroidTestCase {
                 assertEquals("Check that received deck name equals real deck name", realDeck.getString("name"), returnedDeckName);
             }
         } finally {
-            decksCursor.close();
+            if (decksCursor != null) {
+                decksCursor.close();
+            }
         }
     }
 
     /**
      * Test that query for the next card in the schedule returns a valid result without any deck selector
      */
+    @Test
     public void testQueryNextCard(){
         Collection col;
-        col = CollectionHelper.getInstance().getCol(getContext());
+        col = CollectionHelper.getInstance().getCol(InstrumentationRegistry.getTargetContext());
         Sched sched = col.getSched();
 
-        Cursor reviewInfoCursor = getContext().getContentResolver().query(
+        Cursor reviewInfoCursor = InstrumentationRegistry.getTargetContext().getContentResolver().query(
                 FlashCardsContract.ReviewInfo.CONTENT_URI, null, null, null, null);
         assertNotNull(reviewInfoCursor);
         assertEquals("Check that we actually received one card", 1, reviewInfoCursor.getCount());
@@ -690,17 +726,18 @@ public class ContentProviderTest extends AndroidTestCase {
     /**
      * Test that query for the next card in the schedule returns a valid result WITH a deck selector
      */
-    public void testQueryCardFromCertainDeck(){
+    @Test
+    public void testQueryCardFromCertainDeck() {
         long deckToTest = mTestDeckIds[0];
         String deckSelector = "deckID=?";
         String deckArguments[] = {Long.toString(deckToTest)};
         Collection col;
-        col = CollectionHelper.getInstance().getCol(getContext());
+        col = CollectionHelper.getInstance().getCol(InstrumentationRegistry.getTargetContext());
         Sched sched = col.getSched();
         long selectedDeckBeforeTest = col.getDecks().selected();
         col.getDecks().select(1); //select Default deck
 
-        Cursor reviewInfoCursor = getContext().getContentResolver().query(
+        Cursor reviewInfoCursor = InstrumentationRegistry.getTargetContext().getContentResolver().query(
                 FlashCardsContract.ReviewInfo.CONTENT_URI, null, deckSelector, deckArguments, null);
         assertNotNull(reviewInfoCursor);
         assertEquals("Check that we actually received one card", 1, reviewInfoCursor.getCount());
@@ -720,7 +757,7 @@ public class ContentProviderTest extends AndroidTestCase {
             assertNotNull("Check that there actually is a next scheduled card", nextCard);
             assertEquals("Check that received card and actual card have same note id", nextCard.note().getId(), noteID);
             assertEquals("Check that received card and actual card have same card ord", nextCard.getOrd(), cardOrd);
-        }finally {
+        } finally {
             reviewInfoCursor.close();
         }
 
@@ -730,9 +767,10 @@ public class ContentProviderTest extends AndroidTestCase {
     /**
      * Test changing the selected deck
      */
+    @Test
     public void testSetSelectedDeck(){
         long deckId = mTestDeckIds[0];
-        ContentResolver cr = getContext().getContentResolver();
+        ContentResolver cr = InstrumentationRegistry.getTargetContext().getContentResolver();
         Uri selectDeckUri = FlashCardsContract.Deck.CONTENT_SELECTED_URI;
         ContentValues values = new ContentValues();
         values.put(FlashCardsContract.Deck.DECK_ID, deckId);
@@ -744,14 +782,15 @@ public class ContentProviderTest extends AndroidTestCase {
     /**
      * Test giving the answer for a reviewed card
      */
+    @Test
     public void testAnswerCard(){
         Collection col;
-        col = CollectionHelper.getInstance().getCol(getContext());
+        col = CollectionHelper.getInstance().getCol(InstrumentationRegistry.getTargetContext());
         long deckId = mTestDeckIds[0];
         col.getDecks().select(deckId);
         Card card = col.getSched().getCard();
 
-        ContentResolver cr = getContext().getContentResolver();
+        ContentResolver cr = InstrumentationRegistry.getTargetContext().getContentResolver();
         Uri reviewInfoUri = FlashCardsContract.ReviewInfo.CONTENT_URI;
         ContentValues values = new ContentValues();
         long noteId = card.note().getId();
@@ -765,18 +804,16 @@ public class ContentProviderTest extends AndroidTestCase {
         assertEquals("Check if update returns 1", 1, updateCount);
         col.getSched().reset();
         Card newCard = col.getSched().getCard();
-        if(newCard != null){
+        if (newCard != null) {
             if(newCard.note().getId() == card.note().getId() && newCard.getOrd() == card.getOrd()){
                 fail("Next scheduled card has not changed");
             }
-        }else{
-            //We expected this
         }
     }
 
     private Collection reopenCol() {
         CollectionHelper.getInstance().closeCollection(false);
-        return CollectionHelper.getInstance().getCol(getContext());
+        return CollectionHelper.getInstance().getCol(InstrumentationRegistry.getTargetContext());
     }
 
 }

--- a/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/libanki/ImportTest.java
+++ b/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/libanki/ImportTest.java
@@ -1,5 +1,6 @@
 /****************************************************************************************
  * Copyright (c) 2016 Houssam Salem <houssam.salem.au@gmail.com>                        *
+ * Copyright (c) 2018 Mike Hardy <mike@mikehardy.net>                                   *
  *                                                                                      *
  * This program is free software; you can redistribute it and/or modify it under        *
  * the terms of the GNU General Public License as published by the Free Software        *
@@ -16,8 +17,11 @@
 package com.ichi2.anki.tests.libanki;
 
 
-import android.test.AndroidTestCase;
-import android.test.suitebuilder.annotation.Suppress;
+import android.Manifest;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.filters.Suppress;
+import android.support.test.rule.GrantPermissionRule;
+import android.support.test.runner.AndroidJUnit4;
 
 import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.anki.tests.Shared;
@@ -32,90 +36,109 @@ import com.ichi2.libanki.importer.TextImporter;
 
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
-public class ImportTest extends AndroidTestCase {
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
+@RunWith(AndroidJUnit4.class)
+public class ImportTest {
+
+    @Rule
+    public GrantPermissionRule mRuntimePermissionRule =
+            GrantPermissionRule.grant(Manifest.permission.WRITE_EXTERNAL_STORAGE);
+
+
+    // testAnki2Mediadupes() failed on Travis API=22 EMU_FLAVOR=default ABI=armeabi-v7a
+    //com.ichi2.anki.tests.libanki.ImportTest > testAnki2Mediadupes[test(AVD) - 5.1.1] FAILED
+    // error:
+    //android.database.sqlite.SQLiteReadOnlyDatabaseException: attempt to write a readonly database (code 1032)
+    //at io.requery.android.database.sqlite.SQLiteConnection.nativeExecuteForChangedRowCount(Native Method)
+    //        :AnkiDroid:connectedDebugAndroidTest FAILED
+    //
+    // Error code 1032 is https://www.sqlite.org/rescode.html#readonly_dbmoved - which should be impossible
+    //
+    // I was unable to reproduce it on the same emulator locally, even with thousands of iterations.
+    // Allowing it to re-run now, 3 times, in case it flakes again.
+    @Rule
+    public RetryRule retry = new RetryRule(3);
+
+    @Test
     public void testAnki2Mediadupes() throws IOException, JSONException {
-        List<String> expected;
         List<String> actual;
 
-        Collection tmp = Shared.getEmptyCol(getContext());
-        // add a note that references a sound
-        Note n = tmp.newNote();
+        // Build a temporary collection with one note, containing a sound file
+        Collection tmpCol = Shared.getEmptyCol(InstrumentationRegistry.getTargetContext());
+        Note n = tmpCol.newNote();
         n.setItem("Front", "[sound:foo.mp3]");
         long mid = n.model().getLong("id");
-        tmp.addNote(n);
+        tmpCol.addNote(n);
         // add that sound to the media folder
-        FileOutputStream os;
-        os = new FileOutputStream(new File(tmp.getMedia().dir(), "foo.mp3"), false);
-        os.write("foo".getBytes());
-        os.close();
-        tmp.close();
+        FileOutputStream out = new FileOutputStream(new File(tmpCol.getMedia().dir(), "foo.mp3"), false);
+        out.write("foo".getBytes());
+        out.close();
+        tmpCol.close();
+
         // it should be imported correctly into an empty deck
-        Collection empty = Shared.getEmptyCol(getContext());
-        Importer imp = new Anki2Importer(empty, tmp.getPath());
-        imp.run();
-        expected = Arrays.asList("foo.mp3");
-        actual = Arrays.asList(new File(empty.getMedia().dir()).list());
-        actual.retainAll(expected);
-        assertEquals(expected.size(), actual.size());
+        Collection emptyCol = Shared.getEmptyCol(InstrumentationRegistry.getTargetContext());
+        new Anki2Importer(emptyCol, tmpCol.getPath()).run();
+        actual = Arrays.asList(new File(emptyCol.getMedia().dir()).list());
+        assertEquals(1, actual.size());
+
         // and importing again will not duplicate, as the file content matches
-        empty.remCards(Utils.arrayList2array(empty.getDb().queryColumn(Long.class, "select id from cards", 0)));
-        imp = new Anki2Importer(empty, tmp.getPath());
-        imp.run();
-        expected = Arrays.asList("foo.mp3");
-        actual = Arrays.asList(new File(empty.getMedia().dir()).list());
-        actual.retainAll(expected);
-        assertEquals(expected.size(), actual.size());
-        n = empty.getNote(empty.getDb().queryLongScalar("select id from notes"));
-        assertTrue(n.getFields()[0].contains("foo.mp3"));
+        emptyCol.remCards(Utils.arrayList2array(emptyCol.getDb().queryColumn(Long.class, "select id from cards", 0)));
+        new Anki2Importer(emptyCol, tmpCol.getPath()).run();
+        actual = Arrays.asList(new File(emptyCol.getMedia().dir()).list());
+        assertEquals(1, actual.size());
+        n = emptyCol.getNote(emptyCol.getDb().queryLongScalar("select id from notes"));
+        assertEquals("[sound:foo.mp3]", n.getFields()[0]);
+
         // if the local file content is different, and import should trigger a rename
-        empty.remCards(Utils.arrayList2array(empty.getDb().queryColumn(Long.class, "select id from cards", 0)));
-        os = new FileOutputStream(new File(empty.getMedia().dir(), "foo.mp3"), false);
-        os.write("bar".getBytes());
-        os.close();
-        imp = new Anki2Importer(empty, tmp.getPath());
-        imp.run();
-        expected = Arrays.asList("foo.mp3", String.format("foo_%s.mp3", mid));
-        actual = Arrays.asList(new File(empty.getMedia().dir()).list());
-        actual.retainAll(expected);
-        assertEquals(expected.size(), actual.size());
-        n = empty.getNote(empty.getDb().queryLongScalar("select id from notes"));
-        assertTrue(n.getFields()[0].contains("_"));
+        emptyCol.remCards(Utils.arrayList2array(emptyCol.getDb().queryColumn(Long.class, "select id from cards", 0)));
+        out = new FileOutputStream(new File(emptyCol.getMedia().dir(), "foo.mp3"), false);
+        out.write("bar".getBytes());
+        out.close();
+        new Anki2Importer(emptyCol, tmpCol.getPath()).run();
+        actual = Arrays.asList(new File(emptyCol.getMedia().dir()).list());
+        assertEquals(2, actual.size());
+        n = emptyCol.getNote(emptyCol.getDb().queryLongScalar("select id from notes"));
+        assertEquals(String.format("[sound:foo_%s.mp3]", mid), n.getFields()[0]);
+
         // if the localized media file already exists, we rewrite the note and media
-        empty.remCards(Utils.arrayList2array(empty.getDb().queryColumn(Long.class, "select id from cards", 0)));
-        os = new FileOutputStream(new File(empty.getMedia().dir(), "foo.mp3"));
-        os.write("bar".getBytes());
-        os.close();
-        imp = new Anki2Importer(empty, tmp.getPath());
-        imp.run();
-        expected =  Arrays.asList("foo.mp3", String.format("foo_%s.mp3", mid));
-        actual = Arrays.asList(new File(empty.getMedia().dir()).list());
-        actual.retainAll(expected);
-        assertEquals(expected.size(), actual.size());
-        n = empty.getNote(empty.getDb().queryLongScalar("select id from notes"));
-        assertTrue(n.getFields()[0].contains("_"));
+        emptyCol.remCards(Utils.arrayList2array(emptyCol.getDb().queryColumn(Long.class, "select id from cards", 0)));
+        out = new FileOutputStream(new File(emptyCol.getMedia().dir(), "foo.mp3"));
+        out.write("bar".getBytes());
+        out.close();
+        new Anki2Importer(emptyCol, tmpCol.getPath()).run();
+        actual = Arrays.asList(new File(emptyCol.getMedia().dir()).list());
+        assertEquals(2, actual.size());
+        n = emptyCol.getNote(emptyCol.getDb().queryLongScalar("select id from notes"));
+        assertEquals(String.format("[sound:foo_%s.mp3]", mid), n.getFields()[0]);
     }
 
+    @Test
     public void testApkg() throws IOException {
         List<String> expected;
         List<String> actual;
 
-        Collection tmp = Shared.getEmptyCol(getContext());
-        String apkg = Shared.getTestFilePath(getContext(), "media.apkg");
+        Collection tmp = Shared.getEmptyCol(InstrumentationRegistry.getTargetContext());
+        String apkg = Shared.getTestFilePath(InstrumentationRegistry.getTargetContext(), "media.apkg");
         Importer imp = new AnkiPackageImporter(tmp, apkg);
-        expected = Arrays.asList();
+        expected = Collections.emptyList();
         actual = Arrays.asList(new File(tmp.getMedia().dir()).list());
         actual.retainAll(expected);
         assertEquals(actual.size(), expected.size());
         imp.run();
-        expected = Arrays.asList("foo.wav");
+        expected = Collections.singletonList("foo.wav");
         actual = Arrays.asList(new File(tmp.getMedia().dir()).list());
         actual.retainAll(expected);
         assertEquals(expected.size(), actual.size());
@@ -123,7 +146,7 @@ public class ImportTest extends AndroidTestCase {
         tmp.remCards(Utils.arrayList2array(tmp.getDb().queryColumn(Long.class, "select id from cards", 0)));
         imp = new AnkiPackageImporter(tmp, apkg);
         imp.run();
-        expected = Arrays.asList("foo.wav");
+        expected = Collections.singletonList("foo.wav");
         actual = Arrays.asList(new File(tmp.getMedia().dir()).list());
         actual.retainAll(expected);
         assertEquals(actual.size(), expected.size());
@@ -138,11 +161,12 @@ public class ImportTest extends AndroidTestCase {
         assertTrue(new File(tmp.getMedia().dir()).list().length == 2);
     }
 
+    @Test
     public void testAnki2Diffmodels() throws IOException {
         // create a new empty deck
-        Collection dst = Shared.getEmptyCol(getContext());
+        Collection dst = Shared.getEmptyCol(InstrumentationRegistry.getTargetContext());
         // import the 1 card version of the model
-        String tmp = Shared.getTestFilePath(getContext(), "diffmodels2-1.apkg");
+        String tmp = Shared.getTestFilePath(InstrumentationRegistry.getTargetContext(), "diffmodels2-1.apkg");
         AnkiPackageImporter imp = new AnkiPackageImporter(dst, tmp);
         imp.setDupeOnSchemaChange(true);
         imp.run();
@@ -153,7 +177,7 @@ public class ImportTest extends AndroidTestCase {
         imp.run();
         assertTrue(before == dst.noteCount());
         // then the 2 card version
-        tmp = Shared.getTestFilePath(getContext(), "diffmodels2-2.apkg");
+        tmp = Shared.getTestFilePath(InstrumentationRegistry.getTargetContext(), "diffmodels2-2.apkg");
         imp = new AnkiPackageImporter(dst, tmp);
         imp.setDupeOnSchemaChange(true);
         imp.run();
@@ -171,17 +195,18 @@ public class ImportTest extends AndroidTestCase {
         assertTrue(dst.cardCount() == 3);
     }
 
+    @Test
     public void testAnki2DiffmodelTemplates() throws IOException, JSONException {
         // different from the above as this one tests only the template text being
         // changed, not the number of cards/fields
-        Collection dst = Shared.getEmptyCol(getContext());
+        Collection dst = Shared.getEmptyCol(InstrumentationRegistry.getTargetContext());
         // import the first version of the model
-        String tmp = Shared.getTestFilePath(getContext(), "diffmodeltemplates-1.apkg");
+        String tmp = Shared.getTestFilePath(InstrumentationRegistry.getTargetContext(), "diffmodeltemplates-1.apkg");
         AnkiPackageImporter imp = new AnkiPackageImporter(dst, tmp);
         imp.setDupeOnSchemaChange(true);
         imp.run();
         // then the version with updated template
-        tmp = Shared.getTestFilePath(getContext(), "diffmodeltemplates-2.apkg");
+        tmp = Shared.getTestFilePath(InstrumentationRegistry.getTargetContext(), "diffmodeltemplates-2.apkg");
         imp = new AnkiPackageImporter(dst, tmp);
         imp.setDupeOnSchemaChange(true);
         imp.run();
@@ -193,10 +218,11 @@ public class ImportTest extends AndroidTestCase {
         assertTrue(dst.findTemplates(tnote).get(0).getString("qfmt").contains("Changed Front Template"));
     }
 
+    @Test
     public void testAnki2Updates() throws IOException {
         // create a new empty deck
-        Collection dst = Shared.getEmptyCol(getContext());
-        String tmp = Shared.getTestFilePath(getContext(), "update1.apkg");
+        Collection dst = Shared.getEmptyCol(InstrumentationRegistry.getTargetContext());
+        String tmp = Shared.getTestFilePath(InstrumentationRegistry.getTargetContext(), "update1.apkg");
         AnkiPackageImporter imp = new AnkiPackageImporter(dst, tmp);
         imp.run();
         assertTrue(imp.getDupes() == 0);
@@ -211,7 +237,7 @@ public class ImportTest extends AndroidTestCase {
         // importing a newer note should update
         assertTrue(dst.noteCount() == 1);
         assertTrue(dst.getDb().queryString("select flds from notes").startsWith("hello"));
-        tmp = Shared.getTestFilePath(getContext(), "update2.apkg");
+        tmp = Shared.getTestFilePath(InstrumentationRegistry.getTargetContext(), "update2.apkg");
         imp = new AnkiPackageImporter(dst, tmp);
         imp.run();
         assertTrue(imp.getDupes()== 1);
@@ -223,8 +249,8 @@ public class ImportTest extends AndroidTestCase {
     // Remove @Suppress when csv importer is implemented
     @Suppress
     public void testCsv() throws IOException {
-        Collection deck = Shared.getEmptyCol(getContext());
-        String file = Shared.getTestFilePath(getContext(), "text-2fields.txt");
+        Collection deck = Shared.getEmptyCol(InstrumentationRegistry.getTargetContext());
+        String file = Shared.getTestFilePath(InstrumentationRegistry.getTargetContext(), "text-2fields.txt");
         TextImporter i = new TextImporter(deck, file);
         i.initMapping();
         i.run();
@@ -242,7 +268,7 @@ public class ImportTest extends AndroidTestCase {
         n.flush();
         i.run();
         n.load();
-        assertTrue((n.getTags().size() == 1) && (n.getTags().get(0) == "test"));
+        assertTrue((n.getTags().size() == 1) && (n.getTags().get(0).equals("test")));
         // if add-only mode, count will be 0
         i.setImportMode(1);
         i.run();
@@ -260,7 +286,7 @@ public class ImportTest extends AndroidTestCase {
     // Remove @Suppress when csv importer is implemented
     @Suppress
     public void testCsv2() throws  IOException, ConfirmModSchemaException {
-        Collection deck = Shared.getEmptyCol(getContext());
+        Collection deck = Shared.getEmptyCol(InstrumentationRegistry.getTargetContext());
         Models mm = deck.getModels();
         JSONObject m = mm.current();
         JSONObject f = mm.newField("Three");
@@ -272,7 +298,7 @@ public class ImportTest extends AndroidTestCase {
         n.setItem("Three", "3");
         deck.addNote(n);
         // an update with unmapped fields should not clobber those fields
-        String file = Shared.getTestFilePath(getContext(), "text-update.txt");
+        String file = Shared.getTestFilePath(InstrumentationRegistry.getTargetContext(), "text-update.txt");
         TextImporter i = new TextImporter(deck, file);
         i.initMapping();
         i.run();
@@ -286,15 +312,14 @@ public class ImportTest extends AndroidTestCase {
     /**
      * Custom tests for AnkiDroid.
      */
-
-
+    @Test
     public void testDupeIgnore() throws IOException {
         // create a new empty deck
-        Collection dst = Shared.getEmptyCol(getContext());
-        String tmp = Shared.getTestFilePath(getContext(), "update1.apkg");
+        Collection dst = Shared.getEmptyCol(InstrumentationRegistry.getTargetContext());
+        String tmp = Shared.getTestFilePath(InstrumentationRegistry.getTargetContext(), "update1.apkg");
         AnkiPackageImporter imp = new AnkiPackageImporter(dst, tmp);
         imp.run();
-        tmp = Shared.getTestFilePath(getContext(), "update3.apkg");
+        tmp = Shared.getTestFilePath(InstrumentationRegistry.getTargetContext(), "update3.apkg");
         imp = new AnkiPackageImporter(dst, tmp);
         imp.run();
         // there is a dupe, but it was ignored

--- a/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/libanki/MediaTest.java
+++ b/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/libanki/MediaTest.java
@@ -1,5 +1,6 @@
 /****************************************************************************************
  * Copyright (c) 2014 Houssam Salem <houssam.salem.au@gmail.com>                        *
+ * Copyright (c) 2018 Mike Hardy <mike@mikehardy.net>                                   *
  *                                                                                      *
  * This program is free software; you can redistribute it and/or modify it under        *
  * the terms of the GNU General Public License as published by the Free Software        *
@@ -15,8 +16,10 @@
  ****************************************************************************************/
 package com.ichi2.anki.tests.libanki;
 
-import android.test.AndroidTestCase;
-import android.test.suitebuilder.annotation.Suppress;
+
+import android.support.test.InstrumentationRegistry;
+import android.support.test.filters.Suppress;
+import android.support.test.runner.AndroidJUnit4;
 
 import com.ichi2.anki.BackupManager;
 import com.ichi2.anki.tests.Shared;
@@ -24,23 +27,32 @@ import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Media;
 import com.ichi2.libanki.Note;
 
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Unit tests for {@link Media}.
  */
-public class MediaTest extends AndroidTestCase {
+@RunWith(AndroidJUnit4.class)
+public class MediaTest {
+
+    @Test
     public void testAdd() throws IOException {
         // open new empty collection
-        Collection d = Shared.getEmptyCol(getContext());
-        File dir = Shared.getTestDir(getContext());
+        Collection d = Shared.getEmptyCol(InstrumentationRegistry.getTargetContext());
+        File dir = Shared.getTestDir(InstrumentationRegistry.getTargetContext());
         BackupManager.removeDir(dir);
-        dir.mkdirs();
+        assertTrue(dir.mkdirs());
         File path = new File(dir, "foo.jpg");
         FileOutputStream os;
         os = new FileOutputStream(path, false);
@@ -58,19 +70,19 @@ public class MediaTest extends AndroidTestCase {
         assertEquals("foo (1).jpg", d.getMedia().addFile(path));
     }
 
-
+    @Test
     public void testStrings() throws IOException {
-        Collection d = Shared.getEmptyCol(getContext());
+        Collection d = Shared.getEmptyCol(InstrumentationRegistry.getTargetContext());
         Long mid = d.getModels().getModels().entrySet().iterator().next().getKey();
         List<String> expected;
         List<String> actual;
 
-        expected = Arrays.asList();
+        expected = Collections.emptyList();
         actual = d.getMedia().filesInStr(mid, "aoeu");
         actual.retainAll(expected);
         assertEquals(expected.size(), actual.size());
 
-        expected = Arrays.asList("foo.jpg");
+        expected = Collections.singletonList("foo.jpg");
         actual = d.getMedia().filesInStr(mid, "aoeu<img src='foo.jpg'>ao");
         actual.retainAll(expected);
         assertEquals(expected.size(), actual.size());
@@ -80,7 +92,7 @@ public class MediaTest extends AndroidTestCase {
         actual.retainAll(expected);
         assertEquals(expected.size(), actual.size());
 
-        expected = Arrays.asList("foo.jpg");
+        expected = Collections.singletonList("foo.jpg");
         actual = d.getMedia().filesInStr(mid, "aoeu<img src=foo.jpg style=bar>ao");
         actual.retainAll(expected);
         assertEquals(expected.size(), actual.size());
@@ -90,7 +102,7 @@ public class MediaTest extends AndroidTestCase {
         actual.retainAll(expected);
         assertEquals(expected.size(), actual.size());
 
-        expected = Arrays.asList("foo.jpg");
+        expected = Collections.singletonList("foo.jpg");
         actual = d.getMedia().filesInStr(mid, "aoeu<img src=\"foo.jpg\">ao");
         actual.retainAll(expected);
         assertEquals(expected.size(), actual.size());
@@ -100,7 +112,7 @@ public class MediaTest extends AndroidTestCase {
         actual.retainAll(expected);
         assertEquals(expected.size(), actual.size());
 
-        expected = Arrays.asList("foo.mp3");
+        expected = Collections.singletonList("foo.mp3");
         actual = d.getMedia().filesInStr(mid, "aou[sound:foo.mp3]aou");
         actual.retainAll(expected);
         assertEquals(expected.size(), actual.size());
@@ -113,13 +125,14 @@ public class MediaTest extends AndroidTestCase {
         assertEquals("<img src=\"foo%20bar.jpg\">", d.getMedia().escapeImages("<img src=\"foo bar.jpg\">"));
     }
 
+    @Test
     public void testDeckIntegration() throws IOException {
-        Collection d = Shared.getEmptyCol(getContext());
+        Collection d = Shared.getEmptyCol(InstrumentationRegistry.getTargetContext());
         // create a media dir
         d.getMedia().dir();
         // Put a file into it
-        File file = new File(Shared.getTestDir(getContext()), "fake.png");
-        file.createNewFile();
+        File file = new File(Shared.getTestDir(InstrumentationRegistry.getTargetContext()), "fake.png");
+        assertTrue(file.createNewFile());
         d.getMedia().addFile(file);
         // add a note which references it
         Note f = d.newNote();
@@ -140,11 +153,11 @@ public class MediaTest extends AndroidTestCase {
         List<List<String>> ret = d.getMedia().check();
         List<String> expected;
         List<String> actual;
-        expected = Arrays.asList("fake2.png");
+        expected = Collections.singletonList("fake2.png");
         actual = ret.get(0);
         actual.retainAll(expected);
         assertEquals(expected.size(), actual.size());
-        expected = Arrays.asList("foo.jpg");
+        expected = Collections.singletonList("foo.jpg");
         actual = ret.get(1);
         actual.retainAll(expected);
         assertEquals(expected.size(), actual.size());
@@ -161,13 +174,14 @@ public class MediaTest extends AndroidTestCase {
         return d.getMedia().getDb().queryColumn(String.class, "select fname from media where csum is null", 0);
     }
 
+    @Test
     public void testChanges() throws IOException {
-        Collection d = Shared.getEmptyCol(getContext());
+        Collection d = Shared.getEmptyCol(InstrumentationRegistry.getTargetContext());
         assertTrue(d.getMedia()._changed() != null);
         assertTrue(added(d).size() == 0);
         assertTrue(removed(d).size() == 0);
         // add a file
-        File dir = Shared.getTestDir(getContext());
+        File dir = Shared.getTestDir(InstrumentationRegistry.getTargetContext());
         File path = new File(dir, "foo.jpg");
         FileOutputStream os;
         os = new FileOutputStream(path, false);
@@ -193,15 +207,15 @@ public class MediaTest extends AndroidTestCase {
         assertTrue(added(d).size() == 2);
         assertTrue(removed(d).size() == 0);
         // deletions should get noticed too
-        path.delete();
+        assertTrue(path.delete());
         d.getMedia().findChanges(true);
         assertTrue(added(d).size() == 1);
         assertTrue(removed(d).size() == 1);
     }
 
-
+    @Test
     public void testIllegal() throws IOException {
-        Collection d = Shared.getEmptyCol(getContext());
+        Collection d = Shared.getEmptyCol(InstrumentationRegistry.getTargetContext());
         String aString = "a:b|cd\\e/f\0g*h";
         String good = "abcdefgh";
         assertTrue(d.getMedia().stripIllegal(aString).equals(good));

--- a/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/libanki/RetryRule.java
+++ b/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/libanki/RetryRule.java
@@ -1,0 +1,70 @@
+package com.ichi2.anki.tests.libanki;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+/**
+ * Retry a test maxTries times, only failing if zero successes.
+ * Defaults to 3 tries.
+ * <p>
+ * Usage: @Rule public final RetryRule retry = new RetryRule(3);
+ */
+public final class RetryRule implements TestRule {
+
+    /**
+     * How many times to try a test
+     */
+    private int maxTries = 3;
+
+
+    /**
+     * @param i number of times to try
+     * @throws IllegalArgumentException if i is less than 1
+     */
+    private void setMaxTries(int i) {
+        if (i < 1) {
+            throw new IllegalArgumentException("iterations < 1: " + i);
+        }
+        this.maxTries = i;
+    }
+
+
+    /**
+     * Try a test maxTries times in an attempt to not fail a full test suite for one flaky test
+     *
+     * @param i how many times to try
+     * @throws IllegalArgumentException if maxTries is less than 1
+     */
+    public RetryRule(int i) {
+        setMaxTries(i);
+    }
+
+
+    public Statement apply(Statement base, Description description) {
+        return statement(base, description);
+    }
+
+    private Statement statement(final Statement base, final Description description) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                Throwable caughtThrowable = null;
+
+                // implement retry logic here
+                for (int i = 0; i < maxTries; i++) {
+                    try {
+                        base.evaluate();
+                        return;
+                    } catch (Throwable t) {
+                        caughtThrowable = t;
+                        System.err.println(description.getDisplayName() + ": run " + (i+1) + " failed");
+                        t.printStackTrace(System.err);
+                    }
+                }
+                System.err.println(description.getDisplayName() + ": giving up after " + maxTries + " failures");
+                throw caughtThrowable;
+            }
+        };
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/beolingus/parsing/BeolingusParserTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/beolingus/parsing/BeolingusParserTest.java
@@ -1,9 +1,12 @@
 package com.ichi2.anki.multimediacard.beolingus.parsing;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 import static org.junit.Assert.assertEquals;
 
+@RunWith(JUnit4.class)
 public class BeolingusParserTest {
 
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/UtilsTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/UtilsTest.java
@@ -2,10 +2,9 @@ package com.ichi2.libanki;
 
 import junit.framework.Assert;
 
-//import net.lachlanmckee.timberjunit.TimberTestRule;
-
-//import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 import java.io.File;
 import java.io.IOException;
@@ -14,11 +13,8 @@ import java.util.Enumeration;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
+@RunWith(JUnit4.class)
 public class UtilsTest {
-
-    // This depends on a Timber upgrade that should be pursued separately
-    //@Rule
-    //public TimberTestRule logAllAlwaysRule = TimberTestRule.logAllAlways();
 
     @Test
     public void testZipWithPathTraversal() {

--- a/AnkiDroid/src/test/java/com/wildplot/android/rendering/PieChartTest.java
+++ b/AnkiDroid/src/test/java/com/wildplot/android/rendering/PieChartTest.java
@@ -52,12 +52,12 @@ public class PieChartTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void constructorShouldThrowIfSizesMismatch() throws Exception {
+    public void testConstructorShouldThrowIfSizesMismatch() throws Exception {
         new PieChart(plot, new double[]{1, 1}, new ColorWrap[]{ColorWrap.RED});
     }
 
     @Test
-    public void paintShouldNotDrawAnythingIfValuesAreZero() throws Exception {
+    public void testPaintShouldNotDrawAnythingIfValuesAreZero() throws Exception {
         pieChart = new PieChart(plot, new double[]{0, 0}, new ColorWrap[]{
                 ColorWrap.RED, ColorWrap.GREEN});
         pieChart.paint(graphics);
@@ -66,7 +66,7 @@ public class PieChartTest {
     }
 
     @Test
-    public void paintShouldDrawFullRedCircleIfOneValue() throws Exception {
+    public void testPaintShouldDrawFullRedCircleIfOneValue() throws Exception {
         pieChart = new PieChart(plot, new double[]{1.}, new ColorWrap[]{
                 ColorWrap.RED});
         RectangleWrap r = createRectangleMock(100, 100);
@@ -79,7 +79,7 @@ public class PieChartTest {
     }
 
     @Test
-    public void paintShouldDrawTwoSectorsWithGivenColors() throws Exception {
+    public void testPaintShouldDrawTwoSectorsWithGivenColors() throws Exception {
         pieChart = new PieChart(plot, new double[]{1, 1}, new ColorWrap[]{
                 ColorWrap.RED, ColorWrap.GREEN});
         RectangleWrap r = createRectangleMock(100, 100);

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,9 @@ buildscript {
     repositories {
         google()
         jcenter()
+        maven {
+            url "https://oss.sonatype.org/content/repositories/snapshots/"
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.3'
@@ -17,6 +20,9 @@ allprojects {
     repositories {
         google()
         jcenter()
+        maven {
+            url "https://oss.sonatype.org/content/repositories/snapshots/"
+        }
     }
     gradle.projectsEvaluated {
         tasks.withType(JavaCompile) {


### PR DESCRIPTION
## Purpose / Description

Our automated connected testing was unable to run automatically on API >= 23

## Fixes
No issues logged - this was incidental to other work

## Approach
From the commit:
    — Upgrade JUnit3+AndroidTestCase to JUnit4 + Annotations
    — Add ATSL (Android Test Support Library, new from google)
    — Fix test permission errors w/@GrantPermissionRule from ATSL!
    — — https://developer.android.com/reference/android/support/test/rule/GrantPermissionRule
    — Run tests with orchestrator to run connected tests; crash+state isolation
    — Fully de-linted connected test classes


## How Has This Been Tested?
Over and over and over again until it worked locally without granting permissions first
Then I uncommented a couple more emulators in Travis that should work now too...

## Learning (optional, can help others)


https://android-developers.googleblog.com/2017/07/android-testing-support-library-10-is.html
https://developer.android.com/training/testing/junit-runner#using-android-test-orchestrator