### PR TITLE
Bump com.github.triplet.play from 2.2.1 to 2.3.0

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -1,6 +1,6 @@
 plugins {
  // Gradle plugin portal 
- id 'com.github.triplet.play' version '2.2.1'
+ id 'com.github.triplet.play' version '2.3.0'
 }
 
 apply plugin: 'com.android.application'


### PR DESCRIPTION
Bumps com.github.triplet.play from 2.2.1 to 2.3.0.

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>

## Pull Request template

## Purpose / Description

@timrae This was delayed because it was only compatible with gradle plugin 3.5.0 and higher (!?)

At any rate, it's not that important but similar to #5419 keeping the build/release toolchain current while it's easy helps support release branches later I think. This shouldn't affect code so it either works or it doesn't, thus should be okay to cherrypick?
