### PR TITLE
Update ACRA to 5.2.0, starts API28 work (#4910)

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -112,13 +112,13 @@ dependencies {
     }
     implementation 'com.getbase:floatingactionbutton:1.10.1'
     // ACRA pulls in support 27.0.2, we can remove the excludes if we upgrade
-    implementation('ch.acra:acra-http:5.1.3') {
+    implementation('ch.acra:acra-http:5.2.0') {
         exclude group: 'com.android.support'
     }
-    implementation('ch.acra:acra-dialog:5.1.3') {
+    implementation('ch.acra:acra-dialog:5.2.0') {
         exclude group: 'com.android.support'
     }
-    implementation('ch.acra:acra-toast:5.1.3') {
+    implementation('ch.acra:acra-toast:5.2.0') {
         exclude group: 'com.android.support'
     }
     implementation 'com.jakewharton.timber:timber:4.7.1'

--- a/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/ACRATest.java
+++ b/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/ACRATest.java
@@ -92,20 +92,11 @@ public class ACRATest {
         AnkiDroidApp.getSharedPrefs(InstrumentationRegistry.getTargetContext()).edit()
                 .putString(AnkiDroidApp.FEEDBACK_REPORT_KEY, AnkiDroidApp.FEEDBACK_REPORT_NEVER).commit();
 
-        // If the user disabled it, then it's the debug case except the logcat args
+        // ACRA initializes production logcat via annotation and we can't mock Build.DEBUG
+        // That means we are restricted from verifying production logcat args and this is the debug case again
         setAcraConfig("Production", AnkiDroidApp.getSharedPrefs(InstrumentationRegistry.getTargetContext()));
-
-        // ACRA protects itself from re-.init() and with our BuildConfig.BUILD_DEBUG check
-        // it is impossible to reinitialize as a production build until ACRA 5.2.0
-        //verifyProductionLogcat();
         verifyDebugACRAPreferences();
     }
-
-    //private void verifyProductionLogcat() throws Exception {
-    //    assertArrayEquals("Production logcat arguments not set correctly",
-    //            new ImmutableList<>(prodLogcatArguments).toArray(),
-    //            app.getAcraCoreConfigBuilder().build().logcatArguments().toArray());
-    //}
 
     @Test
     public void testProductionConfigurationUserAsk() throws Exception {


### PR DESCRIPTION
## Pull Request template

Please, go through these checks before you submit a PR.

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code

## Purpose / Description
API28 will silently fail dark-greylisted API usage, or throw exceptions (#4910)
Our core error-reporting library used one so if anyone installed AnkiDroid on API28 we'd never get crash reports

This at least fixes that, though we have other API28 greylist usage as noted in #4910 

## How Has This Been Tested?

I cleaned up the ACRATest after seeing what ACRA re-init actually allowed, then ran tests on emulators. Dependabot already submitted a PR for this on my fork and it all built/tested cleanly in all APIs
