### PR TITLE
Test dependency updates

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -134,18 +134,18 @@ dependencies {
 
     testImplementation 'org.junit.vintage:junit-vintage-engine:5.3.1'
     testImplementation 'org.mockito:mockito-core:2.23.0'
-    testImplementation 'org.powermock:powermock-core:2.0.0-beta.5'
-    testImplementation 'org.powermock:powermock-module-junit4:2.0.0-beta.5'
-    testImplementation 'org.powermock:powermock-api-mockito2:2.0.0-beta.5'
+    testImplementation 'org.powermock:powermock-core:2.0.0-RC.1'
+    testImplementation 'org.powermock:powermock-module-junit4:2.0.0-RC.1'
+    testImplementation 'org.powermock:powermock-api-mockito2:2.0.0-RC.1'
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
     testImplementation 'net.lachlanmckee:timber-junit-rule:1.0.1'
 
     // May need a resolution strategy for support libs to our versions
     androidTestImplementation 'com.azimolabs.conditionwatcher:conditionwatcher:0.2'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0-beta02'
-    androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.1.0-beta02'
-    androidTestImplementation 'androidx.test.ext:junit:1.0.0-beta02'
-    androidTestImplementation 'androidx.test:runner:1.1.0-beta02'
-    androidTestImplementation 'androidx.test:rules:1.1.0-beta02'
-    androidTestUtil 'androidx.test:orchestrator:1.1.0-beta02'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.1.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.0.0'
+    androidTestImplementation 'androidx.test:runner:1.1.0'
+    androidTestImplementation 'androidx.test:rules:1.1.0'
+    androidTestUtil 'androidx.test:orchestrator:1.1.0'
 }


### PR DESCRIPTION
AndroidX motion is starting to slow down and stabilize

All of the test dependencies are out of beta now, with only powermock left in RC status.