### PR TITLE
onCreateOptionsMenu() lifecycle crash / UI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ install:
   - adb shell input keyevent 82 &
 
 script:
-  - ./gradlew jacocoTestReport
+  - ./gradlew jacocoTestReport -Pandroid.testInstrumentationRunnerArguments.notAnnotation=android.support.test.filters.LargeTest
 
 # Codacy integration, partials for all APIs, then an optional finalize
 after_success:

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -143,14 +143,18 @@ dependencies {
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
     testImplementation 'net.lachlanmckee:timber-junit-rule:1.0.1'
 
+    androidTestImplementation 'com.azimolabs.conditionwatcher:conditionwatcher:0.2'
     androidTestImplementation('com.android.support.test.espresso:espresso-core:3.0.2') {
-        exclude group: 'com.android.support', module: 'support-annotations'
+        exclude group: 'com.android.support'
+    }
+    androidTestImplementation 'com.android.support.test.espresso:espresso-contrib:3.0.2', {
+        exclude group: 'com.android.support'
     }
     androidTestImplementation('com.android.support.test:runner:1.0.2') {
-        exclude group: 'com.android.support', module: 'support-annotations'
+        exclude group: 'com.android.support'
     }
     androidTestImplementation('com.android.support.test:rules:1.0.2') {
-        exclude group: 'com.android.support', module: 'support-annotations'
+        exclude group: 'com.android.support'
     }
     androidTestUtil 'com.android.support.test:orchestrator:1.0.2'
 }

