### PR TITLE
Extend base FooterButtonLayout to get common style

### DIFF
--- a/AnkiDroid/src/main/res/values-v21/styles.xml
+++ b/AnkiDroid/src/main/res/values-v21/styles.xml
@@ -22,7 +22,7 @@
         <item name="android:textColor">?attr/fab_labelsTextColor</item>
     </style>
 
-    <style name="FooterButtonLayout">
+    <style name="FooterButtonLayout" parent="FooterButtonLayoutBase">
         <item name="android:fontFamily">@string/font_fontFamily_medium</item>
     </style>
 

--- a/AnkiDroid/src/main/res/values/styles.xml
+++ b/AnkiDroid/src/main/res/values/styles.xml
@@ -34,7 +34,7 @@
     </style>
 
     <!--  Material Design-style persistent footer button -->
-    <style name="FooterButtonLayout">
+    <style name="FooterButtonLayoutBase">
         <item name="android:layout_height">48dp</item>
         <item name="android:textAllCaps">true</item>
         <item name="android:textSize">14sp</item>
@@ -43,6 +43,7 @@
         <item name="android:layout_gravity">center_vertical</item>
         <item name="android:singleLine">true</item>
     </style>
+    <style name="FooterButtonLayout" parent="FooterButtonLayoutBase"/>
     <style name="FooterButtonNextTime">
         <item name="android:layout_width">fill_parent</item>
         <item name="android:layout_height">wrap_content</item>


### PR DESCRIPTION
Fixes #5099

I learned that for version-specific styles, you have to have a base style in the default styles area, then extend it for a default style you use, and in the version-specific area you extend the base style again but this time with your version-specific styling.

I didn't know that when I reviewed the PR that created this issue, so we had mostly-unstyled footer buttons during review for API >= 21