### PR TITLE
Bump SDK for API so it remains publishable

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -5,11 +5,11 @@ def artifactId = "api"
 def version = "1.1.0alpha6"
 
 android {
-    compileSdkVersion 26
+    compileSdkVersion 27
 
     defaultConfig {
         minSdkVersion 8
-        targetSdkVersion 25
+        targetSdkVersion 27
         versionCode 11016   // 4th digit: 1=alpha, 2=beta, 3=official
         versionName version
     }


### PR DESCRIPTION
Simple change, but required to pass lint without error with the expiry of API 25 targets