### PR TITLE
Fix analytics opt in

### DIFF
--- a/AnkiDroid/src/main/res/xml/preferences_general.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_general.xml
@@ -56,7 +56,7 @@
             android:key="language"
             android:title="@string/language" />
         <CheckBoxPreference
-            android:defaultValue="true"
+            android:defaultValue="false"
             android:key="analyticsOptIn"
             android:summary="@string/analytics_summ"
             android:title="@string/analytics_title" />


### PR DESCRIPTION
## Purpose / Description
Even the default in UsageAnalytics class is 'false' the default value in the preferences was set to 'true'. That means analytics was disabled by default but if the user opened the preferences screen it got automatically enabled. This commit fixes this issue by setting the default value in the preferences to 'false'.
