### PR TITLE
New card with same due are shown according to their ord

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sched.java
@@ -619,7 +619,7 @@ public class Sched {
                     cur = mCol
                             .getDb()
                             .getDatabase()
-                            .query("SELECT id FROM cards WHERE did = " + did + " AND queue = 0 order by due LIMIT " + lim,
+                            .query("SELECT id FROM cards WHERE did = " + did + " AND queue = 0 order by due, ord LIMIT " + lim,
                                     null);
                     while (cur.moveToNext()) {
                         mNewQueue.add(cur.getLong(0));

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/SchedV2.java
@@ -615,7 +615,7 @@ public class SchedV2 extends Sched {
                     cur = mCol
                             .getDb()
                             .getDatabase()
-                            .query("SELECT id FROM cards WHERE did = " + did + " AND queue = 0 order by due LIMIT " + lim,
+                            .query("SELECT id FROM cards WHERE did = " + did + " AND queue = 0 order by due, ord LIMIT " + lim,
                                     null);
                     while (cur.moveToNext()) {
                         mNewQueue.add(cur.getLong(0));


### PR DESCRIPTION
## Purpose / Description
Main purpose: having libanki similar to Anki's folder Anki.

As a personal note, THIS commit is the very reason why I started to learn how to edit ankidroid in the first place. It corrects a bug which is a real pain for my day to day use of anki. 

## Fixes
This commit corrects the following bug:

* Create a note N in an empty deck D of type basic (reverse), with
only some back, no front. Only card 2 will be generated.
* Edit the note, add a front. Card 1 will be generated.
* In the main window, try to learn deck D. In ankidroid, currently, you'll
  see Card 2 first. According to the manual, Anki, (and to my common sens),
  it should be Card 1 first.

This commit correct this bug, and ensure that new cards are seen
according to their order, and not to their creation date.

It follows commit dae/anki@8e00773

## Approach
As in Anki

## How Has This Been Tested?

gradlew, travis.

Repeat steps explained above on a version of ankidroid with this PR, and on a version of ankidroid without this PR. You'll see that you see Card1 first with this PR, and Card2 first without this PR. Thus this PR corrects the above-mentioned bug.


## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code