### PR TITLE
Add cloze deletion to floating text selection menu

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1712,7 +1712,7 @@ public class NoteEditor extends AnkiActivity {
         public boolean onPrepareActionMode(ActionMode mode, Menu menu) {
             // Adding the cloze deletion floating context menu item, but only once.
             if (menu.findItem(mMenuId) == null) {
-                menu.add(Menu.NONE, mMenuId, Menu.NONE, "Cloze deletion");
+                menu.add(Menu.NONE, mMenuId, Menu.NONE, R.string.multimedia_editor_popup_cloze);
                 return true;
             } else {
                 return false;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -18,6 +18,7 @@
 
 package com.ichi2.anki;
 
+import android.annotation.TargetApi;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
@@ -1691,6 +1692,7 @@ public class NoteEditor extends AnkiActivity {
      * Custom ActionMode.Callback implementation for adding and handling cloze deletion action
      * button in the text selection menu.
      */
+    @TargetApi(23)
     private class ActionModeCallback implements ActionMode.Callback {
         private FieldEditText mTextBox;
         private int mClozeCounter = 1;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1692,8 +1692,8 @@ public class NoteEditor extends AnkiActivity {
      * button in the text selection menu.
      */
     private class ActionModeCallback implements ActionMode.Callback {
-        FieldEditText mTextBox;
-        int mClozeCounter = 1;
+        private FieldEditText mTextBox;
+        private int mClozeCounter = 1;
 
         ActionModeCallback(FieldEditText textBox) {
             super();
@@ -1747,6 +1747,8 @@ public class NoteEditor extends AnkiActivity {
         }
 
         @Override
-        public void onDestroyActionMode(ActionMode mode) { }
+        public void onDestroyActionMode(ActionMode mode) {
+            // Left empty on purpose
+        }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1696,6 +1696,7 @@ public class NoteEditor extends AnkiActivity {
     private class ActionModeCallback implements ActionMode.Callback {
         private FieldEditText mTextBox;
         private int mClozeCounter = 1;
+        private int mMenuId = View.generateViewId();
 
         ActionModeCallback(FieldEditText textBox) {
             super();
@@ -1709,10 +1710,9 @@ public class NoteEditor extends AnkiActivity {
 
         @Override
         public boolean onPrepareActionMode(ActionMode mode, Menu menu) {
-            // TODO: use something better than this magic reference id number 16
             // Adding the cloze deletion floating context menu item, but only once.
-            if (menu.findItem(16) == null) {
-                menu.add(Menu.NONE, 16, Menu.NONE, "Cloze deletion");
+            if (menu.findItem(mMenuId) == null) {
+                menu.add(Menu.NONE, mMenuId, Menu.NONE, "Cloze deletion");
                 return true;
             } else {
                 return false;
@@ -1721,7 +1721,7 @@ public class NoteEditor extends AnkiActivity {
 
         @Override
         public boolean onActionItemClicked(ActionMode mode, MenuItem item) {
-            if (item.getItemId() == 16) {
+            if (item.getItemId() == mMenuId) {
                 // get the current text and selection locations
                 int selectionStart = mTextBox.getSelectionStart();
                 int selectionEnd = mTextBox.getSelectionEnd();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1203,14 +1203,6 @@ public class NoteEditor extends AnkiActivity {
                                 startMultimediaFieldEditor(index, mNote, field);
                                 return true;
                             }
-                            case R.id.menu_multimedia_cloze: {
-                                FieldEditText fieldEditText = mEditFields.get(index);
-                                String text = fieldEditText.getText().toString();
-                                int selectionStart = fieldEditText.getSelectionStart();
-                                int selectionEnd = fieldEditText.getSelectionEnd();
-                                fieldEditText.setText(insertClozeAround(text, selectionStart, selectionEnd));
-                                return true;
-                            }
                             default:
                                 return false;
                         }
@@ -1219,12 +1211,6 @@ public class NoteEditor extends AnkiActivity {
                 }
             }
         });
-    }
-
-    private String insertClozeAround(String text, int selectionStart, int selectionEnd) {
-        int selectionMin = Math.min(selectionStart, selectionEnd);
-        int selectionMax = Math.max(selectionStart, selectionEnd);
-        return text.substring(0, selectionMin) + "{{c1::" + text.substring(selectionMin, selectionMax) + "}}" + text.substring(selectionMax);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -90,6 +90,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import timber.log.Timber;
 
@@ -1695,8 +1697,8 @@ public class NoteEditor extends AnkiActivity {
     @TargetApi(23)
     private class ActionModeCallback implements ActionMode.Callback {
         private FieldEditText mTextBox;
-        private int mClozeCounter = 1;
         private int mMenuId = View.generateViewId();
+        private Pattern mClozeRegexPattern = Pattern.compile("\\{\\{c(\\d+)::");
 
         ActionModeCallback(FieldEditText textBox) {
             super();
@@ -1732,9 +1734,18 @@ public class NoteEditor extends AnkiActivity {
                 String selectedText = text.substring(selectionStart, selectionEnd);
                 String afterText = text.substring(selectionEnd);
 
+                // Find the largest existing cloze deletion id
+                Matcher matcher = mClozeRegexPattern.matcher(text);
+                int highestClozeId = 0;
+                while (matcher.find()) {
+                    int detectedClozeId = Integer.parseInt(matcher.group(1));
+                    if (detectedClozeId > highestClozeId) {
+                        highestClozeId = detectedClozeId;
+                    }
+                }
+
                 // Format the cloze deletion open bracket
-                String clozeOpenBracket = "{{c" + mClozeCounter + "::";
-                mClozeCounter++; // increase counter for next cloze deletion
+                String clozeOpenBracket = "{{c" + (highestClozeId + 1) + "::";
 
                 // Update text field with updated text and selection
                 mTextBox.setText(beforeText + clozeOpenBracket + selectedText + "}}" + afterText);

--- a/AnkiDroid/src/main/res/menu/popupmenu_multimedia_options.xml
+++ b/AnkiDroid/src/main/res/menu/popupmenu_multimedia_options.xml
@@ -12,9 +12,6 @@
         <item
             android:id="@+id/menu_multimedia_text"
             android:title="@string/multimedia_editor_popup_text"/>
-        <item
-            android:id="@+id/menu_multimedia_cloze"
-            android:title="@string/multimedia_editor_popup_cloze"/>
     </group>
 
 </menu>


### PR DESCRIPTION
## Purpose / Description
This pull request adds a cloze deletion button to the floating text selection menu when editing notes.
![screenshot](https://imgur.com/C4R9Tjy.jpg)

## Fixes
This is an alternative fix to issue #2520. The previously accepted implementation (#4606) ended up adding the functionality to the paperclip menu.

I am of course biased, but I think that this implementation has much nicer functionality and is more intuitive to access than the one that is available in the paper clip menu:
1. This one will automatically number all the cloze deletions that you add sequentially.
2. After the cloze deletion has been added, the cursor doesn't jump to the beginning of the text field.

## Approach
This pull request adds cloze deletion to the floating text selection menu by implementing a custom ActionMode.Callback.

## How Has This Been Tested?

I have tested this on my OnePlus 5T running Android Pie (API level 28). Unfortunately, I have not been able to test on other versions of Android due to problems with running the emulator on my computer.

It seems like the insertion menu (as opposed to the selection menu) is only available on API level 23 and newer. I do not know how the menu will be presented in previous versions.

## Open questions
I am not particularly experienced with Java or Android programming, so I probably made a bunch of mistakes along the way. Just let me know if there are things that need to be changed/improved.
A few specific questions that I would like some feedback on:
1. I needed to make an implementation of `ActionMode.Callback` and I just dumped it as a nested class within the NoteEditor. Is that bad practice? Should I put it somewhere else?
2. In the `ActionMode.Callback` implementation we need a unique item identifier for the new menu item. I believe that hardcoding it to be 16 as I have done now is bad practice, but I don't know what else to do.