### PR TITLE
File copy refactor

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/web/HttpFetcher.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/web/HttpFetcher.java
@@ -21,9 +21,10 @@ package com.ichi2.anki.web;
 
 import android.content.Context;
 
+import com.ichi2.compat.CompatHelper;
+
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
@@ -139,18 +140,9 @@ public class HttpFetcher {
             urlConnection.connect();
 
             File file = File.createTempFile(prefix, extension, context.getCacheDir());
-
-            FileOutputStream fileOutput = new FileOutputStream(file);
             InputStream inputStream = urlConnection.getInputStream();
-
-            byte[] buffer = new byte[1024];
-            int bufferLength = 0;
-
-            while ((bufferLength = inputStream.read(buffer)) > 0) {
-                fileOutput.write(buffer, 0, bufferLength);
-            }
-            fileOutput.close();
-
+            CompatHelper.getCompat().copyFile(inputStream, file.getCanonicalPath());
+            inputStream.close();
             return file.getAbsolutePath();
 
         } catch (Exception e) {

--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
@@ -30,6 +30,9 @@ import com.ichi2.anki.AbstractFlashcardViewer;
 import com.ichi2.anki.AnkiActivity;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 
 import io.requery.android.database.sqlite.SQLiteDatabase;
 
@@ -83,5 +86,7 @@ public interface Compat {
     int getMinute(TimePicker picker);
     int getCameraCount();
     void vibrate(Context context, long durationMillis);
+    long copyFile(String source, OutputStream target) throws IOException;
+    long copyFile(InputStream source, String target) throws IOException;
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV15.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV15.java
@@ -92,14 +92,15 @@ public class CompatV15 implements Compat {
 
     // Below API level 17, there is no simple way to enable the auto play feature of HTML media elements.
     @Override
-    public void setHTML5MediaAutoPlay(WebSettings webSettings, Boolean allow) {}
+    public void setHTML5MediaAutoPlay(WebSettings webSettings, Boolean allow) { /* do nothing */ }
 
     // Below API level 16, widget dimensions cannot be adjusted
     @Override
-    public void updateWidgetDimensions(Context context, RemoteViews updateViews, Class<?> cls) {}
+    public void updateWidgetDimensions(Context context, RemoteViews updateViews, Class<?> cls) { /* do nothing */ }
 
     // Immersive full screen isn't ready until API 19
-    static final int FULLSCREEN_ALL_GONE = 2;
+    @SuppressWarnings("PMD.FieldDeclarationsShouldBeAtStartOfClass")
+    protected static final int FULLSCREEN_ALL_GONE = 2;
     @Override
     public void setFullScreen(AbstractFlashcardViewer a) {
         a.getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN, WindowManager.LayoutParams.FLAG_FULLSCREEN);
@@ -128,7 +129,7 @@ public class CompatV15 implements Compat {
 
     // Not settable before API 21 so do nothing
     @Override
-    public void setStatusBarColor(Window window, int color) {}
+    public void setStatusBarColor(Window window, int color) { /* do nothing */ }
 
     // Immersive mode introduced in API 19
     @Override

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV26.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV26.java
@@ -9,6 +9,13 @@ import android.os.Vibrator;
 
 import androidx.core.app.NotificationCompat;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+
 import timber.log.Timber;
 
 /** Implementation of {@link Compat} for SDK level 26 */
@@ -43,5 +50,15 @@ public class CompatV26 extends CompatV24 implements Compat {
             VibrationEffect effect = VibrationEffect.createOneShot(durationMillis, VibrationEffect.DEFAULT_AMPLITUDE);
             vibratorManager.vibrate(effect);
         }
+    }
+
+    @Override
+    public long copyFile(String source, OutputStream target) throws IOException {
+        return Files.copy(Paths.get(source), target);
+    }
+
+    @Override
+    public long copyFile(InputStream source, String target) throws IOException {
+        return Files.copy(source, Paths.get(target), StandardCopyOption.REPLACE_EXISTING);
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
@@ -47,7 +47,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.math.BigInteger;
 import java.nio.channels.FileChannel;
@@ -109,7 +108,7 @@ public class Utils {
     private static final String ALL_CHARACTERS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
     private static final String BASE91_EXTRA_CHARS = "!#$%&()*+,-./:;<=>?@[]^_`{|}~";
 
-    private static final int FILE_COPY_BUFFER_SIZE = 2048;
+    private static final int FILE_COPY_BUFFER_SIZE = 1024 * 32;
 
     /**The time in integer seconds. Pass scale=1000 to get milliseconds. */
     public static double now() {
@@ -688,19 +687,7 @@ public class Utils {
             f.createNewFile();
 
             long startTimeMillis = System.currentTimeMillis();
-            OutputStream output = new BufferedOutputStream(new FileOutputStream(destination));
-
-            // Transfer bytes, from source to destination.
-            byte[] buf = new byte[CHUNK_SIZE];
-            long sizeBytes = 0;
-            int len;
-            if (source == null) {
-                Timber.e("writeToFile :: source is null!");
-            }
-            while ((len = source.read(buf)) >= 0) {
-                output.write(buf, 0, len);
-                sizeBytes += len;
-            }
+            long sizeBytes = CompatHelper.getCompat().copyFile(source, destination);
             long endTimeMillis = System.currentTimeMillis();
 
             Timber.d("Finished writeToFile!");
@@ -711,7 +698,6 @@ public class Utils {
                 speedKbSec = sizeKb * 1000 / (endTimeMillis - startTimeMillis);
             }
             Timber.d("Utils.writeToFile: Size: %d Kb, Duration: %d s, Speed: %d Kb/s", sizeKb, durationSeconds, speedKbSec);
-            output.close();
         } catch (IOException e) {
             throw new IOException(f.getName() + ": " + e.getLocalizedMessage(), e);
         }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
@@ -14,13 +14,12 @@ import com.ichi2.anki.AnkiActivity;
 import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.R;
 import com.ichi2.anki.dialogs.DialogHandler;
+import com.ichi2.compat.CompatHelper;
 
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -204,31 +203,17 @@ public class ImportUtils {
         if (in == null) {
             return false;
         }
-        // Create new output stream in temporary path
-        OutputStream out;
-        try {
-            out = new FileOutputStream(tempPath);
-        } catch (FileNotFoundException e) {
-            Timber.e(e, "Could not access destination file %s", tempPath);
-            return false;
-        }
 
         try {
-            // Copy the input stream to temporary file
-            byte[] buf = new byte[1024];
-            int len;
-            while ((len = in.read(buf)) > 0) {
-                out.write(buf, 0, len);
-            }
-            in.close();
+            CompatHelper.getCompat().copyFile(in, tempPath);
         } catch (IOException e) {
             Timber.e(e, "Could not copy file to %s", tempPath);
             return false;
         } finally {
             try {
-                out.close();
+                in.close();
             } catch (IOException e) {
-                Timber.e(e, "Error closing tempOutDir %s", tempPath);
+                Timber.e(e, "Error closing input stream");
             }
         }
         return true;

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
@@ -35,6 +35,7 @@ public class ImportUtils {
      * @param intent contains the file to import
      * @return null if successful, otherwise error message
      */
+    @SuppressWarnings("PMD.NPathComplexity")
     public static String handleFileImport(Context context, Intent intent) {
         // This intent is used for opening apkg package files
         // We want to go immediately to DeckPicker, clearing any history in the process

--- a/AnkiDroid/src/test/java/com/ichi2/anki/TestUtils.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/TestUtils.java
@@ -1,0 +1,36 @@
+/****************************************************************************************
+ * Copyright (c) 2018 Mike Hardy <mike@mikehardy.net>                                   *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+
+package com.ichi2.anki;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.security.MessageDigest;
+
+public class TestUtils {
+
+    /** get the MD5 checksum (in hex) for the given filename */
+    public static String getMD5(String filename) throws Exception {
+
+        MessageDigest md = MessageDigest.getInstance("MD5");
+        md.update(Files.readAllBytes(Paths.get(filename)));
+        StringBuilder hex = new StringBuilder();
+        for (byte b : md.digest()) {
+            hex.append(String.format("%02x", b));
+        }
+        return hex.toString();
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/compat/CompatDefaultTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/compat/CompatDefaultTest.java
@@ -1,0 +1,103 @@
+/****************************************************************************************
+ * Copyright (c) 2018 Mike Hardy <mike@mikehardy.net>                                   *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+
+package com.ichi2.compat;
+
+import com.ichi2.anki.TestUtils;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Objects;
+
+public class CompatDefaultTest {
+
+    protected Compat getCompat() {
+        return new CompatV15();
+    }
+
+    @Test
+    public void testCopyFileToStream() throws Exception {
+        URL resource = Objects.requireNonNull(getClass().getClassLoader()).getResource("path-traversal.zip");
+        File copy = File.createTempFile("testCopyFileToStream", ".zip");
+        copy.deleteOnExit();
+        FileOutputStream outputStream = new FileOutputStream(copy.getCanonicalPath());
+        getCompat().copyFile(resource.getPath(), outputStream);
+        outputStream.close();
+        Assert.assertEquals(TestUtils.getMD5(resource.getPath()), TestUtils.getMD5(copy.getCanonicalPath()));
+    }
+
+
+    @Test
+    public void testCopyStreamToFile() throws Exception {
+        URL resource = Objects.requireNonNull(getClass().getClassLoader()).getResource("path-traversal.zip");
+        File copy = File.createTempFile("testCopyStreamToFile", ".zip");
+        copy.deleteOnExit();
+        getCompat().copyFile(resource.openStream(), copy.getCanonicalPath());
+        Assert.assertEquals(TestUtils.getMD5(resource.getPath()), TestUtils.getMD5(copy.getCanonicalPath()));
+    }
+
+
+    @Test
+    public void testCopyErrors() throws Exception {
+        URL resource = Objects.requireNonNull(getClass().getClassLoader()).getResource("path-traversal.zip");
+        File copy = File.createTempFile("testCopyStreamToFile", ".zip");
+        copy.deleteOnExit();
+
+        // Try copying from a bogus file
+        try {
+            getCompat().copyFile(new FileInputStream(""), copy.getCanonicalPath());
+            Assert.fail("Should have caught an exception");
+        } catch (FileNotFoundException e) {
+            // This is expected
+        }
+
+        // Try copying to a closed stream
+        try {
+            FileOutputStream outputStream = new FileOutputStream(copy.getCanonicalPath());
+            outputStream.close();
+            getCompat().copyFile(resource.getPath(), outputStream);
+            Assert.fail("Should have caught an exception");
+        } catch (IOException e) {
+            // this is expected
+        }
+
+        // Try copying from a closed stream
+        try {
+            InputStream source = resource.openStream();
+            source.close();
+            getCompat().copyFile(source, copy.getCanonicalPath());
+            Assert.fail("Should have caught an exception");
+        } catch (IOException e) {
+            // this is expected
+        }
+
+        // Try copying to a bogus file
+        try {
+            getCompat().copyFile(resource.openStream(), "");
+            Assert.fail("Should have caught an exception");
+        } catch (Exception e) {
+            // this is expected
+        }
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/compat/CompatV26Test.java
+++ b/AnkiDroid/src/test/java/com/ichi2/compat/CompatV26Test.java
@@ -1,0 +1,29 @@
+/****************************************************************************************
+ * Copyright (c) 2018 Mike Hardy <mike@mikehardy.net>                                   *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+
+package com.ichi2.compat;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.net.URL;
+
+public class CompatV26Test extends CompatDefaultTest {
+
+    protected Compat getCompat() {
+        return new CompatV26();
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/compat/CompatV26Test.java
+++ b/AnkiDroid/src/test/java/com/ichi2/compat/CompatV26Test.java
@@ -16,13 +16,11 @@
 
 package com.ichi2.compat;
 
-import org.junit.Test;
-
-import java.io.File;
-import java.net.URL;
-
 public class CompatV26Test extends CompatDefaultTest {
 
+    // For file copy tests CompatDefaultTest calls getCompat(), overriding here
+    // let's us just re-run all the tests implemented there, but with CompatV26 this time
+    @Override
     protected Compat getCompat() {
         return new CompatV26();
     }

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/UtilsTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/UtilsTest.java
@@ -1,3 +1,19 @@
+/****************************************************************************************
+ * Copyright (c) 2018 Mike Hardy <mike@mikehardy.net>                                   *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+
 package com.ichi2.libanki;
 
 import org.junit.Assert;


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
While reviewing package export using file-picker work in #5054 @timrae [mentioned using the java.nio.files.Files.copy() would be nice](https://github.com/ankidroid/Anki-Android/pull/5054#issuecomment-433613088)

That's correct and while it may just be a nice-to-have since it's for API26 and up only right now, when I looked at how file copy was done elsewhere in AnkiDroid it struck me that having a local copy implementation in 5 places wasn't a great idea, and we may be missing performance due to inconsistent and small buffers

So this PR centralizes file copy logic, and uses java.nio.files.Files.copy where the API supports it

## Fixes
Nothing logged, but #5054 will depend on it now

## Approach

The commits should be viewed individually to best reason about the changes, I think

1.  Implement central file copy logic in Compat infrastructure, with associated unit tests. I chose the 32k buffer carefully and noted with a link in case it changes in the future
1.  Use that central copy logic in place of all local copy implementations
1.  Clean up code style issues

## How Has This Been Tested?

The unit test exercises the basic implementation so I have confidence in the copy and we can make sure the implementation itself doesn't fail

The replacement of local implementations was verified on API27 and API21 emulator (to get both implementation styles) with a shared deck import, full sync to anki web, export, re-import of the export, and then an import of the backup created after full sync when I did the re-import. My collection appeared correct vs expectations at all times so I believe the usage of the centralized copy logic is correct


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
