### PR TITLE
Expose HTML/JS debugging aides in advanced prefs

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -109,13 +109,6 @@ import timber.log.Timber;
 public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
 
     /**
-     * Whether to save the content of the card in the file system.
-     * <p>
-     * Set this to true for debugging only.
-     */
-    private static final boolean SAVE_CARD_CONTENT = BuildConfig.DEBUG;
-
-    /**
      * Result codes that are returned when this activity finishes.
      */
     public static final int RESULT_DEFAULT = 50;
@@ -1772,8 +1765,9 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
         if (mCard == null) {
             mCard = createWebView();
             // On your desktop use chrome://inspect to connect to emulator WebViews
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-                if (BuildConfig.DEBUG) WebView.setWebContentsDebuggingEnabled(true);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT &&
+                    AnkiDroidApp.getSharedPrefs(this).getBoolean("html_javascript_debugging", false)) {
+                WebView.setWebContentsDebuggingEnabled(true);
             }
             mCardFrame.addView(mCard);
         }
@@ -2154,7 +2148,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
                 .replace("::style::", style.toString()).replace("::class::", cardClass));
         Timber.d("base url = %s", mBaseUrl);
 
-        if (SAVE_CARD_CONTENT) {
+        if (AnkiDroidApp.getSharedPrefs(this).getBoolean("html_javascript_debugging", false)) {
             try {
                 FileOutputStream f = new FileOutputStream(new File(CollectionHelper.getCurrentAnkiDroidDirectory(this),
                         "card.html"));

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -153,6 +153,9 @@
     <string name="custom_buttons_setting_menu_only">Menu only</string>
     <string name="reset_custom_buttons">Reset to default</string>
 
+    <string name="html_javascript_debugging">HTML / Javascript Debugging</string>
+    <string name="html_javascript_debugging_summ">Enable remote WebView connections, and save card HTML to AnkiDroid directory</string>
+
     <!-- Advanced statistics settings -->
     <string name="advanced_statistics_title">Advanced statistics</string>
     <string name="enable_advanced_statistics_title">Enable advanced statistics</string>

--- a/AnkiDroid/src/main/res/xml/preferences_advanced.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_advanced.xml
@@ -116,6 +116,11 @@
             <Preference
                 android:key="advanced_statistics_link"
                 android:title="@string/advanced_statistics_title"/>
+            <CheckBoxPreference
+                android:defaultValue="false"
+                android:key="html_javascript_debugging"
+                android:summary="@string/html_javascript_debugging_summ"
+                android:title="@string/html_javascript_debugging"/>
         </PreferenceCategory>
 
 


### PR DESCRIPTION
Fixes #5123 by taking the work from #4979 and making it visible as an
advanced preference instead of as a BuildConfig.DEBUG toggle, this means
the general userbase can debug their own HTML/Javascript items if they want
