### PR TITLE
Alter startup sequence for analytics, add debug mode

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -122,7 +122,7 @@ dependencies {
     implementation'ch.acra:acra-toast:5.2.0'
     implementation'ch.acra:acra-limiter:5.2.0'
 
-    implementation 'net.mikehardy:google-analytics-java:2.0.3'
+    implementation 'net.mikehardy:google-analytics-java:2.0.4'
     implementation 'com.squareup.okhttp3:okhttp:3.11.0'
     implementation 'com.arcao:slf4j-timber:3.0'
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -294,6 +294,19 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                     });
                     screen.addPreference(triggerTestCrashPreference);
                 }
+                // Make it possible to test analytics, but only for DEBUG builds
+                if (BuildConfig.DEBUG) {
+                    Timber.i("Debug mode, allowing for dynamic analytics config");
+                    Preference analyticsDebugMode = new Preference(this);
+                    analyticsDebugMode.setKey("analytics_debug_preference");
+                    analyticsDebugMode.setTitle("Switch Analytics to dev mode");
+                    analyticsDebugMode.setSummary("Touch here to use Analytics dev tag and 100% sample rate");
+                    analyticsDebugMode.setOnPreferenceClickListener(preference -> {
+                        UsageAnalytics.setDevMode();
+                        return true;
+                    });
+                    screen.addPreference(analyticsDebugMode);
+                }
                 // Force full sync option
                 Preference fullSyncPreference = screen.findPreference("force_full_sync");
                 fullSyncPreference.setOnPreferenceClickListener(preference -> {


### PR DESCRIPTION

## Fixes
- #5050 - app startup failure after analytics addition - really bothered me because it was triggered by a hit that went out *prior* to full initialization, which is a major no-no because it violates privacy expectations. This fixes that
- The prompt for people to enable analytics was no longer happening on upgrade, fix that too
- There is no longer a good way to test hits with 10% sampling in place, plus test hits were polluting the regular usage, this fixes that

## Approach
1. The one place I had a "default opt-in" - the UsageAnalytics static member variable for opt-in - was the culprit. Switched it to false and didn't fiddle with preferences on startup which cleaned everything up and eliminated the hit during initialization and the opt-in dialog not showing. Only a 2-line change but vital
1. For debugging I added a feature to the underlying library that exposes the sample percentage and an API to perform the sampling election on demand. Then I added a debug-only preference similar to the crash dialog that initializes a new "dev" analytics property and sets sample to 100% so we can test hits without polluting main analytics

## How Has This Been Tested?

- Multiple emulators through the 2.8.4 -> master upgrade process for the #5050 issue
- emulators with a new version of the analytics library for debug mode


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
