### PR TITLE
Clears undo before changing schedulers

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -223,6 +223,7 @@ public class Collection {
         }
         modSchema(true);
         SchedV2 v2Sched = new SchedV2(this);
+        clearUndo();
         if (ver == 1) {
             v2Sched.moveToV1();
         } else {


### PR DESCRIPTION
## Purpose / Description
Main purpose: having libanki similar to Anki's folder Anki.

## Fixes
In theory, problems may occur if an action is cancelled while the scheduler changed. Indeed, it'll send a note in a state which may be invalid in the new scheduler.

## Approach
As in Anki

## How Has This Been Tested?

gradlew, travis.

In scheduler 1, review a card. Open setting, advanced. Check Experimental V2 Scheduler. Close the advanced window and the setting. Without this commit, you'll see you can cancel the card review. With this commit, you can't.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code