### PR TITLE
Adds CSS to hide content until MathJax renders.

### DIFF
--- a/AnkiDroid/src/main/assets/mathjax/mathjax.css
+++ b/AnkiDroid/src/main/assets/mathjax/mathjax.css
@@ -1,0 +1,3 @@
+.hidden {
+  visibility: hidden;
+}

--- a/AnkiDroid/src/main/assets/mathjax/mathjax.css
+++ b/AnkiDroid/src/main/assets/mathjax/mathjax.css
@@ -1,3 +1,3 @@
-.hidden {
+.mathjax-hasnt-rendered-yet {
   visibility: hidden;
 }

--- a/AnkiDroid/src/main/assets/scripts/card.js
+++ b/AnkiDroid/src/main/assets/scripts/card.js
@@ -111,7 +111,7 @@ var onPageFinished = function() {
         var card = document.querySelector('.card');
         MathJax.Hub.Queue(['Typeset', MathJax.Hub, card]);
         MathJax.Hub.Queue(function () {
-            card.classList.remove("hidden");
+            card.classList.remove("mathjax-hasnt-rendered-yet");
         });
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -2107,7 +2107,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
         content = content.replace("font-weight:600;", "font-weight:700;");
 
         // CSS class for card-specific styling
-        String cardClass = "hidden card card" + (mCurrentCard.getOrd() + 1);
+        String cardClass = "mathjax-hasnt-rendered-yet card card" + (mCurrentCard.getOrd() + 1);
 
         if (mPrefCenterVertically) {
             cardClass += " vertically_centered";


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Mathjax shouldn't show the markup and then rewrite it with the rendered output.  I had set this all up before, having the card template start with a hidden css class, and then removing it when mathjax is done rendering--but I forgot to include the mathjax.css file where I defined it.  This was also creating an ugly message in logcat.

## Fixes
https://github.com/ankidroid/Anki-Android/issues/5377

## Approach
Make the hidden class actually not show things.

## How Has This Been Tested?

Verified on a device, on Mathjax and non mathjax cards.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
