### PR TITLE
Add SchedV2 toggle preference

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -194,7 +194,7 @@ public class Collection {
      */
 
 
-    private int schedVer() {
+    public int schedVer() {
         int ver = mConf.optInt("schedVer", fDefaultSchedulerVersion);
         if (fSupportedSchedulerVersions.contains(ver)) {
             return ver;
@@ -212,7 +212,7 @@ public class Collection {
         }
     }
 
-    private void changeSchedulerVer(Integer ver) throws ConfirmModSchemaException {
+    public void changeSchedulerVer(Integer ver) throws ConfirmModSchemaException {
         if (ver == schedVer()) {
             return;
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/SchedV2.java
@@ -1489,7 +1489,7 @@ public class SchedV2 extends Sched {
 
         try {
             int ivl4 = _constrainedIvl((
-                    (card.getIvl() + delay) * fct * conf.getInt("ease4")), conf, ivl3, fuzz);
+                    (card.getIvl() + delay) * fct * conf.getDouble("ease4")), conf, ivl3, fuzz);
             return ivl4;
         } catch (JSONException e) {
             throw new RuntimeException(e);

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -140,6 +140,11 @@
     <string name="time_limit_summ">XXX min</string>
     <string name="day_offset">Start of next day</string>
     <string name="day_offset_summ">XXX hours past midnight</string>
+    <string name="sched_ver">Experimental V2 scheduler</string>
+    <string name="sched_ver_summ">Enable the experimental scheduler. Forces changes in one direction on next sync</string>
+    <string name="sched_ver_toggle_title">Confirm</string>
+    <string name="sched_ver_2to1">This will reset any cards in learning, clear filtered decks, and change the scheduler version. Proceed?</string>
+    <string name="sched_ver_1to2">The experimental scheduler could cause incorrect scheduling. Please ensure you have read the documentation first. Proceed?</string>
     <string name="pref_keep_screen_on">Keep screen on</string>
     <string name="pref_keep_screen_on_summ">Disable screen timeout</string>
     <string name="convert_fen_text">Chess notation support</string>

--- a/AnkiDroid/src/main/res/xml/preferences_advanced.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_advanced.xml
@@ -133,6 +133,11 @@
         </PreferenceCategory>
 
 
+    <CheckBoxPreference
+        android:defaultValue="false"
+        android:key="schedVer"
+        android:title="@string/sched_ver"
+        android:summary="@string/sched_ver_summ" />
     <Preference
         android:key="about_dialog_preference"
         android:title="@string/about_title">


### PR DESCRIPTION
More work on #4905.

Adds in a scheduler toggle within AnkiDroid. Based on [desktop's preferences screen](https://github.com/dae/anki/blob/master/aqt/preferences.py#L127).