### PR TITLE
Allow two more parallel build names (5 total now)

### DIFF
--- a/tools/parallel-package-release.sh
+++ b/tools/parallel-package-release.sh
@@ -27,7 +27,7 @@ export KEYPWD
 # Get on to the tag requested
 #git checkout $TAG
 
-BUILDNAMES='A B C'
+BUILDNAMES='A B C D E'
 for BUILD in $BUILDNAMES; do
     git reset --hard
     git clean -f


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Multiple profiles (#2545) are the reason I started working on AnkiDroid, no joke.

I still haven't implemented the actual feature but I'm very interested in these working, and working acceptably for people if I can make it happen.

A fellow parent wanted more builds for more children, so this just increases the build count to 5 from 3.

## Fixes
Fix? Not so much. But it is the hack that keeps on working.