### PR TITLE
Fix widget crash from API26 forward port / Use correct context in getResources()

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/widget/AnkiDroidWidgetSmall.java
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/AnkiDroidWidgetSmall.java
@@ -153,14 +153,14 @@ public class AnkiDroidWidgetSmall extends AppWidgetProvider {
                         updateViews.setViewVisibility(R.id.ankidroid_widget_small_finish_layout, View.INVISIBLE);
                         updateViews.setViewVisibility(R.id.widget_due, View.VISIBLE);
                         updateViews.setTextViewText(R.id.widget_due, Integer.toString(dueCardsCount));
-                        updateViews.setContentDescription(R.id.widget_due, getResources().getQuantityString(R.plurals.widget_cards_due, dueCardsCount, dueCardsCount));
+                        updateViews.setContentDescription(R.id.widget_due, context.getResources().getQuantityString(R.plurals.widget_cards_due, dueCardsCount, dueCardsCount));
                     }
                     if (eta <= 0 || dueCardsCount <= 0) {
                         updateViews.setViewVisibility(R.id.widget_eta, View.INVISIBLE);
                     } else {
                         updateViews.setViewVisibility(R.id.widget_eta, View.VISIBLE);
                         updateViews.setTextViewText(R.id.widget_eta, Integer.toString(eta));
-                        updateViews.setContentDescription(R.id.widget_eta, getResources().getQuantityString(R.plurals.widget_eta, eta, eta));
+                        updateViews.setContentDescription(R.id.widget_eta, context.getResources().getQuantityString(R.plurals.widget_eta, eta, eta));
                     }
                 }
             }

--- a/AnkiDroid/src/main/java/com/ichi2/widget/WidgetStatus.java
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/WidgetStatus.java
@@ -47,6 +47,9 @@ public final class WidgetStatus {
 
     /**
      * Request the widget to update its status.
+     * TODO Mike - we can reduce battery usage by widget users by removing updatePeriodMillis from metadata
+     *             and replacing it with an alarm we set so device doesn't wake to update the widget, see:
+     *             https://developer.android.com/guide/topics/appwidgets/#MetaData
      */
     public static void update(Context context) {
         SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(context);


### PR DESCRIPTION
## Pull Request template

Please, go through these checks before you submit a PR.

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code

## Purpose / Description
In the API26 background service change I introduced an error where I was using the wrong context to get resources for localization, causing the widget to crash consistently

## Fixes
Fixes #4960 introduced by #4928

## Approach
Use the resources from the context passed into the call

## How Has This Been Tested?

I was able to reproduce this immediately on an emulator when adding the widget, and verify the fix immediately. Luckily it was a small error
