### PR TITLE
Issue 4820

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1903,7 +1903,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
             if (typeAnswer()) {
                 mAnswerField.setVisibility(View.VISIBLE);
             } else {
-                mAnswerField.setVisibility(View.INVISIBLE);
+                mAnswerField.setVisibility(View.GONE);
             }
 
             displayString = enrichWithQADiv(question, false);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1899,9 +1899,11 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
             question = typeAnsQuestionFilter(question);
 
             Timber.d("question: '%s'", question);
-            // If the user wants to write the answer
+            // Show text entry based on if the user wants to write the answer
             if (typeAnswer()) {
                 mAnswerField.setVisibility(View.VISIBLE);
+            } else {
+                mAnswerField.setVisibility(View.INVISIBLE);
             }
 
             displayString = enrichWithQADiv(question, false);


### PR DESCRIPTION
## Pull Request template

Please, go through these checks before you submit a PR.

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code

## Purpose / Description
'mAnswerField' was displayed on cards without text input when hitting undo from a card with text input, but shouldn't do this anymore

## Fixes
#4820 

## Approach
mAnswerField was never set back to invisible through AbstractFlashcardViewer.displayCardQuestion(). This was where I could find that mAnswerField was being set during the undo process so I went ahead and used the existing check for whether the card wanted an answer field to also determine if it didn't want an answer field.

## How Has This Been Tested?

Tested on a Nexus 5X API 27 virtual device. 
Reproduction steps are the same as in #4820 only the expected outcome (mAnswerField is not displayed) occurs now. Those steps are pasted below for convenience.

Reproduction Steps
Create a card without text input in the answer field (Card type: basic).
Create a second card with text input in the answer field (Card type: basic with text input).
Review the first card (without text input), select (again).
When the second card is displayed (with text input), hit 'undo'.
