### PR TITLE
Fetch new card for review after reschedule, Fixes #5167

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -81,18 +81,14 @@ public class Reviewer extends AbstractFlashcardViewer {
     };
 
     /** We need to listen for and handle repositions / reschedules / resets very similarly */
-    abstract class ScheduleDeckTaskListener extends DeckTask.TaskListener {
+    abstract class ScheduleDeckTaskListener extends NextCardHandler {
 
         abstract protected int getToastResourceId();
 
-        @Override
-        public void onPreExecute() {
-            Timber.d("Reviewer::ScheduleDeckTaskListener() onPreExecute");
-        }
 
         @Override
         public void onPostExecute(DeckTask.TaskData result) {
-            Timber.d("Reviewer::ScheduleDeckTaskListener() onPostExecute");
+            super.onPostExecute(result);
             invalidateOptionsMenu();
             int cardCount = result.getObjArray().length;
             UIUtils.showThemedToast(Reviewer.this,

--- a/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
@@ -773,6 +773,9 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
                                 sched.forgetCards(cardIds);
                                 break;
                         }
+                        // In all cases schedule a new card so Reviewer doesn't sit on the old one
+                        col.reset();
+                        publishProgress(new TaskData(getCard(sched), 0));
                         break;
                     }
                 }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
My rescheduling PR #5113 was correctly rescheduling, except the part where you have to then get a new card into the Reviewer.

This revises that work so that after performing the rescheduling actions you get a new card as well

## Fixes
Fixes #5167 

## Approach
The AbstractFlashcardViewer already had an "answer notes" handler with all the infrastructure to display new cards or not based on DeckTask.TaskData values, and there was a "dismiss notes" handler that called in to it.

Since the rescheduling is just a special form of "dismiss notes" everything already lined up well. I just needed to take my "schedule notes" handler and chain in to the existing "dismiss notes"->"answer notes" handlers and everything worked.

## How Has This Been Tested?
I tested it on an API27 emulator only. However, it is using the existing dismiss notes infrastructure int the same style as the current usage, so it should be fine?

