### PR TITLE
Dependency updates 20190327 (auto-service used by ACRA analytics interaction)

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -160,8 +160,8 @@ task jacocoUnitTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest']) 
 }
 
 dependencies {
-    compileOnly "com.google.auto.service:auto-service:1.0-rc5"
-    annotationProcessor "com.google.auto.service:auto-service:1.0-rc4"
+    compileOnly "com.google.auto.service:auto-service-annotations:1.0-rc5"
+    annotationProcessor "com.google.auto.service:auto-service-annotations:1.0-rc5"
 
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.appcompat:appcompat:1.0.2'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -160,7 +160,7 @@ task jacocoUnitTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest']) 
 }
 
 dependencies {
-    compileOnly "com.google.auto.service:auto-service:1.0-rc4"
+    compileOnly "com.google.auto.service:auto-service:1.0-rc5"
     annotationProcessor "com.google.auto.service:auto-service:1.0-rc4"
 
     implementation fileTree(dir: 'libs', include: ['*.jar'])


### PR DESCRIPTION
Hopefully this dependency will get a real/stable release before 2.9.x but the auto-service dependency actually changed maven/gradle artifact organization during an RC cycle :man_shrugging:

We must use it because using `@AutoService` annotations is the officially-supported mechanism for extending ACRA, and we extend ACRA just a little with a custom interaction so we get an analytics event hit at the same time ACRA posts to ACRAlyzer

Because correctly referencing the new artifact is in the vital crash reporting pathway I used our new advanced preferences test crash button while all using the advanced prefs dev analytics button to connect to the dev analytics instance with hit logging sampled at 100% to make sure it worked. The crash was correctly registered in analytics after this change so I feel confident it worked.