### PR TITLE
Disambiguate deck/deck-group labeling for deck options

### DIFF
--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -172,7 +172,7 @@
     <string name="export_unsuccessful">Error exporting apkg file</string>
     <string name="import_hint">Place the apkg file in directory “%s” and touch “OK” to import cards</string>
     <string name="upgrade_import_no_file_found">No importable %1$s file found</string>
-    <string name="study_options">Deck options</string>
+    <string name="study_options">Options</string>
     <string name="select_tts">Set TTS language</string>
     <string name="custom_study">Custom study</string>
     <string name="more_options">More</string>

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -168,9 +168,10 @@
     <string name="custom_sync_server_media_url_title">Media sync url</string>
 
     <!-- studyoptions -->
+    <string name="deck_conf_group_summ">Changes to deck group options will affect multiple decks. If you wish to change only the current deck, please add a new options group first</string>
     <string name="studyoptions_limit_select_tags">Select tags</string>
     <!-- Deck configurations -->
-    <string name="deck_conf_deck_description">Deck description</string>
+    <string name="deck_conf_deck_description">Deck description (affects current deck only)</string>
     <string name="deck_conf_group">Options group</string>
     <plurals name="deck_conf_group_summ">
         <item quantity="one">%1$s\n%2$d deck uses this group</item>
@@ -235,7 +236,7 @@
     <string name="deck_conf_cram_reschedule_summ">Reschedule cards based on my answers in this deck</string>
     <string name="deck_conf_cram_steps">Custom steps (in minutes)</string>
     <string name="deck_conf_cram_steps_summ">Define custom steps</string>
-    <string name="deck_conf_reminders_enabled">Enable reminder notifications for this deck</string>
+    <string name="deck_conf_reminders_enabled">Enable reminder notifications for decks in this deck group</string>
     <string name="deck_conf_reminders_time">Remind at</string>
 
     <!-- analytics options -->

--- a/AnkiDroid/src/main/res/xml/deck_options.xml
+++ b/AnkiDroid/src/main/res/xml/deck_options.xml
@@ -17,6 +17,8 @@
 
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://arbitrary.app.namespace/com.ichi2.anki" >
+        <Preference
+            android:summary="@string/deck_conf_group_summ" />
         <ListPreference
             android:key="deckConf"
             android:title="@string/deck_conf_group" />


### PR DESCRIPTION
Fixes #4547 by grouping the preference items, and relabeling the context menu entry

Prepared as closely as possible to spec requested here https://github.com/ankidroid/Anki-Android/issues/4547#issuecomment-440807897

Here's what it looks like on an API28 emulator 

![deckoptionspopup](https://user-images.githubusercontent.com/782704/48907018-4d74a400-ee34-11e8-8dfa-d18cd12ac28b.png)

(deleted obsolete screenshot - updated version below)