### PR TITLE
Fix incorrect API 15 usage widget crash + translation compile fix

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/widget/AnkiDroidWidgetSmall.java
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/AnkiDroidWidgetSmall.java
@@ -24,6 +24,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
+import android.os.Build;
 import android.os.IBinder;
 import android.view.View;
 import android.widget.RemoteViews;
@@ -149,14 +150,18 @@ public class AnkiDroidWidgetSmall extends AppWidgetProvider {
                         updateViews.setViewVisibility(R.id.ankidroid_widget_small_finish_layout, View.INVISIBLE);
                         updateViews.setViewVisibility(R.id.widget_due, View.VISIBLE);
                         updateViews.setTextViewText(R.id.widget_due, Integer.toString(dueCardsCount));
-                        updateViews.setContentDescription(R.id.widget_due, getResources().getQuantityString(R.plurals.widget_cards_due, dueCardsCount, dueCardsCount));
+                        if (Build.VERSION.SDK_INT > 15) {
+                            updateViews.setContentDescription(R.id.widget_due, getResources().getQuantityString(R.plurals.widget_cards_due, dueCardsCount, dueCardsCount));
+                        }
                     }
                     if (eta <= 0 || dueCardsCount <= 0) {
                         updateViews.setViewVisibility(R.id.widget_eta, View.INVISIBLE);
                     } else {
                         updateViews.setViewVisibility(R.id.widget_eta, View.VISIBLE);
                         updateViews.setTextViewText(R.id.widget_eta, Integer.toString(eta));
-                        updateViews.setContentDescription(R.id.widget_eta, getResources().getQuantityString(R.plurals.widget_eta, eta, eta));
+                        if (Build.VERSION.SDK_INT > 15) {
+                            updateViews.setContentDescription(R.id.widget_eta, getResources().getQuantityString(R.plurals.widget_eta, eta, eta));
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Pull Request template

Please, go through these checks before you submit a PR.

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code

## Purpose / Description

A good portion of our acralyzer reports are from a widget using an API15 call on lower than API15 devices.

If we intend to support these devices with multiple APKs I assume they'll be built off the 2.8 series since 2.9 removes support for API<15

## Fixes
#4848 incidentally

[Acralyzer report](https://couchdb.ankidroid.org/acralyzer/_design/acralyzer/index.html#/report-details/823ad9c8-c18e-4ec4-8e18-908aa59eb45c)

## Approach
 This wraps that call in an SDK_VERSION check

## How Has This Been Tested?

Unit and integration tests, plus on API<15 devices I added the widget and it crashed, then when I made this change, it worked. 

Note to test in emulators lower than API 16 (I think) now you need an old tools version (25.0.2 works) or the emulators don’t mount the sdcard.

https://stackoverflow.com/questions/45681272/android-emulator-wont-mount-sd-card


## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_
