### PR TITLE
ACRA upgrade to 5.1.3

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -25,10 +25,19 @@ android {
         }
     }
     buildTypes {
+        debug {
+            debuggable true
+            // A free test acralyzer instance that allows report writes and dashboard reads without auth
+            // ...or you can create your own following acralyzer docs
+            // To test ACRA you will also need to manually/temporarily change AnkiDroidApp#onCreate
+            // View at https://918f7f55-f238-436c-b34f-c8b5f1331fe5-bluemix.cloudant.com/acralyzer/_design/acralyzer/index.html#/dashboard/
+            buildConfigField "String", "ACRA_URL", '"https://918f7f55-f238-436c-b34f-c8b5f1331fe5-bluemix.cloudant.com/acra-ankidroid/_design/acra-storage/_update/report"'
+        }
         release {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             signingConfig signingConfigs.release
+            buildConfigField "String", "ACRA_URL", '"https://ankidroid.org/acra/report"'
         }
     }
     useLibrary 'org.apache.http.legacy'
@@ -59,7 +68,10 @@ dependencies {
         transitive = true
     }
     implementation 'com.getbase:floatingactionbutton:1.10.1'
-    implementation 'ch.acra:acra:4.6.2'
+    implementation('ch.acra:acra:4.11') {
+        // This will be solved if we move all the android stuff to 27.1.1
+        exclude group: 'com.android.support'
+    }
     implementation 'com.jakewharton.timber:timber:4.7.0'
     implementation 'com.google.code.gson:gson:2.8.2'
     implementation 'org.jsoup:jsoup:1.10.3'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -27,10 +27,7 @@ android {
     buildTypes {
         debug {
             debuggable true
-            // A free test acralyzer instance that allows report writes and dashboard reads without auth
-            // ...or you can create your own following acralyzer docs
-            // To test ACRA you will also need to manually/temporarily change AnkiDroidApp#onCreate
-            // View at https://918f7f55-f238-436c-b34f-c8b5f1331fe5-bluemix.cloudant.com/acralyzer/_design/acralyzer/index.html#/dashboard/
+            // Check Crash Reports page on developer wiki for info on ACRA testing
             buildConfigField "String", "ACRA_URL", '"https://918f7f55-f238-436c-b34f-c8b5f1331fe5-bluemix.cloudant.com/acra-ankidroid/_design/acra-storage/_update/report"'
         }
         release {

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -46,6 +46,10 @@ android {
         // Skip pre-dexing when running on Travis CI or when disabled via -Dpre-dex=false.
         preDexLibraries = preDexEnabled && !travisBuild
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 
@@ -68,8 +72,14 @@ dependencies {
         transitive = true
     }
     implementation 'com.getbase:floatingactionbutton:1.10.1'
-    implementation('ch.acra:acra:4.11') {
-        // This will be solved if we move all the android stuff to 27.1.1
+    // ACRA pulls in support 27.0.2, we can remove the excludes if we upgrade
+    implementation('ch.acra:acra-http:5.1.3') {
+        exclude group: 'com.android.support'
+    }
+    implementation('ch.acra:acra-dialog:5.1.3') {
+        exclude group: 'com.android.support'
+    }
+    implementation('ch.acra:acra-toast:5.1.3') {
         exclude group: 'com.android.support'
     }
     implementation 'com.jakewharton.timber:timber:4.7.0'

--- a/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/ACRATest.java
+++ b/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/ACRATest.java
@@ -1,0 +1,124 @@
+package com.ichi2.anki.tests;
+;
+import android.Manifest;
+import android.app.Instrumentation;
+import android.support.test.rule.GrantPermissionRule;
+import android.support.test.runner.AndroidJUnit4;
+
+import com.ichi2.anki.AnkiDroidApp;
+import com.ichi2.anki.R;
+
+import org.acra.ACRA;
+import org.acra.ReportingInteractionMode;
+import org.acra.collections.ImmutableList;
+import org.acra.config.ACRAConfiguration;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import android.support.test.InstrumentationRegistry;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(AndroidJUnit4.class)
+public class ACRATest {
+
+    @Rule public GrantPermissionRule mRuntimePermissionRule =
+            GrantPermissionRule.grant(Manifest.permission.WRITE_EXTERNAL_STORAGE);
+
+    private AnkiDroidApp app = null;
+
+    private String[] debugLogcatArguments = { "-t", "300", "-v", "long", "ACRA:S"};
+    private String[] prodLogcatArguments = { "-t", "100", "-v", "time", "ActivityManager:I", "SQLiteLog:W", AnkiDroidApp.TAG + ":D", "*:S" };
+
+
+    @Before
+    public void setUp() {
+        Instrumentation instrumentation = InstrumentationRegistry.getInstrumentation();
+        app = (AnkiDroidApp) instrumentation.getTargetContext().getApplicationContext();
+    }
+
+    @Test
+    public void testDebugConfiguration() throws Exception {
+
+        // Debug mode overrides all saved state so no setup needed
+        app.setDebugACRAConfig(AnkiDroidApp.getSharedPrefs(InstrumentationRegistry.getTargetContext()));
+        assertArrayEquals("Debug logcat arguments not set correctly",
+                app.getAcraConfigBuilder().build().logcatArguments().toArray(),
+                new ImmutableList<>(debugLogcatArguments).toArray());
+        verifyDebugACRAPreferences();
+    }
+
+    private void verifyDebugACRAPreferences() {
+        assertEquals("ACRA was not disabled correctly",
+                true,
+                AnkiDroidApp.getSharedPrefs(InstrumentationRegistry.getTargetContext())
+                        .getBoolean(ACRA.PREF_DISABLE_ACRA, true));
+        assertEquals("ACRA feedback was not turned off correctly",
+                AnkiDroidApp.FEEDBACK_REPORT_NEVER,
+                AnkiDroidApp.getSharedPrefs(InstrumentationRegistry.getTargetContext())
+                        .getString(AnkiDroidApp.FEEDBACK_REPORT_KEY, "undefined"));
+    }
+
+    @Test
+    public void testProductionConfigurationUserDisabled() throws Exception {
+
+        // set up as if the user had prefs saved to disable completely
+        AnkiDroidApp.getSharedPrefs(InstrumentationRegistry.getTargetContext()).edit()
+                .putString(AnkiDroidApp.FEEDBACK_REPORT_KEY, AnkiDroidApp.FEEDBACK_REPORT_NEVER).commit();
+
+        // If the user disabled it, then it's the debug case except the logcat args
+        app.setProductionACRAConfig(AnkiDroidApp.getSharedPrefs(InstrumentationRegistry.getTargetContext()));
+
+        // ACRA protects itself from re-.init() and with our BuildConfig.BUILD_DEBUG check
+        // it is impossible to reinitialize as a production build, so we can't verify this
+        // right now
+        //verifyProductionLogcat();
+        verifyDebugACRAPreferences();
+    }
+
+    private void verifyProductionLogcat() throws Exception {
+        assertArrayEquals("Production logcat arguments not set correctly",
+                new ImmutableList<>(prodLogcatArguments).toArray(),
+                app.getAcraConfigBuilder().build().logcatArguments().toArray());
+    }
+
+    @Test
+    public void testProductionConfigurationUserAsk() throws Exception {
+        // set up as if the user had prefs saved to ask
+        AnkiDroidApp.getSharedPrefs(InstrumentationRegistry.getTargetContext()).edit()
+                .putString(AnkiDroidApp.FEEDBACK_REPORT_KEY, AnkiDroidApp.FEEDBACK_REPORT_ASK).commit();
+
+        // If the user is set to ask, then it's production, with interaction mode dialog
+        app.setProductionACRAConfig(AnkiDroidApp.getSharedPrefs(InstrumentationRegistry.getTargetContext()));
+        verifyACRANotDisabled();
+
+        ACRAConfiguration config = app.getAcraConfigBuilder().build();
+        assertEquals(ReportingInteractionMode.DIALOG, config.reportingInteractionMode());
+        assertEquals(R.string.feedback_manual_toast_text, config.resToastText());
+    }
+
+
+    private void verifyACRANotDisabled() {
+        assertEquals("ACRA was not enabled correctly",
+                false,
+                AnkiDroidApp.getSharedPrefs(InstrumentationRegistry.getTargetContext()).getBoolean(ACRA.PREF_DISABLE_ACRA, false));
+    }
+
+    @Test
+    public void testProductionConfigurationUserAlways() throws Exception {
+        // set up as if the user had prefs saved to full auto
+        AnkiDroidApp.getSharedPrefs(InstrumentationRegistry.getTargetContext()).edit()
+                .putString(AnkiDroidApp.FEEDBACK_REPORT_KEY, AnkiDroidApp.FEEDBACK_REPORT_ALWAYS).commit();
+
+        // If the user is set to always, then it's production, with interaction mode toast
+        app.setProductionACRAConfig(AnkiDroidApp.getSharedPrefs(InstrumentationRegistry.getTargetContext()));
+        verifyACRANotDisabled();
+
+        ACRAConfiguration config = app.getAcraConfigBuilder().build();
+        assertEquals(ReportingInteractionMode.TOAST, config.reportingInteractionMode());
+        assertEquals(R.string.feedback_auto_toast_text, config.resToastText());
+    }
+}

--- a/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/ACRATest.java
+++ b/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/ACRATest.java
@@ -2,6 +2,7 @@ package com.ichi2.anki.tests;
 
 import android.Manifest;
 import android.app.Instrumentation;
+import android.content.SharedPreferences;
 import android.support.test.rule.GrantPermissionRule;
 import android.support.test.runner.AndroidJUnit4;
 
@@ -21,8 +22,7 @@ import org.junit.runner.RunWith;
 
 import android.support.test.InstrumentationRegistry;
 
-import java.util.Iterator;
-import java.util.List;
+import java.lang.reflect.Method;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -52,7 +52,9 @@ public class ACRATest {
     public void testDebugConfiguration() throws Exception {
 
         // Debug mode overrides all saved state so no setup needed
-        app.setDebugACRAConfig(AnkiDroidApp.getSharedPrefs(InstrumentationRegistry.getTargetContext()));
+        Method method = app.getClass().getDeclaredMethod("setDebugACRAConfig", SharedPreferences.class);
+        method.setAccessible(true);
+        method.invoke(app, AnkiDroidApp.getSharedPrefs(InstrumentationRegistry.getTargetContext()));
         assertArrayEquals("Debug logcat arguments not set correctly",
                 app.getAcraCoreConfigBuilder().build().logcatArguments().toArray(),
                 new ImmutableList<>(debugLogcatArguments).toArray());
@@ -78,7 +80,9 @@ public class ACRATest {
                 .putString(AnkiDroidApp.FEEDBACK_REPORT_KEY, AnkiDroidApp.FEEDBACK_REPORT_NEVER).commit();
 
         // If the user disabled it, then it's the debug case except the logcat args
-        app.setProductionACRAConfig(AnkiDroidApp.getSharedPrefs(InstrumentationRegistry.getTargetContext()));
+        Method method = app.getClass().getDeclaredMethod("setProductionACRAConfig", SharedPreferences.class);
+        method.setAccessible(true);
+        method.invoke(app, AnkiDroidApp.getSharedPrefs(InstrumentationRegistry.getTargetContext()));
 
         // ACRA protects itself from re-.init() and with our BuildConfig.BUILD_DEBUG check
         // it is impossible to reinitialize as a production build, so we can't verify this
@@ -100,7 +104,9 @@ public class ACRATest {
                 .putString(AnkiDroidApp.FEEDBACK_REPORT_KEY, AnkiDroidApp.FEEDBACK_REPORT_ASK).commit();
 
         // If the user is set to ask, then it's production, with interaction mode dialog
-        app.setProductionACRAConfig(AnkiDroidApp.getSharedPrefs(InstrumentationRegistry.getTargetContext()));
+        Method method = app.getClass().getDeclaredMethod("setProductionACRAConfig", SharedPreferences.class);
+        method.setAccessible(true);
+        method.invoke(app, AnkiDroidApp.getSharedPrefs(InstrumentationRegistry.getTargetContext()));
         verifyACRANotDisabled();
 
         CoreConfiguration config = app.getAcraCoreConfigBuilder().build();
@@ -137,7 +143,9 @@ public class ACRATest {
                 .putString(AnkiDroidApp.FEEDBACK_REPORT_KEY, AnkiDroidApp.FEEDBACK_REPORT_ALWAYS).commit();
 
         // If the user is set to always, then it's production, with interaction mode toast
-        app.setProductionACRAConfig(AnkiDroidApp.getSharedPrefs(InstrumentationRegistry.getTargetContext()));
+        Method method = app.getClass().getDeclaredMethod("setProductionACRAConfig", SharedPreferences.class);
+        method.setAccessible(true);
+        method.invoke(app, AnkiDroidApp.getSharedPrefs(InstrumentationRegistry.getTargetContext()));
         verifyACRANotDisabled();
 
         CoreConfiguration config = app.getAcraCoreConfigBuilder().build();

--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -240,6 +240,7 @@
         </activity>
         <activity android:name="com.ichi2.anki.dialogs.AnkiDroidCrashReportDialog"
             android:theme="@style/Theme.CrashReportDialog"
+            android:process=":acra"
             android:launchMode="singleInstance"
             android:excludeFromRecents="true"
             android:finishOnTaskLaunch="true" />

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -102,7 +102,7 @@ import static timber.log.Timber.DebugTree;
             //ReportField.SETTINGS_SECURE,
             //ReportField.SETTINGS_GLOBAL,
             ReportField.SHARED_PREFERENCES,
-            ReportField.APPLICATION_LOG,
+            //ReportField.APPLICATION_LOG,
             ReportField.MEDIA_CODEC_LIST,
             ReportField.THREAD_DETAILS
             //ReportField.USER_IP
@@ -194,12 +194,12 @@ public class AnkiDroidApp extends Application {
             // Enable verbose error logging and do method tracing to put the Class name as log tag
             Timber.plant(new DebugTree());
 
-            // If you need to test ACRA to make sure it's working, switch which of these is commented
+            // If you need to test ACRA to make sure it's working, switch which of these lines are commented
             // and do a local build then trigger a crash
             // Note that you need to disable advanced profiling in Android Studio for API < 26 for the
             // Crash Dialog to work or you'll get a masking error
             // https://stackoverflow.com/questions/49830593/null-pointer-exception-in-inputconnection-finishcomposingtext-method
-            //setAcraTestACRAConfig(preferences);
+            //setAcraTestACRAConfig(preferences); Timber.plant(new ProductionCrashReportingTree());
             setDebugACRAConfig(preferences);
         } else {
             Timber.plant(new ProductionCrashReportingTree());

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -173,7 +173,7 @@ public class AnkiDroidApp extends Application {
      * Set the ACRA ConfigurationBuilder and <b>re-initialize the ACRA system</b> with the contents
      * @param acraCoreConfigBuilder the full ACRA config to initialize ACRA with
      */
-    public void setAcraConfigBuilder(CoreConfigurationBuilder acraCoreConfigBuilder) {
+    private void setAcraConfigBuilder(CoreConfigurationBuilder acraCoreConfigBuilder) {
         this.acraCoreConfigBuilder = acraCoreConfigBuilder;
         ACRA.init(this, acraCoreConfigBuilder);
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -194,8 +194,6 @@ public class AnkiDroidApp extends Application {
             // Enable verbose error logging and do method tracing to put the Class name as log tag
             Timber.plant(new DebugTree());
 
-            // To test ACRA switch which of these lines are commented, do a local build, trigger a crash
-            //setAcraTestACRAConfig(preferences); Timber.plant(new ProductionCrashReportingTree());
             setDebugACRAConfig(preferences);
         } else {
             Timber.plant(new ProductionCrashReportingTree());
@@ -370,15 +368,6 @@ public class AnkiDroidApp extends Application {
     private void setProductionACRAConfig(SharedPreferences prefs) {
         // Enable or disable crash reporting based on user setting
         setAcraReportingMode(prefs.getString(FEEDBACK_REPORT_KEY, FEEDBACK_REPORT_ASK));
-    }
-
-
-    /**
-     * Puts ACRA Reporting mode into "ask" every time, overrides user choice
-     */
-    private void setAcraTestACRAConfig(SharedPreferences prefs) {
-        prefs.edit().putString(FEEDBACK_REPORT_KEY, FEEDBACK_REPORT_ASK).apply();
-        setAcraReportingMode(FEEDBACK_REPORT_ASK);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -194,11 +194,7 @@ public class AnkiDroidApp extends Application {
             // Enable verbose error logging and do method tracing to put the Class name as log tag
             Timber.plant(new DebugTree());
 
-            // If you need to test ACRA to make sure it's working, switch which of these lines are commented
-            // and do a local build then trigger a crash
-            // Note that you need to disable advanced profiling in Android Studio for API < 26 for the
-            // Crash Dialog to work or you'll get a masking error
-            // https://stackoverflow.com/questions/49830593/null-pointer-exception-in-inputconnection-finishcomposingtext-method
+            // To test ACRA switch which of these lines are commented, do a local build, trigger a crash
             //setAcraTestACRAConfig(preferences); Timber.plant(new ProductionCrashReportingTree());
             setDebugACRAConfig(preferences);
         } else {
@@ -356,7 +352,7 @@ public class AnkiDroidApp extends Application {
      *
      * @param prefs SharedPreferences object the reporting state is persisted in
      */
-    public void setDebugACRAConfig(SharedPreferences prefs) {
+    private void setDebugACRAConfig(SharedPreferences prefs) {
         // Disable crash reporting
         setAcraReportingMode(FEEDBACK_REPORT_NEVER);
         prefs.edit().putString(FEEDBACK_REPORT_KEY, FEEDBACK_REPORT_NEVER).apply();
@@ -371,7 +367,7 @@ public class AnkiDroidApp extends Application {
      *
      * @param prefs SharedPreferences object the reporting state is persisted in
      */
-    public void setProductionACRAConfig(SharedPreferences prefs) {
+    private void setProductionACRAConfig(SharedPreferences prefs) {
         // Enable or disable crash reporting based on user setting
         setAcraReportingMode(prefs.getString(FEEDBACK_REPORT_KEY, FEEDBACK_REPORT_ASK));
     }
@@ -380,7 +376,7 @@ public class AnkiDroidApp extends Application {
     /**
      * Puts ACRA Reporting mode into "ask" every time, overrides user choice
      */
-    public void setAcraTestACRAConfig(SharedPreferences prefs) {
+    private void setAcraTestACRAConfig(SharedPreferences prefs) {
         prefs.edit().putString(FEEDBACK_REPORT_KEY, FEEDBACK_REPORT_ASK).apply();
         setAcraReportingMode(FEEDBACK_REPORT_ASK);
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -512,8 +512,8 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                     }
                     break;
                 }
-                case "reportErrorMode": {
-                    String value = prefs.getString("reportErrorMode", "");
+                case AnkiDroidApp.FEEDBACK_REPORT_KEY: {
+                    String value = prefs.getString(AnkiDroidApp.FEEDBACK_REPORT_KEY, "");
                     AnkiDroidApp.getInstance().setAcraReportingMode(value);
                     AnkiDroidApp.getSharedPrefs(this).edit().remove("sentExceptionReports").apply();    // clear cache
                     break;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/AnkiDroidCrashReportDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/AnkiDroidCrashReportDialog.java
@@ -28,8 +28,10 @@ import android.widget.EditText;
 import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.R;
 
-import org.acra.config.ACRAConfiguration;
 import org.acra.config.ACRAConfigurationException;
+import org.acra.config.CoreConfigurationBuilder;
+import org.acra.config.DialogConfiguration;
+import org.acra.config.DialogConfigurationBuilder;
 import org.acra.dialog.BaseCrashReportDialog;
 
 import timber.log.Timber;
@@ -48,14 +50,12 @@ public class AnkiDroidCrashReportDialog extends BaseCrashReportDialog implements
         AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(this);
 
         try {
-            ACRAConfiguration acraConfig = AnkiDroidApp.getInstance().getAcraConfigBuilder().build();
-            int resourceId = acraConfig.resDialogTitle();
-            if(resourceId != 0) {
-                dialogBuilder.setTitle(resourceId);
-            }
-            dialogBuilder.setPositiveButton(getText(acraConfig.resDialogPositiveButtonText()), AnkiDroidCrashReportDialog.this);
-            dialogBuilder.setNegativeButton(getText(acraConfig.resDialogNegativeButtonText()), AnkiDroidCrashReportDialog.this);
+            CoreConfigurationBuilder builder = AnkiDroidApp.getInstance().getAcraCoreConfigBuilder();
+            DialogConfiguration dialogConfig =
+                    (DialogConfiguration)builder.getPluginConfigurationBuilder((DialogConfigurationBuilder.class)).build();
 
+            dialogBuilder.setPositiveButton(dialogConfig.positiveButtonText(), AnkiDroidCrashReportDialog.this);
+            dialogBuilder.setNegativeButton(dialogConfig.negativeButtonText(), AnkiDroidCrashReportDialog.this);
         }
         catch (ACRAConfigurationException ace) {
             Timber.e(ace, "Unable to initialize ACRA while creating ACRA dialog?");

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/AnkiDroidCrashReportDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/AnkiDroidCrashReportDialog.java
@@ -28,8 +28,11 @@ import android.widget.EditText;
 import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.R;
 
-import org.acra.ACRA;
-import org.acra.BaseCrashReportDialog;
+import org.acra.config.ACRAConfiguration;
+import org.acra.config.ACRAConfigurationException;
+import org.acra.dialog.BaseCrashReportDialog;
+
+import timber.log.Timber;
 
 public class AnkiDroidCrashReportDialog extends BaseCrashReportDialog implements DialogInterface.OnClickListener, DialogInterface.OnDismissListener {
     private static final String STATE_COMMENT = "comment";
@@ -39,21 +42,25 @@ public class AnkiDroidCrashReportDialog extends BaseCrashReportDialog implements
     AlertDialog mDialog;
 
     @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
+    protected void init(Bundle savedInstanceState) {
+        super.init(savedInstanceState);
 
         AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(this);
-        int resourceId = ACRA.getConfig().resDialogTitle();
-        if(resourceId != 0) {
-            dialogBuilder.setTitle(resourceId);
+
+        try {
+            ACRAConfiguration acraConfig = AnkiDroidApp.getInstance().getAcraConfigBuilder().build();
+            int resourceId = acraConfig.resDialogTitle();
+            if(resourceId != 0) {
+                dialogBuilder.setTitle(resourceId);
+            }
+            dialogBuilder.setPositiveButton(getText(acraConfig.resDialogPositiveButtonText()), AnkiDroidCrashReportDialog.this);
+            dialogBuilder.setNegativeButton(getText(acraConfig.resDialogNegativeButtonText()), AnkiDroidCrashReportDialog.this);
+
         }
-        resourceId = ACRA.getConfig().resDialogIcon();
-        if(resourceId != 0) {
-            dialogBuilder.setIcon(resourceId);
+        catch (ACRAConfigurationException ace) {
+            Timber.e(ace, "Unable to initialize ACRA while creating ACRA dialog?");
         }
         dialogBuilder.setView(buildCustomView(savedInstanceState));
-        dialogBuilder.setPositiveButton(getText(ACRA.getConfig().resDialogPositiveButtonText()), AnkiDroidCrashReportDialog.this);
-        dialogBuilder.setNegativeButton(getText(ACRA.getConfig().resDialogNegativeButtonText()), AnkiDroidCrashReportDialog.this);
 
         mDialog = dialogBuilder.create();
         mDialog.setCanceledOnTouchOutside(false);
@@ -92,7 +99,7 @@ public class AnkiDroidCrashReportDialog extends BaseCrashReportDialog implements
             preferences.edit().putBoolean("autoreportCheckboxValue", autoReport).commit();
             // Set the autoreport value to true if ticked
             if (autoReport) {
-                preferences.edit().putString("reportErrorMode", AnkiDroidApp.FEEDBACK_REPORT_ALWAYS).commit();
+                preferences.edit().putString(AnkiDroidApp.FEEDBACK_REPORT_KEY, AnkiDroidApp.FEEDBACK_REPORT_ALWAYS).commit();
                 AnkiDroidApp.getInstance().setAcraReportingMode(AnkiDroidApp.FEEDBACK_REPORT_ALWAYS);
             }
             // Send the crash report


### PR DESCRIPTION
## Pull Request template

Please, go through these checks before you submit a PR.

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code

## Purpose / Description

ACRA 4.6 was noted to have a problem in #4200

## Fixes

ACRA 4.11 or 5.x is necessary to move to API>=26 as in #4883 

## Approach

I upgraded the library and our usage of it according to the documentation.

First I went to 4.11 which enforced a much more rigorous use of configuration and is most of the way to 5.x

Then I went to 5.x which separates the ACRA functionality into multiple modules. This requires Java 1.8 but it's still okay with minSdkVersion as low as 14 

The commit messages for each step overview the changes. It's a bit spaghetti unfortunately.

## How Has This Been Tested?

I made an instrumented test that verifies our 4 different configs
- debug
- production but disabled
- production and ask
- production and auto-send

I also set up a test acralyzer instance on cloudant and configured it so that with one code change and a known crash bug (like #4200 ) you can build with ACRA enabled and see the report generation + result to make sure it works, which I did for both the 4.x and 5.x upgrades. All documented for future devs

## Learning (optional, can help others)

I feel like Neo plugged into the training simulator in the matrix and now I know ACRA-fu (and acralyzer)