### PR TITLE
Issue4987/previewer issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ install:
   - adb shell input keyevent 82 &
 
 script:
-  - ./gradlew jacocoTestReport -Pandroid.testInstrumentationRunnerArguments.notAnnotation=androidx.test.filters.LargeTest
+  - ./gradlew jacocoTestReport -Pandroid.testInstrumentationRunnerArguments.notPackage=com.ichi2.anki.uitests
 
 # Codacy integration, partials for all APIs, then an optional finalize
 after_success:

--- a/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/Shared.java
+++ b/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/Shared.java
@@ -74,8 +74,12 @@ public class Shared {
         /** Get the current activity so, to inspect for View ids */
         private Activity getCurrentActivity() {
             final Activity[] activity = new Activity[1];
-            onView(isRoot()).check((view, noViewFoundException) ->
-                    activity[0] = scanForActivity(view.findViewById(android.R.id.content).getContext()));
+            onView(isRoot()).check((view, noViewFoundException) -> {
+                    View content = view.findViewById(android.R.id.content);
+                    if (content != null) {
+                        activity[0] = scanForActivity(content.getContext());
+                    }
+            });
             return activity[0];
         }
 
@@ -115,10 +119,11 @@ public class Shared {
      * @return See getTestDir.
      */
     private static File getTestDir(Context context, String name) {
+        String suffix = "";
         if (!TextUtils.isEmpty(name)) {
-            name = "-" + name;
+            suffix = "-" + name;
         }
-        File dir = new File(context.getCacheDir(), "testfiles" + name);
+        File dir = new File(context.getCacheDir(), "testfiles" + suffix);
         if (!dir.exists()) {
             assertTrue(dir.mkdir());
         }

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/uitests/ActivityTestUI.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/uitests/ActivityTestUI.java
@@ -1,4 +1,4 @@
-package com.ichi2.anki.tests;
+package com.ichi2.anki.uitests;
 
 
 import android.Manifest;
@@ -15,6 +15,7 @@ import android.view.ViewParent;
 import com.azimolabs.conditionwatcher.ConditionWatcher;
 import com.ichi2.anki.IntentHandler;
 import com.ichi2.anki.R;
+import com.ichi2.anki.tests.Shared;
 
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
@@ -35,12 +36,14 @@ import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static androidx.test.espresso.matcher.ViewMatchers.withClassName;
 import static androidx.test.espresso.matcher.ViewMatchers.withContentDescription;
 import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withSubstring;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.anything;
 import static org.hamcrest.Matchers.is;
 
 @LargeTest
+@SuppressWarnings("PMD.ExcessiveMethodLength")
 @RunWith(AndroidJUnit4.class)
 public class ActivityTestUI {
 
@@ -290,14 +293,8 @@ public class ActivityTestUI {
                         isDisplayed()));
         floatingActionButton.perform(click());
 
-        ViewInteraction appCompatTextView = onView(
-                allOf(withId(R.id.CardEditorCardsText), withText("Cards: Card 1"),
-                        childAtPosition(
-                                allOf(withId(R.id.CardEditorCardsButton),
-                                        childAtPosition(
-                                                withClassName(is("android.widget.LinearLayout")),
-                                                0)),
-                                0)));
+        ConditionWatcher.waitForCondition(new Shared.ViewItemWaitingInstruction(R.id.CardEditorCardsText));
+        ViewInteraction appCompatTextView = onView(allOf(withId(R.id.CardEditorCardsText), withSubstring("Cards: Card 1")));
         appCompatTextView.perform(scrollTo(), click());
 
         ViewInteraction actionMenuItemView = onView(

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/uitests/CardBrowserPreviewUI.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/uitests/CardBrowserPreviewUI.java
@@ -1,0 +1,320 @@
+package com.ichi2.anki.uitests;
+
+
+import android.Manifest;
+import androidx.test.espresso.ViewInteraction;
+import androidx.test.espresso.matcher.ViewMatchers;
+import androidx.test.rule.ActivityTestRule;
+import androidx.test.rule.GrantPermissionRule;
+import androidx.test.runner.AndroidJUnit4;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.ViewParent;
+
+import com.azimolabs.conditionwatcher.ConditionWatcher;
+import com.ichi2.anki.IntentHandler;
+import com.ichi2.anki.R;
+import com.ichi2.anki.tests.Shared;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+import org.hamcrest.TypeSafeMatcher;
+import org.hamcrest.core.IsInstanceOf;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static androidx.test.InstrumentationRegistry.getInstrumentation;
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
+import static androidx.test.espresso.Espresso.pressBack;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.action.ViewActions.closeSoftKeyboard;
+import static androidx.test.espresso.action.ViewActions.pressImeActionButton;
+import static androidx.test.espresso.action.ViewActions.replaceText;
+import static androidx.test.espresso.action.ViewActions.scrollTo;
+import static androidx.test.espresso.assertion.ViewAssertions.doesNotExist;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withContentDescription;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+
+@androidx.test.filters.LargeTest
+@SuppressWarnings("PMD.ExcessiveMethodLength")
+@RunWith(AndroidJUnit4.class)
+public class CardBrowserPreviewUI {
+
+    @Rule
+    public GrantPermissionRule mRuntimePermissionRule =
+            GrantPermissionRule.grant(Manifest.permission.WRITE_EXTERNAL_STORAGE);
+
+    @Rule
+    public ActivityTestRule<IntentHandler> mActivityTestRule = new ActivityTestRule<>(IntentHandler.class);
+
+
+    @Test
+    public void cardBrowserPreview3UI() throws Exception {
+        ViewInteraction appCompatImageButton = onView(
+                Matchers.allOf(withContentDescription("Navigate up"),
+                        childAtPosition(
+                                Matchers.allOf(ViewMatchers.withId(com.ichi2.anki.R.id.toolbar),
+                                        childAtPosition(
+                                                ViewMatchers.withId(com.ichi2.anki.R.id.deckpicker_view),
+                                                0)),
+                                0),
+                        isDisplayed()));
+        appCompatImageButton.perform(click());
+
+        ViewInteraction navigationMenuItemView = onView(
+                Matchers.allOf(childAtPosition(
+                        Matchers.allOf(ViewMatchers.withId(com.ichi2.anki.R.id.design_navigation_view),
+                                childAtPosition(
+                                        ViewMatchers.withId(com.ichi2.anki.R.id.navdrawer_items_container),
+                                        0)),
+                        2),
+                        isDisplayed()));
+        navigationMenuItemView.perform(click());
+
+        ConditionWatcher.waitForCondition(new Shared.ViewItemWaitingInstruction(com.ichi2.anki.R.id.action_add_card_from_card_browser));
+        ViewInteraction actionMenuItemView = onView(
+                Matchers.allOf(ViewMatchers.withId(com.ichi2.anki.R.id.action_add_card_from_card_browser), withContentDescription("Add note"),
+                        childAtPosition(
+                                childAtPosition(
+                                        ViewMatchers.withId(com.ichi2.anki.R.id.toolbar),
+                                        3),
+                                0),
+                        isDisplayed()));
+        actionMenuItemView.perform(click());
+
+        ConditionWatcher.waitForCondition(new Shared.ViewItemWaitingInstruction(com.ichi2.anki.R.id.id_note_editText));
+        ViewInteraction fieldEditText = onView(
+                Matchers.allOf(ViewMatchers.withId(com.ichi2.anki.R.id.id_note_editText), withContentDescription("Front"),
+                        childAtPosition(
+                                childAtPosition(
+                                        ViewMatchers.withId(com.ichi2.anki.R.id.CardEditorEditFieldsLayout),
+                                        1),
+                                0)));
+        String cardId = "test" + Long.toString(System.currentTimeMillis());
+        fieldEditText.perform(scrollTo(), replaceText(cardId), closeSoftKeyboard());
+
+        ViewInteraction fieldEditText2 = onView(
+                Matchers.allOf(ViewMatchers.withId(com.ichi2.anki.R.id.id_note_editText), withContentDescription("Back"),
+                        childAtPosition(
+                                childAtPosition(
+                                        ViewMatchers.withId(com.ichi2.anki.R.id.CardEditorEditFieldsLayout),
+                                        3),
+                                0)));
+        fieldEditText2.perform(scrollTo(), replaceText("back"), closeSoftKeyboard());
+
+        ViewInteraction actionMenuItemView2 = onView(
+                Matchers.allOf(ViewMatchers.withId(com.ichi2.anki.R.id.action_save), withContentDescription("Save"),
+                        childAtPosition(
+                                childAtPosition(
+                                        ViewMatchers.withId(com.ichi2.anki.R.id.toolbar),
+                                        4),
+                                0),
+                        isDisplayed()));
+        actionMenuItemView2.perform(click());
+
+        pressBack();
+
+        ConditionWatcher.waitForCondition(new Shared.ViewItemWaitingInstruction(com.ichi2.anki.R.id.action_search));
+        ViewInteraction actionMenuItemView3 = onView(
+                Matchers.allOf(ViewMatchers.withId(com.ichi2.anki.R.id.action_search), withContentDescription("Search"),
+                        childAtPosition(
+                                childAtPosition(
+                                        ViewMatchers.withId(com.ichi2.anki.R.id.toolbar),
+                                        3),
+                                1),
+                        isDisplayed()));
+        actionMenuItemView3.perform(click());
+
+        ConditionWatcher.waitForCondition(new Shared.ViewItemWaitingInstruction(com.ichi2.anki.R.id.search_src_text));
+        ViewInteraction searchAutoComplete = onView(
+                Matchers.allOf(ViewMatchers.withId(com.ichi2.anki.R.id.search_src_text),
+                        childAtPosition(
+                                Matchers.allOf(ViewMatchers.withId(com.ichi2.anki.R.id.search_plate),
+                                        childAtPosition(
+                                                ViewMatchers.withId(com.ichi2.anki.R.id.search_edit_frame),
+                                                1)),
+                                0),
+                        isDisplayed()));
+        searchAutoComplete.perform(replaceText(cardId + "bad"), closeSoftKeyboard());
+
+        ViewInteraction searchAutoComplete2 = onView(
+                Matchers.allOf(ViewMatchers.withId(com.ichi2.anki.R.id.search_src_text), withText(cardId + "bad"),
+                        childAtPosition(
+                                Matchers.allOf(ViewMatchers.withId(com.ichi2.anki.R.id.search_plate),
+                                        childAtPosition(
+                                                ViewMatchers.withId(com.ichi2.anki.R.id.search_edit_frame),
+                                                1)),
+                                0),
+                        isDisplayed()));
+        searchAutoComplete2.perform(pressImeActionButton());
+
+        openActionBarOverflowOrOptionsMenu(getInstrumentation().getTargetContext());
+        ViewInteraction linearLayout42 = onView(
+                Matchers.allOf(withText("Preview"),
+                        childAtPosition(
+                                IsInstanceOf.<View>instanceOf(android.widget.FrameLayout.class),
+                                0),
+                        isDisplayed()));
+        linearLayout42.check(doesNotExist());
+        pressBack();
+
+        ConditionWatcher.waitForCondition(new Shared.ViewItemWaitingInstruction(com.ichi2.anki.R.id.search_close_btn));
+        ViewInteraction appCompatImageView = onView(
+                Matchers.allOf(ViewMatchers.withId(com.ichi2.anki.R.id.search_close_btn), withContentDescription("Clear query"),
+                        childAtPosition(
+                                Matchers.allOf(ViewMatchers.withId(com.ichi2.anki.R.id.search_plate),
+                                        childAtPosition(
+                                                ViewMatchers.withId(com.ichi2.anki.R.id.search_edit_frame),
+                                                1)),
+                                1),
+                        isDisplayed()));
+        appCompatImageView.perform(click());
+
+        ViewInteraction searchAutoComplete3 = onView(
+                Matchers.allOf(ViewMatchers.withId(com.ichi2.anki.R.id.search_src_text),
+                        childAtPosition(
+                                Matchers.allOf(ViewMatchers.withId(com.ichi2.anki.R.id.search_plate),
+                                        childAtPosition(
+                                                ViewMatchers.withId(com.ichi2.anki.R.id.search_edit_frame),
+                                                1)),
+                                0),
+                        isDisplayed()));
+        searchAutoComplete3.perform(replaceText(cardId), closeSoftKeyboard());
+
+        ViewInteraction searchAutoComplete4 = onView(
+                Matchers.allOf(ViewMatchers.withId(com.ichi2.anki.R.id.search_src_text), withText(cardId),
+                        childAtPosition(
+                                Matchers.allOf(ViewMatchers.withId(com.ichi2.anki.R.id.search_plate),
+                                        childAtPosition(
+                                                ViewMatchers.withId(com.ichi2.anki.R.id.search_edit_frame),
+                                                1)),
+                                0),
+                        isDisplayed()));
+        searchAutoComplete4.perform(pressImeActionButton());
+        Thread.sleep(200);
+
+        openActionBarOverflowOrOptionsMenu(getInstrumentation().getTargetContext());
+        Thread.sleep(200);
+
+        ViewInteraction appCompatTextView = onView(
+                Matchers.allOf(ViewMatchers.withId(com.ichi2.anki.R.id.title), withText("Preview"),
+                        isDisplayed()));
+        Thread.sleep(200);
+
+        appCompatTextView.perform(click());
+        Thread.sleep(200);
+
+        ConditionWatcher.waitForCondition(new Shared.ViewItemWaitingInstruction(com.ichi2.anki.R.id.flashcard_layout_ease1));
+        ViewInteraction textView = onView(
+                Matchers.allOf(ViewMatchers.withId(com.ichi2.anki.R.id.nextTime1), withText("-"),
+                        isDisplayed()));
+        textView.check(matches(withText("-")));
+
+        ViewInteraction textView2 = onView(
+                Matchers.allOf(ViewMatchers.withId(com.ichi2.anki.R.id.nextTime2), withText(">"),
+                        isDisplayed()));
+        textView2.check(matches(withText(">")));
+
+        ViewInteraction linearLayout = onView(
+                Matchers.allOf(ViewMatchers.withId(com.ichi2.anki.R.id.flashcard_layout_ease2),
+                        childAtPosition(
+                                Matchers.allOf(ViewMatchers.withId(com.ichi2.anki.R.id.answer_options_layout),
+                                        childAtPosition(
+                                                ViewMatchers.withId(com.ichi2.anki.R.id.bottom_area_layout),
+                                                1)),
+                                2),
+                        isDisplayed()));
+        linearLayout.perform(click());
+
+        ViewInteraction textView3 = onView(
+                Matchers.allOf(ViewMatchers.withId(com.ichi2.anki.R.id.nextTime1), withText("<"),
+                        isDisplayed()));
+        textView3.check(matches(withText("<")));
+
+        ViewInteraction textView4 = onView(
+                Matchers.allOf(ViewMatchers.withId(com.ichi2.anki.R.id.nextTime2), withText(">"),
+                        isDisplayed()));
+        textView4.check(matches(withText(">")));
+
+        ViewInteraction linearLayout2 = onView(
+                Matchers.allOf(ViewMatchers.withId(com.ichi2.anki.R.id.flashcard_layout_ease2),
+                        isDisplayed()));
+        linearLayout2.perform(click());
+
+        ViewInteraction linearLayout3 = onView(
+                Matchers.allOf(ViewMatchers.withId(com.ichi2.anki.R.id.flashcard_layout_ease2),
+                        isDisplayed()));
+        linearLayout3.perform(click());
+
+        ViewInteraction textView5 = onView(
+                Matchers.allOf(ViewMatchers.withId(com.ichi2.anki.R.id.nextTime1), withText("<"),
+                        isDisplayed()));
+        textView5.check(matches(withText("<")));
+
+        ViewInteraction textView6 = onView(
+                Matchers.allOf(ViewMatchers.withId(com.ichi2.anki.R.id.nextTime2), withText("-"),
+                        isDisplayed()));
+        textView6.check(matches(withText("-")));
+
+        ViewInteraction linearLayout4 = onView(
+                Matchers.allOf(ViewMatchers.withId(com.ichi2.anki.R.id.flashcard_layout_ease1),
+                        isDisplayed()));
+        linearLayout4.perform(click());
+
+        ViewInteraction linearLayout5 = onView(
+                Matchers.allOf(ViewMatchers.withId(com.ichi2.anki.R.id.flashcard_layout_ease1),
+                        isDisplayed()));
+        linearLayout5.perform(click());
+
+        ViewInteraction linearLayout6 = onView(
+                Matchers.allOf(ViewMatchers.withId(com.ichi2.anki.R.id.flashcard_layout_ease1),
+                        isDisplayed()));
+        linearLayout6.perform(click());
+
+        ViewInteraction textView8 = onView(
+                Matchers.allOf(ViewMatchers.withId(com.ichi2.anki.R.id.nextTime1), withText("-"),
+                        isDisplayed()));
+        textView8.check(matches(withText("-")));
+
+        ViewInteraction textView9 = onView(
+                Matchers.allOf(ViewMatchers.withId(com.ichi2.anki.R.id.nextTime2), withText(">"),
+                        isDisplayed()));
+        textView9.check(matches(withText(">")));
+        pressBack();
+
+        ConditionWatcher.waitForCondition(new Shared.ViewItemWaitingInstruction(com.ichi2.anki.R.id.search_src_text));
+        ViewInteraction searchAutoComplete42 = onView(
+                Matchers.allOf(ViewMatchers.withId(R.id.search_src_text),
+                        isDisplayed()));
+        searchAutoComplete42.check(matches(withText(cardId)));
+        Assert.assertNotNull("Did not make it to the end of the UI run", searchAutoComplete42);
+
+    }
+
+
+    private static Matcher<View> childAtPosition(
+            final Matcher<View> parentMatcher, final int position) {
+
+        return new TypeSafeMatcher<View>() {
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("Child at position " + position + " in parent ");
+                parentMatcher.describeTo(description);
+            }
+
+
+            @Override
+            public boolean matchesSafely(View view) {
+                ViewParent parent = view.getParent();
+                return parent instanceof ViewGroup && parentMatcher.matches(parent)
+                        && view.equals(((ViewGroup) parent).getChildAt(position));
+            }
+        };
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.java
@@ -104,16 +104,22 @@ public class Previewer extends AbstractFlashcardViewer {
     private View.OnClickListener mSelectScrollHandler = new View.OnClickListener() {
         @Override
         public void onClick(View view) {
-            if (!mShowingAnswer) {
-                displayCardAnswer();
-            } else {
-                if (view.getId() == R.id.flashcard_layout_ease1) {
-                    mIndex--;
-                } else if (view.getId() == R.id.flashcard_layout_ease2) {
+            if (mShowingAnswer) {
+                // If we are showing the answer, any click will show a question...
+                if (view.getId() == R.id.flashcard_layout_ease2) {
+                    // ...but if they clicked "forward" we need to move to the next card first
                     mIndex++;
+                    mCurrentCard = getCol().getCard(mCardList[mIndex]);
                 }
-                mCurrentCard = getCol().getCard(mCardList[mIndex]);
                 displayCardQuestion();
+            } else {
+                // If we are showing the question, any click will show an answer...
+                if (view.getId() == R.id.flashcard_layout_ease1) {
+                    // ...but if they clicked "reverse" we need to go to the previous card first
+                    mIndex--;
+                    mCurrentCard = getCol().getCard(mCardList[mIndex]);
+                }
+                displayCardAnswer();
             }
         }
     };
@@ -153,8 +159,7 @@ public class Previewer extends AbstractFlashcardViewer {
         mEase2Layout.setOnClickListener(mSelectScrollHandler);
         mEase2Layout.setBackgroundResource(background[0]);
 
-
-        if (mIndex == 0 && mShowingAnswer) {
+        if (mIndex == 0 && !mShowingAnswer) {
             mEase1Layout.setEnabled(false);
             mNext1.setText("-");
         } else {


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
3 of the 9 robots google play sent at our last alpha errored in an easy way on the CardBrowser, this fixes that error as well as quite a few CardBrowser/Previewer integration issues

## Fixes
Fixes #4987 

## Approach

1. commit 1 - fixing the Previewer cycling - showing <, > and - at right times
1. commit 2 - Preview option menu item in CardBrowser dynamic so it is hidden if the browser is empty (prevents the crash), also save CardBrowser search state when you go to other activities and return
1. commit 3 - A UI test to exercise all this stuff, but isolated in it's own package and excluded from CI (they are flaky there)

## How Has This Been Tested?
A ton by hand, and I made another UI unit test. I posted videos on the linked issue demonstrating before and after

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
