### PR TITLE
Update test dependencies, remove deprecated test runner

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -132,7 +132,7 @@ dependencies {
     api project(":api")
 
     testImplementation 'org.junit.vintage:junit-vintage-engine:5.3.1'
-    testImplementation 'org.mockito:mockito-core:2.22.0'
+    testImplementation 'org.mockito:mockito-core:2.23.0'
     testImplementation 'org.powermock:powermock-core:2.0.0-beta.5'
     testImplementation 'org.powermock:powermock-module-junit4:2.0.0-beta.5'
     testImplementation 'org.powermock:powermock-api-mockito2:2.0.0-beta.5'
@@ -141,9 +141,10 @@ dependencies {
 
     // May need a resolution strategy for support libs to our versions
     androidTestImplementation 'com.azimolabs.conditionwatcher:conditionwatcher:0.2'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0-beta01'
-    androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.1.0-beta01'
-    androidTestImplementation 'androidx.test:runner:1.1.0-beta01'
-    androidTestImplementation 'androidx.test:rules:1.1.0-beta01'
-    androidTestUtil 'androidx.test:orchestrator:1.1.0-beta01'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0-beta02'
+    androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.1.0-beta02'
+    androidTestImplementation 'androidx.test.ext:junit:1.0.0-beta02'
+    androidTestImplementation 'androidx.test:runner:1.1.0-beta02'
+    androidTestImplementation 'androidx.test:rules:1.1.0-beta02'
+    androidTestUtil 'androidx.test:orchestrator:1.1.0-beta02'
 }

--- a/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/ACRATest.java
+++ b/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/ACRATest.java
@@ -33,8 +33,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-@SuppressWarnings("deprecation")
-@RunWith(androidx.test.runner.AndroidJUnit4.class)
+@RunWith(androidx.test.ext.junit.runners.AndroidJUnit4.class)
 public class ACRATest {
 
     @Rule public GrantPermissionRule mRuntimePermissionRule =

--- a/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/CollectionTest.java
+++ b/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/CollectionTest.java
@@ -15,8 +15,7 @@ import static org.junit.Assert.assertNotNull;
 /**
  * This test case verifies that the directory initialization works even if the app is not yet fully initialized.
  */
-@SuppressWarnings("deprecation")
-@RunWith(androidx.test.runner.AndroidJUnit4.class)
+@RunWith(androidx.test.ext.junit.runners.AndroidJUnit4.class)
 public class CollectionTest {
 
     @Rule

--- a/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/ContentProviderTest.java
+++ b/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/ContentProviderTest.java
@@ -65,8 +65,7 @@ import static org.junit.Assert.fail;
  * <p/>
  * These tests should cover all supported operations for each URI.
  */
-@SuppressWarnings("deprecation")
-@RunWith(androidx.test.runner.AndroidJUnit4.class)
+@RunWith(androidx.test.ext.junit.runners.AndroidJUnit4.class)
 public class ContentProviderTest {
 
     @Rule

--- a/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/NotificationChannelTest.java
+++ b/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/NotificationChannelTest.java
@@ -39,8 +39,7 @@ import timber.log.Timber;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-@SuppressWarnings("deprecation")
-@RunWith(androidx.test.runner.AndroidJUnit4.class)
+@RunWith(androidx.test.ext.junit.runners.AndroidJUnit4.class)
 public class NotificationChannelTest {
 
     @Rule

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/uitests/ActivityTestUI.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/uitests/ActivityTestUI.java
@@ -42,8 +42,8 @@ import static org.hamcrest.Matchers.anything;
 import static org.hamcrest.Matchers.is;
 
 @LargeTest
-@SuppressWarnings({"PMD.ExcessiveMethodLength", "deprecation"})
-@RunWith(androidx.test.runner.AndroidJUnit4.class)
+@SuppressWarnings({"PMD.ExcessiveMethodLength"})
+@RunWith(androidx.test.ext.junit.runners.AndroidJUnit4.class)
 public class ActivityTestUI {
 
     @Rule

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/uitests/CardBrowserPreviewUI.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/uitests/CardBrowserPreviewUI.java
@@ -47,8 +47,8 @@ import static org.hamcrest.Matchers.anything;
 import static org.hamcrest.Matchers.is;
 
 @androidx.test.filters.LargeTest
-@SuppressWarnings({"PMD.ExcessiveMethodLength", "deprecation"})
-@RunWith(androidx.test.runner.AndroidJUnit4.class)
+@SuppressWarnings({"PMD.ExcessiveMethodLength"})
+@RunWith(androidx.test.ext.junit.runners.AndroidJUnit4.class)
 public class CardBrowserPreviewUI {
 
     @Rule


### PR DESCRIPTION

Dependabot notified me there were updates available, and this one resolves a publishing error they had with beta01 where their POMs were actually unusable. Awesome! But we have to stay on this major version as part of androidx conversion so it's nice to see it stabilize.

Affects nothing non-test