### PR TITLE
Clear search intent info after retrieving it so we aren't stuck in a loop

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -636,6 +636,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
             if (search != null && search.length() != 0) {
                 Timber.d("CardBrowser :: Called with search intent: %s", search.toString());
                 mSearchView.setQuery(search, true);
+                intent.setAction(Intent.ACTION_DEFAULT);
             }
         }
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
If you use the text search intent from the system to reach the card browser, you get stuck there because the intent stays with the activity for it's entire life and we just keep re-checking it. This fixes that so the card browser behaves normally after the initial search

## Fixes
Fixes #5016 

## Approach
The search mechanism is simple enough, we just check Intent.getAction() and do a search on the included term(s) if it was a search action. To make sure this isn't an infinite loop, I set the Intent action to DEFAULT after initial search

## How Has This Been Tested?
Tested on the same emulators I used to reproduce in the first instance

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
