### PR TITLE
Check for null before calling View.removeAllViews()

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -921,7 +921,9 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
         }
         // WebView.destroy() should be called after the end of use
         // http://developer.android.com/reference/android/webkit/WebView.html#destroy()
-        mCardFrame.removeAllViews();
+        if (mCardFrame != null) {
+            mCardFrame.removeAllViews();
+        }
         destroyWebView(mCard);
     }
 


### PR DESCRIPTION
This is almost a one-liner, but I was testing split-window mode and when I left it apparently the WebView container was already gone when we tried to access it. Adding a null check is a trivial fix 

The stack has moved a little since this was from 2.8.4 on my main install on the phone

https://couchdb.ankidroid.org/acralyzer/_design/acralyzer/index.html#/report-details/c31f1217-5928-41b1-aa45-7f546d1da031

java.lang.NullPointerException: Attempt to invoke virtual method 'void android.view.ViewGroup.removeAllViews()' on a null object reference
at com.ichi2.anki.AbstractFlashcardViewer.onDestroy(AbstractFlashcardViewer.java:963)
at android.app.Activity.performDestroy(Activity.java:7259)
at android.app.Instrumentation.callActivityOnDestroy(Instrumentation.java:1266)
at android.app.ActivityThread.performDestroyActivity(ActivityThread.java:4542)
at android.app.ActivityThread.handleDestroyActivity(ActivityThread.java:4573)
at android.app.ActivityThread.-wrap5(Unknown Source:0)
at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1748)
at android.os.Handler.dispatchMessage(Handler.java:106)
at android.os.Looper.loop(Looper.java:164)
at android.app.ActivityThread.main(ActivityThread.java:6753)
at java.lang.reflect.Method.invoke(Native Method)
at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:482)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:807)