### PR TITLE
Improve detection of display dimensions

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.java
@@ -234,7 +234,8 @@ public class Whiteboard extends View {
 
     private void createBitmap() {
         // To fix issue #1336, just make the whiteboard big and square.
-        int bitmapSize = Math.max(getDisplayWidth(), getDisplayHeight());
+        final Point p = getDisplayDimenions();
+        int bitmapSize = Math.max(p.x, p.y);
         if (mMonochrome && !mInvertedColors) {
             createBitmap(bitmapSize, bitmapSize, Bitmap.Config.ALPHA_8);
         } else {
@@ -342,22 +343,12 @@ public class Whiteboard extends View {
         return false;
     }
 
-
-    private static int getDisplayHeight() {
+    private static Point getDisplayDimenions() {
         Display display = ((WindowManager) AnkiDroidApp.getInstance().getApplicationContext().
                 getSystemService(Context.WINDOW_SERVICE)).getDefaultDisplay();
         Point point = new Point();
         display.getSize(point);
-        return point.y;
-    }
-
-
-    private static int getDisplayWidth() {
-        Display display = ((WindowManager) AnkiDroidApp.getInstance().getApplicationContext().
-                getSystemService(Context.WINDOW_SERVICE)).getDefaultDisplay();
-        Point point = new Point();
-        display.getSize(point);
-        return point.x;
+        return point;
     }
 
     /**


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
I noticed that `getDisplayHeight` and `getDisplayWidth` both receive width and height from Android system and pick only one of those. It seems like they could be unified without loss of generality.

## Fixes
No issues were created to date.

## Approach
This change unifies  `getDisplayHeight` and `getDisplayWidth` methods into one. 

## How Has This Been Tested?
I've built the project and run it on my local device.

## Learning (optional, can help others)

## Checklist

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
