### PR TITLE
Preview fix

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -80,10 +80,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 import timber.log.Timber;
@@ -163,7 +164,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
     private TextView mActionBarTitle;
     private boolean mReloadRequired = false;
     private boolean mInMultiSelectMode = false;
-    private HashSet<Integer> mCheckedCardPositions = new HashSet<>();
+    private Set<Integer> mCheckedCardPositions = new LinkedHashSet<>();
     private int mLastSelectedPosition;
     private Menu mActionBarMenu;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -904,10 +904,14 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
             case R.id.action_preview: {
                 Intent previewer = new Intent(CardBrowser.this, Previewer.class);
-                previewer.putExtra("index", 0);
-                if (mInMultiSelectMode) {
+                if (mInMultiSelectMode && mCheckedCardPositions.size() > 1) {
+                    // Multiple cards have been explicitly selected, so preview only those cards
+                    previewer.putExtra("index", 0);
                     previewer.putExtra("cardList", getSelectedCardIds());
                 } else {
+                    // Preview all cards, starting from the one that is currently selected
+                    int startIndex = mCheckedCardPositions.isEmpty() ? 0: mCheckedCardPositions.iterator().next();
+                    previewer.putExtra("index", startIndex);
                     previewer.putExtra("cardList", getAllCardIds());
                 }
                 startActivityWithoutAnimation(previewer);


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Currently it's not possible to preview all cards starting from a given index in the browser. This is pretty unintuitive.

## Fixes
Fixes #5220 

## Approach
In the case where we have selected only one card we show all cards starting at the selected index. In the case where we have selected multiple cards, we show only those cards (this isn't supported by desktop which instead shows "please select 1 card" when multiple cards are selected).

I also switched from HashSet to LinkedHashSet for the selected card indices so that we correctly maintain insertion order, so that when multiple cards are selected for preview they show up in the correct order.

## How Has This Been Tested?

I ran through it with the emulator to check that it's all good