### PR TITLE
Avoid deprecated network status API, Fixes #4537

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
@@ -20,7 +20,6 @@ package com.ichi2.async;
 
 import android.content.Context;
 import android.net.ConnectivityManager;
-import android.net.NetworkInfo;
 import android.os.AsyncTask;
 import android.os.PowerManager;
 
@@ -475,11 +474,7 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
     public static boolean isOnline() {
         ConnectivityManager cm = (ConnectivityManager) AnkiDroidApp.getInstance().getApplicationContext()
                 .getSystemService(Context.CONNECTIVITY_SERVICE);
-        NetworkInfo netInfo = cm.getActiveNetworkInfo();
-        if (netInfo == null || !netInfo.isConnected() || !netInfo.isAvailable()) {
-            return false;
-        }
-        return true;
+        return (cm != null) && (cm.getActiveNetworkInfo() != null) && (cm.getActiveNetworkInfo().isConnected());
     }
 
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Android Lollipop altered return value of one of the network availability APIs in a way that likely caused AnkiDroid to think there was connectivity when there wasn't. This avoids using that API and relies on ones documented as being more authoritative.

## Fixes
Fixes #4537 

## Approach
Just following the API documentation as I forward port - and handling deprecation as the docs indicate

## How Has This Been Tested?
Checked it online and offline on API19 and API28 emulators, seems to work? I don't have flaky connection to test though
