### PR TITLE
Fixes Mathjax inside of a cloze replacement.

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/template/Template.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/template/Template.java
@@ -298,7 +298,7 @@ public class Template {
             String buf;
             if (type == 'q') {
                 if (!TextUtils.isEmpty(m.group(4))) {
-                    buf = "[$4]";
+                    buf = "[" + m.group(4) + "]";
                 } else {
                     buf = "[...]";
                 }
@@ -310,7 +310,7 @@ public class Template {
                 buf = String.format("<span class=cloze>%s</span>", buf);
             }
 
-            m.appendReplacement(repl, buf);
+            m.appendReplacement(repl, Matcher.quoteReplacement(buf));
         }
         txt = m.appendTail(repl).toString();
         // and display other clozes normally

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/MathJaxClozeTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/MathJaxClozeTest.java
@@ -60,4 +60,22 @@ public class MathJaxClozeTest extends RobolectricTest {
         assertTrue(cards.get(3).q().contains("class=cloze"));
         assertTrue(cards.get(4).q().contains("class=cloze"));
     }
+
+    @Test
+    public void verifyMathJaxInCloze() {
+        final Context context = ApplicationProvider.getApplicationContext();
+
+        Collection c = getCol();
+        Note f = c.newNote(c.getModels().byName("Cloze"));
+        f.setItem("Text", "\\(1 \\div 2 =\\){{c1::\\(\\frac{1}{2}\\)}}");
+        c.addNote(f);
+
+        ArrayList<Card> cards = f.cards();
+        Card c2 = cards.get(0);
+        String q = c2.q();
+        String a = c2.a();
+        assertTrue(q.contains("\\(1 \\div 2 =\\)"));
+        assertTrue(a.contains("\\(1 \\div 2 =\\)"));
+        assertTrue(a.contains("<span class=cloze>\\(\\frac{1}{2}\\)</span>"));
+    }
 }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Mathjax wasn't being rendered inside of cloze replacements.  I tracked it down to clozeText() which was eating the backslashes needed for \\(.

## Fixes
#5323 

## Approach
Escapes the backslashes.

## How Has This Been Tested?

I created a test to replicate the issue.  It now passes.  The old tests still pass.

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
