### PR TITLE
Simplify rules for initially selected deck in stats and browser

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -837,6 +837,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
             loadStudyOptionsFragment(false);
         }
         automaticSync();
+        CardBrowser.clearLastDeckId();
     }
 
     private void showCollectionErrorDialog() {
@@ -1812,16 +1813,6 @@ public class DeckPicker extends NavigationDrawerActivity implements
         }
     }
 
-    @Override
-    protected void openCardBrowser() {
-        Intent cardBrowser = new Intent(this, CardBrowser.class);
-        cardBrowser.putExtra("selectedDeck", getCol().getDecks().selected());
-        long lastDeckId = AnkiDroidApp.getSharedPrefs(this).getLong("browserDeckIdFromDeckPicker", -1L);
-        cardBrowser.putExtra("defaultDeckId", lastDeckId);
-        startActivityForResultWithAnimation(cardBrowser, REQUEST_BROWSE_CARDS, ActivityTransitionAnimation.LEFT);
-    }
-
-
     private void handleDeckSelection(long did, boolean dontSkipStudyOptions) {
         // Clear the undo history when selecting a new deck
         if (getCol().getDecks().selected() != did) {
@@ -1829,6 +1820,8 @@ public class DeckPicker extends NavigationDrawerActivity implements
         }
         // Select the deck
         getCol().getDecks().select(did);
+        // Also forget the last deck used by the Browser
+        CardBrowser.clearLastDeckId();
         // Reset the schedule so that we get the counts for the currently selected deck
         getCol().getSched().reset();
         mFocusedDeck = did;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
@@ -167,6 +167,7 @@ public abstract class NavigationDrawerActivity extends AnkiActivity implements N
         }
     }
 
