### PR TITLE
Fix emulator-28.0.5 emulator regression w/canary, add modern x86_64 emulators

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,27 +13,29 @@ env:
     - TOOLS=${ANDROID_HOME}/tools
     - PATH=${ANDROID_HOME}:${ANDROID_HOME}/emulator:${TOOLS}:${TOOLS}/bin:${ANDROID_HOME}/platform-tools:${PATH}
   matrix:
-   #- API=15 # fails consistently but can run locally
+   #- API=15 # only runs locally. Create+Start once from AndroidStudio to init sdcard. Then only from command-line w/-engine classic
    - API=16 AUDIO=-no-audio
    - API=17
-   #- API=18 # API18 has started being flaky
-   # API 20 doesn't have an emulator
-   - API=21
-   - API=22
-   #- API=23 EMU_FLAVOR=google_apis # fails consistently but can run local
-   #- API=24 #API24 flaky now as well (after API18 started flaking). It is a progressive disease with more tests I think
-   # API16 and API19 are the fastest APIs, Travis runs 5 at a time and we have 6, this is the fastest way to do all 6 APIs
-   - API=19
-   #- API=25 EMU_FLAVOR=google_apis # fails consistently but can run local
-   # API >= 26 don't have arm emulators, and Travis doesn't support x86
+   - API=18 # API18 has started being flaky
+   #- API=19 # Kernel/emulator mismatch failure probably fixible with -engine classic
+   # API 20 was Android Wear only
+   - API=21 ABI=x86_64
+   - API=22 ABI=x86_64
+   - API=23 ABI=x86_64
+   - API=24 ABI=x86_64
+   - API=25 ABI=x86_64 
+   #- API=26 ABI=x86_64 # Fails with unrecognized tests? orchestrator change or something?
+   - API=27 ABI=x86_64
+   #- API=28 ABI=x86_64 # Slowness/timing issues / Fails with unresponsive adb command / so unrecognized API for adb
+   #- API=Q ABI=x86_64 # Fails I think because of perf + timeouts. 10 minute wait not enough, fixable
 
-# All failing emulators are disabled now, but leaving this in for future work enabling them
+# This block currently does not work, but it used to. API=28/Q are probably fixable
+# but we don't need allow_failures to be on in master to work through them
 #matrix:
 #  fast_finish: true # We can report success without waiting for these
 #  allow_failures:
-#    - env: API=15 # sometimes emulator hangs, sometimes not - possibly fixable
-#    - env: API=23 EMU_FLAVOR=google_apis # has permission errors
-#    - env: API=25 EMU_FLAVOR=google_apis # has permission errors, emulator timeout
+#     - API=28 ABI=x86_64 
+#     #- env: API=28 ABI=x86_64 # allowing failure to see how it works flake-wise
 
 jobs:
   include:
@@ -61,10 +63,11 @@ install:
   - echo y | sdkmanager "build-tools;28.0.3" >/dev/null # Implicit gradle dependency - gradle drives changes
   - echo y | sdkmanager "platforms;android-$API" >/dev/null # We need the API of the emulator we will run
   - echo y | sdkmanager "platforms;android-28" >/dev/null # We need the API of the current compileSdkVersion from gradle.properties
+  - echo y | sdkmanager --channel=4 "emulator" # Experiment with canary, specifying 28.0.3 (prior version) did not work
   - echo y | sdkmanager "extras;android;m2repository" >/dev/null
-  - echo y | sdkmanager "system-images;android-$API;$EMU_FLAVOR;$ABI" >/dev/null # install our emulator
+  - echo y | sdkmanager "system-images;android-$API;$EMU_FLAVOR;$ABI" #>/dev/null # install our emulator
   - echo no | avdmanager create avd --force -n test -k "system-images;android-$API;$EMU_FLAVOR;$ABI" -c 10M
-  - emulator -avd test -engine classic -no-window $AUDIO -camera-back none -camera-front none -selinux permissive -qemu -m 1536 &
+  - emulator -verbose -avd test -no-accel -no-snapshot -no-window $AUDIO -camera-back none -camera-front none -selinux permissive -qemu -m 2048 &
   - android-wait-for-emulator
   - adb shell input keyevent 82 &
 


### PR DESCRIPTION
Google pushed out a stable emulator version that blew up all the CIs in the world I think.

But their canary emulator works with x86_64 system images so we have access to modern emulators now, which is awesome.

I will squash merge this if it looks like it's working - it's a little speculative right now