### PR TITLE
Bump Junit to 5.4.0, with opt-in concurrency

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -87,6 +87,8 @@ android {
         }
 
         maxParallelForks = gradleTestMaxParallelForks
+        systemProperties['junit.jupiter.execution.parallel.enabled'] = true
+        systemProperties['junit.jupiter.execution.parallel.mode.default'] = "concurrent"
     }
 }
 
@@ -184,7 +186,7 @@ dependencies {
     implementation 'org.jsoup:jsoup:1.11.3'
     api project(":api")
 
-    testImplementation 'org.junit.vintage:junit-vintage-engine:5.3.2'
+    testImplementation 'org.junit.vintage:junit-vintage-engine:5.4.0'
     testImplementation 'org.mockito:mockito-core:2.23.4'
     testImplementation 'org.powermock:powermock-core:2.0.0'
     testImplementation 'org.powermock:powermock-module-junit4:2.0.0'


### PR DESCRIPTION

This minor bump altered their parallel concurrency model default and showed me I think I was doing it slightly wrong in the first place and not exploiting available parallelism 


Shaved 20% off ./gradlew jacocoUnitTestReport on a 4-core / hyperthread
MacBookPro, I imagine the results will scale well, without hurting small
machines (like CI)

## Pull Request template

## Purpose / Description
_Describe the problem or feature and motivation_

## Fixes
_Link to the issues._

## Approach
_How does this change address the problem?_

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration (SDK version(s), emulator or physical, etc)

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [ ] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
