### PR TITLE
Implement API26 Notification Channels

### DIFF
--- a/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/NotificationChannelTest.java
+++ b/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/NotificationChannelTest.java
@@ -1,0 +1,89 @@
+/****************************************************************************************
+ * Copyright (c) 2018 Mike Hardy <mike@mikehardy.net>                                   *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+
+package com.ichi2.anki.tests;
+
+import android.Manifest;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.content.Context;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.rule.GrantPermissionRule;
+import android.support.test.runner.AndroidJUnit4;
+
+import com.ichi2.anki.AnkiDroidApp;
+import com.ichi2.anki.NotificationChannels;
+import com.ichi2.compat.CompatHelper;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.List;
+
+import timber.log.Timber;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(AndroidJUnit4.class)
+public class NotificationChannelTest {
+
+    @Rule
+    public GrantPermissionRule mRuntimePermissionRule =
+            GrantPermissionRule.grant(Manifest.permission.WRITE_EXTERNAL_STORAGE);
+
+    private int mCurrentAPI = -1;
+    private int mTargetAPI = -1;
+    private NotificationManager mManager = null;
+
+    @Before
+    public void setUp() {
+        Context targetContext = InstrumentationRegistry.getTargetContext();
+        ((AnkiDroidApp)targetContext.getApplicationContext()).onCreate();
+        mCurrentAPI = CompatHelper.getSdkVersion();
+        mTargetAPI = targetContext.getApplicationInfo().targetSdkVersion;
+        mManager = (NotificationManager)targetContext.getSystemService(Context.NOTIFICATION_SERVICE);
+    }
+
+    private boolean channelsInAPI() {
+        return mCurrentAPI >= 26;
+    }
+
+    @Test
+    public void testChannelCreation() {
+        if (!channelsInAPI()) return;
+
+        // onCreate was called in setUp(), so we should have channels now
+        List<NotificationChannel> channels = mManager.getNotificationChannels();
+        for (int i = 0; i < channels.size(); i++) {
+            Timber.d("Found channel with id %s", channels.get(i).getId());
+        }
+
+        int expectedChannels = NotificationChannels.Channel.values().length;
+        // If we have channels but have *targeted* pre-26, there is a "miscellaneous" channel auto-defined
+        if (mTargetAPI < 26) {
+            expectedChannels += 1;
+        }
+        assertEquals("Incorrect channel count", expectedChannels, channels.size());
+
+        for (NotificationChannels.Channel channel : NotificationChannels.Channel.values()) {
+            assertTrue("There should be a reminder channel",
+                    mManager.getNotificationChannel(NotificationChannels.getId(channel)) != null);
+        }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
@@ -351,13 +351,25 @@ public class AnkiActivity extends AppCompatActivity implements LoaderManager.Loa
 
 
     /**
+     * Calls {@link #showAsyncDialogFragment(AsyncDialogFragment, NotificationChannels.Channel)} internally, using the channel
+     * {@link NotificationChannels.Channel#GENERAL}
+     *
+     * @param newFragment  the AsyncDialogFragment you want to show
+     */
+    public void showAsyncDialogFragment(AsyncDialogFragment newFragment) {
+        showAsyncDialogFragment(newFragment, NotificationChannels.Channel.GENERAL);
+    }
+
+
+    /**
      * Global method to show a dialog fragment including adding it to back stack and handling the case where the dialog
      * is shown from an async task, by showing the message in the notification bar if the activity was stopped before the
      * AsyncTask completed
      *
      * @param newFragment  the AsyncDialogFragment you want to show
+     * @param channel the NotificationChannels.Channel to use for the notification
      */
