### PR TITLE
2019101 Dependency updates

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -195,7 +195,7 @@ dependencies {
     api project(":api")
 
     testImplementation 'org.junit.vintage:junit-vintage-engine:5.5.2'
-    testImplementation 'org.mockito:mockito-core:3.0.0'
+    testImplementation 'org.mockito:mockito-core:3.1.0'
     testImplementation 'org.powermock:powermock-core:2.0.2'
     testImplementation 'org.powermock:powermock-module-junit4:2.0.2'
     testImplementation 'org.powermock:powermock-api-mockito2:2.0.2'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -1,6 +1,6 @@
 plugins {
  // Gradle plugin portal 
- id 'com.github.triplet.play' version '2.4.1'
+ id 'com.github.triplet.play' version '2.4.2'
 }
 
 apply plugin: 'com.android.application'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -186,7 +186,7 @@ dependencies {
     implementation'ch.acra:acra-limiter:5.2.1'
 
     implementation 'net.mikehardy:google-analytics-java7:2.0.10'
-    implementation 'com.squareup.okhttp3:okhttp:3.12.5'
+    implementation 'com.squareup.okhttp3:okhttp:3.12.6'
     implementation 'com.arcao:slf4j-timber:3.1'
 
     implementation 'com.jakewharton.timber:timber:4.7.1'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -1,6 +1,6 @@
 plugins {
  // Gradle plugin portal 
- id 'com.github.triplet.play' version '2.3.0'
+ id 'com.github.triplet.play' version '2.4.1'
 }
 
 apply plugin: 'com.android.application'
@@ -186,7 +186,7 @@ dependencies {
     implementation'ch.acra:acra-limiter:5.2.1'
 
     implementation 'net.mikehardy:google-analytics-java7:2.0.10'
-    implementation 'com.squareup.okhttp3:okhttp:3.12.4'
+    implementation 'com.squareup.okhttp3:okhttp:3.12.5'
     implementation 'com.arcao:slf4j-timber:3.1'
 
     implementation 'com.jakewharton.timber:timber:4.7.1'
@@ -194,7 +194,7 @@ dependencies {
     implementation 'org.jsoup:jsoup:1.12.1'
     api project(":api")
 
-    testImplementation 'org.junit.vintage:junit-vintage-engine:5.5.1'
+    testImplementation 'org.junit.vintage:junit-vintage-engine:5.5.2'
     testImplementation 'org.mockito:mockito-core:3.0.0'
     testImplementation 'org.powermock:powermock-core:2.0.2'
     testImplementation 'org.powermock:powermock-module-junit4:2.0.2'

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -43,7 +43,7 @@ android {
 
 dependencies {
     api fileTree(dir: 'libs', include: ['*.jar'])
-    testImplementation 'org.junit.vintage:junit-vintage-engine:5.5.1'
+    testImplementation 'org.junit.vintage:junit-vintage-engine:5.5.2'
     testImplementation "org.robolectric:robolectric:4.2.1"
 }
 


### PR DESCRIPTION
Standard slow increments of things

I don't believe there is a single thing controversial in here, likewise I don't think there is anything really important in here, but it does include a bump to the play publishing bit

Not important to merge into 2.9 unless  you want to track patch versions