### PR TITLE
intNow to intTime

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.java
@@ -123,7 +123,7 @@ public class BackupManager {
                 lastBackupDate = null;
             }
         }
-        if (lastBackupDate != null && lastBackupDate.getTime() + interval * 3600000L > Utils.intNow(1000) && !force) {
+        if (lastBackupDate != null && lastBackupDate.getTime() + interval * 3600000L > Utils.intTime(1000) && !force) {
             Timber.d("performBackup: No backup created. Last backup younger than 5 hours");
             return false;
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -794,7 +794,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
         String hkey = preferences.getString("hkey", "");
         long lastSyncTime = preferences.getLong("lastSyncTime", 0);
         if (hkey.length() != 0 && preferences.getBoolean("automaticSyncMode", false) &&
-                Connection.isOnline() && Utils.intNow(1000) - lastSyncTime > AUTOMATIC_SYNC_MIN_INTERVAL) {
+                Connection.isOnline() && Utils.intTime(1000) - lastSyncTime > AUTOMATIC_SYNC_MIN_INTERVAL) {
             sync();
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DialogHandler.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DialogHandler.java
@@ -118,7 +118,7 @@ public class DialogHandler extends Handler {
             SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(mActivity.get());
             Resources res = mActivity.get().getResources();
             String hkey = preferences.getString("hkey", "");
-            boolean limited = Utils.intNow(1000) - preferences.getLong("lastSyncTime", 0) < INTENT_SYNC_MIN_INTERVAL;
+            boolean limited = Utils.intTime(1000) - preferences.getLong("lastSyncTime", 0) < INTENT_SYNC_MIN_INTERVAL;
             if (!limited && hkey.length() > 0 && Connection.isOnline()) {
                 ((DeckPicker) mActivity.get()).sync();
             } else {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.java
@@ -182,7 +182,7 @@ public class Card implements Cloneable {
 
     public void flush(boolean changeModUsn) {
         if (changeModUsn) {
-            mMod = Utils.intNow();
+            mMod = Utils.intTime();
             mUsn = mCol.usn();
         }
         // bug check
@@ -218,7 +218,7 @@ public class Card implements Cloneable {
 
 
     public void flushSched() {
-        mMod = Utils.intNow();
+        mMod = Utils.intTime();
         mUsn = mCol.usn();
         // bug check
         //if ((mQueue == 2 && mODue != 0) && !mCol.getDecks().isDyn(mDid)) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/CardStats.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/CardStats.java
@@ -34,7 +34,7 @@ public class CardStats {
                 next = 0;
             } else {
                 if (c.getQueue() == 2 || c.getQueue() == 3) {
-                    next = Utils.intNow(1000) + ((c.getDue() - col.getSched().getToday()) * 86400000);
+                    next = Utils.intTime(1000) + ((c.getDue() - col.getSched().getToday()) * 86400000);
                 } else {
                     next = c.getDue();
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -326,7 +326,7 @@ public class Collection {
      */
     public void flush(long mod) {
         Timber.i("flush - Saving information to DB...");
-        mMod = (mod == 0 ? Utils.intNow(1000) : mod);
+        mMod = (mod == 0 ? Utils.intTime(1000) : mod);
         ContentValues values = new ContentValues();
         values.put("crt", mCrt);
         values.put("mod", mMod);
@@ -469,7 +469,7 @@ public class Collection {
                 throw new ConfirmModSchemaException();
             }
         }
-        mScm = Utils.intNow(1000);
+        mScm = Utils.intTime(1000);
         setMod();
     }
 
@@ -742,7 +742,7 @@ public class Collection {
         // build cards for each note
         ArrayList<Object[]> data = new ArrayList<>();
         long ts = Utils.maxID(mDb);
-        long now = Utils.intNow();
+        long now = Utils.intTime();
         ArrayList<Long> rem = new ArrayList<>();
         int usn = usn();
         cur = null;
@@ -1308,7 +1308,7 @@ public class Collection {
                 mDb.execute("DELETE FROM revlog WHERE id = " + last);
                 // restore any siblings
                 mDb.execute("update cards set queue=type,mod=?,usn=? where queue=-2 and nid=?",
-                        new Object[]{Utils.intNow(), usn(), c.getNid()});
+                        new Object[]{Utils.intTime(), usn(), c.getNid()});
                 // and finally, update daily count
                 int n = c.getQueue() == 3 ? 1 : c.getQueue();
                 String type = (new String[]{"new", "lrn", "rev"})[n];
@@ -1668,7 +1668,7 @@ public class Collection {
                 }
                 // new cards can't have a due position > 32 bits
                 fixIntegrityProgress(progressCallback, currentTask++, totalTasks);
-                mDb.execute("UPDATE cards SET due = 1000000, mod = " + Utils.intNow() + ", usn = " + usn()
+                mDb.execute("UPDATE cards SET due = 1000000, mod = " + Utils.intTime() + ", usn = " + usn()
                         + " WHERE due > 1000000 AND type = 0");
                 // new card position
                 mConf.put("nextPos", mDb.queryScalar("SELECT max(due) + 1 FROM cards WHERE type = 0"));
@@ -1678,7 +1678,7 @@ public class Collection {
                 fixIntegrityProgress(progressCallback, currentTask++, totalTasks);
                 if (ids.size() > 0) {
                 	problems.add("Reviews had incorrect due date.");
-                    mDb.execute("UPDATE cards SET due = " + mSched.getToday() + ", ivl = 1, mod = " +  Utils.intNow() +
+                    mDb.execute("UPDATE cards SET due = " + mSched.getToday() + ", ivl = 1, mod = " +  Utils.intTime() +
                             ", usn = " + usn() + " WHERE id IN " + Utils.ids2str(Utils.arrayList2array(ids)));
                 }
                 // v2 sched had a bug that could create decimal intervals
@@ -1779,7 +1779,7 @@ public class Collection {
                 args[i] = Arrays.toString((long []) args[i]);
             }
         }
-        String s = String.format("[%s] %s:%s(): %s", Utils.intNow(), trace.getFileName(), trace.getMethodName(),
+        String s = String.format("[%s] %s:%s(): %s", Utils.intTime(), trace.getFileName(), trace.getMethodName(),
                 TextUtils.join(",  ", args));
         mLogHnd.println(s);
         Timber.d(s);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -179,7 +179,7 @@ public class Decks {
     public void save(JSONObject g) {
         if (g != null) {
             try {
-                g.put("mod", Utils.intNow());
+                g.put("mod", Utils.intTime());
                 g.put("usn", mCol.usn());
             } catch (JSONException e) {
                 throw new RuntimeException(e);
@@ -255,7 +255,7 @@ public class Decks {
             g = new JSONObject(type);
             g.put("name", name);
             while (true) {
-                id = Utils.intNow(1000);
+                id = Utils.intTime(1000);
                 if (!mDecks.containsKey(id)) {
                     break;
                 }
@@ -690,7 +690,7 @@ public class Decks {
         try {
             c = new JSONObject(cloneFrom);
             while (true) {
-                id = Utils.intNow(1000);
+                id = Utils.intTime(1000);
                 if (!mDconf.containsKey(id)) {
                     break;
                 }
@@ -813,7 +813,7 @@ public class Decks {
 
     public void setDeck(long[] cids, long did) {
         mCol.getDb().execute("update cards set did=?,usn=?,mod=? where id in " + Utils.ids2str(cids),
-                new Object[] { did, mCol.usn(), Utils.intNow() });
+                new Object[] { did, mCol.usn(), Utils.intTime() });
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
@@ -905,7 +905,7 @@ public class Finder {
                 if (!flds.equals(origFlds)) {
                     long nid = cur.getLong(0);
                     nids.add(nid);
-                    d.add(new Object[] { flds, Utils.intNow(), col.usn(), nid }); // order based on query below
+                    d.add(new Object[] { flds, Utils.intTime(), col.usn(), nid }); // order based on query below
                 }
             }
         } finally {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -305,6 +305,8 @@ public class Models {
 
 
     /** Create a new model, save it in the registry, and return it. */
+	// Called `new` in Anki's code. New is a reserved word in java,
+	// not in python. Thus the method has to be renamed.
     public JSONObject newModel(String name) {
         // caller should call save() after modifying
         JSONObject m;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -98,8 +98,8 @@ public class Models {
     // BEGIN SQL table entries
     private int mId;
     private String mName = "";
-    //private long mCrt = Utils.intNow();
-    //private long mMod = Utils.intNow();
+    //private long mCrt = Utils.intTime();
+    //private long mMod = Utils.intTime();
     //private JSONObject mConf;
     //private String mCss = "";
     //private JSONArray mFields;
@@ -183,7 +183,7 @@ public class Models {
     public void save(JSONObject m, boolean templates) {
         if (m != null && m.has("id")) {
             try {
-                m.put("mod", Utils.intNow());
+                m.put("mod", Utils.intTime());
                 m.put("usn", mCol.usn());
                 // TODO: fix empty id problem on _updaterequired (needed for model adding)
                 if (m.getLong("id") != 0) {
@@ -311,7 +311,7 @@ public class Models {
         try {
             m = new JSONObject(defaultModel);
             m.put("name", name);
-            m.put("mod", Utils.intNow());
+            m.put("mod", Utils.intTime());
             m.put("flds", new JSONArray());
             m.put("tmpls", new JSONArray());
             m.put("tags", new JSONArray());
@@ -367,9 +367,9 @@ public class Models {
 
 
     private void _setID(JSONObject m) {
-        long id = Utils.intNow(1000);
+        long id = Utils.intTime(1000);
         while (mModels.containsKey(id)) {
-            id = Utils.intNow(1000);
+            id = Utils.intTime(1000);
         }
         try {
             m.put("id", id);
@@ -725,7 +725,7 @@ public class Models {
                 while (cur.moveToNext()) {
                     r.add(new Object[] {
                             Utils.joinFields(fn.transform(Utils.splitFields(cur.getString(1)))),
-                            Utils.intNow(), mCol.usn(), cur.getLong(0) });
+                            Utils.intTime(), mCol.usn(), cur.getLong(0) });
                 }
             } finally {
                 if (cur != null) {
@@ -807,7 +807,7 @@ public class Models {
             mCol.getDb()
                     .execute(
                             "update cards set ord = ord - 1, usn = ?, mod = ? where nid in (select id from notes where mid = ?) and ord > ?",
-                            new Object[] { mCol.usn(), Utils.intNow(), m.getLong("id"), ord });
+                            new Object[] { mCol.usn(), Utils.intTime(), m.getLong("id"), ord });
             JSONArray tmpls = m.getJSONArray("tmpls");
             JSONArray ja2 = new JSONArray();
             for (int i = 0; i < tmpls.length(); ++i) {
@@ -875,7 +875,7 @@ public class Models {
             save(m);
             mCol.getDb().execute("update cards set ord = (case " + sb.toString() +
             		" end),usn=?,mod=? where nid in (select id from notes where mid = ?)",
-                    new Object[] { mCol.usn(), Utils.intNow(), m.getLong("id") });
+                    new Object[] { mCol.usn(), Utils.intTime(), m.getLong("id") });
         } catch (JSONException e) {
             throw new RuntimeException(e);
         }
@@ -947,7 +947,7 @@ public class Models {
                     }
                 }
                 String joinedFlds = Utils.joinFields(flds2.toArray(new String[flds2.size()]));
-                d.add(new Object[] { joinedFlds, mid, Utils.intNow(), mCol.usn(), nid });
+                d.add(new Object[] { joinedFlds, mid, Utils.intTime(), mCol.usn(), nid });
             }
         } finally {
             if (cur != null) {
@@ -995,7 +995,7 @@ public class Models {
                     newOrd = map.get(ord);
                 }
                 if (newOrd != null) {
-                    d.add(new Object[] { newOrd, mCol.usn(), Utils.intNow(), cid });
+                    d.add(new Object[] { newOrd, mCol.usn(), Utils.intTime(), cid });
                 } else {
                     deleted.add(cid);
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Note.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Note.java
@@ -147,7 +147,7 @@ public class Note implements Cloneable {
             return;
         }
         long csum = Utils.fieldChecksum(mFields[0]);
-        mMod = mod != null ? mod : Utils.intNow();
+        mMod = mod != null ? mod : Utils.intTime();
         mCol.getDb().execute("insert or replace into notes values (?,?,?,?,?,?,?,?,?,?,?)",
                 new Object[] { mId, mGuId, mMid, mMod, mUsn, tags, fields, sfld, csum, mFlags, mData });
         mCol.getTags().register(mTags);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sched.java
@@ -192,7 +192,7 @@ public class Sched {
             throw new RuntimeException("Invalid queue");
         }
         _updateStats(card, "time", card.timeTaken());
-        card.setMod(Utils.intNow());
+        card.setMod(Utils.intTime());
         card.setUsn(mCol.usn());
         card.flushSched();
     }
@@ -286,7 +286,7 @@ public class Sched {
         String sids = Utils.ids2str(allDecks);
         mCol.log(mCol.getDb().queryColumn(Long.class, "select id from cards where queue = -2 and did in " + sids, 0));
         mCol.getDb().execute("update cards set mod=?,usn=?,queue=type where queue = -2 and did in " + sids,
-                new Object[] { Utils.intNow(), mCol.usn() });
+                new Object[] { Utils.intTime(), mCol.usn() });
     }
 
     /**
@@ -1072,7 +1072,7 @@ public class Sched {
 
     private int _leftToday(JSONArray delays, int left, long now) {
         if (now == 0) {
-            now = Utils.intNow();
+            now = Utils.intTime();
         }
         int ok = 0;
         int offset = Math.min(left, delays.length());
@@ -1180,7 +1180,7 @@ public class Sched {
         }
         // review cards in relearning
         mCol.getDb().execute(
-                "update cards set due = odue, queue = 2, mod = " + Utils.intNow() +
+                "update cards set due = odue, queue = 2, mod = " + Utils.intTime() +
                 ", usn = " + mCol.usn() + ", odue = 0 where queue IN (1,3) and type = 2 " + extra);
         // new cards in learning
         forgetCards(Utils.arrayList2array(mCol.getDb().queryColumn(Long.class, "SELECT id FROM cards WHERE queue IN (1,3) " + extra, 0)));
@@ -1191,7 +1191,7 @@ public class Sched {
         try {
             int cnt = mCol.getDb().queryScalar(
                     "SELECT sum(left / 1000) FROM (SELECT left FROM cards WHERE did = " + did
-                            + " AND queue = 1 AND due < " + (Utils.intNow() + mCol.getConf().getInt("collapseTime"))
+                            + " AND queue = 1 AND due < " + (Utils.intTime() + mCol.getConf().getInt("collapseTime"))
                             + " LIMIT " + mReportLimit + ")");
             return cnt + mCol.getDb().queryScalar(
                     "SELECT count() FROM (SELECT 1 FROM cards WHERE did = " + did
@@ -1669,7 +1669,7 @@ public class Sched {
 
     private void _moveToDyn(long did, List<Long> ids) {
         ArrayList<Object[]> data = new ArrayList<>();
-        //long t = Utils.intNow(); // unused variable present (and unused) upstream
+        //long t = Utils.intTime(); // unused variable present (and unused) upstream
         int u = mCol.usn();
         for (long c = 0; c < ids.size(); c++) {
             // start at -100000 so that reviews are all due
@@ -2081,7 +2081,7 @@ public class Sched {
         remFromDyn(ids);
         removeLrn(ids);
         mCol.getDb().execute(
-                "UPDATE cards SET queue = -1, mod = " + Utils.intNow() + ", usn = " + mCol.usn() + " WHERE id IN "
+                "UPDATE cards SET queue = -1, mod = " + Utils.intTime() + ", usn = " + mCol.usn() + " WHERE id IN "
                         + Utils.ids2str(ids));
     }
 
@@ -2092,7 +2092,7 @@ public class Sched {
     public void unsuspendCards(long[] ids) {
         mCol.log(ids);
         mCol.getDb().execute(
-                "UPDATE cards SET queue = type, mod = " + Utils.intNow() + ", usn = " + mCol.usn()
+                "UPDATE cards SET queue = type, mod = " + Utils.intTime() + ", usn = " + mCol.usn()
                         + " WHERE queue = -1 AND id IN " + Utils.ids2str(ids));
     }
 
@@ -2190,7 +2190,7 @@ public class Sched {
     public void reschedCards(long[] ids, int imin, int imax) {
         ArrayList<Object[]> d = new ArrayList<>();
         int t = mToday;
-        long mod = Utils.intNow();
+        long mod = Utils.intTime();
         Random rnd = new Random();
         for (long id : ids) {
             int r = rnd.nextInt(imax - imin + 1) + imin;
@@ -2228,7 +2228,7 @@ public class Sched {
 
     public void sortCards(long[] cids, int start, int step, boolean shuffle, boolean shift) {
         String scids = Utils.ids2str(cids);
-        long now = Utils.intNow();
+        long now = Utils.intTime();
         ArrayList<Long> nids = new ArrayList<>();
         for (long id : cids) {
         	long nid = mCol.getDb().queryLongScalar("SELECT nid FROM cards WHERE id = " + id);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/SchedV2.java
@@ -165,7 +165,7 @@ public class SchedV2 extends Sched {
         _answerCard(card, ease);
 
         _updateStats(card, "time", card.timeTaken());
-        card.setMod(Utils.intNow());
+        card.setMod(Utils.intTime());
         card.setUsn(mCol.usn());
         card.flushSched();
     }
@@ -210,7 +210,7 @@ public class SchedV2 extends Sched {
         if (ease == 1) {
             // Repeat after delay
             card.setQueue(4);
-            card.setDue(Utils.intNow() + _previewDelay(card));
+            card.setDue(Utils.intTime() + _previewDelay(card));
             mLrnCount += 1;
         } else if (ease == 2) {
             // Restore original card state and remove from filtered deck
@@ -762,7 +762,7 @@ public class SchedV2 extends Sched {
 
     private boolean _updateLrnCutoff(boolean force) {
         try {
-            long nextCutoff = Utils.intNow() + mCol.getConf().getInt("collapseTime");
+            long nextCutoff = Utils.intTime() + mCol.getConf().getInt("collapseTime");
             if (nextCutoff - mLrnCutoff > 60 || force) {
                 mLrnCutoff = nextCutoff;
                 return true;
@@ -816,7 +816,7 @@ public class SchedV2 extends Sched {
         }
         long cutoff = 0;
         try {
-            cutoff = Utils.intNow() + mCol.getConf().getLong("collapseTime");
+            cutoff = Utils.intTime() + mCol.getConf().getLong("collapseTime");
         } catch (JSONException e) {
             throw new RuntimeException(e);
         }
@@ -1013,7 +1013,7 @@ public class SchedV2 extends Sched {
         if (delay == null) {
             delay = _delayForGrade(conf, card.getLeft());
         }
-        card.setDue(Utils.intNow() + delay);
+        card.setDue(Utils.intTime() + delay);
 
         // due today?
         if (card.getDue() < mDayCutoff) {
@@ -1023,7 +1023,7 @@ public class SchedV2 extends Sched {
             card.setDue(Math.min(mDayCutoff - 1, card.getDue() + fuzz));
             card.setQueue(1);
             try {
-                if (card.getDue() < (Utils.intNow() + mCol.getConf().getInt("collapseTime"))) {
+                if (card.getDue() < (Utils.intTime() + mCol.getConf().getInt("collapseTime"))) {
                     mLrnCount += 1;
                     // if the queue is not empty and there's nothing else to do, make
                     // sure we don't put it at the head of the queue and end up showing
@@ -1142,7 +1142,7 @@ public class SchedV2 extends Sched {
 
     private int _leftToday(JSONArray delays, int left, long now) {
         if (now == 0) {
-            now = Utils.intNow();
+            now = Utils.intTime();
         }
         int ok = 0;
         int offset = Math.min(left, delays.length());
@@ -1231,7 +1231,7 @@ public class SchedV2 extends Sched {
         try {
             int cnt = mCol.getDb().queryScalar(
                     "SELECT count() FROM (SELECT null FROM cards WHERE did = " + did
-                            + " AND queue = 1 AND due < " + (Utils.intNow() + mCol.getConf().getInt("collapseTime"))
+                            + " AND queue = 1 AND due < " + (Utils.intTime() + mCol.getConf().getInt("collapseTime"))
                             + " LIMIT " + mReportLimit + ")");
             return cnt + mCol.getDb().queryScalar(
                     "SELECT count() FROM (SELECT null FROM cards WHERE did = " + did
@@ -2240,7 +2240,7 @@ public class SchedV2 extends Sched {
     public void suspendCards(long[] ids) {
         mCol.log(ids);
         mCol.getDb().execute(
-                "UPDATE cards SET queue = -1, mod = " + Utils.intNow() + ", usn = " + mCol.usn() + " WHERE id IN "
+                "UPDATE cards SET queue = -1, mod = " + Utils.intTime() + ", usn = " + mCol.usn() + " WHERE id IN "
                         + Utils.ids2str(ids));
     }
 
@@ -2251,7 +2251,7 @@ public class SchedV2 extends Sched {
     public void unsuspendCards(long[] ids) {
         mCol.log(ids);
         mCol.getDb().execute(
-                "UPDATE cards SET " + _restoreQueueSnippet() + ", mod = " + Utils.intNow() + ", usn = " + mCol.usn()
+                "UPDATE cards SET " + _restoreQueueSnippet() + ", mod = " + Utils.intTime() + ", usn = " + mCol.usn()
                         + " WHERE queue = -1 AND id IN " + Utils.ids2str(ids));
     }
 
@@ -2303,7 +2303,7 @@ public class SchedV2 extends Sched {
 
         mCol.log(mCol.getDb().queryColumn(Long.class,"select id from cards where " + queue + " and did in " + sids, 0));
         mCol.getDb().execute("update cards set mod=?,usn=?, " + _restoreQueueSnippet() + " where " + queue + " and did in " + sids,
-                new Object[]{Utils.intNow(), mCol.usn()});
+                new Object[]{Utils.intTime(), mCol.usn()});
     }
 
 
@@ -2389,7 +2389,7 @@ public class SchedV2 extends Sched {
     public void reschedCards(long[] ids, int imin, int imax) {
         ArrayList<Object[]> d = new ArrayList<>();
         int t = mToday;
-        long mod = Utils.intNow();
+        long mod = Utils.intTime();
         Random rnd = new Random();
         for (long id : ids) {
             int r = rnd.nextInt(imax - imin + 1) + imin;
@@ -2427,7 +2427,7 @@ public class SchedV2 extends Sched {
 
     public void sortCards(long[] cids, int start, int step, boolean shuffle, boolean shift) {
         String scids = Utils.ids2str(cids);
-        long now = Utils.intNow();
+        long now = Utils.intTime();
         ArrayList<Long> nids = new ArrayList<>();
         for (long id : cids) {
         	long nid = mCol.getDb().queryLongScalar("SELECT nid FROM cards WHERE id = " + id);
@@ -2546,9 +2546,9 @@ public class SchedV2 extends Sched {
     private void _removeAllFromLearning(int schedVer) {
         // remove review cards from relearning
         if (schedVer == 1) {
-            mCol.getDb().execute(String.format(Locale.US,"update cards set due = odue, queue = 2, type = 2, mod = %d, usn = %d, odue = 0 where queue in (1,3) and type in (2,3)", Utils.intNow(), mCol.usn()));
+            mCol.getDb().execute(String.format(Locale.US,"update cards set due = odue, queue = 2, type = 2, mod = %d, usn = %d, odue = 0 where queue in (1,3) and type in (2,3)", Utils.intTime(), mCol.usn()));
         } else {
-            mCol.getDb().execute(String.format(Locale.US,"update cards set due = %d+ivl, queue = 2, type = 2, mod = %d, usn = %d, odue = 0 where queue in (1,3) and type in (2,3)", mToday, Utils.intNow(), mCol.usn()));
+            mCol.getDb().execute(String.format(Locale.US,"update cards set due = %d+ivl, queue = 2, type = 2, mod = %d, usn = %d, odue = 0 where queue in (1,3) and type in (2,3)", mToday, Utils.intTime(), mCol.usn()));
         }
 
 
@@ -2559,13 +2559,13 @@ public class SchedV2 extends Sched {
 
     // v1 doesn't support buried/suspended (re)learning cards
     private void _resetSuspendedLearning() {
-        mCol.getDb().execute(String.format(Locale.US,"update cards set type = (case when type = 1 then 0 when type in (2, 3) then 2 else type end), due = (case when odue then odue else due end), odue = 0, mod = %d, usn = %d where queue < 0", Utils.intNow(), mCol.usn()));
+        mCol.getDb().execute(String.format(Locale.US,"update cards set type = (case when type = 1 then 0 when type in (2, 3) then 2 else type end), due = (case when odue then odue else due end), odue = 0, mod = %d, usn = %d where queue < 0", Utils.intTime(), mCol.usn()));
     }
 
 
     // no 'manually buried' queue in v1
     private void _moveManuallyBuried() {
-        mCol.getDb().execute(String.format(Locale.US, "update cards set queue=-2, mod=%d where queue=-3", Utils.intNow()));
+        mCol.getDb().execute(String.format(Locale.US, "update cards set queue=-2, mod=%d where queue=-3", Utils.intTime()));
     }
 
     // adding 'hard' in v2 scheduler means old ease entries need shifting

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Storage.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Storage.java
@@ -318,7 +318,7 @@ public class Storage {
         db.execute("create table if not exists graves (" + "    usn             integer not null,"
                 + "    oid             integer not null," + "    type            integer not null" + ")");
         db.execute("INSERT OR IGNORE INTO col VALUES(1,0,0," +
-                Utils.intNow(1000) + "," + Consts.SCHEMA_VERSION +
+                Utils.intTime(1000) + "," + Consts.SCHEMA_VERSION +
                 ",0,0,0,'','{}','','','{}')");
         if (setColConf) {
             _setColVars(db);
@@ -332,7 +332,7 @@ public class Storage {
             g.put("id", 1);
             g.put("name", "Default");
             g.put("conf", 1);
-            g.put("mod", Utils.intNow());
+            g.put("mod", Utils.intTime());
             JSONObject gc = new JSONObject(Decks.defaultConf);
             gc.put("id", 1);
             JSONObject ag = new JSONObject();

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Tags.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Tags.java
@@ -263,12 +263,12 @@ public class Tags {
             if (add) {
                 while (cur.moveToNext()) {
                     nids.add(cur.getLong(0));
-                    res.add(new Object[] { addToStr(tags, cur.getString(1)), Utils.intNow(), mCol.usn(), cur.getLong(0) });
+                    res.add(new Object[] { addToStr(tags, cur.getString(1)), Utils.intTime(), mCol.usn(), cur.getLong(0) });
                 }
             } else {
                 while (cur.moveToNext()) {
                     nids.add(cur.getLong(0));
-                    res.add(new Object[] { remFromStr(tags, cur.getString(1)), Utils.intNow(), mCol.usn(),
+                    res.add(new Object[] { remFromStr(tags, cur.getString(1)), Utils.intTime(), mCol.usn(),
                             cur.getLong(0) });
                 }
             }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
@@ -114,10 +114,10 @@ public class Utils {
 
 
     /**The time in integer seconds. Pass scale=1000 to get milliseconds. */
-    public static long intNow() {
-        return intNow(1);
+    public static long intTime() {
+        return intTime(1);
     }
-    public static long intNow(int scale) {
+    public static long intTime(int scale) {
         return (long) (now() * scale);
     }
 
@@ -356,7 +356,7 @@ public class Utils {
     public static long timestampID(DB db, String table) {
         // be careful not to create multiple objects without flushing them, or they
         // may share an ID.
-        long t = intNow(1000);
+        long t = intTime(1000);
         while (db.queryScalar("SELECT id FROM " + table + " WHERE id = " + t) != 0) {
             t += 1;
         }
@@ -366,7 +366,7 @@ public class Utils {
 
     /** Return the first safe ID to use. */
     public static long maxID(DB db) {
-        long now = intNow(1000);
+        long now = intTime(1000);
         now = Math.max(now, db.queryLongScalar("SELECT MAX(id) FROM cards"));
         now = Math.max(now, db.queryLongScalar("SELECT MAX(id) FROM notes"));
         return now + 1;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
@@ -354,7 +354,7 @@ public class Anki2Importer extends Importer {
                     // copy it over
                     JSONObject model = new JSONObject(Utils.jsonToString(srcModel));
                     model.put("id", mid);
-                    model.put("mod", Utils.intNow());
+                    model.put("mod", Utils.intTime());
                     model.put("usn", mCol.usn());
                     mDst.getModels().update(model);
                     break;
@@ -366,7 +366,7 @@ public class Anki2Importer extends Importer {
                     // they do; we can reuse this mid
                     JSONObject model = new JSONObject(Utils.jsonToString(srcModel));
                     model.put("id", mid);
-                    model.put("mod", Utils.intNow());
+                    model.put("mod", Utils.intTime());
                     model.put("usn", mCol.usn());
                     mDst.getModels().update(model);
                     break;
@@ -528,7 +528,7 @@ public class Anki2Importer extends Importer {
                 // update cid, nid, etc
                 card[1] = mNotes.get(guid)[0];
                 card[2] = _did((Long) card[2]);
-                card[4] = Utils.intNow();
+                card[4] = Utils.intTime();
                 card[5] = usn;
                 // review cards have a due date relative to collection
                 if ((Integer) card[7] == 2 || (Integer) card[7] == 3 || (Integer) card[6] == 2) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.java
@@ -250,7 +250,7 @@ public class Syncer {
         j.put("mod", mCol.getMod());
         j.put("scm", mCol.getScm());
         j.put("usn", mCol.getUsnForSync());
-        j.put("ts", Utils.intNow());
+        j.put("ts", Utils.intTime());
         j.put("musn", 0);
         j.put("msg", "");
         j.put("cont", true);
@@ -427,7 +427,7 @@ public class Syncer {
     private long finish(long mod) {
         if (mod == 0) {
             // server side; we decide new mod time
-            mod = Utils.intNow(1000);
+            mod = Utils.intTime(1000);
         }
         mCol.setLs(mod);
         mCol.setUsnAfterSync(mMaxUsn + 1);


### PR DESCRIPTION
In order to be consistent with anki code

## Purpose / Description
libanki tries to be as consistent as possible with Anki code. There is at least two functions where the name was changed. 
One change was motivated - I guess - by the fact that "new" is a valid method name in Python and not in Java. The other change seems useless. So in this branch/pull request, I just intend to do a global search/replace to be consistent with anki as far as function name goes.

## How Has This Been Tested?
Gradlew and Travis.

Honestly, there is nothing to test here. It's just a method whose name is changed. The only point is to be consistent with anki code.


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
