### PR TITLE
Reload Note.model from db when returning to NoteEditor from CardTemplateEditor

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -146,7 +146,7 @@ public class AnkiDroidApp extends Application {
      * collections being upgraded to (or after) this version must run an integrity check as it will contain fixes that
      * all collections should have.
      */
-    public static final int CHECK_DB_AT_VERSION = 40;
+    public static final int CHECK_DB_AT_VERSION = 20805000;
 
     /**
      * The latest package version number that included changes to the preferences that requires handling. All

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -936,12 +936,13 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
             if (previous < upgradeDbVersion || previous < upgradePrefsVersion) {
                 if (previous < upgradePrefsVersion && current >= upgradePrefsVersion) {
-                    Timber.d("Upgrading preferences");
+                    Timber.i("showStartupScreensAndDialogs() running upgradePreferences()");
                     CompatHelper.removeHiddenPreferences(this.getApplicationContext());
                     upgradePreferences(previous);
                 }
                 // Integrity check loads asynchronously and then restart deckpicker when finished
                 if (previous < upgradeDbVersion && current >= upgradeDbVersion) {
+                    Timber.i("showStartupScreensAndDialogs() running integrityCheck()");
                     integrityCheck();
                 } else if (previous < upgradePrefsVersion && current >= upgradePrefsVersion) {
                     // If integrityCheck() doesn't occur, but we did update preferences we should restart DeckPicker to

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -335,7 +335,7 @@ public class NoteEditor extends AnkiActivity {
         this.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN);
 
         Intent intent = getIntent();
-        Timber.d("onCollectionLoaded: caller: %d", mCaller);
+        Timber.d("NoteEditor() onCollectionLoaded: caller: %d", mCaller);
 
         SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(getBaseContext());
 
@@ -534,7 +534,7 @@ public class NoteEditor extends AnkiActivity {
         });
 
         if (!mAddNote && mCurrentEditedCard != null) {
-            Timber.i("NoteEditor:: Edit note activity successfully started with card id %d", mCurrentEditedCard.getId());
+            Timber.i("onCollectionLoaded() Edit note activity successfully started with card id %d", mCurrentEditedCard.getId());
         }
     }
 
@@ -1008,12 +1008,14 @@ public class NoteEditor extends AnkiActivity {
         // Pass the model ID
         try {
             intent.putExtra("modelId", getCurrentlySelectedModel().getLong("id"));
+            Timber.d("showCardTemplateEditor() for model %s", intent.getLongExtra("modelId", -1L));
         } catch (JSONException e) {
            throw new RuntimeException(e);
         }
         // Also pass the card ID if not adding new note
         if (!mAddNote) {
             intent.putExtra("noteId", mCurrentEditedCard.note().getId());
+            Timber.d("showCardTemplateEditor() with note %s", mCurrentEditedCard.note().getId());
         }
         startActivityForResultWithAnimation(intent, REQUEST_TEMPLATE_EDIT, ActivityTransitionAnimation.LEFT);
     }
@@ -1021,6 +1023,7 @@ public class NoteEditor extends AnkiActivity {
 
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        Timber.d("onActivityResult() with request/result: %s/%s", requestCode, resultCode);
         super.onActivityResult(requestCode, resultCode, data);
 
         if (resultCode == DeckPicker.RESULT_DB_ERROR) {
@@ -1065,6 +1068,9 @@ public class NoteEditor extends AnkiActivity {
                 if (resultCode == RESULT_OK) {
                     mReloadRequired = true;
                 }
+                // rebuild the model post-template-edit so we get the correct number of cards
+                Timber.d("onActivityResult() template edit - reloading model");
+                mEditorNote.reloadModel();
                 updateCards(mEditorNote.model());
         }
     }
@@ -1407,10 +1413,12 @@ public class NoteEditor extends AnkiActivity {
 
     /** Update the list of card templates for current note type */
     private void updateCards(JSONObject model) {
+        Timber.d("updateCards()");
         try {
             JSONArray tmpls = model.getJSONArray("tmpls");
             String cardsList = "";
             // Build comma separated list of card names
+            Timber.d("updateCards() template count is %s", tmpls.length());
             for (int i = 0; i < tmpls.length(); i++) {
                 String name = tmpls.getJSONObject(i).optString("name");
                 // If more than one card then make currently selected card underlined

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1510,7 +1510,7 @@ public class Collection {
         if (problems.size() > 0) {
             modSchemaNoCheck();
         }
-        // TODO: report problems
+        logProblems(problems);
         return (oldSize - newSize) / 1024;
     }
 
@@ -1527,6 +1527,27 @@ public class Collection {
      * Logging
      * ***********************************************************
      */
+
+    /**
+     * Track database corruption problems - AcraLimiter should quench it if it's a torrent
+     * but we will take care to limit possible data usage by limiting count we send regardless
+     *
+     * @param integrityCheckProblems list of problems, the first 10 will be logged and sent via ACRA
+     */
+    private void logProblems(ArrayList integrityCheckProblems) {
+
+        if (integrityCheckProblems.size() > 0) {
+            StringBuffer additionalInfo = new StringBuffer();
+            for (int i = 0; ((i < 10) && (integrityCheckProblems.size() > i)); i++) {
+                additionalInfo.append(integrityCheckProblems.get(i)).append("\n");
+            }
+            AnkiDroidApp.sendExceptionReport(
+                    new Exception("Problem list (limited to first 10)"), "Collection.fixIntegrity()", additionalInfo.toString());
+            Timber.i("fixIntegrity() Problem list (limited to first 10):\n%s", additionalInfo);
+        } else {
+            Timber.i("fixIntegrity() no problems found");
+        }
+    }
 
     public void log(Object... args) {
         if (!mDebugLog) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Note.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Note.java
@@ -31,6 +31,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+import timber.log.Timber;
+
 
 public class Note implements Cloneable {
 
@@ -88,6 +90,7 @@ public class Note implements Cloneable {
 
 
     public void load() {
+        Timber.d("load()");
         Cursor cursor = null;
         try {
             cursor = mCol.getDb().getDatabase()
@@ -111,6 +114,10 @@ public class Note implements Cloneable {
                 cursor.close();
             }
         }
+    }
+
+    public void reloadModel() {
+        mModel = mCol.getModels().get(mMid);
     }
 
 


### PR DESCRIPTION

## Pull Request template

## Purpose / Description
Fix a crash where CardTemplateEditor corrupts Note.model.templates leaving a reference to a non-existent template in the Note

## Fixes
#5011 

## Approach

Commit 1 triggers database integrity check with next build because this bug generated persistent corruption that integrity check does fix

Commit 2 adds Logging and ACRA send if integrity check finds problems so we can track that. Only the first 10 (if there are that many) so it's not overwhelming amounts of data to transmit though (just in case)

Commit 3 is the real fix:
CardTemplateEditor edits the model in the database directly, persisting speculative edits even before user clicks save. If user discards a template addition or subtraction, CardTemplateEditor saves a pre-edit backup copy of the model before returning.

Problem is the model.templates state bleeds into Notes.model.templates somehow, so the fix is that when NoteEditor gets the control back from CardTemplateEditor it NoteEditor calls a new Note.reloadModel() hook to reload Note.model from the database directly, where CardTemplateEditor does always leave the correct state.


## How Has This Been Tested?

Emulators, lots of clicking around...