### PR TITLE
Fix-Issue5426 : Default Format of Recording changed from 3gp to mp4

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicAudioRecordingFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicAudioRecordingFieldController.java
@@ -22,6 +22,7 @@ package com.ichi2.anki.multimediacard.fields;
 import android.content.Context;
 import android.content.Intent;
 
+import android.view.View;
 import android.widget.LinearLayout;
 
 import com.ichi2.anki.CollectionHelper;
@@ -62,7 +63,9 @@ public class BasicAudioRecordingFieldController extends FieldControllerBase impl
             try {
                 Collection col = CollectionHelper.getInstance().getCol(context);
                 File storingDirectory = new File(col.getMedia().dir());
-                tempAudioPath = File.createTempFile("ankidroid_audiorec", ".3gp", storingDirectory).getAbsolutePath();
+                tempAudioPath = File.createTempFile("ankidroid_audiorec", ".mp4", storingDirectory).getAbsolutePath();
+                Timber.i("Name of the File is : " + tempAudioPath);
+
             } catch (IOException e) {
                 Timber.e(e, "Could not create temporary audio file.");
                 tempAudioPath = null;
@@ -71,10 +74,10 @@ public class BasicAudioRecordingFieldController extends FieldControllerBase impl
 
         mAudioView = AudioView.createRecorderInstance(mActivity, R.drawable.av_play, R.drawable.av_pause,
                 R.drawable.av_stop, R.drawable.av_rec, R.drawable.av_rec_stop, tempAudioPath);
-        mAudioView.setOnRecordingFinishEventListener(v -> {
+        mAudioView.setOnRecordingFinishEventListener((View v ,String AudioPath) -> {
             // currentFilePath.setText("Recording done, you can preview it. Hit save after finish");
             // FIXME is this okay if it is still null?
-            mField.setAudioPath(tempAudioPath);
+            mField.setAudioPath(AudioPath);
             mField.setHasTemporaryMedia(true);
         });
         layout.addView(mAudioView, LinearLayout.LayoutParams.MATCH_PARENT);


### PR DESCRIPTION
## Default Audio  Recording Format

This commit is a fix to [Issue5426](https://github.com/ankidroid/Anki-Android/issues/5426) .
Default Audio Recording Format was 3gp in Earlier Version which required to be changed to mp4 so as to be compatible on all Devices .

## Fixes
Fixes #5426

## Approach

Now Default Format has been Set to mp4  . 

## How Has This Been Tested?

I have Tested it manually on AnkiWeb , Ankidroid , AnkiDesktop 

[https://developer.android.com/guide/topics/media/media-formats](https://developer.android.com/guide/topics/media/media-formats)
[https://stackoverflow.com/questions/4886365/androidhow-to-get-media-recorder-output-in-mp3-format](https://stackoverflow.com/questions/4886365/androidhow-to-get-media-recorder-output-in-mp3-format)

