### PR TITLE
Use divider style attributes for deck item decorator

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -31,8 +31,10 @@ import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
 import android.content.pm.PackageManager;
 import android.content.res.Resources;
+import android.content.res.TypedArray;
 import android.database.SQLException;
 import android.graphics.PixelFormat;
+import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
@@ -394,7 +396,12 @@ public class DeckPicker extends NavigationDrawerActivity implements
         // specify a LinearLayoutManager and set up item dividers for the RecyclerView
         mRecyclerViewLayoutManager = new LinearLayoutManager(this);
         mRecyclerView.setLayoutManager(mRecyclerViewLayoutManager);
-        mRecyclerView.addItemDecoration(new DividerItemDecoration(this, mRecyclerViewLayoutManager.getOrientation()));
+        TypedArray ta = this.obtainStyledAttributes(new int[] { R.attr.deckDivider });
+        Drawable divider = ta.getDrawable(0);
+        ta.recycle();
+        DividerItemDecoration dividerDecorator = new DividerItemDecoration(this, mRecyclerViewLayoutManager.getOrientation());
+        dividerDecorator.setDrawable(divider);
+        mRecyclerView.addItemDecoration(dividerDecorator);
 
         // create and set an adapter for the RecyclerView
         mDeckListAdapter = new DeckAdapter(getLayoutInflater(), this);


### PR DESCRIPTION
In this commit https://github.com/ankidroid/Anki-Android/commit/9a04d086ee5b9ee83889d03ce9d0cd6bdf69ae8f#diff-f50a1149d9cb92269cbf94c417602c5cL21
...we moved to the "new" framework item decorator that wasn't available when
our custom implementation was written

But during the conversion I didn't correctly set the drawable style, this sets the style
as it was prior

Should Fix #4942

## Pull Request template

## Purpose / Description
_Describe the problem or feature and motivation_

## Fixes
_Link to the issues._

## Approach
_How does this change address the problem?_

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration (SDK version(s), emulator or physical, etc)

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [ ] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