--- a/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/ActivityTestUI.java
+++ b/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/ActivityTestUI.java
@@ -1,0 +1,341 @@
+package com.ichi2.anki.tests;
+
+
+import android.Manifest;
+import android.support.test.espresso.DataInteraction;
+import android.support.test.espresso.ViewInteraction;
+import android.support.test.filters.LargeTest;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.rule.GrantPermissionRule;
+import android.support.test.runner.AndroidJUnit4;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.ViewParent;
+
+import com.azimolabs.conditionwatcher.ConditionWatcher;
+import com.ichi2.anki.IntentHandler;
+import com.ichi2.anki.R;
+
+import junit.framework.Assert;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static android.support.test.InstrumentationRegistry.getInstrumentation;
+import static android.support.test.espresso.Espresso.onData;
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
+import static android.support.test.espresso.Espresso.pressBack;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.action.ViewActions.scrollTo;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withClassName;
+import static android.support.test.espresso.matcher.ViewMatchers.withContentDescription;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.anything;
+import static org.hamcrest.Matchers.is;
+
+@LargeTest
+@RunWith(AndroidJUnit4.class)
+public class ActivityTestUI {
+
+    @Rule
+    public GrantPermissionRule mRuntimePermissionRule =
+            GrantPermissionRule.grant(Manifest.permission.WRITE_EXTERNAL_STORAGE);
+
+    @Rule
+    public ActivityTestRule<IntentHandler> mActivityTestRule = new ActivityTestRule<>(IntentHandler.class);
+
+
+    @Test
+    public void activityTestUI() throws Exception {
+        ViewInteraction appCompatImageButton = onView(
+                allOf(withContentDescription("Navigate up"),
+                        childAtPosition(allOf(withId(R.id.toolbar),
+                                childAtPosition(withId(R.id.deckpicker_view), 0)),
+                                0),
+                        isDisplayed()));
+        appCompatImageButton.perform(click());
+
+        ViewInteraction navigationMenuItemView = onView(
+                allOf(childAtPosition(
+                        allOf(withId(R.id.design_navigation_view),
+                                childAtPosition(
+                                        withId(R.id.navdrawer_items_container),
+                                        0)),
+                        2),
+                        isDisplayed()));
+        navigationMenuItemView.perform(click());
+
+        pressBack();
+
+        ConditionWatcher.waitForCondition(new Shared.ViewItemWaitingInstruction(R.id.deckpicker_view));
+        ViewInteraction appCompatImageButton2 = onView(
+                allOf(withContentDescription("Navigate up"),
+                        childAtPosition(
+                                allOf(withId(R.id.toolbar),
+                                        childAtPosition(
+                                                withId(R.id.deckpicker_view),
+                                                0)),
+                                0),
+                        isDisplayed()));
+        appCompatImageButton2.perform(click());
+
+        ViewInteraction navigationMenuItemView2 = onView(
+                allOf(childAtPosition(
+                        allOf(withId(R.id.design_navigation_view),
+                                childAtPosition(
+                                        withId(R.id.navdrawer_items_container),
+                                        0)),
+                        3),
+                        isDisplayed()));
+        navigationMenuItemView2.perform(click());
+
+        ViewInteraction appCompatImageButton3 = onView(
+                allOf(withContentDescription("Navigate up"),
+                        childAtPosition(
+                                allOf(withId(R.id.toolbar),
+                                        childAtPosition(
+                                                withClassName(is("android.widget.LinearLayout")),
+                                                0)),
+                                0),
+                        isDisplayed()));
+        appCompatImageButton3.perform(click());
+
+        ViewInteraction navigationMenuItemView3 = onView(
+                allOf(childAtPosition(
+                        allOf(withId(R.id.design_navigation_view),
+                                childAtPosition(
+                                        withId(R.id.navdrawer_items_container),
+                                        0)),
+                        6),
+                        isDisplayed()));
+        navigationMenuItemView3.perform(click());
+
+        ViewInteraction appCompatImageButton4 = onView(
+                allOf(withContentDescription("Navigate up"),
+                        childAtPosition(
+                                allOf(withId(R.id.action_bar),
+                                        childAtPosition(
+                                                withId(R.id.action_bar_container),
+                                                0)),
+                                1),
+                        isDisplayed()));
+        appCompatImageButton4.perform(click());
+
+        ViewInteraction appCompatImageButton5 = onView(
+                allOf(withContentDescription("Navigate up"),
+                        childAtPosition(
+                                allOf(withId(R.id.toolbar),
+                                        childAtPosition(
+                                                withClassName(is("android.widget.LinearLayout")),
+                                                0)),
+                                0),
+                        isDisplayed()));
+        appCompatImageButton5.perform(click());
+
+        ViewInteraction navigationMenuItemView4 = onView(
+                allOf(childAtPosition(
+                        allOf(withId(R.id.design_navigation_view),
+                                childAtPosition(
+                                        withId(R.id.navdrawer_items_container),
+                                        0)),
+                        6),
+                        isDisplayed()));
+        navigationMenuItemView4.perform(click());
+
+        DataInteraction linearLayout = onData(anything())
+                .inAdapterView(allOf(withId(android.R.id.list),
+                        childAtPosition(
+                                withClassName(is("android.widget.LinearLayout")),
+                                0)))
+                .atPosition(4);
+        linearLayout.perform(click());
+
+        ConditionWatcher.waitForCondition(new Shared.ViewItemWaitingInstruction(android.R.id.list_container));
+        DataInteraction linearLayout2 = onData(anything())
+                .inAdapterView(allOf(withId(android.R.id.list),
+                        childAtPosition(
+                                withId(android.R.id.list_container),
+                                0)))
+                .atPosition(16);
+        linearLayout2.perform(click());
+
+        ViewInteraction appCompatImageButton6 = onView(
+                allOf(withContentDescription("Navigate up"),
+                        childAtPosition(
+                                allOf(withId(R.id.toolbar),
+                                        childAtPosition(
+                                                withClassName(is("android.widget.LinearLayout")),
+                                                0)),
+                                0),
+                        isDisplayed()));
+        appCompatImageButton6.perform(click());
+
+        ViewInteraction appCompatImageButton7 = onView(
+                allOf(withContentDescription("Navigate up"),
+                        childAtPosition(
+                                allOf(withId(R.id.action_bar),
+                                        childAtPosition(
+                                                withId(R.id.action_bar_container),
+                                                0)),
+                                1),
+                        isDisplayed()));
+        appCompatImageButton7.perform(click());
+
+        ViewInteraction appCompatImageButton8 = onView(
+                allOf(withContentDescription("Navigate up"),
+                        childAtPosition(
+                                allOf(withId(R.id.action_bar),
+                                        childAtPosition(
+                                                withId(R.id.action_bar_container),
+                                                0)),
+                                1),
+                        isDisplayed()));
+        appCompatImageButton8.perform(click());
+
+        ViewInteraction appCompatImageButton9 = onView(
+                allOf(withContentDescription("Navigate up"),
+                        childAtPosition(
+                                allOf(withId(R.id.toolbar),
+                                        childAtPosition(
+                                                withClassName(is("android.widget.LinearLayout")),
+                                                0)),
+                                0),
+                        isDisplayed()));
+        appCompatImageButton9.perform(click());
+
+        ViewInteraction appCompatImageButton61 = onView(
+                allOf(withContentDescription("Navigate up"),
+                        childAtPosition(
+                                allOf(withId(R.id.toolbar),
+                                        childAtPosition(
+                                                withClassName(is("android.widget.LinearLayout")),
+                                                0)),
+                                0),
+                        isDisplayed()));
+        appCompatImageButton61.perform(click());
+
+        ViewInteraction navigationMenuItemView123 = onView(
+                allOf(childAtPosition(
+                        allOf(withId(R.id.design_navigation_view),
+                                childAtPosition(
+                                        withId(R.id.navdrawer_items_container),
+                                        0)),
+                        1),
+                        isDisplayed()));
+        navigationMenuItemView123.perform(click());
+
+        openActionBarOverflowOrOptionsMenu(getInstrumentation().getTargetContext());
+
+        ViewInteraction appCompatTextView6 = onView(
+                allOf(withId(R.id.title), withText("Manage note types"),
+                        childAtPosition(
+                                childAtPosition(
+                                        withClassName(is("android.support.v7.view.menu.ListMenuItemView")),
+                                        0),
+                                0),
+                        isDisplayed()));
+        appCompatTextView6.perform(click());
+
+        DataInteraction linearLayout1 = onData(anything())
+                .inAdapterView(allOf(withId(R.id.note_type_browser_list),
+                        childAtPosition(
+                                withClassName(is("android.widget.LinearLayout")),
+                                1)))
+                .atPosition(0);
+        linearLayout1.perform(click());
+
+        ViewInteraction appCompatImageButton35 = onView(
+                allOf(withContentDescription("Navigate up"),
+                        childAtPosition(
+                                allOf(withId(R.id.toolbar),
+                                        childAtPosition(
+                                                withClassName(is("android.widget.LinearLayout")),
+                                                0)),
+                                0),
+                        isDisplayed()));
+        appCompatImageButton35.perform(click());
+
+        ViewInteraction appCompatImageButton42 = onView(
+                allOf(withContentDescription("Navigate up"),
+                        childAtPosition(
+                                allOf(withId(R.id.toolbar),
+                                        childAtPosition(
+                                                withClassName(is("android.widget.LinearLayout")),
+                                                0)),
+                                0),
+                        isDisplayed()));
+        appCompatImageButton42.perform(click());
+
+        ViewInteraction viewInteraction = onView(
+                allOf(withId(R.id.fab_expand_menu_button), withContentDescription("Add"),
+                        childAtPosition(
+                                allOf(withId(R.id.add_content_menu),
+                                        childAtPosition(
+                                                withId(R.id.root_layout),
+                                                2)),
+                                3),
+                        isDisplayed()));
+        viewInteraction.perform(click());
+
+        ViewInteraction floatingActionButton = onView(
+                allOf(withId(R.id.add_note_action), withContentDescription("Add"),
+                        childAtPosition(
+                                allOf(withId(R.id.add_content_menu),
+                                        childAtPosition(
+                                                withId(R.id.root_layout),
+                                                2)),
+                                2),
+                        isDisplayed()));
+        floatingActionButton.perform(click());
+
+        ViewInteraction appCompatTextView = onView(
+                allOf(withId(R.id.CardEditorCardsText), withText("Cards: Card 1"),
+                        childAtPosition(
+                                allOf(withId(R.id.CardEditorCardsButton),
+                                        childAtPosition(
+                                                withClassName(is("android.widget.LinearLayout")),
+                                                0)),
+                                0)));
+        appCompatTextView.perform(scrollTo(), click());
+
+        ViewInteraction actionMenuItemView = onView(
+                allOf(withId(R.id.action_preview), withContentDescription("Preview"),
+                        childAtPosition(
+                                childAtPosition(
+                                        withId(R.id.toolbar),
+                                        5),
+                                0),
+                        isDisplayed()));
+        Assert.assertNotNull("Did not make it to the end of the UI run", actionMenuItemView);
+        actionMenuItemView.perform(click());
+    }
+
+
+    private static Matcher<View> childAtPosition(
+            final Matcher<View> parentMatcher, final int position) {
+
+        return new TypeSafeMatcher<View>() {
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("Child at position " + position + " in parent ");
+                parentMatcher.describeTo(description);
+            }
+
+
+            @Override
+            public boolean matchesSafely(View view) {
+                ViewParent parent = view.getParent();
+                return parent instanceof ViewGroup && parentMatcher.matches(parent)
+                        && view.equals(((ViewGroup) parent).getChildAt(position));
+            }
+        };
+    }
+}

