### PR TITLE
Fix display language changing bug

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -28,6 +28,7 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.OnSharedPreferenceChangeListener;
 import android.content.pm.PackageManager;
+import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.net.Uri;
 import android.os.Bundle;
@@ -38,6 +39,7 @@ import android.preference.Preference;
 import android.preference.PreferenceActivity;
 import android.preference.PreferenceCategory;
 import android.preference.PreferenceGroup;
+import android.preference.PreferenceManager;
 import android.preference.PreferenceScreen;
 import android.text.TextUtils;
 import android.view.MenuItem;
@@ -441,6 +443,19 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                     break;
                 }
                 case LANGUAGE:
+
+                    //change language fix
+                    SharedPreferences settings = AnkiDroidApp.getSharedPrefs(getBaseContext());
+                    Configuration config = getBaseContext().getResources().getConfiguration();
+
+                    String lang1 = settings.getString("language","");
+
+                    Locale locale = new Locale(lang1);
+                    Locale.setDefault(locale);
+
+                    config.locale = locale;
+                    getBaseContext().getResources().updateConfiguration(config, getBaseContext().getResources().getDisplayMetrics());
+
                     closePreferences();
                     break;
                 case "convertFenText":


### PR DESCRIPTION
- Added code that changes app Locale when changed language in settings
- This fixes the issue for a lot of languages such as Japanese, Korean, Esperanto, etc.
- Languages with locale code longer than 2 characters such as zn_CN (China), pt_BR (Brazil), and others still do not work due to another (most likely unrelated) bug.

Purpose / Description:
Changing Ankidroid language to anything does not have any effect (the language remains system default)

Fixes
[https://github.com/ankidroid/Anki-Android/issues/4729](https://github.com/ankidroid/Anki-Android/issues/4729)

Approach
Add code to update app Locale and BaseContext Configuration after choosing language.

How Has This Been Tested?
Original problem: language does not change from default language when changed in settings
Reproduce:
1. Install Ankidroid with English as system language.
2. Choose another language (such as Japanese or Korean)
3. Language will not change.

Fix tested on Android Q Emulator Pixel 2 profile and Physical Pixel 3 XL running android Pie 9.0

Solution::
[https://stackoverflow.com/a/4239680](https://stackoverflow.com/a/4239680)