### PR TITLE
Complete SchedV2 with collection and syncing support

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -222,7 +222,7 @@ public class Collection {
         modSchema(true);
         SchedV2 v2Sched = new SchedV2(this);
         if (ver == 1) {
-            v2Sched.moveToV1()
+            v2Sched.moveToV1();
         } else {
             v2Sched.moveToV2();
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Consts.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Consts.java
@@ -63,7 +63,7 @@ public class Consts {
     public static final int SYNC_ZIP_COUNT = 25;
     public static final String SYNC_BASE = "https://sync.ankiweb.net/";
     public static final String SYNC_MEDIA_BASE = "https://sync.ankiweb.net/msync/";
-    public static final int SYNC_VER = 8;
+    public static final int SYNC_VER = 9;
 
     public static final String HELP_SITE = "http://ankisrs.net/docs/manual.html";
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -946,12 +946,12 @@ public class Decks {
 
     public ArrayList<Long> childDids(long did, HashMap<Long, HashMap<Long, HashMap>> childMap) {
         ArrayList<Long> array = new ArrayList<>();
-
-        for (HashMap.Entry<Long, HashMap> entry : childMap.get(did).entrySet()) {
-            array.add(entry.getKey());
-            array.addAll(childDids(entry.getKey(), entry.getValue()));
+        if (childMap.containsKey(did)) {
+            for (HashMap.Entry<Long, HashMap> entry : childMap.get(did).entrySet()) {
+                array.add(entry.getKey());
+                array.addAll(childDids(entry.getKey(), entry.getValue()));
+            }
         }
-
         return array;
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sched.java
@@ -96,6 +96,14 @@ public class Sched {
     // Not in libanki
     private WeakReference<Activity> mContextReference;
 
+
+    /**
+     * This is a do-nothing constructor for descendants (ScedV2) to use.
+     */
+    public Sched() {
+
+    }
+
     /**
      * queue types: 0=new/cram, 1=lrn, 2=rev, 3=day lrn, -1=suspended, -2=buried
      * revlog types: 0=lrn, 1=rev, 2=relrn, 3=cram

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/SchedV2.java
@@ -29,7 +29,6 @@ import android.text.SpannableStringBuilder;
 import android.text.TextUtils;
 import android.text.style.StyleSpan;
 
-import com.google.common.primitives.Longs;
 import com.ichi2.anki.R;
 import com.ichi2.libanki.hooks.Hooks;
 
@@ -112,7 +111,7 @@ public class SchedV2 extends Sched {
      */
 
     public SchedV2(Collection col) {
-        super(col);
+        super();
         mCol = col;
         mQueueLimit = 50;
         mReportLimit = 1000;
@@ -2363,7 +2362,7 @@ public class SchedV2 extends Sched {
         }
         // then bury
         if (toBury.size() > 0) {
-            buryCards(Longs.toArray(toBury),false);
+            buryCards(Utils.arrayList2array(toBury),false);
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/SchedV2.java
@@ -1007,6 +1007,7 @@ public class SchedV2 extends Sched {
         if (delay == null) {
             delay = _delayForGrade(conf, card.getLeft());
         }
+        card.setDue(Utils.intNow() + delay);
 
         // due today?
         if (card.getDue() < mDayCutoff) {


### PR DESCRIPTION
Further work to satisfy #4905. Putting it up here in case anyone wants to pull the branch and give it a try.

I will continue to add to the PR as I work on it, but the core functionality is now complete. You can enable the experimental scheduler on the desktop client and AnkiDroid should now be able to sync it and use it without issue. Syncing worked fine when I bumped the version number so there are no issues with the server rejecting it like I assumed before.

I've used this today to do some reviews, including decks with subdecks and filtered decks + empty/rebuild and it all seems to work fine so far.

The only thing remaining is to add a setting to toggle it on/off and I'll consider this complete.