### PR TITLE
build: travis migrates to xenial but android only works on trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: android
+dist: trusty
 
 jdk:
   - oraclejdk8


### PR DESCRIPTION
https://changelog.travis-ci.com/xenial-as-the-default-build-environment-99476
https://docs.travis-ci.com/user/languages/android/
