### PR TITLE
Use system deck picker for package import

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
@@ -1,6 +1,7 @@
 
 package com.ichi2.anki;
 
+import android.app.Activity;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
@@ -218,6 +219,12 @@ public class AnkiActivity extends AppCompatActivity implements SimpleMessageDial
         } else {
             view.setAnimation(animation);
         }
+    }
+
+    /** Finish Activity using FADE animation **/
+    public static void finishActivityWithFade(Activity activity) {
+        activity.finish();
+        ActivityTransitionAnimation.slide(activity, ActivityTransitionAnimation.UP);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -150,7 +150,8 @@ public class DeckPicker extends NavigationDrawerActivity implements
     private RecyclerView mRecyclerView;
     private LinearLayoutManager mRecyclerViewLayoutManager;
     private DeckAdapter mDeckListAdapter;
-    private FloatingActionsMenu mActionsMenu;   // Note this will be null below SDK 14
+    private FloatingActionsMenu mActionsMenu;
+    private Snackbar.Callback mSnackbarShowHideCallback = new Snackbar.Callback();
 
     private SwipeRefreshLayout mPullToSyncWrapper;
 
@@ -271,6 +272,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
         @Override
         public void onCancelled() {
+            // do nothing
         }
     };
 
@@ -313,6 +315,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
         @Override
         public void onCancelled() {
+            // do nothing
         }
     };
 
@@ -341,11 +344,13 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
         @Override
         public void onProgressUpdate(TaskData... values) {
+            // do nothing
         }
 
 
         @Override
         public void onCancelled() {
+            // do nothing
         }
     };
 
@@ -421,18 +426,18 @@ public class DeckPicker extends NavigationDrawerActivity implements
             showStartupScreensAndDialogs(preferences, 0);
         } else {
             // Show error dialogs
-            if (!CollectionHelper.hasStorageAccessPermission(this)) {
-                // This case is handled by onRequestPermissionsResult() so don't need to do anything
-            } else if (!AnkiDroidApp.isSdCardMounted()) {
-                // SD card not mounted
-                onSdCardNotMounted();
-            } else if (!CollectionHelper.isCurrentAnkiDroidDirAccessible(this)) {
-                // AnkiDroid directory inaccessible
-                Intent i = Preferences.getPreferenceSubscreenIntent(this, "com.ichi2.anki.prefs.advanced");
-                startActivityForResultWithoutAnimation(i, REQUEST_PATH_UPDATE);
-                Toast.makeText(this, R.string.directory_inaccessible, Toast.LENGTH_LONG).show();
-            } else {
-                showDatabaseErrorDialog(DatabaseErrorDialog.DIALOG_LOAD_FAILED);
+            if (CollectionHelper.hasStorageAccessPermission(this)) {
+                if (!AnkiDroidApp.isSdCardMounted()) {
+                    // SD card not mounted
+                    onSdCardNotMounted();
+                } else if (!CollectionHelper.isCurrentAnkiDroidDirAccessible(this)) {
+                    // AnkiDroid directory inaccessible
+                    Intent i = Preferences.getPreferenceSubscreenIntent(this, "com.ichi2.anki.prefs.advanced");
+                    startActivityForResultWithoutAnimation(i, REQUEST_PATH_UPDATE);
+                    Toast.makeText(this, R.string.directory_inaccessible, Toast.LENGTH_LONG).show();
+                } else {
+                    showDatabaseErrorDialog(DatabaseErrorDialog.DIALOG_LOAD_FAILED);
+                }
             }
         }
     }
@@ -886,7 +891,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
                     // The last version of AnkiDroid that stored this as a string was 2.0.2.
                     // We manually set the version here, but anything older will force a DB
                     // check.
-                    if (s.equals("2.0.2")) {
+                    if ("2.0.2".equals(s)) {
                         previous = 40;
                     } else {
                         previous = 0;
@@ -1032,6 +1037,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
             @Override
             public void onProgressUpdate(TaskData... values) {
+                // do nothing
             }
         });
     }
@@ -1168,11 +1174,13 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
             @Override
             public void onProgressUpdate(TaskData... values) {
+                // do nothing
             }
 
 
             @Override
             public void onCancelled() {
+                // do nothing
             }
         });
     }
