### PR TITLE
chore: forward-port to new appcompat libraries, should fix #5262

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -166,7 +166,7 @@ dependencies {
     annotationProcessor "com.google.auto.service:auto-service:1.0-rc5"
 
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'androidx.appcompat:appcompat:1.0.2'
+    implementation 'androidx.appcompat:appcompat:1.1.0-beta01'
     // Note: the design support library can be quite buggy, so test everything thoroughly before updating it
     implementation 'com.google.android.material:material:1.0.0'
     implementation 'androidx.browser:browser:1.0.0'
@@ -176,7 +176,7 @@ dependencies {
     implementation 'android.arch.persistence:db-framework:1.1.1'
     implementation 'com.afollestad.material-dialogs:core:0.9.6.0'
     implementation 'com.getbase:floatingactionbutton:1.10.1'
-    implementation 'androidx.annotation:annotation:1.0.2'
+    implementation 'androidx.annotation:annotation:1.1.0'
     implementation 'org.bitbucket.cowwoc:diff-match-patch:1.2'
 
     // May need a resolution strategy for support libs to our versions

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
@@ -302,7 +302,7 @@ public class CardTemplateEditor extends AnkiActivity {
     // ----------------------------------------------------------------------------
 
     /**
-     * A {@link androidx.core.app.FragmentPagerAdapter} that returns a fragment corresponding to
+     * A {@link androidx.fragment.app.FragmentPagerAdapter} that returns a fragment corresponding to
      * one of the tabs.
      */
     public class TemplatePagerAdapter extends FragmentPagerAdapter {
@@ -310,7 +310,7 @@ public class CardTemplateEditor extends AnkiActivity {
         private long baseId = 0;
 
         public TemplatePagerAdapter(FragmentManager fm) {
-            super(fm);
+            super(fm, BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT);
         }
 
         //this is called when notifyDataSetChanged() is called

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.java
@@ -280,7 +280,7 @@ public class Statistics extends NavigationDrawerActivity implements DeckDropDown
     public class SectionsPagerAdapter extends FragmentPagerAdapter {
 
         public SectionsPagerAdapter(FragmentManager fm) {
-            super(fm);
+            super(fm, BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT);
         }
 
         //this is called when mSectionsPagerAdapter.notifyDataSetChanged() is called, so checkAndUpdate() here


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

The linked issue has a direct pointer to a reproduction via an available shared deck (thank you @weirdalsuperfan!) and some excellent sleuthing by @timrae 

The point is that the deck spinner has awful scroll behavior due to an underlying library bug, and upgrading appcompat seems to fix it, so this does the upgrade

## Fixes
Fixes #5262 

## Approach

Upgrade appcompat to 1.1.0-beta01 and fix the 2 newly deprecated API calls in the fashion documented in the library

## How Has This Been Tested?

I installed the shared deck referenced from the linked issue https://ankiweb.net/shared/info/779483253 - and I was able to see the problem. I upgraded appcompat, and I could no longer see the problem, but `./gradlew jacocoTestReport` continued to run so I think it's okay?

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [ ] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
