### PR TITLE
Use a lifecycle aware async task instead of a loader to open collection

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -108,11 +108,12 @@ task jacocoTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest', 'crea
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'com.android.support:appcompat-v7:27.0.2'
+    def support_lib_version = '27.1.1'
+    implementation "com.android.support:appcompat-v7:$support_lib_version"
     // Note: the design support library can be quite buggy, so test everything thoroughly before updating it
-    implementation 'com.android.support:design:27.0.2'
-    implementation 'com.android.support:customtabs:27.0.2'
-    implementation 'com.android.support:recyclerview-v7:27.0.2'
+    implementation "com.android.support:design:$support_lib_version"
+    implementation "com.android.support:customtabs:$support_lib_version"
+    implementation "com.android.support:recyclerview-v7:$support_lib_version"
     implementation 'io.requery:sqlite-android:3.24.0'
     implementation 'android.arch.persistence:db:1.1.1'
     implementation 'com.afollestad.material-dialogs:core:0.9.6.0'

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -823,7 +823,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
                 getCol().modSchema();
             } catch (ConfirmModSchemaException e) {
                 // If libanki determines it's necessary to confirm the full sync then show a confirmation dialog
-                // We have to show the dialog via the DialogHandler since this method is called via a Loader
+                // We have to show the dialog via the DialogHandler since this method is called via an async task
                 Resources res = getResources();
                 Message handlerMessage = Message.obtain();
                 handlerMessage.what = DialogHandler.MSG_SHOW_FORCE_FULL_SYNC_DIALOG;
@@ -841,11 +841,9 @@ public class DeckPicker extends NavigationDrawerActivity implements
         automaticSync();
     }
 
-    @Override
-    protected void onCollectionLoadError() {
+    private void showCollectionErrorDialog() {
         getDialogHandler().sendEmptyMessage(DialogHandler.MSG_SHOW_COLLECTION_LOADING_ERROR_DIALOG);
     }
-
 
     public void addNote() {
         Intent intent = new Intent(DeckPicker.this, NoteEditor.class);
@@ -1144,7 +1142,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
                 }
                 if (result == null || !result.getBoolean()) {
                     UIUtils.showThemedToast(DeckPicker.this, getResources().getString(R.string.deck_repair_error), true);
-                    onCollectionLoadError();
+                    showCollectionErrorDialog();
                 }
             }
 
@@ -1871,7 +1869,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
                 }
                 if (result == null) {
                     Timber.e("null result loading deck counts");
-                    onCollectionLoadError();
+                    showCollectionErrorDialog();
                     return;
                 }
                 List<Sched.DeckDueTreeNode> nodes = (List<Sched.DeckDueTreeNode>) result.getObjArray()[0];

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionLoader.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionLoader.java
@@ -1,7 +1,8 @@
 package com.ichi2.async;
 
-import android.content.Context;
-import android.support.v4.content.AsyncTaskLoader;
+import android.arch.lifecycle.Lifecycle;
+import android.arch.lifecycle.LifecycleOwner;
+import android.os.AsyncTask;
 
 import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.CollectionHelper;
@@ -9,62 +10,48 @@ import com.ichi2.libanki.Collection;
 
 import timber.log.Timber;
 
-public class CollectionLoader extends AsyncTaskLoader<Collection> {
+public final class CollectionLoader extends AsyncTask<Void, Void, Collection> {
+    private LifecycleOwner mLifecycleOwner;
+    private Callback mCallback;
 
-    public CollectionLoader(Context context) {
-        super(context);
+    public interface Callback {
+        void execute(Collection col);
+    }
+
+    public static void load(LifecycleOwner lifecycleOwner, Callback callback) {
+        CollectionLoader loader = new CollectionLoader(lifecycleOwner, callback);
+        loader.execute();
+    }
+
+    private CollectionLoader(LifecycleOwner lifecycleOwner, Callback callback) {
+        mLifecycleOwner = lifecycleOwner;
+        mCallback = callback;
     }
 
     @Override
-    public Collection loadInBackground() {
+    protected Collection doInBackground(Void... params) {
+        // Don't touch collection if lockCollection flag is set
+        if (CollectionHelper.getInstance().isCollectionLocked()) {
+            Timber.w("onStartLoading() :: Another thread has requested to keep the collection closed.");
+            return null;
+        }
         // load collection
         try {
             Timber.d("CollectionLoader accessing collection");
-            return CollectionHelper.getInstance().getCol(getContext());
+            return CollectionHelper.getInstance().getCol(AnkiDroidApp.getInstance().getApplicationContext());
         } catch (RuntimeException e) {
             Timber.e(e, "loadInBackground - RuntimeException on opening collection");
             AnkiDroidApp.sendExceptionReport(e, "CollectionLoader.loadInBackground");
             return null;
         }
     }
-    
+
     @Override
-    public void deliverResult(Collection col) {
-        Timber.d("CollectionLoader.deliverResult()");
-        // Loader has been reset so don't forward data to listener
-        if (isReset()) {
-            if (col != null) {
-                return;
-            }
-        }
-        // Loader is running so forward data to listener
-        if (isStarted()) {
-            super.deliverResult(col);
+    protected void onPostExecute(Collection col) {
+        super.onPostExecute(col);
+        if (mLifecycleOwner.getLifecycle().getCurrentState().isAtLeast(Lifecycle.State.CREATED)) {
+            mCallback.execute(col);
         }
     }
-    
-    @Override
-    protected void onStartLoading() {
-        // Don't touch collection if lockCollection flag is set
-        if (CollectionHelper.getInstance().isCollectionLocked()) {
-            Timber.w("onStartLoading() :: Another thread has requested to keep the collection closed.");
-            return;
-        }
-        // Since the CollectionHelper only opens if necessary, we can just force every time
-        forceLoad();
-    }
-    
-    @Override
-    protected void onStopLoading() {
-        // The Loader has been put in a stopped state, so we should attempt to cancel the current load (if there is one).
-        Timber.d("CollectionLoader.onStopLoading()");
-        cancelLoad();
-    }
-    
-    @Override
-    protected void onReset() {
-        // Ensure the loader is stopped.
-        Timber.d("CollectionLoader.onReset()");
-        onStopLoading();
-    }
+
 }


### PR DESCRIPTION
## Fixes
Fixes #4938 and is related to #4937 and #4939
Supersedes #4950

## Approach
The new lifecycle support library makes it pretty easy to build lifecycle aware components, and Loaders have now been deprecated in favor of that library. So instead of using an `AsyncTaskLoader` as the base class, I've used an `AsyncTask` and added some simple logic to ensure that `onCollectionLoaded()` is not called when the `Activity` is stopped.

I was originally considering to use the new `ViewModels` plus `LiveData` approach, but quickly realized that's overkill for the simple task we're trying to achieve here.

In the future I think we should probably refactor the guts of this into a more general `LifecycleAwareAsyncTask` and use that more liberally in our code base.

## How Has This Been Tested?

I did some basic sanity checks on the simulator with a phone and tablet profile to make sure that all  Activities are starting up correctly and that no crashes occur when the Activity is paused or stopped while the collection is loading.

## Learning (optional, can help others)
https://developer.android.com/topic/libraries/architecture/lifecycle

This was pretty good as well:
https://developer.android.com/topic/libraries/architecture/guide.html
