### PR TITLE
CI: Add support for builds with Oracle JDK 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,21 +30,23 @@ env:
    #- API=28 # Fails on adb 2 second getprop timeout and get API getprop takes 2.2s, so emulator boots but adb won't install on unknown API
    #- API=Q  # Fails at some point on emulator startup or detecting startup complete
 
-# This block currently does not work, but it used to. API=28/Q are probably fixable
-# but we don't need allow_failures to be on in master to work through them
-#matrix:
-#  fast_finish: true # We can report success without waiting for these
-#  allow_failures:
-#     - env: API=28
-#     - env: API=Q
-
 jobs:
+  fast_finish: true  # We can report success without waiting for jobs that we
+                     # allow / expect to fail.
   include:
+    - jdk: oraclejdk11
+      env: API=24
     # The test stage is implicit, we only need to define a post-test stage for codacy finalization
     - stage: finalize_coverage
       env: FINALIZE_COVERAGE=TRUE API=NONE
       install: skip
       script: echo finalize codacy coverage uploads
+  allow_failures:
+    - jdk: oraclejdk11
+    # API=28/Q are probably fixable but we don't need allow_failures to be on
+    # in master to work through them.
+    #- env: API=28
+    #- env: API=Q
 
 android:
   components:


### PR DESCRIPTION
## Purpose / Description

This adds support in Travis to build API 24 with Oracle JDK 11. However, at the current time, only Oracle JDK 8 is in active use on the project. As such, we allow JDK 11 builds to fail without affecting the build status for the project overall.

@mikehardy, I believe the `allow_failures` block for Android APIs `26` and `Q` are fixed (as in Travis could allow them to fail) as a result of these changes, but I left the commented out entries within that block since that isn't the target of this PR. I don't mind adding them here and now if you like, but I figured that would be best saved for another pull request.

## Fixes

Fixes #5115.

## Approach

I manually defined an extra job that specifically targets the combination of API 24 and Oracle JDK 11, then allowed anything using `oraclejdk11` to fail.

## How Has This Been Tested?

This was tested with Travis using a public fork of the project.

## Learning (optional, can help others)

In Travis, `jobs` is an alias for `matrix`. This is not very clear, and
is mentioned casually and off-handedly in their [documentation](https://docs.travis-ci.com/user/conditional-builds-stages-jobs/#conditional-jobs).

Explicitly including a job is documented [here](https://docs.travis-ci.com/user/build-matrix/#explicitly-including-jobs), and the keys supported in the matrix / jobs configuration is documented [here](https://docs.travis-ci.com/user/languages/java/#what-this-guide-covers).

## Checklist

_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
