### PR TITLE
Dependency updates 20191009

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -190,7 +190,7 @@ dependencies {
     implementation 'com.arcao:slf4j-timber:3.1'
 
     implementation 'com.jakewharton.timber:timber:4.7.1'
-    implementation 'com.google.code.gson:gson:2.8.5'
+    implementation 'com.google.code.gson:gson:2.8.6'
     implementation 'org.jsoup:jsoup:1.12.1'
     api project(":api")
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:3.5.1'
         classpath "org.jacoco:org.jacoco.core:0.8.4"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
Standard periodic dependency updates

No need to move these to release-2.9 except maybe cherry-picking the gradle bump to keep the build chain up to date on release-2.9, that became a problem on 2.8