### PR TITLE
Don't ignore ResultCode on image selection

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
@@ -20,6 +20,7 @@
 package com.ichi2.anki.multimediacard.fields;
 
 import android.Manifest;
+import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
@@ -159,6 +160,9 @@ public class BasicImageFieldController extends FieldControllerBase implements IF
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
         // ignore RESULT_CANCELED but handle image select and take
+        if (resultCode == Activity.RESULT_CANCELED) {
+            return;
+        }
         if (requestCode == ACTIVITY_SELECT_IMAGE) {
             Uri selectedImage = data.getData();
             // Timber.d(selectedImage.toString());


### PR DESCRIPTION
PR #5004 was complaining of an empty if:
https://github.com/ankidroid/Anki-Android/pull/5004/files#diff-097a1b08d60abe4a789cc6394b0dbf27L173

I thought it was collapsible but missed that it was two different objects - this first if
was needed but could return immediately. If you ignore that it was cancelled you'll take a NullPointerException
when you try to access the non-existent image


## How Has This Been Tested?

Noticed this while testing #5005 - went to create some unused media and crashed as I clicked around...
