### PR TITLE
Brand crash dialog, add crash trigger if debug

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -113,7 +113,8 @@ import static timber.log.Timber.DebugTree;
         resCommentPrompt =  R.string.empty_string,
         resTitle =  R.string.feedback_title,
         resText =  R.string.feedback_default_text,
-        resPositiveButtonText = R.string.feedback_report
+        resPositiveButtonText = R.string.feedback_report,
+        resIcon = R.drawable.logo_star_144dp
 )
 @AcraHttpSender(
         httpMethod = HttpSender.Method.PUT,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -281,6 +281,19 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                     startActivity(i);
                     return true;
                 });
+                // Make it possible to test crash reporting, but only for DEBUG builds
+                if (BuildConfig.DEBUG) {
+                    Timber.i("Debug mode, allowing for test crashes");
+                    Preference triggerTestCrashPreference = new Preference(this);
+                    triggerTestCrashPreference.setKey("trigger_crash_preference");
+                    triggerTestCrashPreference.setTitle("Trigger test crash");
+                    triggerTestCrashPreference.setSummary("Touch here for an immediate test crash");
+                    triggerTestCrashPreference.setOnPreferenceClickListener(preference -> {
+                        Timber.w("Crash triggered on purpose from advanced preferences in debug mode");
+                        throw new RuntimeException("This is a test crash");
+                    });
+                    screen.addPreference(triggerTestCrashPreference);
+                }
                 // Force full sync option
                 Preference fullSyncPreference = screen.findPreference("force_full_sync");
                 fullSyncPreference.setOnPreferenceClickListener(preference -> {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/AnkiDroidCrashReportDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/AnkiDroidCrashReportDialog.java
@@ -54,6 +54,8 @@ public class AnkiDroidCrashReportDialog extends BaseCrashReportDialog implements
             DialogConfiguration dialogConfig =
                     (DialogConfiguration)builder.getPluginConfigurationBuilder((DialogConfigurationBuilder.class)).build();
 
+            dialogBuilder.setIcon(dialogConfig.resIcon());
+            dialogBuilder.setTitle(dialogConfig.title());
             dialogBuilder.setPositiveButton(dialogConfig.positiveButtonText(), AnkiDroidCrashReportDialog.this);
             dialogBuilder.setNegativeButton(dialogConfig.negativeButtonText(), AnkiDroidCrashReportDialog.this);
         }

--- a/AnkiDroid/src/main/res/values/05-feedback.xml
+++ b/AnkiDroid/src/main/res/values/05-feedback.xml
@@ -24,7 +24,7 @@
     <string name="empty_string"/>
     <string name="error_reporting_choice">Error reporting mode</string>
     <string name="feedback_disclaimer">Disclaimer: We don’t collect any personal information such as your email address, phone number, or your phone IMEI. We do collect some information about your device such as the manufacturer, model and version of Android, as well as the nature of reported errors themselves and the steps which led up to them occurring.</string>
-    <string name="feedback_title">Feedback</string>
+    <string name="feedback_title">AnkiDroid Feedback</string>
     <string name="feedback_default_text">Enter your feedback or information about the nature of any errors you’re reporting.</string>
     <string name="feedback_auto_toast_text">AnkiDroid has encountered a problem; a report is being sent to the developers…</string>
     <string name="feedback_manual_toast_text">AnkiDroid has encountered a problem; a report is being generated…</string>


### PR DESCRIPTION
## Purpose / Description

Previously I've been relying on a personal collection of
crash bugs to test the crash dialog, but that's a poor testing
experience - now we have an advanced preference area to just crash

During the ACRA upgrade #4893 some branding was already broken, and
the rest was lost, when I finally saw the dialog again with
fresh eyes on my son's tablet it was terrible so this puts the 
icon and title where they belong

## Fixes
No issue logged, just fixed it

## Approach
This adds a beautiful icon and nice text

## How Has This Been Tested?
I am getting better at UI things so I added an advanced preference to trigger crashes, in debug mode only. I tested the pref was disabled in release builds and then tested the crash - debug/release + pre/post images attached

It does add one Codacy warning because I throw RuntimeException in the trigger

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code


![ankidroid_advanced_pref_release_no_trigger](https://user-images.githubusercontent.com/782704/45722730-64b4be00-bb73-11e8-82c3-62dee085dadd.png)
![ankidroid_advanced_pref_debug_crash_trigger](https://user-images.githubusercontent.com/782704/45722731-64b4be00-bb73-11e8-8c12-b65bcd53b396.png)
![ankidroid_crash_dialog_no_branding](https://user-images.githubusercontent.com/782704/45722732-654d5480-bb73-11e8-8216-038bb497866a.png)
![ankidroid_crash_dialog_branded](https://user-images.githubusercontent.com/782704/45722733-654d5480-bb73-11e8-9e03-5703c4085f2f.png)
