### PR TITLE
Fix Beolingus on API28 / Fix crash after downloading pronunciation

### DIFF
--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -83,6 +83,7 @@
         android:roundIcon="@mipmap/anki_round"
         android:label="@string/app_name"
         android:windowSoftInputMode="adjustResize"
+        android:usesCleartextTraffic="true"
         android:largeHeap="true">
         <activity
             android:name="com.ichi2.anki.IntentHandler"

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
@@ -317,6 +317,7 @@ public class MultimediaEditFieldActivity extends AnkiActivity
         }
 
         super.onActivityResult(requestCode, resultCode, data);
+        supportInvalidateOptionsMenu();
     }
 
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
2.9alpha37 was better than 36 on the crash front but the Play Console robot army still found something in the multimedia card / pronunciation interaction. This fixes that crash and also fixes a regression where on API28 pronunciation downloads fail completely because of HTTP cleartext restrictions

## Fixes
Fixes #5002 

## Approach
The Multimedia field editor defaults to a text state which exposes the record audio action bar button. After loading the pronunciation audio it needed to re-initialize itself as audio so the action bar buttons showed text and image. I just hooked for an action bar reinit when child Activities of multimedia edit return

For the HTTP cleartext thing I added a manifest entry per API docs

## How Has This Been Tested?

Test the reproduction scenario on API27 and API28 emulators, as well as all paths I could think of in the advanced editor

## Learning (optional, can help others)
API28 / Android P will by default deny all HTTP (cleartext) transmission, including down to the WebViews embedded in an app, if you don't explicitly allow them.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
