### PR TITLE
Show a confirmation before full sync, Fixes #5176

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -59,6 +59,7 @@ import com.ichi2.libanki.hooks.Hooks;
 import com.ichi2.preferences.NumberRangePreference;
 import com.ichi2.themes.Themes;
 import com.ichi2.ui.AppCompatPreferenceActivity;
+import com.ichi2.ui.ConfirmationPreference;
 import com.ichi2.ui.SeekBarPreference;
 import com.ichi2.utils.LanguageUtil;
 import com.ichi2.anki.analytics.UsageAnalytics;
@@ -309,17 +310,17 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                     screen.addPreference(analyticsDebugMode);
                 }
                 // Force full sync option
-                Preference fullSyncPreference = screen.findPreference("force_full_sync");
-                fullSyncPreference.setOnPreferenceClickListener(preference -> {
+                ConfirmationPreference fullSyncPreference = (ConfirmationPreference)screen.findPreference("force_full_sync");
+                fullSyncPreference.setDialogMessage(R.string.force_full_sync_summary);
+                fullSyncPreference.setDialogTitle(R.string.force_full_sync_title);
+                fullSyncPreference.setOkHandler(() -> {
                     if (getCol() == null) {
-                        Toast.makeText(this, R.string.directory_inaccessible, Toast.LENGTH_LONG).show();
-                        return false;
+                        Toast.makeText(getApplicationContext(), R.string.directory_inaccessible, Toast.LENGTH_LONG).show();
+                        return;
                     }
-                    // TODO: Could be useful to show the full confirmation dialog
                     getCol().modSchemaNoCheck();
                     getCol().setMod();
                     Toast.makeText(getApplicationContext(), android.R.string.ok, Toast.LENGTH_SHORT).show();
-                    return true;
                 });
                 // Workaround preferences
                 removeUnnecessaryAdvancedPrefs(screen);

--- a/AnkiDroid/src/main/java/com/ichi2/ui/ConfirmationPreference.java
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/ConfirmationPreference.java
@@ -1,0 +1,51 @@
+/****************************************************************************************
+ * Copyright (c) 2018 Mike Hardy <mike@mikehardy.net>                                   *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+
+package com.ichi2.ui;
+
+import android.content.Context;
+import android.preference.DialogPreference;
+import android.util.AttributeSet;
+
+public class ConfirmationPreference extends DialogPreference {
+
+    private Runnable cancelHandler = () -> { /* do nothing by default */ };
+    private Runnable okHandler = () -> { /* do nothing by default */ };
+
+    public ConfirmationPreference(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+
+    public void setCancelHandler(Runnable cancelHandler) {
+        this.cancelHandler = cancelHandler;
+    }
+
+
+    public void setOkHandler(Runnable okHandler) {
+        this.okHandler = okHandler;
+    }
+
+
+    @Override
+    protected void onDialogClosed(boolean positiveResult) {
+        if (positiveResult) {
+            okHandler.run();
+        } else {
+            cancelHandler.run();
+        }
+    }
+}

--- a/AnkiDroid/src/main/res/xml/preferences_advanced.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_advanced.xml
@@ -31,7 +31,7 @@
             android:key="deckPath"
             android:summary="@string/preference_summary_literal"
             android:title="@string/col_path" />
-        <Preference
+        <com.ichi2.ui.ConfirmationPreference
             android:key="force_full_sync"
             android:title="@string/force_full_sync_title"
             android:summary="@string/force_full_sync_summary" />


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
A single tap to do something incredibly expensive (full sync) without confirm isn't great. The current implementation even has a TODO mentioning a confirmation would be nice.

## Fixes
Fixes #5176 

## Approach
In order to pop a dialog from preferences (which is not capable of handling dialog fragments apparently) you have to extend some other Preference superclass.

So I extended DialogPreference, following the existing AnkiDroid example of SeekBarPreference, but this time just allowing the ok or cancel buttons to have custom Runnables hooked to them.

Then I hooked a custom ok Runnable that does the full sync marking, leaving the cancel handler with the no-op implementation.

## How Has This Been Tested?

API27 emulator, but it uses the same style as SeekBarPreference and should have no problems elsewhere?
