### PR TITLE
Use centralized file copy logic in Utils, extends #5093

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV15.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV15.java
@@ -194,19 +194,13 @@ public class CompatV15 implements Compat {
 
     // Until API 26 do the copy using streams
     public long copyFile(@NonNull String source, @NonNull OutputStream target) throws IOException {
-        InputStream fileInputStream = null;
         long count;
 
-        try {
-            fileInputStream = new FileInputStream(new File(source));
+        try (InputStream fileInputStream = new FileInputStream(new File(source))) {
             count = copyFile(fileInputStream, target);
         } catch (IOException e) {
             Timber.e(e, "copyFile() error copying source %s", source);
             throw e;
-        } finally {
-            if (fileInputStream != null) {
-                fileInputStream.close();
-            }
         }
 
         return count;
@@ -214,16 +208,13 @@ public class CompatV15 implements Compat {
 
     // Until API 26 do the copy using streams
     public long copyFile(@NonNull InputStream source, @NonNull String target) throws IOException {
-        OutputStream targetStream = new FileOutputStream(target);
         long bytesCopied;
 
-        try {
+        try (OutputStream targetStream = new FileOutputStream(target)) {
             bytesCopied = copyFile(source, targetStream);
         } catch (IOException ioe) {
             Timber.e(ioe, "Error while copying to file %s", target);
             throw ioe;
-        } finally {
-            targetStream.close();
         }
         return bytesCopied;
     }

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/UtilsTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/UtilsTest.java
@@ -16,6 +16,8 @@
 
 package com.ichi2.libanki;
 
+import com.ichi2.anki.TestUtils;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -23,6 +25,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Enumeration;
+import java.util.Objects;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
@@ -69,5 +72,14 @@ public class UtilsTest {
         } catch (IOException ioe) {
             Assert.fail("Unexpected exception: " + ioe);
         }
+    }
+
+    @Test
+    public void testCopyFile() throws Exception {
+        URL resource = Objects.requireNonNull(getClass().getClassLoader()).getResource("path-traversal.zip");
+        File copy = File.createTempFile("testCopyFileToStream", ".zip");
+        copy.deleteOnExit();
+        Utils.copyFile(new File(resource.getFile()), copy);
+        Assert.assertEquals(TestUtils.getMD5(resource.getPath()), TestUtils.getMD5(copy.getCanonicalPath()));
     }
 }


### PR DESCRIPTION
## Purpose / Description

Turns out file copy logic was duplicated in 6 places, not just the 5
that I saw in #5093

I noticed this while doing my periodic sweep on Play Console crashes and chasing a Zip import error

## Approach
This uses the new centralized logic from the #5093 PR while converting
some of it to "try-with-resources" which android back-ported down to API15 even
so allows for much cleaner code while still cleaning up streams/files on exception

## How Has This Been Tested?
Since this touched new code (libanki.Utils) vs the previous PR I added
test coverage to make sure I hadn't done anything stupid.

Also, because the try-with-resources backport uses some dark magic, I wanted to be sure, so I fired up an API15 emulator with valid sdcard mounted (difficult in itself these days), and synced a test deck with media to make sure I hit a code path (Compat.copyFile()) that had been converted to try-with-resources

## Learning (optional, can help others)

1. [Getting sdcards to work down to our oldest API(15)](https://issuetracker.google.com/issues/37138030#comment13)
1. [Try-with-resources backport to all Android APIs](https://developer.android.com/studio/write/java8-support): 
```
In addition to the Java 8 language features and APIs above, Android Studio 3.0 and later extends support for try-with-resources to all Android API levels.
```

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
