### PR TITLE
Isolate support from test / remove test deprecation+lint / emulator fleet mgmt

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -130,8 +130,14 @@ dependencies {
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
     testImplementation 'net.lachlanmckee:timber-junit-rule:1.0.1'
 
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test:rules:1.0.2'
+    androidTestImplementation('com.android.support.test.espresso:espresso-core:3.0.2') {
+        exclude group: 'com.android.support', module: 'support-annotations'
+    }
+    androidTestImplementation('com.android.support.test:runner:1.0.2') {
+        exclude group: 'com.android.support', module: 'support-annotations'
+    }
+    androidTestImplementation('com.android.support.test:rules:1.0.2') {
+        exclude group: 'com.android.support', module: 'support-annotations'
+    }
     androidTestUtil 'com.android.support.test:orchestrator:1.0.2'
 }

--- a/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/CollectionTest.java
+++ b/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/CollectionTest.java
@@ -11,8 +11,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.io.IOException;
-
 import static org.junit.Assert.assertNotNull;
 
 /**
@@ -26,7 +24,7 @@ public class CollectionTest {
             GrantPermissionRule.grant(Manifest.permission.WRITE_EXTERNAL_STORAGE);
 
     @Test
-    public void testOpenCollection() throws IOException {
+    public void testOpenCollection() {
         assertNotNull("Collection could not be opened",
                 CollectionHelper.getInstance().getCol(InstrumentationRegistry.getTargetContext()));
     }

--- a/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/ContentProviderTest.java
+++ b/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/ContentProviderTest.java
@@ -28,7 +28,6 @@ import android.net.Uri;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.rule.GrantPermissionRule;
 import android.support.test.runner.AndroidJUnit4;
-import android.test.AndroidTestCase;
 import android.util.Log;
 
 import com.ichi2.anki.AbstractFlashcardViewer;

--- a/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/Shared.java
+++ b/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/Shared.java
@@ -17,17 +17,17 @@
 package com.ichi2.anki.tests;
 
 import android.content.Context;
-import android.content.res.AssetManager;
 import android.text.TextUtils;
 
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Storage;
 import com.ichi2.libanki.Utils;
-import com.ichi2.libanki.hooks.Hooks;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+
+import static org.junit.Assert.assertTrue;
 
 /**
  * Shared methods for unit tests.
@@ -39,7 +39,7 @@ public class Shared {
         // Provide a string instead of an actual File. Storage.Collection won't populate the DB
         // if the file already exists (it assumes it's an existing DB).
         String path = f.getAbsolutePath();
-        f.delete();
+        assertTrue(f.delete());
         return Storage.Collection(context, path);
     }
 
@@ -59,14 +59,16 @@ public class Shared {
      * @param name An additional suffix to ensure the test directory is only used by a particular resource.
      * @return See getTestDir.
      */