@@ -1212,11 +1220,13 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
             @Override
             public void onProgressUpdate(TaskData... values) {
+                // do nothing
             }
 
 
             @Override
             public void onCancelled() {
+                // do nothing
             }
         });
     }
@@ -1249,11 +1259,13 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
             @Override
             public void onProgressUpdate(TaskData... values) {
+                // do nothing
             }
 
 
             @Override
             public void onCancelled() {
+                // do nothing
             }
         });
     }
@@ -1449,7 +1461,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
                 Object[] result = (Object[]) data.result;
                 if (result[0] instanceof String) {
                     String resultType = (String) result[0];
-                    if (resultType.equals("badAuth")) {
+                    if ("badAuth".equals(resultType)) {
                         // delete old auth information
                         SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(getBaseContext());
                         Editor editor = preferences.edit();
@@ -1458,10 +1470,10 @@ public class DeckPicker extends NavigationDrawerActivity implements
                         editor.apply();
                         // then show not logged in dialog
                         showSyncErrorDialog(SyncErrorDialog.DIALOG_USER_NOT_LOGGED_IN_SYNC);
-                    } else if (resultType.equals("noChanges")) {
+                    } else if ("noChanges".equals(resultType)) {
                         // show no changes message, use false flag so we don't show "sync error" as the Dialog title
                         showSyncLogMessage(R.string.sync_no_changes_message, "");
-                    } else if (resultType.equals("clockOff")) {
+                    } else if ("clockOff".equals(resultType)) {
                         long diff = (Long) result[1];
                         if (diff >= 86100) {
                             // The difference if more than a day minus 5 minutes acceptable by ankiweb error
@@ -1476,7 +1488,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
                             dialogMessage = res.getString(R.string.sync_log_clocks_unsynchronized, diff, "");
                         }
                         showSyncErrorMessage(joinSyncMessages(dialogMessage, syncMessage));
-                    } else if (resultType.equals("fullSync")) {
+                    } else if ("fullSync".equals(resultType)) {
                         if (getCol().isEmpty()) {
                             // don't prompt user to resolve sync conflict if local collection empty
                             sync("download");
@@ -1486,41 +1498,41 @@ public class DeckPicker extends NavigationDrawerActivity implements
                             // If can't be resolved then automatically then show conflict resolution dialog
                             showSyncErrorDialog(SyncErrorDialog.DIALOG_SYNC_CONFLICT_RESOLUTION);
                         }
-                    } else if (resultType.equals("dbError")  || resultType.equals("basicCheckFailed")) {
+                    } else if ("dbError".equals(resultType) || "basicCheckFailed".equals(resultType)) {
                         String repairUrl = res.getString(R.string.repair_deck);
                         dialogMessage = res.getString(R.string.sync_corrupt_database, repairUrl);
                         showSyncErrorMessage(joinSyncMessages(dialogMessage, syncMessage));
-                    } else if (resultType.equals("overwriteError")) {
+                    } else if ("overwriteError".equals(resultType)) {
                         dialogMessage = res.getString(R.string.sync_overwrite_error);
                         showSyncErrorMessage(joinSyncMessages(dialogMessage, syncMessage));
-                    } else if (resultType.equals("remoteDbError")) {
+                    } else if ("remoteDbError".equals(resultType)) {
                         dialogMessage = res.getString(R.string.sync_remote_db_error);
                         showSyncErrorMessage(joinSyncMessages(dialogMessage, syncMessage));
-                    } else if (resultType.equals("sdAccessError")) {
+                    } else if ("sdAccessError".equals(resultType)) {
                         dialogMessage = res.getString(R.string.sync_write_access_error);
                         showSyncErrorMessage(joinSyncMessages(dialogMessage, syncMessage));
-                    } else if (resultType.equals("finishError")) {
+                    } else if ("finishError".equals(resultType)) {
                         dialogMessage = res.getString(R.string.sync_log_finish_error);
                         showSyncErrorMessage(joinSyncMessages(dialogMessage, syncMessage));
-                    } else if (resultType.equals("connectionError")) {
+                    } else if ("connectionError".equals(resultType)) {
                         dialogMessage = res.getString(R.string.sync_connection_error);
                         showSyncErrorMessage(joinSyncMessages(dialogMessage, syncMessage));
-                    } else if (resultType.equals("IOException")) {
+                    } else if ("IOException".equals(resultType)) {
                         handleDbError();
-                    } else if (resultType.equals("genericError")) {
+                    } else if ("genericError".equals(resultType)) {
                         dialogMessage = res.getString(R.string.sync_generic_error);
                         showSyncErrorMessage(joinSyncMessages(dialogMessage, syncMessage));
-                    } else if (resultType.equals("OutOfMemoryError")) {
+                    } else if ("OutOfMemoryError".equals(resultType)) {
                         dialogMessage = res.getString(R.string.error_insufficient_memory);
                         showSyncErrorMessage(joinSyncMessages(dialogMessage, syncMessage));
-                    } else if (resultType.equals("sanityCheckError")) {
+                    } else if ("sanityCheckError".equals(resultType)) {
                         dialogMessage = res.getString(R.string.sync_sanity_failed);
                         showSyncErrorDialog(SyncErrorDialog.DIALOG_SYNC_SANITY_ERROR,
                                 joinSyncMessages(dialogMessage, syncMessage));
-                    } else if (resultType.equals("serverAbort")) {
+                    } else if ("serverAbort".equals(resultType)) {
                         // syncMsg has already been set above, no need to fetch it here.
                         showSyncErrorMessage(joinSyncMessages(dialogMessage, syncMessage));
-                    } else if (resultType.equals("mediaSyncServerError")) {
+                    } else if ("mediaSyncServerError".equals(resultType)) {
                         dialogMessage = res.getString(R.string.sync_media_error_check);
                         showSyncErrorDialog(SyncErrorDialog.DIALOG_MEDIA_SYNC_ERROR,
                                 joinSyncMessages(dialogMessage, syncMessage));
@@ -1552,7 +1564,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
                 }
             } else {
                 // Sync was successful!
-                if (data.data[2] != null && !data.data[2].equals("")) {
+                if (data.data[2] != null && !"".equals(data.data[2])) {
                     // There was a media error, so show it
                     String message = res.getString(R.string.sync_database_acknowledge) + "\n\n" + data.data[2];
                     showSimpleMessageDialog(message);
@@ -1918,12 +1930,13 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
             @Override
             public void onProgressUpdate(TaskData... values) {
+                // do nothing
             }
 
             @Override
             public void onCancelled() {
+                // do nothing
             }
-
         });
     }
 
@@ -2094,11 +2107,13 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
             @Override
             public void onProgressUpdate(TaskData... values) {
+                // do nothing
             }
 
 
             @Override
             public void onCancelled() {
+                // do nothing
             }
         }, new TaskData(did));
     }
