### PR TITLE
CardTemplateEditor pre4 - track unsaved template/add deletes for later persistence

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -141,7 +141,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
     public static final int EASE_4 = 4;
 
     /** Maximum time in milliseconds to wait before accepting answer button presses. */
-    private static final int DOUBLE_TAP_IGNORE_THRESHOLD = 200;
+    protected static final int DOUBLE_TAP_IGNORE_THRESHOLD = 200;
 
     /** Time to wait in milliseconds before resuming fullscreen mode **/
     protected static final int INITIAL_HIDE_DELAY = 200;
@@ -253,7 +253,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
      * A record of the last time the "show answer" or ease buttons were pressed. We keep track
      * of this time to ignore accidental button presses.
      */
-    private long mLastClickTime;
+    protected long mLastClickTime;
 
     /**
      * Swipe Detection

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
@@ -77,6 +77,7 @@ import timber.log.Timber;
 public class CardTemplateEditor extends AnkiActivity {
     private TemplatePagerAdapter mTemplateAdapter;
     private JSONObject mModelBackup = null;
+    public static String INTENT_MODEL_FILENAME = "editedModelFilename";
     private ViewPager mViewPager;
     private SlidingTabLayout mSlidingTabLayout;
     private long mModelId;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
@@ -225,7 +225,7 @@ public class CardTemplateEditor extends AnkiActivity {
         super.onCollectionLoaded(col);
         // Create the adapter that will return a fragment for each of the three
         // primary sections of the activity.
-        mTemplateAdapter = new TemplatePagerAdapter(getSupportFragmentManager());
+        mTemplateAdapter = getNewTemplatePagerAdapter(getSupportFragmentManager());
         mTemplateAdapter.setModel(col.getModels().get(mModelId));
         // Set up the ViewPager with the sections adapter.
         mViewPager = (ViewPager) findViewById(R.id.pager);
@@ -314,8 +314,14 @@ public class CardTemplateEditor extends AnkiActivity {
     // INNER CLASSES
     // ----------------------------------------------------------------------------
 
+
+    protected TemplatePagerAdapter getNewTemplatePagerAdapter(FragmentManager fm) {
+        return new TemplatePagerAdapter(fm);
+    }
+
+
     /**
-     * A {@link androidx.core.app.FragmentPagerAdapter} that returns a fragment corresponding to
+     * A {@link androidx.fragment.app.FragmentPagerAdapter} that returns a fragment corresponding to
      * one of the tabs.
      */
     public class TemplatePagerAdapter extends FragmentPagerAdapter {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.java
@@ -24,9 +24,15 @@ import android.view.View;
 
 import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
+import com.ichi2.libanki.Models;
+import com.ichi2.libanki.Note;
 import com.ichi2.themes.Themes;
 
 import org.json.JSONObject;
+
+import java.util.ArrayList;
+
+import javax.annotation.Nullable;
 
 import timber.log.Timber;
 
@@ -38,7 +44,7 @@ import timber.log.Timber;
 public class Previewer extends AbstractFlashcardViewer {
     private long[] mCardList;
     private int mIndex;
-    private boolean mShowingAnswer;
+    protected boolean mShowingAnswer;
     private String mEditedModelFileName = null;
     private JSONObject mEditedModel = null;
 
@@ -47,17 +53,33 @@ public class Previewer extends AbstractFlashcardViewer {
         Timber.d("onCreate()");
         super.onCreate(savedInstanceState);
 
-        mCardList = getIntent().getLongArrayExtra("cardList");
-        mIndex = getIntent().getIntExtra("index", -1);
-        if (mCardList.length == 0 || mIndex < 0 || mIndex > mCardList.length - 1) {
-            Timber.e("Previewer started with empty card list or invalid index");
-            finishWithoutAnimation();
-            return;
+        Bundle parameters = savedInstanceState;
+        if (parameters == null) {
+            parameters = getIntent().getExtras();
         }
-        mEditedModelFileName = getIntent().getStringExtra("editedModelFileName");
+        mEditedModelFileName = parameters.getString(CardTemplateEditor.INTENT_MODEL_FILENAME);
+        mCardList = parameters.getLongArray("cardList");
+        mIndex = parameters.getInt("index");
+
         if (mEditedModelFileName != null) {
             Timber.d("onCreate() loading edited model from %s", mEditedModelFileName);
             mEditedModel = CardTemplateEditor.getTempModel(mEditedModelFileName);
+        }
+
+        if (mEditedModel != null && mIndex != -1) {
+            Timber.d("onCreate() Previewer started with edited model and index, displaying blank to preview formatting");
+            mCurrentCard = getDummyCard(mEditedModel, mIndex);
+            if (mCurrentCard == null) {
+                UIUtils.showSimpleSnackbar(this, R.string.invalid_template, false);
+                finishWithoutAnimation();
+                return;
+            }
+        }
+
+        if (mCurrentCard == null && (mCardList == null || mCardList.length == 0 || mIndex < 0 || mIndex > mCardList.length - 1)) {
+            Timber.e("Previewer started with empty card list or invalid index");
+            finishWithoutAnimation();
+            return;
         }
         showBackIcon();
         // Ensure navigation drawer can't be opened. Various actions in the drawer cause crashes.
@@ -65,10 +87,22 @@ public class Previewer extends AbstractFlashcardViewer {
         startLoadingCollection();
     }
 
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        outState.putLongArray("cardList", mCardList);
+        outState.putString(CardTemplateEditor.INTENT_MODEL_FILENAME, mEditedModelFileName);
+        outState.putInt("index", mIndex);
+        super.onSaveInstanceState(outState);
+    }
+
+
     @Override
     protected void onCollectionLoaded(Collection col) {
         super.onCollectionLoaded(col);
-        mCurrentCard = new PreviewerCard(col, mCardList[mIndex]);
+        if (mCurrentCard == null) {
+            mCurrentCard = new PreviewerCard(col, mCardList[mIndex]);
+        }
         displayCardQuestion();
         showBackIcon();
     }
@@ -138,8 +172,8 @@ public class Previewer extends AbstractFlashcardViewer {
 
     private void updateButtonState() {
         // If we are in single-card mode, we show the "Show Answer" button on the question side
-        // and hide all the button s on the answer side.
-        if (mCardList.length == 1) {
+        // and hide all the buttons on the answer side.
+        if (mCardList == null || mCardList.length == 1) {
             if (!mShowingAnswer) {
                 mFlipCardLayout.setVisibility(View.VISIBLE);
             } else {
@@ -188,11 +222,80 @@ public class Previewer extends AbstractFlashcardViewer {
         }
     }
 
+    /** Get a dummy card */
+    protected @Nullable Card getDummyCard(JSONObject model, int ordinal) {
+        Timber.d("getDummyCard() Creating dummy note for position %s", ordinal);
+        if (model == null) {
+            return null;
+        }
+        Note n = getCol().newNote(model);
+        ArrayList<String> fieldNames = Models.fieldNames(model);
+        for (int i = 0; i < fieldNames.size(); i++) {
+            n.setField(i, fieldNames.get(i));
+        }
+        try {
+            JSONObject template = (JSONObject)model.getJSONArray("tmpls").get(ordinal);
+            PreviewerCard card = (PreviewerCard)getCol()._newCard(new PreviewerCard(getCol()), n, template, 1, false);
+            card.setNote(n);
+            return card;
+        } catch (Exception e) {
+            Timber.e("getDummyCard() unable to create card");
+        }
+        return null;
+    }
 
+
+    /** Override certain aspects of Card behavior so we may display unsaved data */
     public class PreviewerCard extends Card {
+
+        private Note mNote;
+
+
+        public PreviewerCard(Collection col) {
+            super(col);
+        }
+
+
         public PreviewerCard(Collection col, long id) {
             super(col, id);
         }
+
+
+        @Override
+        /** if we have an unsaved note saved, use it instead of a collection lookup */
+        public Note note(boolean reload) {
+            if (mNote != null) {
+                return mNote;
+            }
+            return super.note(reload);
+        }
+
+
+        @Override
+        /** if we have an unsaved note saved, use it instead of a collection lookup */
+        public Note note() {
+            if (mNote != null) {
+                return mNote;
+            }
+            return super.note();
+        }
+
+
+        /** set an unsaved note to use for rendering */
+        public void setNote(Note note) {
+            mNote = note;
+        }
+
+
+        @Override
+        /** if we have an unsaved note, never return empty */
+        public boolean isEmpty() {
+            if (mNote != null) {
+                return false;
+            }
+            return super.isEmpty();
+        }
+
 
         @Override
         /** Override the method that fetches the model so we can render unsaved models */

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.java
@@ -291,12 +291,7 @@ public class Card implements Cloneable {
             JSONObject m = model();
             JSONObject t = template();
             Object[] data;
-            try {
-                data = new Object[] { mId, f.getId(), m.getLong("id"), mODid != 0L ? mODid : mDid, mOrd,
-                        f.stringTags(), f.joinedFields() };
-            } catch (JSONException e) {
-                throw new RuntimeException(e);
-            }
+            data = new Object[] { mId, f.getId(), m, mODid != 0L ? mODid : mDid, mOrd, f.stringTags(), f.joinedFields() };
 
             if (browser) {
                 try {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1006,13 +1006,12 @@ public class Collection {
         return _renderQA(data, null, null);
     }
 
-
     public HashMap<String, String> _renderQA(Object[] data, String qfmt, String afmt) {
         // data is [cid, nid, mid, did, ord, tags, flds]
         // unpack fields and create dict
         String[] flist = Utils.splitFields((String) data[6]);
         Map<String, String> fields = new HashMap<>();
-        JSONObject model = mModels.get((Long) data[2]);
+        JSONObject model = (JSONObject)data[2];
         Map<String, Pair<Integer, JSONObject>> fmap = mModels.fieldMap(model);
         for (String name : fmap.keySet()) {
             fields.put(name, flist[fmap.get(name).first]);
@@ -1083,7 +1082,7 @@ public class Collection {
                     "SELECT c.id, n.id, n.mid, c.did, c.ord, "
                             + "n.tags, n.flds FROM cards c, notes n WHERE c.nid == n.id " + where, null);
             while (cur.moveToNext()) {
-                data.add(new Object[] { cur.getLong(0), cur.getLong(1), cur.getLong(2), cur.getLong(3), cur.getInt(4),
+                data.add(new Object[] { cur.getLong(0), cur.getLong(1), getModels().get(cur.getLong(2)), cur.getLong(3), cur.getInt(4),
                         cur.getString(5), cur.getString(6) });
             }
         } finally {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -800,12 +800,15 @@ public class Collection {
 
 
     private Card _newCard(Note note, JSONObject template, int due, boolean flush) {
-        Card card = new Card(this);
+        return _newCard(new Card(this), note, template, due, flush);
+    }
+
+    public Card _newCard(Card card, Note note, JSONObject template, int due, boolean flush) {
         card.setNid(note.getId());
         try {
             card.setOrd(template.getInt("ord"));
         } catch (JSONException e) {
-            new RuntimeException(e);
+            throw new RuntimeException(e);
         }
         // Use template did (deck override) if valid, otherwise model did
         long did = template.optLong("did", 0);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -489,7 +489,7 @@ public class Models {
     }
 
 
-    public ArrayList<String> fieldNames(JSONObject m) {
+    public static ArrayList<String> fieldNames(JSONObject m) {
         JSONArray ja;
         try {
             ja = m.getJSONArray("flds");

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -1078,10 +1078,10 @@ public class Models {
                 b.add("");
             }
             Object[] data;
-            data = new Object[] {1L, 1L, m.getLong("id"), 1L, t.getInt("ord"), "",
+            data = new Object[] {1L, 1L, m, 1L, t.getInt("ord"), "",
                     Utils.joinFields(a.toArray(new String[a.size()])) };
             String full = mCol._renderQA(data).get("q");
-            data = new Object[] {1L, 1L, m.getLong("id"), 1L, t.getInt("ord"), "",
+            data = new Object[] {1L, 1L, m, 1L, t.getInt("ord"), "",
                     Utils.joinFields(b.toArray(new String[b.size()])) };
             String empty = mCol._renderQA(data).get("q");
             // if full and empty are the same, the template is invalid and there is no way to satisfy it

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateEditorTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateEditorTest.java
@@ -1,18 +1,30 @@
 package com.ichi2.anki;
 
 import android.content.Context;
+import android.content.Intent;
 
 import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.android.controller.ActivityController;
+import org.robolectric.annotation.Config;
 
+import java.io.Serializable;
+import java.util.ArrayList;
+
+import androidx.fragment.app.FragmentManager;
 import androidx.test.platform.app.InstrumentationRegistry;
 import timber.log.Timber;
 
+import static com.ichi2.anki.CardTemplateEditor.ChangeType.ADD;
+import static com.ichi2.anki.CardTemplateEditor.ChangeType.DELETE;
+
 
 @RunWith(RobolectricTestRunner.class)
+@Config(shadows = { ShadowViewPager.class })
 public class CardTemplateEditorTest extends RobolectricTest {
 
     @Test
@@ -33,5 +45,92 @@ public class CardTemplateEditorTest extends RobolectricTest {
         Assert.assertEquals(1, CardTemplateEditor.clearTempModelFiles(context));
         Timber.i("The following logged NoSuchFileException is an expected part of verifying a file delete.");
         Assert.assertNull("tempModel not correctly deleted", CardTemplateEditor.getTempModel(tempModelPath));
+    }
+
+
+    @Test
+    public void testAddDeleteTracking() throws Exception {
+
+        // Assume you start with a 2 template model (like "Basic (and reversed)")
+        // Add a 3rd new template, remove the 2nd, remove the 1st, add a new now-2nd, remove 1st again
+        // ...and it should reduce to just removing the original 1st/2nd and adding the final as first
+
+        // We'll create an actual Activity here to use later for lifecycle persistence checks. The model we use is unimportant for the test.
+        String modelName = "Basic (and reversed card)";
+        JSONObject collectionBasicModelOriginal = getCurrentDatabaseModelCopy(modelName);
+        Intent intent = new Intent(Intent.ACTION_VIEW);
+        intent.putExtra("modelId", collectionBasicModelOriginal.getLong("id"));
+        ActivityController templateEditorController = Robolectric.buildActivity(CardTemplateEditor.class, intent).create().start().resume().visible();
+        CardTemplateEditor testEditor = (CardTemplateEditor) templateEditorController.get();
+
+
+        testEditor.addTemplateChange(ADD, 3);
+        Object[][] expected1 = {{3, ADD}};
+        assertTemplateChangesEqual(expected1, testEditor.getTemplateChanges());
+        testEditor.addTemplateChange(DELETE, 2);
+        testEditor.addTemplateChange(DELETE, 1);
+        Object[][] expected2 = {{3, ADD}, {2, DELETE}, {1, DELETE}};
+        assertTemplateChangesEqual(expected2, testEditor.getTemplateChanges());
+        testEditor.addTemplateChange(ADD, 2);
+        Object[][] expected3 = {{3, ADD}, {2, DELETE}, {1, DELETE}, {2, ADD}};
+        assertTemplateChangesEqual(expected3, testEditor.getTemplateChanges());
+
+        // This is the hard part. We will delete a template we added so everything shifts.
+        // The template currently at ordinal 1 was added as template 3 at the start before it slid down on the deletes
+        // So the first template add should be negated by this delete, and the second template add should slide down to 1
+        testEditor.addTemplateChange(DELETE, 1);
+        Object[][] expected4 = {{2, DELETE}, {1, DELETE}, {1, ADD}};
+        assertTemplateChangesEqual(expected4, testEditor.getTemplateChanges());
+        testEditor.addTemplateChange(ADD, 2);
+        Object[][] expected5 = {{2, DELETE}, {1, DELETE}, {1, ADD}, {2, ADD}};
+        assertTemplateChangesEqual(expected5, testEditor.getTemplateChanges());
+        testEditor.addTemplateChange(DELETE, 2);
+        Object[][] expected6 = {{2, DELETE}, {1, DELETE}, {1, ADD}};
+        assertTemplateChangesEqual(expected6, testEditor.getTemplateChanges());
+    }
+
+
+    private void assertTemplateChangesEqual(Object[][] expected, Serializable actual) {
+        if (!(actual instanceof ArrayList)) {
+            Assert.fail("actual array null or not the correct type");
+        }
+        Assert.assertEquals("arrays didn't have the same length?", expected.length, ((ArrayList) actual).size());
+        for (int i = 0; i < expected.length; i++) {
+            if (!(((ArrayList) actual).get(i) instanceof Object[])) {
+                Assert.fail("actual array does not contain Object[] entries");
+            }
+            Object[] actualChange = (Object[]) ((ArrayList) actual).get(i);
+            Assert.assertEquals("ordinal at " + i + " not correct?", expected[i][0], actualChange[0]);
+            Assert.assertEquals("changeType at " + i + " not correct?", expected[i][1], actualChange[1]);
+        }
+    }
+}
+
+
+
+// Robolectric is great, but ViewPager support is very incomplete.
+// We have to avoid paging or we get exceptions
+// https://github.com/robolectric/robolectric/issues/3698
+class NonPagingCardTemplateEditor extends CardTemplateEditor {
+    public static int pagerCount = 2;
+
+
+    public void selectTemplate(int idx) { /* do nothing */ }
+
+
+    public TemplatePagerAdapter getNewTemplatePagerAdapter(FragmentManager fm) {
+        return new TestTemplatePagerAdapter(fm);
+    }
+
+
+    class TestTemplatePagerAdapter extends CardTemplateEditor.TemplatePagerAdapter {
+        private TestTemplatePagerAdapter(FragmentManager fm) {
+            super(fm);
+        }
+
+
+        public int getCount() {
+            return pagerCount;
+        }
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateEditorTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateEditorTest.java
@@ -1,0 +1,37 @@
+package com.ichi2.anki;
+
+import android.content.Context;
+
+import org.json.JSONObject;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import androidx.test.platform.app.InstrumentationRegistry;
+import timber.log.Timber;
+
+
+@RunWith(RobolectricTestRunner.class)
+public class CardTemplateEditorTest extends RobolectricTest {
+
+    @Test
+    public void testTempModelStorage() throws Exception {
+        Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+
+        // Start off with clean state in the cache dir
+        CardTemplateEditor.clearTempModelFiles(context);
+
+        // Make sure save / retrieve works
+        String tempModelPath = CardTemplateEditor.saveTempModel(context, new JSONObject("{foo: bar}"));
+        Assert.assertNotNull("Saving temp model unsuccessful", tempModelPath);
+        JSONObject tempModel = CardTemplateEditor.getTempModel(tempModelPath);
+        Assert.assertNotNull("Temp model not read successfully", tempModel);
+        Assert.assertEquals(new JSONObject("{foo: bar}").toString(), tempModel.toString());
+
+        // Make sure clearing works
+        Assert.assertEquals(1, CardTemplateEditor.clearTempModelFiles(context));
+        Timber.i("The following logged NoSuchFileException is an expected part of verifying a file delete.");
+        Assert.assertNull("tempModel not correctly deleted", CardTemplateEditor.getTempModel(tempModelPath));
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.java
@@ -2,8 +2,6 @@ package com.ichi2.anki;
 
 import android.content.Context;
 
-import androidx.test.core.app.ApplicationProvider;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
@@ -22,7 +20,7 @@ public class DeckPickerTest extends RobolectricTest {
     public void verifyCodeMessages() {
 
         Map<Integer, String> mCodeResponsePairs = new HashMap<>();
-        final Context context = ApplicationProvider.getApplicationContext();
+        final Context context = getTargetContext();
         mCodeResponsePairs.put(407, context.getString(R.string.sync_error_407_proxy_required));
         mCodeResponsePairs.put(409, context.getString(R.string.sync_error_409));
         mCodeResponsePairs.put(413, context.getString(R.string.sync_error_413_collection_size));

--- a/AnkiDroid/src/test/java/com/ichi2/anki/PreviewerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/PreviewerTest.java
@@ -1,0 +1,121 @@
+/****************************************************************************************
+ * Copyright (c) 2018 Mike Hardy <mike@mikehardy.net>                                   *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+
+package com.ichi2.anki;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.widget.LinearLayout;
+
+import com.ichi2.libanki.Card;
+import com.ichi2.libanki.Models;
+import com.ichi2.libanki.Note;
+
+import org.json.JSONObject;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.android.controller.ActivityController;
+
+import java.util.ArrayList;
+
+@RunWith(RobolectricTestRunner.class)
+public class PreviewerTest extends RobolectricTest {
+
+    @Test
+    public void testPreviewUnsavedTemplate() throws Exception {
+
+        String modelName = "Basic";
+        JSONObject collectionBasicModelOriginal = getCurrentDatabaseModelCopy(modelName);
+        JSONObject template = (JSONObject)collectionBasicModelOriginal.getJSONArray("tmpls").get(0);
+        template.put("qfmt", template.getString("qfmt").concat("PREVIEWER_TEST"));
+        String tempModelPath = CardTemplateEditor.saveTempModel(getTargetContext(), collectionBasicModelOriginal);
+        Intent intent = new Intent(Intent.ACTION_VIEW);
+        intent.putExtra(CardTemplateEditor.INTENT_MODEL_FILENAME, tempModelPath);
+        intent.putExtra("index", 0);
+
+        ActivityController previewerController = Robolectric.buildActivity(TestPreviewer.class, intent).create().start().resume().visible();
+        TestPreviewer testPreviewer = (TestPreviewer) previewerController.get();
+        Assert.assertTrue("model change did not show up?",
+                testPreviewer.getDummyCard(collectionBasicModelOriginal, 0).q().contains("PREVIEWER_TEST") &&
+                        testPreviewer.getDummyCard(collectionBasicModelOriginal, 0).a().contains("PREVIEWER_TEST"));
+
+        // Take it through a destroy/re-create lifecycle in order to test instance state persistence
+        Bundle outBundle = new Bundle();
+        previewerController.saveInstanceState(outBundle);
+        previewerController.pause().stop().destroy();
+        previewerController = Robolectric.buildActivity(TestPreviewer.class).create(outBundle).start().resume().visible();
+        testPreviewer = (TestPreviewer) previewerController.get();
+        Assert.assertTrue("model change not preserved in lifecycle??",
+                testPreviewer.getDummyCard(collectionBasicModelOriginal, 0).q().contains("PREVIEWER_TEST") &&
+                        testPreviewer.getDummyCard(collectionBasicModelOriginal, 0).a().contains("PREVIEWER_TEST"));
+
+
+        // Make sure we can click
+        Assert.assertFalse("Showing the answer already?", testPreviewer.getShowingAnswer());
+        testPreviewer.disableDoubleClickPrevention();
+        LinearLayout showAnswerButton = testPreviewer.findViewById(R.id.flashcard_layout_flip);
+        showAnswerButton.performClick();
+        Assert.assertTrue("Not showing the answer?", testPreviewer.getShowingAnswer());
+    }
+
+    @Test
+    public void testPreviewNormal() throws Exception {
+
+        // Make sure we test previewing a new card template
+        String modelName = "Basic (and reversed card)";
+        JSONObject collectionBasicModelOriginal = getCurrentDatabaseModelCopy(modelName);
+        Card testCard1 = getSavedCard(collectionBasicModelOriginal, 0);
+        Card testCard2 = getSavedCard(collectionBasicModelOriginal, 1);
+
+        Intent intent = new Intent(Intent.ACTION_VIEW);
+        intent.putExtra("cardList", new long[] { testCard1.getId(), testCard2.getId() } );
+        intent.putExtra("index", 0);
+
+        ActivityController previewerController = Robolectric.buildActivity(TestPreviewer.class, intent).create().start().resume().visible();
+
+        // Take it through a destroy/re-create lifecycle in order to test instance state persistence
+        Bundle outBundle = new Bundle();
+        previewerController.saveInstanceState(outBundle);
+        previewerController.pause().stop().destroy();
+        previewerController = Robolectric.buildActivity(TestPreviewer.class).create(outBundle).start().resume().visible();
+        TestPreviewer testPreviewer = (TestPreviewer) previewerController.get();
+
+        // Make sure we can click
+        Assert.assertFalse("Showing the answer already?", testPreviewer.getShowingAnswer());
+        testPreviewer.disableDoubleClickPrevention();
+        LinearLayout showAnswerButton = testPreviewer.findViewById(R.id.flashcard_layout_flip);
+        showAnswerButton.performClick();
+        Assert.assertTrue("Not showing the answer?", testPreviewer.getShowingAnswer());
+    }
+
+    private Card getSavedCard(JSONObject model, int ordinal) throws Exception {
+        Note n = getCol().newNote(model);
+        ArrayList<String> fieldNames = Models.fieldNames(model);
+        for (int i = 0; i < fieldNames.size(); i++) {
+            n.setField(i, fieldNames.get(i));
+        }
+        n.flush();
+        return getCol()._newCard(new Card(getCol()), n, (JSONObject)model.getJSONArray("tmpls").get(ordinal), 1, true);
+    }
+}
+
+class TestPreviewer extends Previewer {
+    public boolean getShowingAnswer() { return mShowingAnswer; }
+    public void disableDoubleClickPrevention() { mLastClickTime = (AbstractFlashcardViewer.DOUBLE_TAP_IGNORE_THRESHOLD * -2); }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
@@ -32,7 +32,7 @@ import org.robolectric.shadows.ShadowDialog;
 import org.robolectric.shadows.ShadowLog;
 
 import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory;
-import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.core.app.ApplicationProvider;
 
 public class RobolectricTest {
 
@@ -68,7 +68,7 @@ public class RobolectricTest {
 
 
     protected Context getTargetContext() {
-        return InstrumentationRegistry.getInstrumentation().getTargetContext();
+        return ApplicationProvider.getApplicationContext();
     }
 
 
@@ -78,7 +78,7 @@ public class RobolectricTest {
 
 
     protected Collection getCol() {
-        return CollectionHelper.getInstance().getCol(InstrumentationRegistry.getInstrumentation().getTargetContext());
+        return CollectionHelper.getInstance().getCol(getTargetContext());
     }
 
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ShadowViewPager.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ShadowViewPager.java
@@ -1,0 +1,71 @@
+/****************************************************************************************
+ * Copyright (c) 2018 Mike Hardy <mike@mikehardy.net>                                   *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+
+package com.ichi2.anki;
+
+import androidx.fragment.app.FragmentManager;
+import androidx.viewpager.widget.PagerAdapter;
+import androidx.viewpager.widget.ViewPager;
+
+import org.mockito.internal.util.reflection.Fields;
+import org.mockito.internal.util.reflection.InstanceField;
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+import org.robolectric.annotation.RealObject;
+import org.robolectric.shadows.ShadowViewGroup;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
+import static org.robolectric.shadow.api.Shadow.directlyOn;
+
+/**
+ * This only exists as a workaround for a Robolectric bug with Fragments and ViewPagers - it can be deleted
+ * and the relevant @Config( shadows = { ShadowViewPager.class }) entries may be removed once Robolectric is fixed
+ * https://github.com/robolectric/robolectric/issues/3698#issuecomment-441839491
+ */
+@Implements(ViewPager.class)
+public class ShadowViewPager extends ShadowViewGroup {
+
+    @RealObject
+    protected ViewPager realViewPager;
+
+    @Implementation
+    public void setAdapter(PagerAdapter adapter) {
+        directlyOn(realViewPager, ViewPager.class).setAdapter(addWorkaround(adapter));
+    }
+
+    private PagerAdapter addWorkaround(PagerAdapter adapter) {
+        PagerAdapter spied = spy(adapter);
+        FragmentManager fragmentManager = getFragmentManagerFromAdapter(spied);
+        doAnswer(invocation -> {
+            if (fragmentManager.getFragments().isEmpty())
+                invocation.callRealMethod();
+            return null;
+        }).when(spied).finishUpdate(any());
+        return spied;
+    }
+
+    private FragmentManager getFragmentManagerFromAdapter(PagerAdapter adapter) {
+        for (InstanceField instanceField : Fields.allDeclaredFieldsOf(adapter).instanceFields()) {
+            Object obj = instanceField.read();
+            if (obj instanceof FragmentManager) {
+                return (FragmentManager) obj;
+            }
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
Continuing to feed in the changes for #5011 in hopefully-reviewable chunks, this is the heart of the new code but is still standalone, and can be merged without affecting current behavior - the implementation at this point has not actually been altered, we've just been growing features (e.g. Preview on unsaved cards) we can use to alter it later

This is the algorithm that keeps track of template add/deletes while we're working in memory. It's tricky because when you delete a template, cards using the same model with higher ordinals have their ordinals shifted down, which if I understand correctly means we have to remember and apply deletes in order to get the same affect.

This implements that tracking along with a test that (as near as I could make it) left no branch unchecked.

These PRs are additive but stand (compile, test correctly, seem to run fine) on their own so as with the previous ones as review happens I'll rebase to unwind things until this is down to the 3 unique commits intended