### PR TITLE
Allow parentheses in field names to conform with Anki Desktop

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -24,17 +24,8 @@
         <package name="" withSubpackages="true" static="true" />
       </value>
     </option>
-    <option name="RIGHT_MARGIN" value="100" />
-    <AndroidXmlCodeStyleSettings>
-      <option name="USE_CUSTOM_SETTINGS" value="true" />
-    </AndroidXmlCodeStyleSettings>
     <JavaCodeStyleSettings>
       <option name="BLANK_LINES_AROUND_INITIALIZER" value="2" />
-      <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
-      <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="99" />
-      <option name="PACKAGES_TO_USE_IMPORT_ON_DEMAND">
-        <value />
-      </option>
       <option name="IMPORT_LAYOUT_TABLE">
         <value>
           <package name="android" withSubpackages="true" static="false" />
@@ -73,7 +64,6 @@
       <option name="FOR_BRACE_FORCE" value="3" />
     </codeStyleSettings>
     <codeStyleSettings language="XML">
-      <option name="FORCE_REARRANGE_MODE" value="1" />
       <indentOptions>
         <option name="CONTINUATION_INDENT_SIZE" value="4" />
       </indentOptions>

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.java
@@ -179,7 +179,7 @@ public class ModelFieldEditor extends AnkiActivity {
                 .customView(mFieldNameInput, true)
                 .onPositive((dialog, which) -> {
                     String fieldName = mFieldNameInput.getText().toString()
-                            .replaceAll("[\'\"\\n\\r\\[\\]\\(\\)]", "");
+                            .replaceAll("[\'\"\\n\\r\\[\\]]", "");
 
                     if (fieldName.length() == 0) {
                         showToast(getResources().getString(R.string.toast_empty_name));

--- a/AnkiDroid/src/test/java/com/ichi2/compat/CompatCopyFileTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/compat/CompatCopyFileTest.java
@@ -80,7 +80,7 @@ public class CompatCopyFileTest {
             outputStream.close();
             CompatHelper.getCompat().copyFile(resource.getPath(), outputStream);
             Assert.fail("Should have caught an exception");
-        } catch (IOException e) {
+        } catch (Exception e) {
             // this is expected
         }
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

Anki Desktop allows parentheses in field names, we should as well

## Fixes

#5352 

## Approach

Per suggestion of @sudomain I've altered the regex to not delete parentheses when editing fields

## How Has This Been Tested?

I have not tested this, so this should not be merged until @sudomain tests it and explains how

## Learning (optional, can help others)

There was an unrelated issue with the tests running on Windows in that the path-traversal test throws a RuntimeException on windows, not an IOException, so I altered the test to catch Exception - tests should pass on windows now

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
