### PR TITLE
Cherry-pick ACRA upgrade (downgraded to 5.0.2) and implement Limiter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,7 @@ android:
   components:
     - tools
     - platform-tools
-    - build-tools-24.0.3
-    - build-tools-25.0.1
+    - build-tools-28.0.2
     - android-22
     - android-25
     - extra-android-support

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -25,10 +25,16 @@ android {
         }
     }
     buildTypes {
+        debug {
+            debuggable true
+            // Check Crash Reports page on developer wiki for info on ACRA testing
+            buildConfigField "String", "ACRA_URL", '"https://918f7f55-f238-436c-b34f-c8b5f1331fe5-bluemix.cloudant.com/acra-ankidroid/_design/acra-storage/_update/report"'
+        }
         release {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             signingConfig signingConfigs.release
+            buildConfigField "String", "ACRA_URL", '"https://ankidroid.org/acra/report"'
         }
     }
     useLibrary 'org.apache.http.legacy'
@@ -58,11 +64,25 @@ dependencies {
         //exclude group: 'com.android.support'  // uncomment to force our local support lib version
         transitive = true
     }
+
     compile 'com.getbase:floatingactionbutton:1.10.1'
-    compile 'ch.acra:acra:4.6.2'
     compile 'com.jakewharton.timber:timber:2.7.1'
     compile 'com.google.code.gson:gson:2.4'
     compile project(":api")
+
+    // ACRA pulls in support 27.0.2, we can remove the excludes if we upgrade
+    compile('ch.acra:acra-http:5.0.2') {
+        exclude group: 'com.android.support'
+    }
+    compile('ch.acra:acra-dialog:5.0.2') {
+        exclude group: 'com.android.support'
+    }
+    compile('ch.acra:acra-toast:5.0.2') {
+        exclude group: 'com.android.support'
+    }
+    compile('ch.acra:acra-limiter:5.0.2') {
+        exclude group: 'com.android.support'
+    }
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:1.10.19' // v1 while PowerMock does not fully support v2.

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -43,6 +43,11 @@ android {
         // Skip pre-dexing when running on Travis CI or when disabled via -Dpre-dex=false.
         preDexLibraries = preDexEnabled && !travisBuild
     }
+    applicationVariants.all { variant ->
+        variant.outputs.all {
+            outputFileName = "../" + outputFileName
+        }
+    }
 }
 
 

--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -234,6 +234,7 @@
         </activity>
         <activity android:name="com.ichi2.anki.dialogs.AnkiDroidCrashReportDialog"
             android:theme="@style/Theme.CrashReportDialog"
+            android:process=":acra"
             android:launchMode="singleInstance"
             android:excludeFromRecents="true"
             android:finishOnTaskLaunch="true" />

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -40,7 +40,6 @@ import org.acra.annotation.AcraDialog;
 import org.acra.annotation.AcraHttpSender;
 import org.acra.annotation.AcraLimiter;
 import org.acra.annotation.AcraToast;
