### PR TITLE
Various CardTemplateEditor fixes

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
@@ -168,14 +168,19 @@ public class CardTemplateEditor extends AnkiActivity {
     }
 
     @Override
+    public void onBackPressed() {
+        if (modelHasChanged()) {
+            showDiscardChangesDialog();
+        } else {
+            super.onBackPressed();
+        }
+    }
+
+    @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
             case android.R.id.home: {
-                if (modelHasChanged()) {
-                    showDiscardChangesDialog();
-                } else {
-                    finishWithAnimation(ActivityTransitionAnimation.RIGHT);
-                }
+                onBackPressed();
                 return true;
             }
             default:

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
@@ -71,6 +71,7 @@ public class CardTemplateEditor extends AnkiActivity {
     private SlidingTabLayout mSlidingTabLayout;
     private long mModelId;
     private long mNoteId;
+    private int mOrdId;
     private static final int REQUEST_PREVIEWER = 0;
     private static final String DUMMY_TAG = "DUMMY_NOTE_TO_DELETE_x0-90-fa";
 
@@ -132,11 +133,14 @@ public class CardTemplateEditor extends AnkiActivity {
                 finishWithoutAnimation();
                 return;
             }
-            // get id for currently edited card (optional)
+            // get id for currently edited note (optional)
             mNoteId = getIntent().getLongExtra("noteId", -1L);
+            // get id for currently edited template (optional)
+            mOrdId = getIntent().getIntExtra("ordId", -1);
         } else {
             mModelId = savedInstanceState.getLong("modelId");
             mNoteId = savedInstanceState.getLong("noteId");
+            mOrdId = savedInstanceState.getInt("ordId");
             try {
                 mModelBackup = new JSONObject(savedInstanceState.getString("modelBackup"));
             } catch (JSONException e) {
@@ -159,6 +163,7 @@ public class CardTemplateEditor extends AnkiActivity {
         }
         outState.putLong("modelId", mModelId);
         outState.putLong("noteId", mNoteId);
+        outState.putLong("ordId", mOrdId);
         super.onSaveInstanceState(outState);
     }
 
@@ -240,6 +245,11 @@ public class CardTemplateEditor extends AnkiActivity {
         }
         // Close collection opening dialog if needed
         Timber.i("CardTemplateEditor:: Card template editor successfully started for model id %d", mModelId);
+
+        // Set the tab to the current template if an ord id was provided
+        if (mOrdId != -1) {
+            mViewPager.setCurrentItem(mOrdId);
+        }
     }
 
     public boolean modelHasChanged() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
