### PR TITLE
Add option to turn on sentence auto-capitalization in the Note Editor

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -31,6 +31,7 @@ import android.os.Bundle;
 import androidx.appcompat.widget.PopupMenu;
 import androidx.appcompat.widget.Toolbar;
 import android.text.Editable;
+import android.text.InputType;
 import android.text.TextUtils;
 import android.text.TextWatcher;
 
@@ -1296,6 +1297,13 @@ public class NoteEditor extends AnkiActivity {
                 // do nothing
             }
         });
+
+        SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(getBaseContext());
+        if(preferences.getBoolean("autoCapitalization", false)) {
+            int currentInputType = editText.getInputType();
+            editText.setInputType(currentInputType | InputType.TYPE_TEXT_FLAG_CAP_SENTENCES);
+        }
+
         editText.setEnabled(enabled);
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -252,6 +252,16 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                     return true;
                 });
                 break;
+            case "com.ichi2.anki.prefs.editing":
+                listener.addPreferencesFromResource(R.xml.preferences_editing);
+                screen = listener.getPreferenceScreen();
+                CheckBoxPreference checkBoxPreference = (CheckBoxPreference) screen.findPreference("autoCapitalization");
+                checkBoxPreference.setOnPreferenceChangeListener(((preference, newValue) -> {
+                    SharedPreferences.Editor edit = AnkiDroidApp.getSharedPrefs(getBaseContext()).edit();
+                    edit.putBoolean("autoCapitalization", ((CheckBoxPreference)preference).isChecked()).apply();
+                    return true;
+                }));
+                break;
             case "com.ichi2.anki.prefs.advanced":
                 listener.addPreferencesFromResource(R.xml.preferences_advanced);
                 screen = listener.getPreferenceScreen();

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -32,6 +32,8 @@
     <string name="pref_cat_automatic_display">Automatic display answer</string>
     <string name="pref_cat_appearance">Appearance</string>
     <string name="pref_cat_appearance_summ">Change themes and default font</string>
+    <string name="pref_cat_editing">Editing</string>
+    <string name="pref_cat_editing_summ">Control note editor behavior.</string>
     <string name="pref_cat_themes">Themes</string>
     <string name="pref_cat_fonts">Fonts</string>
     <string name="pref_cat_gestures">Gestures</string>
@@ -163,6 +165,10 @@
     <string name="html_javascript_debugging">HTML / Javascript Debugging</string>
     <string name="html_javascript_debugging_summ">Enable remote WebView connections, and save card HTML to AnkiDroid directory</string>
 
+    <!-- Editing settings -->
+    <string name="auto_capitalization_summ">Auto-capitalize the first word in sentences when entering text into note fields.</string>
+    <string name="auto_capitalization">Enable auto-capitalization</string>
+
     <!-- Advanced statistics settings -->
     <string name="advanced_statistics_title">Advanced statistics</string>
     <string name="enable_advanced_statistics_title">Enable advanced statistics</string>
@@ -253,4 +259,4 @@
     <string name="analytics_dialog_title">Help make AnkiDroid better!</string>
     <string name="analytics_title">Share feature usage</string>
     <string name="analytics_summ">You can contribute to AnkiDroid by helping the development team see which features people use</string>
-"</resources>
+    "</resources>

--- a/AnkiDroid/src/main/res/xml/preference_headers.xml
+++ b/AnkiDroid/src/main/res/xml/preference_headers.xml
@@ -61,6 +61,16 @@
             android:value="com.ichi2.anki.prefs.gestures" />
     </header>
 
+    <!-- Editing Prefrences -->
+    <header
+        android:fragment="com.ichi2.anki.Preferences$SettingsFragment"
+        android:summary="@string/pref_cat_editing_summ"
+        android:title="@string/pref_cat_editing">
+        <extra
+            android:name="subscreen"
+            android:value="com.ichi2.anki.prefs.editing" />
+    </header>
+
     <!-- Advanced Preferences -->
     <header
         android:fragment="com.ichi2.anki.Preferences$SettingsFragment"

--- a/AnkiDroid/src/main/res/xml/preferences_editing.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_editing.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+~ Copyright (c) 2009 Nicolas Raoul <nicolas.raoul@gmail.com>
+~ Copyright (c) 2009 Edu Zamora <edu.zasu@gmail.com>
+~ Copyright (c) 2009 Jordi Chacon <jordi.chacon@gmail.com>
+~ Copyright (c) 2011 Norbert Nagold <norbert.nagold@gmail.com>
+~ Copyright (c) 2012 Kostas Spyropoulos <inigo.aldana@gmail.com>
+~ Copyright (c) 2014 Timothy Rae <perceptualchaos2@gmail.com>
+~
+~ This program is free software; you can redistribute it and/or modify it under
+~ the terms of the GNU General Public License as published by the Free Software
+~ Foundation; either version 3 of the License, or (at your option) any later
+~ version.
+~
+~ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+~ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+~ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+~
+~ You should have received a copy of the GNU General Public License along with
+~ this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<!-- Editing Preferences -->
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+                  xmlns:app="http://arbitrary.app.namespace/com.ichi2.anki"
+                  android:title="@string/pref_cat_editing"
+                  android:summary="@string/pref_cat_editing_summ" >
+    <CheckBoxPreference
+        android:defaultValue="false"
+        android:key="autoCapitalization"
+        android:summary="@string/auto_capitalization_summ"
+        android:title="@string/auto_capitalization" />
+</PreferenceScreen>


### PR DESCRIPTION
## Purpose / Description
Proof of concept for adding an option for whether auto-capitalization should be enabled when adding cards.

## Fixes
#3758

## Approach
Add a new settings section For the note editor and an option for turning on auto-capitalization. When the option is enabled, the first letter of every sentence is capitalized. When the option is disabled, no auto-capitalization is performed.

## How Has This Been Tested?

Manual testing of the "add note" view as launched from the deck picker and the card browser. Tested adding text to front and back fields of a note.

## Checklist
_Please, go through these checks before submitting the PR._

- [x ] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [ x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ x] You have commented your code, particularly in hard-to-understand areas
- [ x] You have performed a self-review of your own code
