### PR TITLE
Make sure startLoadingCollection() is called at end of onCreate

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.java
@@ -78,7 +78,6 @@ public class ModelFieldEditor extends AnkiActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.model_field_editor);
-        startLoadingCollection();
 
         Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
         mFieldLabelView = (ListView) findViewById(R.id.note_type_editor_fields);
@@ -87,11 +86,11 @@ public class ModelFieldEditor extends AnkiActivity {
             setSupportActionBar(toolbar);
         }
 
-
         if (getSupportActionBar() != null) {
             getSupportActionBar().setTitle(R.string.model_field_editor_title);
             getSupportActionBar().setSubtitle(getIntent().getStringExtra("title"));
         }
+        startLoadingCollection();
     }
 
 
@@ -120,6 +119,7 @@ public class ModelFieldEditor extends AnkiActivity {
 
     @Override
     protected void onCollectionLoaded(Collection col) {
+        super.onCollectionLoaded(col);
         this.mCol = col;
         setupLabels();
         createfieldLabels();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.java
@@ -91,6 +91,7 @@ public class Statistics extends NavigationDrawerActivity implements DeckDropDown
     @Override
     protected void onCollectionLoaded(Collection col) {
         Timber.d("onCollectionLoaded()");
+        super.onCollectionLoaded(col);
         SlidingTabLayout slidingTabLayout;
         // Add drop-down menu to select deck to action bar.
         mDropDownDecks = getCol().getDecks().allSorted();


### PR DESCRIPTION
The new behavior of CollectionLoader is to immediately call `onCollectionLoaded()` if the collection is already open, so `startLoadingCollection()` *must* be called after all the initialization is complete, ideally at the end of `onCreate()`. Also we need to call `super.onCollectionLoaded()` in order for the progress bar to be cleared.

Fixes #4975 