### PR TITLE
Robolectric to 4.0.1 - fixes bug that lets use all their new 4.x features

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -140,7 +140,7 @@ dependencies {
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
     testImplementation 'net.lachlanmckee:timber-junit-rule:1.0.1'
     testImplementation 'androidx.test:core:1.0.0'
-    testImplementation "org.robolectric:robolectric:4.0"
+    testImplementation "org.robolectric:robolectric:4.0.1"
 
     // May need a resolution strategy for support libs to our versions
     androidTestImplementation 'com.azimolabs.conditionwatcher:conditionwatcher:0.2'

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -29,7 +29,7 @@ android {
 dependencies {
     api fileTree(dir: 'libs', include: ['*.jar'])
     testImplementation 'org.junit.vintage:junit-vintage-engine:5.3.1'
-    testImplementation "org.robolectric:robolectric:4.0"
+    testImplementation "org.robolectric:robolectric:4.0.1"
 }
 
 // Borrowed from here:

--- a/api/src/test/AndroidManifest.xml
+++ b/api/src/test/AndroidManifest.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.ichi2.anki.api">
+    <uses-sdk tools:overrideLibrary="androidx.test"/>
+</manifest>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 android.enableJetifier=true
 android.useAndroidX=true
+android.enableUnitTestBinaryResources=true


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Robolectric is the present and future of android unit testing - it lets you do almost all tests you need even when they rely on logic from android.jar

4.x extends this power to resource loading so you can check different languages, devices etc to execute different test logic based on different device profiles

This PR finishes the migration to a version of Robolectric that can do that

There is one semi-interesting bit in that the test libraries are all minSdk 14 now so for tests only in the API modules we have to allow a library that is minSdk 14 as an override, since we are minSdk 8 (or something very old, I forget) in the API module

