### PR TITLE
Upgrade instrumented tests to Junit4 / Fix permission errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ matrix:
   allow_failures:
     - env: API=15  # sometimes emulator hangs, sometimes not - possibly fixable
     - env: API=23 EMU_FLAVOR=google_apis # has permission errors
-    - env: API=24                        # has permission errors
     - env: API=25 EMU_FLAVOR=google_apis # has permission errors
 
 android:

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -10,6 +10,7 @@ android {
         targetSdkVersion 25
         testApplicationId "com.ichi2.anki.tests"
         vectorDrawables.useSupportLibrary = true
+        testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
     }
     lintOptions {
         abortOnError false
@@ -71,4 +72,17 @@ dependencies {
     testImplementation 'org.powermock:powermock-api-mockito2:2.0.0-beta.5'
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
     testImplementation 'net.lachlanmckee:timber-junit-rule:1.0.1'
+
+    // 3 excludes, to avoid dependency resolve clash between our 26.0.1 and 27.1.1
+    // This will be solved if we move all the android stuff to 27.1.1
+    androidTestImplementation('com.android.support.test.espresso:espresso-core:3.0.2') {
+        exclude group: 'com.android.support', module: 'support-annotations'
+    }
+    androidTestImplementation('com.android.support.test:runner:1.0.2') {
+        exclude group: 'com.android.support', module: 'support-annotations'
+    }
+    androidTestImplementation('com.android.support.test:rules:1.0.2') {
+        exclude group: 'com.android.support', module: 'support-annotations'
+    }
+    androidTestUtil 'com.android.support.test:orchestrator:1.0.2'
 }

--- a/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/CollectionTest.java
+++ b/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/CollectionTest.java
@@ -1,16 +1,33 @@
 package com.ichi2.anki.tests;
 
-import android.test.AndroidTestCase;
+import android.Manifest;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.rule.GrantPermissionRule;
+import android.support.test.runner.AndroidJUnit4;
 
 import com.ichi2.anki.CollectionHelper;
 
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
 import java.io.IOException;
+
+import static org.junit.Assert.assertNotNull;
 
 /**
  * This test case verifies that the directory initialization works even if the app is not yet fully initialized.
  */
-public class CollectionTest extends AndroidTestCase{
+@RunWith(AndroidJUnit4.class)
+public class CollectionTest {
+
+    @Rule
+    public GrantPermissionRule mRuntimePermissionRule =
+            GrantPermissionRule.grant(Manifest.permission.WRITE_EXTERNAL_STORAGE);
+
+    @Test
     public void testOpenCollection() throws IOException {
-        assertNotNull("Collection could not be opened", CollectionHelper.getInstance().getCol(getContext()));
+        assertNotNull("Collection could not be opened",
+                CollectionHelper.getInstance().getCol(InstrumentationRegistry.getTargetContext()));
     }
 }

--- a/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/libanki/MediaTest.java
+++ b/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/libanki/MediaTest.java
@@ -15,7 +15,10 @@
  ****************************************************************************************/
 package com.ichi2.anki.tests.libanki;
 
-import android.test.AndroidTestCase;
+import android.Manifest;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.rule.GrantPermissionRule;
+import android.support.test.runner.AndroidJUnit4;
 import android.test.suitebuilder.annotation.Suppress;
 
 import com.ichi2.anki.BackupManager;
@@ -24,21 +27,36 @@ import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Media;
 import com.ichi2.libanki.Note;
 
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 
 /**
  * Unit tests for {@link Media}.
  */
-public class MediaTest extends AndroidTestCase {
+@RunWith(AndroidJUnit4.class)
+public class MediaTest {
+
+    @Rule
+    public GrantPermissionRule mRuntimePermissionRule =
+            GrantPermissionRule.grant(Manifest.permission.WRITE_EXTERNAL_STORAGE);
+
+
+    @Test
     public void testAdd() throws IOException {
         // open new empty collection
-        Collection d = Shared.getEmptyCol(getContext());
-        File dir = Shared.getTestDir(getContext());
+        Collection d = Shared.getEmptyCol(InstrumentationRegistry.getTargetContext());
+        File dir = Shared.getTestDir(InstrumentationRegistry.getTargetContext());
         BackupManager.removeDir(dir);
         dir.mkdirs();
         File path = new File(dir, "foo.jpg");
@@ -59,8 +77,9 @@ public class MediaTest extends AndroidTestCase {
     }
 
 
+    @Test
     public void testStrings() throws IOException {
-        Collection d = Shared.getEmptyCol(getContext());
+        Collection d = Shared.getEmptyCol(InstrumentationRegistry.getTargetContext());
         Long mid = d.getModels().getModels().entrySet().iterator().next().getKey();
         List<String> expected;
         List<String> actual;
@@ -113,12 +132,13 @@ public class MediaTest extends AndroidTestCase {
         assertEquals("<img src=\"foo%20bar.jpg\">", d.getMedia().escapeImages("<img src=\"foo bar.jpg\">"));
     }
 
+    @Test
     public void testDeckIntegration() throws IOException {
-        Collection d = Shared.getEmptyCol(getContext());
+        Collection d = Shared.getEmptyCol(InstrumentationRegistry.getTargetContext());
         // create a media dir
         d.getMedia().dir();
         // Put a file into it
-        File file = new File(Shared.getTestDir(getContext()), "fake.png");
+        File file = new File(Shared.getTestDir(InstrumentationRegistry.getTargetContext()), "fake.png");
         file.createNewFile();
         d.getMedia().addFile(file);
         // add a note which references it
@@ -161,13 +181,14 @@ public class MediaTest extends AndroidTestCase {
         return d.getMedia().getDb().queryColumn(String.class, "select fname from media where csum is null", 0);
     }
 
+    @Test
     public void testChanges() throws IOException {
-        Collection d = Shared.getEmptyCol(getContext());
+        Collection d = Shared.getEmptyCol(InstrumentationRegistry.getTargetContext());
         assertTrue(d.getMedia()._changed() != null);
         assertTrue(added(d).size() == 0);
         assertTrue(removed(d).size() == 0);
         // add a file
-        File dir = Shared.getTestDir(getContext());
+        File dir = Shared.getTestDir(InstrumentationRegistry.getTargetContext());
         File path = new File(dir, "foo.jpg");
         FileOutputStream os;
         os = new FileOutputStream(path, false);
@@ -200,8 +221,9 @@ public class MediaTest extends AndroidTestCase {
     }
 
 
+    @Test
     public void testIllegal() throws IOException {
-        Collection d = Shared.getEmptyCol(getContext());
+        Collection d = Shared.getEmptyCol(InstrumentationRegistry.getTargetContext());
         String aString = "a:b|cd\\e/f\0g*h";
         String good = "abcdefgh";
         assertTrue(d.getMedia().stripIllegal(aString).equals(good));

--- a/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/libanki/RetryRule.java
+++ b/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/libanki/RetryRule.java
@@ -1,0 +1,70 @@
+package com.ichi2.anki.tests.libanki;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+/**
+ * Retry a test maxTries times, only failing if zero successes.
+ * Defaults to 3 tries.
+ * <p>
+ * Usage: @Rule public final RetryRule retry = new RetryRule(3);
+ */
+public final class RetryRule implements TestRule {
+
+    /**
+     * How many times to try a test
+     */
+    private int maxTries = 3;
+
+
+    /**
+     * @param i number of times to try
+     * @throws IllegalArgumentException if i is less than 1
+     */
+    private void setMaxTries(int i) {
+        if (i < 1) {
+            throw new IllegalArgumentException("iterations < 1: " + i);
+        }
+        this.maxTries = i;
+    }
+
+
+    /**
+     * Try a test maxTries times in an attempt to not fail a full test suite for one flaky test
+     *
+     * @param i how many times to try
+     * @throws IllegalArgumentException if maxTries is less than 1
+     */
+    public RetryRule(int i) {
+        setMaxTries(i);
+    }
+
+
+    public Statement apply(Statement base, Description description) {
+        return statement(base, description);
+    }
+
+    private Statement statement(final Statement base, final Description description) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                Throwable caughtThrowable = null;
+
+                // implement retry logic here
+                for (int i = 0; i < maxTries; i++) {
+                    try {
+                        base.evaluate();
+                        return;
+                    } catch (Throwable t) {
+                        caughtThrowable = t;
+                        System.err.println(description.getDisplayName() + ": run " + (i+1) + " failed");
+                        t.printStackTrace(System.err);
+                    }
+                }
+                System.err.println(description.getDisplayName() + ": giving up after " + maxTries + " failures");
+                throw caughtThrowable;
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Pull Request template

Please, go through these checks before you submit a PR.

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code

## Purpose / Description
It's difficult to test Android things without good test support, and the new ATSL helps a lot... also the new test orchestrator will allow for coverage reports shortly which I have queued in a branch

## Fixes
Fixes automated testing on API>23 out of the box. API24 works in Travis now

This is building towards a fix for #4200 and #4883 

I have a [second branch queued with a working / tested ACRA upgrade](https://github.com/mikehardy/Anki-Android/commits/acra-upgrade) to API>=26 compatible 4.11 but in order to test it I needed the ATSL

## Approach
- Add ATSL (Android Test Support Library, new from google)
- Upgrade JUnit3+AndroidTestCase to JUnit4 + Annotations
- Fix test permission errors w/@GrantPermissionRule from ATSL!
  - https://developer.android.com/reference/android/support/test/rule/GrantPermissionRule
- Run tests with orchestrator to run connected tests; crash+state isolation
- Added a "RetryRule" to re-run a flaky test and used it on MediaImporter, works 100000 times and fails 1... 


## How Has This Been Tested?

I re-ran the tests locally on clean emulators until they ran out of the box, and confirmed on a private Travis instance they work

## Learning (optional, can help others)

The subject of flaky tests is academically interesting and practically useful.
Here's everything I read and found interesting enough to save on the subject, with a summary at the top:


There is currently no good way to handle flaky tests outside of Jenkins but Jenkins has some good ideas and Google has studied this. Problem statement is that even Google sees just over 1% error rate in tests that were passing before and didn’t receive a code change (!). Mitigation strategies:
- MAYBE: baseline stats and watch for statistical movement in each tests flakiness
— MAYBE: quarantine tests that increase flakiness to ungate builds and feed backlog
- IMPLEMENTED: runner or rule retry each some arbitrary number of times
- runner re-run only failing tests option
- runner re-run failed test automatically option
- MAYBE new tests get run extra to check for flakiness / baseline stats
- Randomize order of execution of tests? https://github.com/junit-team/junit4/wiki/test-execution-order (maybe a specific randomizer during flake-finding runs

https://testing.googleblog.com/2016/05/flaky-tests-at-google-and-how-we.html
https://github.com/jenkinsci/flaky-test-handler-plugin
https://wiki.jenkins-ci.org/display/JENKINS/Test+Results+Analyzer+Plugin
https://bitbucket.org/osrf/release-tools/src/default/jenkins-scripts/tools/
https://github.com/cloudera/dist_test
https://github.com/osrg/namazu
tempus-fugit library isn’t bad - has an iterator at least
list of all runners (for implementation ideas?):
https://github.com/junit-team/junit4/wiki/Custom-runners
RetryRunner here, IMPLEMENTED: https://stackoverflow.com/a/20762914/9910298
