### PR TITLE
Handle null correctly for db w/no version but stable app version

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -907,7 +907,8 @@ public class DeckPicker extends NavigationDrawerActivity implements
         }
 
         if (skip >= 2 || (preferences.getString("lastVersion", "").equals(VersionUtils.getPkgVersionName()) &&
-            getCol().getLastAnkiDroidVersion() == VersionUtils.getPkgVersionCode())) {
+                getCol().getLastAnkiDroidVersion() != null &&
+                getCol().getLastAnkiDroidVersion() == VersionUtils.getPkgVersionCode())) {
             // This is the main call when there is nothing special required
             onFinishedStartup();
             return;

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.java
@@ -230,6 +230,25 @@ public class DeckPickerTest extends RobolectricTest {
     }
 
 
+    @Test
+    public void verifyNoColVersionStableAppVersion() {
+
+        // Issue #5354 - Pretend we are 2.9alpha75, no app upgrade, but we get a collection with no db version
+        prepareUpgrade(null, 20900175, "2.9alpha75", 20900175, "2.9alpha75");
+        deckPickerController.create();
+        assertState(
+                deckPicker.startupScreensDisplayed, // method call should work
+                !deckPicker.mRecommendFullSync,     // unsure about full sync status on that one actually
+                !deckPicker.prefsUpgraded,          // not old enough to upgrade prefs
+                deckPicker.integrityChecked,        // check integrity because there was no version
+                !deckPicker.finishedStartup,        // startup won't finish because of the other work
+                !deckPicker.activityRestarted,      // activity doesn't restart because integrity check hijacks
+                null, shadowDeckPicker.getNextStartedActivity(),       // no intents should start
+                "2.9alpha75",            // we put a lastVersion now
+                20900175);
+    }
+
+
     @SuppressWarnings("PMD.ExcessiveParameterList")
     private void assertState(boolean startupScreens, boolean fullSync, boolean prefsUpgrade, boolean integrity,
                              boolean finished, boolean restart, Class intentWanted, Intent intent, String lastVersion,


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
There is a mis-handled case if the app is not upgrading based on preferences version, but there is a database that does not have our version yet. It causes a NullPointerException and crashes on startup

This can happen if you have already done the 2.9alpha74 / database-version PR, but then do a full sync from a collection in the cloud from before the 2.9alpha74 / database-version PR

This correctly demonstrates the case with a test, and fixes it

## Fixes
#5343 

## Approach
Code examination / reasoning showed a potential NPE during Long unboxing I hadn't thought about, and when I tried to tickle it with a new unit test I got the same stack I'm seeing in ACRA. I add a null check, and it seems to work.

## How Has This Been Tested?

Unit test failed before I fixed it, passes now

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
