### PR TITLE
Deprecation: SharedPreferences Version code from int to long

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -995,11 +995,9 @@ public class DeckPicker extends NavigationDrawerActivity implements
             // to a version that contains additions to the database integrity check routine that we would
             // like to run on all collections. A missing version number is assumed to be a fresh
             // installation of AnkiDroid and we don't run the check.
-            // FIXME to use new API and change from int to long is very problematic. It's strongly typed in the XML and needs handling
-            // FIXME or it isn't backwards compatible - blows up development and may hurt users
-            int current = VersionUtils.getPkgVersionCode();
+            long current = VersionUtils.getPkgVersionCode();
             Timber.i("Current AnkiDroid version: %s", current);
-            int previous;
+            long previous;
             if (preferences.contains(UPGRADE_VERSION_KEY)) {
                 // Upgrading currently installed app
                 previous = getPreviousVersion(preferences, current);
@@ -1007,7 +1005,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
                 // Fresh install
                 previous = current;
             }
-            preferences.edit().putInt(UPGRADE_VERSION_KEY, current).apply();
+            preferences.edit().putLong(UPGRADE_VERSION_KEY, current).apply();
 
             // New version, clear out old exception report limits
             AnkiDroidApp.deleteACRALimiterData(this);
@@ -1131,22 +1129,30 @@ public class DeckPicker extends NavigationDrawerActivity implements
         }
     }
 
