### PR TITLE
Only interact with TTS object if init was successful

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.java
@@ -283,27 +283,28 @@ public class ReadText {
                         Toast.makeText(mReviewer.get(), mReviewer.get().getString(R.string.no_tts_available_message), Toast.LENGTH_LONG).show();
                         Timber.w("TTS initialized but no available languages found");
                     }
+                    mTts.setOnUtteranceProgressListener(new UtteranceProgressListener() {
+                        @Override
+                        public void onDone(String arg0) {
+                            if (ReadText.sTextQueue.size() > 0) {
+                                String[] text = ReadText.sTextQueue.remove(0);
+                                ReadText.speak(text[0], text[1], TextToSpeech.QUEUE_FLUSH);
+                            }
+                        }
+                        @Override
+                        @Deprecated
+                        public void onError(String arg0) {
+                            // do nothing
+                        }
+                        @Override
+                        public void onStart(String arg0) {
+                            // no nothing
+                        }
+                    });
                 } else {
                     Toast.makeText(mReviewer.get(), mReviewer.get().getString(R.string.no_tts_available_message), Toast.LENGTH_LONG).show();
+                    Timber.w("TTS not successfully initialized");
                 }
-                mTts.setOnUtteranceProgressListener(new UtteranceProgressListener() {
-                    @Override
-                    public void onDone(String arg0) {
-                        if (ReadText.sTextQueue.size() > 0) {
-                            String[] text = ReadText.sTextQueue.remove(0);
-                            ReadText.speak(text[0], text[1], TextToSpeech.QUEUE_FLUSH);
-                        }
-                    }
-                    @Override
-                    @Deprecated
-                    public void onError(String arg0) {
-                        // do nothing
-                    }
-                    @Override
-                    public void onStart(String arg0) {
-                        // no nothing
-                    }
-                });
             }
         });
         mTtsParams = new HashMap<>();


### PR DESCRIPTION
Most interaction with the TTS object was gated by a check for
successful initialization, but there was one interaction to set a listener
that was performed even onInit if initialization wasn't successfull, despite the API
docs indicating the init listener could be called even if the object didn't initialize

This Fixes #5067 by moving this interaction with the TTS object to a location that
is only executed if the TTS init was successful


## How Has This Been Tested?

I used an emulator and enabled TTS, it still worked after this change, so I didn't break TTS, and the change otherwise seems like a no-brainer. Code inspection shows that if AbstractFlashcardViewer.ttsInitialized() isn't called, the viewer won't interact with the ReadText (and thus TTS) object so this was the only interaction that was un-protected from a check on successful initialization
