### PR TITLE
Stop all sounds on card deletion

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1195,6 +1195,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
                 .negativeText(res.getString(R.string.dialog_cancel))
                 .onPositive((dialog, which) -> {
                     Timber.i("AbstractFlashcardViewer:: OK button pressed to delete note %d", mCurrentCard.getNid());
+                    mSoundPlayer.stopSounds();
                     dismiss(Collection.DismissType.DELETE_NOTE);
                 })
                 .build().show();


### PR DESCRIPTION
## Purpose / Description
This PR fixes an issue where the card audio would keep playing after card deletion.

## Fixes
Issue #5391.

## Approach
All sounds are stopped after the user confirms deletion of the card.

## How Has This Been Tested?
A new deck was created containing a card with an (recorded) audio attachment. Another card with only text was added. The first card was displayed and deleted while audio was still playing.
With the suggested change, the audio stops before the next card is displayed.
This has been tested two times on a physical device.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code