### PR TITLE
Dependency updates 20190906

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -186,7 +186,7 @@ dependencies {
     implementation'ch.acra:acra-limiter:5.2.1'
 
     implementation 'net.mikehardy:google-analytics-java7:2.0.10'
-    implementation 'com.squareup.okhttp3:okhttp:3.12.3'
+    implementation 'com.squareup.okhttp3:okhttp:3.12.4'
     implementation 'com.arcao:slf4j-timber:3.1'
 
     implementation 'com.jakewharton.timber:timber:4.7.1'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -166,7 +166,7 @@ dependencies {
     annotationProcessor "com.google.auto.service:auto-service:1.0-rc6"
 
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'androidx.appcompat:appcompat:1.1.0-rc01'
+    implementation 'androidx.appcompat:appcompat:1.1.0'
     // Note: the design support library can be quite buggy, so test everything thoroughly before updating it
     implementation 'com.google.android.material:material:1.0.0'
     implementation 'androidx.browser:browser:1.0.0'


### PR DESCRIPTION
@timrae this takes appcompat from rc1 to general release, and the okhttp is a specific SDK-check to fix a crash bug on Android 4.x devices within our supported SDK range (I checked their diff)

Both seem important. I would merge this and cherry-pick them both (assuming CI agrees with me and goes green)
