### PR TITLE
Don't send exception reports for media sync errors

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
@@ -409,8 +409,6 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
                         data.result = new Object[] {"connectionError" };
                     } else if (e.getMessage().equals("UserAbortedSync")) {
                         data.result = new Object[] {"UserAbortedSync" };
-                    } else {
-                        AnkiDroidApp.sendExceptionReport(e, "doInBackgroundSync-mediaSync");
                     }
                     mediaError = AnkiDroidApp.getAppResources().getString(R.string.sync_media_error) + "\n\n" + e.getLocalizedMessage();
                 }


### PR DESCRIPTION
Acralyzer gets a report every time there's any issue with any users download of a big zip file during media sync - seems excessive since they are not actionable