### PR TITLE
Fix 4999

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -511,7 +511,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
         getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN);
 
         // set the currently selected deck
-        selectDropDownItem(getDeckPositionFromDeckId(getIntent().getLongExtra("defaultDeckId", -1)));
+        selectDropDownItem(getDeckPositionFromDeckId(getIntent().getLongExtra("selectedDeck", -1)));
     }
 
     @Override

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1015,24 +1015,26 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
     /**
      * Get the index in the deck spinner for a given deck ID
-     * @param did the id of a deck
+     * @param did the id of a deck, -1 if none selected
      * @return the corresponding index in the deck spinner, or 0 if not found
      */
     private int getDeckPositionFromDeckId(long did) {
-        for (int dropDownDeckIdx = 0; dropDownDeckIdx < mDropDownDecks.size(); dropDownDeckIdx++) {
-            JSONObject deck = mDropDownDecks.get(dropDownDeckIdx);
-            long cdid;
-            try {
-                cdid = deck.getLong("id");
-            } catch (JSONException e) {
-                throw new RuntimeException();
-            }
-            if (cdid == did) {
-                // NOTE: mDropDownDecks.get(0) is the first deck, whereas index 0 in mActionBarSpinner is "All Decks"
-                return dropDownDeckIdx + 1;
+        if (did != -1) {
+            for (int dropDownDeckIdx = 0; dropDownDeckIdx < mDropDownDecks.size(); dropDownDeckIdx++) {
+                JSONObject deck = mDropDownDecks.get(dropDownDeckIdx);
+                long cdid;
+                try {
+                    cdid = deck.getLong("id");
+                } catch (JSONException e) {
+                    throw new RuntimeException();
+                }
+                if (cdid == did) {
+                    // NOTE: mDropDownDecks.get(0) is the first deck, whereas index 0 in mActionBarSpinner is "All Decks"
+                    return dropDownDeckIdx + 1;
+                }
             }
         }
-        // Fall back on "All Decks" if did wasn't found
+        // Fall back on "All Decks" if no did or did wasn't found
         return 0;
     }
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Makes switching between browser, statistics and picker more consistent - switching the current deck in one is reflected in the other activities.

## Fixes
https://github.com/ankidroid/Anki-Android/issues/4999


## How Has This Been Tested?

Yes, I tested switching between the three mentioned activities and changed the current decks and it seems to work fine. Tested on a Naxus 6p (API level 27), but the change is so minor I can see any issues on any other levels or devices.

## Learning (optional, can help others)
Basically just cloned the code, found the browser activity class, looked for what happens when the deck is loaded (triggered when the activity is initialized) and looked for the code to select the dropdown item.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
