### PR TITLE
Store a version in the database and use it for database activity on startup

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -889,6 +889,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
 
     @VisibleForTesting
+    @SuppressWarnings({"PMD.NPathComplexity","PMD.ExcessiveMethodLength"})
     protected void showStartupScreensAndDialogs(SharedPreferences preferences, int skip) {
         Timber.d("showStartupScreensAndDialogs()");
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -54,9 +54,8 @@ import java.util.Map;
 import java.util.Random;
 import java.util.regex.Pattern;
 
-import javax.annotation.Nullable;
-
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.sqlite.db.SupportSQLiteDatabase;
 import androidx.sqlite.db.SupportSQLiteStatement;
 import timber.log.Timber;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -54,6 +54,9 @@ import java.util.Map;
 import java.util.Random;
 import java.util.regex.Pattern;
 
+import javax.annotation.Nullable;
+
+import androidx.annotation.NonNull;
 import androidx.sqlite.db.SupportSQLiteDatabase;
 import androidx.sqlite.db.SupportSQLiteStatement;
 import timber.log.Timber;
@@ -305,6 +308,33 @@ public class Collection {
         }
         return buf.toString();
     }
+
+
+    // NOT in libanki
+    @Nullable
+    public Long getLastAnkiDroidVersion() {
+        try {
+            if (mConf.optLong("AnkiDroidVersion", -1) != -1) {
+                return mConf.getLong("AnkiDroidVersion");
+            }
+        } catch (JSONException e) {
+            Timber.w(e, "Unable to get AnkiDroidVersion from Deck conf");
+        }
+        return null;
+    }
+
+
+    // NOT in libanki
+    public void setLastAnkiDroidVersion(@NonNull Long versionCode) {
+        try {
+            mConf.put("AnkiDroidVersion", versionCode);
+            flush();
+        } catch (JSONException e) {
+            Timber.e(e, "Unable to set AnkiDroidVersion in Deck conf");
+            AnkiDroidApp.sendExceptionReport(e, "Unable to set AnkiDroidVersion in Deck conf");
+        }
+    }
+
 
     /**
      * Mark DB modified. DB operations and the deck/tag/model managers do this automatically, so this is only necessary

--- a/AnkiDroid/src/test/AndroidManifest.xml
+++ b/AnkiDroid/src/test/AndroidManifest.xml
@@ -10,6 +10,9 @@
              https://issuetracker.google.com/issues/37001185
              -->
         <activity
+            android:name="com.ichi2.anki.TestDeckPicker">
+        </activity>
+        <activity
             android:name="com.ichi2.anki.NullCollectionReviewer">
         </activity>
     </application>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.java
@@ -104,12 +104,30 @@ public class DeckPickerTest extends RobolectricTest {
                 !deckPicker.mRecommendFullSync,      // we should not recommend a sync
                 !deckPicker.prefsUpgraded,           // no prefs upgrade
                 !deckPicker.integrityChecked,        // no integrity check
-                !deckPicker.finishedStartup,          // we not should finish startup
+                !deckPicker.finishedStartup,         // we not should finish startup
                 !deckPicker.activityRestarted,       // we should not restart
                 Info.class, shadowDeckPicker.getNextStartedActivity(),  // Info intent
                 "9.9.1");                  // we have a 9.9.1 last version
     }
 
+
+    @Test
+    public void verifyDevelopmentUpgrade() {
+
+        // Pretend we are 9.9alpha1, going to 9.9alpha2 and make sure we get no Info popup
+        // This may break at some point if we get past version 9.9.0 with the same naming scheme
+        prepareVersion(90900101, "9.9alpha1", 90900102, "9.9alpha2");
+        deckPickerController.create();
+        assertState(
+                deckPicker.startupScreensDisplayed,  // we should be called
+                !deckPicker.mRecommendFullSync,      // we should not recommend a sync
+                !deckPicker.prefsUpgraded,           // no prefs upgrade
+                !deckPicker.integrityChecked,        // no integrity check
+                deckPicker.finishedStartup,          // we should finish startup
+                !deckPicker.activityRestarted,       // we should not restart
+                null, shadowDeckPicker.getNextStartedActivity(),  // No intent
+                "9.9alpha2");              // we have a 9.9.2 last version
+    }
 
     @Test
     public void verifyFreshInstall() {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.java
@@ -1,14 +1,26 @@
 package com.ichi2.anki;
 
 import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.content.pm.PackageInfo;
 
 import androidx.test.core.app.ActivityScenario;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
+import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.Shadows;
+import org.robolectric.android.controller.ActivityController;
+import org.robolectric.shadows.ShadowActivity;
+import org.robolectric.shadows.ShadowPackageManager;
+import org.robolectric.shadows.ShadowStatFs;
 
+import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -17,6 +29,32 @@ import static org.junit.Assert.assertNull;
 
 @RunWith(AndroidJUnit4.class)
 public class DeckPickerTest extends RobolectricTest {
+
+    private ActivityController deckPickerController;
+
+    private TestDeckPicker deckPicker;
+
+    private ShadowActivity shadowDeckPicker;
+
+    @Before
+    public void setUp() {
+
+        super.setUp();
+
+        // Create the DeckPicker and make sure it has write permission so the Collection may be opened
+        deckPickerController = Robolectric.buildActivity(TestDeckPicker.class);
+        deckPicker = (TestDeckPicker) deckPickerController.get();
+        shadowDeckPicker = Shadows.shadowOf(deckPicker);
+        shadowDeckPicker.grantPermissions("android.permission.WRITE_EXTERNAL_STORAGE");
+
+        // Make sure the Backup system thinks it has enough space so startup isn't blocked
+        String backupPath = new File(CollectionHelper.getCurrentAnkiDroidDirectory(getTargetContext())).getParent();
+        ShadowStatFs.registerStats(backupPath, 10 * 1024 * 1024, 10 * 1024 * 1024, 10 * 1024 * 1024);
+
+        // Make sure that we are clean to start
+        Assert.assertFalse("startup screens already displayed?", deckPicker.startupScreensDisplayed);
+        Assert.assertFalse("startup already finished?", deckPicker.finishedStartup);
+    }
 
     @Test
     public void verifyCodeMessages() {
@@ -52,5 +90,124 @@ public class DeckPickerTest extends RobolectricTest {
                 assertNull(deckPicker.rewriteError(Integer.MAX_VALUE));
             });
         }
+    }
+
+    @Test
+    public void verifyReleaseUpgrade() {
+
+        // Pretend we are 9.9.0, going to 9.9.1 and make sure we get an Info popup
+        // This may break at some point if we get past version 9.9.0 with the same naming scheme
+        prepareVersion(90901300, "9.9.1", 90902300, "9.9.2");
+        deckPickerController.create();
+        assertState(
+                deckPicker.startupScreensDisplayed,  // we should be called
+                !deckPicker.mRecommendFullSync,      // we should not recommend a sync
+                !deckPicker.prefsUpgraded,           // no prefs upgrade
+                !deckPicker.integrityChecked,        // no integrity check
+                !deckPicker.finishedStartup,          // we not should finish startup
+                !deckPicker.activityRestarted,       // we should not restart
+                Info.class, shadowDeckPicker.getNextStartedActivity(),  // Info intent
+                "9.9.1");                  // we have a 9.9.1 last version
+    }
+
+
+    @Test
+    public void verifyFreshInstall() {
+
+        // Pretend we are a fresh 2.9.1 install
+        prepareVersion(0, "", 20901300, "2.9.1");
+        deckPickerController.create();
+        assertState(
+                deckPicker.startupScreensDisplayed,  // we should be called
+                !deckPicker.mRecommendFullSync,      // we should not recommend a sync
+                !deckPicker.prefsUpgraded,           // no prefs upgrade
+                !deckPicker.integrityChecked,        // no integrity check
+                deckPicker.finishedStartup,          // we should finish startup
+                !deckPicker.activityRestarted,       // we should not restart
+                null, shadowDeckPicker.getNextStartedActivity(),  // no intent
+                "2.9.1");                  // we have a 2.9.1 last version
+    }
+
+    @Test
+    public void verifyNoUpgrade() {
+
+        // Set things up so it looks like a simple app restart on same versions
+        prepareVersion(20901300, "2.9.1", 20901300, "2.9.1");
+        deckPickerController.create();
+        assertState(
+                deckPicker.startupScreensDisplayed,  // we should be called
+                !deckPicker.mRecommendFullSync,      // we should not recommend a sync
+                !deckPicker.prefsUpgraded,           // no prefs upgrade
+                !deckPicker.integrityChecked,        // no integrity check
+                deckPicker.finishedStartup,          // we should finish startup
+                !deckPicker.activityRestarted,       // we should not restart
+                null, shadowDeckPicker.getNextStartedActivity(),  // no intent
+                "2.9.1");                  // we have a 2.9.1 last version
+    }
+
+
+    @Test
+    public void verifyPrefsNoDatabaseUpgrade() {
+
+        // Set things up so it looks like it would trigger a prefs upgrade but no database check
+        deckPicker.prefCheckVersion = 20902300;
+        deckPicker.dbCheckVersion = 20901300;
+        prepareVersion(20901300, "2.9.1", 20902300, "2.9.2");
+        deckPickerController.create();
+        assertState(
+                deckPicker.startupScreensDisplayed,  // we should be called
+                !deckPicker.mRecommendFullSync,      // we should not recommend a sync
+                deckPicker.prefsUpgraded,            // prefs should upgrade
+                !deckPicker.integrityChecked,        // no integrity check
+                !deckPicker.finishedStartup,         // we should not finish startup
+                deckPicker.activityRestarted,        // we should restart
+                TestDeckPicker.class, shadowDeckPicker.getNextStartedActivity(),  // restart is ourselves
+                "2.9.1");                  // we have a 2.9.1 last version
+    }
+
+
+    @Test
+    public void verifyInterruptingUpgrade() {
+
+        // Pretend we are before 2.3.0beta, and across to 2.9.2, verify full sync and integrity check
+        prepareVersion(20201300, "2.2.1", 20902300, "2.9.2");
+        deckPickerController.create();
+        assertState(
+                deckPicker.startupScreensDisplayed, // method call should work
+                deckPicker.mRecommendFullSync,      // this was old enough full sync should be triggered
+                deckPicker.prefsUpgraded,           // old enough to upgrade prefs
+                deckPicker.integrityChecked,        // old enough to check integrity
+                !deckPicker.finishedStartup,        // startup won't finish because of the other work
+                !deckPicker.activityRestarted,      // activity doesn't restart because integrity check hijacks
+                null, shadowDeckPicker.getNextStartedActivity(),       // no intents should start
+                "");                      // no one puts a lastVersion yet
+    }
+
+
+    private void assertState(boolean startupScreens, boolean fullSync, boolean prefsUpgrade, boolean integrity,
+                             boolean finished, boolean restart, Class intentWanted, Intent intent, String lastVersion) {
+        Assert.assertTrue("startup screen state incorrect", startupScreens);
+        Assert.assertTrue("full sync state incorrect", fullSync);
+        Assert.assertTrue("prefs upgrade state incorrect", prefsUpgrade);
+        Assert.assertTrue("integrity check state incorrect", integrity);
+        Assert.assertTrue("startup finish state incorrect", finished);
+        Assert.assertTrue("restart state incorrect", restart);
+        if (intentWanted == null) {
+            Assert.assertNull("should not have started an Intent", intent);
+        } else {
+            Assert.assertEquals("Wrong intent started", intentWanted, Shadows.shadowOf(intent).getIntentClass());
+        }
+        Assert.assertEquals("lastVersion set incorrectly", lastVersion, AnkiDroidApp.getSharedPrefs(getTargetContext()).getString("lastVersion", ""));
+    }
+
+
+    private void prepareVersion(int prevCode, String prevName, int curCode, String curName) {
+        SharedPreferences prefs = AnkiDroidApp.getSharedPrefs(getTargetContext());
+        prefs.edit().putInt("lastUpgradeVersion", prevCode).apply();
+        prefs.edit().putString("lastVersion", prevName).apply();
+        ShadowPackageManager shadowPackageManager = Shadows.shadowOf(getTargetContext().getPackageManager());
+        PackageInfo ankiPackageInfo = shadowPackageManager.getInternalMutablePackageInfo(getTargetContext().getPackageName());
+        ankiPackageInfo.setLongVersionCode(curCode);
+        ankiPackageInfo.versionName = curName;
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/TestDeckPicker.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/TestDeckPicker.java
@@ -4,13 +4,13 @@ import android.content.SharedPreferences;
 
 // Simple testability overrides and verification toggles
 public class TestDeckPicker extends DeckPicker {
-    boolean startupScreensDisplayed = false;
-    boolean finishedStartup = false;
-    boolean integrityChecked = false;
-    boolean prefsUpgraded = false;
-    boolean activityRestarted = false;
-    int prefCheckVersion = -1;
-    int dbCheckVersion = -1;
+    protected boolean startupScreensDisplayed = false;
+    protected boolean finishedStartup = false;
+    protected boolean integrityChecked = false;
+    protected boolean prefsUpgraded = false;
+    protected boolean activityRestarted = false;
+    protected int prefCheckVersion = -1;
+    protected int dbCheckVersion = -1;
 
     @Override protected void showStartupScreensAndDialogs(SharedPreferences preferences, int skip) {
         startupScreensDisplayed = true;

--- a/AnkiDroid/src/test/java/com/ichi2/anki/TestDeckPicker.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/TestDeckPicker.java
@@ -1,0 +1,25 @@
+package com.ichi2.anki;
+
+import android.content.SharedPreferences;
+
+// Simple testability overrides and verification toggles
+public class TestDeckPicker extends DeckPicker {
+    boolean startupScreensDisplayed = false;
+    boolean finishedStartup = false;
+    boolean integrityChecked = false;
+    boolean prefsUpgraded = false;
+    boolean activityRestarted = false;
+    int prefCheckVersion = -1;
+    int dbCheckVersion = -1;
+
+    @Override protected void showStartupScreensAndDialogs(SharedPreferences preferences, int skip) {
+        startupScreensDisplayed = true;
+        super.showStartupScreensAndDialogs(preferences, skip);
+    }
+    @Override protected void onFinishedStartup() { finishedStartup = true; super.onFinishedStartup(); }
+    @Override public void integrityCheck() { integrityChecked = true; super.integrityCheck(); }
+    @Override public void upgradePreferences(long prefs) { prefsUpgraded = true; super.upgradePreferences(prefs); }
+    @Override public void restartActivity() { activityRestarted = true; super.restartActivity(); }
+    @Override protected int getUpgradePrefsVersion() { return prefCheckVersion == -1 ? super.getUpgradePrefsVersion() : prefCheckVersion; }
+    @Override protected int getCheckDbAtVersion() { return dbCheckVersion == -1 ? super.getCheckDbAtVersion() : dbCheckVersion; }
+}


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
The application has a version in the preferences right now, and uses that to decide if special activity (migrations, integrity checks etc) need to happen on startup.

It's possible that preferences are backed up and restored from Google though, leaving the current application in an inconsistent state where the database (which is not backed up with google services) may have had different things done to it than the preferences.

This adds an ankidroid version to the Collection configuration, and uses it to decide what to do on startup.

For the special case where we have no version in the database (the first time this code runs, or if there is a new collection), we assume that we need to run a database check and then set the version to current.

## Fixes
#5106

## Approach
This builds on #5171 which was just refactoring/setup to try to avoid messing things up with this one. I kept them separate even though they are connected, so each commit / file history would be coherent historically, and ideally is easier to review? If #5171 is merged before this I'll either rebase this one, or it will rebase itself on merge

The approach is as discussed in the relevant issue as well as the first attempt #5120 which was insufficient - store a version in deck conf

## How Has This Been Tested?

Tested in emulators as well as with automated robolectric coverage in unit tests (`./gradlew jacocoUnitTestReport` then open the report HTML file in the build/reports directory)

## Learning (optional, can help others)
Nothing special with this one
