### PR TITLE
Adds missing last MIME Multipart boundary during syncing.

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HttpSyncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HttpSyncer.java
@@ -171,6 +171,7 @@ public class HttpSyncer {
             } else {
                 buf.close();
                 bos.write(buf.toString().getBytes("UTF-8"));
+                bos.write((bdry + "--\r\n").getBytes("UTF-8"));
             }
             bos.flush();
             bos.close();


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Some requests to the syncing service are malformed. It appears that Ankiweb is fine with it, but Wireshark and other tools show the issue.

Requests from HttpSyncer (and anything that inherits from it) that do not have files attached, namely full sync download requests, are missing the final MIME Multipart boundary of `--Anki-Sync-Server--`.

You can see this using Wireshark.

/meta request from before:

```--Anki-sync-boundary\r\nContent-Disposition: form-data; name="s"\r\n\r\n05daa93b\r\n--Anki-sync-boundary\r\nContent-Disposition: form-data; name="c"\r\n\r\n1\r\n--Anki-sync-boundary\r\nContent-Disposition: form-data; name="k"\r\n\r\nad83aREDACTEDee4f6c9d26\r\n--Anki-sync-boundary\r\nContent-Disposition: form-data; name="data"; filename="data"\r\nContent-Type: application/octet-stream\r\n\r\n\x1f\x8b\REDACTEDx00\x00\x00\r\n--Anki-sync-boundary--\r\n```

Note the final --Anki-sync-boundary.

a full download request from before

```--Anki-sync-boundary\r\nContent-Disposition: form-data; name="c"\r\n\r\n1\r\n--Anki-sync-boundary\r\nContent-Disposition: form-data; name="v"\r\n\r\nankidroid,2.9alpha71,android:9:Pixel 2\r\n--Anki-sync-boundary\r\nContent-Disposition: form-data; name="k"\r\n\r\nad83a66dREDACTEDe4f6c9d26\r\n```

Note the missing final boundary. :(

a full download request, after this PR:

```--Anki-sync-boundary\r\nContent-Disposition: form-data; name="c"\r\n\r\n1\r\n--Anki-sync-boundary\r\nContent-Disposition: form-data; name="v"\r\n\r\nankidroid,2.9alpha67,android:9:Android SDK built for x86\r\n--Anki-sync-boundary\r\nContent-Disposition: form-data; name="k"\r\n\r\n75b419aREDACTEDb894d12\r\n--Anki-sync-boundary--\r\n```

## Fixes
I haven't filed an issue since I expect this is not something that would ever get fixed if it didn't have a PR with it :)

## Approach
If there aren't any file objects, we add the boundary explicitly to those too.

## How Has This Been Tested?

I ran all the emulator tests.  I did full syncs, uploads and downloads, against Ankiweb, as well as incremental syncs.  I had media files, and then reran them all without media files.

## Learning (optional, can help others)
Holy moly, folks.   This was a 6 hour endeavor.  I had the Anki-Android source up in the debugger, I had Wireshark up, and a bunch of terminals.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
