### PR TITLE
Storage Access Framework take 2 (export, and import bug fix)

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerExportCompleteDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerExportCompleteDialog.java
@@ -8,6 +8,7 @@ import com.afollestad.materialdialogs.MaterialDialog;
 import com.ichi2.anki.CollectionHelper;
 import com.ichi2.anki.DeckPicker;
 import com.ichi2.anki.R;
+import com.ichi2.compat.CompatHelper;
 
 import java.io.File;
 
@@ -26,18 +27,31 @@ public class DeckPickerExportCompleteDialog extends AsyncDialogFragment {
     public MaterialDialog onCreateDialog(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         final String exportPath = getArguments().getString("exportPath");
-        return new MaterialDialog.Builder(getActivity())
+        MaterialDialog.Builder dialogBuilder = new MaterialDialog.Builder(getActivity())
                 .title(getNotificationTitle())
                 .content(getNotificationMessage())
                 .iconAttr(R.attr.dialogSendIcon)
-                .positiveText(R.string.dialog_ok)
+                .positiveText(R.string.export_send_button)
                 .negativeText(R.string.dialog_cancel)
                 .onPositive((dialog, which) -> {
                     ((DeckPicker) getActivity()).dismissAllDialogFragments();
                     ((DeckPicker) getActivity()).emailFile(exportPath);
                 })
-                .onNegative((dialog, which) -> ((DeckPicker) getActivity()).dismissAllDialogFragments())
-                .show();
+                .onNegative((dialog, which) -> ((DeckPicker) getActivity()).dismissAllDialogFragments());
+
+        // If they have the system storage framework, allow for a save option
+        if (CompatHelper.getSdkVersion() >= 19) {
+            dialogBuilder
+                    .neutralText(R.string.dialog_cancel)
+                    .onNeutral((dialog, which) -> ((DeckPicker) getActivity()).dismissAllDialogFragments())
+                    .negativeText(R.string.export_save_button)
+                    .onNegative((dialog, which) -> {
+                        ((DeckPicker) getActivity()).dismissAllDialogFragments();
+                        ((DeckPicker) getActivity()).saveExportFile(exportPath);
+                    });
+        }
+
+        return dialogBuilder.show();
     }
     
     public String getNotificationTitle() {

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
@@ -76,9 +76,9 @@ public class ImportUtils {
             } else if (filename != null) {
                 // Copy to temporary file
                 String tempOutDir = Uri.fromFile(new File(context.getCacheDir(), filename)).getEncodedPath();
-                errorMessage = ImportUtils.copyFileToCache(context, intent, tempOutDir) ? "" : "copyFileToCache() failed";
+                errorMessage = ImportUtils.copyFileToCache(context, intent, tempOutDir) ? null : "copyFileToCache() failed";
                 // Show import dialog
-                if ("".equals(errorMessage)) {
+                if (errorMessage == null) {
                     ImportUtils.sendShowImportFileDialogMsg(tempOutDir);
                 } else {
                     AnkiDroidApp.sendExceptionReport(new RuntimeException("Error importing apkg file"), "IntentHandler.java", "apkg import failed");

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -154,6 +154,11 @@
     <string name="confirm_apkg_export_deck">Export “%s” as apkg file?</string>
     <string name="export_in_progress">Exporting apkg file…</string>
     <string name="export_successful_title">Send apkg?</string>
+    <string name="export_send_button">Send to app</string>
+    <string name="export_save_button">Save to file</string>
+    <string name="export_send_no_handlers">No applications available to handle apkg. Saving...</string>
+    <string name="export_save_apkg_successful">Successfully saved apkg</string>
+    <string name="export_save_apkg_unsuccessful">Save apkg failed</string>
     <string name="export_successful">File “%s” was exported. Do you want to send it with another app?</string>
     <string name="export_email_subject">AnkiDroid exported flashcards: %s</string>
     <string name="export_email_text">


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
File this under "no good deed goes unpunished" ;-)

When I converted the errorMessage return from handleFileImport to null I missed a case returns "" instead of null, causing spurious invalid apkg dialogs to pop up even though importing worked perfectly.

Then when I tested it on Chromebook I noticed that import was perfect (except the popups) but export doesn't work because there are no handlers, we need a SAF export too.

## Fixes
Fixes #3420 - this handles chromebook export well now

## Approach
It solves the errorMessage problem for the apkg import error by fixing the last "" return

I wrote a system-picker-based exporter that follows SAF style by allowing the user to pick a file name, then we write the file out to the returned ContentProvider. I hooked the same in the export dialog. 

Definitely solves Chromebook export with the SAF write in case of no handlers, and in general I prefer a save file option on regular devices so I think the added export dialog option is nice

## How Has This Been Tested?

The save-when-send-fails path is only testable if you have a device with no handlers - a stripped emulator usually or a chromebook. 

The save path in general from the new dialog option is testable anywhere

Import was tested on emulator and chromebook - sorry the dialog popup slipped through on #5032 


## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
