### PR TITLE
Disable pull-to-refresh if not at top

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -37,6 +37,7 @@ import android.os.Bundle;
 import android.os.Message;
 import android.provider.Settings;
 import com.google.android.material.snackbar.Snackbar;
+
 import androidx.core.app.ActivityCompat;
 import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.Fragment;
@@ -393,6 +394,8 @@ public class DeckPicker extends NavigationDrawerActivity implements
             mPullToSyncWrapper.setRefreshing(false);
             sync();
         });
+        mPullToSyncWrapper.getViewTreeObserver().addOnScrollChangedListener(() ->
+                mPullToSyncWrapper.setEnabled(mRecyclerViewLayoutManager.findFirstCompletelyVisibleItemPosition() == 0));
 
         // Setup the FloatingActionButtons, should work everywhere with min API >= 15
         mActionsMenu = findViewById(R.id.add_content_menu);


### PR DESCRIPTION
## Pull Request template

(the first time I attempted this PR I temporarily removed the one commit and that made github thing it was all merged, so it closed it - re-trying)

## Purpose / Description
If you have enough decks your deck picker scrolls, you'll notice it auto-refreshes even if you fling it to the top, which is not the design idiom used by Chrome or other apps - they only do pull to refresh when idle at the top. This disables pull to refresh unless you are idle at the top of the deck picker

## Fixes
Fixes #4495 

## Approach
I just add an onScrollListener to the RecyclerView, if the layout manager says we are the top, I enable pull to refresh. In all other cases pull to refresh is disabled.

## How Has This Been Tested?
Flinging around the card browser etc on emulators


## Learning (optional, can help others)
We are not the only people that want to do this, that's for sure. StackOverflow is full of this stuff

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
