### PR TITLE
add link to third party apps which support AnkiDroid API integration inside preferences ->advanced->plugins

### DIFF
--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -152,6 +152,8 @@
     <string name="custom_buttons_setting_if_room">Show if room</string>
     <string name="custom_buttons_setting_menu_only">Menu only</string>
     <string name="reset_custom_buttons">Reset to default</string>
+    <string name="thirdparty_apps_title">Third-party API apps</string>
+    <string name="thirdparty_apps_summary">See a list of applications which make use of the AnkiDroid API such as dictionaries, utilities.</string>
 
     <string name="html_javascript_debugging">HTML / Javascript Debugging</string>
     <string name="html_javascript_debugging_summ">Enable remote WebView connections, and save card HTML to AnkiDroid directory</string>

--- a/AnkiDroid/src/main/res/xml/preferences_advanced.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_advanced.xml
@@ -78,8 +78,8 @@
                 android:title="@string/enable_api_title"/>
             <Preference
                 android:key="thirdpartyapps_link"
-                android:summary="See a list of applications which make use of the AnkiDroid API such as dictionaries, utilities."
-                android:title="Apps which work with AnkiDroid">
+                android:summary="@string/thirdparty_apps_summary"
+                android:title="@string/thirdparty_apps_title">
                 <intent
                     android:action="android.intent.action.VIEW"
                     android:data="https://github.com/ankidroid/Anki-Android/wiki/Third-Party-Apps"

--- a/AnkiDroid/src/main/res/xml/preferences_advanced.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_advanced.xml
@@ -101,6 +101,15 @@
                 android:key="convertFenText"
                 android:summary="@string/convert_fen_text_summ"
                 android:title="@string/convert_fen_text" />
+            <Preference
+                android:key="ankireview_link"
+                android:summary="Review is an alternative flashcard review plugin with a gesture and animation based UI."
+                android:title="Review for AnkiDroid">
+                <intent
+                    android:action="android.intent.action.VIEW"
+                    android:data="market://details?id=com.luc.ankireview"
+                    />
+            </Preference>
             <CheckBoxPreference
                 android:id="@+id/scrolling_buttons_checkbox"
                 android:defaultValue="false"

--- a/AnkiDroid/src/main/res/xml/preferences_advanced.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_advanced.xml
@@ -76,6 +76,15 @@
                 android:key="providerEnabled"
                 android:summary="@string/enable_api_summary"
                 android:title="@string/enable_api_title"/>
+            <Preference
+                android:key="thirdpartyapps_link"
+                android:summary="See a list of applications which make use of the AnkiDroid API such as dictionaries, utilities."
+                android:title="Apps which work with AnkiDroid">
+                <intent
+                    android:action="android.intent.action.VIEW"
+                    android:data="https://github.com/ankidroid/Anki-Android/wiki/Third-Party-Apps"
+                    />
+            </Preference>
             <CheckBoxPreference
                 android:defaultValue="false"
                 android:key="tts"
@@ -101,15 +110,6 @@
                 android:key="convertFenText"
                 android:summary="@string/convert_fen_text_summ"
                 android:title="@string/convert_fen_text" />
-            <Preference
-                android:key="ankireview_link"
-                android:summary="Review is an alternative flashcard review plugin with a gesture and animation based UI."
-                android:title="Review for AnkiDroid">
-                <intent
-                    android:action="android.intent.action.VIEW"
-                    android:data="market://details?id=com.luc.ankireview"
-                    />
-            </Preference>
             <CheckBoxPreference
                 android:id="@+id/scrolling_buttons_checkbox"
                 android:defaultValue="false"


### PR DESCRIPTION
As suggested in this comment, https://github.com/ankidroid/Anki-Android/pull/5203#issuecomment-457814074
this change introduces a preferences entry which when clicked, opens this page: https://github.com/ankidroid/Anki-Android/wiki/Third-Party-Apps

see prefererences entry:
https://i.imgur.com/wkCKEq0.png
see how the wiki page looks like on a mobile browser:
https://i.imgur.com/xoEAEVr.png