### PR TITLE
Ask to reinit options menu after permissions, Fixes #4951

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -517,6 +517,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
+        Timber.d("onCreateOptionsMenu()");
         getMenuInflater().inflate(R.menu.deck_picker, menu);
         boolean sdCardAvailable = AnkiDroidApp.isSdCardMounted();
         menu.findItem(R.id.action_sync).setEnabled(sdCardAvailable);
@@ -673,6 +674,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
     public void onRequestPermissionsResult (int requestCode, String[] permissions, int[] grantResults) {
         if (requestCode == REQUEST_STORAGE_PERMISSION && permissions.length == 1) {
             if (grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                invalidateOptionsMenu();
                 showStartupScreensAndDialogs(AnkiDroidApp.getSharedPrefs(this), 0);
             } else {
                 // User denied access to the SD card so show error toast and finish activity


### PR DESCRIPTION
The DeckPicker options menu wasn't being initialized correctly
during the first run of the application after install when all
the dialogs popped up.

The correct thing to do is invalidate it, the system will re-init

https://stackoverflow.com/a/41631514/9910298

## How Has This Been Tested?

I started my full-API fleet of emulators and manually did the fresh-install flow and n+1 flow on DeckPicker and it all works now
