### PR TITLE
fix negative due dates in filtered decks

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/SchedV2.java
@@ -1764,7 +1764,7 @@ public class SchedV2 extends Sched {
 
         mCol.getDb().executeMany(
                 "UPDATE cards SET odid = did, " +
-                        "odue = due, did = ?, due = ?, usn = ? " + queue + " WHERE id = ?", data);
+                        "odue = due, did = ?, due = (case when due <= 0 then due else ? end), usn = ? " + queue + " WHERE id = ?", data);
     }
 
 


### PR DESCRIPTION
## Purpose / Description
Main purpose: having libanki similar to Anki's folder Anki.

## Fixes
fix negative due dates in filtered decks ￼
https://anki.tenderapp.com/discussions/ankidesktop/35978-rebuilding-filtered-deck-on-experimental-v2-empties-deck-and-reschedules-to-the-year-1745

this means affected cards will not have the selected ordering applied,
but that seems preferable to the alternatives

dae/anki@d468999


## Approach
As in Anki

## How Has This Been Tested?

gradlew and travis.
On ankidroid I took a collection with some due cards. Switched to Sched V2. I created a filtered deck without any condition. I emptied it. I then synchronized to my computer and verified in the browser that all due dates are still correct.

I must admit however that I did not try to reproduce the long process described in the link given above. I certainly want that filtered decks continue to works flawlessly in any normal usage. The case in which the bug was reported is complex to test, should not occur often, and since the correction is simply a change in a sql request, I'm pretty sure that the same correction works in both case. Since the normal usage of anki is not broken; I don't intend to spend more time on this PR. If you reject it because of that; I won't fight for it.


## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code