### PR TITLE
Use test orchestrator for instrumented tests

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -57,7 +57,7 @@ android {
 
     testOptions {
         // we should use orchestrator, but app data shared on /sdcard makes it unstable
-        //execution 'ANDROID_TEST_ORCHESTRATOR'
+        execution 'ANDROIDX_TEST_ORCHESTRATOR'
         animationsDisabled true
 
         unitTests {


### PR DESCRIPTION
This change should isolate individual tests, making test
results more useful as one test won't halt the whole run

This should work okay now with the change to ANDROIDX prefix