### PR TITLE
Revert support libs to 27.0.x, Fixes #4938

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -99,18 +99,24 @@ task jacocoTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest', 'crea
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'com.android.support:appcompat-v7:27.1.1'
+    implementation 'com.android.support:appcompat-v7:27.0.2'
     // Note: the design support library can be quite buggy, so test everything thoroughly before updating it
-    implementation 'com.android.support:design:27.1.1'
-    implementation 'com.android.support:customtabs:27.1.1'
-    implementation 'com.android.support:recyclerview-v7:27.1.1'
+    implementation 'com.android.support:design:27.0.2'
+    implementation 'com.android.support:customtabs:27.0.2'
+    implementation 'com.android.support:recyclerview-v7:27.0.2'
     implementation 'io.requery:sqlite-android:3.24.0'
     implementation 'android.arch.persistence:db:1.1.1'
     implementation 'com.afollestad.material-dialogs:core:0.9.6.0'
     implementation 'com.getbase:floatingactionbutton:1.10.1'
-    implementation 'ch.acra:acra-http:5.2.0'
-    implementation 'ch.acra:acra-dialog:5.2.0'
-    implementation 'ch.acra:acra-toast:5.2.0'
+    implementation('ch.acra:acra-http:5.2.0') {
+        exclude group: 'com.android.support'
+    }
+    implementation('ch.acra:acra-dialog:5.2.0') {
+        exclude group: 'com.android.support'
+    }
+    implementation('ch.acra:acra-toast:5.2.0') {
+        exclude group: 'com.android.support'
+    }
     implementation 'com.jakewharton.timber:timber:4.7.1'
     implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'org.jsoup:jsoup:1.11.3'


### PR DESCRIPTION
Using support libs 27.1.x causes cards to not display after screen off

https://developer.android.com/topic/libraries/support-library/revisions#27-1-0

Hopefully I'll figure out why shortly, but in the meantime, the issue is resolved by downgrading the libs to 27.0.x and making sure ACRA doesn't pull them again via dependency isolation in the gradle build.
