### PR TITLE
add API support for burying and suspending

### DIFF
--- a/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/ContentProviderTest.java
+++ b/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/ContentProviderTest.java
@@ -48,7 +48,6 @@ import org.json.JSONObject;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/ContentProviderTest.java
+++ b/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/ContentProviderTest.java
@@ -46,7 +46,9 @@ import com.ichi2.libanki.Utils;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -787,6 +789,10 @@ public class ContentProviderTest {
         long deckId = mTestDeckIds[0];
         col.getDecks().select(deckId);
         Card card = col.getSched().getCard();
+        long cardId = card.getId();
+
+        // the card starts out being new
+        assertEquals("card is initial new", Card.TYPE_NEW, card.getQueue());
 
         ContentResolver cr = InstrumentationRegistry.getTargetContext().getContentResolver();
         Uri reviewInfoUri = FlashCardsContract.ReviewInfo.CONTENT_URI;
@@ -794,10 +800,12 @@ public class ContentProviderTest {
         long noteId = card.note().getId();
         int cardOrd = card.getOrd();
         int ease = AbstractFlashcardViewer.EASE_3; //<- insert real ease here
+        long timeTaken = 5000; // 5 seconds
 
         values.put(FlashCardsContract.ReviewInfo.NOTE_ID, noteId);
         values.put(FlashCardsContract.ReviewInfo.CARD_ORD, cardOrd);
         values.put(FlashCardsContract.ReviewInfo.EASE, ease);
+        values.put(FlashCardsContract.ReviewInfo.TIME_TAKEN, timeTaken);
         int updateCount = cr.update(reviewInfoUri, values, null, null);
         assertEquals("Check if update returns 1", 1, updateCount);
         col.getSched().reset();
@@ -809,6 +817,157 @@ public class ContentProviderTest {
         }else{
             //We expected this
         }
+
+        // lookup the card after update, ensure it's not new anymore
+        Card cardAfterReview = col.getCard(cardId);
+        assertEquals("card is now type rev", Card.TYPE_REV, cardAfterReview.getQueue());
+
+    }
+
+
+    /**
+     * Test burying a card through the ReviewInfo endpoint
+     */
+    @Test
+    public void testBuryCard(){
+        // get the first card due
+        // ----------------------
+        Collection col;
+        col = CollectionHelper.getInstance().getCol(InstrumentationRegistry.getTargetContext());
+        long deckId = mTestDeckIds[0];
+        col.getDecks().select(deckId);
+        Card card = col.getSched().getCard();
+
+        // verify that the card is not already user-buried
+        Assert.assertNotEquals("Card is not user-buried before test", Card.QUEUE_USER_BRD, card.getQueue());
+
+        // retain the card id, we will lookup the card after the update
+        long cardId = card.getId();
+
+        // bury it through the API
+        // -----------------------
+        ContentResolver cr = InstrumentationRegistry.getTargetContext().getContentResolver();
+        Uri reviewInfoUri = FlashCardsContract.ReviewInfo.CONTENT_URI;
+        ContentValues values = new ContentValues();
+        long noteId = card.note().getId();
+        int cardOrd = card.getOrd();
+        int bury = 1;
+
+        values.put(FlashCardsContract.ReviewInfo.NOTE_ID, noteId);
+        values.put(FlashCardsContract.ReviewInfo.CARD_ORD, cardOrd);
+        values.put(FlashCardsContract.ReviewInfo.BURY, bury);
+
+        int updateCount = cr.update(reviewInfoUri, values, null, null);
+        assertEquals("Check if update returns 1", 1, updateCount);
+
+        // verify that it did get buried
+        // -----------------------------
+
+        Card cardAfterUpdate = col.getCard(cardId);
+        assertEquals("Card is user-buried", Card.QUEUE_USER_BRD, cardAfterUpdate.getQueue());
+
+        // cleanup, unbury cards
+        // ---------------------
+
+        col.getSched().unburyCards();
+    }
+
+    /**
+     * Test suspending a card through the ReviewInfo endpoint
+     */
+    @Test
+    public void testSuspendCard(){
+
+        // get the first card due
+        // ----------------------
+        Collection col;
+        col = CollectionHelper.getInstance().getCol(InstrumentationRegistry.getTargetContext());
+        long deckId = mTestDeckIds[0];
+        col.getDecks().select(deckId);
+        Card card = col.getSched().getCard();
+
+        // verify that the card is not already suspended
+        Assert.assertNotEquals("Card is not suspended before test", Card.QUEUE_SUSP, card.getQueue());
+
+        // retain the card id, we will lookup the card after the update
+        long cardId = card.getId();
+
+        // suspend it through the API
+        // --------------------------
+        ContentResolver cr = InstrumentationRegistry.getTargetContext().getContentResolver();
+        Uri reviewInfoUri = FlashCardsContract.ReviewInfo.CONTENT_URI;
+        ContentValues values = new ContentValues();
+        long noteId = card.note().getId();
+        int cardOrd = card.getOrd();
+        int suspend = 1;
+
+        values.put(FlashCardsContract.ReviewInfo.NOTE_ID, noteId);
+        values.put(FlashCardsContract.ReviewInfo.CARD_ORD, cardOrd);
+        values.put(FlashCardsContract.ReviewInfo.SUSPEND, suspend);
+
+        int updateCount = cr.update(reviewInfoUri, values, null, null);
+        assertEquals("Check if update returns 1", 1, updateCount);
+
+        // verify that it did get suspended
+        // --------------------------------
+
+        Card cardAfterUpdate = col.getCard(cardId);
+        assertEquals("Card is suspended", Card.QUEUE_SUSP, cardAfterUpdate.getQueue());
+
+        // cleanup, unsuspend card and reschedule
+        // --------------------------------------
+
+        col.getSched().unsuspendCards(new long[]{cardId});
+        col.getSched().reset();
+    }
+
+
+    /**
+     * Update tags on a note
+     */
+    @Test
+    public void testUpdateTags() {
+        // get the first card due
+        // ----------------------
+        Collection col;
+        col = CollectionHelper.getInstance().getCol(InstrumentationRegistry.getTargetContext());
+        long deckId = mTestDeckIds[0];
+        col.getDecks().select(deckId);
+        Card card = col.getSched().getCard();
+        Note note = card.note();
+        long noteId = note.getId();
+
+        // make sure the tag is what we expect initially
+        // ---------------------------------------------
+
+        List<String> tagList = note.getTags();
+        assertEquals("only one tag", 1, tagList.size());
+        assertEquals("check tag value", TEST_TAG, tagList.get(0));
+
+        // update tags
+        // -----------
+        String tag1 = TEST_TAG;
+        String tag2 = "mynewtag";
+
+        ContentResolver cr = InstrumentationRegistry.getTargetContext().getContentResolver();
+        Uri updateNoteUri = Uri.withAppendedPath(FlashCardsContract.Note.CONTENT_URI, Long.toString(noteId));
+        ContentValues values = new ContentValues();
+        values.put(FlashCardsContract.Note.TAGS, tag1 + " " + tag2);
+        int updateCount = cr.update(updateNoteUri, values, null, null);
+
+        assertEquals("updateCount is 1", 1, updateCount);
+
+
+        // lookup the note now and verify tags
+        // -----------------------------------
+
+        Note noteAfterUpdate = col.getNote(noteId);
+        List<String> newTagList = noteAfterUpdate.getTags();
+        assertEquals("two tags", 2, newTagList.size());
+        assertEquals("check first tag", TEST_TAG, newTagList.get(0));
+        assertEquals("check second tag", tag2, newTagList.get(1));
+
+
     }
 
     private Collection reopenCol() {

--- a/api/src/main/java/com/ichi2/anki/FlashCardsContract.java
+++ b/api/src/main/java/com/ichi2/anki/FlashCardsContract.java
@@ -169,6 +169,16 @@ public class FlashCardsContract {
      *     </code>
      * </pre>
      * <p>
+     * <p>
+     * Updating tags for a note can be done this way:
+     * <pre>
+     *     <code>
+             Uri updateNoteUri = Uri.withAppendedPath(FlashCardsContract.Note.CONTENT_URI, Long.toString(noteId));
+             ContentValues values = new ContentValues();
+             values.put(FlashCardsContract.Note.TAGS, tag1 + " " + tag2);
+             int updateCount = cr.update(updateNoteUri, values, null, null);
+     *     </code>
+     * </pre>
      *
      * <p>
      * A note consists of the following columns:
@@ -214,13 +224,13 @@ public class FlashCardsContract {
      * <tr>
      * <td>long</td>
      * <td>{@link #TAGS}</td>
-     * <td>read-only</td>
+     * <td>read-write</td>
      * <td>NoteTag of this note. NoteTag are separated  by spaces.</td>
      * </tr>
      * <tr>
      * <td>String</td>
      * <td>{@link #FLDS}</td>
-     * <td>read-only</td>
+     * <td>read-write</td>
      * <td>Fields of this note. Fields are separated by "\\x1f"</td>
      * </tr>
      * <tr>
@@ -876,10 +886,24 @@ public class FlashCardsContract {
      * <td>The it took to answer the card (in milliseconds). Used when answering the card.
      * </td>
      * </tr>
+     * <tr>
+     * <td>int</td>
+     * <td>{@link #BURY}</td>
+     * <td>write-only</td>
+     * <td>Set to 1 to bury the card. Mutually exclusive with setting EASE/TIME_TAKEN/SUSPEND
+     * </td>
+     * </tr>
+     * <tr>
+     * <td>int</td>
+     * <td>{@link #SUSPEND}</td>
+     * <td>write-only</td>
+     * <td>Set to 1 to suspend the card. Mutually exclusive with setting EASE/TIME_TAKEN/BURY
+     * </td>
+     * </tr>
      * </table>
      *
-     * The only writable column is the {@link #EASE}, which is used for answering a card.<br>
-     * Answering a card can be done as shown in this example
+     * <p>
+     * Answering a card can be done as shown in this example. Don't set BURY/SUSPEND when answering a card.
      * <pre>
      *    <code>ContentResolver cr = getContentResolver();
      *    Uri reviewInfoUri = FlashCardsContract.ReviewInfo.CONTENT_URI;
@@ -896,6 +920,31 @@ public class FlashCardsContract {
      *    cr.update(reviewInfoUri, values, null, null);
      *    </code>
      * </pre>
+     * </p>
+     *
+     * <p>
+     * Burying or suspending a card can be done this way. Don't set EASE/TIME_TAKEN when burying/suspending a card
+     * <pre>
+     *    <code>
+     *    ContentResolver cr = getContentResolver();
+     *    Uri reviewInfoUri = FlashCardsContract.ReviewInfo.CONTENT_URI;
+     *    ContentValues values = new ContentValues();
+     *    long noteId = card.note().getId();
+     *    int cardOrd = card.getOrd();
+     *
+     *    values.put(FlashCardsContract.ReviewInfo.NOTE_ID, noteId);
+     *    values.put(FlashCardsContract.ReviewInfo.CARD_ORD, cardOrd);
+     *
+     *    // use this to bury a card
+     *    values.put(FlashCardsContract.ReviewInfo.BURY, 1);
+     *
+     *    // if you want to suspend, use this instead
+     *    // values.put(FlashCardsContract.ReviewInfo.SUSPEND, 1);
+     *
+     *    int updateCount = cr.update(reviewInfoUri, values, null, null);
+     *    </code>
+     * </pre>
+     * </p>
      */
     public static class ReviewInfo {
 
@@ -942,6 +991,16 @@ public class FlashCardsContract {
          */
 
         public static final String TIME_TAKEN = "time_taken";
+
+        /**
+         * Write-only field, allows burying of a card when set to 1
+         */
+        public static final String BURY = "buried";
+
+        /**
+         * Write-only field, allows suspending of a card when set to 1
+         */
+        public static final String SUSPEND = "suspended";
 
         public static final String[] DEFAULT_PROJECTION = {
                 NOTE_ID,


### PR DESCRIPTION

## Purpose / Description
Allow burying or suspending cards from the API, using the **ReviewInfo** / **SCHEDULE** endpoint.

## Fixes
#4986

## Approach
Add support for bury/suspend in the **ReviewInfo** / **SCHEDULE** endpoint, using two new write-only fields.

## How Has This Been Tested?

- Added test **ContentProviderTest.testBuryCard()**
- Added test **ContentProviderTest.testSuspendCard()**
- Added test **ContentProviderTest.testUpdateTags()**. this functionality existed in the API previously but was undocumented/untested.
- Added another check in **ContentProviderTest.testAnswerCard()** to ensure bury/suspend support is not breaking regular card reviews.

## Learning (optional, can help others)

Updated Javadoc for **FlashCardsContract**

- Example for burying/suspending a card
- Example for updating tags for a note
- Classified FLDS/TAGS fields as read-write

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
