### PR TITLE
Limit the displayed review count to 99999 instead of 1000

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
@@ -63,7 +63,7 @@ public class StudyOptionsFragment extends Fragment implements Toolbar.OnMenuItem
     private static final int CONTENT_EMPTY = 2;
 
     // Threshold at which the total number of new cards is truncated by libanki
-    private static final int NEW_CARD_COUNT_TRUNCATE_THRESHOLD = 1000;
+    private static final int NEW_CARD_COUNT_TRUNCATE_THRESHOLD = 99999;
 
     /**
      * Preferences

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sched.java
@@ -113,7 +113,7 @@ public class Sched {
     public Sched(Collection col) {
         mCol = col;
         mQueueLimit = 50;
-        mReportLimit = 1000;
+        mReportLimit = 99999;
         mReps = 0;
         mHaveQueues = false;
         _updateCutoff();

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/SchedV2.java
@@ -114,7 +114,7 @@ public class SchedV2 extends Sched {
         super();
         mCol = col;
         mQueueLimit = 50;
-        mReportLimit = 1000;
+        mReportLimit = 99999;
         mDynReportLimit = 99999;
         mReps = 0;
         mToday = null;


### PR DESCRIPTION
## Purpose / Description

Unlimit the displayed review counts, by limiting them to 99999 instead of 1000, as per https://github.com/ankidroid/Anki-Android/issues/5197#issuecomment-452549094

## Fixes

Fixes #5092, #5197 and https://github.com/ankidroid/Anki-Android/issues/5322

## Approach

I don't know Ankidroid's architecture, and at parts of what I've seen it sounds like it aims to be almost a transcription of the python code, so I've changed as little as possible.

Note that here I think I change the constants limiting both the study counters and the deck list counters. Potentially the slowdown caused by counting all the full deck counters will be a problem, in which case it should be possible to revert the `Sched{,V2}.java` parts of it, I think (or roll them back to “just” 9999, maybe?). This would unfix #5092 and #5197, though, but keep #5322 fixed.

## How Has This Been Tested?

This is the first time I attempt to contribute to an android project, so it has not actually been tested. Given what the code around it looks like, I'm relatively confident it's OK-ish, though.

## Learning (optional, can help others)

Grep'd through the source code for 1000, looked at all occurrences: `rg -w 1000 | rg -v '............................................................................................................................................................................................................................' > 1000-occurrences && vim 1000-occurrences`

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
