### PR TITLE
database versioning / migration support

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -21,7 +21,6 @@ package com.ichi2.anki;
 import android.annotation.SuppressLint;
 import android.app.Application;
 import android.content.Context;
-import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.content.res.Resources;
@@ -35,7 +34,6 @@ import android.webkit.CookieManager;
 
 import com.ichi2.anki.analytics.AnkiDroidCrashReportDialog;
 import com.ichi2.anki.exception.StorageAccessException;
-import com.ichi2.anki.services.BootService;
 import com.ichi2.compat.CompatHelper;
 import com.ichi2.utils.LanguageUtil;
 import com.ichi2.anki.analytics.UsageAnalytics;
@@ -241,7 +239,6 @@ public class AnkiDroidApp extends Application {
                 }
             }
         }
-        new BootService().onReceive(this, new Intent(this, BootService.class));
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Storage.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Storage.java
@@ -50,7 +50,12 @@ public class Storage {
         File dbFile = new File(path);
         boolean create = !dbFile.exists();
         // connect
-        DB db = new DB(path);
+        DB db;
+        if (context instanceof DB.MigrationCallback) {
+            db = new DB(path, (DB.MigrationCallback) context);
+        } else {
+            db = new DB(path);
+        }
         try {
             // initialize
             int ver;


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
AnkiDroid relies on app preferences for migration state, but app preferences could be restored by google backup/restore prior to app startup, meaning we can't rely on preferences to indicate if a database has been updated or not - the database itself has to store this state.

This patch implements versioning stored in the database, and can handle upgrades based on changes between the app version in the database and the current app version.

## Fixes
#5106 - fresh install treated as an upgrade

## Approach
The upgrade logic is currently in DeckPicker and Storage, and handles preference data, database SQL data and database JSON data - it has a lot to handle potentially but is scattered about. Per #5106 a move to a standard migration tool (like Flyway) is possible, but isn't wanted yet.

Those tools all have the general idea that versioning info is stored in the database, and before anyone uses the database, the versioning tool discovers and applies migrations with callbacks, then you get a connection.

This patch doesn't integrate a tool but does move to that style - it make sure first database access happens in a controlled location, it uses the underlying Android SQL Framework APIs to trigger migrations first thing, and uses callbacks so we can communicate API status.

## How Has This Been Tested?

I extended the new DBTest to show that database migrations do work correctly and are very easy to use, then the rest of the test was via an emulator with a collection from prior to this change. It correctly ran the integrity check on startup, then did not run it the second time

## Learning (optional, can help others)
- I looked at how flywaydb.org organizes things - with migrations and callbacks
- I noticed how the app needs UI ability during migrations, with DeckPicker doing it now, but migrations are done outside of Activities, meaning callbacks really would be necessary
- I examined adding our own version tables but using the framework APIs seemed much easier since they do all the work for us (which rely on a special 'user_version' byte in the database header, accessible with a `PRAGMA user_version;`



## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
