### PR TITLE
ACRA defines WAKE_LOCK w/maxSdkVersion, replace

### DIFF
--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -58,7 +58,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
-    <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" tools:node="replace"/>
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <permission android:name="com.ichi2.anki.permission.READ_WRITE_DATABASE"


### PR DESCRIPTION
Just saw this over in ACRA-land, and it explains why I was suddenly seeing WAKE_LOCK permission failures. I think it's good I was requesting the permission where I added it, but this fixes up the manifest

https://github.com/ACRA/acra/wiki/Troubleshooting-Guide#wake_lock

```
ACRA is using android.permission.WAKE_LOCK with maxSdkVersion="25". If you need this 
permission also in higher versions, you need to use the following declaration:

<uses-permission android:name="android.permission.WAKE_LOCK" tools:node="replace"/>
```