### PR TITLE
Adds missing quotes to generated html

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -123,10 +123,10 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
     public static final int DECK_OPTIONS = 1;
 
     /** Constant for class attribute signaling answer */
-    public static final String ANSWER_CLASS = "answer";
+    public static final String ANSWER_CLASS = "\"answer\"";
 
     /** Constant for class attribute signaling question */
-    public static final String QUESTION_CLASS = "question";
+    public static final String QUESTION_CLASS = "\"question\"";
 
     /** Max size of the font for dynamic calculation of font size */
     private static final int DYNAMIC_FONT_MAX_SIZE = 14;
@@ -2329,13 +2329,13 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
      */
     private static String enrichWithQADiv(String content, boolean isAnswer) {
         StringBuilder sb = new StringBuilder();
-        sb.append("<div class=\"");
+        sb.append("<div class=");
         if (isAnswer) {
             sb.append(ANSWER_CLASS);
         } else {
             sb.append(QUESTION_CLASS);
         }
-        sb.append("\" id=\"qa\">");
+        sb.append(" id=\"qa\">");
         sb.append(content);
         sb.append("</div>");
         return sb.toString();

--- a/api/src/main/java/com/ichi2/anki/api/Basic2Model.java
+++ b/api/src/main/java/com/ichi2/anki/api/Basic2Model.java
@@ -9,6 +9,6 @@ class Basic2Model {
     public static final String[] CARD_NAMES = {"Card 1", "Card 2"};
     // Template for the question of each card
     static final String[] QFMT = {"{{Front}}", "{{Back}}"};
-    static final String[] AFMT = {"{{FrontSide}}\n\n<hr id=answer>\n\n{{Back}}",
-            "{{FrontSide}}\n\n<hr id=answer>\n\n{{Front}}"};
+    static final String[] AFMT = {"{{FrontSide}}\n\n<hr id=\"answer\">\n\n{{Back}}",
+            "{{FrontSide}}\n\n<hr id=\"answer\">\n\n{{Front}}"};
 }

--- a/api/src/main/java/com/ichi2/anki/api/BasicModel.java
+++ b/api/src/main/java/com/ichi2/anki/api/BasicModel.java
@@ -9,5 +9,5 @@ class BasicModel {
     public static final String[] CARD_NAMES = {"Card 1"};
     // Template for the question of each card
     static final String[] QFMT = {"{{Front}}"};
-    static final String[] AFMT = {"{{FrontSide}}\n\n<hr id=answer>\n\n{{Back}}"};
+    static final String[] AFMT = {"{{FrontSide}}\n\n<hr id=\"answer\">\n\n{{Back}}"};
 }


### PR DESCRIPTION
To question and answer class tags. Removing the closing quote from the following id tag.
To Basic (Basic2) template cards' id tags

issue: #5356