-    public static File getTestDir(Context context, String name) {
+    private static File getTestDir(Context context, String name) {
         if (!TextUtils.isEmpty(name)) {
             name = "-" + name;
         }
         File dir = new File(context.getCacheDir(), "testfiles" + name);
-        dir.mkdir();
+        if (!dir.exists()) {
+            assertTrue(dir.mkdir());
+        }
         for (File f : dir.listFiles()) {
-            f.delete();
+            assertTrue(f.delete());
         }
         return dir;
     }

--- a/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/libanki/ImportTest.java
+++ b/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/libanki/ImportTest.java
@@ -20,21 +20,16 @@ import android.Manifest;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.rule.GrantPermissionRule;
 import android.support.test.runner.AndroidJUnit4;
-import android.test.suitebuilder.annotation.Suppress;
 
-import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.anki.tests.Shared;
 import com.ichi2.libanki.Collection;
-import com.ichi2.libanki.Models;
 import com.ichi2.libanki.Note;
 import com.ichi2.libanki.Utils;
 import com.ichi2.libanki.importer.Anki2Importer;
 import com.ichi2.libanki.importer.AnkiPackageImporter;
 import com.ichi2.libanki.importer.Importer;
-import com.ichi2.libanki.importer.TextImporter;
 
 import org.json.JSONException;
-import org.json.JSONObject;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -43,6 +38,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -90,7 +86,7 @@ public class ImportTest {
         Collection empty = Shared.getEmptyCol(InstrumentationRegistry.getTargetContext());
         Importer imp = new Anki2Importer(empty, tmp.getPath());
         imp.run();
-        expected = Arrays.asList("foo.mp3");
+        expected = Collections.singletonList("foo.mp3");
         actual = Arrays.asList(new File(empty.getMedia().dir()).list());
         actual.retainAll(expected);
         assertEquals(expected.size(), actual.size());
@@ -98,7 +94,7 @@ public class ImportTest {
         empty.remCards(Utils.arrayList2array(empty.getDb().queryColumn(Long.class, "select id from cards", 0)));
         imp = new Anki2Importer(empty, tmp.getPath());
         imp.run();
-        expected = Arrays.asList("foo.mp3");
+        expected = Collections.singletonList("foo.mp3");
         actual = Arrays.asList(new File(empty.getMedia().dir()).list());
         actual.retainAll(expected);
         assertEquals(expected.size(), actual.size());
@@ -140,12 +136,12 @@ public class ImportTest {
         Collection tmp = Shared.getEmptyCol(InstrumentationRegistry.getTargetContext());
         String apkg = Shared.getTestFilePath(InstrumentationRegistry.getTargetContext(), "media.apkg");
         Importer imp = new AnkiPackageImporter(tmp, apkg);
-        expected = Arrays.asList();
+        expected = Collections.emptyList();
         actual = Arrays.asList(new File(tmp.getMedia().dir()).list());
         actual.retainAll(expected);
         assertEquals(actual.size(), expected.size());
         imp.run();
-        expected = Arrays.asList("foo.wav");
+        expected = Collections.singletonList("foo.wav");
         actual = Arrays.asList(new File(tmp.getMedia().dir()).list());
         actual.retainAll(expected);
         assertEquals(expected.size(), actual.size());
@@ -153,7 +149,7 @@ public class ImportTest {
         tmp.remCards(Utils.arrayList2array(tmp.getDb().queryColumn(Long.class, "select id from cards", 0)));
         imp = new AnkiPackageImporter(tmp, apkg);
         imp.run();
-        expected = Arrays.asList("foo.wav");
+        expected = Collections.singletonList("foo.wav");
         actual = Arrays.asList(new File(tmp.getMedia().dir()).list());
         actual.retainAll(expected);
         assertEquals(actual.size(), expected.size());
@@ -254,67 +250,67 @@ public class ImportTest {
     }
 
     // Exchange @Suppress for @Test when csv importer is implemented
-    @Suppress
-    public void testCsv() throws IOException {
-        Collection deck = Shared.getEmptyCol(InstrumentationRegistry.getTargetContext());
-        String file = Shared.getTestFilePath(InstrumentationRegistry.getTargetContext(), "text-2fields.txt");
-        TextImporter i = new TextImporter(deck, file);
-        i.initMapping();
-        i.run();
-        // four problems - too many & too few fields, a missing front, and a
-        // duplicate entry
-        assertTrue(i.getLog().size() == 5);
-        assertTrue(i.getTotal() == 5);
-        // if we run the import again, it should update instead
-        i.run();
-        assertTrue(i.getLog().size() == 10);
-        assertTrue(i.getTotal() == 5);
-        // but importing should not clobber tags if they're unmapped
-        Note n = deck.getNote(deck.getDb().queryLongScalar("select id from notes"));
-        n.addTag("test");
-        n.flush();
-        i.run();
-        n.load();
-        assertTrue((n.getTags().size() == 1) && (n.getTags().get(0) == "test"));
-        // if add-only mode, count will be 0
-        i.setImportMode(1);
-        i.run();
-        assertTrue(i.getTotal() == 0);
-        // and if dupes mode, will reimport everything
-        assertTrue(deck.cardCount() == 5);
-        i.setImportMode(2);
-        i.run();
-        // includes repeated field
-        assertTrue(i.getTotal() == 6);
-        assertTrue(deck.cardCount() == 11);
-        deck.close();
-    }
-
-    // Exchange @Suppress for @Test when csv importer is implemented
-    @Suppress
-    public void testCsv2() throws  IOException, ConfirmModSchemaException {
-        Collection deck = Shared.getEmptyCol(InstrumentationRegistry.getTargetContext());
-        Models mm = deck.getModels();
-        JSONObject m = mm.current();
-        JSONObject f = mm.newField("Three");
-        mm.addField(m, f);
-        mm.save(m);
-        Note n = deck.newNote();
-        n.setItem("Front", "1");
-        n.setItem("Back", "2");
-        n.setItem("Three", "3");
-        deck.addNote(n);
-        // an update with unmapped fields should not clobber those fields
-        String file = Shared.getTestFilePath(InstrumentationRegistry.getTargetContext(), "text-update.txt");
-        TextImporter i = new TextImporter(deck, file);
-        i.initMapping();
-        i.run();
-        n.load();
-        assertTrue(n.getItem("Front").equals("1"));
-        assertTrue(n.getItem("Back").equals("x"));
-        assertTrue(n.getItem("Three").equals("3"));
-        deck.close();
-    }
+//    @Suppress
+//    public void testCsv() throws IOException {
+//        Collection deck = Shared.getEmptyCol(InstrumentationRegistry.getTargetContext());
+//        String file = Shared.getTestFilePath(InstrumentationRegistry.getTargetContext(), "text-2fields.txt");
+//        TextImporter i = new TextImporter(deck, file);
+//        i.initMapping();
+//        i.run();
+//        // four problems - too many & too few fields, a missing front, and a
+//        // duplicate entry
+//        assertTrue(i.getLog().size() == 5);
+//        assertTrue(i.getTotal() == 5);
+//        // if we run the import again, it should update instead
+//        i.run();
+//        assertTrue(i.getLog().size() == 10);
+//        assertTrue(i.getTotal() == 5);
+//        // but importing should not clobber tags if they're unmapped
+//        Note n = deck.getNote(deck.getDb().queryLongScalar("select id from notes"));
+//        n.addTag("test");
+//        n.flush();
+//        i.run();
+//        n.load();
+//        assertTrue((n.getTags().size() == 1) && (n.getTags().get(0) == "test"));
+//        // if add-only mode, count will be 0
+//        i.setImportMode(1);
+//        i.run();
+//        assertTrue(i.getTotal() == 0);
+//        // and if dupes mode, will reimport everything
+//        assertTrue(deck.cardCount() == 5);
+//        i.setImportMode(2);
+//        i.run();
+//        // includes repeated field
+//        assertTrue(i.getTotal() == 6);
+//        assertTrue(deck.cardCount() == 11);
+//        deck.close();
+//    }
+//
+//    // Exchange @Suppress for @Test when csv importer is implemented
+//    @Suppress
+//    public void testCsv2() throws  IOException, ConfirmModSchemaException {
+//        Collection deck = Shared.getEmptyCol(InstrumentationRegistry.getTargetContext());
+//        Models mm = deck.getModels();
+//        JSONObject m = mm.current();
+//        JSONObject f = mm.newField("Three");
+//        mm.addField(m, f);
+//        mm.save(m);
+//        Note n = deck.newNote();
+//        n.setItem("Front", "1");
+//        n.setItem("Back", "2");
+//        n.setItem("Three", "3");
+//        deck.addNote(n);
+//        // an update with unmapped fields should not clobber those fields
+//        String file = Shared.getTestFilePath(InstrumentationRegistry.getTargetContext(), "text-update.txt");
+//        TextImporter i = new TextImporter(deck, file);
+//        i.initMapping();
+//        i.run();
+//        n.load();
+//        assertTrue(n.getItem("Front").equals("1"));
+//        assertTrue(n.getItem("Back").equals("x"));
+//        assertTrue(n.getItem("Three").equals("3"));
+//        deck.close();
+//    }
 
     /**
      * Custom tests for AnkiDroid.

--- a/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/libanki/MediaTest.java
+++ b/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/libanki/MediaTest.java
@@ -19,7 +19,6 @@ import android.Manifest;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.rule.GrantPermissionRule;
 import android.support.test.runner.AndroidJUnit4;
-import android.test.suitebuilder.annotation.Suppress;
 
 import com.ichi2.anki.BackupManager;
 import com.ichi2.anki.tests.Shared;
@@ -35,6 +34,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -58,7 +58,7 @@ public class MediaTest {
         Collection d = Shared.getEmptyCol(InstrumentationRegistry.getTargetContext());
         File dir = Shared.getTestDir(InstrumentationRegistry.getTargetContext());
         BackupManager.removeDir(dir);
-        dir.mkdirs();
+        assertTrue(dir.mkdirs());
         File path = new File(dir, "foo.jpg");
         FileOutputStream os;
         os = new FileOutputStream(path, false);
@@ -84,12 +84,12 @@ public class MediaTest {
         List<String> expected;
         List<String> actual;
 
-        expected = Arrays.asList();
+        expected = Collections.emptyList();
         actual = d.getMedia().filesInStr(mid, "aoeu");
         actual.retainAll(expected);
         assertEquals(expected.size(), actual.size());
 
-        expected = Arrays.asList("foo.jpg");
+        expected = Collections.singletonList("foo.jpg");
         actual = d.getMedia().filesInStr(mid, "aoeu<img src='foo.jpg'>ao");
         actual.retainAll(expected);
         assertEquals(expected.size(), actual.size());
@@ -99,7 +99,7 @@ public class MediaTest {
         actual.retainAll(expected);
         assertEquals(expected.size(), actual.size());
 
-        expected = Arrays.asList("foo.jpg");
+        expected = Collections.singletonList("foo.jpg");
         actual = d.getMedia().filesInStr(mid, "aoeu<img src=foo.jpg style=bar>ao");
         actual.retainAll(expected);
         assertEquals(expected.size(), actual.size());
@@ -109,7 +109,7 @@ public class MediaTest {
         actual.retainAll(expected);
         assertEquals(expected.size(), actual.size());
 
-        expected = Arrays.asList("foo.jpg");
+        expected = Collections.singletonList("foo.jpg");
         actual = d.getMedia().filesInStr(mid, "aoeu<img src=\"foo.jpg\">ao");
         actual.retainAll(expected);
         assertEquals(expected.size(), actual.size());
@@ -119,7 +119,7 @@ public class MediaTest {
         actual.retainAll(expected);
         assertEquals(expected.size(), actual.size());
 
-        expected = Arrays.asList("foo.mp3");
+        expected = Collections.singletonList("foo.mp3");
         actual = d.getMedia().filesInStr(mid, "aou[sound:foo.mp3]aou");
         actual.retainAll(expected);
         assertEquals(expected.size(), actual.size());
@@ -139,7 +139,7 @@ public class MediaTest {
         d.getMedia().dir();
         // Put a file into it
         File file = new File(Shared.getTestDir(InstrumentationRegistry.getTargetContext()), "fake.png");
-        file.createNewFile();
+        assertTrue(file.createNewFile());
         d.getMedia().addFile(file);
         // add a note which references it
         Note f = d.newNote();
@@ -160,23 +160,20 @@ public class MediaTest {
         List<List<String>> ret = d.getMedia().check();
         List<String> expected;
         List<String> actual;
-        expected = Arrays.asList("fake2.png");
+        expected = Collections.singletonList("fake2.png");
         actual = ret.get(0);
         actual.retainAll(expected);
         assertEquals(expected.size(), actual.size());
-        expected = Arrays.asList("foo.jpg");
+        expected = Collections.singletonList("foo.jpg");
         actual = ret.get(1);
         actual.retainAll(expected);
         assertEquals(expected.size(), actual.size());
     }
 
-
-    @Suppress
     private List<String> added(Collection d) {
         return d.getMedia().getDb().queryColumn(String.class, "select fname from media where csum is not null", 0);
     }
 
-    @Suppress
     private List<String> removed(Collection d) {
         return d.getMedia().getDb().queryColumn(String.class, "select fname from media where csum is null", 0);
     }
@@ -214,7 +211,7 @@ public class MediaTest {
         assertTrue(added(d).size() == 2);
         assertTrue(removed(d).size() == 0);
         // deletions should get noticed too
-        path.delete();
+        assertTrue(path.delete());
         d.getMedia().findChanges(true);
         assertTrue(added(d).size() == 1);
         assertTrue(removed(d).size() == 1);

--- a/tools/quality-check/codacy-ankidroid.sh
+++ b/tools/quality-check/codacy-ankidroid.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# This script can help you see how you stand vs Codacy review BEFORE you issue a Pull Request
+#
+# You need to install Docker first
+# You need to install 'codacy-analysis-cli' second
+#
+# You should run this against master frequently to generate a base for comparison
+# Then pre-checkin you run this against your branch and diff your branch vs master
+
+SOURCE_BASE=/home/$USER/work/AnkiDroid
+SOURCE=$SOURCE_BASE/Anki-Android
+TIMESTAMP=`date +"%Y%m%d-%H%M%S"`
+TOKEN=<SECRET TOKEN, YOU NEED TO REQUEST THIS TOKEN FROM TIM OR MIKE>
+
+if [ "$1" == "" ]; then
+  OUTPUT=$SOURCE_BASE/reports/codacy/codacy-report-$TIMESTAMP.txt
+  echo "no suffix specified - output to $OUTPUT"
+else
+  OUTPUT=$SOURCE_BASE/reports/codacy/codacy-report-$1.txt
+  echo "suffix specifed - output to $OUTPUT"
+fi
+
+codacy-analysis-cli analyse --directory $SOURCE --project-token $TOKEN -p 6 -f text -o $SOURCE/build/reports/codacy-report.txt
+
+mkdir -p $SOURCE_BASE/reports/codacy/
+cat $SOURCE/build/reports/codacy-report.txt | sort > $OUTPUT

--- a/tools/quality-check/old_emulator.sh
+++ b/tools/quality-check/old_emulator.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+#
+# This makes sure that the sdcard mounts for old emulators, API15-17
+# You have to run it once with the non-classic engine after creation though
+
+# We must be in the right directory
+~/Android/Sdk/emulator/emulator @$1 -engine classic

--- a/tools/quality-check/start_all_emulators.sh
+++ b/tools/quality-check/start_all_emulators.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# This will start a fleet of android emulators that have been created using avdmanager or Android Studio
+#
+# You should follow the convention of naming them xxx_OLD for API15-17, and xxx_NEW for API18+
+# Name ARM emulators (if you have them) xxxARM and make sure Chomebook is in the Chromebook emulators name
+# as adb isn't available until you log in on Chromebooks
+#
+# Final note is that for the OLD emulators, you create them with avdmanager or Android Studio, then
+# you have to start them once the *new* way to initialize things, but the sdcard won't mount. Then you
+# start them the old way and everything works. If you get it wrong, either you won't have an sdcard, or
+# the emulator will fail to boot with "Failed to decrypt" or similar
+#
+# Note that if you have many emulators, you may need to increase your file handles or you'll run out
+# of file handles in your user session and enjoy very strange behavior (Chrome extensions crashing, 
+# terminals behaving strangely etc)
+
+
+for AVD in `emulator -list-avds`; do
+  echo -n Found $AVD...
+
+  #SDCARD="/tmp/$AVD-sdcard.img"
+  NORMAL_ARGS="-no-snapshot -no-boot-anim " #-sdcard $SDCARD"
+  EXTRA_ARGS=""
+
+  case "$AVD" in
+    #*21*)
+    #  echo "API 21 is problematic, skipping for now..."
+    #  continue
+    #  ;;
+    #*15*)
+    #  echo "API 15 is problematic, skipping for now..."
+    #  continue
+    #  ;;
+    *OLD*)
+      # Name your emulators with an "OLD" tag for API <=17 or sdcard doesn't auto-mount
+      echo "$AVD is old, using workaround..."
+      EXTRA_ARGS="$EXTRA_ARGS -engine classic"
+      ;;
+    *NEW*)
+      # Name your emulators with a "NEW" tag for API >17 
+      echo "$AVD is new, normal emulator..."
+      ;;
+    *ARM*)
+      # Don't use ARM emulators by default on x86 (so slow...)
+      echo "Skipping ARM emulator $AVD..."
+      continue
+      ;;
+    *Chromebook*)
+      # Don't use Chromebook emulators by default
+      echo "Skipping Chromebook emulator $AVD..."
+      continue
+      ;;
+  esac
+
+  #$ANDROID_SDK/tools/mksdcard -l sdcard 100M $SDCARD
+  $ANDROID_SDK/emulator/emulator $NORMAL_ARGS $EXTRA_ARGS @$AVD &
+  sleep 10
+done

--- a/tools/quality-check/stop_all_emulators.sh
+++ b/tools/quality-check/stop_all_emulators.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# This attempts to stop all your emulators (on Ubuntu 18.04.01 LTS at least...) nicely
+#
+# ...then if they don't stop it kills them
+
+killall -9 adb
+adb devices -l > /dev/null
+sleep 2
+adb devices -l > /dev/null
+sleep 2
+
+for EMU_ID in `adb devices -l | grep emulator | cut -d' ' -f1`; do
+  echo Stopping emulator $EMU_ID...
+  adb -s $EMU_ID emu kill
+done
+
+sleep 10
+for PID in `ps -eo pid,cmd,args |grep emulator|grep Android|grep -v bash|grep -v crash|grep -v grep|cut -d/ -f1`; do
+  echo "Stopping emulator with $PID..."
+  kill $PID
+done


### PR DESCRIPTION
## Pull Request template

Please, go through these checks before you submit a PR.

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code

## Purpose / Description
CI is currently failing because test dependencies are resolving to conflicting support libraries, this isolates the support library dependencies

This also fixes all AndroidStudio deprecation and lint on the test packages, and adds my local emulator fleet management scripts as well as my local codacy checker

## Fixes


## Approach
All the test tools are documents in the scripts, the gradle dep isolation is standard

## How Has This Been Tested?

I used emulators API15-28 to verify that jacocoTestReport runs (with no test class deprecation during compile or lint in AndroidStudio), with my emulator fleet tools (i.e., after running start_all_emulators.sh they are all up, then a single ./gradlew clean jacocoTestReport runs it on ALL of them at once, then stop_all_emulators.sh cleans up - you need a lot of RAM/CPU but it's actually fast and works)

## Learning (optional, can help others)
Getting emulators API15-17 to boot correctly is interesting - it's documented in the scripts
