### PR TITLE
Dependency updates (SLF4J-Timber, Powermock, Appcompat)

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -125,7 +125,7 @@ dependencies {
 
     implementation 'net.mikehardy:google-analytics-java:2.0.4'
     implementation 'com.squareup.okhttp3:okhttp:3.11.0'
-    implementation 'com.arcao:slf4j-timber:3.0'
+    implementation 'com.arcao:slf4j-timber:3.1'
 
     implementation 'com.jakewharton.timber:timber:4.7.1'
     implementation 'com.google.code.gson:gson:2.8.5'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -134,7 +134,7 @@ dependencies {
 
     testImplementation 'org.junit.vintage:junit-vintage-engine:5.3.1'
     testImplementation 'org.mockito:mockito-core:2.23.0'
-    testImplementation 'org.powermock:powermock-core:2.0.0-RC.1'
+    testImplementation 'org.powermock:powermock-core:2.0.0-RC.3'
     testImplementation 'org.powermock:powermock-module-junit4:2.0.0-RC.3'
     testImplementation 'org.powermock:powermock-api-mockito2:2.0.0-RC.3'
     testImplementation 'org.hamcrest:hamcrest-all:1.3'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -135,7 +135,7 @@ dependencies {
     testImplementation 'org.junit.vintage:junit-vintage-engine:5.3.1'
     testImplementation 'org.mockito:mockito-core:2.23.0'
     testImplementation 'org.powermock:powermock-core:2.0.0-RC.1'
-    testImplementation 'org.powermock:powermock-module-junit4:2.0.0-RC.1'
+    testImplementation 'org.powermock:powermock-module-junit4:2.0.0-RC.3'
     testImplementation 'org.powermock:powermock-api-mockito2:2.0.0-RC.1'
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
     testImplementation 'net.lachlanmckee:timber-junit-rule:1.0.1'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -136,7 +136,7 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:2.23.0'
     testImplementation 'org.powermock:powermock-core:2.0.0-RC.1'
     testImplementation 'org.powermock:powermock-module-junit4:2.0.0-RC.3'
-    testImplementation 'org.powermock:powermock-api-mockito2:2.0.0-RC.1'
+    testImplementation 'org.powermock:powermock-api-mockito2:2.0.0-RC.3'
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
     testImplementation 'net.lachlanmckee:timber-junit-rule:1.0.1'
     testImplementation 'androidx.test:core:1.0.0'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -106,7 +106,7 @@ dependencies {
     annotationProcessor "com.google.auto.service:auto-service:1.0-rc4"
 
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'androidx.appcompat:appcompat:1.0.1'
+    implementation 'androidx.appcompat:appcompat:1.0.2'
     // Note: the design support library can be quite buggy, so test everything thoroughly before updating it
     implementation 'com.google.android.material:material:1.0.0'
     implementation 'androidx.browser:browser:1.0.0'


### PR DESCRIPTION
The SLF4J-Timber is an upstream fix from me for dependencies I brought in with analytics

Powermock is just slowly working towards real 2.x release

Appcompat bumped yesterday too but there are no release notes available to see why

Intention is to squash merge this but this is sort of a test of my dependabot workflow