@@ -2125,11 +2140,13 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
         @Override
         public void onProgressUpdate(TaskData... values) {
+            // do nothing
         }
 
 
         @Override
         public void onCancelled() {
+            // do nothing
         }
     };
 
@@ -2181,11 +2198,6 @@ public class DeckPicker extends NavigationDrawerActivity implements
         updateDeckList();
     }
 
-    /**
-     * There was pre-honeycomb override here, removed now, just instantiate regular callback
-     */
-    private Snackbar.Callback mSnackbarShowHideCallback = new Snackbar.Callback();
-
     public void handleEmptyCards() {
         DeckTask.launchDeckTask(DeckTask.TASK_TYPE_FIND_EMPTY_CARDS, new DeckTask.Listener() {
             @Override
@@ -2219,12 +2231,12 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
             @Override
             public void onProgressUpdate(DeckTask task, TaskData... values) {
-
+                // do nothing
             }
 
             @Override
             public void onCancelled() {
-
+                // do nothing
             }
         });
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.java
@@ -2,26 +2,12 @@ package com.ichi2.anki;
 
 import android.app.Activity;
 import android.content.Intent;
-import android.database.Cursor;
-import android.net.Uri;
 import android.os.Bundle;
 import android.os.Message;
-import android.provider.OpenableColumns;
 
-import com.afollestad.materialdialogs.MaterialDialog;
-
-import com.ichi2.anim.ActivityTransitionAnimation;
 import com.ichi2.anki.dialogs.DialogHandler;
 import com.ichi2.anki.services.ReminderService;
-
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipInputStream;
+import com.ichi2.utils.ImportUtils;
 
 import timber.log.Timber;
 
@@ -36,6 +22,7 @@ import timber.log.Timber;
 public class IntentHandler extends Activity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        Timber.d("onCreate()");
         super.onCreate(savedInstanceState);
         setContentView(R.layout.progress_bar);
         Intent intent = getIntent();
@@ -44,239 +31,53 @@ public class IntentHandler extends Activity {
         reloadIntent.setDataAndType(getIntent().getData(), getIntent().getType());
         String action = intent.getAction();
         if (Intent.ACTION_VIEW.equals(action)) {
-            // This intent is used for opening apkg package files
-            // We want to go immediately to DeckPicker, clearing any history in the process
-            Timber.i("IntentHandler/ User requested to view a file");
-            boolean successful = false;
-            String errorMessage = getResources().getString(R.string.import_error_content_provider, AnkiDroidApp.getManualUrl() + "#importing");
-            // If the file is being sent from a content provider we need to read the content before we can open the file
-            if (intent.getData().getScheme().equals("content")) {
-                // Get the original filename from the content provider URI
-                String filename = null;
-                Cursor cursor = null;
-                try {
-                    cursor = this.getContentResolver().query(intent.getData(), new String[]{OpenableColumns.DISPLAY_NAME}, null, null, null);
-                    if (cursor != null && cursor.moveToFirst()) {
-                        filename = cursor.getString(0);
-                    }
-                } finally {
-                    if (cursor != null)
-                        cursor.close();
-                }
 
-                // Hack to fix bug where ContentResolver not returning filename correctly
-                if (filename == null) {
-                    if (intent.getType().equals("application/apkg") || hasValidZipFile(intent)) {
-                        // Set a dummy filename if MIME type provided or is a valid zip file
-                        filename = "unknown_filename.apkg";
-                        Timber.w("Could not retrieve filename from ContentProvider, but was valid zip file so we try to continue");
-                    } else {
-                        Timber.e("Could not retrieve filename from ContentProvider or read content as ZipFile");
-                        AnkiDroidApp.sendExceptionReport(new RuntimeException("Could not import apkg from ContentProvider"), "IntentHandler.java", "apkg import failed");
-                    }
-                }
-
-                if (filename != null && !filename.toLowerCase().endsWith(".apkg")) {
-                    // Don't import if not apkg file
-                    errorMessage = getResources().getString(R.string.import_error_not_apkg_extension, filename);
-                } else if (filename != null) {
-                    // Copy to temporary file
-                    String tempOutDir = Uri.fromFile(new File(getCacheDir(), filename)).getEncodedPath();
-                    successful = copyFileToCache(intent, tempOutDir);
-                    // Show import dialog
-                    if (successful) {
-                        sendShowImportFileDialogMsg(tempOutDir);
-                    } else {
-                        AnkiDroidApp.sendExceptionReport(new RuntimeException("Error importing apkg file"), "IntentHandler.java", "apkg import failed");
-                    }
-                }
-            } else if (intent.getData().getScheme().equals("file")) {
-                // When the VIEW intent is sent as a file, we can open it directly without copying from content provider                
-                String filename = intent.getData().getPath();
-                if (filename != null && filename.endsWith(".apkg")) {
-                    // If file has apkg extension then send message to show Import dialog
-                    sendShowImportFileDialogMsg(filename);
-                    successful = true;
-                } else {
-                    errorMessage = getResources().getString(R.string.import_error_not_apkg_extension, filename);
-                }
-            }
+            String errorMessage = ImportUtils.handleFileImport(this, intent);
             // Start DeckPicker if we correctly processed ACTION_VIEW
-            if (successful) {
+            if (errorMessage == null) {
+                Timber.d("onCreate() import successful");
                 reloadIntent.setAction(action);
                 reloadIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
                 startActivity(reloadIntent);
-                finishWithFade();
+                AnkiActivity.finishActivityWithFade(this);
             } else {
                 // Don't import the file if it didn't load properly or doesn't have apkg extension
                 //Themes.showThemedToast(this, getResources().getString(R.string.import_log_no_apkg), true);
-                String title = getResources().getString(R.string.import_log_no_apkg);
-                new MaterialDialog.Builder(this)
-                        .title(title)
-                        .content(errorMessage)
-                        .positiveText(getResources().getString(R.string.dialog_ok))
-                        .onPositive((dialog, which) -> {
-                                finishWithFade();
-                            })
-                        .build().show();
+                ImportUtils.showImportUnsuccessfulDialog(this, errorMessage, true);
             }
         } else if ("com.ichi2.anki.DO_SYNC".equals(action)) {
             sendDoSyncMsg();
             reloadIntent.setAction(action);
             reloadIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
             startActivity(reloadIntent);
-            finishWithFade();
+            AnkiActivity.finishActivityWithFade(this);
         } else if (intent.hasExtra(ReminderService.EXTRA_DECK_ID)) {
             final Intent reviewIntent = new Intent(this, Reviewer.class);
 
             CollectionHelper.getInstance().getCol(this).getDecks().select(intent.getLongExtra(ReminderService.EXTRA_DECK_ID, 0));
             startActivity(reviewIntent);
-            finishWithFade();
+            AnkiActivity.finishActivityWithFade(this);
         } else {
             // Launcher intents should start DeckPicker if no other task exists,
             // otherwise go to previous task
+            Timber.d("onCreate() performing default action");
             reloadIntent.setAction(Intent.ACTION_MAIN);
             reloadIntent.addCategory(Intent.CATEGORY_LAUNCHER);
             reloadIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
             startActivityIfNeeded(reloadIntent, 0);
-            finishWithFade();
+            AnkiActivity.finishActivityWithFade(this);
         }
     }
 
-
-    /**
-     * Send a Message to AnkiDroidApp so that the DialogMessageHandler shows the Import apkg dialog.
-     * @param path path to apkg file which will be imported
-     */
-    private void sendShowImportFileDialogMsg(String path) {
-        // Get the filename from the path
-        File f = new File(path);
-        String filename = f.getName();
-
-        // Create a new message for DialogHandler so that we see the appropriate import dialog in DeckPicker
-        Message handlerMessage = Message.obtain();
-        Bundle msgData = new Bundle();
-        msgData.putString("importPath", path);
-        handlerMessage.setData(msgData);
-        if ("collection.apkg".equals(filename)) {
-            // Show confirmation dialog asking to confirm import with replace when file called "collection.apkg"
-            handlerMessage.what = DialogHandler.MSG_SHOW_COLLECTION_IMPORT_REPLACE_DIALOG;
-        } else {
-            // Otherwise show confirmation dialog asking to confirm import with add
-            handlerMessage.what = DialogHandler.MSG_SHOW_COLLECTION_IMPORT_ADD_DIALOG;
-        }
-        // Store the message in AnkiDroidApp message holder, which is loaded later in AnkiActivity.onResume
-        DialogHandler.storeMessage(handlerMessage);
-    }
 
     /**
      * Send a Message to AnkiDroidApp so that the DialogMessageHandler forces a sync
      */
-    private void sendDoSyncMsg() {
+    public static void sendDoSyncMsg() {
         // Create a new message for DialogHandler
         Message handlerMessage = Message.obtain();
         handlerMessage.what = DialogHandler.MSG_DO_SYNC;
         // Store the message in AnkiDroidApp message holder, which is loaded later in AnkiActivity.onResume
         DialogHandler.storeMessage(handlerMessage);
-    }
-
-    /** Finish Activity using FADE animation **/
-    private void finishWithFade() {
-    	finish();
-    	ActivityTransitionAnimation.slide(this, ActivityTransitionAnimation.UP);
-    }
-
-    /**
-     * Check if the InputStream is to a valid non-empty zip file
-     * @param intent intent from which to get input stream
-     * @return whether or not valid zip file
-     */
-    private boolean hasValidZipFile(Intent intent) {
-        // Get an input stream to the data in ContentProvider
-        InputStream in = null;
-        try {
-            in = getContentResolver().openInputStream(intent.getData());
-        } catch (FileNotFoundException e) {
-            Timber.e(e, "Could not open input stream to intent data");
-        }
-        // Make sure it's not null
-        if (in == null) {
-            Timber.e("Could not open input stream to intent data");
-            return false;
-        }
-        // Open zip input stream
-        ZipInputStream zis = new ZipInputStream(in);
-        boolean ok = false;
-        try {
-            try {
-                ZipEntry ze = zis.getNextEntry();
-                if (ze != null) {
-                    // set ok flag to true if there are any valid entries in the zip file
-                    ok = true;
-                }
-            } catch (IOException e) {
-                // don't set ok flag
-                Timber.d(e, "Error checking if provided file has a zip entry");
-            }
-        } finally {
-            // close the input streams
-            try {
-                zis.close();
-                in.close();
-            } catch (Exception e) {
-                Timber.d(e, "Error closing the InputStream");
-            }
-        }
-        return ok;
-    }
-
-
-    /**
-     * Copy the data from the intent to a temporary file
-     * @param intent intent from which to get input stream
-     * @param tempPath temporary path to store the cached file
-     * @return whether or not copy was successful
-     */
-    private boolean copyFileToCache(Intent intent, String tempPath) {
-        // Get an input stream to the data in ContentProvider
-        InputStream in;
-        try {
-            in = getContentResolver().openInputStream(intent.getData());
-        } catch (FileNotFoundException e) {
-            Timber.e(e, "Could not open input stream to intent data");
-            return false;
-        }
-        // Check non-null
-        if (in == null) {
-            return false;
-        }
-        // Create new output stream in temporary path
-        OutputStream out;
-        try {
-            out = new FileOutputStream(tempPath);
-        } catch (FileNotFoundException e) {
-            Timber.e(e, "Could not access destination file %s", tempPath);
-            return false;
-        }
-
-        try {
-            // Copy the input stream to temporary file
-            byte[] buf = new byte[1024];
-            int len;
-            while ((len = in.read(buf)) > 0) {
-                out.write(buf, 0, len);
-            }
-            in.close();
-        } catch (IOException e) {
-            Timber.e(e, "Could not copy file to %s", tempPath);
-            return false;
-        } finally {
-            try {
-                out.close();
-            } catch (IOException e) {
-                Timber.e(e, "Error closing tempOutDir %s", tempPath);
-            }
-        }
-        return true;
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
@@ -1,0 +1,236 @@
+package com.ichi2.utils;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.database.Cursor;
+import android.net.Uri;
+import android.os.Bundle;
+import android.os.Message;
+import android.provider.OpenableColumns;
+
+import com.afollestad.materialdialogs.MaterialDialog;
+import com.ichi2.anki.AnkiActivity;
+import com.ichi2.anki.AnkiDroidApp;
+import com.ichi2.anki.R;
+import com.ichi2.anki.dialogs.DialogHandler;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import timber.log.Timber;
+
+public class ImportUtils {
+
+
+    /**
+     * This code is used in multiple places to handle package imports
+     *
+     * @param context for use in resource resolution and path finding
+     * @param intent contains the file to import
+     * @return null if successful, otherwise error message
+     */
+    public static String handleFileImport(Context context, Intent intent) {
+        // This intent is used for opening apkg package files
+        // We want to go immediately to DeckPicker, clearing any history in the process
+        Timber.i("IntentHandler/ User requested to view a file");
+        String errorMessage = null;
+        // If the file is being sent from a content provider we need to read the content before we can open the file
+        if (intent.getData().getScheme().equals("content")) {
+            // Get the original filename from the content provider URI
+            String filename = null;
+            Cursor cursor = null;
+            try {
+                cursor = context.getContentResolver().query(intent.getData(), new String[]{OpenableColumns.DISPLAY_NAME}, null, null, null);
+                if (cursor != null && cursor.moveToFirst()) {
+                    filename = cursor.getString(0);
+                    Timber.d("handleFileImport() Importing from content provider: %s", filename);
+                }
+            } finally {
+                if (cursor != null)
+                    cursor.close();
+            }
+
+            // Hack to fix bug where ContentResolver not returning filename correctly
+            if (filename == null) {
+                if (intent.getType().equals("application/apkg") || ImportUtils.hasValidZipFile(context, intent)) {
+                    // Set a dummy filename if MIME type provided or is a valid zip file
+                    filename = "unknown_filename.apkg";
+                    Timber.w("Could not retrieve filename from ContentProvider, but was valid zip file so we try to continue");
+                } else {
+                    Timber.e("Could not retrieve filename from ContentProvider or read content as ZipFile");
+                    AnkiDroidApp.sendExceptionReport(new RuntimeException("Could not import apkg from ContentProvider"), "IntentHandler.java", "apkg import failed");
+                    errorMessage = AnkiDroidApp.getAppResources().getString(R.string.import_error_content_provider, AnkiDroidApp.getManualUrl() + "#importing");
+                }
+            }
+
+            if ((filename != null) && !filename.toLowerCase().endsWith(".apkg")) {
+                // Don't import if not apkg file
+                errorMessage = context.getResources().getString(R.string.import_error_not_apkg_extension, filename);
+            } else if (filename != null) {
+                // Copy to temporary file
+                String tempOutDir = Uri.fromFile(new File(context.getCacheDir(), filename)).getEncodedPath();
+                errorMessage = ImportUtils.copyFileToCache(context, intent, tempOutDir) ? "" : "copyFileToCache() failed";
+                // Show import dialog
+                if ("".equals(errorMessage)) {
+                    ImportUtils.sendShowImportFileDialogMsg(tempOutDir);
+                } else {
+                    AnkiDroidApp.sendExceptionReport(new RuntimeException("Error importing apkg file"), "IntentHandler.java", "apkg import failed");
+                }
+            }
+        } else if (intent.getData().getScheme().equals("file")) {
+            // When the VIEW intent is sent as a file, we can open it directly without copying from content provider
+            String filename = intent.getData().getPath();
+            Timber.d("Importing regular file: %s", filename);
+            if (filename != null && filename.endsWith(".apkg")) {
+                // If file has apkg extension then send message to show Import dialog
+                ImportUtils.sendShowImportFileDialogMsg(filename);
+            } else {
+                errorMessage = context.getResources().getString(R.string.import_error_not_apkg_extension, filename);
+            }
+        }
+        return errorMessage;
+    }
+
+
+    public static void showImportUnsuccessfulDialog(Activity activity, String errorMessage, boolean exitActivity) {
+        Timber.e("showImportUnsuccessfulDialog() message %s", errorMessage);
+        String title = activity.getResources().getString(R.string.import_log_no_apkg);
+        new MaterialDialog.Builder(activity)
+                .title(title)
+                .content(errorMessage)
+                .positiveText(activity.getResources().getString(R.string.dialog_ok))
+                .onPositive((dialog, which) -> {
+                    if (exitActivity) {
+                        AnkiActivity.finishActivityWithFade(activity);
+                    }
+                })
+                .build().show();
+    }
+
+
+    /**
+     * Send a Message to AnkiDroidApp so that the DialogMessageHandler shows the Import apkg dialog.
+     * @param path path to apkg file which will be imported
+     */
+    private static void sendShowImportFileDialogMsg(String path) {
+        // Get the filename from the path
+        File f = new File(path);
+        String filename = f.getName();
+
+        // Create a new message for DialogHandler so that we see the appropriate import dialog in DeckPicker
+        Message handlerMessage = Message.obtain();
+        Bundle msgData = new Bundle();
+        msgData.putString("importPath", path);
+        handlerMessage.setData(msgData);
+        if ("collection.apkg".equals(filename)) {
+            // Show confirmation dialog asking to confirm import with replace when file called "collection.apkg"
+            handlerMessage.what = DialogHandler.MSG_SHOW_COLLECTION_IMPORT_REPLACE_DIALOG;
+        } else {
+            // Otherwise show confirmation dialog asking to confirm import with add
+            handlerMessage.what = DialogHandler.MSG_SHOW_COLLECTION_IMPORT_ADD_DIALOG;
+        }
+        // Store the message in AnkiDroidApp message holder, which is loaded later in AnkiActivity.onResume
+        DialogHandler.storeMessage(handlerMessage);
+    }
+
+    /**
+     * Check if the InputStream is to a valid non-empty zip file
+     * @param intent intent from which to get input stream
+     * @return whether or not valid zip file
+     */
+    private static boolean hasValidZipFile(Context context, Intent intent) {
+        // Get an input stream to the data in ContentProvider
+        InputStream in = null;
+        try {
+            in = context.getContentResolver().openInputStream(intent.getData());
+        } catch (FileNotFoundException e) {
+            Timber.e(e, "Could not open input stream to intent data");
+        }
+        // Make sure it's not null
+        if (in == null) {
+            Timber.e("Could not open input stream to intent data");
+            return false;
+        }
+        // Open zip input stream
+        ZipInputStream zis = new ZipInputStream(in);
+        boolean ok = false;
+        try {
+            try {
+                ZipEntry ze = zis.getNextEntry();
+                if (ze != null) {
+                    // set ok flag to true if there are any valid entries in the zip file
+                    ok = true;
+                }
+            } catch (Exception e) {
+                // don't set ok flag
+                Timber.d(e, "Error checking if provided file has a zip entry");
+            }
+        } finally {
+            // close the input streams
+            try {
+                zis.close();
+                in.close();
+            } catch (Exception e) {
+                Timber.d(e, "Error closing the InputStream");
+            }
+        }
+        return ok;
+    }
+
+
+    /**
+     * Copy the data from the intent to a temporary file
+     * @param intent intent from which to get input stream
+     * @param tempPath temporary path to store the cached file
+     * @return whether or not copy was successful
+     */
+    private static boolean copyFileToCache(Context context, Intent intent, String tempPath) {
+        // Get an input stream to the data in ContentProvider
+        InputStream in;
+        try {
+            in = context.getContentResolver().openInputStream(intent.getData());
+        } catch (FileNotFoundException e) {
+            Timber.e(e, "Could not open input stream to intent data");
+            return false;
+        }
+        // Check non-null
+        if (in == null) {
+            return false;
+        }
+        // Create new output stream in temporary path
+        OutputStream out;
+        try {
+            out = new FileOutputStream(tempPath);
+        } catch (FileNotFoundException e) {
+            Timber.e(e, "Could not access destination file %s", tempPath);
+            return false;
+        }
+
+        try {
+            // Copy the input stream to temporary file
+            byte[] buf = new byte[1024];
+            int len;
+            while ((len = in.read(buf)) > 0) {
+                out.write(buf, 0, len);
+            }
+            in.close();
+        } catch (IOException e) {
+            Timber.e(e, "Could not copy file to %s", tempPath);
+            return false;
+        } finally {
+            try {
+                out.close();
+            } catch (IOException e) {
+                Timber.e(e, "Error closing tempOutDir %s", tempPath);
+            }
+        }
+        return true;
+    }
+}


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Android provides a nice file picker for Android 4.4+ / KitKat / API19+ - this change defers to that file picker for package selection and only falls back to our internal "picker" for API<19

## Fixes
Fixes #4932 - the enhancement request
Obsoletes / Fixes #4834 - UI issue with regard to how to display filename
Fixes #3420 - Chromebook import/export (it works!)

## Approach
3 commits - review them separately for easy review

1. I decomposed the application IntentHandler, which was already charged with ingesting unknown files with the intention of importing them, so that I could re-use all the sanity checking and processing inside it and avoid code duplication in code pathways dealing with external input

1. Then for API19+ if the user chooses to import decks I simply fire a normal file open intent, tuned for "CATEGORY_OPENABLE" which avoids all the new virtual file / content streaming stuff Android allows but won't work for us, then listen for the result and handle it the same as if a user had picked a file from our internal picker dialog

1. De-lint / codacy commit that doesn't alter functionality at all

## How Has This Been Tested?

I checked it on an API18 and API28 emulator (before and after the system picker) with a valid apkg, an invalid file, and the same apkg twice. Everything seemed fine

## Checklist

I changed unnecessary things in the 3rd commit, but it's how I'm slowly pushing the project to comply with style

- [ ] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
