### PR TITLE
Move the checklists in the templates to the bottom

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,13 +1,3 @@
-###### Research
-*Enter an [ x ] character to confirm the points below:*
-
-[  ] I have read the [support page](https://ankidroid.org/docs/help.html) and am reporting a bug or enhancement request specific to AnkiDroid
-
-[  ] I have checked the [manual](https://ankidroid.org/docs/manual.html) and the [FAQ](https://github.com/ankidroid/Anki-Android/wiki/FAQ) and could not find a solution to my issue
-
-[  ] I have searched for similar existing issues here and on the user forum
-
-
 ###### Reproduction Steps
 
 1. 
@@ -26,4 +16,12 @@
 ###### Debug info
 Refer to the [support page](https://ankidroid.org/docs/help.html) if you are unsure where to get the "debug info".
 
+###### Research
+*Enter an [ x ] character to confirm the points below:*
+
+[  ] I have read the [support page](https://ankidroid.org/docs/help.html) and am reporting a bug or enhancement request specific to AnkiDroid
+
+[  ] I have checked the [manual](https://ankidroid.org/docs/manual.html) and the [FAQ](https://github.com/ankidroid/Anki-Android/wiki/FAQ) and could not find a solution to my issue
+
+[  ] I have searched for similar existing issues here and on the user forum
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,5 @@
 ## Pull Request template
 
-Please, go through these checks before you submit a PR.
-
-- [ ] You have not changed whitespace unnecessarily (it makes diffs hard to read)
-- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
-- [ ] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
-- [ ] You have commented your code, particularly in hard-to-understand areas
-- [ ] You have performed a self-review of your own code
-
 ## Purpose / Description
 _Describe the problem or feature and motivation_
 
@@ -25,3 +17,12 @@ Please describe the tests that you ran to verify your changes. Provide instructi
 _Describe the research stage_
 
 _Links to blog posts, patterns, libraries or addons used to solve this problem_
+
+## Checklist
+_Please, go through these checks before submitting the PR._
+
+- [ ] You have not changed whitespace unnecessarily (it makes diffs hard to read)
+- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
+- [ ] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
+- [ ] You have commented your code, particularly in hard-to-understand areas
+- [ ] You have performed a self-review of your own code


### PR DESCRIPTION
These are primarily to help first-time reporters/contributors, and I find they get in the way when I'm creating issues/prs. Moving to the bottom seems like a reasonable compromise to me.