### PR TITLE
Catch common Play Console crash, logging for root cause

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/utils/VersionUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/VersionUtils.java
@@ -62,6 +62,14 @@ public class VersionUtils {
             return pInfo.versionCode;
         } catch (PackageManager.NameNotFoundException e) {
             Timber.e(e, "Couldn't find package named %s", context.getPackageName());
+        } catch (NullPointerException npe) {
+            if (context.getPackageManager() == null) {
+                Timber.e("getPkgVersionCode() null package manager?");
+            } else if (context.getPackageName() == null) {
+                Timber.e("getPkgVersionCode() null package name?");
+            }
+            AnkiDroidApp.sendExceptionReport(npe, "Unexpected exception getting version code?");
+            Timber.e(npe, "Unexpected exception getting version code?");
         }
         return 0;
     }


### PR DESCRIPTION
I know just catching null pointers isn't the solution, but I can't
figure out how this code is causing a crash, so I'm logging the
object lookup chain parts then logging the NullPointerException that
is our current top crash on Play Console that I haven't fixed yet
