### PR TITLE
Update to requery-3.25.2, can remove ABI filter now

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -14,10 +14,6 @@ android {
         vectorDrawables.useSupportLibrary = true
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
 
-        // filter out binaries to reduce APK size. Requery > 3.25.1 should allow removal of this
-        ndk {
-            abiFilters "armeabi-v7a", "arm64-v8a", "x86", "x86_64"
-        }
         // This enables long timeouts required on slow ARM emulators, e.g. Travis
         adbOptions {
             timeOutInMs 10 * 60 * 1000  // 10 minutes
@@ -115,7 +111,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.0.0'
     implementation 'androidx.browser:browser:1.0.0'
     implementation 'androidx.recyclerview:recyclerview:1.0.0'
-    implementation 'io.requery:sqlite-android:3.25.1'
+    implementation 'io.requery:sqlite-android:3.25.2'
     implementation 'androidx.sqlite:sqlite:2.0.0'
     implementation 'com.afollestad.material-dialogs:core:0.9.6.0'
     implementation 'com.getbase:floatingactionbutton:1.10.1'


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Generally keeping up with upstream here, but this release fixes the upstream bug with MIPs ABI removal that caused us to need an ABI filter - https://github.com/requery/sqlite-android/issues/78

## Fixes
Not an issue, but cleaner now...
