### PR TITLE
Dependency updates 20190718

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -195,7 +195,7 @@ dependencies {
     api project(":api")
 
     testImplementation 'org.junit.vintage:junit-vintage-engine:5.5.0'
-    testImplementation 'org.mockito:mockito-core:2.28.2'
+    testImplementation 'org.mockito:mockito-core:3.0.0'
     testImplementation 'org.powermock:powermock-core:2.0.2'
     testImplementation 'org.powermock:powermock-module-junit4:2.0.2'
     testImplementation 'org.powermock:powermock-api-mockito2:2.0.2'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -162,7 +162,7 @@ task jacocoUnitTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest']) 
 }
 
 dependencies {
-    compileOnly "com.google.auto.service:auto-service-annotations:1.0-rc5"
+    compileOnly "com.google.auto.service:auto-service-annotations:1.0-rc6"
     annotationProcessor "com.google.auto.service:auto-service:1.0-rc5"
 
     implementation fileTree(dir: 'libs', include: ['*.jar'])

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -163,7 +163,7 @@ task jacocoUnitTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest']) 
 
 dependencies {
     compileOnly "com.google.auto.service:auto-service-annotations:1.0-rc6"
-    annotationProcessor "com.google.auto.service:auto-service:1.0-rc5"
+    annotationProcessor "com.google.auto.service:auto-service:1.0-rc6"
 
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.appcompat:appcompat:1.1.0-rc01'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -185,8 +185,8 @@ dependencies {
     implementation'ch.acra:acra-toast:5.2.1'
     implementation'ch.acra:acra-limiter:5.2.1'
 
-    implementation 'net.mikehardy:google-analytics-java7:2.0.8'
-    implementation 'com.squareup.okhttp3:okhttp:4.0.0'
+    implementation 'net.mikehardy:google-analytics-java7:2.0.10'
+    implementation 'com.squareup.okhttp3:okhttp:3.12.3'
     implementation 'com.arcao:slf4j-timber:3.1'
 
     implementation 'com.jakewharton.timber:timber:4.7.1'

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.1'
+        classpath 'com.android.tools.build:gradle:3.4.2'
         classpath "org.jacoco:org.jacoco.core:0.8.4"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

Most of these are standard but but the analytics/okhttp change is vital to support our remaining users on Android 4.x - I inadvertently snuck in an update to okhttp 4.x which is API19+ only - this fixes it but dropping okhttp back to 3.x-current

## Fixes
@milyukhin noticed it and mentioned this in #5021 (thank you Max!)

## How Has This Been Tested?

test suite in analytics package passed, and test suite here passes as well, and it's a major version of okhttp that was in use before

## Other notes

@timrae note that you seem to have some local changes (related to the 2.9 betas?) that are not reflected in upstream/master? Or maybe my local state is a little off - but I don't seem to have commits that correspond to the tags
