### PR TITLE
Add possibility to swap front/back contents

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -853,6 +853,9 @@ public class NoteEditor extends AnkiActivity {
                     menu.findItem(R.id.action_copy_card).setEnabled(false);
                 }
             }
+            if (mEditFields.size() == 2) {
+                menu.findItem(R.id.action_swap_front_back).setEnabled(true);
+            }
         }
         return super.onCreateOptionsMenu(menu);
     }
@@ -883,6 +886,17 @@ public class NoteEditor extends AnkiActivity {
                 startActivityForResultWithAnimation(intent, REQUEST_ADD, ActivityTransitionAnimation.LEFT);
                 return true;
             }
+            case R.id.action_swap_front_back:
+                // Swap text in first and second field.
+                final FieldEditText first = mEditFields.get(0);
+                final FieldEditText second = mEditFields.get(1);
+                if (first != null && first.getText() != null && second != null && second.getText() != null) {
+                    final String firstText = first.getText().toString();
+                    final String secondText = second.getText().toString();
+                    first.setText(secondText);
+                    second.setText(firstText);
+                }
+                return true;
             default:
                 return super.onOptionsItemSelected(item);
 

--- a/AnkiDroid/src/main/res/menu/note_editor.xml
+++ b/AnkiDroid/src/main/res/menu/note_editor.xml
@@ -14,4 +14,8 @@
         android:id="@+id/action_copy_card"
         android:enabled="false"
         android:title="@string/card_editor_copy_card"/>
+    <item
+        android:id="@+id/action_swap_front_back"
+        android:title="@string/card_editor_swap_front_back"
+        android:enabled="false"/>
 </menu>

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -114,6 +114,7 @@
     <string name="fact_adder_intent_title">AnkiDroid card</string>
     <string name="card_editor_add_card">Add note</string>
     <string name="card_editor_copy_card">Copy card</string>
+    <string name="card_editor_swap_front_back">Swap front/back</string>
     <string name="card_editor_card_scheduling">Scheduling</string>
     <string name="card_editor_reposition_card">Reposition</string>
     <string name="card_editor_reset_card">Reset progress</string>


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

I added some cards using the "Basic (and reverse)" type, but later decided that for the cards I added only learing them in one direction makes more sense.

So I changed the type to "Basic", but now the order was the wrong way around. I need a way to quickly swap front/back for about 1-2 dozen cards in the app without copy-pasting.

## Approach

If there are exactly 2 input fields, add a menu entry in the note editor to swap them.

Note: Currently the text is "Swap front/back" even though the labels can be different. Should we create that string dynamically, or use a more generic text?

## How Has This Been Tested?

Manual testing in the emulator. It's quite a simple feature, so there should not be too much that can go wrong.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
