### PR TITLE
Coverage reports / Codacy integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,20 +31,22 @@ env:
 matrix:
   fast_finish: true # We can report success without waiting for these
   allow_failures:
-    - env: API=15  # sometimes emulator hangs, sometimes not - possibly fixable
+    - env: API=15 # sometimes emulator hangs, sometimes not - possibly fixable
     - env: API=23 EMU_FLAVOR=google_apis # has permission errors
-    - env: API=25 EMU_FLAVOR=google_apis # has permission errors
+    - env: API=25 EMU_FLAVOR=google_apis # has permission errors, emulator timeout
+
+jobs:
+  include:
+    # The test stage is implicit, we only need to define a post-test stage for codacy finalization
+    - stage: finalize_coverage
+      env: FINALIZE_COVERAGE=TRUE API=NONE
+      install: skip
+      script: echo finalize codacy coverage uploads
 
 android:
   components:
-    # installing things this way vs 'sdkmanager' is deprecated, should move to sdkmanager over time
+    # installing tools to start, then use `sdkmanager` below to get the rest
     - tools
-    - platform-tools
-    - tools              # a second time per Travis official docs, necessary for newest versions
-    - build-tools-27.0.3 # Automated dependency from gradle - gradle will drive the changes
-    - android-$API       # We need the API of the emulator we will run
-    - android-26         # We need the API of the current build target
-    - extra-android-m2repository
 
 licenses:
     - 'android-sdk-preview-license-.+'
@@ -54,16 +56,26 @@ licenses:
 # Emulator Management: Create, Start and Wait
 install:
   - echo 'count=0' > /home/travis/.android/repositories.cfg # Avoid harmless sdkmanager warning
-  - echo yes | sdkmanager tools # 'emulator' is deprecated, 'avdmanager' is current, this installs it
-  - echo yes | sdkmanager "system-images;android-$API;$EMU_FLAVOR;$ABI" # install our emulator
+  - echo y | sdkmanager "platform-tools" >/dev/null
+  - echo y | sdkmanager "tools" >/dev/null # A second time per Travis docs, gets latest versions
+  - echo y | sdkmanager "build-tools;28.0.2" >/dev/null # Implicit gradle dependency - gradle drives changes
+  - echo y | sdkmanager "platforms;android-$API" >/dev/null # We need the API of the emulator we will run
+  - echo y | sdkmanager "platforms;android-26" >/dev/null # We need the API of the current compileSdkVersion from gradle.properties
+  - echo y | sdkmanager "extras;android;m2repository" >/dev/null
+  - echo y | sdkmanager "system-images;android-$API;$EMU_FLAVOR;$ABI" >/dev/null # install our emulator
   - echo no | avdmanager create avd --force -n test -k "system-images;android-$API;$EMU_FLAVOR;$ABI" -c 10M
-  - emulator -avd test -engine classic -no-window $AUDIO -camera-back none -camera-front none -selinux permissive -qemu -m 512 &
-
-before_script:
+  - emulator -avd test -engine classic -no-window $AUDIO -camera-back none -camera-front none -selinux permissive -qemu -m 1536 &
   - android-wait-for-emulator
   - adb shell input keyevent 82 &
 
-script: ./gradlew test :AnkiDroid:connectedCheck
+script:
+  - ./gradlew jacocoTestReport
+
+# Codacy integration, partials for all APIs, then an optional finalize
+after_success:
+  - wget --progress=dot:giga -O ~/codacy-coverage-reporter-assembly-latest.jar https://oss.sonatype.org/service/local/repositories/releases/content/com/codacy/codacy-coverage-reporter/4.0.2/codacy-coverage-reporter-4.0.2-assembly.jar
+  - if [[ ( "$API" != "NONE" ) ]]; then java -jar ~/codacy-coverage-reporter-assembly-latest.jar report -l Java -r AnkiDroid/build/reports/jacoco/report.xml --partial; fi
+  - if [[ ( "$FINALIZE_COVERAGE" == "TRUE" ) ]]; then java -jar ~/codacy-coverage-reporter-assembly-latest.jar final; fi
 
 before_cache:
   - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -1,5 +1,7 @@
 apply plugin: 'com.android.application'
 apply plugin: 'com.github.triplet.play'