--- a/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/Shared.java
+++ b/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/Shared.java
@@ -16,9 +16,13 @@
 
 package com.ichi2.anki.tests;
 
+import android.app.Activity;
 import android.content.Context;
+import android.content.ContextWrapper;
 import android.text.TextUtils;
+import android.view.View;
 
+import com.azimolabs.conditionwatcher.Instruction;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Storage;
 import com.ichi2.libanki.Utils;
@@ -27,12 +31,63 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.matcher.ViewMatchers.isRoot;
 import static org.junit.Assert.assertTrue;
 
 /**
  * Shared methods for unit tests.
  */
 public class Shared {
+
+
+    /**
+     * Instantiate one of these with the View id of the item you want Robolectric to wait on, and it will
+     * fast-poll until the item is inflated and visible
+     */
+    public static class ViewItemWaitingInstruction extends Instruction {
+
+        private int viewId;
+
+
+        public  String getDescription() {
+            return "Waits for an id to be visible";
+        }
+
+
+        /**
+         * Instantiate this with the Resource id of the view to wait for
+         */
+        public ViewItemWaitingInstruction(int viewId) {
+            this.viewId = viewId;
+        }
+
+
+        @Override
+        public boolean checkCondition() {
+            Activity activity = getCurrentActivity();
+            return ((activity != null) && (activity.findViewById(viewId) != null) &&
+                    (activity.findViewById(viewId).getVisibility() == View.VISIBLE));
+        }
+
+
+        /** Get the current activity so, to inspect for View ids */
+        private Activity getCurrentActivity() {
+            final Activity[] activity = new Activity[1];
+            onView(isRoot()).check((view, noViewFoundException) ->
+                    activity[0] = scanForActivity(view.findViewById(android.R.id.content).getContext()));
+            return activity[0];
+        }
+
+
+        /** If the Context is a wrapper, recursively go for the Activity */
+        private Activity scanForActivity(Context cont) {
+            if (cont == null) return null;
+            else if (cont instanceof Activity) return (Activity)cont;
+            else if (cont instanceof ContextWrapper) return scanForActivity(((ContextWrapper)cont).getBaseContext());
+            return null;
+        }
+    }
 
     public static Collection getEmptyCol(Context context) throws IOException {
         File f = File.createTempFile("test", ".anki2");

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -567,6 +567,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
     @Override
     public boolean onCreateOptionsMenu(final Menu menu) {
+        Timber.d("onCreateOptionsMenu()");
         mActionBarMenu = menu;
         if (!mInMultiSelectMode) {
             // restore drawer click listener and icon
@@ -1359,9 +1360,9 @@ public class CardBrowser extends NavigationDrawerActivity implements
         @Override
         public void onPostExecute(TaskData result) {
             if (result != null && mCards != null) {
-                Timber.i("CardBrowser:: Completed doInBackgroundSearchCards Successfuly");
+                Timber.i("CardBrowser:: Completed doInBackgroundSearchCards Successfully");
                 updateList();
-                if (!mSearchView.isIconified()) {
+                if ((mSearchView != null) && !mSearchView.isIconified()) {
                     UIUtils.showSimpleSnackbar(CardBrowser.this, getSubtitleText(), true);
                 }
             }

--- a/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
@@ -217,14 +217,14 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 // We have been interrupted, return immediately.
-                Timber.e(e, "interrupted while waiting for previous task: %d", mPreviousTask.mType);
+                Timber.d(e, "interrupted while waiting for previous task: %d", mPreviousTask.mType);
                 return null;
             } catch (ExecutionException e) {
                 // Ignore failures in the previous task.
                 Timber.e(e, "previously running task failed with exception: %d", mPreviousTask.mType);
             } catch (CancellationException e) {
                 // Ignore cancellation of previous task
-                Timber.e(e, "previously running task was cancelled: %d", mPreviousTask.mType);
+                Timber.d(e, "previously running task was cancelled: %d", mPreviousTask.mType);
             }
         }
         sLatestInstance = this;

--- a/tools/quality-check/adb_shell_all_emulators.sh
+++ b/tools/quality-check/adb_shell_all_emulators.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# This attempts to send an adb shell command to all your emulators (on Ubuntu 18.04.01 LTS at least...) 
+
+if [ "$1" == "" ]; then
+  echo "You must provide the adb shell command to execute as the argument"
+  exit 1
+fi
+
+killall -9 adb
+adb devices -l > /dev/null
+sleep 2
+adb devices -l > /dev/null
+sleep 2
+
+for EMU_ID in `adb devices -l | grep emulator | cut -d' ' -f1`; do
+  echo "adb -s $EMU_ID shell $1 $2 $3 $4 $5 $6"
+  adb -s $EMU_ID shell $1 $2 $3 $4 $5 $6
+done

--- a/tools/quality-check/disable_animation_all_emulators.sh
+++ b/tools/quality-check/disable_animation_all_emulators.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+adb_shell_all_emulators.sh settings put global window_animation_scale 0
+adb_shell_all_emulators.sh settings put global transition_animation_scale 0
+adb_shell_all_emulators.sh settings put global animator_duration_scale 0


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
We have been crashing on Activity startup a lot, this adds our first UI test that would have caught 2 of the recent crashes, and adds a fix for one of the crashes

## Fixes
Fixes #4977 

## Approach
Adds Robolectric test, that just clicks into each activity once by View ids so it should not be brittle but it would have caught two recent crashes. We can delete it later if it sucks, but it works on my emulator fleet. I'm filtering it out of Travis though because the flakiness there would be unbearable.

Other than that it just adds a null check but lest you think I was lazy ;-), I checked 27.0.2 to 27.1.1, it was in 27.0.2 also, and I verified that no other Activities seemed to be doing unsafe onCreate()/onCollectionLoaded() access of View items inflated in onCreateOptionsMenu(). So I think this is really the fix

## How Has This Been Tested?
By hand then fully auto local, all APIs with the nifty new UI test in here

## Learning (optional, can help others)
UI testing is difficult. For Robolectric delay/timing issues this article and related classes (I used them):
https://medium.com/azimolabs/wait-for-it-idlingresource-and-conditionwatcher-602055f32356

onCreate/onOptionsCreated lifecycle stuff:
It's vague when exactly the options menu will be called, but it is definitely after onCreate is mostly done, even on Honeycomb- https://stackoverflow.com/questions/9492333/when-does-oncreateoptionsmenu-happen-in-an-actionbar-enabled-activity?noredirect=1&lq=1


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
