### PR TITLE
when sorting by easiness, put new card separately

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
@@ -408,7 +408,7 @@ public class Finder {
                 } else if (type.startsWith("cardDue")) {
                     sort = "c.type, c.due";
                 } else if (type.startsWith("cardEase")) {
-                    sort = "c.factor";
+                    sort = "c.type == 0, c.factor";
                 } else if (type.startsWith("cardLapses")) {
                     sort = "c.lapses";
                 } else if (type.startsWith("cardIvl")) {


### PR DESCRIPTION
## Purpose / Description
Main purpose: having libanki similar to Anki's folder Anki.

## Fixes
The factor of new cards is not relevant. It's ignored by the scheduler. However, it's not ignored by the finder. This ensures that if a card is new, it's easiness is ignored.

Note that, normally, if you don't hack anki, there are two factors that a new card can have. 0 and 250. 0 is the default one when a card is created. 250 is the one given to cards which are rescheduled as new.

## Approach
As in Anki

## How Has This Been Tested?

gradlew and Travis.

Create a collection with five cards created in this order:
* a new card never reviewed
* a card reviewed, and a later day stated to be hard. I.e. it's ease should be <250
* a card, reviewed and rescheduled as new
* a card reviewed, stated to be easy two different day. It's ease should be >250
* a new card never reviewed

In ankidroid browser, sort by ease. Without this PR
You should see first and last card together.
You should see third card between the easy one and the hard one.

With this PR, the three new cards are together, and separated from the seen cards.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code