-import org.acra.config.ACRAConfigurationException;
 import org.acra.config.CoreConfigurationBuilder;
 import org.acra.config.DialogConfigurationBuilder;
 import org.acra.config.ToastConfigurationBuilder;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -275,39 +275,20 @@ public class AnkiDroidApp extends Application {
 
 
     public static void sendExceptionReport(Throwable e, String origin, String additionalInfo) {
-        //CustomExceptionHandler.getInstance().uncaughtException(null, e, origin, additionalInfo);
-        SharedPreferences prefs = getSharedPrefs(getInstance());
-        // Only send report if we have not sent an identical report before
-        try {
-            JSONObject sentReports = new JSONObject(prefs.getString("sentExceptionReports", "{}"));
-            String hash = getExceptionHash(e);
-            if (sentReports.has(hash)) {
-                Timber.i("The exception report with hash %s has already been sent from this device", hash);
-                return;
-            } else {
-                sentReports.put(hash, true);
-                prefs.edit().putString("sentExceptionReports", sentReports.toString()).apply();
-            }
-        } catch (JSONException e1) {
-            Timber.i(e1, "Could not get cache of sent exception reports");
-        }
         ACRA.getErrorReporter().putCustomData("origin", origin);
         ACRA.getErrorReporter().putCustomData("additionalInfo", additionalInfo);
         ACRA.getErrorReporter().handleException(e);
     }
 
-    private static String getExceptionHash(Throwable th) {
-        final StringBuilder res = new StringBuilder();
-        Throwable cause = th;
-        while (cause != null) {
-            final StackTraceElement[] stackTraceElements = cause.getStackTrace();
-            for (final StackTraceElement e : stackTraceElements) {
-                res.append(e.getClassName());
-                res.append(e.getMethodName());
-            }
-            cause = cause.getCause();
-        }
-        return Integer.toHexString(res.toString().hashCode());
+
+    /**
+     * If you want to make sure that the next exception of any time is posted, you need to clear limiter data
+     *
+     * There is an enhancement request in ACRA to do this via API, until then they blessed deleting file directly
+     * @param context
+     */
+    public static void deleteACRALimiterData(Context context) {
+        context.getFileStreamPath("ACRA-limiter.json").delete();
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -34,10 +34,16 @@ import com.ichi2.compat.CompatHelper;
 import com.ichi2.utils.LanguageUtil;
 
 import org.acra.ACRA;
-import org.acra.ACRAConfigurationException;
 import org.acra.ReportField;
-import org.acra.ReportingInteractionMode;
-import org.acra.annotation.ReportsCrashes;
+import org.acra.annotation.AcraCore;
+import org.acra.annotation.AcraDialog;
+import org.acra.annotation.AcraHttpSender;
+import org.acra.annotation.AcraLimiter;
+import org.acra.annotation.AcraToast;
+import org.acra.config.ACRAConfigurationException;
+import org.acra.config.CoreConfigurationBuilder;
+import org.acra.config.DialogConfigurationBuilder;
+import org.acra.config.ToastConfigurationBuilder;
 import org.acra.sender.HttpSender;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -51,20 +57,10 @@ import timber.log.Timber;
 /**
  * Application class.
  */
-@ReportsCrashes(
-        reportDialogClass = AnkiDroidCrashReportDialog.class,
-        httpMethod = HttpSender.Method.PUT,
-        reportType = HttpSender.Type.JSON,
-        formUri = "https://ankidroid.org/acra/report",
-        mode = ReportingInteractionMode.DIALOG,
-        resDialogCommentPrompt =  R.string.empty_string,
-        resDialogTitle =  R.string.feedback_title,
-        resDialogText =  R.string.feedback_default_text,
-        resToastText = R.string.feedback_auto_toast_text,
-        resDialogPositiveButtonText = R.string.feedback_report,
-        additionalSharedPreferences = {"com.ichi2.anki"},
+@AcraCore(
+        buildConfigClass = org.acra.dialog.BuildConfig.class,
         excludeMatchingSharedPreferencesKeys = {"username","hkey"},
-        customReportContent = {
+        reportContent = {
             ReportField.REPORT_ID,
             ReportField.APP_VERSION_CODE,
             ReportField.APP_VERSION_NAME,
@@ -101,16 +97,37 @@ import timber.log.Timber;
             //ReportField.SETTINGS_SECURE,
             //ReportField.SETTINGS_GLOBAL,
             ReportField.SHARED_PREFERENCES,
-            ReportField.APPLICATION_LOG,
+            //ReportField.APPLICATION_LOG,
             ReportField.MEDIA_CODEC_LIST,
             ReportField.THREAD_DETAILS
             //ReportField.USER_IP
         },
         logcatArguments = { "-t", "100", "-v", "time", "ActivityManager:I", "SQLiteLog:W", AnkiDroidApp.TAG + ":D", "*:S" }
 )
+@AcraDialog(
+        reportDialogClass = AnkiDroidCrashReportDialog.class,
+        resCommentPrompt =  R.string.empty_string,
+        resTitle =  R.string.feedback_title,
+        resText =  R.string.feedback_default_text,
+        resPositiveButtonText = R.string.feedback_report
+)
+@AcraHttpSender(
+        httpMethod = HttpSender.Method.PUT,
+        uri = BuildConfig.ACRA_URL
+)
+@AcraToast(
+        resText = R.string.feedback_auto_toast_text
+)
+@AcraLimiter(
+        exceptionClassLimit = 1000,
+        stacktraceLimit = 1
+)
 public class AnkiDroidApp extends Application {
 
     public static final String XML_CUSTOM_NAMESPACE = "http://arbitrary.app.namespace/com.ichi2.anki";
+
+    // ACRA constants used for stored preferences
+    public static final String FEEDBACK_REPORT_KEY = "reportErrorMode";
     public static final String FEEDBACK_REPORT_ASK = "2";
     public static final String FEEDBACK_REPORT_NEVER = "1";
     public static final String FEEDBACK_REPORT_ALWAYS = "0";
@@ -138,6 +155,28 @@ public class AnkiDroidApp extends Application {
      */
     public static final int CHECK_PREFERENCES_AT_VERSION = 20500225;
 
+    /** Our ACRA configurations, initialized during onCreate() */
+    private CoreConfigurationBuilder acraCoreConfigBuilder;
+
+
+    /**
+     * Get the ACRA ConfigurationBuilder - use this followed by setting it to modify the config
+     * @return ConfigurationBuilder for the current ACRA config
+     */
+    public CoreConfigurationBuilder getAcraCoreConfigBuilder() {
+        return acraCoreConfigBuilder;
+    }
+
+
+    /**
+     * Set the ACRA ConfigurationBuilder and <b>re-initialize the ACRA system</b> with the contents
+     * @param acraCoreConfigBuilder the full ACRA config to initialize ACRA with
+     */
+    private void setAcraConfigBuilder(CoreConfigurationBuilder acraCoreConfigBuilder) {
+        this.acraCoreConfigBuilder = acraCoreConfigBuilder;
+        ACRA.init(this, acraCoreConfigBuilder);
+    }
+
 
     /**
      * On application creation.
@@ -148,27 +187,18 @@ public class AnkiDroidApp extends Application {
         // Get preferences
         SharedPreferences preferences = getSharedPrefs(this);
 
-        // Initialize crash reporting module
-        ACRA.init(this);
-
         // Setup logging and crash reporting
+        acraCoreConfigBuilder = new CoreConfigurationBuilder(this);
         if (BuildConfig.DEBUG) {
             // Enable verbose error logging and do method tracing to put the Class name as log tag
             Timber.plant(new Timber.DebugTree());
-            // Disable crash reporting
-            setAcraReportingMode(FEEDBACK_REPORT_NEVER);
-            preferences.edit().putString("reportErrorMode", FEEDBACK_REPORT_NEVER).commit();
-            // Use a wider logcat filter incase crash reporting manually re-enabled
-            String [] logcatArgs = { "-t", "300", "-v", "long", "ACRA:S"};
-            ACRA.getConfig().setLogcatArguments(logcatArgs);
+            setDebugACRAConfig(preferences);
         } else {
             // Disable verbose error logging and use fixed log tag "AnkiDroid"
             Timber.plant(new ProductionCrashReportingTree());
-            // Enable or disable crash reporting based on user setting
-            setAcraReportingMode(preferences.getString("reportErrorMode", FEEDBACK_REPORT_ASK));
+            setProductionACRAConfig(preferences);
         }
         Timber.tag(TAG);
-
 
         sInstance = this;
         setLanguage(preferences.getString(Preferences.LANGUAGE, ""));
@@ -313,30 +343,57 @@ public class AnkiDroidApp extends Application {
 
 
     /**
-     * Set the reporting mode for ACRA based on the value of the reportErrorMode preference
-     * @param value value of reportErrorMode preference
+     * Turns ACRA reporting off completely and persists it to shared prefs
+     * But expands logcat search in case developer manually re-enables it
+     *
+     * @param prefs SharedPreferences object the reporting state is persisted in
+     */
+    private void setDebugACRAConfig(SharedPreferences prefs) {
+        // Disable crash reporting
+        setAcraReportingMode(FEEDBACK_REPORT_NEVER);
+        prefs.edit().putString(FEEDBACK_REPORT_KEY, FEEDBACK_REPORT_NEVER).apply();
+        // Use a wider logcat filter in case crash reporting manually re-enabled
+        String [] logcatArgs = { "-t", "300", "-v", "long", "ACRA:S"};
+        setAcraConfigBuilder(getAcraCoreConfigBuilder().setLogcatArguments(logcatArgs));
+    }
+
+
+    /**
+     * Puts ACRA Reporting mode into user-specified mode, with default of "ask first"
+     *
+     * @param prefs SharedPreferences object the reporting state is persisted in
+     */
+    private void setProductionACRAConfig(SharedPreferences prefs) {
+        // Enable or disable crash reporting based on user setting
+        setAcraReportingMode(prefs.getString(FEEDBACK_REPORT_KEY, FEEDBACK_REPORT_ASK));
+    }
+
+
+    /**
+     * Set the reporting mode for ACRA based on the value of the FEEDBACK_REPORT_KEY preference
+     * @param value value of FEEDBACK_REPORT_KEY preference
      */
     public void setAcraReportingMode(String value) {
-        SharedPreferences.Editor editor = ACRA.getACRASharedPreferences().edit();
+        SharedPreferences.Editor editor = getSharedPrefs(this).edit();
         // Set the ACRA disable value
         if (value.equals(FEEDBACK_REPORT_NEVER)) {
-            editor.putBoolean("acra.disable", true);
+            editor.putBoolean(ACRA.PREF_DISABLE_ACRA, true);
         } else {
-            editor.putBoolean("acra.disable", false);
+            editor.putBoolean(ACRA.PREF_DISABLE_ACRA, false);
             // Switch between auto-report via toast and manual report via dialog
-            try {
-                if (value.equals(FEEDBACK_REPORT_ALWAYS)) {
-                    ACRA.getConfig().setMode(ReportingInteractionMode.TOAST);
-                    ACRA.getConfig().setResToastText(R.string.feedback_auto_toast_text);
-                } else if (value.equals(FEEDBACK_REPORT_ASK)) {
-                    ACRA.getConfig().setMode(ReportingInteractionMode.DIALOG);
-                    ACRA.getConfig().setResToastText(R.string.feedback_manual_toast_text);
-                }
-            } catch (ACRAConfigurationException e) {
-                Timber.e("Could not set ACRA report mode");
+            CoreConfigurationBuilder builder = getAcraCoreConfigBuilder();
+            if (value.equals(FEEDBACK_REPORT_ALWAYS)) {
+                // Toast text defaults to always, we just need to disable the dialog
+                builder.getPluginConfigurationBuilder(DialogConfigurationBuilder.class)
+                        .setEnabled(false);
+            } else if (value.equals(FEEDBACK_REPORT_ASK)) {
+                // Both are enabled via annotation, just need to alter toast text
+                builder.getPluginConfigurationBuilder(ToastConfigurationBuilder.class)
+                        .setResText(R.string.feedback_manual_toast_text);
             }
+            setAcraConfigBuilder(builder);
         }
-        editor.commit();
+        editor.apply();
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -896,7 +896,10 @@ public class DeckPicker extends NavigationDrawerActivity implements
                 }
             }
             preferences.edit().putInt("lastUpgradeVersion", current).commit();
-            preferences.edit().remove("sentExceptionReports").commit();     // clear cache of sent exception reports
+
+            // New version, clear out old exception report limits
+            AnkiDroidApp.deleteACRALimiterData(this);
+
             // Delete the media database made by any version before 2.3 beta due to upgrade errors.
             // It is rebuilt on the next sync or media check
             if (previous < 20300200) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -536,7 +536,8 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                 case AnkiDroidApp.FEEDBACK_REPORT_KEY: {
                     String value = prefs.getString(AnkiDroidApp.FEEDBACK_REPORT_KEY, "");
                     AnkiDroidApp.getInstance().setAcraReportingMode(value);
-                    AnkiDroidApp.getSharedPrefs(this).edit().remove("sentExceptionReports").apply();    // clear cache
+                    // If the user changed error reporting, make sure future reports have a chance to pose
+                    AnkiDroidApp.deleteACRALimiterData(this);
                     break;
                 }
                 case "syncAccount": {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -533,8 +533,8 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                     }
                     break;
                 }
-                case "reportErrorMode": {
-                    String value = prefs.getString("reportErrorMode", "");
+                case AnkiDroidApp.FEEDBACK_REPORT_KEY: {
+                    String value = prefs.getString(AnkiDroidApp.FEEDBACK_REPORT_KEY, "");
                     AnkiDroidApp.getInstance().setAcraReportingMode(value);
                     AnkiDroidApp.getSharedPrefs(this).edit().remove("sentExceptionReports").apply();    // clear cache
                     break;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/AnkiDroidCrashReportDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/AnkiDroidCrashReportDialog.java
@@ -28,8 +28,13 @@ import android.widget.EditText;
 import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.R;
 
-import org.acra.ACRA;
-import org.acra.BaseCrashReportDialog;
+import org.acra.config.ACRAConfigurationException;
+import org.acra.config.CoreConfigurationBuilder;
+import org.acra.config.DialogConfiguration;
+import org.acra.config.DialogConfigurationBuilder;
+import org.acra.dialog.BaseCrashReportDialog;
+
+import timber.log.Timber;
 
 public class AnkiDroidCrashReportDialog extends BaseCrashReportDialog implements DialogInterface.OnClickListener, DialogInterface.OnDismissListener {
     private static final String STATE_COMMENT = "comment";
@@ -39,21 +44,23 @@ public class AnkiDroidCrashReportDialog extends BaseCrashReportDialog implements
     AlertDialog mDialog;
 
     @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
+    protected void init(Bundle savedInstanceState) {
+        super.init(savedInstanceState);
 
         AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(this);
-        int resourceId = ACRA.getConfig().resDialogTitle();
-        if(resourceId != 0) {
-            dialogBuilder.setTitle(resourceId);
+
+        try {
+            CoreConfigurationBuilder builder = AnkiDroidApp.getInstance().getAcraCoreConfigBuilder();
+            DialogConfiguration dialogConfig =
+                    (DialogConfiguration)builder.getPluginConfigurationBuilder((DialogConfigurationBuilder.class)).build();
+
+            dialogBuilder.setPositiveButton(dialogConfig.resPositiveButtonText(), AnkiDroidCrashReportDialog.this);
+            dialogBuilder.setNegativeButton(dialogConfig.resNegativeButtonText(), AnkiDroidCrashReportDialog.this);
         }
-        resourceId = ACRA.getConfig().resDialogIcon();
-        if(resourceId != 0) {
-            dialogBuilder.setIcon(resourceId);
+        catch (ACRAConfigurationException ace) {
+            Timber.e(ace, "Unable to initialize ACRA while creating ACRA dialog?");
         }
         dialogBuilder.setView(buildCustomView(savedInstanceState));
-        dialogBuilder.setPositiveButton(getText(ACRA.getConfig().resDialogPositiveButtonText()), AnkiDroidCrashReportDialog.this);
-        dialogBuilder.setNegativeButton(getText(ACRA.getConfig().resDialogNegativeButtonText()), AnkiDroidCrashReportDialog.this);
 
         mDialog = dialogBuilder.create();
         mDialog.setCanceledOnTouchOutside(false);
@@ -92,7 +99,7 @@ public class AnkiDroidCrashReportDialog extends BaseCrashReportDialog implements
             preferences.edit().putBoolean("autoreportCheckboxValue", autoReport).commit();
             // Set the autoreport value to true if ticked
             if (autoReport) {
-                preferences.edit().putString("reportErrorMode", AnkiDroidApp.FEEDBACK_REPORT_ALWAYS).commit();
+                preferences.edit().putString(AnkiDroidApp.FEEDBACK_REPORT_KEY, AnkiDroidApp.FEEDBACK_REPORT_ALWAYS).commit();
                 AnkiDroidApp.getInstance().setAcraReportingMode(AnkiDroidApp.FEEDBACK_REPORT_ALWAYS);
             }
             // Send the crash report

--- a/build.gradle
+++ b/build.gradle
@@ -2,10 +2,11 @@
 
 buildscript {
     repositories {
+        google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.2.0'
         classpath 'com.github.triplet.gradle:play-publisher:1.1.5'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -14,6 +15,7 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         jcenter()
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip


### PR DESCRIPTION
## Pull Request template

Please, go through these checks before you submit a PR.

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code

## Purpose / Description
The ACRA report database is very difficult to get signal out of because of repeated exceptions as repeated exceptions clutter it up

## Fixes
Fixes #4949 on API<15 devices for long term support

## Approach
This limits the same exception to being sent once from each device per 7 day period (we could increase that if it is still too noisy)

## How Has This Been Tested?
I pulled the hotfix-2.8.5 branch, cherry-picked the ACRA upgrade commit #4893 - downgraded that to 5.0.2 (last ACRA upgrade that worked for API<9, and we were API<10 in the 2.8 branch), then added the Limiter configuration

I booted that up in an API15 emulator and used the known crash bug of turning off all background processes and killing activities immediately while you edit card templates, and checked the debug database - got one report even though I did it a few times: https://918f7f55-f238-436c-b34f-c8b5f1331fe5-bluemix.cloudant.com/acralyzer/_design/acralyzer/index.html#/report-details/ankidroid/a8ba91f9-29e9-485e-8131-d1b4535c1ae8

I can also see the expected contents in /data/data/com.ichi2.anki/files/ACRA-limiter.json

The ACRA upgrade has worked well since implementation (also verified via production Acralyzer) so I'm comfortable with this even though it is core functionality. Should improve long-term support enough to maybe be worth it

## Learning (optional, can help others)
I looked through the ACRA commits to find the last version that supported our versions in 2.8 and luckily it included all the ACRA forward-porting work I did except a couple tiny bits about text resources. It also included the Limiter.