### PR TITLE
Only clear CardBrowser deck when starting app for first time

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -227,6 +227,9 @@ public class AnkiDroidApp extends Application {
         DEFAULT_SWIPE_MIN_DISTANCE = vc.getScaledPagingTouchSlop();
         DEFAULT_SWIPE_THRESHOLD_VELOCITY = vc.getScaledMinimumFlingVelocity();
 
+        // Forget the last deck that was used in the CardBrowser
+        CardBrowser.clearLastDeckId();
+
         // Create the AnkiDroid directory if missing. Send exception report if inaccessible.
         if (CollectionHelper.hasStorageAccessPermission(this)) {
             try {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -875,7 +875,6 @@ public class DeckPicker extends NavigationDrawerActivity implements
             loadStudyOptionsFragment(false);
         }
         automaticSync();
-        CardBrowser.clearLastDeckId();
     }
 
     private void showCollectionErrorDialog() {


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Only clear CardBrowser deck when starting app for first time

## Fixes
Fixes #5452 

## Approach
Clear the last deck in `AnkiDroidApplication` instead of `DeckPicker`

## How Has This Been Tested?

On emulator:

1. Open browser
1. Change deck
1. Go back to deck list via the hamburger icon
1. Open browser again via hamburger icon

--> Previously selected deck is still selected
--> Same behavior when going back to deck list via back button