### PR TITLE
Allow connections to user-trusted CAs

### DIFF
--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -84,7 +84,8 @@
         android:label="@string/app_name"
         android:windowSoftInputMode="adjustResize"
         android:usesCleartextTraffic="true"
-        android:largeHeap="true">
+        android:largeHeap="true"
+        android:networkSecurityConfig="@xml/network_security_config">
         <activity
             android:name="com.ichi2.anki.IntentHandler"
             android:configChanges="keyboardHidden|orientation|screenSize|locale"

--- a/AnkiDroid/src/main/res/xml/network_security_config.xml
+++ b/AnkiDroid/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config>
+        <trust-anchors>
+            <!-- Trust preinstalled CAs -->
+            <certificates src="system" />
+            <!-- Additionally trust user added CAs -->
+            <certificates src="user" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>


### PR DESCRIPTION
For custom sync servers. Fixes #5423; details are there.

## Approach
The Android documentation acknowledges the problem and suggests a simple fix [here](https://android-developers.googleblog.com/2016/07/changes-to-trusted-certificate.html). I have implemented that fix.

## How Has This Been Tested?

It has not been tested. I currently have no Android development environment. I do not anticipate problems, though, as this is a simple XML fix provided in the Android documentation.

## Checklist
- [ x ] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [ x ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ x ] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ x ] You have commented your code, particularly in hard-to-understand areas
- [ x ] You have performed a self-review of your own code
