### PR TITLE
Dependency updates 20190128 (JaCoCo and Robolectric)

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -191,7 +191,7 @@ dependencies {
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
     testImplementation 'net.lachlanmckee:timber-junit-rule:1.0.1'
     testImplementation 'androidx.test:core:1.1.0'
-    testImplementation "org.robolectric:robolectric:4.0.2"
+    testImplementation "org.robolectric:robolectric:4.1"
 
     // May need a resolution strategy for support libs to our versions
     androidTestImplementation 'com.azimolabs.conditionwatcher:conditionwatcher:0.2'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -2,6 +2,10 @@ apply plugin: 'com.android.application'
 apply plugin: 'com.github.triplet.play'
 apply plugin: 'jacoco'
 
+jacoco {
+    toolVersion = "$rootProject.ext.jacocoVersion"
+
+}
 repositories {
     google()
     jcenter()
@@ -61,6 +65,9 @@ android {
         }
     }
 
+    jacoco {
+        version = "$rootProject.ext.jacocoVersion"
+    }
     dexOptions {
         // Skip pre-dexing when running on Travis CI or when disabled via -Dpre-dex=false.
         preDexLibraries = preDexEnabled && !travisBuild

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -109,6 +109,7 @@ tasks.withType(JavaCompile) {
 
 tasks.withType(Test) {
     jacoco.includeNoLocationClasses = true
+    jacoco.excludes = ['jdk.internal.*']
 }
 
 // Our merge report task

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -42,7 +42,7 @@ android {
 dependencies {
     api fileTree(dir: 'libs', include: ['*.jar'])
     testImplementation 'org.junit.vintage:junit-vintage-engine:5.3.2'
-    testImplementation "org.robolectric:robolectric:4.0.2"
+    testImplementation "org.robolectric:robolectric:4.1"
 }
 
 // Borrowed from here:

--- a/build.gradle
+++ b/build.gradle
@@ -9,13 +9,16 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.3.0'
         classpath 'com.github.triplet.gradle:play-publisher:1.1.5'
-        classpath "org.jacoco:org.jacoco.core:0.8.2"
+        classpath "org.jacoco:org.jacoco.core:0.8.3"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
 }
 
 ext {
+
+    jacocoVersion = "0.8.3"
+
     travisBuild = System.getenv("TRAVIS") == "true"
     // allows for -Dpre-dex=false to be set
     preDexEnabled = "true".equals(System.getProperty("pre-dex", "true"))


### PR DESCRIPTION
Updates to Robolectric and JaCoCo - this whole PR is test-related

This continues some work on #5088 as well - where testing doesn't work with JDK>8 but we're not there yet

As these are test-only changes, I'll merge if CI goes green.