### PR TITLE
Fix display of $ and \ in typed answers

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -694,11 +694,14 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
         StringBuilder sb = new StringBuilder();
         sb.append("<div");
         sb.append("><code id=typeans>");
+
+        // We have to use Matcher.quoteReplacement because the inputs here might have $ or \.
+
         if (!TextUtils.isEmpty(userAnswer)) {
             // The user did type something.
             if (userAnswer.equals(correctAnswer)) {
                 // and it was right.
-                sb.append(DiffEngine.wrapGood(correctAnswer));
+                sb.append(Matcher.quoteReplacement(DiffEngine.wrapGood(correctAnswer)));
                 sb.append("\u2714"); // Heavy check mark
             } else {
                 // Answer not correct.
@@ -706,15 +709,15 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
                 // exactly the same as the correct text.
                 String[] diffedStrings = diffEngine.diffedHtmlStrings(correctAnswer, userAnswer);
                 // We know we get back two strings.
-                sb.append(diffedStrings[0]);
+                sb.append(Matcher.quoteReplacement(diffedStrings[0]));
                 sb.append("<br>&darr;<br>");
-                sb.append(diffedStrings[1]);
+                sb.append(Matcher.quoteReplacement(diffedStrings[1]));
             }
         } else {
             if (!mUseInputTag) {
-                sb.append(DiffEngine.wrapMissing(correctAnswer));
+                sb.append(Matcher.quoteReplacement(DiffEngine.wrapMissing(correctAnswer)));
             } else {
-                sb.append(correctAnswer);
+                sb.append(Matcher.quoteReplacement(correctAnswer));
             }
         }
         sb.append("</code></div>");

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.java
@@ -1,0 +1,228 @@
+package com.ichi2.anki;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static org.junit.Assert.*;
+
+@RunWith(AndroidJUnit4.class)
+public class AbstractFlashcardViewerTest extends RobolectricTest {
+
+    public class NonabstractFlashcardViewer extends AbstractFlashcardViewer {
+        @Override
+        protected void setTitle() {
+        }
+    }
+
+    public String typeAnsAnswerFilter(String buf, String userAnswer, String correctAnswer) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        NonabstractFlashcardViewer nafv = new NonabstractFlashcardViewer();
+
+        Class[] argClasses = {String.class, String.class, String.class};
+        Method method = AbstractFlashcardViewer.class.getDeclaredMethod("typeAnsAnswerFilter", argClasses);
+        method.setAccessible(true);
+        return (String) method.invoke(nafv, buf, userAnswer, correctAnswer);
+    }
+
+    @Test
+    public void testTypeAnsAnswerFilterNormalCorrect() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        String buf = "<style>.card {\n" +
+                " font-family: arial;\n" +
+                " font-size: 20px;\n" +
+                " text-align: center;\n" +
+                " color: black;\n" +
+                " background-color: white;\n" +
+                "}\n" +
+                "</style>Type in hello\n" +
+                "[[type:Back]]\n" +
+                "\n" +
+                "<hr id=answer>\n" +
+                "\n" +
+                "$!";
+
+        String expectedOutput = "<style>.card {\n" +
+                " font-family: arial;\n" +
+                " font-size: 20px;\n" +
+                " text-align: center;\n" +
+                " color: black;\n" +
+                " background-color: white;\n" +
+                "}\n" +
+                "</style>Type in hello\n" +
+                "<div><code id=typeans><span class=\"typeGood\">hello</span>✔</code></div>\n" +
+                "\n" +
+                "<hr id=answer>\n" +
+                "\n" +
+                "$!";
+
+        assertEquals(expectedOutput, typeAnsAnswerFilter(buf, "hello", "hello"));
+    }
+
+    @Test
+    public void testTypeAnsAnswerFilterNormalIncorrect() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        String buf = "<style>.card {\n" +
+                " font-family: arial;\n" +
+                " font-size: 20px;\n" +
+                " text-align: center;\n" +
+                " color: black;\n" +
+                " background-color: white;\n" +
+                "}\n" +
+                "</style>Type in hello\n" +
+                "[[type:Back]]\n" +
+                "\n" +
+                "<hr id=answer>\n" +
+                "\n" +
+                "hello";
+
+        String expectedOutput = "<style>.card {\n" +
+                " font-family: arial;\n" +
+                " font-size: 20px;\n" +
+                " text-align: center;\n" +
+                " color: black;\n" +
+                " background-color: white;\n" +
+                "}\n" +
+                "</style>Type in hello\n" +
+                "<div><code id=typeans><span class=\"typeBad\">hello</span><br>&darr;<br><span class=\"typeMissed\">xyzzy$$$22</span></code></div>\n" +
+                "\n" +
+                "<hr id=answer>\n" +
+                "\n" +
+                "hello";
+        // Make sure $! as typed shows up as $!
+        assertEquals(expectedOutput, typeAnsAnswerFilter(buf, "hello", "xyzzy$$$22"));
+    }
+
+    @Test
+    public void testTypeAnsAnswerFilterNormalEmpty() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        String buf = "<style>.card {\n" +
+                " font-family: arial;\n" +
+                " font-size: 20px;\n" +
+                " text-align: center;\n" +
+                " color: black;\n" +
+                " background-color: white;\n" +
+                "}\n" +
+                "</style>Type in hello\n" +
+                "[[type:Back]]\n" +
+                "\n" +
+                "<hr id=answer>\n" +
+                "\n" +
+                "hello";
+
+        String expectedOutput = "<style>.card {\n" +
+                " font-family: arial;\n" +
+                " font-size: 20px;\n" +
+                " text-align: center;\n" +
+                " color: black;\n" +
+                " background-color: white;\n" +
+                "}\n" +
+                "</style>Type in hello\n" +
+                "<div><code id=typeans><span class=\"typeMissed\">hello</span></code></div>\n" +
+                "\n" +
+                "<hr id=answer>\n" +
+                "\n" +
+                "hello";
+        // Make sure $! as typed shows up as $!
+        assertEquals(expectedOutput, typeAnsAnswerFilter(buf, "", "hello"));
+    }
+
+    @Test
+    public void testTypeAnsAnswerFilterDollarSignsCorrect() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        String buf = "<style>.card {\n" +
+                " font-family: arial;\n" +
+                " font-size: 20px;\n" +
+                " text-align: center;\n" +
+                " color: black;\n" +
+                " background-color: white;\n" +
+                "}\n" +
+                "</style>Type in $!\n" +
+                "[[type:Back]]\n" +
+                "\n" +
+                "<hr id=answer>\n" +
+                "\n" +
+                "$!";
+
+        String expectedOutput = "<style>.card {\n" +
+                " font-family: arial;\n" +
+                " font-size: 20px;\n" +
+                " text-align: center;\n" +
+                " color: black;\n" +
+                " background-color: white;\n" +
+                "}\n" +
+                "</style>Type in $!\n" +
+                "<div><code id=typeans><span class=\"typeGood\">$!</span>✔</code></div>\n" +
+                "\n" +
+                "<hr id=answer>\n" +
+                "\n" +
+                "$!";
+        // Make sure $! as typed shows up as $!
+        assertEquals(expectedOutput, typeAnsAnswerFilter(buf, "$!", "$!"));
+    }
+
+    @Test
+    public void testTypeAnsAnswerFilterDollarSignsIncorrect() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        String buf = "<style>.card {\n" +
+                " font-family: arial;\n" +
+                " font-size: 20px;\n" +
+                " text-align: center;\n" +
+                " color: black;\n" +
+                " background-color: white;\n" +
+                "}\n" +
+                "</style>Type in $!\n" +
+                "[[type:Back]]\n" +
+                "\n" +
+                "<hr id=answer>\n" +
+                "\n" +
+                "$!";
+
+        String expectedOutput = "<style>.card {\n" +
+                " font-family: arial;\n" +
+                " font-size: 20px;\n" +
+                " text-align: center;\n" +
+                " color: black;\n" +
+                " background-color: white;\n" +
+                "}\n" +
+                "</style>Type in $!\n" +
+                "<div><code id=typeans><span class=\"typeBad\">$!</span><br>&darr;<br><span class=\"typeMissed\">hello</span></code></div>\n" +
+                "\n" +
+                "<hr id=answer>\n" +
+                "\n" +
+                "$!";
+        // Make sure $! as typed shows up as $!
+        assertEquals(expectedOutput, typeAnsAnswerFilter(buf, "$!", "hello"));
+    }
+
+    @Test
+    public void testTypeAnsAnswerFilterDollarSignsEmpty() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        String buf = "<style>.card {\n" +
+                " font-family: arial;\n" +
+                " font-size: 20px;\n" +
+                " text-align: center;\n" +
+                " color: black;\n" +
+                " background-color: white;\n" +
+                "}\n" +
+                "</style>Type in $!\n" +
+                "[[type:Back]]\n" +
+                "\n" +
+                "<hr id=answer>\n" +
+                "\n" +
+                "$!";
+
+        String expectedOutput = "<style>.card {\n" +
+                " font-family: arial;\n" +
+                " font-size: 20px;\n" +
+                " text-align: center;\n" +
+                " color: black;\n" +
+                " background-color: white;\n" +
+                "}\n" +
+                "</style>Type in $!\n" +
+                "<div><code id=typeans><span class=\"typeMissed\">$!</span></code></div>\n" +
+                "\n" +
+                "<hr id=answer>\n" +
+                "\n" +
+                "$!";
+        // Make sure $! as typed shows up as $!
+        assertEquals(expectedOutput, typeAnsAnswerFilter(buf, "", "$!"));
+    }
+}


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Sometimes typed answers include \ or $, which must be handled specially in Ankidroid due to the use of Matcher.

## Fixes
https://github.com/ankidroid/Anki-Android/issues/5334

## Approach
Uses Matcher.quoteReplacement, which is a slick way to have Matcher work around its own restrictions.

## How Has This Been Tested?

I made some cards, tested on an emulator.  I ran the existing tests.  None seemed to touch this.   I added some tests, but they use a private method.  Please let me know if the way I did it is not  acceptable or if it is fine.

Attached is one screenshot, although the test cases test more cases than just this.

![Screenshot_1562336363](https://user-images.githubusercontent.com/35681/60730252-510ff380-9f0a-11e9-9fe0-d3733f7a87a5.png)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