@@ -80,8 +80,8 @@ public class CardTemplateEditor extends AnkiActivity {
     // Listeners
     // ----------------------------------------------------------------------------
 
-    /* Used for updating the collection when a reverse card is added */
-    private DeckTask.TaskListener mUpdateTemplateHandler = new DeckTask.TaskListener() {
+    /* Used for updating the collection when a reverse card is added or a template is deleted */
+    private DeckTask.TaskListener mAddRemoveTemplateHandler = new DeckTask.TaskListener() {
         @Override
         public void onPreExecute() {
             showProgressBar();
@@ -667,7 +667,7 @@ public class CardTemplateEditor extends AnkiActivity {
             activity.getCol().modSchemaNoCheck();
             Object [] args = new Object[] {model, tmpl};
             DeckTask.launchDeckTask(DeckTask.TASK_TYPE_REMOVE_TEMPLATE,
-                    activity.mUpdateTemplateHandler,  new DeckTask.TaskData(args));
+                    activity.mAddRemoveTemplateHandler,  new DeckTask.TaskData(args));
             activity.dismissAllDialogFragments();
         }
 
@@ -723,7 +723,7 @@ public class CardTemplateEditor extends AnkiActivity {
             // Add new template to the current model via AsyncTask
             Object [] args = new Object[] {model, newTemplate};
             DeckTask.launchDeckTask(DeckTask.TASK_TYPE_ADD_TEMPLATE,
-                    activity.mUpdateTemplateHandler,  new DeckTask.TaskData(args));
+                    activity.mAddRemoveTemplateHandler,  new DeckTask.TaskData(args));
             activity.dismissAllDialogFragments();
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1007,10 +1007,12 @@ public class NoteEditor extends AnkiActivity {
         } catch (JSONException e) {
            throw new RuntimeException(e);
         }
-        // Also pass the card ID if not adding new note
+        // Also pass the note id and ord if not adding new note
         if (!mAddNote) {
             intent.putExtra("noteId", mCurrentEditedCard.note().getId());
             Timber.d("showCardTemplateEditor() with note %s", mCurrentEditedCard.note().getId());
+            intent.putExtra("ordId", mCurrentEditedCard.getOrd());
+            Timber.d("showCardTemplateEditor() with ord %s", mCurrentEditedCard.getOrd());
         }
         startActivityForResultWithAnimation(intent, REQUEST_TEMPLATE_EDIT, ActivityTransitionAnimation.LEFT);
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1062,17 +1062,21 @@ public class NoteEditor extends AnkiActivity {
                 break;
             }
             case REQUEST_TEMPLATE_EDIT: {
-                if (resultCode == RESULT_OK) {
+                    // Model can change regardless of exit type - update ourselves and CardBrowser
                     mReloadRequired = true;
-                }
-                // rebuild the model post-template-edit so we get the correct number of cards
-                Timber.d("onActivityResult() template edit - reloading model");
-                mEditorNote.reloadModel();
-                updateCards(mEditorNote.model());
+                    mEditorNote.reloadModel();
+                    if (!mEditorNote.cards().contains(mCurrentEditedCard)) {
+                        Timber.d("onActivityResult() template edit return - current card is gone");
+                        UIUtils.showSimpleSnackbar(this, R.string.template_for_current_card_deleted, false);
+                        closeNoteEditor();
+                    } else {
+                        Timber.d("onActivityResult() template edit return - current card exists");
+                        // reload current card - the template ordinals are possibly different post-edit
+                        mCurrentEditedCard = getCol().getCard(mCurrentEditedCard.getId());
+                        updateCards(mEditorNote.model());
+                    }
                 break;
             }
-            default:
-                break;
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.java
@@ -648,4 +648,18 @@ public class Card implements Cloneable {
         }
         return TextUtils.join(",  ", members);
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof Card) {
+            return this.getId() == ((Card)obj).getId();
+        }
+        return super.equals(obj);
+    }
+
+    @Override
+    public int hashCode() {
+        // Map a long to an int. For API>=24 you would just do `Long.hashCode(this.getId())`
+        return (int)(this.getId()^(this.getId()>>>32));
+    }
 }

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -152,6 +152,7 @@
     </plurals>
     <string name="invalid_template">A card could not be generated</string>
     <string name="card_template_editor_would_delete_note">Removing this card type would cause one or more notes to be deleted. Please create a new card type first.</string>
+    <string name="template_for_current_card_deleted">The template for the current card was deleted.</string>
     <!-- Permissions -->
     <string name="read_write_permission_label">Read and write to the AnkiDroid database</string>
     <string name="read_write_permission_description">access existing notes, cards, note types, and decks, as well as create new ones</string>


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
These are various CardTemplateEditor fixes, including one crash bug on returning from CardTemplateEditor if the user deleted the template that generated the card the user was on in NoteEditor.

## Fixes
Does not fix the main CardTemplateEditor problem, but that fix will be based off this

## Approach

1.  add better message-passing communication between the three of NoteEditor, DeckTask, and CardTemplateEditor - this lets them communicate the current card and the action being taken amongst themselves
1.  from NoteEditor, when you go to CardTemplateEditor, it sends the current card now so the right tab is focused (improvement)
1.  in NoteEditor, if we return from a template add, we just reload and go. If we come from a template delete we see if it was the card we were on and if it was we snackbar a notice and exit back to CardBrowser with a reload triggered
1.  It also handles the hardware back button in CardTemplateEditor but at this point that's the smallest part.

*This includes a new string in 01-core.xml (right now)*


## How Has This Been Tested?

Extensive emulator use on all the use cases here, plus a full emulator (API15-28) fleet test on automated tests including UI tests. Seems to work

## Learning (optional, can help others)

It's more clear to me now that Intents (and our TaskData) forward and backward either async or not are just fancy arguments to disconnected method calls.


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
