### PR TITLE
Make Reviewer reschedule function closer to Anki Desktop

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -39,7 +39,6 @@ import android.widget.FrameLayout;
 import com.ichi2.anim.ActivityTransitionAnimation;
 import com.ichi2.anki.dialogs.ConfirmationDialog;
 import com.ichi2.anki.dialogs.IntegerDialog;
-import com.ichi2.anki.dialogs.SimpleMessageDialog;
 import com.ichi2.async.DeckTask;
 import com.ichi2.compat.CompatHelper;
 import com.ichi2.libanki.Card;
@@ -69,19 +68,13 @@ public class Reviewer extends AbstractFlashcardViewer {
         }
     };
 
-    private DeckTask.TaskListener mRepositionCardHandler =new ScheduleDeckTaskListener() {
-        protected int getToastResourceId() {
-            return R.plurals.reposition_card_dialog_acknowledge;
-        }
-    };
-
     private DeckTask.TaskListener mResetProgressCardHandler = new ScheduleDeckTaskListener() {
         protected int getToastResourceId() {
             return R.plurals.reset_cards_dialog_acknowledge;
         }
     };
 
-    /** We need to listen for and handle repositions / reschedules / resets very similarly */
+    /** We need to listen for and handle reschedules / resets very similarly */
     abstract class ScheduleDeckTaskListener extends NextCardHandler {
 
         abstract protected int getToastResourceId();
@@ -303,33 +296,6 @@ public class Reviewer extends AbstractFlashcardViewer {
         }
         return true;
     }
-
-
-    private void showRepositionCardDialog() {
-
-        // Only new cards may be repositioned
-        if (mCurrentCard.getQueue() != Card.TYPE_NEW) {
-            SimpleMessageDialog dialog = SimpleMessageDialog.newInstance(
-                    getString(R.string.vague_error),
-                    getString(R.string.reposition_card_not_new_error),
-                    false);
-            showDialogFragment(dialog);
-            return;
-        }
-
-        IntegerDialog repositionDialog = new IntegerDialog();
-        repositionDialog.setArgs(
-                getResources().getString(R.string.reposition_card_dialog_title),
-                getResources().getString(R.string.reposition_card_dialog_message),
-                5);
-        repositionDialog.setCallbackRunnable(repositionDialog.new IntRunnable() {
-            public void run() {
-                DeckTask.launchDeckTask(DeckTask.TASK_TYPE_DISMISS_MULTI, mRepositionCardHandler,
-                        new DeckTask.TaskData(new Object[]{new long[]{mCurrentCard.getId()}, Collection.DismissType.REPOSITION_CARDS, this.getInt()}));                    }
-        });
-        showDialogFragment(repositionDialog);
-    }
-
 
     private void showRescheduleCardDialog() {
         IntegerDialog rescheduleDialog = new IntegerDialog();
@@ -793,9 +759,6 @@ public class Reviewer extends AbstractFlashcardViewer {
         @Override
         public boolean onMenuItemClick(MenuItem item) {
             switch (item.getItemId()) {
-                case R.id.action_reposition_card:
-                    showRepositionCardDialog();
-                    return true;
                 case R.id.action_reschedule_card:
                     showRescheduleCardDialog();
                     return true;

--- a/AnkiDroid/src/main/res/menu/reviewer.xml
+++ b/AnkiDroid/src/main/res/menu/reviewer.xml
@@ -52,6 +52,12 @@
         android:title="@string/menu_delete_note"
         android:icon="@drawable/ic_delete_white_24dp"/>
     <item
+        android:id="@+id/action_schedule"
+        android:title="@string/card_editor_reschedule_card"
+        android:icon="@drawable/ic_card_reschedule_white">
+        <menu/>
+    </item>
+    <item
         android:id="@+id/action_search_dictionary"
         android:title="@string/menu_select"
         android:visible="false"/>
@@ -66,10 +72,4 @@
         android:id="@+id/action_select_tts"
         android:title="@string/select_tts"
         android:visible="false" />
-    <item
-        android:id="@+id/action_schedule"
-        android:title="@string/card_editor_card_scheduling"
-        android:icon="@drawable/ic_card_reschedule_white">
-        <menu />
-    </item>
 </menu>

--- a/AnkiDroid/src/main/res/menu/reviewer_schedule.xml
+++ b/AnkiDroid/src/main/res/menu/reviewer_schedule.xml
@@ -1,10 +1,7 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
     <item
-        android:id="@+id/action_reposition_card"
-        android:title="@string/card_editor_reposition_card" />
-    <item
         android:id="@+id/action_reschedule_card"
-        android:title="@string/card_editor_reschedule_card" />
+        android:title="@string/reschedule_card_dialog_message" />
     <item
         android:id="@+id/action_reset_card_progress"
         android:title="@string/card_editor_reset_card" />

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -114,7 +114,6 @@
     <string name="fact_adder_intent_title">AnkiDroid card</string>
     <string name="card_editor_add_card">Add note</string>
     <string name="card_editor_copy_card">Copy card</string>
-    <string name="card_editor_card_scheduling">Scheduling</string>
     <string name="card_editor_reposition_card">Reposition</string>
     <string name="card_editor_reset_card">Reset progress</string>
     <string name="card_editor_reschedule_card">Reschedule</string>

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -58,7 +58,7 @@
         <item quantity="other">%d cards reset</item>
     </plurals>
     <string name="reschedule_card_dialog_title">Reschedule card</string>
-    <string name="reschedule_card_dialog_message">Reschedule for review in x days:</string>
+    <string name="reschedule_card_dialog_message">Reschedule for review in x days</string>
     <plurals name="reschedule_cards_dialog_acknowledge">
         <item quantity="one">%d card rescheduled</item>
         <item quantity="other">%d cards rescheduled</item>

--- a/AnkiDroid/src/main/res/xml/preferences_custom_buttons.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_custom_buttons.xml
@@ -38,7 +38,7 @@ MENU_DISABLED = 3
             android:entries="@array/custom_button_labels"
             android:entryValues="@array/custom_button_values"
             android:key="customButtonScheduleCard"
-            android:title="@string/card_editor_card_scheduling" />
+            android:title="@string/card_editor_reschedule_card" />
         <ListPreference
             android:defaultValue="2"
             android:entries="@array/custom_button_labels"


### PR DESCRIPTION
Reschedule works a bit different in AnkiDroid compared to Anki Desktop,
in the sense that Anki Desktop pops up a custom dialog for reschedule,
which let the user choose between rescheduling as a new card (reset progress),
or rescheduling as a review card in x days (or rather between x~y days),
whereas we avoid the custom dialog on AnkiDroid because it's quite a lot of work,
and it deviates even further from material design principles than we already do.

Here I've made a few minor changes that make the implementation of the reschedule
function in the AnkiDroid reviewer a little bit closer to the original implementation
of the reschedule function in the Anki Desktop Browser:

1. Remove the "change position" action. This is a totally separate feature from reschedule
in Anki Desktop, and I argue that it only makes sense in the context of the browser,
with multiple new cards IMO

2. Rename the top level menu from "Schedule" to "Reschedule", and the second level action
to "Reschedule for review in x days". These renames put the feature back inline
with the original Anki Desktop feature, and are more intuitive IMO

3. Move the top level menu from the bottom to just after "Delete note".
Options should always be the last item in the menu to make it easy to access,
and the Reschedule feature logically should be grouped together with the other
card/note related actions.