### PR TITLE
Multi-select-mode: prevent cells from jumping out of view

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -34,6 +34,7 @@ import android.support.v4.view.MenuItemCompat;
 import android.support.v7.app.ActionBar;
 import android.support.v7.widget.SearchView;
 import android.text.TextUtils;
+import android.util.DisplayMetrics;
 import android.util.TypedValue;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -47,6 +48,7 @@ import android.widget.AdapterView.OnItemSelectedListener;
 import android.widget.ArrayAdapter;
 import android.widget.BaseAdapter;
 import android.widget.CheckBox;
+import android.widget.LinearLayout;
 import android.widget.ListView;
 import android.widget.Spinner;
 import android.widget.TextView;
@@ -1524,6 +1526,22 @@ public class CardBrowser extends NavigationDrawerActivity implements
         }
 
 
+        /**
+         * @param marginsDp Left, top, right and bottom margins in dp
+         * @param v View to change
+         */
+        private void setMargin(int[] marginsDp, View v) {
+            // convert dp to pixels
+            int[] marginsPx = new int[marginsDp.length];
+            DisplayMetrics dm = getResources().getDisplayMetrics();
+            for (int i = 0; i < marginsPx.length; i++) {
+                marginsPx[i] = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, marginsDp[i], dm);
+            }
+            LinearLayout.LayoutParams lp = (LinearLayout.LayoutParams) v.getLayoutParams();
+            lp.setMargins(marginsPx[0], marginsPx[1], marginsPx[2], marginsPx[3]);
+            v.setLayoutParams(lp);
+        }
+
         public View getView(int position, View convertView, ViewGroup parent) {
             // Get the main container view if it doesn't already exist, and call bindView
             View v;
@@ -1556,6 +1574,13 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 setFont(col);
                 // set text for column
                 col.setText(dataSet.get(mFromKeys[i]));
+                if (mInMultiSelectMode) {
+                    // set smaller margins so cells have about the same height
+                    // even though extra space for the checkbox is needed
+                    setMargin(new int[] {3, 0, 3, 0}, col);
+                } else {
+                    setMargin(new int[] {12, 0, 12, 5}, col);
+                }
             }
             // set card's background color
             final int backgroundColor = colors[colorIdx];

--- a/AnkiDroid/src/main/res/layout/card_item_browser.xml
+++ b/AnkiDroid/src/main/res/layout/card_item_browser.xml
@@ -18,15 +18,15 @@
         android:layout_width="0dip"
         android:layout_height="fill_parent"
         android:layout_weight="1"
-        android:paddingLeft="3dp"
-        android:paddingRight="3dp" />
+        android:layout_marginLeft="13dp"
+        android:layout_marginRight="13dp" />
 
     <TextView
         android:id="@+id/card_column2"
         android:layout_width="0dip"
         android:layout_height="fill_parent"
         android:layout_weight="1"
-        android:paddingLeft="3dp"
-        android:paddingRight="3dp"/>
+        android:layout_marginLeft="13dp"
+        android:layout_marginRight="13dp"/>
 
 </LinearLayout>


### PR DESCRIPTION

## Pull Request template

Please, go through these checks before you submit a PR.

- [ X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [ X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ X] You have commented your code, particularly in hard-to-understand areas
- [ X] You have performed a self-review of your own code

## Purpose / Description
So far, in multi-select mode, the cell gets larger when clicked because it needs additional horizontal space for the checkbox. In this PR, this is accommodated by having larger horizontal margins first and then decreasing those margins when transitioning to multi-select mode. Now the cells only jump minimally.

## Fixes
See https://github.com/ankidroid/Anki-Android/pull/4839