### PR TITLE
Add method setUserFlag in collection

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1816,6 +1816,15 @@ public class Collection {
     }
 
     /**
+     * Card Flags *****************************************************************************************************
+     */
+    public void setUserFlag(int flag, List<Long> cids)  {
+        assert (0<= flag && flag <= 7);
+		mDb.execute("update cards set flags = (flags & ~?) | ?, usn=?, mod=? where id in " + Utils.ids2str(cids),
+					new Object[]{0b111, flag, usn(), Utils.intNow()});
+    }
+
+    /**
      * Getters/Setters ********************************************************** *************************************
      */
 


### PR DESCRIPTION
## Purpose / Description
Main purpose: having libanki similar to Anki's folder Anki.

## Fixes
No problem, appart that user flag can't be set now

## Approach
As in Anki

## How Has This Been Tested?

gradlew. 
It can't be tested, because there is no way in Ankidroid to add flag to a set of cards. (Or even to a single card until you accept my PR card). 
So it'll be usefull only if and when the browser allow to select multiple cards.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code