### PR TITLE
Reduce APK size by filtering ABIs

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -13,6 +13,11 @@ android {
         testApplicationId "com.ichi2.anki.tests"
         vectorDrawables.useSupportLibrary = true
         testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
+
+        // filter out binaries to reduce APK size. Requery > 3.24.0 should allow removal of this
+        ndk {
+            abiFilters "armeabi-v7a", "arm64-v8a", "x86", "x86_64"
+        }
     }
     lintOptions {
         abortOnError false

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -18,6 +18,10 @@ android {
         ndk {
             abiFilters "armeabi-v7a", "arm64-v8a", "x86", "x86_64"
         }
+        // This enables long timeouts required on slow ARM emulators, e.g. Travis
+        adbOptions {
+            timeOutInMs 10 * 60 * 1000  // 10 minutes
+        }
     }
     lintOptions {
         abortOnError false


### PR DESCRIPTION
## Pull Request template

Please, go through these checks before you submit a PR.

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code

## Purpose / Description
I noticed that our APK size had ballooned in the latest alphas and I thought it might be my work. Turns out it was - the requery upgrade pulled in 3 more ABIs for their JNI library. Further investigation showed that we could remove not just those but 2 more ABIs that we'd had since we converted to requery, shrinking the APK from the 8.5MB or so 2.8.x had to maybe 7.3MB

## Fixes
Nothing logged, was just something I noticed and after being in the terrible-bandwidth jungles of Belize I'm sensitive to bandwidth needs

## Approach
I evaluated device support metrics from Google Play Console, and a highly-regarded article on trimming APK size, and came up with a trim of 3MB from current, and 1MB from previous stable:

proposed change, supported 9906 devices, 7.33MB
2.9alpha30 API15+ supported 9906 devices, 10.44MB
2.9alpha28 API15+ supported 9906 devices, 10.39MB ABIs mips, mips64, armeabi, armv8, armv7, x86, x86_64
2.9alpha20 API15+ supported 9906 devices, 8.36MB
2.9alpha14 API14+ supported 9906 devices, 8.22MB
2.9alpha13 API10+ supported 10219 devices, 8.24MB
2.8.4 API10+ supported 10219 devices, 8.18MB
2.8alpha6 API10+ supported 10219 devices, 7.99MB ABIs arm64-v8a, armeabi-v7a, x86, x86_64
2.7.3 API10+ supported 10364 devices, 5.66MB ABIs no native
2.6.1 API10+ supported 10364 devices, 5.55MB ABIs no native

In per-change form it was:
-  converting to requery with the 4 ABIs added 2.33MB and dropped 150 devices or so with armeabi (very old ABI!)
- going to API14+ dropped another 300 or so devices, no ABI changes
- upgrading requery and adding 3 ABIs added no devices, implying none were filtered prior but cost 2MB

That means filtering those 3 ABIs will drop support for no one.
Further, filtering the two higher-level ABIs (arm v8 and x86_64) still works everywhere as those fall back to the lower-level ABIs, and saves another 2MB

## How Has This Been Tested?

I ran this on all APIs as x86 or x86_64 where available, also on ARM v7 and v8 emulators, everything was fine.

My performance tests (and the CPU usage on the console) indicate we are not limited by CPU even on the large operations (huge deck imports), we are limited by memory, so I don't see a difference really between ARM v7 and ARM v8 or x86 / x86_64

## Learning (optional, can help others)

https://android.jlelse.eu/controlling-apk-size-when-using-native-libraries-45c6c0e5b70a