### PR TITLE
Issue5409/status bar dark mode

### DIFF
--- a/AnkiDroid/src/main/res/values-v21/styles.xml
+++ b/AnkiDroid/src/main/res/values-v21/styles.xml
@@ -8,9 +8,11 @@
     </style>
     <style name="Theme_Dark_Compat" parent="Theme_Dark">
         <item name="currentDeckBackground">@drawable/item_background_selected</item>
+        <item name="android:navigationBarColor">@color/black</item>
     </style>
     <style name="Theme_Black_Compat" parent="Theme_Dark.Black">
         <item name="currentDeckBackground">@drawable/item_background_selected</item>
+        <item name="android:navigationBarColor">@color/black</item>
     </style>
 
     <style name="menu_labels_style">


### PR DESCRIPTION
## Purpose / Description
In Night Mode , Color of the Navigation Bar was white which didn't do any good & was needed to be changed to fit the meaning of Night Mode  .

## Fixes
[Issue Reported by User ](https://github.com/ankidroid/Anki-Android/issues/5409#issue-481971673)

## Approach

[Code Snippet](https://github.com/ankidroid/Anki-Android/issues/5409#issuecomment-523704480)

## How Has This Been Tested?

It has been Tested Manually , Here is the Link for the screenshots 
[Manual Test](https://github.com/ankidroid/Anki-Android/issues/5409#issuecomment-524518671)


