### PR TITLE
Protect against uninitialized collection access

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -310,6 +310,10 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                 // Force full sync option
                 Preference fullSyncPreference = screen.findPreference("force_full_sync");
                 fullSyncPreference.setOnPreferenceClickListener(preference -> {
+                    if (getCol() == null) {
+                        Toast.makeText(this, R.string.directory_inaccessible, Toast.LENGTH_LONG).show();
+                        return false;
+                    }
                     // TODO: Could be useful to show the full confirmation dialog
                     getCol().modSchemaNoCheck();
                     getCol().setMod();


### PR DESCRIPTION
The app sends users to the advanced preferences screen under
conditions where the collection will definitely be null, and
configures a click listener that then may access the collection

If the user attempts a full sync (which accesses the collection)
we will now toast the same message that sent them there in the
first place

Fixes #5074
