### PR TITLE
Update tool versions, w/JDK1.8 check + warning fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,7 @@ android:
   components:
     - tools
     - platform-tools
-    - build-tools-24.0.3
-    - build-tools-25.0.1
+    - build-tools-28.0.2
     - android-22
     - android-25
     - extra-android-support

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -3,7 +3,6 @@ apply plugin: 'com.github.triplet.play'
 def homePath = System.properties['user.home']
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.1'
 
     defaultConfig {
         applicationId "com.ichi2.anki"
@@ -43,6 +42,11 @@ android {
         // Skip pre-dexing when running on Travis CI or when disabled via -Dpre-dex=false.
         preDexLibraries = preDexEnabled && !travisBuild
     }
+    applicationVariants.all { variant ->
+        variant.outputs.all {
+            outputFileName = "../" + outputFileName
+        }
+    }
 }
 
 
@@ -53,43 +57,43 @@ play {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation 'com.android.support:appcompat-v7:25.1.0'
     // Note: the design support library can be quite buggy, so test everything thoroughly before updating it
-    compile 'com.android.support:design:25.1.0'
-    compile 'com.android.support:customtabs:25.1.0'
-    compile 'com.android.support:recyclerview-v7:25.1.0'
-    compile 'io.requery:sqlite-android:3.16.0'
-    compile('com.afollestad.material-dialogs:core:0.8.6.2@aar') {
+    implementation 'com.android.support:design:25.1.0'
+    implementation 'com.android.support:customtabs:25.1.0'
+    implementation 'com.android.support:recyclerview-v7:25.1.0'
+    implementation 'io.requery:sqlite-android:3.16.0'
+    implementation('com.afollestad.material-dialogs:core:0.8.6.2@aar') {
         //exclude group: 'com.android.support'  // uncomment to force our local support lib version
         transitive = true
     }
 
-    compile 'com.getbase:floatingactionbutton:1.10.1'
-    compile 'com.jakewharton.timber:timber:2.7.1'
-    compile 'com.google.code.gson:gson:2.4'
-    compile project(":api")
+    implementation 'com.getbase:floatingactionbutton:1.10.1'
+    implementation 'com.jakewharton.timber:timber:2.7.1'
+    implementation 'com.google.code.gson:gson:2.4'
+    implementation project(":api")
 
     // ACRA pulls in support 27.0.2, we can remove the excludes if we upgrade
-    compile('ch.acra:acra-http:5.0.2') {
+    implementation('ch.acra:acra-http:5.0.2') {
         exclude group: 'com.android.support'
     }
-    compile('ch.acra:acra-dialog:5.0.2') {
+    implementation('ch.acra:acra-dialog:5.0.2') {
         exclude group: 'com.android.support'
     }
-    compile('ch.acra:acra-toast:5.0.2') {
+    implementation('ch.acra:acra-toast:5.0.2') {
         exclude group: 'com.android.support'
     }
-    compile('ch.acra:acra-limiter:5.0.2') {
+    implementation('ch.acra:acra-limiter:5.0.2') {
         exclude group: 'com.android.support'
     }
 
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.mockito:mockito-core:1.10.19' // v1 while PowerMock does not fully support v2.
-    testCompile 'org.powermock:powermock-core:1.6.5'
-    testCompile 'org.powermock:powermock-module-junit4:1.6.5'
-    testCompile 'org.powermock:powermock-api-mockito:1.6.5'
-    testCompile 'org.hamcrest:hamcrest-all:1.3'
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.mockito:mockito-core:1.10.19' // v1 while PowerMock does not fully support v2.
+    testImplementation 'org.powermock:powermock-core:1.6.5'
+    testImplementation 'org.powermock:powermock-module-junit4:1.6.5'
+    testImplementation 'org.powermock:powermock-api-mockito:1.6.5'
+    testImplementation 'org.hamcrest:hamcrest-all:1.3'
 
 }
 

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -6,7 +6,6 @@ def version = "1.1.0alpha5"
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.1'
 
     defaultConfig {
         minSdkVersion 8
@@ -23,7 +22,7 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
 }
 
 // Borrowed from here:

--- a/build.gradle
+++ b/build.gradle
@@ -2,10 +2,11 @@
 
 buildscript {
     repositories {
+        google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.2.0'
         classpath 'com.github.triplet.gradle:play-publisher:1.1.5'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -14,8 +15,13 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         jcenter()
     }
+}
+
+if (JavaVersion.current() != JavaVersion.VERSION_1_8) {
+    throw new GradleException("This build must be run with Java 8 to match test environments");
 }
 
 ext {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip


### PR DESCRIPTION
Same patch as was reverted - but this time with two additional changes:

1.  added a check to make sure it is run with exactly JDK1.8 (matches our test environment tool chain, 1.7 is possible but 1.9 does not work with our v2.8 branch - https://github.com/powermock/powermock/issues/783)

1.  removed buildTools entries from build.gradle files - they emit warnings

If this isn't acceptable that's okay as far as it goes, but I swear it works for me on OS X, and on local Ubuntu, and the original worked in Travis (Ubuntu) as well. Should work...