+
     @Override
     public void onConfigurationChanged(Configuration newConfig) {
         super.onConfigurationChanged(newConfig);
@@ -211,7 +212,7 @@ public abstract class NavigationDrawerActivity extends AnkiActivity implements N
         NotificationChannels.setup(getApplicationContext());
         // Restart the activity on preference change
         if (requestCode == REQUEST_PREFERENCES_UPDATE) {
-            if (mOldColPath!=null && CollectionHelper.getCurrentAnkiDroidDirectory(this).equals(mOldColPath)) {
+            if (mOldColPath != null && CollectionHelper.getCurrentAnkiDroidDirectory(this).equals(mOldColPath)) {
                 // collection path hasn't been changed so just restart the current activity
                 if ((this instanceof Reviewer) && preferences.getBoolean("tts", false)) {
                     // Workaround to kick user back to StudyOptions after opening settings from Reviewer
@@ -270,19 +271,20 @@ public abstract class NavigationDrawerActivity extends AnkiActivity implements N
         pendingRunnable = () -> {
             // Take action if a different item selected
             switch (item.getItemId()) {
-                case R.id.nav_decks:
+                case R.id.nav_decks: {
                     Intent deckPicker = new Intent(NavigationDrawerActivity.this, DeckPicker.class);
                     deckPicker.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);    // opening DeckPicker should clear back history
                     startActivityWithAnimation(deckPicker, ActivityTransitionAnimation.RIGHT);
                     break;
+                }
                 case R.id.nav_browser:
                     openCardBrowser();
                     break;
-                case R.id.nav_stats:
+                case R.id.nav_stats: {
                     Intent intent = new Intent(NavigationDrawerActivity.this, Statistics.class);
-                    intent.putExtra("selectedDeck", getCol().getDecks().selected());
                     startActivityForResultWithAnimation(intent, REQUEST_STATISTICS, ActivityTransitionAnimation.LEFT);
                     break;
+                }
                 case R.id.nav_night_mode:
                     mNightModeSwitch.performClick();
                     break;
@@ -307,13 +309,18 @@ public abstract class NavigationDrawerActivity extends AnkiActivity implements N
         return true;
     }
 
-    /**
-     * Open the card browser. Override this method to pass it custom arguments
-     */
     protected void openCardBrowser() {
-        Intent cardBrowser = new Intent(this, CardBrowser.class);
-        cardBrowser.putExtra("selectedDeck", getCol().getDecks().selected());
-        startActivityForResultWithAnimation(cardBrowser, REQUEST_BROWSE_CARDS, ActivityTransitionAnimation.LEFT);
+        Intent intent = new Intent(NavigationDrawerActivity.this, CardBrowser.class);
+        Long currentCardId = getCurrentCardId();
+        if (currentCardId != null) {
+            intent.putExtra("currentCard", currentCardId);
+        }
+        startActivityForResultWithAnimation(intent, REQUEST_BROWSE_CARDS, ActivityTransitionAnimation.LEFT);
+    }
+
+    // Override this to specify a specific card id
+    protected Long getCurrentCardId() {
+        return null;
     }
 
     protected void showBackIcon() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -540,16 +540,8 @@ public class Reviewer extends AbstractFlashcardViewer {
 
 
     @Override
-    protected void openCardBrowser() {
-        Intent cardBrowser = new Intent(this, CardBrowser.class);
-        cardBrowser.putExtra("selectedDeck", getCol().getDecks().selected());
-        if (mLastSelectedBrowserDid != null) {
-            cardBrowser.putExtra("defaultDeckId", mLastSelectedBrowserDid);
-        } else {
-            cardBrowser.putExtra("defaultDeckId", getCol().getDecks().selected());
-        }
-        cardBrowser.putExtra("currentCard", mCurrentCard.getId());
-        startActivityForResultWithAnimation(cardBrowser, REQUEST_BROWSE_CARDS, ActivityTransitionAnimation.LEFT);
+    protected Long getCurrentCardId() {
+        return mCurrentCard.getId();
     }
 
 
@@ -562,23 +554,6 @@ public class Reviewer extends AbstractFlashcardViewer {
         } else {
             mFullScreenHandler.removeMessages(0);
         }
-    }
-
-    @Override
-    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
-        if (requestCode == REQUEST_STATISTICS || requestCode == REQUEST_BROWSE_CARDS) {
-            // Store the selected deck
-            if (data != null && data.getBooleanExtra("allDecksSelected", false)) {
-                mLastSelectedBrowserDid = -1L;
-            } else {
-                mLastSelectedBrowserDid = getCol().getDecks().selected();
-            }
-            // select original deck if the statistics or card browser were opened, which can change the selected deck
-            if (data != null && data.hasExtra("originalDeck")) {
-                getCol().getDecks().select(data.getLongExtra("originalDeck", 0L));
-            }
-        }
-        super.onActivityResult(requestCode, resultCode, data);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/stats/AnkiStatsTaskHandler.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/stats/AnkiStatsTaskHandler.java
@@ -43,7 +43,7 @@ public class AnkiStatsTaskHandler {
     private Collection mCollectionData;
     private float mStandardTextSize = 10f;
     private Stats.AxisType mStatType = Stats.AxisType.TYPE_MONTH;
-    private boolean mIsWholeCollection = false;
+    private long mDeckId;
     private static Lock sLock = new ReentrantLock();
 
 
@@ -52,8 +52,8 @@ public class AnkiStatsTaskHandler {
         mCollectionData = collection;
     }
 
-    public void setIsWholeCollection(boolean wholeCollection) {
-        mIsWholeCollection = wholeCollection;
+    public void setDeckId(long deckId) {
+        mDeckId = deckId;
     }
 
     public static AnkiStatsTaskHandler getInstance() {
@@ -104,7 +104,7 @@ public class AnkiStatsTaskHandler {
                 mImageView = (ChartView) params[0];
                 mProgressBar = (ProgressBar) params[1];
                 ChartBuilder chartBuilder = new ChartBuilder(mImageView, mCollectionData,
-                        mIsWholeCollection, mChartType);
+                        mDeckId, mChartType);
                 return chartBuilder.renderChart(mStatType);
             } finally {
                 sLock.unlock();
@@ -152,7 +152,7 @@ public class AnkiStatsTaskHandler {
                 }
                 mWebView = (WebView) params[0];
                 mProgressBar = (ProgressBar) params[1];
-                OverviewStatsBuilder overviewStatsBuilder = new OverviewStatsBuilder(mWebView, mCollectionData, mIsWholeCollection, mStatType);
+                OverviewStatsBuilder overviewStatsBuilder = new OverviewStatsBuilder(mWebView, mCollectionData, mDeckId, mStatType);
                 return overviewStatsBuilder.createInfoHtmlString();
             } finally {
                 sLock.unlock();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/stats/ChartBuilder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/stats/ChartBuilder.java
@@ -42,7 +42,7 @@ public class ChartBuilder {
     private static final double Y_AXIS_STRETCH_FACTOR = 1.05;
 
     private final Stats.ChartType mChartType;
-    private boolean mIsWholeCollection = false;
+    private long mDeckId;
     private ChartView mChartView;
     private Collection mCollectionData;
 
@@ -59,15 +59,15 @@ public class ChartBuilder {
     private double mMcount;
     private boolean mDynamicAxis;
 
-    public ChartBuilder(ChartView chartView, Collection collectionData, boolean isWholeCollection, Stats.ChartType chartType){
+    public ChartBuilder(ChartView chartView, Collection collectionData, long deckId, Stats.ChartType chartType){
         mChartView = chartView;
         mCollectionData = collectionData;
-        mIsWholeCollection = isWholeCollection;
+        mDeckId = deckId;
         mChartType = chartType;
     }
 
     private void calcStats(Stats.AxisType type){
-        Stats stats = new Stats(mCollectionData, mIsWholeCollection);
+        Stats stats = new Stats(mCollectionData, mDeckId);
         switch (mChartType){
             case FORECAST:
                 stats.calculateDue(mChartView.getContext(), type);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/stats/OverviewStatsBuilder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/stats/OverviewStatsBuilder.java
@@ -48,7 +48,7 @@ public class OverviewStatsBuilder {
 
     private final WebView mWebView; //for resources access
     private final Collection mCol;
-    private final boolean mWholeCollection;
+    private final long mDeckId;
     private final Stats.AxisType mType;
 
 
@@ -70,10 +70,10 @@ public class OverviewStatsBuilder {
         public double longestInterval;
     }
 
-    public OverviewStatsBuilder(WebView chartView, Collection collectionData, boolean isWholeCollection, Stats.AxisType mStatType) {
+    public OverviewStatsBuilder(WebView chartView, Collection collectionData, long deckId, Stats.AxisType mStatType) {
         mWebView = chartView;
         mCol = collectionData;
-        mWholeCollection = isWholeCollection;
+        mDeckId = deckId;
         mType = mStatType;
     }
 
@@ -99,7 +99,7 @@ public class OverviewStatsBuilder {
     }
 
     private void appendOverViewStats(StringBuilder stringBuilder) {
-        Stats stats = new Stats(mCol, mWholeCollection);
+        Stats stats = new Stats(mCol, mDeckId);
 
         OverviewStats oStats = new OverviewStats();
         stats.calculateOverviewStatistics(mType, oStats);
@@ -172,7 +172,7 @@ public class OverviewStatsBuilder {
     }
 
     private void appendTodaysStats(StringBuilder stringBuilder) {
-        Stats stats = new Stats(mCol, mWholeCollection);
+        Stats stats = new Stats(mCol, mDeckId);
         int[] todayStats = stats.calculateTodayStats();
         stringBuilder.append(_title(mWebView.getResources().getString(R.string.stats_today)));
         Resources res = mWebView.getResources();
@@ -280,18 +280,6 @@ public class OverviewStatsBuilder {
 
 
     private String _limit() {
-        if (mWholeCollection) {
-            ArrayList<Long> ids = new ArrayList<>();
-            for (JSONObject d : mCol.getDecks().all()) {
-                try {
-                    ids.add(d.getLong("id"));
-                } catch (JSONException e) {
-                    throw new RuntimeException(e);
-                }
-            }
-            return Utils.ids2str(Utils.arrayList2array(ids));
-        } else {
-            return mCol.getSched()._deckLimit();
-        }
+        return Stats.deckLimit(mDeckId, mCol);
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -42,6 +42,8 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.regex.Pattern;
 
+import androidx.annotation.NonNull;
+
 // fixmes:
 // - make sure users can't set grad interval < 1
 
@@ -439,7 +441,7 @@ public class Decks {
     }
 
 
-    public JSONObject get(long did) {
+    public @NonNull JSONObject get(long did) {
         return get(did, true);
     }
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
For both stats and browser, the deck spinner no longer changes the libanki current deck. Changing the libanki deck was awkward and unintuitive, and we were only doing that to avoid changing libanki (in #766).

When opening the browser for the first time, the current libanki deck is always selected. When the deck is changed via the spinner, we remember the choice and use it next time the browser is opened (as before). Now however, the choice is cleared when the app is first started or a new deck is selected from the deck picker to avoid a seemingly "random" deck getting selected. This memory of the deck id deviates somewhat from Anki Desktop, but IMO it makes sense to deviate here, since users often switch back and forward between the reviewer and the browser while reviewing. This use case is addressed in Anki Desktop by allowing users to keep both windows open, which in general we can't do in AnkiDroid. 

For stats, there is little benefit to remembering the deck id, so the current libanki deck is always shown when the stats Activity is opened, as per Anki Desktop. The user can change to "all decks", or a specific deck (a feature not yet offered by Anki desktop) via the deck spinner, which no longer affects the libanki selected deck.

## Fixes
Fixes #4999
Fixes #5010 

## Approach
* Refactor libanki a bit to allow getting stats for an arbitrary deck id
* Remove a bunch of intent crud for handling the previous business logic
* Implement the business logic described above from scratch

## How Has This Been Tested?

Basic functionality testing on the emulator