### PR TITLE
Junit point release

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -134,7 +134,7 @@ dependencies {
     implementation 'org.jsoup:jsoup:1.11.3'
     api project(":api")
 
-    testImplementation 'org.junit.vintage:junit-vintage-engine:5.3.0'
+    testImplementation 'org.junit.vintage:junit-vintage-engine:5.3.1'
     testImplementation 'org.mockito:mockito-core:2.21.0'
     testImplementation 'org.powermock:powermock-core:2.0.0-beta.5'
     testImplementation 'org.powermock:powermock-module-junit4:2.0.0-beta.5'

--- a/tools/quality-check/start_all_emulators.sh
+++ b/tools/quality-check/start_all_emulators.sh
@@ -15,6 +15,13 @@
 # of file handles in your user session and enjoy very strange behavior (Chrome extensions crashing, 
 # terminals behaving strangely etc)
 
+SLEEP=$1
+if [ "$SLEEP" == "" ];
+  then SLEEP=10
+else
+  SLEEP=0
+fi
+
 
 for AVD in `emulator -list-avds`; do
   echo -n Found $AVD...
@@ -55,5 +62,5 @@ for AVD in `emulator -list-avds`; do
 
   #$ANDROID_SDK/tools/mksdcard -l sdcard 100M $SDCARD
   $ANDROID_SDK/emulator/emulator $NORMAL_ARGS $EXTRA_ARGS @$AVD &
-  sleep 10
+  sleep $SLEEP
 done


### PR DESCRIPTION
Even if unimportant in the grand scheme, would be completely trivial if dependabot was integrated ;-)

Small change to emulator fleet startup script to make it possible to skip the timeout I inserted while using start/jacocoTestReport/stop in an automated loop. This makes it possible to start 10 emulators in about 10 seconds on my machine, very useful to confirm I haven't broken anything in the existing test suite