### PR TITLE
Dependency updates - androidx.test / google-analytics-java7

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -167,7 +167,7 @@ dependencies {
     implementation'ch.acra:acra-toast:5.2.1'
     implementation'ch.acra:acra-limiter:5.2.1'
 
-    implementation 'net.mikehardy:google-analytics-java:2.0.4'
+    implementation 'net.mikehardy:google-analytics-java7:2.0.6'
     implementation 'com.squareup.okhttp3:okhttp:3.12.0'
     implementation 'com.arcao:slf4j-timber:3.1'
 
@@ -183,15 +183,15 @@ dependencies {
     testImplementation 'org.powermock:powermock-api-mockito2:2.0.0-RC.4'
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
     testImplementation 'net.lachlanmckee:timber-junit-rule:1.0.1'
-    testImplementation 'androidx.test:core:1.0.0'
+    testImplementation 'androidx.test:core:1.1.0'
     testImplementation "org.robolectric:robolectric:4.0.2"
 
     // May need a resolution strategy for support libs to our versions
     androidTestImplementation 'com.azimolabs.conditionwatcher:conditionwatcher:0.2'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.1.0'
-    androidTestImplementation 'androidx.test.ext:junit:1.0.0'
-    androidTestImplementation 'androidx.test:runner:1.1.0'
-    androidTestImplementation 'androidx.test:rules:1.1.0'
-    androidTestUtil 'androidx.test:orchestrator:1.1.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.1.1'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.0'
+    androidTestImplementation 'androidx.test:runner:1.1.1'
+    androidTestImplementation 'androidx.test:rules:1.1.1'
+    androidTestUtil 'androidx.test:orchestrator:1.1.1'
 }

--- a/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/libanki/DBTest.java
+++ b/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/libanki/DBTest.java
@@ -3,8 +3,10 @@ package com.ichi2.anki.tests.libanki;
 import android.Manifest;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteDatabaseCorruptException;
+import android.os.Build;
 
 import com.ichi2.anki.CollectionHelper;
+import com.ichi2.compat.CompatHelper;
 import com.ichi2.libanki.DB;
 
 import org.junit.Assert;
@@ -29,6 +31,13 @@ public class DBTest {
 
     @Test
     public void testDBCorruption() throws Exception {
+
+        // SQLiteDatabase.deleteDatabase() was added in API16.
+        // Corruption handling added in API1 and changed in API11 so implementation's ok
+        // Per Google Play Console 2018/12/11 potential impact is 141 users.
+        if (CompatHelper.getSdkVersion() < Build.VERSION_CODES.JELLY_BEAN) {
+            return;
+        }
 
         String storagePath = CollectionHelper.getDefaultAnkiDroidDirectory();
         File illFatedDBFile = new File(storagePath, "illFatedDB.anki2");


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Bunch of updates for androidx.test today, this incorporates them

This also includes a switch from the upstream/master 'google-analytics-java' to the Java7-compatible 'google-analytics-java7' artifact. That allows me to keep the dependency list clean upstream while still incorporating a pull request that converted the library to fully async Java8 language features that nevertheless work fine with a compatibility library (tested and confirmed working here in our code all the way to the API15 emulator)

## How Has This Been Tested?
Tested with manual usage while watching the analytics console in API18, API15 and API28 emulators - everything works fine. Automated `./gradlew clean jacocoTestReport` run against emulators for *every* API level from 15 to 28 including a Chromebook. Everything's fine.


## Learning (optional, can help others)
If you want Java8 features in a library for use on Android Java7 devices (<API24) then you can use [the 'streamsupport' library](https://github.com/stefan-zobel/streamsupport) and (for example) 'java8.util.concurrent' as your import and it all works.

If you want Java8 features in your *app* (not a library other apps use) then you can do very similar but you use [the 'android-retrostreams' family of dependencies](https://github.com/retrostreams/android-retrostreams) (based on streamsupport) and again everything works
