### PR TITLE
Added missing \" to close the class attribute

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -2335,7 +2335,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
         } else {
             sb.append(QUESTION_CLASS);
         }
-        sb.append(" id=\"qa\">");
+        sb.append("\" id=\"qa\">");
         sb.append(content);
         sb.append("</div>");
         return sb.toString();


### PR DESCRIPTION
#5357 Purpose / Description
In L2338, the closing double quotes for the class attribute for the card type (question/answer) were missing. 

## Fixes
https://github.com/ankidroid/Anki-Android/issues/5356

## How Has This Been Tested?
I havent't tested it

## Checklist
_Please, go through these checks before submitting the PR._

- [x ] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x ] You have commented your code, particularly in hard-to-understand areas
- [x ] You have performed a self-review of your own code
