### PR TITLE
Browser scroll position

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -34,7 +34,6 @@ import android.support.v4.view.MenuItemCompat;
 import android.support.v7.app.ActionBar;
 import android.support.v7.widget.SearchView;
 import android.text.TextUtils;
-import android.util.DisplayMetrics;
 import android.util.TypedValue;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -48,7 +47,6 @@ import android.widget.AdapterView.OnItemSelectedListener;
 import android.widget.ArrayAdapter;
 import android.widget.BaseAdapter;
 import android.widget.CheckBox;
-import android.widget.LinearLayout;
 import android.widget.ListView;
 import android.widget.Spinner;
 import android.widget.TextView;
@@ -1526,22 +1524,6 @@ public class CardBrowser extends NavigationDrawerActivity implements
         }
 
 
-        /**
-         * @param marginsDp Left, top, right and bottom margins in dp
-         * @param v View to change
-         */
-        private void setMargin(int[] marginsDp, View v) {
-            // convert dp to pixels
-            int[] marginsPx = new int[marginsDp.length];
-            DisplayMetrics dm = getResources().getDisplayMetrics();
-            for (int i = 0; i < marginsPx.length; i++) {
-                marginsPx[i] = (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, marginsDp[i], dm);
-            }
-            LinearLayout.LayoutParams lp = (LinearLayout.LayoutParams) v.getLayoutParams();
-            lp.setMargins(marginsPx[0], marginsPx[1], marginsPx[2], marginsPx[3]);
-            v.setLayoutParams(lp);
-        }
-
         public View getView(int position, View convertView, ViewGroup parent) {
             // Get the main container view if it doesn't already exist, and call bindView
             View v;
@@ -1574,13 +1556,6 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 setFont(col);
                 // set text for column
                 col.setText(dataSet.get(mFromKeys[i]));
-                if (mInMultiSelectMode) {
-                    // set smaller margins so cells have about the same height
-                    // even though extra space for the checkbox is needed
-                    setMargin(new int[] {3, 0, 3, 0}, col);
-                } else {
-                    setMargin(new int[] {12, 0, 12, 5}, col);
-                }
             }
             // set card's background color
             final int backgroundColor = colors[colorIdx];

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -28,7 +28,9 @@ import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.graphics.Typeface;
 import android.os.Bundle;
+import android.os.Handler;
 import android.os.SystemClock;
+import android.support.annotation.NonNull;
 import android.support.design.widget.Snackbar;
 import android.support.v4.view.MenuItemCompat;
 import android.support.v7.app.ActionBar;
@@ -161,6 +163,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
     private boolean mReloadRequired = false;
     private boolean mInMultiSelectMode = false;
     private HashSet<Integer> mCheckedCardPositions = new HashSet<>();
+    private int mLastSelectedPosition;
     private Menu mActionBarMenu;
 
     private final int SNACKBAR_DURATION = 8000;
@@ -486,14 +489,15 @@ public class CardBrowser extends NavigationDrawerActivity implements
         });
         mCardsListView.setOnItemLongClickListener(new ListView.OnItemLongClickListener() {
             @Override
-            public boolean onItemLongClick(AdapterView<?> adapterView, View view, int position, long id) {
+            public boolean onItemLongClick(AdapterView<?> adapterView, View view, final int position, long id) {
+                mLastSelectedPosition = position;
                 loadMultiSelectMode();
 
                 // click on whole cell triggers select
                 CheckBox cb = (CheckBox) view.findViewById(R.id.card_checkbox);
                 cb.toggle();
                 onCheck(position, view);
-
+                recenterListView(view);
                 mCardsAdapter.notifyDataSetChanged();
                 return true;
             }
@@ -1723,12 +1727,31 @@ public class CardBrowser extends NavigationDrawerActivity implements
     }
 
     /**
+     * The views expand / contract when switching between multi-select mode so we manually
+     * adjust so that the vertical position of the given view is maintained
+     */
+    private void recenterListView(@NonNull View view) {
+        final int position = mCardsListView.getPositionForView(view);
+        // Get the current vertical position of the top of the selected view
+        final int top = view.getTop();
+        final Handler handler = new Handler();
+        // Post to event queue with some delay to give time for the UI to update the layout
+        handler.postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                // Scroll to the same vertical position before the layout was changed
+                mCardsListView.setSelectionFromTop(position, top);
+            }
+        }, 10);
+    }
+
+    /**
      * Turn on Multi-Select Mode so that the user can select multiple cards at once.
      */
     private void loadMultiSelectMode() {
-        if (mInMultiSelectMode)
+        if (mInMultiSelectMode) {
             return;
-
+        }
         // set in multi-select mode
         mInMultiSelectMode = true;
         // show title and hide spinner
@@ -1743,10 +1766,13 @@ public class CardBrowser extends NavigationDrawerActivity implements
      * Turn off Multi-Select Mode and return to normal state
      */
     private void endMultiSelectMode() {
-        // clear all selected cards from list
         mCheckedCardPositions.clear();
-        // turn of multi-select mode
         mInMultiSelectMode = false;
+        // If view which was originally selected when entering multi-select is visible then maintain its position
+        View view = mCardsListView.getChildAt(mLastSelectedPosition - mCardsListView.getFirstVisiblePosition());
+        if (view != null) {
+            recenterListView(view);
+        }
         // update adapter to remove check boxes
         mCardsAdapter.notifyDataSetChanged();
         // update action bar

--- a/AnkiDroid/src/main/res/layout/card_item_browser.xml
+++ b/AnkiDroid/src/main/res/layout/card_item_browser.xml
@@ -18,15 +18,15 @@
         android:layout_width="0dip"
         android:layout_height="fill_parent"
         android:layout_weight="1"
-        android:layout_marginLeft="13dp"
-        android:layout_marginRight="13dp" />
+        android:paddingLeft="3dp"
+        android:paddingRight="3dp" />
 
     <TextView
         android:id="@+id/card_column2"
         android:layout_width="0dip"
         android:layout_height="fill_parent"
         android:layout_weight="1"
-        android:layout_marginLeft="13dp"
-        android:layout_marginRight="13dp"/>
+        android:paddingLeft="3dp"
+        android:paddingRight="3dp"/>
 
 </LinearLayout>


### PR DESCRIPTION
## Purpose / Description
In the current master branch there's a problem where the selected item position in the card browser jumps around when entering / exiting multi-select mode due to the resizing of the rows. This issue was introduced in #4839 and partially addressed in #4895 by @vrublack, but I found that approach was unreliable.

## Fixes
Reverts #4895 and takes a different approach to solving the problem

## Approach
When multi-select mode is first entered we find the vertical position of the selected view before the layout is updated, and then post a call to the event queue to scroll back to that same position with a small delay to allow the layout to get updated. We do the same thing on exiting multi-select mode if the originally selected view is still visible.

## How Has This Been Tested?

I tested entering and exiting multiselect mode in the API 27 pixel simulator