### PR TITLE
20190210 dependency updates (mockito-core, junit in api module)

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -187,7 +187,7 @@ dependencies {
     api project(":api")
 
     testImplementation 'org.junit.vintage:junit-vintage-engine:5.4.0'
-    testImplementation 'org.mockito:mockito-core:2.23.4'
+    testImplementation 'org.mockito:mockito-core:2.24.0'
     testImplementation 'org.powermock:powermock-core:2.0.0'
     testImplementation 'org.powermock:powermock-module-junit4:2.0.0'
     testImplementation 'org.powermock:powermock-api-mockito2:2.0.0'

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -36,12 +36,14 @@ android {
         }
 
         maxParallelForks = gradleTestMaxParallelForks
+        systemProperties['junit.jupiter.execution.parallel.enabled'] = true
+        systemProperties['junit.jupiter.execution.parallel.mode.default'] = "concurrent"
     }
 }
 
 dependencies {
     api fileTree(dir: 'libs', include: ['*.jar'])
-    testImplementation 'org.junit.vintage:junit-vintage-engine:5.3.2'
+    testImplementation 'org.junit.vintage:junit-vintage-engine:5.4.0'
     testImplementation "org.robolectric:robolectric:4.1"
 }
 


### PR DESCRIPTION
Just generally moving things forward while we're still in alpha

- Previous junit bump missed the api module's usage of junit (but dependabot reminded me)
- mockito-core was likewise a dependabot bump but it was lost in my series of force-pushes
  as I made secondary alterations based on the minor (vs patch) change for junit