### PR TITLE
add link to ankireview plugin inside preferences->advanced

### DIFF
--- a/AnkiDroid/src/main/res/xml/preferences_advanced.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_advanced.xml
@@ -101,6 +101,15 @@
                 android:key="convertFenText"
                 android:summary="@string/convert_fen_text_summ"
                 android:title="@string/convert_fen_text" />
+            <Preference
+                android:key="ankireview_link"
+                android:summary="Review is an alternative flashcard review plugin with a gesture and animation based UI."
+                android:title="Review for AnkiDroid">
+                <intent
+                    android:action="android.intent.action.VIEW"
+                    android:data="market://details?id=com.luc.ankireview"
+                    />
+            </Preference>
             <CheckBoxPreference
                 android:id="@+id/scrolling_buttons_checkbox"
                 android:defaultValue="false"


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Add a play store link to "Review for AnkiDroid" external app/plugin for those wishing to experiment with an alternative reviewing UI.

## Fixes
Initially proposed by @timrae in https://github.com/ankidroid/Anki-Android/pull/4832#issuecomment-389716337_

## Approach
This change is a simple preference entry consisting of a play store link, with no additional code and hence is very low risk.

## How Has This Been Tested?

Deployed AnkiDroid with the change on my android 9.0 phone, tested that a click on the preference entry takes me to the play store as expected.

## Learning (optional, can help others)

Technique to link to play store from preference screen described here: https://stackoverflow.com/questions/12058823/launch-android-play-store-app-from-preferenceactivity/26749772#26749772

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