+apply plugin: 'jacoco'
+
 def homePath = System.properties['user.home']
 android {
     compileSdkVersion 26
@@ -29,6 +31,7 @@ android {
             debuggable true
             // Check Crash Reports page on developer wiki for info on ACRA testing
             buildConfigField "String", "ACRA_URL", '"https://918f7f55-f238-436c-b34f-c8b5f1331fe5-bluemix.cloudant.com/acra-ankidroid/_design/acra-storage/_update/report"'
+            testCoverageEnabled true
         }
         release {
             minifyEnabled true
@@ -38,6 +41,16 @@ android {
         }
     }
     useLibrary 'org.apache.http.legacy'
+
+    testOptions {
+        // we should use orchestrator, but app data shared on /sdcard makes it unstable
+        //execution 'ANDROID_TEST_ORCHESTRATOR'
+        animationsDisabled true
+
+        unitTests {
+            includeAndroidResources = true
+        }
+    }
 
     dexOptions {
         // Skip pre-dexing when running on Travis CI or when disabled via -Dpre-dex=false.
@@ -54,6 +67,36 @@ play {
     serviceAccountEmail = '294046724212-r3bef6kl46pb9gk0h1pl5rcjmpfrdpjl@developer.gserviceaccount.com'
     pk12File = file("${homePath}/src/583631bdd16d.p12")
     track = 'alpha'
+}
+
+jacoco {
+    toolVersion = "$jacocoVersion"
+}
+
+tasks.withType(Test) {
+    jacoco.includeNoLocationClasses = true
+}
+
+// Our merge report task
+task jacocoTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest', 'createDebugCoverageReport']) {
+
+    reports {
+        xml.enabled = true
+        xml.destination = "${buildDir}/reports/jacoco/report.xml"
+        html.enabled = true
+        html.destination = "${buildDir}/reports/jacoco"
+    }
+
+    def fileFilter = ['**/R.class', '**/R$*.class', '**/BuildConfig.*', '**/Manifest*.*', '**/*Test*.*', 'android/**/*.*']
+    def debugTree = fileTree(dir: "$project.buildDir/intermediates/javac/debug/compileDebugJavaWithJavac/classes", excludes: fileFilter)
+    def mainSrc = "$project.projectDir/src/main/java"
+
+    sourceDirectories = files([mainSrc])
+    classDirectories = files([debugTree])
+    executionData = fileTree(dir: project.buildDir, includes: [
+            'jacoco/testDebugUnitTest.exec',
+            'outputs/code-coverage/connected/**/*.ec'
+    ])
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,16 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
+    ext.jacocoVersion = '0.8.2'
+
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.0-beta05'
+        classpath 'com.android.tools.build:gradle:3.2.0-rc02'
         classpath 'com.github.triplet.gradle:play-publisher:1.1.5'
+        classpath "org.jacoco:org.jacoco.core:$jacocoVersion"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }


### PR DESCRIPTION
## Pull Request template

Please, go through these checks before you submit a PR.

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code

## Purpose / Description
Automate code analysis for pull requests, and integrate the results in an actionable way

## Fixes
Fixes #4914 (codacy integration)
Fixes #3056 (coverity integration, by obsoletion)
Fixes #4588 (reporting valid lint warnings, by obsoletion)
Fixes #2254 (lint continunous integration, by obsoletion)

## Approach
This PR implements a jacoco report, then generates that report in Travis CI for all APIs and uploads them all to the Codacy servers in a way that Codacy can aggregate them correctly, while using our local checkstyle.

I did the major steps in separate commits but I can squash them if desired.

I tried to do this using Travis resources efficiently by only doing android SDK installs / emulator starts when necessary through the use of Travis build stages

This should also make coverage information available in the local development environment either by viewing the generated HTML report or in Android Studio directly

## How Has This Been Tested?

Tested against a [personal Travis environment](https://travis-ci.com/mikehardy/Anki-Android/branches) and [personal Codacy environment](https://app.codacy.com/project/mikehardy/Anki-Android/dashboard?branchId=8429314) until it worked as desired

## Learning (optional, can help others)
We can't use the ANDROID_TEST_ORCHESTRATOR style of instrumented testing because it destabilizes all the emulators in Travis CI, I think because we store state outside of the application area (on /sdcard) and the orchestrator is racy unless it can reset properly. Not reproducible locally.



_Links to blog posts, patterns, libraries or addons used to solve this problem_

- Creating an integrated (unit test + instrumented test) jacoco report:
https://proandroiddev.com/unified-code-coverage-for-android-revisited-44789c9b722f
- Integrating Travis + Codacy:  https://github.com/codacy/codacy-coverage-reporter#travis-ci
- Using travis build stages: https://docs.travis-ci.com/user/build-stages/define-steps/