-    protected int getPreviousVersion(SharedPreferences preferences, int current) {
-        int previous;
+    protected long getPreviousVersion(SharedPreferences preferences, long current) {
+        long previous;
         try {
-            previous = preferences.getInt(UPGRADE_VERSION_KEY, current);
-            Timber.i("Previous AnkiDroid version: %s", previous);
+            previous = preferences.getLong(UPGRADE_VERSION_KEY, current);
         } catch (ClassCastException e) {
-            // Previous versions stored this as a string.
-            String s = preferences.getString(UPGRADE_VERSION_KEY, "");
-            // The last version of AnkiDroid that stored this as a string was 2.0.2.
-            // We manually set the version here, but anything older will force a DB check.
-            if ("2.0.2".equals(s)) {
-                previous = 40;
-            } else {
-                previous = 0;
+            try {
+                // set 20900203 to default value, as it's the latest version that stores integer in shared prefs
+                previous = preferences.getInt(UPGRADE_VERSION_KEY, 20900203);
+            } catch (ClassCastException cce) {
+                // Previous versions stored this as a string.
+                String s = preferences.getString(UPGRADE_VERSION_KEY, "");
+                // The last version of AnkiDroid that stored this as a string was 2.0.2.
+                // We manually set the version here, but anything older will force a DB check.
+                if ("2.0.2".equals(s)) {
+                    previous = 40;
+                } else {
+                    previous = 0;
+                }
             }
+            Timber.d("Updating shared preferences stored key %s type to long", UPGRADE_VERSION_KEY);
+            // Expected Editor.putLong to be called later to update the value in shared prefs
+            preferences.edit().remove(UPGRADE_VERSION_KEY).apply();
         }
+        Timber.i("Previous AnkiDroid version: %s", previous);
         return previous;
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -999,10 +999,8 @@ public class DeckPicker extends NavigationDrawerActivity implements
             int current = VersionUtils.getPkgVersionCode();
             Timber.i("Current AnkiDroid version: %s", current);
             int previous;
-            if (!preferences.contains("lastUpgradeVersion")) {
-                // Fresh install
-                previous = current;
-            } else {
+            if (preferences.contains("lastUpgradeVersion")) {
+                // Upgrading currently installed app
                 try {
                     previous = preferences.getInt("lastUpgradeVersion", current);
                     Timber.i("Previous AnkiDroid version: %s", previous);
@@ -1010,14 +1008,16 @@ public class DeckPicker extends NavigationDrawerActivity implements
                     // Previous versions stored this as a string.
                     String s = preferences.getString("lastUpgradeVersion", "");
                     // The last version of AnkiDroid that stored this as a string was 2.0.2.
-                    // We manually set the version here, but anything older will force a DB
-                    // check.
+                    // We manually set the version here, but anything older will force a DB check.
                     if ("2.0.2".equals(s)) {
                         previous = 40;
                     } else {
                         previous = 0;
                     }
                 }
+            } else {
+                // Fresh install
+                previous = current;
             }
             preferences.edit().putInt("lastUpgradeVersion", current).apply();
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -137,6 +137,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
     public static final int RESULT_MEDIA_EJECTED = 202;
     public static final int RESULT_DB_ERROR = 203;
 
+    protected static final String UPGRADE_VERSION_KEY = "lastUpgradeVersion";
 
     /**
      * Available options performed by other activities (request codes for onActivityResult())
@@ -999,27 +1000,14 @@ public class DeckPicker extends NavigationDrawerActivity implements
             int current = VersionUtils.getPkgVersionCode();
             Timber.i("Current AnkiDroid version: %s", current);
             int previous;
-            if (preferences.contains("lastUpgradeVersion")) {
+            if (preferences.contains(UPGRADE_VERSION_KEY)) {
                 // Upgrading currently installed app
-                try {
-                    previous = preferences.getInt("lastUpgradeVersion", current);
-                    Timber.i("Previous AnkiDroid version: %s", previous);
-                } catch (ClassCastException e) {
-                    // Previous versions stored this as a string.
-                    String s = preferences.getString("lastUpgradeVersion", "");
-                    // The last version of AnkiDroid that stored this as a string was 2.0.2.
-                    // We manually set the version here, but anything older will force a DB check.
-                    if ("2.0.2".equals(s)) {
-                        previous = 40;
-                    } else {
-                        previous = 0;
-                    }
-                }
+                previous = getPreviousVersion(preferences, current);
             } else {
                 // Fresh install
                 previous = current;
             }
-            preferences.edit().putInt("lastUpgradeVersion", current).apply();
+            preferences.edit().putInt(UPGRADE_VERSION_KEY, current).apply();
 
             // New version, clear out old exception report limits
             AnkiDroidApp.deleteACRALimiterData(this);
@@ -1143,6 +1131,24 @@ public class DeckPicker extends NavigationDrawerActivity implements
         }
     }
 
+    protected int getPreviousVersion(SharedPreferences preferences, int current) {
+        int previous;
+        try {
+            previous = preferences.getInt(UPGRADE_VERSION_KEY, current);
+            Timber.i("Previous AnkiDroid version: %s", previous);
+        } catch (ClassCastException e) {
+            // Previous versions stored this as a string.
+            String s = preferences.getString(UPGRADE_VERSION_KEY, "");
+            // The last version of AnkiDroid that stored this as a string was 2.0.2.
+            // We manually set the version here, but anything older will force a DB check.
+            if ("2.0.2".equals(s)) {
+                previous = 40;
+            } else {
+                previous = 0;
+            }
+        }
+        return previous;
+    }
 
     private void upgradePreferences(long previousVersionCode) {
         SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(getBaseContext());

--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
@@ -17,6 +17,7 @@
 package com.ichi2.compat;
 
 import android.content.Context;
+import android.content.pm.PackageInfo;
 import android.os.StatFs;
 import android.speech.tts.TextToSpeech;
 import android.text.Spanned;
@@ -83,5 +84,6 @@ public interface Compat {
     /** TextToSpeech API. {@link Compat#initTtsParams} should be called before calling {@link Compat#speak*/
     Object initTtsParams();
     int speak(TextToSpeech tts, String text, int queueMode, Object ttsParams, String utteranceId);
+    long getVersionCode(PackageInfo pInfo);
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatHelper.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatHelper.java
@@ -27,7 +27,9 @@ public class CompatHelper {
 
     private CompatHelper() {
 
-        if (getSdkVersion() >= 26) {
+        if (getSdkVersion() >= 28) {
+            mCompat = new CompatV28();
+        } else if (getSdkVersion() >= 26) {
             mCompat = new CompatV26();
         } else if (getSdkVersion() >= 24) {
             mCompat = new CompatV24();

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV16.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV16.java
@@ -3,6 +3,7 @@ package com.ichi2.compat;
 
 import android.annotation.TargetApi;
 import android.content.Context;
+import android.content.pm.PackageInfo;
 import android.content.res.TypedArray;
 
 import androidx.annotation.NonNull;
@@ -198,4 +199,9 @@ public class CompatV16 implements Compat {
         return tts.speak(text, queueMode, params);
     }
 
+    @Override
+    @SuppressWarnings("deprecation")
+    public long getVersionCode(PackageInfo pInfo) {
+        return pInfo.versionCode;
+    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV28.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV28.java
@@ -1,0 +1,14 @@
+package com.ichi2.compat;
+
+import android.annotation.TargetApi;
+import android.content.pm.PackageInfo;
+
+/** Implementation of {@link Compat} for SDK level 28 */
+@TargetApi(28)
+public class CompatV28 extends CompatV26 implements Compat {
+
+    @Override
+    public long getVersionCode(PackageInfo pInfo) {
+        return pInfo.getLongVersionCode() ;
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/utils/VersionUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/VersionUtils.java
@@ -5,6 +5,8 @@ import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 
 import com.ichi2.anki.AnkiDroidApp;
+import com.ichi2.compat.Compat;
+import com.ichi2.compat.CompatHelper;
 
 import timber.log.Timber;
 
@@ -13,6 +15,7 @@ import timber.log.Timber;
  */
 public class VersionUtils {
 
+    private static Compat compat = CompatHelper.getCompat();
 
     /**
      * Get package name as defined in the manifest.
@@ -53,13 +56,13 @@ public class VersionUtils {
     /**
      * Get the package versionCode as defined in the manifest.
      */
-    @SuppressWarnings("deprecation") // tracked as #5018 in github
-    public static int getPkgVersionCode() {
+    public static long getPkgVersionCode() {
         Context context = AnkiDroidApp.getInstance();
         try {
             PackageInfo pInfo = context.getPackageManager().getPackageInfo(context.getPackageName(), 0);
-            Timber.d("getPkgVersionCode() is %s", pInfo.versionCode);
-            return pInfo.versionCode;
+            long versionCode = compat.getVersionCode(pInfo);
+            Timber.d("getPkgVersionCode() is %s", versionCode);
+            return versionCode;
         } catch (PackageManager.NameNotFoundException e) {
             Timber.e(e, "Couldn't find package named %s", context.getPackageName());
         } catch (NullPointerException npe) {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import androidx.test.core.app.ActivityScenario;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import android.content.SharedPreferences;
+import android.content.SharedPreferences.Editor;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -17,6 +18,9 @@ import static com.ichi2.anki.DeckPicker.UPGRADE_VERSION_KEY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(AndroidJUnit4.class)
@@ -60,66 +64,93 @@ public class DeckPickerTest extends RobolectricTest {
     }
 
     @Test
-    public void getPreviousVersion_from201to292() {
+    public void getPreviousVersionUpgradeFrom201to292() {
         int newVersion = 20900302; // 2.9.2
 
         SharedPreferences preferences = mock(SharedPreferences.class);
+        when(preferences.getLong(UPGRADE_VERSION_KEY, newVersion)).thenThrow(ClassCastException.class);
         when(preferences.getInt(UPGRADE_VERSION_KEY, newVersion)).thenThrow(ClassCastException.class);
         when(preferences.getString(UPGRADE_VERSION_KEY, "")).thenReturn("2.0.1");
 
+        Editor editor = mock(Editor.class);
+        when(preferences.edit()).thenReturn(editor);
+        Editor updated = mock(Editor.class);
+        when(editor.remove(UPGRADE_VERSION_KEY)).thenReturn(updated);
+
         try (ActivityScenario<DeckPicker> scenario = ActivityScenario.launch(DeckPicker.class)) {
             scenario.onActivity(deckPicker -> {
-                int previousVersion = deckPicker.getPreviousVersion(preferences, newVersion);
+                long previousVersion = deckPicker.getPreviousVersion(preferences, newVersion);
                 assertEquals(0, previousVersion);
             });
         }
+        verify(editor, times(1)).remove(UPGRADE_VERSION_KEY);
+        verify(updated, times(1)).apply();
     }
 
     @Test
-    public void getPreviousVersion_from202to292() {
-        int newVersion = 20900302; // 2.9.2
+    public void getPreviousVersionUpgradeFrom202to292() {
+        long newVersion = 20900302; // 2.9.2
 
         SharedPreferences preferences = mock(SharedPreferences.class);
-        when(preferences.getInt(UPGRADE_VERSION_KEY, newVersion)).thenThrow(ClassCastException.class);
+        when(preferences.getLong(UPGRADE_VERSION_KEY, newVersion)).thenThrow(ClassCastException.class);
+        when(preferences.getInt(UPGRADE_VERSION_KEY, 20900203)).thenThrow(ClassCastException.class);
         when(preferences.getString(UPGRADE_VERSION_KEY, "")).thenReturn("2.0.2");
+
+        Editor editor = mock(Editor.class);
+        when(preferences.edit()).thenReturn(editor);
+        Editor updated = mock(Editor.class);
+        when(editor.remove(UPGRADE_VERSION_KEY)).thenReturn(updated);
 
         try (ActivityScenario<DeckPicker> scenario = ActivityScenario.launch(DeckPicker.class)) {
             scenario.onActivity(deckPicker -> {
-                int previousVersion = deckPicker.getPreviousVersion(preferences, newVersion);
+                long previousVersion = deckPicker.getPreviousVersion(preferences, newVersion);
                 assertEquals(40, previousVersion);
             });
         }
+        verify(editor, times(1)).remove(UPGRADE_VERSION_KEY);
+        verify(updated, times(1)).apply();
     }
 
     @Test
-    public void getPreviousVersion_version203() {
-        int prevVersion = 20030301; // 2.0.3
-        int newVersion = 20900302;  // 2.9.2
-
-        SharedPreferences preferences = mock(SharedPreferences.class);
-        when(preferences.getInt(UPGRADE_VERSION_KEY, newVersion)).thenReturn(prevVersion);
-
-        try (ActivityScenario<DeckPicker> scenario = ActivityScenario.launch(DeckPicker.class)) {
-            scenario.onActivity(deckPicker -> {
-                int previousVersion = deckPicker.getPreviousVersion(preferences, newVersion);
-                assertEquals(prevVersion, previousVersion);
-            });
-        }
-    }
-
-    @Test
-    public void getPreviousVersion_version291() {
+    public void getPreviousVersionUpgradeFrom281to291() {
         int prevVersion = 20800301; // 2.8.1
-        int newVersion = 20900301;  // 2.9.1
+        long newVersion = 20900301; // 2.9.1
 
         SharedPreferences preferences = mock(SharedPreferences.class);
-        when(preferences.getInt(UPGRADE_VERSION_KEY, newVersion)).thenReturn(prevVersion);
+        when(preferences.getLong(UPGRADE_VERSION_KEY, newVersion)).thenThrow(ClassCastException.class);
+        when(preferences.getInt(UPGRADE_VERSION_KEY, 20900203)).thenReturn(prevVersion);
+
+        Editor editor = mock(Editor.class);
+        when(preferences.edit()).thenReturn(editor);
+        Editor updated = mock(Editor.class);
+        when(editor.remove(UPGRADE_VERSION_KEY)).thenReturn(updated);
 
         try (ActivityScenario<DeckPicker> scenario = ActivityScenario.launch(DeckPicker.class)) {
             scenario.onActivity(deckPicker -> {
-                int previousVersion = deckPicker.getPreviousVersion(preferences, newVersion);
+                long previousVersion = deckPicker.getPreviousVersion(preferences, newVersion);
                 assertEquals(prevVersion, previousVersion);
             });
         }
+        verify(editor, times(1)).remove(UPGRADE_VERSION_KEY);
+        verify(updated, times(1)).apply();
+    }
+
+    @Test
+    public void getPreviousVersionUpgradeFrom291to292() {
+        long prevVersion = 20900301; // 2.9.1
+        long newVersion = 20900302;  // 2.9.2
+
+        SharedPreferences preferences = mock(SharedPreferences.class);
+        when(preferences.getLong(UPGRADE_VERSION_KEY, newVersion)).thenReturn(prevVersion);
+        Editor editor = mock(Editor.class);
+        when(preferences.edit()).thenReturn(editor);
+
+        try (ActivityScenario<DeckPicker> scenario = ActivityScenario.launch(DeckPicker.class)) {
+            scenario.onActivity(deckPicker -> {
+                long previousVersion = deckPicker.getPreviousVersion(preferences, newVersion);
+                assertEquals(prevVersion, previousVersion);
+            });
+        }
+        verify(editor, never()).remove(UPGRADE_VERSION_KEY);
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.java
@@ -4,6 +4,7 @@ import android.content.Context;
 
 import androidx.test.core.app.ActivityScenario;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+import android.content.SharedPreferences;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -12,8 +13,11 @@ import org.robolectric.annotation.LooperMode;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.ichi2.anki.DeckPicker.UPGRADE_VERSION_KEY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @RunWith(AndroidJUnit4.class)
 @LooperMode(LooperMode.Mode.PAUSED)
@@ -51,6 +55,70 @@ public class DeckPickerTest extends RobolectricTest {
                 assertNull(deckPicker.rewriteError(1));
                 assertNull(deckPicker.rewriteError(Integer.MIN_VALUE));
                 assertNull(deckPicker.rewriteError(Integer.MAX_VALUE));
+            });
+        }
+    }
+
+    @Test
+    public void getPreviousVersion_from201to292() {
+        int newVersion = 20900302; // 2.9.2
+
+        SharedPreferences preferences = mock(SharedPreferences.class);
+        when(preferences.getInt(UPGRADE_VERSION_KEY, newVersion)).thenThrow(ClassCastException.class);
+        when(preferences.getString(UPGRADE_VERSION_KEY, "")).thenReturn("2.0.1");
+
+        try (ActivityScenario<DeckPicker> scenario = ActivityScenario.launch(DeckPicker.class)) {
+            scenario.onActivity(deckPicker -> {
+                int previousVersion = deckPicker.getPreviousVersion(preferences, newVersion);
+                assertEquals(0, previousVersion);
+            });
+        }
+    }
+
+    @Test
+    public void getPreviousVersion_from202to292() {
+        int newVersion = 20900302; // 2.9.2
+
+        SharedPreferences preferences = mock(SharedPreferences.class);
+        when(preferences.getInt(UPGRADE_VERSION_KEY, newVersion)).thenThrow(ClassCastException.class);
+        when(preferences.getString(UPGRADE_VERSION_KEY, "")).thenReturn("2.0.2");
+
+        try (ActivityScenario<DeckPicker> scenario = ActivityScenario.launch(DeckPicker.class)) {
+            scenario.onActivity(deckPicker -> {
+                int previousVersion = deckPicker.getPreviousVersion(preferences, newVersion);
+                assertEquals(40, previousVersion);
+            });
+        }
+    }
+
+    @Test
+    public void getPreviousVersion_version203() {
+        int prevVersion = 20030301; // 2.0.3
+        int newVersion = 20900302;  // 2.9.2
+
+        SharedPreferences preferences = mock(SharedPreferences.class);
+        when(preferences.getInt(UPGRADE_VERSION_KEY, newVersion)).thenReturn(prevVersion);
+
+        try (ActivityScenario<DeckPicker> scenario = ActivityScenario.launch(DeckPicker.class)) {
+            scenario.onActivity(deckPicker -> {
+                int previousVersion = deckPicker.getPreviousVersion(preferences, newVersion);
+                assertEquals(prevVersion, previousVersion);
+            });
+        }
+    }
+
+    @Test
+    public void getPreviousVersion_version291() {
+        int prevVersion = 20800301; // 2.8.1
+        int newVersion = 20900301;  // 2.9.1
+
+        SharedPreferences preferences = mock(SharedPreferences.class);
+        when(preferences.getInt(UPGRADE_VERSION_KEY, newVersion)).thenReturn(prevVersion);
+
+        try (ActivityScenario<DeckPicker> scenario = ActivityScenario.launch(DeckPicker.class)) {
+            scenario.onActivity(deckPicker -> {
+                int previousVersion = deckPicker.getPreviousVersion(preferences, newVersion);
+                assertEquals(prevVersion, previousVersion);
             });
         }
     }


### PR DESCRIPTION
## Purpose / Description
#5018 
Extracts method to `getPreviousVersion`, which supports other types (`int`, `String`) previously stored in shared preferences, as well as the new one `long`.

## Approach
Created new class `CompatV28.java`

## How Has This Been Tested?
Added few unit tests.
