### PR TITLE
make CustomTabs warmup crash non-fatal, Fixes #5337

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/compat/customtabs/CustomTabActivityHelper.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/customtabs/CustomTabActivityHelper.java
@@ -120,7 +120,13 @@ public class CustomTabActivityHelper implements ServiceConnectionCallback {
     @Override
     public void onServiceConnected(CustomTabsClient client) {
         mClient = client;
-        mClient.warmup(0L);
+        try {
+            mClient.warmup(0L);
+        } catch (IllegalStateException e) {
+            // Issue 5337 - some browsers like TorBrowser don't adhere to Android 8 background limits
+            // They will crash as they attempt to start services. warmup failure shouldn't be fatal though.
+            Timber.w(e, "Ignoring CustomTabs implementation that doesn't conform to Android 8 background limits");
+        }
         getSession();
     }
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
CustomTabs.warmup can crash if the underlying system WebView doesn't implement it correctly, but the CustomTabs themselves might be able to work later. So for warmup, we can eat the IllegalStateException and it should be okay (or we'll crash later, but we would have crashed anyway, so at least this way we have a chance)

Deep inspection of the problem on the related issue

## Fixes
#5337 

## Approach
Ignore IllegalStateException on CustomTabs warmup

## How Has This Been Tested?

I haven't tested it other than to make sure test suites pass. The original issue submitter @nvbln should test this once it is included in a release.

## Learning (optional, can help others)
All included on linked issue

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
