### PR TITLE
Issue5409 : Fix Navigation Bar Color in Night Mode

### DIFF
--- a/AnkiDroid/src/main/res/values/theme_black.xml
+++ b/AnkiDroid/src/main/res/values/theme_black.xml
@@ -88,7 +88,6 @@
 
     <!-- Preferences screens -->
     <style name="LegacyActionBarBlack" parent="Theme_Dark.Black">
-        <item name="android:navigationBarColor">@color/black</item>
         <item name="windowActionBar">true</item>
         <item name="windowNoTitle">false</item>
         <item name="android:textColor">@color/prefs_item_dark</item>

--- a/AnkiDroid/src/main/res/values/theme_black.xml
+++ b/AnkiDroid/src/main/res/values/theme_black.xml
@@ -88,6 +88,7 @@
 
     <!-- Preferences screens -->
     <style name="LegacyActionBarBlack" parent="Theme_Dark.Black">
+        <item name="android:navigationBarColor">@color/black</item>
         <item name="windowActionBar">true</item>
         <item name="windowNoTitle">false</item>
         <item name="android:textColor">@color/prefs_item_dark</item>

--- a/AnkiDroid/src/main/res/values/theme_dark.xml
+++ b/AnkiDroid/src/main/res/values/theme_dark.xml
@@ -97,6 +97,7 @@
     <!-- Preferences screens -->
     <!-- Legacy action bar  (used in Preferences with no explicit Toolbar) -->
     <style name="LegacyActionBarDark" parent="Theme_Dark">
+        <item name="android:navigationBarColor">@color/black</item>
         <item name="windowActionBar">true</item>
         <item name="windowNoTitle">false</item>
         <item name="android:textColor">@color/prefs_item_dark</item>

--- a/AnkiDroid/src/main/res/values/theme_dark.xml
+++ b/AnkiDroid/src/main/res/values/theme_dark.xml
@@ -97,7 +97,6 @@
     <!-- Preferences screens -->
     <!-- Legacy action bar  (used in Preferences with no explicit Toolbar) -->
     <style name="LegacyActionBarDark" parent="Theme_Dark">
-        <item name="android:navigationBarColor">@color/black</item>
         <item name="windowActionBar">true</item>
         <item name="windowNoTitle">false</item>
         <item name="android:textColor">@color/prefs_item_dark</item>


### PR DESCRIPTION
## Purpose / Description

Naivagation Bar Color has been fixed to Black Color in Night Mode  .

## Fixes

[https://github.com/ankidroid/Anki-Android/issues/5409](https://github.com/ankidroid/Anki-Android/issues/5409)

## How Has This Been Tested?

Tested Manually on Samsung Galaxy A50 , Android 9 ( Pie ) 

Below are the Steps :
- Open AnkiDroid App 
- Open Side View Menu
- Set the Night Mode to ON 
- Then Again Launch Side View Menu
- Go to Settings 
- Launch Preferences 
- Navigation Bar Color should be Black 


## Learning (optional, can help others)
[https://github.com/ankidroid/Anki-Android/issues/5409#issuecomment-530140065](https://github.com/ankidroid/Anki-Android/issues/5409#issuecomment-530140065)

