### PR TITLE
handle empty return from audio clip attach

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/AudioField.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/AudioField.java
@@ -118,12 +118,15 @@ public abstract class AudioField extends FieldBase implements IField {
 
     @Override
     public String getFormattedValue() {
-        File file = new File(getAudioPath());
-        if (file.exists()) {
-            return String.format("[sound:%s]", file.getName());
-        } else {
-            return "";
+        String formattedValue = "";
+        if (getAudioPath() != null) {
+            File file = new File(getAudioPath());
+            if (file.exists()) {
+                formattedValue = String.format("[sound:%s]", file.getName());
+            }
         }
+
+        return formattedValue;
     }
 
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

If you add a note, then click the paperclip on either front or back field and choose attach audio clip, then just try to save, you'll crash. This fixes that

## Fixes
#5342 

## Approach
It is okay to just back out of that screen, with a save attempt even. So just tolerate the empty field to return empty string as it was doing in other cases already

## How Has This Been Tested?

I manually reproduced the crash on emulator API28 with the same stack traces the firebase test lab found on the automated pre-launch test report for alpha72

Then I added this change and could no longer reproduce it

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
