### PR TITLE
Bump sqlite-android from 3.27.2 to 3.28.0

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -172,7 +172,7 @@ dependencies {
     implementation 'androidx.browser:browser:1.0.0'
     implementation 'androidx.exifinterface:exifinterface:1.0.0'
     implementation 'androidx.recyclerview:recyclerview:1.0.0'
-    implementation 'io.requery:sqlite-android:3.27.2'
+    implementation 'io.requery:sqlite-android:3.28.0'
     implementation 'android.arch.persistence:db-framework:1.1.1'
     implementation 'com.afollestad.material-dialogs:core:0.9.6.0'
     implementation 'com.getbase:floatingactionbutton:1.10.1'


### PR DESCRIPTION
Note that CI is fully green for me on these changes as well. Not sure why #5285 is not going green at this point?

Bumps [sqlite-android](https://github.com/requery/sqlite-android) from 3.27.2 to 3.28.0.
- [Release notes](https://github.com/requery/sqlite-android/releases)
- [Changelog](https://github.com/requery/sqlite-android/blob/master/CHANGELOG.md)
- [Commits](https://github.com/requery/sqlite-android/commits)

Signed-off-by: dependabot[bot] <support@dependabot.com>

## Pull Request template

## Purpose / Description
_Describe the problem or feature and motivation_

## Fixes
_Link to the issues._

## Approach
_How does this change address the problem?_

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration (SDK version(s), emulator or physical, etc)

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [ ] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
