### PR TITLE
Avoid production crash for short stack traces

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -472,8 +472,13 @@ public class AnkiDroidApp extends Application {
             // because Robolectric runs them on the JVM but on Android the elements are different.
             StackTraceElement[] stackTrace = new Throwable().getStackTrace();
             if (stackTrace.length <= CALL_STACK_INDEX) {
-                throw new IllegalStateException(
-                        "Synthetic stacktrace didn't have enough elements: are you using proguard?");
+
+                // --- this is not present in the Timber.DebugTree copy/paste ---
+                // We are in production and should not crash the app for a logging failure
+                return TAG + " unknown class";
+                //throw new IllegalStateException(
+                //        "Synthetic stacktrace didn't have enough elements: are you using proguard?");
+                // --- end of alteration from upstream Timber.DebugTree.getTag ---
             }
             return createStackElementTag(stackTrace[CALL_STACK_INDEX]);
         }


### PR DESCRIPTION
There are user reports in issue #5205 of repeatable
production crashes related to logging failures.

The affected code is copied from a section of the logging
library that is intended for debug use, where a crash is
acceptable, but for production the logging code should never
trigger a crash on its own

@timrae - if you look at this one, I'll think you'll agree on the "log code should never crash in production" assertion. I thought about whether I should log the "we might have crashed here" event itself but I didn't want to tempt an infinite logging loop, and I didn't want to go outside of format. I chose to tag these rare occurrences with something obvious instead. And we can't avoid the inlining of the package-private method from upstream without altering how we tag (and then filter + ACRAlyze) our logging completely, something I don't want to do now since it works well empirically given I don't see these often at all. I'd like to have this merged before the next release as it's crashing a helpful alpha tester