### PR TITLE
Dependency updates 20190813

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -172,7 +172,7 @@ dependencies {
     implementation 'androidx.browser:browser:1.0.0'
     implementation 'androidx.exifinterface:exifinterface:1.0.0'
     implementation 'androidx.recyclerview:recyclerview:1.0.0'
-    implementation 'io.requery:sqlite-android:3.28.0'
+    implementation 'io.requery:sqlite-android:3.29.0'
     implementation 'android.arch.persistence:db-framework:1.1.1'
     implementation 'com.afollestad.material-dialogs:core:0.9.6.0'
     implementation 'com.getbase:floatingactionbutton:1.10.1'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -194,7 +194,7 @@ dependencies {
     implementation 'org.jsoup:jsoup:1.12.1'
     api project(":api")
 
-    testImplementation 'org.junit.vintage:junit-vintage-engine:5.5.0'
+    testImplementation 'org.junit.vintage:junit-vintage-engine:5.5.1'
     testImplementation 'org.mockito:mockito-core:3.0.0'
     testImplementation 'org.powermock:powermock-core:2.0.2'
     testImplementation 'org.powermock:powermock-module-junit4:2.0.2'

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -43,7 +43,7 @@ android {
 
 dependencies {
     api fileTree(dir: 'libs', include: ['*.jar'])
-    testImplementation 'org.junit.vintage:junit-vintage-engine:5.5.0'
+    testImplementation 'org.junit.vintage:junit-vintage-engine:5.5.1'
     testImplementation "org.robolectric:robolectric:4.2.1"
 }
 


### PR DESCRIPTION

Standard periodic dependency update

These are minor versions - and the sqlite one has performance improvements but no bugfixes, so it's optional to put it in 2.9. Not expected to cause problems, but not going to fix problems either.

So I would not merge to release-2.9

https://sqlite.org/releaselog/3_29_0.html