### PR TITLE
Track and publish database check progress. Fixes #5155

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -1215,7 +1215,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
         DeckTask.launchDeckTask(DeckTask.TASK_TYPE_CHECK_DATABASE, new DeckTask.TaskListener() {
             @Override
             public void onPreExecute() {
-                mProgressDialog = StyledProgressDialog.show(DeckPicker.this, "",
+                mProgressDialog = StyledProgressDialog.show(DeckPicker.this, AnkiDroidApp.getAppResources().getString(R.string.app_name),
                         getResources().getString(R.string.check_db_message), false);
             }
 
@@ -1239,6 +1239,12 @@ public class DeckPicker extends NavigationDrawerActivity implements
                 } else {
                     handleDbError();
                 }
+            }
+
+
+            @Override
+            public void onProgressUpdate(DeckTask.TaskData... values) {
+                mProgressDialog.setContent(values[0].getString());
             }
         });
     }

--- a/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
@@ -902,7 +902,7 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
             return new TaskData(false);
         }
 
-        long result = col.fixIntegrity();
+        long result = col.fixIntegrity(new ProgressCallback(this, AnkiDroidApp.getAppResources()));
         if (result == -1) {
             return new TaskData(false);
         } else {


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Database checks can take a long time, and the database check dialog published no indication of progress.

We're forcing a check with the next betas and stable release, so this should calm everyone when they hit it.

## Fixes
#5155 

## Approach
I used the built in ProgressCallback / publishProgress infrastructure from DeckTask - just passing a ProgressCallback through to Collection so it could publish as it worked. The hardest part of the patch was accurately counting the amount of tasks that could happen so I could generate the correct total task count.

I contemplated doing a percentage calculation but I dislike "fake" percentages where the units are of varying duration but each is supposedly 1/100th of the work. With the current / total style it appears more arbitrary what the units are, which fits the irregular durations of the units themselves.

## How Has This Been Tested?

API27 emulator, but it's infrastructure used everywhere, should be fine?

I pre-checked with codacy as well