### PR TITLE
Disable pull-to-refresh if not at top, Fixes #4495

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -52,6 +52,7 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.View.OnClickListener;
+import android.view.ViewTreeObserver;
 import android.view.Window;
 import android.widget.EditText;
 import android.widget.TextView;
@@ -400,6 +401,13 @@ public class DeckPicker extends NavigationDrawerActivity implements
                 sync();
             }
         });
+        mPullToSyncWrapper.getViewTreeObserver()
+                .addOnScrollChangedListener(new ViewTreeObserver.OnScrollChangedListener() {
+                    @Override
+                    public void onScrollChanged() {
+                        mPullToSyncWrapper.setEnabled(mRecyclerViewLayoutManager.findFirstCompletelyVisibleItemPosition() == 0);
+                        }
+                });
 
         // Setup the FloatingActionButtons
         mActionsMenu = (FloatingActionsMenu) findViewById(R.id.add_content_menu);


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Cherry-pick of the same fix, re-shaped for Java 1.7, from master. Just listens to scroll events, and only enables the swipe layout refresh listener if we are at the top of the recycler view. This prevents syncs when you just fling to the top - you have to do it on purpose. Still easy to do, just not easy to false-trigger.

## Fixes
Fixes #4495 on 2.8 branch


## How Has This Been Tested?
I tested this on an API15 and API28 emulator, behaved the same as master for this use case
