### PR TITLE
Handle all ZipEntry exceptions not just IO, Fixes #4978

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/AnkiPackageImporter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/AnkiPackageImporter.java
@@ -135,7 +135,7 @@ public class AnkiPackageImporter extends Anki2Importer {
         if (mNameToNum.containsKey(fname)) {
             try {
                 return new BufferedInputStream(mZip.getInputStream(mZip.getEntry(mNameToNum.get(fname))));
-            } catch (IOException e) {
+            } catch (IOException | NullPointerException e) {
                 Timber.e("Could not extract media file " + fname + "from zip file.");
             }
         }


### PR DESCRIPTION
## Purpose / Description
Importing media collections is fraught because they become corrupt in so many ways. This fixes one of the ways

## Fixes
Fixes #4978 

## Approach

Calling code handles null return values from IOExceptions (indicating possibly serious corruption) already and silently moves on

Called library method will immediately throw NPE if the requested
entry name doesn't exist, so any media database / file de-synchronization
blocks us from importing otherwise. 

Catching that NPE alongside the IOException allows us to successfully import
exports that have media db / file discrepancies

## How Has This Been Tested?

I successfully recovered a users database (attached to the issue as a test case), and I've been able to import databases I've manually corrupted but I can't reproduce the export of corruption (even when deleting media from sdcard and exporting without checking media...). Hopefully that means current code doesn't export corrupt media collections...