-    public void showAsyncDialogFragment(AsyncDialogFragment newFragment) {
+    public void showAsyncDialogFragment(AsyncDialogFragment newFragment, NotificationChannels.Channel channel) {
         try {
             showDialogFragment(newFragment);
         } catch (IllegalStateException e) {
@@ -366,7 +378,7 @@ public class AnkiActivity extends AppCompatActivity implements LoaderManager.Loa
             // Show a basic notification to the user in the notification bar in the meantime
             String title = newFragment.getNotificationTitle();
             String message = newFragment.getNotificationMessage();
-            showSimpleNotification(title, message);
+            showSimpleNotification(title, message, channel);
         }
     }
 
@@ -407,7 +419,7 @@ public class AnkiActivity extends AppCompatActivity implements LoaderManager.Loa
     }
 
 
-    public void showSimpleNotification(String title, String message) {
+    public void showSimpleNotification(String title, String message, NotificationChannels.Channel channel) {
         SharedPreferences prefs = AnkiDroidApp.getSharedPrefs(this);
         // Don't show notification if disabled in preferences
         if (Integer.parseInt(prefs.getString("minimumCardsDueForNotification", "0")) <= 1000000) {
@@ -417,7 +429,8 @@ public class AnkiActivity extends AppCompatActivity implements LoaderManager.Loa
                 ticker = message;
             }
             // Build basic notification
-            NotificationCompat.Builder builder = new NotificationCompat.Builder(this)
+            NotificationCompat.Builder builder = new NotificationCompat.Builder(this,
+                    NotificationChannels.getId(channel))
                     .setSmallIcon(R.drawable.ic_stat_notify)
                     .setContentTitle(title)
                     .setContentText(message)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -203,6 +203,7 @@ public class AnkiDroidApp extends Application {
 
         sInstance = this;
         setLanguage(preferences.getString(Preferences.LANGUAGE, ""));
+        NotificationChannels.setup(getApplicationContext());
 
         // Configure WebView to allow file scheme pages to access cookies.
         CookieManager.setAcceptFileSchemeCookies(true);
@@ -317,7 +318,7 @@ public class AnkiDroidApp extends Application {
     /**
      * Sets the user language.
      *
-     * @param localeCode The locale code of the language to set
+     * @param localeCode The locale code of the language to set, system language if empty
      */
     public static void setLanguage(String localeCode) {
         Configuration config = getInstance().getResources().getConfiguration();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -1072,7 +1072,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
     @Override
     public void showSyncErrorDialog(int id, String message) {
         AsyncDialogFragment newFragment = SyncErrorDialog.newInstance(id, message);
-        showAsyncDialogFragment(newFragment);
+        showAsyncDialogFragment(newFragment, NotificationChannels.Channel.SYNC);
     }
 
     /**
@@ -1091,7 +1091,9 @@ public class DeckPicker extends NavigationDrawerActivity implements
     private void showSyncLogMessage(int messageResource, String syncMessage) {
         if (mActivityPaused) {
             Resources res = AnkiDroidApp.getAppResources();
-            showSimpleNotification(res.getString(R.string.app_name), res.getString(messageResource));
+            showSimpleNotification(res.getString(R.string.app_name),
+                    res.getString(messageResource),
+                    NotificationChannels.Channel.SYNC);
         } else {
             if (syncMessage == null || syncMessage.length() == 0) {
                 UIUtils.showSimpleSnackbar(this, messageResource, false);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
@@ -219,6 +219,7 @@ public class NavigationDrawerActivity extends AnkiActivity implements Navigation
         SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(this);
         // Update language
         AnkiDroidApp.setLanguage(preferences.getString(Preferences.LANGUAGE, ""));
+        NotificationChannels.setup(getApplicationContext());
         // Restart the activity on preference change
         if (requestCode == REQUEST_PREFERENCES_UPDATE) {
             if (mOldColPath!=null && CollectionHelper.getCurrentAnkiDroidDirectory(this).equals(mOldColPath)) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NotificationChannels.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NotificationChannels.java
@@ -1,0 +1,70 @@
+/****************************************************************************************
+ * Copyright (c) 2018 Timothy Rae <perceptualchaos2@gmail.com>                          *
+ * Copyright (c) 2018 Mike Hardy <mike@mikehardy.net>                                   *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+
+package com.ichi2.anki;
+
+import android.content.Context;
+import android.content.res.Resources;
+
+import com.ichi2.compat.Compat;
+import com.ichi2.compat.CompatHelper;
+
+public final class NotificationChannels {
+    public enum Channel { GENERAL, SYNC, GLOBAL_REMINDERS, DECK_REMINDERS }
+
+    public static String getId(Channel channel) {
+        switch (channel) {
+            case SYNC:
+                return "Synchronization";
+            case GLOBAL_REMINDERS:
+                return "Global Reminders";
+            case DECK_REMINDERS:
+                return "Deck Reminders";
+            case GENERAL:
+            default:
+                return "General Notifications";
+        }
+    }
+
+    private static String getName(Channel channel, Resources res) {
+        switch (channel) {
+            case SYNC:
+                return res.getString(R.string.sync_title);
+            case GLOBAL_REMINDERS:
+                return res.getString(R.string.widget_minimum_cards_due_notification_ticker_title);
+            case DECK_REMINDERS:
+                return res.getString(R.string.deck_conf_reminders);
+            case GENERAL:
+            default:
+                return res.getString(R.string.app_name);
+        }
+    }
+
+    /**
+     * Create or update all the notification channels for the app
+     *
+     * TODO should be called in response to {@link android.content.Intent#ACTION_LOCALE_CHANGED}
+     * @param context the context for access to localized strings for channel names
+     */
+    public static void setup(Context context) {
+        Resources res = context.getResources();
+        Compat compat = CompatHelper.getCompat();
+        for (Channel channel : Channel.values()) {
+            compat.setupNotificationChannel(context, getId(channel), getName(channel, res));
+        }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DialogHandler.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DialogHandler.java
@@ -10,6 +10,7 @@ import com.ichi2.anki.AnkiActivity;
 import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.CollectionHelper;
 import com.ichi2.anki.DeckPicker;
+import com.ichi2.anki.NotificationChannels;
 import com.ichi2.anki.R;
 import com.ichi2.async.Connection;
 import com.ichi2.libanki.Utils;
@@ -109,9 +110,9 @@ public class DialogHandler extends Handler {
             } else {
                 String err = res.getString(R.string.sync_error);
                 if (limited) {
-                    mActivity.get().showSimpleNotification(err, res.getString(R.string.sync_too_busy));
+                    mActivity.get().showSimpleNotification(err, res.getString(R.string.sync_too_busy), NotificationChannels.Channel.SYNC);
                 } else {
-                    mActivity.get().showSimpleNotification(err, res.getString(R.string.youre_offline));
+                    mActivity.get().showSimpleNotification(err, res.getString(R.string.youre_offline), NotificationChannels.Channel.SYNC);
                 }
             }
             mActivity.get().finishWithoutAnimation();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/NotificationService.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/NotificationService.java
@@ -28,11 +28,15 @@ import android.support.v4.content.IntentCompat;
 
 import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.DeckPicker;
+import com.ichi2.anki.NotificationChannels;
 import com.ichi2.anki.R;
 import com.ichi2.widget.WidgetStatus;
 
 import timber.log.Timber;
 
+/**
+ * This Service handles notifications for general work due
+ */
 public class NotificationService extends Service {
 
     /** The notification service to show notifications of due cards. */
@@ -60,7 +64,13 @@ public class NotificationService extends Service {
         if (dueCardsCount >= minCardsDue) {
             // Build basic notification
             String cardsDueText = getString(R.string.widget_minimum_cards_due_notification_ticker_text, dueCardsCount);
-            NotificationCompat.Builder builder = new NotificationCompat.Builder(this)
+
+            // This generates a log warning "Use of stream types is deprecated..."
+            // The NotificationCompat code uses setSound() no matter what we do and triggers it.
+            NotificationCompat.Builder builder =
+                    new NotificationCompat.Builder(this,
+                            NotificationChannels.getId(NotificationChannels.Channel.GENERAL))
+                    .setCategory(NotificationCompat.CATEGORY_REMINDER)
                     .setSmallIcon(R.drawable.ic_stat_notify)
                     .setColor(ContextCompat.getColor(context, R.color.material_light_blue_700))
                     .setContentTitle(cardsDueText)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/ReminderService.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/ReminderService.java
@@ -1,3 +1,17 @@
+/***************************************************************************************
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+
 package com.ichi2.anki.services;
 
 import android.app.AlarmManager;
@@ -12,10 +26,14 @@ import android.support.v4.content.ContextCompat;
 
 import com.ichi2.anki.CollectionHelper;
 import com.ichi2.anki.IntentHandler;
+import com.ichi2.anki.NotificationChannels;
 import com.ichi2.anki.R;
 import com.ichi2.anki.receiver.ReminderReceiver;
 import com.ichi2.libanki.Sched;
 
+/**
+ * This service handles notifications for each deck when work is due
+ */
 public class ReminderService extends IntentService {
     public static final String EXTRA_DECK_ID = "EXTRA_DECK_ID";
 
@@ -62,11 +80,14 @@ public class ReminderService extends IntentService {
         final NotificationManagerCompat notificationManager = NotificationManagerCompat.from(this);
 
         if (notificationManager.areNotificationsEnabled()) {
-            final Notification notification = new NotificationCompat.Builder(this)
+            final Notification notification =
+                    new NotificationCompat.Builder(this,
+                            NotificationChannels.getId(NotificationChannels.Channel.DECK_REMINDERS))
+                    .setCategory(NotificationCompat.CATEGORY_REMINDER)
                     .setContentTitle(this.getString(R.string.reminder_title))
                     .setContentText(this.getResources().getQuantityString(
                             R.plurals.reminder_text,
-                            deckDue.newCount,
+                            total,
                             CollectionHelper.getInstance().getCol(this).getDecks().name(deckId),
                             total
                     ))

--- a/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
@@ -18,11 +18,14 @@
 
 package com.ichi2.async;
 
+import android.Manifest;
 import android.content.Context;
+import android.content.pm.PackageManager;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.os.AsyncTask;
 import android.os.PowerManager;
+import android.support.v4.content.ContextCompat;
 
 import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.CollectionHelper;
@@ -124,7 +127,10 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
     protected void onPreExecute() {
         super.onPreExecute();
         // Acquire the wake lock before syncing to ensure CPU remains on until the sync completes.
-        mWakeLock.acquire();
+        if (ContextCompat.checkSelfPermission(AnkiDroidApp.getInstance().getApplicationContext(),
+                Manifest.permission.WAKE_LOCK) == PackageManager.PERMISSION_GRANTED) {
+            mWakeLock.acquire();
+        }
         if (mListener != null) {
             mListener.onPreExecute();
         }
@@ -138,7 +144,9 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
     protected void onPostExecute(Payload data) {
         super.onPostExecute(data);
         // Sync has ended so release the wake lock
-        mWakeLock.release();
+        if (mWakeLock.isHeld()) {
+            mWakeLock.release();
+        }
         if (mListener != null) {
             mListener.onPostExecute(data);
         }

--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
@@ -71,5 +71,6 @@ public interface Compat {
     boolean isImmersiveSystemUiVisible(AnkiActivity activity);
     boolean deleteDatabase(File db);
     Uri getExportUri(Context context, File file);
+    void setupNotificationChannel(Context context, String id, String name);
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatHelper.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatHelper.java
@@ -32,6 +32,8 @@ public class CompatHelper {
 
         if (isNookHdOrHdPlus() && getSdkVersion() == 15) {
             mCompat = new CompatV15NookHdOrHdPlus();
+        } else if (getSdkVersion() >= 26) {
+            mCompat = new CompatV26();
         } else if (getSdkVersion() >= 23) {
             mCompat = new CompatV23();
         } else if (getSdkVersion() >= 21) {

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV15.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV15.java
@@ -113,4 +113,7 @@ public class CompatV15 implements Compat {
     public Uri getExportUri(Context context, File file) {
         return Uri.fromFile(file);
     }
+
+    @Override
+    public void setupNotificationChannel(Context context, String id, String name) { /* pre-API26, do nothing */ }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV26.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV26.java
@@ -1,0 +1,35 @@
+package com.ichi2.compat;
+
+import android.annotation.TargetApi;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.content.Context;
+import android.support.v4.app.NotificationCompat;
+
+import timber.log.Timber;
+
+/** Implementation of {@link Compat} for SDK level 26 */
+@TargetApi(26)
+public class CompatV26 extends CompatV23 implements Compat {
+
+    /**
+     * In Oreo and higher, you must create a channel for all notifications.
+     * This will create the channel if it doesn't exist, or if it exists it will update the name.
+     *
+     * Note that once a channel is created, only the name may be changed as long as the application
+     * is installed on the user device. All other settings are fully under user control.
+     *
+     * @param context the Context with a handle to the NotificationManager
+     * @param id the unique (within the package) id the channel for programmatic access
+     * @param name the user-visible name for the channel
+     */
+    @Override
+    public void setupNotificationChannel(Context context, String id, String name) {
+        Timber.i("Creating notification channel with id/name: %s/%s",id, name);
+        NotificationManager manager = (NotificationManager)context.getSystemService(Context.NOTIFICATION_SERVICE);
+        NotificationChannel notificationChannel = new NotificationChannel(id, name, NotificationManager.IMPORTANCE_DEFAULT);
+        notificationChannel.setShowBadge(true);
+        notificationChannel.setLockscreenVisibility(NotificationCompat.VISIBILITY_PUBLIC);
+        manager.createNotificationChannel(notificationChannel);
+    }
+}

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -216,8 +216,8 @@
 
     <string name="reminder_title">Do not forget to study today!</string>
     <plurals name="reminder_text">
-        <item quantity="one">%2$d new card to review in %1$s</item>
-        <item quantity="other">%2$d new cards to review in %1$s</item>
+        <item quantity="one">%2$d card to review in %1$s</item>
+        <item quantity="other">%2$d cards to review in %1$s</item>
     </plurals>
     <!-- Currently only used if exporting APKG fails -->
     <string name="apk_share_error">Error sharing apkg file</string>


### PR DESCRIPTION
## Pull Request template

Please, go through these checks before you submit a PR.

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code

## Purpose / Description
API26 blocks notifications that aren't using notification channels

## Fixes
-  Fixes #4884 
-  **This may require re-translation in 02-strings.xml::reminder_text** The per-deck reminders trigger for total reviews but the text was for new cards - a semantic confusion. I aligned it by altering the text to match the trigger so you don't get "0 new card due" or "1 new cards due", which were possible previously. 
-  Fixes a crash on login on Android 6.0+ where WAKE_LOCK permission needed to be requested even though it is non-dangerous and in the manifest

## Approach
-  Added a new CompatV26 class that handles channel creation
-  Setup channels on app startup (create, or update translations)
-  Send the notifications to the right channel id
-  Uses translated string ("Cards due", "Reminders") for our channel names, as it seemed appropriate.
-  Hook Intent.ACTION_LOCALE_CHANGED and AnkiDroidApp.setLanguage to re-translate channels



## How Has This Been Tested?

Automated testing with a new test and CI. I also installed it on API 15, 23, 26 and 28 emulators, both with targetSdkVersion set to 25 and to 26 (when enforcement starts), and it seemed to work fine, even with app-specific or system-level language changes

## Learning (optional, can help others)
The migration from the linked react-native-music-control project in the related issue fit our use case fairly closely.

Language settings learning was added to our GUI language issue #4729 

To see application badges, you have to go to Settings -> Apps & Notifications -> Special app access and grant Notification access to your launcher