### PR TITLE
Fix French translation of “Lapses” in preferences

### DIFF
--- a/AnkiDroid/src/main/res/values-fr/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-fr/10-preferences.xml
@@ -205,7 +205,7 @@
     </plurals>
     <string name="deck_conf_new_cards">Nouvelles cartes</string>
     <string name="deck_conf_rev_cards">Révisions</string>
-    <string name="deck_conf_lps_cards">Intervalles</string>
+    <string name="deck_conf_lps_cards">Oublis</string>
     <string name="deck_conf_general">Général</string>
     <string name="deck_conf_reminders">Rappels</string>
     <string name="deck_conf_steps">Intervalle (en minutes)</string>


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
I have always found this translation confusing. In the context “Lapses” is really about forgotten cards, so it makes more sense to translate it as [“Oublis”](https://en.wiktionary.org/wiki/oubli) in French. I haven't found a better alternative (http://www.synonymo.fr/synonyme/oubli).

## Fixes
There does not seem to be a corresponding issue.

## Approach
Use a more accurate translation.

## How Has This Been Tested?
I am not willing to install the apparatus to build an Android project, but the replacement string is only ASCII/Basic Latin, and is made of fewer characters than the original one. So I highly doubt it will cause any trouble.

## Learning (optional, can help others)
Finally decided to get this fix after noticing the mistranslation once again. Looked for AnkiDroid GitHub project, checked it was not a mirror, went in main “AnkiDroid/” directory, followed to “src/”, then “main/” as best guesses. Tried “assets/” but it did not seem like it contained translation files, so backtracked. Went to “res/” instead, noticed “values-XY/” region directories, so opened “values-fr/”. Looked up “Intervalles” in the first two global files but found nothing relevant, scanned the names of the other files, noticed “10-preferences.xml”, found the string here (checked with surrounding values for the context), edited, replaced, made commit, made PR.

_Links to blog posts, patterns, libraries or addons used to solve this problem_

Well, I did use [Mozilla Firefox](https://www.mozilla.org/fr/firefox/) on [Debian buster](https://www.debian.org/) with [Linux 4.19.0-5](https://www.kernel.org/) using a personal computer based on an [i5-4210H CPU](https://ark.intel.com/content/www/us/en/ark/products/78929/intel-core-i5-4210h-processor-3m-cache-up-to-3-50-ghz.html). But maybe it's all in a [simulation](https://en.wikipedia.org/wiki/Simulation_hypothesis).

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
