### PR TITLE
Dependency updates 20190219 - Robolectric, mockito, sqlite-android

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -167,7 +167,7 @@ dependencies {
     implementation 'androidx.browser:browser:1.0.0'
     implementation 'androidx.exifinterface:exifinterface:1.0.0'
     implementation 'androidx.recyclerview:recyclerview:1.0.0'
-    implementation 'io.requery:sqlite-android:3.26.0'
+    implementation 'io.requery:sqlite-android:3.27.1'
     implementation 'android.arch.persistence:db-framework:1.1.1'
     implementation 'com.afollestad.material-dialogs:core:0.9.6.0'
     implementation 'com.getbase:floatingactionbutton:1.10.1'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -197,7 +197,7 @@ dependencies {
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
     testImplementation 'net.lachlanmckee:timber-junit-rule:1.0.1'
     testImplementation 'androidx.test:core:1.1.0'
-    testImplementation "org.robolectric:robolectric:4.1"
+    testImplementation "org.robolectric:robolectric:4.2"
 
     // May need a resolution strategy for support libs to our versions
     androidTestImplementation 'com.azimolabs.conditionwatcher:conditionwatcher:0.2'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -190,7 +190,7 @@ dependencies {
     api project(":api")
 
     testImplementation 'org.junit.vintage:junit-vintage-engine:5.4.0'
-    testImplementation 'org.mockito:mockito-core:2.24.0'
+    testImplementation 'org.mockito:mockito-core:2.24.5'
     testImplementation 'org.powermock:powermock-core:2.0.0'
     testImplementation 'org.powermock:powermock-module-junit4:2.0.0'
     testImplementation 'org.powermock:powermock-api-mockito2:2.0.0'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -60,8 +60,6 @@ android {
     useLibrary 'org.apache.http.legacy'
 
     testOptions {
-        // we should use orchestrator, but app data shared on /sdcard makes it unstable
-        //execution 'ANDROIDX_TEST_ORCHESTRATOR'
         animationsDisabled true
 
         unitTests {
@@ -93,6 +91,11 @@ android {
         maxParallelForks = gradleTestMaxParallelForks
         systemProperties['junit.jupiter.execution.parallel.enabled'] = true
         systemProperties['junit.jupiter.execution.parallel.mode.default'] = "concurrent"
+    }
+    sourceSets {
+        debug {
+            manifest.srcFile 'src/test/AndroidManifest.xml'
+        }
     }
 }
 
@@ -196,15 +199,14 @@ dependencies {
     testImplementation 'org.powermock:powermock-api-mockito2:2.0.0'
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
     testImplementation 'net.lachlanmckee:timber-junit-rule:1.0.1'
-    testImplementation 'androidx.test:core:1.1.0'
     testImplementation "org.robolectric:robolectric:4.2"
+    testImplementation 'androidx.test:core:1.1.0'
+    testImplementation 'androidx.test.ext:junit:1.1.0'
 
     // May need a resolution strategy for support libs to our versions
     androidTestImplementation 'com.azimolabs.conditionwatcher:conditionwatcher:0.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.1.1'
     androidTestImplementation 'androidx.test.ext:junit:1.1.0'
-    androidTestImplementation 'androidx.test:runner:1.1.1'
     androidTestImplementation 'androidx.test:rules:1.1.1'
-    androidTestUtil 'androidx.test:orchestrator:1.1.1'
 }

--- a/AnkiDroid/src/test/AndroidManifest.xml
+++ b/AnkiDroid/src/test/AndroidManifest.xml
@@ -1,0 +1,16 @@
+<manifest xmlns:tools="http://schemas.android.com/tools"
+          xmlns:android="http://schemas.android.com/apk/res/android">
+    <application tools:ignore="AllowBackup,GoogleAppIndexingWarning">
+
+        <!-- To use AndroidX Test APIs on Activity sub-classes, you must have valid
+             Activity entries in your AndroidManifest. Manifest merger only happens with
+             build variants, and tests always run with the debug build variant, so test-only
+             Activity subclasses are defined here, and this file is included in debug.sourceSet
+             https://developer.android.com/studio/build/manifest-merge
+             https://issuetracker.google.com/issues/37001185
+             -->
+        <activity
+            android:name="com.ichi2.anki.NullCollectionReviewer">
+        </activity>
+    </application>
+</manifest>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.java
@@ -2,12 +2,12 @@ package com.ichi2.anki;
 
 import android.content.Context;
 
+import androidx.test.core.app.ActivityScenario;
 import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.Robolectric;
-import org.robolectric.RobolectricTestRunner;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -15,7 +15,7 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
-@RunWith(RobolectricTestRunner.class)
+@RunWith(AndroidJUnit4.class)
 public class DeckPickerTest extends RobolectricTest {
 
     @Test
@@ -32,19 +32,25 @@ public class DeckPickerTest extends RobolectricTest {
         mCodeResponsePairs.put(503, context.getString(R.string.sync_too_busy));
         mCodeResponsePairs.put(504, context.getString(R.string.sync_error_504_gateway_timeout));
 
-        DeckPicker deckPicker = Robolectric.setupActivity(DeckPicker.class);
-        for (Map.Entry<Integer, String> entry : mCodeResponsePairs.entrySet()) {
-            assertEquals(deckPicker.rewriteError(entry.getKey()), entry.getValue());
+        try (ActivityScenario<DeckPicker> scenario = ActivityScenario.launch(DeckPicker.class)) {
+            scenario.onActivity(deckPicker -> {
+                for (Map.Entry<Integer, String> entry : mCodeResponsePairs.entrySet()) {
+                    assertEquals(deckPicker.rewriteError(entry.getKey()), entry.getValue());
+                }
+            });
         }
     }
 
     @Test
     public void verifyBadCodesNoMessage() {
-        DeckPicker deckPicker = Robolectric.setupActivity(DeckPicker.class);
-        assertNull(deckPicker.rewriteError(0));
-        assertNull(deckPicker.rewriteError(-1));
-        assertNull(deckPicker.rewriteError(1));
-        assertNull(deckPicker.rewriteError(Integer.MIN_VALUE));
-        assertNull(deckPicker.rewriteError(Integer.MAX_VALUE));
+        try (ActivityScenario<DeckPicker> scenario = ActivityScenario.launch(DeckPicker.class)) {
+            scenario.onActivity(deckPicker -> {
+                assertNull(deckPicker.rewriteError(0));
+                assertNull(deckPicker.rewriteError(-1));
+                assertNull(deckPicker.rewriteError(1));
+                assertNull(deckPicker.rewriteError(Integer.MIN_VALUE));
+                assertNull(deckPicker.rewriteError(Integer.MAX_VALUE));
+            });
+        }
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NullCollectionReviewer.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NullCollectionReviewer.java
@@ -1,0 +1,21 @@
+package com.ichi2.anki;
+
+import com.ichi2.libanki.Collection;
+
+/**
+ * Test support class that returns a null collection every time for getCol()
+ */
+public class NullCollectionReviewer extends Reviewer {
+    @Override
+    public Collection getCol() {
+        return null;
+    }
+    @Override
+    public boolean colIsOpen() {
+        return false;
+    }
+    @Override
+    protected void onCollectionLoaded(Collection col) {
+        // it's not fair to expect the classes under test to handle this when we return null for getCol()
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.java
@@ -5,38 +5,28 @@ import com.ichi2.libanki.Collection;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
-import org.robolectric.RobolectricTestRunner;
+
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
-@RunWith(RobolectricTestRunner.class)
+@RunWith(AndroidJUnit4.class)
 public class ReviewerTest extends RobolectricTest {
 
     @Test
     public void verifyStartupNoCollection() {
-        Reviewer reviewer = Robolectric.setupActivity(NullCollectionReviewer.class);
-        assertNull("Collection should have been null", reviewer.getCol());
+        try (ActivityScenario<NullCollectionReviewer> scenario = ActivityScenario.launch(NullCollectionReviewer.class)) {
+            scenario.onActivity(reviewer -> assertNull("Collection should have been null", reviewer.getCol()));
+        }
     }
 
     @Test
     public void verifyNormalStartup() {
-        Reviewer reviewer = Robolectric.setupActivity(Reviewer.class);
-        assertNotNull("Collection should be non-null", reviewer.getCol());
+        try (ActivityScenario<Reviewer> scenario = ActivityScenario.launch(Reviewer.class)) {
+            scenario.onActivity(reviewer -> assertNotNull("Collection should be non-null", reviewer.getCol()));
+        }
     }
 }
 
-class NullCollectionReviewer extends Reviewer {
-    @Override
-    public Collection getCol() {
-        return null;
-    }
-    @Override
-    public boolean colIsOpen() {
-        return false;
-    }
-    @Override
-    protected void onCollectionLoaded(Collection col) {
-        // it's not fair to expect the classes under test to handle this when we return null for getCol()
-    }
-}

--- a/AnkiDroid/src/test/java/com/ichi2/compat/CompatCopyFileTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/compat/CompatCopyFileTest.java
@@ -21,7 +21,6 @@ import com.ichi2.anki.TestUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import java.io.File;
@@ -33,7 +32,9 @@ import java.io.InputStream;
 import java.net.URL;
 import java.util.Objects;
 
-@RunWith(RobolectricTestRunner.class)
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+@RunWith(AndroidJUnit4.class)
 @Config(sdk = { 16, 26 })
 public class CompatCopyFileTest {
 

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -44,7 +44,7 @@ android {
 dependencies {
     api fileTree(dir: 'libs', include: ['*.jar'])
     testImplementation 'org.junit.vintage:junit-vintage-engine:5.4.0'
-    testImplementation "org.robolectric:robolectric:4.1"
+    testImplementation "org.robolectric:robolectric:4.2"
 }
 
 // Borrowed from here:

--- a/tools/quality-check/stop_all_emulators.sh
+++ b/tools/quality-check/stop_all_emulators.sh
@@ -1,14 +1,8 @@
 #!/bin/bash
 
-# This attempts to stop all your emulators (on Ubuntu 18.04.01 LTS at least...) nicely
+# This attempts to stop all your emulators (on Ubuntu 18.10 at least...) nicely
 #
 # ...then if they don't stop it kills them
-
-killall -9 adb
-adb devices -l > /dev/null
-sleep 2
-adb devices -l > /dev/null
-sleep 2
 
 for EMU_ID in `adb devices -l | grep emulator | cut -d' ' -f1`; do
   echo Stopping emulator $EMU_ID...


### PR DESCRIPTION
Still keeping dependencies super fresh as we're in alpha, with the help of dependabot.

The only thing of note is that the Robolectric update from 4.1 to 4.2 deprecated our style of starting Activity objects to put them under test. The solution is a net-positive as it moves to using [standard AndroidX APIs](http://robolectric.org/androidx_test/), but it required some work to make my test Activity-subclass function correctly. That work is described in the associated commit message

This was tested on the full fleet of emulators, every API from API15 to API28, locally; plus the diminished but publicly visible set of APIs supported in Travis CI