### PR TITLE
Add HTML debug aides

### DIFF
--- a/AnkiDroid/src/main/assets/flashcard.css
+++ b/AnkiDroid/src/main/assets/flashcard.css
@@ -13,7 +13,7 @@ body.night_mode {
 }
 
 /* For the typed/correct answer comparison. The typePrompt and typeOff
-  classes are AnkiDroid specific, and used only for older (beforer
+  classes are AnkiDroid specific, and used only for older (before
   4.0) Android versions . typePrompt is a placeholder where the input
   box should be. typeOff is added when the user switched off entering
   the answer. */

--- a/AnkiDroid/src/main/assets/scripts/card.js
+++ b/AnkiDroid/src/main/assets/scripts/card.js
@@ -69,7 +69,7 @@ function taBlur(itag) {
     window.location.href = "typeblurtext:" + itag.value;
 }
 
-/* Look at the text enterend into the input box and send the text on a return */
+/* Look at the text entered into the input box and send the text on a return */
 function taKey(itag, e) {
     var keycode;
     if (window.event) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -114,7 +114,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
      * <p>
      * Set this to true for debugging only.
      */
-    private static final boolean SAVE_CARD_CONTENT = false;
+    private static final boolean SAVE_CARD_CONTENT = BuildConfig.DEBUG;
 
     /**
      * Result codes that are returned when this activity finishes.
@@ -1760,6 +1760,10 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
         }
         if (mCard == null) {
             mCard = createWebView();
+            // On your desktop use chrome://inspect to connect to emulator WebViews
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+                if (BuildConfig.DEBUG) WebView.setWebContentsDebuggingEnabled(true);
+            }
             mCardFrame.addView(mCard);
         }
         if (mCard.getVisibility() != View.VISIBLE) {
@@ -2122,7 +2126,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
             style.append(String.format("img { zoom: %s }\n", mImageZoom / 100.0));
         }
 
-        Timber.d("::style::", style);
+        Timber.d("::style:: / %s", style);
 
         if (mNightMode) {
             // Enable the night-mode class


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
#4941 made me think we were navigating to data urls and on future versions of Chrome AnkiDroid would simply stop reviewing completely, so I went to investigate

We do support passing a data url through, but we don't use one ourselves. Altering that would alter decks out in the wild so I want to leave that be. So I think we're safe

Edit - dropped this part of the patch per discussion below: That said, we were emitting malformed HTML/CSS so I patched that up while maintaining backwards compatibility with the CardContentProvider.

There is still something going on with some other issues with fonts and memory usage in Chrome so this patch also includes better debugging support

## Fixes
Fixes #4941 - with the debugging support added it's possible to see how the WebView is working and look at the HTML easily

## Approach
- Dropped: For the HTML/CSS, I decomposed the card-specific CSS from the card HTML chunks and put the CSS in the right spot in the emitted HTML
- For debugging support, if it's a debug build I emit the card.html every time (should be okay?) and I enable WebView debugging where possible - chrome://inspect on your desktop when the emulator is up, it's nice

## How Has This Been Tested?

I used remote webview debugging on emulators to make sure the HTML we emit was well-formed and not using data URLs

## Learning (optional, can help others)
https://developers.google.com/web/tools/chrome-devtools/remote-debugging/webviews
chrome://inspect
https://validator.w3.org/#validate_by_input

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements)
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code

