### PR TITLE
Allow for plurals in widget notification, Fixes #5240

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/NotificationService.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/NotificationService.java
@@ -47,7 +47,8 @@ public class NotificationService extends BroadcastReceiver {
         int dueCardsCount = WidgetStatus.fetchDue(context);
         if (dueCardsCount >= minCardsDue) {
             // Build basic notification
-            String cardsDueText = context.getString(R.string.widget_minimum_cards_due_notification_ticker_text, dueCardsCount);
+            String cardsDueText = context.getResources()
+                    .getQuantityString(R.plurals.widget_minimum_cards_due_notification_ticker_text, dueCardsCount, dueCardsCount);
 
             // This generates a log warning "Use of stream types is deprecated..."
             // The NotificationCompat code uses setSound() no matter what we do and triggers it.

--- a/AnkiDroid/src/main/res/values/08-widget.xml
+++ b/AnkiDroid/src/main/res/values/08-widget.xml
@@ -21,7 +21,10 @@
 
     <!-- Widget -->
     <string name="widget_minimum_cards_due_notification_ticker_title">Cards due</string>
-    <string name="widget_minimum_cards_due_notification_ticker_text">%d AnkiDroid cards due</string>
+    <plurals name="widget_minimum_cards_due_notification_ticker_text">
+        <item quantity="one">%d AnkiDroid card due</item>
+        <item quantity="other">%d AnkiDroid cards due</item>
+    </plurals>
     <string name="widget_no_cards_due">No cards due</string>
     <string name="widget_loading">Widget loading…</string>
 


### PR DESCRIPTION
The string contained a variable plural, but did not allow for plurals, which doesn't work well in all languages even if you assume the value will be more than 2