### PR TITLE
Migrate to beta test APIs from alpha

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -108,18 +108,13 @@ dependencies {
     implementation 'androidx.sqlite:sqlite:2.0.0'
     implementation 'com.afollestad.material-dialogs:core:0.9.6.0'
     implementation 'com.getbase:floatingactionbutton:1.10.1'
-    implementation('ch.acra:acra-http:5.2.0') {
-        exclude group: 'com.android.support'
-    }
-    implementation('ch.acra:acra-dialog:5.2.0') {
-        exclude group: 'com.android.support'
-    }
-    implementation('ch.acra:acra-toast:5.2.0') {
-        exclude group: 'com.android.support'
-    }
-    implementation('ch.acra:acra-limiter:5.2.0') {
-        exclude group: 'com.android.support'
-    }
+
+    // May need a resolution strategy for support libs to our versions
+    implementation'ch.acra:acra-http:5.2.0'
+    implementation'ch.acra:acra-dialog:5.2.0'
+    implementation'ch.acra:acra-toast:5.2.0'
+    implementation'ch.acra:acra-limiter:5.2.0'
+
     implementation 'com.jakewharton.timber:timber:4.7.1'
     implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'org.jsoup:jsoup:1.11.3'
@@ -133,18 +128,11 @@ dependencies {
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
     testImplementation 'net.lachlanmckee:timber-junit-rule:1.0.1'
 
+    // May need a resolution strategy for support libs to our versions
     androidTestImplementation 'com.azimolabs.conditionwatcher:conditionwatcher:0.2'
-    androidTestImplementation('androidx.test.espresso:espresso-core:3.1.0-alpha4') {
-        exclude group: 'com.android.support'
-    }
-    androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.1.0-alpha4', {
-        exclude group: 'com.android.support'
-    }
-    androidTestImplementation('androidx.test:runner:1.1.0-alpha4') {
-        exclude group: 'com.android.support'
-    }
-    androidTestImplementation('androidx.test:rules:1.1.0-alpha4') {
-        exclude group: 'com.android.support'
-    }
-    androidTestUtil 'androidx.test:orchestrator:1.1.0-alpha4'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0-beta01'
+    androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.1.0-beta01'
+    androidTestImplementation 'androidx.test:runner:1.1.0-beta01'
+    androidTestImplementation 'androidx.test:rules:1.1.0-beta01'
+    androidTestUtil 'androidx.test:orchestrator:1.1.0-beta01'
 }

