### PR TITLE
Handle hardware back on card template edits, and array overrun after template delete

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -146,7 +146,7 @@ public class AnkiDroidApp extends Application {
      * collections being upgraded to (or after) this version must run an integrity check as it will contain fixes that
      * all collections should have.
      */
-    public static final int CHECK_DB_AT_VERSION = 20805000;
+    public static final int CHECK_DB_AT_VERSION = 20805202;
 
     /**
      * The latest package version number that included changes to the preferences that requires handling. All

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1071,7 +1071,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
             if (result != null && mCards != null) {
                 Timber.i("CardBrowser:: Completed doInBackgroundSearchCards Successfuly");
                 updateList();
-                if (!mSearchView.isIconified()) {
+                if (mSearchView != null && !mSearchView.isIconified()) {
                     UIUtils.showSimpleSnackbar(CardBrowser.this, getSubtitleText(), false);
                 }
             }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Bug #5011 is a multi-bug - this stops another way of crashing when there are unconfirmed edits because we didn't handle the hardware back button

Also if you delete a card template from the NoteEditor and it was the card that was underlined in the template button bar on the NoteEditor, NoteEditor will crash trying to underline it again. This guards against array overrun there

## Fixes
Fixes #5011 (again)

## Approach
I put a hardware back button handler in and sent it through the same discard changes logic as the "home" button

I moved the database check up since there could still be corruption from the remnant of this bug

Additionally I just check the "current edited card" in NoteEditor to make sure it's ordinal isn't past the number of templates, and if it is we don't attempt to get it's name to underline things

Not sure if there's more to do there? CardBrowser will reload via intent on return since we had a successful edit from template editor so I think this is enough?

## How Has This Been Tested?

All API18 emulator but I don't think it's API specific

## Learning (optional, can help others)
