### PR TITLE
Issue5106/database migrations 2 - preparation

### DIFF
--- a/AnkiDroid/src/test/AndroidManifest.xml
+++ b/AnkiDroid/src/test/AndroidManifest.xml
@@ -10,6 +10,9 @@
              https://issuetracker.google.com/issues/37001185
              -->
         <activity
+            android:name="com.ichi2.anki.TestDeckPicker">
+        </activity>
+        <activity
             android:name="com.ichi2.anki.NullCollectionReviewer">
         </activity>
     </application>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.java
@@ -104,12 +104,30 @@ public class DeckPickerTest extends RobolectricTest {
                 !deckPicker.mRecommendFullSync,      // we should not recommend a sync
                 !deckPicker.prefsUpgraded,           // no prefs upgrade
                 !deckPicker.integrityChecked,        // no integrity check
-                !deckPicker.finishedStartup,          // we not should finish startup
+                !deckPicker.finishedStartup,         // we not should finish startup
                 !deckPicker.activityRestarted,       // we should not restart
                 Info.class, shadowDeckPicker.getNextStartedActivity(),  // Info intent
                 "9.9.1");                  // we have a 9.9.1 last version
     }
 
+
+    @Test
+    public void verifyDevelopmentUpgrade() {
+
+        // Pretend we are 9.9alpha1, going to 9.9alpha2 and make sure we get no Info popup
+        // This may break at some point if we get past version 9.9.0 with the same naming scheme
+        prepareVersion(90900101, "9.9alpha1", 90900102, "9.9alpha2");
+        deckPickerController.create();
+        assertState(
+                deckPicker.startupScreensDisplayed,  // we should be called
+                !deckPicker.mRecommendFullSync,      // we should not recommend a sync
+                !deckPicker.prefsUpgraded,           // no prefs upgrade
+                !deckPicker.integrityChecked,        // no integrity check
+                deckPicker.finishedStartup,          // we should finish startup
+                !deckPicker.activityRestarted,       // we should not restart
+                null, shadowDeckPicker.getNextStartedActivity(),  // No intent
+                "9.9alpha2");              // we have a 9.9.2 last version
+    }
 
     @Test
     public void verifyFreshInstall() {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.java
@@ -1,14 +1,26 @@
 package com.ichi2.anki;
 
 import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.content.pm.PackageInfo;
 
 import androidx.test.core.app.ActivityScenario;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
+import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.Shadows;
+import org.robolectric.android.controller.ActivityController;
+import org.robolectric.shadows.ShadowActivity;
+import org.robolectric.shadows.ShadowPackageManager;
+import org.robolectric.shadows.ShadowStatFs;
 
+import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -17,6 +29,32 @@ import static org.junit.Assert.assertNull;
 
 @RunWith(AndroidJUnit4.class)
 public class DeckPickerTest extends RobolectricTest {
+
+    private ActivityController deckPickerController;
+
+    private TestDeckPicker deckPicker;
+
+    private ShadowActivity shadowDeckPicker;
+
+    @Before
+    public void setUp() {
+
+        super.setUp();
+
+        // Create the DeckPicker and make sure it has write permission so the Collection may be opened
+        deckPickerController = Robolectric.buildActivity(TestDeckPicker.class);
+        deckPicker = (TestDeckPicker) deckPickerController.get();
+        shadowDeckPicker = Shadows.shadowOf(deckPicker);
+        shadowDeckPicker.grantPermissions("android.permission.WRITE_EXTERNAL_STORAGE");
+
+        // Make sure the Backup system thinks it has enough space so startup isn't blocked
+        String backupPath = new File(CollectionHelper.getCurrentAnkiDroidDirectory(getTargetContext())).getParent();
+        ShadowStatFs.registerStats(backupPath, 10 * 1024 * 1024, 10 * 1024 * 1024, 10 * 1024 * 1024);
+
+        // Make sure that we are clean to start
+        Assert.assertFalse("startup screens already displayed?", deckPicker.startupScreensDisplayed);
+        Assert.assertFalse("startup already finished?", deckPicker.finishedStartup);
+    }
 
     @Test
     public void verifyCodeMessages() {
@@ -52,5 +90,124 @@ public class DeckPickerTest extends RobolectricTest {
                 assertNull(deckPicker.rewriteError(Integer.MAX_VALUE));
             });
         }
+    }
+
+    @Test
+    public void verifyReleaseUpgrade() {
+
+        // Pretend we are 9.9.0, going to 9.9.1 and make sure we get an Info popup
+        // This may break at some point if we get past version 9.9.0 with the same naming scheme
+        prepareVersion(90901300, "9.9.1", 90902300, "9.9.2");
+        deckPickerController.create();
+        assertState(
+                deckPicker.startupScreensDisplayed,  // we should be called
+                !deckPicker.mRecommendFullSync,      // we should not recommend a sync
+                !deckPicker.prefsUpgraded,           // no prefs upgrade
+                !deckPicker.integrityChecked,        // no integrity check
+                !deckPicker.finishedStartup,          // we not should finish startup
+                !deckPicker.activityRestarted,       // we should not restart
+                Info.class, shadowDeckPicker.getNextStartedActivity(),  // Info intent
+                "9.9.1");                  // we have a 9.9.1 last version
+    }
+
+
+    @Test
+    public void verifyFreshInstall() {
+
+        // Pretend we are a fresh 2.9.1 install
+        prepareVersion(0, "", 20901300, "2.9.1");
+        deckPickerController.create();
+        assertState(
+                deckPicker.startupScreensDisplayed,  // we should be called
+                !deckPicker.mRecommendFullSync,      // we should not recommend a sync
+                !deckPicker.prefsUpgraded,           // no prefs upgrade
+                !deckPicker.integrityChecked,        // no integrity check
+                deckPicker.finishedStartup,          // we should finish startup
+                !deckPicker.activityRestarted,       // we should not restart
+                null, shadowDeckPicker.getNextStartedActivity(),  // no intent
+                "2.9.1");                  // we have a 2.9.1 last version
+    }
+
+    @Test
+    public void verifyNoUpgrade() {
+
+        // Set things up so it looks like a simple app restart on same versions
+        prepareVersion(20901300, "2.9.1", 20901300, "2.9.1");
+        deckPickerController.create();
+        assertState(
+                deckPicker.startupScreensDisplayed,  // we should be called
+                !deckPicker.mRecommendFullSync,      // we should not recommend a sync
+                !deckPicker.prefsUpgraded,           // no prefs upgrade
+                !deckPicker.integrityChecked,        // no integrity check
+                deckPicker.finishedStartup,          // we should finish startup
+                !deckPicker.activityRestarted,       // we should not restart
+                null, shadowDeckPicker.getNextStartedActivity(),  // no intent
+                "2.9.1");                  // we have a 2.9.1 last version
+    }
+
+
+    @Test
+    public void verifyPrefsNoDatabaseUpgrade() {
+
+        // Set things up so it looks like it would trigger a prefs upgrade but no database check
+        deckPicker.prefCheckVersion = 20902300;
+        deckPicker.dbCheckVersion = 20901300;
+        prepareVersion(20901300, "2.9.1", 20902300, "2.9.2");
+        deckPickerController.create();
+        assertState(
+                deckPicker.startupScreensDisplayed,  // we should be called
+                !deckPicker.mRecommendFullSync,      // we should not recommend a sync
+                deckPicker.prefsUpgraded,            // prefs should upgrade
+                !deckPicker.integrityChecked,        // no integrity check
+                !deckPicker.finishedStartup,         // we should not finish startup
+                deckPicker.activityRestarted,        // we should restart
+                TestDeckPicker.class, shadowDeckPicker.getNextStartedActivity(),  // restart is ourselves
+                "2.9.1");                  // we have a 2.9.1 last version
+    }
+
+
+    @Test
+    public void verifyInterruptingUpgrade() {
+
+        // Pretend we are before 2.3.0beta, and across to 2.9.2, verify full sync and integrity check
+        prepareVersion(20201300, "2.2.1", 20902300, "2.9.2");
+        deckPickerController.create();
+        assertState(
+                deckPicker.startupScreensDisplayed, // method call should work
+                deckPicker.mRecommendFullSync,      // this was old enough full sync should be triggered
+                deckPicker.prefsUpgraded,           // old enough to upgrade prefs
+                deckPicker.integrityChecked,        // old enough to check integrity
+                !deckPicker.finishedStartup,        // startup won't finish because of the other work
+                !deckPicker.activityRestarted,      // activity doesn't restart because integrity check hijacks
+                null, shadowDeckPicker.getNextStartedActivity(),       // no intents should start
+                "");                      // no one puts a lastVersion yet
+    }
+
+
+    private void assertState(boolean startupScreens, boolean fullSync, boolean prefsUpgrade, boolean integrity,
+                             boolean finished, boolean restart, Class intentWanted, Intent intent, String lastVersion) {
+        Assert.assertTrue("startup screen state incorrect", startupScreens);
+        Assert.assertTrue("full sync state incorrect", fullSync);
+        Assert.assertTrue("prefs upgrade state incorrect", prefsUpgrade);
+        Assert.assertTrue("integrity check state incorrect", integrity);
+        Assert.assertTrue("startup finish state incorrect", finished);
+        Assert.assertTrue("restart state incorrect", restart);
+        if (intentWanted == null) {
+            Assert.assertNull("should not have started an Intent", intent);
+        } else {
+            Assert.assertEquals("Wrong intent started", intentWanted, Shadows.shadowOf(intent).getIntentClass());
+        }
+        Assert.assertEquals("lastVersion set incorrectly", lastVersion, AnkiDroidApp.getSharedPrefs(getTargetContext()).getString("lastVersion", ""));
+    }
+
+
+    private void prepareVersion(int prevCode, String prevName, int curCode, String curName) {
+        SharedPreferences prefs = AnkiDroidApp.getSharedPrefs(getTargetContext());
+        prefs.edit().putInt("lastUpgradeVersion", prevCode).apply();
+        prefs.edit().putString("lastVersion", prevName).apply();
+        ShadowPackageManager shadowPackageManager = Shadows.shadowOf(getTargetContext().getPackageManager());
+        PackageInfo ankiPackageInfo = shadowPackageManager.getInternalMutablePackageInfo(getTargetContext().getPackageName());
+        ankiPackageInfo.setLongVersionCode(curCode);
+        ankiPackageInfo.versionName = curName;
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/TestDeckPicker.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/TestDeckPicker.java
@@ -1,0 +1,25 @@
+package com.ichi2.anki;
+
+import android.content.SharedPreferences;
+
+// Simple testability overrides and verification toggles
+public class TestDeckPicker extends DeckPicker {
+    boolean startupScreensDisplayed = false;
+    boolean finishedStartup = false;
+    boolean integrityChecked = false;
+    boolean prefsUpgraded = false;
+    boolean activityRestarted = false;
+    int prefCheckVersion = -1;
+    int dbCheckVersion = -1;
+
+    @Override protected void showStartupScreensAndDialogs(SharedPreferences preferences, int skip) {
+        startupScreensDisplayed = true;
+        super.showStartupScreensAndDialogs(preferences, skip);
+    }
+    @Override protected void onFinishedStartup() { finishedStartup = true; super.onFinishedStartup(); }
+    @Override public void integrityCheck() { integrityChecked = true; super.integrityCheck(); }
+    @Override public void upgradePreferences(long prefs) { prefsUpgraded = true; super.upgradePreferences(prefs); }
+    @Override public void restartActivity() { activityRestarted = true; super.restartActivity(); }
+    @Override protected int getUpgradePrefsVersion() { return prefCheckVersion == -1 ? super.getUpgradePrefsVersion() : prefCheckVersion; }
+    @Override protected int getCheckDbAtVersion() { return dbCheckVersion == -1 ? super.getCheckDbAtVersion() : dbCheckVersion; }
+}


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
#5106 points out the need to handle preferences and databases separately from the perspective of upgrades.

That code was confusing to me though, and the last time I attempted something in the area I made a serious error.

This time prior to going in I've refactored it and put test support over it covering (I think) all of the various upgrade scenarios with verification of their end states.

I want to push these changes in prior to making the actual changes so that each change is clear.

As with #5151 / card template editor, each commit here should stand on it's own but they build on each other.

The goal with these changes is no semantic changes at all, but the final state is a crystal clear control flow with automated test coverage.

In particular, examine the DeckPickerTest to see the tests performed and if something is missing, please let me know

## How Has This Been Tested?

With hopefully robust automated unit tests and demonstrable coverage + assertions, also API18 and API28 emulators. Seems to work as it did prior