### PR TITLE
Current crash fixes

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -74,7 +74,10 @@ public class Reviewer extends AbstractFlashcardViewer {
 
     private void selectDeckFromExtra() {
         Bundle extras = getIntent().getExtras();
-        long did = extras.getLong("deckId", Long.MIN_VALUE);
+        long did = Long.MIN_VALUE;
+        if (extras != null) {
+            did = extras.getLong("deckId", Long.MIN_VALUE);
+        }
 
         if(did == Long.MIN_VALUE) {
             // deckId is not set, load default

--- a/AnkiDroid/src/main/java/com/ichi2/anki/receiver/SdCardReceiver.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/receiver/SdCardReceiver.java
@@ -45,9 +45,13 @@ public class SdCardReceiver extends BroadcastReceiver {
             Intent i = new Intent();
             i.setAction(MEDIA_EJECT);
             context.sendBroadcast(i);
-            Collection col = CollectionHelper.getInstance().getCol(context);
-            if (col != null) {
-                col.close();
+            try {
+                Collection col = CollectionHelper.getInstance().getCol(context);
+                if (col != null) {
+                    col.close();
+                }
+            } catch (Exception e) {
+                Timber.w(e, "Exception while trying to close collection likely because it was already unmounted");
             }
         } else if (intent.getAction().equals(Intent.ACTION_MEDIA_MOUNTED)) {
             Timber.i("media mount detected - sending broadcast");


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
These are our top crashers in ACRA right now

## Fixes
Unlogged

## Approach
One is just quietly going away if there's an SdCardReceiver exception on MEDIA_EJECT because the database is likely not there anymore

Another is Bundle.extras() is null in Reviewer - this is a bit more speculative, I'm not sure how that happens but we already have code to handle the case where no deck id is provided so it seems nicer to not crash

## How Has This Been Tested?

Only automated tests


## Learning (optional, can help others)
Just looking in ACRA while trying to help other people with different crashes
