### PR TITLE
Implement standard gradle build/test optimizations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,13 @@ env:
    - API=16 AUDIO=-no-audio
    - API=17
    #- API=18 # API18 has started being flaky
-   - API=19
    # API 20 doesn't have an emulator
    - API=21
    - API=22
    #- API=23 EMU_FLAVOR=google_apis # fails consistently but can run local
    - API=24
+   # API16 and API19 are the fastest APIs, Travis runs 5 at a time and we have 6, this is the fastest way to do all 6 APIs
+   - API=19
    #- API=25 EMU_FLAVOR=google_apis # fails consistently but can run local
    # API >= 26 don't have arm emulators, and Travis doesn't support x86
 

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -123,6 +123,25 @@ task jacocoTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest', 'crea
     ])
 }
 
+// A unit-test only report task
+task jacocoUnitTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest']) {
+
+    reports {
+        xml.enabled = true
+    }
+
+    def fileFilter = ['**/R.class', '**/R$*.class', '**/BuildConfig.*', '**/Manifest*.*', '**/*Test*.*', 'android/**/*.*']
+    def debugTree = fileTree(dir: "$project.buildDir/intermediates/javac/debug/compileDebugJavaWithJavac/classes", excludes: fileFilter)
+    def mainSrc = "$project.projectDir/src/main/java"
+
+    sourceDirectories = files([mainSrc])
+    classDirectories = files([debugTree])
+    executionData = fileTree(dir: project.buildDir, includes: [
+            'jacoco/testDebugUnitTest.exec'
+
+    ])
+}
+
 dependencies {
     compileOnly "com.google.auto.service:auto-service:1.0-rc4"
     annotationProcessor "com.google.auto.service:auto-service:1.0-rc4"

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -2,6 +2,10 @@ apply plugin: 'com.android.application'
 apply plugin: 'com.github.triplet.play'
 apply plugin: 'jacoco'
 
+repositories {
+    google()
+    jcenter()
+}
 def homePath = System.properties['user.home']
 android {
     compileSdkVersion 28
@@ -68,8 +72,16 @@ android {
     packagingOptions {
         exclude 'META-INF/DEPENDENCIES'
     }
-}
+    testOptions.unitTests.all {
+        testLogging {
+            events "failed", "skipped"
+            showStackTraces = true
+            exceptionFormat = "full"
+        }
 
+        maxParallelForks = gradleTestMaxParallelForks
+    }
+}
 
 play {
     serviceAccountEmail = '294046724212-r3bef6kl46pb9gk0h1pl5rcjmpfrdpjl@developer.gserviceaccount.com'
@@ -80,6 +92,16 @@ play {
 // Deprecation is an error. Use @SuppressWarnings("deprecation") and justify in the PR if you must
 tasks.withType(JavaCompile) {
     options.compilerArgs << "-Xlint:deprecation" << "-Xmaxwarns" << "1000" << "-Werror"
+
+    // https://guides.gradle.org/performance/#compiling_java
+    // 1- fork improves things over time with repeated builds, doesn't harm CI single builds
+    options.fork = true
+    // 2- incremental will be the default in the future and can help now
+    options.incremental = true
+}
+
+tasks.withType(Test) {
+    jacoco.includeNoLocationClasses = true
 }
 
 // Our merge report task

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -4,6 +4,10 @@ def groupId = "com.ichi2.anki"
 def artifactId = "api"
 def version = "1.1.0alpha6"
 
+repositories {
+    google()
+    jcenter()
+}
 android {
     compileSdkVersion 28
 
@@ -23,6 +27,15 @@ android {
         unitTests {
             includeAndroidResources = true
         }
+    }
+    testOptions.unitTests.all {
+        testLogging {
+            events "failed", "skipped"
+            showStackTraces = true
+            exceptionFormat = "full"
+        }
+
+        maxParallelForks = gradleTestMaxParallelForks
     }
 }
 
@@ -94,4 +107,15 @@ generateRelease.dependsOn(zipRelease)
 artifacts {
     archives androidSourcesJar
     archives androidJavadocsJar
+}
+
+// Deprecation is an error. Use @SuppressWarnings("deprecation") and justify in the PR if you must
+tasks.withType(JavaCompile) {
+    options.compilerArgs << "-Xlint:deprecation" << "-Xmaxwarns" << "1000" << "-Werror"
+
+    // https://guides.gradle.org/performance/#compiling_java
+    // 1- fork improves things over time with repeated builds, doesn't harm CI single builds
+    options.fork = true
+    // 2- incremental will be the default in the future and can help now
+    options.incremental = true
 }

--- a/build.gradle
+++ b/build.gradle
@@ -15,15 +15,15 @@ buildscript {
     }
 }
 
-allprojects {
-    repositories {
-        google()
-        jcenter()
-    }
-}
-
 ext {
     travisBuild = System.getenv("TRAVIS") == "true"
     // allows for -Dpre-dex=false to be set
     preDexEnabled = "true".equals(System.getProperty("pre-dex", "true"))
+
+    // Travis may report host CPU counts vs guest, everyone else gets 50% of cores
+    gradleTestMaxParallelForks = 1
+    if (!travisBuild) {
+        gradleTestMaxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
+    }
 }
+

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,9 @@
 android.enableJetifier=true
 android.useAndroidX=true
 android.enableUnitTestBinaryResources=true
+
+# With de-coupled gradle sub-modules, they may run in parallel
+org.gradle.parallel=true
+
+# The default in the future, let's true the future now...
+org.gradle.caching=true


### PR DESCRIPTION
- de-couple api + AnkiDroid by making sure all evaluation may be done separately
- fork and incremental compile
- scale concurrent tests by CPU count, mindful of containerization

All of these tested to have only a small positive impact on CI or old/small machines (my 4-core MacBook Pro and 2-core MacBook Air) but on my main dev machine (6 fast cores) this is a 30% speedup that will only grow as we add heavier tests (like Robolectric stuff now that #5103 is in)

There was one recommended optimization that didn't pan out and hammered small machines - setting the heap big enough to dex in process - but other than this is the full suite of recommended gradle optimizations

I will also note that I've worked a lot in the gradle files adding build system features, and while I love the features, I'm unhappy with the file organization. Either in the beta cycle (while waiting for stabilization) of 2.9 or after, I can re-organize so that chunks of functionality (jacoco, test options) are in separate files like so https://github.com/spotbugs/spotbugs-gradle-plugin/tree/master/gradle/