### PR TITLE
CI: Only attempt Codacy coverage report upload if not a PR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ script:
   - ./gradlew jacocoTestReport # This produces an error while doing the API getprop on API 28...
 
 after_success:
-  - bash tools/upload-codacy-report.sh
+  - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then bash tools/upload-codacy-report.sh; fi
 
 before_cache:
   - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,11 +74,8 @@ install:
 script:
   - ./gradlew jacocoTestReport # This produces an error while doing the API getprop on API 28...
 
-# Codacy integration, partials for all APIs, then an optional finalize
 after_success:
-  - wget --progress=dot:giga -O ~/codacy-coverage-reporter-assembly-latest.jar https://oss.sonatype.org/service/local/repositories/releases/content/com/codacy/codacy-coverage-reporter/4.0.2/codacy-coverage-reporter-4.0.2-assembly.jar
-  - if [[ ( "$API" != "NONE" ) ]]; then java -jar ~/codacy-coverage-reporter-assembly-latest.jar report -l Java -r AnkiDroid/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml --partial; fi
-  - if [[ ( "$FINALIZE_COVERAGE" == "TRUE" ) ]]; then java -jar ~/codacy-coverage-reporter-assembly-latest.jar final; fi
+  - bash tools/upload-codacy-report.sh
 
 before_cache:
   - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/tools/upload-codacy-report.sh
+++ b/tools/upload-codacy-report.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# Upload codacy coverage reports.
+#
+# Partial uploads for APIs, with an option to finalize.
+#
+
+set -e
+
+ wget --progress=dot:giga -O ~/codacy-coverage-reporter-assembly-latest.jar https://oss.sonatype.org/service/local/repositories/releases/content/com/codacy/codacy-coverage-reporter/4.0.2/codacy-coverage-reporter-4.0.2-assembly.jar
+
+if [[ ( "$API" != "NONE" ) ]]; then
+    java -jar ~/codacy-coverage-reporter-assembly-latest.jar report \
+        -l Java \
+        -r AnkiDroid/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml \
+        --partial
+fi
+
+if [[ ( "$FINALIZE_COVERAGE" == "TRUE" ) ]]; then
+    java -jar ~/codacy-coverage-reporter-assembly-latest.jar final
+fi
+


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Travis CI attempts to upload Codacy coverage artifacts on every successful run. Codacy requires an API token to function correctly. Since we only care about uploading these artifacts from the main repository and because it is not safe to source-control that token in a public repository, I've made a change that allows Travis to skip the upload of coverage artifacts entirely when building from a pull request.

## Fixes
Fixes #5080.

## Approach
- Move existing upload steps from the `.travis.yml` file into a dedicated shell script.
- Leverage the `$TRAVIS_PULL_REQUEST` environment variable to conditionally upload codacy reports.

## How Has This Been Tested?
1. Fork repo
2. Link fork to Travis and Codacy
3. Create a branch and make a change
4. Push branch to repo
5. Make pull request from the new branch

Travis will begin building the branch after step 4, and will also trigger a second build from step 5. Within the build from step 4 we can see Travis attempting to upload the reports, but the build from step 5 will show that the upload step is skipped.

For reviewer convenience, a sample of the output of step 4 (a branch build) can be seen [here](https://travis-ci.com/Overflow0xFFFF/Anki-Android/jobs/206103055#L1915), and a sample output of step 5 (a PR build) can be seen [here](https://travis-ci.com/Overflow0xFFFF/Anki-Android/jobs/206106599#L1918).

## Learning (optional, can help others)
The official Travis CI documentation talks about how to conditionally run items for pull requests [here](https://docs.travis-ci.com/user/pull-requests/).

The docs also detail [environment variables](https://docs.travis-ci.com/user/environment-variables/), which allowed me to better research the `$TRAVIS_PULL_REQUEST` var and to be certain it was available throughout the entire pipeline, including the `after_success` stage.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
