### PR TITLE
Update dependencies that required no code changes

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -60,13 +60,13 @@ dependencies {
     }
     implementation 'com.getbase:floatingactionbutton:1.10.1'
     implementation 'ch.acra:acra:4.6.2'
-    implementation 'com.jakewharton.timber:timber:4.7.0'
-    implementation 'com.google.code.gson:gson:2.8.2'
-    implementation 'org.jsoup:jsoup:1.10.3'
+    implementation 'com.jakewharton.timber:timber:4.7.1'
+    implementation 'com.google.code.gson:gson:2.8.5'
+    implementation 'org.jsoup:jsoup:1.11.3'
     api project(":api")
 
     testImplementation 'org.junit.vintage:junit-vintage-engine:5.2.0'
-    testImplementation 'org.mockito:mockito-core:2.18.3'
+    testImplementation 'org.mockito:mockito-core:2.21.0'
     testImplementation 'org.powermock:powermock-core:2.0.0-beta.5'
     testImplementation 'org.powermock:powermock-module-junit4:2.0.0-beta.5'
     testImplementation 'org.powermock:powermock-api-mockito2:2.0.0-beta.5'

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
+        classpath 'com.android.tools.build:gradle:3.2.0-beta05'
         classpath 'com.github.triplet.gradle:play-publisher:1.1.5'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,8 +1,6 @@
-#Fri Dec 15 07:46:44 JST 2017
+#Wed Aug 15 23:41:35 ECT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-# Gradle now auto-selects build tools versions based on gradle version
-# If you change this, it may select a new version of build tools, reflected in .travis.yml
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.5.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-all.zip


### PR DESCRIPTION

## Pull Request template

Please, go through these checks before you submit a PR.

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code

## Purpose / Description

Slowly but surely getting our dependencies up to date

## Fixes
Nothing logged, these were all minor.

## Approach
I've started testing ["dependabot"](https://dependabot.com/) and it automatically generates [pull requests for dependency bumps](https://github.com/mikehardy/Anki-Android/pulls) with ability to mute/ignore/rebase etc from the PR comments which is pretty slick. I packaged a bunch of dependency bumps together as a single PR here, then once we're mostly clear we should integrate it I think

Note the beta android gradle plugin is needed in combo with gradle 4.9,
but it should not have any change on compilation artifacts until R8 is enabled by default in Android Studio 3.3. It did move Java8 de-sugaring from post-compile to post-dex but that only affected tool authors, and they already handle it (or our mock/powermock tests would have failed). Edit that plugin to 3.1.4 and gradle to 4.5.1-all


## How Has This Been Tested?

CI is running it, I've done unit and integrated tests and used it lightly.

## Learning (optional, can help others)
D8 - description https://developer.android.com/studio/preview/features/#d8_desugaring
D8 - impact of de-sugaring at the end: https://android-developers.googleblog.com/2017/08/next-generation-dex-compiler-now-in.html