--- a/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/ACRATest.java
+++ b/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/ACRATest.java
@@ -34,6 +34,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+@SuppressWarnings("deprecation")
 @RunWith(AndroidJUnit4.class)
 public class ACRATest {
 
@@ -78,8 +79,7 @@ public class ACRATest {
     }
 
     private void verifyDebugACRAPreferences() {
-        assertEquals("ACRA was not disabled correctly",
-                true,
+        assertTrue("ACRA was not disabled correctly",
                 AnkiDroidApp.getSharedPrefs(InstrumentationRegistry.getTargetContext())
                         .getBoolean(ACRA.PREF_DISABLE_ACRA, true));
         assertEquals("ACRA feedback was not turned off correctly",
@@ -179,8 +179,7 @@ public class ACRATest {
 
 
     private void verifyACRANotDisabled() {
-        assertEquals("ACRA was not enabled correctly",
-                false,
+        assertFalse("ACRA was not enabled correctly",
                 AnkiDroidApp.getSharedPrefs(InstrumentationRegistry.getTargetContext()).getBoolean(ACRA.PREF_DISABLE_ACRA, false));
     }
 

--- a/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/CollectionTest.java
+++ b/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/CollectionTest.java
@@ -1,7 +1,7 @@
 package com.ichi2.anki.tests;
 
 import android.Manifest;
-import androidx.test.InstrumentationRegistry;
+import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.rule.GrantPermissionRule;
 import androidx.test.runner.AndroidJUnit4;
 
@@ -16,6 +16,7 @@ import static org.junit.Assert.assertNotNull;
 /**
  * This test case verifies that the directory initialization works even if the app is not yet fully initialized.
  */
+@SuppressWarnings("deprecation")
 @RunWith(AndroidJUnit4.class)
 public class CollectionTest {
 
@@ -26,6 +27,6 @@ public class CollectionTest {
     @Test
     public void testOpenCollection() {
         assertNotNull("Collection could not be opened",
-                CollectionHelper.getInstance().getCol(InstrumentationRegistry.getTargetContext()));
+                CollectionHelper.getInstance().getCol(InstrumentationRegistry.getInstrumentation().getTargetContext()));
     }
 }

--- a/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/ContentProviderTest.java
+++ b/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/ContentProviderTest.java
@@ -25,7 +25,7 @@ import android.content.ContentUris;
 import android.content.ContentValues;
 import android.database.Cursor;
 import android.net.Uri;
-import androidx.test.InstrumentationRegistry;
+import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.rule.GrantPermissionRule;
 import androidx.test.runner.AndroidJUnit4;
 import android.util.Log;
@@ -66,6 +66,7 @@ import static org.junit.Assert.fail;
  * <p/>
  * These tests should cover all supported operations for each URI.
  */
+@SuppressWarnings("deprecation")
 @RunWith(AndroidJUnit4.class)
 public class ContentProviderTest {
 
@@ -104,7 +105,7 @@ public class ContentProviderTest {
     public void setUp() throws Exception {
         Log.i(AnkiDroidApp.TAG, "setUp()");
         mCreatedNotes = new ArrayList<>();
-        final Collection col = CollectionHelper.getInstance().getCol(InstrumentationRegistry.getTargetContext());
+        final Collection col = CollectionHelper.getInstance().getCol(InstrumentationRegistry.getInstrumentation().getTargetContext());
         // Add a new basic model that we use for testing purposes (existing models could potentially be corrupted)
         JSONObject model = Models.addBasicModel(col, BASIC_MODEL_NAME);
         mModelId = model.getLong("id");
@@ -142,7 +143,7 @@ public class ContentProviderTest {
     @After
     public void tearDown() throws Exception {
         Log.i(AnkiDroidApp.TAG, "tearDown()");
-        final Collection col = CollectionHelper.getInstance().getCol(InstrumentationRegistry.getTargetContext());
+        final Collection col = CollectionHelper.getInstance().getCol(InstrumentationRegistry.getInstrumentation().getTargetContext());
         // Delete all notes
         List<Long> remnantNotes = col.findNotes("tag:" + TEST_TAG);
         if (remnantNotes.size() > 0) {
@@ -172,7 +173,7 @@ public class ContentProviderTest {
     @Test
     public void testInsertAndRemoveNote() throws Exception {
         // Get required objects for test
-        final ContentResolver cr = InstrumentationRegistry.getTargetContext().getContentResolver();
+        final ContentResolver cr = InstrumentationRegistry.getInstrumentation().getTargetContext().getContentResolver();
         // Add the note
         ContentValues values = new ContentValues();
         values.put(FlashCardsContract.Note.MID, mModelId);
@@ -204,8 +205,8 @@ public class ContentProviderTest {
     @Test
     public void testInsertTemplate() throws Exception {
         // Get required objects for test
-        final ContentResolver cr = InstrumentationRegistry.getTargetContext().getContentResolver();
-        Collection col = CollectionHelper.getInstance().getCol(InstrumentationRegistry.getTargetContext());
+        final ContentResolver cr = InstrumentationRegistry.getInstrumentation().getTargetContext().getContentResolver();
+        Collection col = CollectionHelper.getInstance().getCol(InstrumentationRegistry.getInstrumentation().getTargetContext());
         // Add a new basic model that we use for testing purposes (existing models could potentially be corrupted)
         JSONObject model = Models.addBasicModel(col, BASIC_MODEL_NAME);
         long modelId = model.getLong("id");
@@ -240,8 +241,8 @@ public class ContentProviderTest {
     @Test
     public void testInsertField() throws Exception {
         // Get required objects for test
-        final ContentResolver cr = InstrumentationRegistry.getTargetContext().getContentResolver();
-        Collection col = CollectionHelper.getInstance().getCol(InstrumentationRegistry.getTargetContext());
+        final ContentResolver cr = InstrumentationRegistry.getInstrumentation().getTargetContext().getContentResolver();
+        Collection col = CollectionHelper.getInstance().getCol(InstrumentationRegistry.getInstrumentation().getTargetContext());
         JSONObject model = Models.addBasicModel(col, BASIC_MODEL_NAME);
         long modelId = model.getLong("id");
         JSONArray initialFldsArr = model.getJSONArray("flds");
@@ -269,7 +270,7 @@ public class ContentProviderTest {
     @Test
     public void testQueryDirectSqlQuery() {
         // search for correct mid
-        final ContentResolver cr = InstrumentationRegistry.getTargetContext().getContentResolver();
+        final ContentResolver cr = InstrumentationRegistry.getInstrumentation().getTargetContext().getContentResolver();
         Cursor cursor = cr.query(FlashCardsContract.Note.CONTENT_URI_V2, null, String.format("mid=%d", mModelId), null, null);
         assertNotNull(cursor);
         try {
@@ -295,7 +296,7 @@ public class ContentProviderTest {
      */
     @Test
     public void testQueryNoteIds() {
-        final ContentResolver cr = InstrumentationRegistry.getTargetContext().getContentResolver();
+        final ContentResolver cr = InstrumentationRegistry.getInstrumentation().getTargetContext().getContentResolver();
         // Query all available notes
         final Cursor allNotesCursor = cr.query(FlashCardsContract.Note.CONTENT_URI, null, "tag:" + TEST_TAG, null, null);
         assertNotNull(allNotesCursor);
@@ -332,7 +333,7 @@ public class ContentProviderTest {
      */
     @Test
     public void testQueryNotesProjection() {
-        final ContentResolver cr = InstrumentationRegistry.getTargetContext().getContentResolver();
+        final ContentResolver cr = InstrumentationRegistry.getInstrumentation().getTargetContext().getContentResolver();
         // Query all available notes
         for (int i = 0; i < FlashCardsContract.Note.DEFAULT_PROJECTION.length; i++) {
             String[] projection = removeFromProjection(FlashCardsContract.Note.DEFAULT_PROJECTION, i);
@@ -368,7 +369,7 @@ public class ContentProviderTest {
      */
     @Test
     public void testUpdateNoteFields() {
-        final ContentResolver cr = InstrumentationRegistry.getTargetContext().getContentResolver();
+        final ContentResolver cr = InstrumentationRegistry.getInstrumentation().getTargetContext().getContentResolver();
         ContentValues cv = new ContentValues();
         // Change the fields so that the first field is now "newTestValue"
         String[] dummyFields2 = mDummyFields.clone();
@@ -398,7 +399,7 @@ public class ContentProviderTest {
      */
     @Test
     public void testInsertAndUpdateModel() throws Exception {
-        final ContentResolver cr = InstrumentationRegistry.getTargetContext().getContentResolver();
+        final ContentResolver cr = InstrumentationRegistry.getInstrumentation().getTargetContext().getContentResolver();
         ContentValues cv = new ContentValues();
         // Insert a new model
         cv.put(FlashCardsContract.Model.NAME, TEST_MODEL_NAME);
@@ -448,7 +449,6 @@ public class ContentProviderTest {
                 col.getModels().rem(col.getModels().get(mid));
             } catch (ConfirmModSchemaException e) {
                 // This will never happen
-                throw new IllegalStateException("Unexpected ConfirmModSchemaException trying to remove model");
             }
         }
     }
@@ -458,7 +458,7 @@ public class ContentProviderTest {
      */
     @Test
     public void testQueryAllModels() {
-        final ContentResolver cr = InstrumentationRegistry.getTargetContext().getContentResolver();
+        final ContentResolver cr = InstrumentationRegistry.getInstrumentation().getTargetContext().getContentResolver();
         // Query all available models
         final Cursor allModels = cr.query(FlashCardsContract.Model.CONTENT_URI, null, null, null, null);
         assertNotNull(allModels);
@@ -493,7 +493,7 @@ public class ContentProviderTest {
      */
     @Test
     public void testMoveCardsToOtherDeck() {
-        final ContentResolver cr = InstrumentationRegistry.getTargetContext().getContentResolver();
+        final ContentResolver cr = InstrumentationRegistry.getInstrumentation().getTargetContext().getContentResolver();
         // Query all available notes
         final Cursor allNotesCursor = cr.query(FlashCardsContract.Note.CONTENT_URI, null, "tag:" + TEST_TAG, null, null);
         assertNotNull(allNotesCursor);
@@ -536,7 +536,7 @@ public class ContentProviderTest {
      */
     @Test
     public void testQueryCurrentModel() {
-        final ContentResolver cr = InstrumentationRegistry.getTargetContext().getContentResolver();
+        final ContentResolver cr = InstrumentationRegistry.getInstrumentation().getTargetContext().getContentResolver();
         Uri uri = Uri.withAppendedPath(FlashCardsContract.Model.CONTENT_URI, FlashCardsContract.Model.CURRENT_MODEL_ID);
         final Cursor modelCursor = cr.query(uri, null, null, null, null);
         assertNotNull(modelCursor);
@@ -557,7 +557,7 @@ public class ContentProviderTest {
      */
     @Test
     public void testUnsupportedOperations() {
-        final ContentResolver cr = InstrumentationRegistry.getTargetContext().getContentResolver();
+        final ContentResolver cr = InstrumentationRegistry.getInstrumentation().getTargetContext().getContentResolver();
         ContentValues dummyValues = new ContentValues();
         Uri[] updateUris = {
                 // Can't update most tables in bulk -- only via ID
@@ -636,15 +636,14 @@ public class ContentProviderTest {
 
     /**
      * Test query to decks table
-     * @throws Exception
      */
     @Test
     public void testQueryAllDecks() throws Exception{
         Collection col;
-        col = CollectionHelper.getInstance().getCol(InstrumentationRegistry.getTargetContext());
+        col = CollectionHelper.getInstance().getCol(InstrumentationRegistry.getInstrumentation().getTargetContext());
         Decks decks = col.getDecks();
 
-        Cursor decksCursor = InstrumentationRegistry.getTargetContext().getContentResolver()
+        Cursor decksCursor = InstrumentationRegistry.getInstrumentation().getTargetContext().getContentResolver()
                 .query(FlashCardsContract.Deck.CONTENT_ALL_URI, FlashCardsContract.Deck.DEFAULT_PROJECTION, null, null, null);
 
         assertNotNull(decksCursor);
@@ -665,16 +664,15 @@ public class ContentProviderTest {
 
     /**
      * Test query to specific deck ID
-     * @throws Exception
      */
     @Test
     public void testQueryCertainDeck() throws Exception {
         Collection col;
-        col = CollectionHelper.getInstance().getCol(InstrumentationRegistry.getTargetContext());
+        col = CollectionHelper.getInstance().getCol(InstrumentationRegistry.getInstrumentation().getTargetContext());
 
         long deckId = mTestDeckIds[0];
         Uri deckUri = Uri.withAppendedPath(FlashCardsContract.Deck.CONTENT_ALL_URI, Long.toString(deckId));
-        Cursor decksCursor = InstrumentationRegistry.getTargetContext().getContentResolver().query(deckUri, null, null, null, null);
+        Cursor decksCursor = InstrumentationRegistry.getInstrumentation().getTargetContext().getContentResolver().query(deckUri, null, null, null, null);
         try {
             if (decksCursor == null || !decksCursor.moveToFirst()) {
                 fail("No deck received. Should have delivered deck with id " + deckId);
@@ -697,10 +695,10 @@ public class ContentProviderTest {
     @Test
     public void testQueryNextCard(){
         Collection col;
-        col = CollectionHelper.getInstance().getCol(InstrumentationRegistry.getTargetContext());
+        col = CollectionHelper.getInstance().getCol(InstrumentationRegistry.getInstrumentation().getTargetContext());
         Sched sched = col.getSched();
 
-        Cursor reviewInfoCursor = InstrumentationRegistry.getTargetContext().getContentResolver().query(
+        Cursor reviewInfoCursor = InstrumentationRegistry.getInstrumentation().getTargetContext().getContentResolver().query(
                 FlashCardsContract.ReviewInfo.CONTENT_URI, null, null, null, null);
         assertNotNull(reviewInfoCursor);
         assertEquals("Check that we actually received one card", 1, reviewInfoCursor.getCount());
@@ -731,12 +729,12 @@ public class ContentProviderTest {
         String deckSelector = "deckID=?";
         String deckArguments[] = {Long.toString(deckToTest)};
         Collection col;
-        col = CollectionHelper.getInstance().getCol(InstrumentationRegistry.getTargetContext());
+        col = CollectionHelper.getInstance().getCol(InstrumentationRegistry.getInstrumentation().getTargetContext());
         Sched sched = col.getSched();
         long selectedDeckBeforeTest = col.getDecks().selected();
         col.getDecks().select(1); //select Default deck
 
-        Cursor reviewInfoCursor = InstrumentationRegistry.getTargetContext().getContentResolver().query(
+        Cursor reviewInfoCursor = InstrumentationRegistry.getInstrumentation().getTargetContext().getContentResolver().query(
                 FlashCardsContract.ReviewInfo.CONTENT_URI, null, deckSelector, deckArguments, null);
         assertNotNull(reviewInfoCursor);
         assertEquals("Check that we actually received one card", 1, reviewInfoCursor.getCount());
@@ -769,7 +767,7 @@ public class ContentProviderTest {
     @Test
     public void testSetSelectedDeck(){
         long deckId = mTestDeckIds[0];
-        ContentResolver cr = InstrumentationRegistry.getTargetContext().getContentResolver();
+        ContentResolver cr = InstrumentationRegistry.getInstrumentation().getTargetContext().getContentResolver();
         Uri selectDeckUri = FlashCardsContract.Deck.CONTENT_SELECTED_URI;
         ContentValues values = new ContentValues();
         values.put(FlashCardsContract.Deck.DECK_ID, deckId);
@@ -784,7 +782,7 @@ public class ContentProviderTest {
     @Test
     public void testAnswerCard(){
         Collection col;
-        col = CollectionHelper.getInstance().getCol(InstrumentationRegistry.getTargetContext());
+        col = CollectionHelper.getInstance().getCol(InstrumentationRegistry.getInstrumentation().getTargetContext());
         long deckId = mTestDeckIds[0];
         col.getDecks().select(deckId);
         Card card = col.getSched().getCard();
@@ -793,7 +791,7 @@ public class ContentProviderTest {
         // the card starts out being new
         assertEquals("card is initial new", Card.TYPE_NEW, card.getQueue());
 
-        ContentResolver cr = InstrumentationRegistry.getTargetContext().getContentResolver();
+        ContentResolver cr = InstrumentationRegistry.getInstrumentation().getTargetContext().getContentResolver();
         Uri reviewInfoUri = FlashCardsContract.ReviewInfo.CONTENT_URI;
         ContentValues values = new ContentValues();
         long noteId = card.note().getId();
@@ -813,8 +811,6 @@ public class ContentProviderTest {
             if(newCard.note().getId() == card.note().getId() && newCard.getOrd() == card.getOrd()){
                 fail("Next scheduled card has not changed");
             }
-        }else{
-            //We expected this
         }
 
         // lookup the card after update, ensure it's not new anymore
@@ -832,7 +828,7 @@ public class ContentProviderTest {
         // get the first card due
         // ----------------------
         Collection col;
-        col = CollectionHelper.getInstance().getCol(InstrumentationRegistry.getTargetContext());
+        col = CollectionHelper.getInstance().getCol(InstrumentationRegistry.getInstrumentation().getTargetContext());
         long deckId = mTestDeckIds[0];
         col.getDecks().select(deckId);
         Card card = col.getSched().getCard();
@@ -845,7 +841,7 @@ public class ContentProviderTest {
 
         // bury it through the API
         // -----------------------
-        ContentResolver cr = InstrumentationRegistry.getTargetContext().getContentResolver();
+        ContentResolver cr = InstrumentationRegistry.getInstrumentation().getTargetContext().getContentResolver();
         Uri reviewInfoUri = FlashCardsContract.ReviewInfo.CONTENT_URI;
         ContentValues values = new ContentValues();
         long noteId = card.note().getId();
@@ -880,7 +876,7 @@ public class ContentProviderTest {
         // get the first card due
         // ----------------------
         Collection col;
-        col = CollectionHelper.getInstance().getCol(InstrumentationRegistry.getTargetContext());
+        col = CollectionHelper.getInstance().getCol(InstrumentationRegistry.getInstrumentation().getTargetContext());
         long deckId = mTestDeckIds[0];
         col.getDecks().select(deckId);
         Card card = col.getSched().getCard();
@@ -893,7 +889,7 @@ public class ContentProviderTest {
 
         // suspend it through the API
         // --------------------------
-        ContentResolver cr = InstrumentationRegistry.getTargetContext().getContentResolver();
+        ContentResolver cr = InstrumentationRegistry.getInstrumentation().getTargetContext().getContentResolver();
         Uri reviewInfoUri = FlashCardsContract.ReviewInfo.CONTENT_URI;
         ContentValues values = new ContentValues();
         long noteId = card.note().getId();
@@ -929,7 +925,7 @@ public class ContentProviderTest {
         // get the first card due
         // ----------------------
         Collection col;
-        col = CollectionHelper.getInstance().getCol(InstrumentationRegistry.getTargetContext());
+        col = CollectionHelper.getInstance().getCol(InstrumentationRegistry.getInstrumentation().getTargetContext());
         long deckId = mTestDeckIds[0];
         col.getDecks().select(deckId);
         Card card = col.getSched().getCard();
@@ -948,7 +944,7 @@ public class ContentProviderTest {
         String tag1 = TEST_TAG;
         String tag2 = "mynewtag";
 
-        ContentResolver cr = InstrumentationRegistry.getTargetContext().getContentResolver();
+        ContentResolver cr = InstrumentationRegistry.getInstrumentation().getTargetContext().getContentResolver();
         Uri updateNoteUri = Uri.withAppendedPath(FlashCardsContract.Note.CONTENT_URI, Long.toString(noteId));
         ContentValues values = new ContentValues();
         values.put(FlashCardsContract.Note.TAGS, tag1 + " " + tag2);
@@ -971,7 +967,7 @@ public class ContentProviderTest {
 
     private Collection reopenCol() {
         CollectionHelper.getInstance().closeCollection(false);
-        return CollectionHelper.getInstance().getCol(InstrumentationRegistry.getTargetContext());
+        return CollectionHelper.getInstance().getCol(InstrumentationRegistry.getInstrumentation().getTargetContext());
     }
 
 }

--- a/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/NotificationChannelTest.java
+++ b/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/NotificationChannelTest.java
@@ -20,7 +20,7 @@ import android.Manifest;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.content.Context;
-import androidx.test.InstrumentationRegistry;
+import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.rule.GrantPermissionRule;
 import androidx.test.runner.AndroidJUnit4;
 
@@ -38,8 +38,9 @@ import java.util.List;
 import timber.log.Timber;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNotNull;
 
+@SuppressWarnings("deprecation")
 @RunWith(AndroidJUnit4.class)
 public class NotificationChannelTest {
 
@@ -53,7 +54,7 @@ public class NotificationChannelTest {
 
     @Before
     public void setUp() {
-        Context targetContext = InstrumentationRegistry.getTargetContext();
+        Context targetContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
         ((AnkiDroidApp)targetContext.getApplicationContext()).onCreate();
         mCurrentAPI = CompatHelper.getSdkVersion();
         mTargetAPI = targetContext.getApplicationInfo().targetSdkVersion;
@@ -82,8 +83,8 @@ public class NotificationChannelTest {
         assertEquals("Incorrect channel count", expectedChannels, channels.size());
 
         for (NotificationChannels.Channel channel : NotificationChannels.Channel.values()) {
-            assertTrue("There should be a reminder channel",
-                    mManager.getNotificationChannel(NotificationChannels.getId(channel)) != null);
+            assertNotNull("There should be a reminder channel",
+                    mManager.getNotificationChannel(NotificationChannels.getId(channel)));
         }
     }
 }

--- a/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/libanki/HttpTest.java
+++ b/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/libanki/HttpTest.java
@@ -11,10 +11,11 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import androidx.test.InstrumentationRegistry;
+import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.rule.GrantPermissionRule;
 import androidx.test.runner.AndroidJUnit4;
 
+@SuppressWarnings("deprecation")
 @RunWith(AndroidJUnit4.class)
 public class HttpTest {
 

--- a/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/libanki/ImportTest.java
+++ b/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/libanki/ImportTest.java
@@ -17,7 +17,7 @@ package com.ichi2.anki.tests.libanki;
 
 
 import android.Manifest;
-import androidx.test.InstrumentationRegistry;
+import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.rule.GrantPermissionRule;
 import androidx.test.runner.AndroidJUnit4;
 
@@ -44,6 +44,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+@SuppressWarnings("deprecation")
 @RunWith(AndroidJUnit4.class)
 public class ImportTest {
 
@@ -70,7 +71,7 @@ public class ImportTest {
         List<String> expected;
         List<String> actual;
 
-        Collection tmp = Shared.getEmptyCol(InstrumentationRegistry.getTargetContext());
+        Collection tmp = Shared.getEmptyCol(InstrumentationRegistry.getInstrumentation().getTargetContext());
         // add a note that references a sound
         Note n = tmp.newNote();
         n.setItem("Front", "[sound:foo.mp3]");
@@ -83,7 +84,7 @@ public class ImportTest {
         os.close();
         tmp.close();
         // it should be imported correctly into an empty deck
-        Collection empty = Shared.getEmptyCol(InstrumentationRegistry.getTargetContext());
+        Collection empty = Shared.getEmptyCol(InstrumentationRegistry.getInstrumentation().getTargetContext());
         Importer imp = new Anki2Importer(empty, tmp.getPath());
         imp.run();
         expected = Collections.singletonList("foo.mp3");
@@ -133,8 +134,8 @@ public class ImportTest {
         List<String> expected;
         List<String> actual;
 
-        Collection tmp = Shared.getEmptyCol(InstrumentationRegistry.getTargetContext());
-        String apkg = Shared.getTestFilePath(InstrumentationRegistry.getTargetContext(), "media.apkg");
+        Collection tmp = Shared.getEmptyCol(InstrumentationRegistry.getInstrumentation().getTargetContext());
+        String apkg = Shared.getTestFilePath(InstrumentationRegistry.getInstrumentation().getTargetContext(), "media.apkg");
         Importer imp = new AnkiPackageImporter(tmp, apkg);
         expected = Collections.emptyList();
         actual = Arrays.asList(new File(tmp.getMedia().dir()).list());
@@ -161,15 +162,15 @@ public class ImportTest {
         os.close();
         imp = new AnkiPackageImporter(tmp, apkg);
         imp.run();
-        assertTrue(new File(tmp.getMedia().dir()).list().length == 2);
+        assertEquals(new File(tmp.getMedia().dir()).list().length, 2);
     }
 
     @Test
     public void testAnki2Diffmodels() throws IOException {
         // create a new empty deck
-        Collection dst = Shared.getEmptyCol(InstrumentationRegistry.getTargetContext());
+        Collection dst = Shared.getEmptyCol(InstrumentationRegistry.getInstrumentation().getTargetContext());
         // import the 1 card version of the model
-        String tmp = Shared.getTestFilePath(InstrumentationRegistry.getTargetContext(), "diffmodels2-1.apkg");
+        String tmp = Shared.getTestFilePath(InstrumentationRegistry.getInstrumentation().getTargetContext(), "diffmodels2-1.apkg");
         AnkiPackageImporter imp = new AnkiPackageImporter(dst, tmp);
         imp.setDupeOnSchemaChange(true);
         imp.run();
@@ -178,43 +179,43 @@ public class ImportTest {
         imp = new AnkiPackageImporter(dst, tmp);
         imp.setDupeOnSchemaChange(true);
         imp.run();
-        assertTrue(before == dst.noteCount());
+        assertEquals(before, dst.noteCount());
         // then the 2 card version
-        tmp = Shared.getTestFilePath(InstrumentationRegistry.getTargetContext(), "diffmodels2-2.apkg");
+        tmp = Shared.getTestFilePath(InstrumentationRegistry.getInstrumentation().getTargetContext(), "diffmodels2-2.apkg");
         imp = new AnkiPackageImporter(dst, tmp);
         imp.setDupeOnSchemaChange(true);
         imp.run();
         int after = dst.noteCount();
         // as the model schemas differ, should have been imported as new model
-        assertTrue(after == before + 1);
+        assertEquals(after, before + 1);
         // and the new model should have both cards
-        assertTrue(dst.cardCount() == 3);
+        assertEquals(dst.cardCount(), 3);
         // repeating the process should do nothing
         imp = new AnkiPackageImporter(dst, tmp);
         imp.setDupeOnSchemaChange(true);
         imp.run();
         after = dst.noteCount();
-        assertTrue(after == before + 1);
-        assertTrue(dst.cardCount() == 3);
+        assertEquals(after, before + 1);
+        assertEquals(dst.cardCount(), 3);
     }
 
     @Test
     public void testAnki2DiffmodelTemplates() throws IOException, JSONException {
         // different from the above as this one tests only the template text being
         // changed, not the number of cards/fields
-        Collection dst = Shared.getEmptyCol(InstrumentationRegistry.getTargetContext());
+        Collection dst = Shared.getEmptyCol(InstrumentationRegistry.getInstrumentation().getTargetContext());
         // import the first version of the model
-        String tmp = Shared.getTestFilePath(InstrumentationRegistry.getTargetContext(), "diffmodeltemplates-1.apkg");
+        String tmp = Shared.getTestFilePath(InstrumentationRegistry.getInstrumentation().getTargetContext(), "diffmodeltemplates-1.apkg");
         AnkiPackageImporter imp = new AnkiPackageImporter(dst, tmp);
         imp.setDupeOnSchemaChange(true);
         imp.run();
         // then the version with updated template
-        tmp = Shared.getTestFilePath(InstrumentationRegistry.getTargetContext(), "diffmodeltemplates-2.apkg");
+        tmp = Shared.getTestFilePath(InstrumentationRegistry.getInstrumentation().getTargetContext(), "diffmodeltemplates-2.apkg");
         imp = new AnkiPackageImporter(dst, tmp);
         imp.setDupeOnSchemaChange(true);
         imp.run();
         // collection should contain the note we imported
-        assertTrue(dst.noteCount() == 1);
+        assertEquals(dst.noteCount(), 1);
         // the front template should contain the text added in the 2nd package
         Long tcid = dst.findCards("").get(0);
         Note tnote = dst.getCard(tcid).note();
@@ -224,36 +225,36 @@ public class ImportTest {
     @Test
     public void testAnki2Updates() throws IOException {
         // create a new empty deck
-        Collection dst = Shared.getEmptyCol(InstrumentationRegistry.getTargetContext());
-        String tmp = Shared.getTestFilePath(InstrumentationRegistry.getTargetContext(), "update1.apkg");
+        Collection dst = Shared.getEmptyCol(InstrumentationRegistry.getInstrumentation().getTargetContext());
+        String tmp = Shared.getTestFilePath(InstrumentationRegistry.getInstrumentation().getTargetContext(), "update1.apkg");
         AnkiPackageImporter imp = new AnkiPackageImporter(dst, tmp);
         imp.run();
-        assertTrue(imp.getDupes() == 0);
-        assertTrue(imp.getAdded() == 1);
-        assertTrue(imp.getUpdated() == 0);
+        assertEquals(imp.getDupes(), 0);
+        assertEquals(imp.getAdded(), 1);
+        assertEquals(imp.getUpdated(), 0);
         // importing again should be idempotent
         imp = new AnkiPackageImporter(dst, tmp);
         imp.run();
-        assertTrue(imp.getDupes() == 1);
-        assertTrue(imp.getAdded() == 0);
-        assertTrue(imp.getUpdated() == 0);
+        assertEquals(imp.getDupes(), 1);
+        assertEquals(imp.getAdded(), 0);
+        assertEquals(imp.getUpdated(), 0);
         // importing a newer note should update
-        assertTrue(dst.noteCount() == 1);
+        assertEquals(dst.noteCount(), 1);
         assertTrue(dst.getDb().queryString("select flds from notes").startsWith("hello"));
-        tmp = Shared.getTestFilePath(InstrumentationRegistry.getTargetContext(), "update2.apkg");
+        tmp = Shared.getTestFilePath(InstrumentationRegistry.getInstrumentation().getTargetContext(), "update2.apkg");
         imp = new AnkiPackageImporter(dst, tmp);
         imp.run();
-        assertTrue(imp.getDupes()== 1);
-        assertTrue(imp.getAdded() == 0);
-        assertTrue(imp.getUpdated() == 1);
+        assertEquals(imp.getDupes(), 1);
+        assertEquals(imp.getAdded(), 0);
+        assertEquals(imp.getUpdated(), 1);
         assertTrue(dst.getDb().queryString("select flds from notes").startsWith("goodbye"));
     }
 
     // Exchange @Suppress for @Test when csv importer is implemented
 //    @Suppress
 //    public void testCsv() throws IOException {
-//        Collection deck = Shared.getEmptyCol(InstrumentationRegistry.getTargetContext());
-//        String file = Shared.getTestFilePath(InstrumentationRegistry.getTargetContext(), "text-2fields.txt");
+//        Collection deck = Shared.getEmptyCol(InstrumentationRegistry.getInstrumentation().getTargetContext());
+//        String file = Shared.getTestFilePath(InstrumentationRegistry.getInstrumentation().getTargetContext(), "text-2fields.txt");
 //        TextImporter i = new TextImporter(deck, file);
 //        i.initMapping();
 //        i.run();
@@ -289,7 +290,7 @@ public class ImportTest {
 //    // Exchange @Suppress for @Test when csv importer is implemented
 //    @Suppress
 //    public void testCsv2() throws  IOException, ConfirmModSchemaException {
-//        Collection deck = Shared.getEmptyCol(InstrumentationRegistry.getTargetContext());
+//        Collection deck = Shared.getEmptyCol(InstrumentationRegistry.getInstrumentation().getTargetContext());
 //        Models mm = deck.getModels();
 //        JSONObject m = mm.current();
 //        JSONObject f = mm.newField("Three");
@@ -301,7 +302,7 @@ public class ImportTest {
 //        n.setItem("Three", "3");
 //        deck.addNote(n);
 //        // an update with unmapped fields should not clobber those fields
-//        String file = Shared.getTestFilePath(InstrumentationRegistry.getTargetContext(), "text-update.txt");
+//        String file = Shared.getTestFilePath(InstrumentationRegistry.getInstrumentation().getTargetContext(), "text-update.txt");
 //        TextImporter i = new TextImporter(deck, file);
 //        i.initMapping();
 //        i.run();
@@ -319,16 +320,16 @@ public class ImportTest {
     @Test
     public void testDupeIgnore() throws IOException {
         // create a new empty deck
-        Collection dst = Shared.getEmptyCol(InstrumentationRegistry.getTargetContext());
-        String tmp = Shared.getTestFilePath(InstrumentationRegistry.getTargetContext(), "update1.apkg");
+        Collection dst = Shared.getEmptyCol(InstrumentationRegistry.getInstrumentation().getTargetContext());
+        String tmp = Shared.getTestFilePath(InstrumentationRegistry.getInstrumentation().getTargetContext(), "update1.apkg");
         AnkiPackageImporter imp = new AnkiPackageImporter(dst, tmp);
         imp.run();
-        tmp = Shared.getTestFilePath(InstrumentationRegistry.getTargetContext(), "update3.apkg");
+        tmp = Shared.getTestFilePath(InstrumentationRegistry.getInstrumentation().getTargetContext(), "update3.apkg");
         imp = new AnkiPackageImporter(dst, tmp);
         imp.run();
         // there is a dupe, but it was ignored
-        assertTrue(imp.getDupes() == 1);
-        assertTrue(imp.getAdded() == 0);
-        assertTrue(imp.getUpdated() == 0);
+        assertEquals(imp.getDupes(), 1);
+        assertEquals(imp.getAdded(), 0);
+        assertEquals(imp.getUpdated(), 0);
     }
 }

--- a/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/libanki/MediaTest.java
+++ b/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/libanki/MediaTest.java
@@ -16,7 +16,7 @@
 package com.ichi2.anki.tests.libanki;
 
 import android.Manifest;
-import androidx.test.InstrumentationRegistry;
+import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.rule.GrantPermissionRule;
 import androidx.test.runner.AndroidJUnit4;
 
@@ -38,12 +38,15 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 
 /**
  * Unit tests for {@link Media}.
  */
+@SuppressWarnings("deprecation")
 @RunWith(AndroidJUnit4.class)
 public class MediaTest {
 
@@ -55,8 +58,8 @@ public class MediaTest {
     @Test
     public void testAdd() throws IOException {
         // open new empty collection
-        Collection d = Shared.getEmptyCol(InstrumentationRegistry.getTargetContext());
-        File dir = Shared.getTestDir(InstrumentationRegistry.getTargetContext());
+        Collection d = Shared.getEmptyCol(InstrumentationRegistry.getInstrumentation().getTargetContext());
+        File dir = Shared.getTestDir(InstrumentationRegistry.getInstrumentation().getTargetContext());
         BackupManager.removeDir(dir);
         assertTrue(dir.mkdirs());
         File path = new File(dir, "foo.jpg");
@@ -79,7 +82,7 @@ public class MediaTest {
 
     @Test
     public void testStrings() throws IOException {
-        Collection d = Shared.getEmptyCol(InstrumentationRegistry.getTargetContext());
+        Collection d = Shared.getEmptyCol(InstrumentationRegistry.getInstrumentation().getTargetContext());
         Long mid = d.getModels().getModels().entrySet().iterator().next().getKey();
         List<String> expected;
         List<String> actual;
@@ -134,11 +137,11 @@ public class MediaTest {
 
     @Test
     public void testDeckIntegration() throws IOException {
-        Collection d = Shared.getEmptyCol(InstrumentationRegistry.getTargetContext());
+        Collection d = Shared.getEmptyCol(InstrumentationRegistry.getInstrumentation().getTargetContext());
         // create a media dir
         d.getMedia().dir();
         // Put a file into it
-        File file = new File(Shared.getTestDir(InstrumentationRegistry.getTargetContext()), "fake.png");
+        File file = new File(Shared.getTestDir(InstrumentationRegistry.getInstrumentation().getTargetContext()), "fake.png");
         assertTrue(file.createNewFile());
         d.getMedia().addFile(file);
         // add a note which references it
@@ -180,12 +183,12 @@ public class MediaTest {
 
     @Test
     public void testChanges() throws IOException {
-        Collection d = Shared.getEmptyCol(InstrumentationRegistry.getTargetContext());
-        assertTrue(d.getMedia()._changed() != null);
-        assertTrue(added(d).size() == 0);
-        assertTrue(removed(d).size() == 0);
+        Collection d = Shared.getEmptyCol(InstrumentationRegistry.getInstrumentation().getTargetContext());
+        assertNotNull(d.getMedia()._changed());
+        assertEquals(added(d).size(), 0);
+        assertEquals(removed(d).size(), 0);
         // add a file
-        File dir = Shared.getTestDir(InstrumentationRegistry.getTargetContext());
+        File dir = Shared.getTestDir(InstrumentationRegistry.getInstrumentation().getTargetContext());
         File path = new File(dir, "foo.jpg");
         FileOutputStream os;
         os = new FileOutputStream(path, false);
@@ -195,42 +198,42 @@ public class MediaTest {
         // should have been logged
         d.getMedia().findChanges();
         assertTrue(added(d).size() > 0);
-        assertTrue(removed(d).size() == 0);
+        assertEquals(removed(d).size(), 0);
         // if we modify it, the cache won't notice
         os = new FileOutputStream(path, true);
         os.write("world".getBytes());
         os.close();
-        assertTrue(added(d).size() == 1);
-        assertTrue(removed(d).size() == 0);
+        assertEquals(added(d).size(), 1);
+        assertEquals(removed(d).size(), 0);
         // but if we add another file, it will
         path = new File(path.getAbsolutePath()+"2");
         os = new FileOutputStream(path, true);
         os.write("yo".getBytes());
         os.close();
         d.getMedia().findChanges(true);
-        assertTrue(added(d).size() == 2);
-        assertTrue(removed(d).size() == 0);
+        assertEquals(added(d).size(), 2);
+        assertEquals(removed(d).size(), 0);
         // deletions should get noticed too
         assertTrue(path.delete());
         d.getMedia().findChanges(true);
-        assertTrue(added(d).size() == 1);
-        assertTrue(removed(d).size() == 1);
+        assertEquals(added(d).size(), 1);
+        assertEquals(removed(d).size(), 1);
     }
 
 
     @Test
     public void testIllegal() throws IOException {
-        Collection d = Shared.getEmptyCol(InstrumentationRegistry.getTargetContext());
+        Collection d = Shared.getEmptyCol(InstrumentationRegistry.getInstrumentation().getTargetContext());
         String aString = "a:b|cd\\e/f\0g*h";
         String good = "abcdefgh";
-        assertTrue(d.getMedia().stripIllegal(aString).equals(good));
+        assertEquals(d.getMedia().stripIllegal(aString), good);
         for (int i = 0; i < aString.length(); i++) {
             char c = aString.charAt(i);
             boolean bad = d.getMedia().hasIllegal("something" + c + "morestring");
             if (bad) {
-                assertTrue(good.indexOf(c) == -1);
+                assertEquals(good.indexOf(c), -1);
             } else {
-                assertTrue(good.indexOf(c) != -1);
+                assertNotEquals(good.indexOf(c), -1);
             }
         }
     }

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/uitests/ActivityTestUI.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/uitests/ActivityTestUI.java
@@ -25,7 +25,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static androidx.test.InstrumentationRegistry.getInstrumentation;
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
 import static androidx.test.espresso.Espresso.onData;
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
@@ -43,7 +43,7 @@ import static org.hamcrest.Matchers.anything;
 import static org.hamcrest.Matchers.is;
 
 @LargeTest
-@SuppressWarnings("PMD.ExcessiveMethodLength")
+@SuppressWarnings({"PMD.ExcessiveMethodLength", "deprecation"})
 @RunWith(AndroidJUnit4.class)
 public class ActivityTestUI {
 
@@ -171,12 +171,6 @@ public class ActivityTestUI {
 
         ViewInteraction appCompatImageButton6 = onView(
                 allOf(withContentDescription("Navigate up"),
-                        childAtPosition(
-                                allOf(withId(R.id.toolbar),
-                                        childAtPosition(
-                                                withClassName(is("android.widget.LinearLayout")),
-                                                0)),
-                                0),
                         isDisplayed()));
         appCompatImageButton6.perform(click());
 

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/uitests/CardBrowserPreviewUI.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/uitests/CardBrowserPreviewUI.java
@@ -2,6 +2,8 @@ package com.ichi2.anki.uitests;
 
 
 import android.Manifest;
+
+import androidx.test.espresso.DataInteraction;
 import androidx.test.espresso.ViewInteraction;
 import androidx.test.espresso.matcher.ViewMatchers;
 import androidx.test.rule.ActivityTestRule;
@@ -26,7 +28,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static androidx.test.InstrumentationRegistry.getInstrumentation;
+import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentation;
+import static androidx.test.espresso.Espresso.onData;
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
 import static androidx.test.espresso.Espresso.pressBack;
@@ -38,11 +41,16 @@ import static androidx.test.espresso.action.ViewActions.scrollTo;
 import static androidx.test.espresso.assertion.ViewAssertions.doesNotExist;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withClassName;
 import static androidx.test.espresso.matcher.ViewMatchers.withContentDescription;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.anything;
+import static org.hamcrest.Matchers.is;
 
 @androidx.test.filters.LargeTest
-@SuppressWarnings("PMD.ExcessiveMethodLength")
+@SuppressWarnings({"PMD.ExcessiveMethodLength", "deprecation"})
 @RunWith(AndroidJUnit4.class)
 public class CardBrowserPreviewUI {
 
@@ -87,6 +95,40 @@ public class CardBrowserPreviewUI {
                                 0),
                         isDisplayed()));
         actionMenuItemView.perform(click());
+
+        // Added a sleep statement to match the app's execution delay.
+        // The recommended way to handle such scenarios is to use Espresso idling resources:
+        // https://google.github.io/android-testing-support-library/docs/espresso/idling-resource/index.html
+        try {
+            Thread.sleep(300);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        ViewInteraction appCompatSpinner = onView(
+                allOf(withId(R.id.note_type_spinner),
+                        childAtPosition(
+                                childAtPosition(
+                                        withId(R.id.CardEditorLayout),
+                                        0),
+                                1)));
+        appCompatSpinner.perform(scrollTo(), click());
+
+        // Added a sleep statement to match the app's execution delay.
+        // The recommended way to handle such scenarios is to use Espresso idling resources:
+        // https://google.github.io/android-testing-support-library/docs/espresso/idling-resource/index.html
+        try {
+            Thread.sleep(250);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        DataInteraction appCompatCheckedTextView = onData(anything())
+                .inAdapterView(childAtPosition(
+                        withClassName(is("android.widget.PopupWindow$PopupBackgroundView")),
+                        0))
+                .atPosition(1);
+        appCompatCheckedTextView.perform(click());
 
         ConditionWatcher.waitForCondition(new Shared.ViewItemWaitingInstruction(com.ichi2.anki.R.id.id_note_editText));
         ViewInteraction fieldEditText = onView(
@@ -158,7 +200,7 @@ public class CardBrowserPreviewUI {
         ViewInteraction linearLayout42 = onView(
                 Matchers.allOf(withText("Preview"),
                         childAtPosition(
-                                IsInstanceOf.<View>instanceOf(android.widget.FrameLayout.class),
+                                IsInstanceOf.instanceOf(android.widget.FrameLayout.class),
                                 0),
                         isDisplayed()));
         linearLayout42.check(doesNotExist());

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.jacocoVersion = '0.8.2'
 
     repositories {
         google()
@@ -10,7 +9,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.2.0'
         classpath 'com.github.triplet.gradle:play-publisher:1.1.5'
-        classpath "org.jacoco:org.jacoco.core:$jacocoVersion"
+        classpath "org.jacoco:org.jacoco.core:0.8.2"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
There was no avoiding using alpha dependencies for tests on the move to androidx but they went beta just now which freezes their APIs I believe. Some of the APIs moved too, so this mops up that deprecation and everything still works after

## Fixes
deprecation warnings / unstable-ish dependencies

## Approach
Followed API docs to migrate to new APIs, dependabot showed me that it was time

## How Has This Been Tested?

Automated testing harness still works (with all UI tests working well on API28 emulator)