### PR TITLE
Add new field template method

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.java
@@ -418,8 +418,6 @@ public class ModelBrowser extends AnkiActivity {
             } else {
                 showToast(getResources().getString(R.string.toast_empty_name));
             }
-        } catch (ConfirmModSchemaException e) {
-            //We should never get here since we're only modifying new mModels
         } catch (JSONException e) {
             throw new RuntimeException(e);
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
@@ -901,7 +901,7 @@ public class CardContentProvider extends ContentProvider {
                     // Add the fields
                     String[] allFields = Utils.splitFields(fieldNames);
                     for (String f: allFields) {
-                        mm.addField(newModel, mm.newField(f));
+                        mm.addFieldInNewModel(newModel, mm.newField(f));
                     }
                     // Add some empty card templates
                     for (int idx = 0; idx < numCards; idx++) {
@@ -912,7 +912,7 @@ public class CardContentProvider extends ContentProvider {
                             answerField = allFields[1];
                         }
                         t.put("afmt",String.format("{{FrontSide}}\\n\\n<hr id=answer>\\n\\n{{%s}}", answerField));
-                        mm.addTemplate(newModel, t);
+                        mm.addTemplateInNewModel(newModel, t);
                     }
                     // Add the CSS if specified
                     if (css != null) {
@@ -940,10 +940,6 @@ public class CardContentProvider extends ContentProvider {
                     // Get the mid and return a URI
                     String mid = Long.toString(newModel.getLong("id"));
                     return Uri.withAppendedPath(FlashCardsContract.Model.CONTENT_URI, mid);
-                } catch (ConfirmModSchemaException e) {
-                    // This exception should never be thrown when inserting new models
-                    Timber.e(e, "Unexpected ConfirmModSchema exception adding new model %s", modelName);
-                    throw new IllegalArgumentException("ConfirmModSchema exception adding new model " + modelName);
                 } catch (JSONException e) {
                     Timber.e(e, "Could not set a field of new model %s", modelName);
                     return null;

--- a/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
@@ -1271,19 +1271,16 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
      * Add a new card template
      */
     private TaskData doInBackgroundAddTemplate(TaskData... params) {
+        // mod should have been changed by addNewTemplateWithCheck in
+        // main/java/com/ichi2/anki/CardTemplateEditor
         Timber.d("doInBackgroundAddTemplate");
         Collection col = CollectionHelper.getInstance().getCol(mContext);
         Object [] args = params[0].getObjArray();
         JSONObject model = (JSONObject) args[0];
         JSONObject template = (JSONObject) args[1];
         // add the new template
-        try {
-            col.getModels().addTemplate(model, template);
-            col.save();
-        } catch (ConfirmModSchemaException e) {
-            Timber.e("doInBackgroundAddTemplate :: ConfirmModSchemaException");
-            return new TaskData(false);
-        }
+        col.getModels().addTemplateModChanged(model, template);
+        col.save();
         return new TaskData(true);
     }
 
@@ -1439,13 +1436,8 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
         String fieldName = (String) objects[1];
 
         Collection col = CollectionHelper.getInstance().getCol(mContext);
-        try {
-            col.getModels().addField(model, col.getModels().newField(fieldName));
-            col.save();
-        } catch (ConfirmModSchemaException e) {
-            //Should never be reached
-            return new TaskData(false);
-        }
+        col.getModels().addFieldModChanged(model, col.getModels().newField(fieldName));
+        col.save();
         return new TaskData(true);
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1747,6 +1747,10 @@ public class Collection {
             AnkiDroidApp.sendExceptionReport(e, "doInBackgroundCheckDatabase");
             return -1;
         }
+        // models
+        if (mModels.ensureNotEmpty()) {
+            problems.add("Added missing note type.");
+        }
         // and finally, optimize
         optimize(progressCallback, currentTask, totalTasks);
         file = new File(mPath);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -1307,8 +1307,7 @@ public class Models {
 
     /**
      * Routines from Stdmodels.py
-     * *
-     * @throws ConfirmModSchemaException **********************************************************************************************
+     **********************************************************************************************
      */
 
     private static JSONObject _newBasicModel(Collection col) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -788,14 +788,11 @@ public class Models {
         return t;
     }
 
-
-    /** Note: should col.genCards() afterwards. 
-     * @throws ConfirmModSchemaException */
-    public void addTemplate(JSONObject m, JSONObject template) throws ConfirmModSchemaException {
+    /** Note: should col.genCards() afterwards. */
+    private void _addTemplate(JSONObject m, JSONObject template) {
+        // do the actual work of addTemplate. Do not consider whether
+        // model is new or not.
         try {
-            if (!isModelNew(m)) {
-                mCol.modSchema(true);
-            }
             JSONArray ja = m.getJSONArray("tmpls");
             ja.put(template);
             m.put("tmpls", ja);
@@ -806,6 +803,28 @@ public class Models {
         }
     }
 
+    /** @throws ConfirmModSchemaException */
+    public void addTemplate(JSONObject m, JSONObject template) throws ConfirmModSchemaException {
+        //That is Anki's addTemplate method
+        if (!isModelNew(m)) {
+            mCol.modSchema(true);
+        }
+        _addTemplate(m, template);
+    }
+
+    public void addTemplateInNewModel(JSONObject m, JSONObject template)  {
+        // similar to addTemplate, but doesn't throw exception;
+        // asserting the model is new.
+        Assert.that(isModelNew(m), "Model was assumed to be new, but is not");
+        _addTemplate(m, template);
+    }
+
+    public void addTemplateModChanged(JSONObject m, JSONObject template)  {
+        // similar to addTemplate, but doesn't throw exception;
+        // asserting the model is new.
+        Assert.that(mCol.schemaChanged(), "Mod was assumed to be already changed, but is not");
+        _addTemplate(m, template);
+    }
 
     /**
      * Removing a template

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -209,6 +209,7 @@ public class Models {
      */
     public void flush() {
         if (mChanged) {
+            ensureNotEmpty();
             JSONObject array = new JSONObject();
             try {
                 for (Map.Entry<Long, JSONObject> o : mModels.entrySet()) {
@@ -224,6 +225,14 @@ public class Models {
         }
     }
 
+    public boolean ensureNotEmpty() {
+        if (mModels.isEmpty()) {
+            addBasicModel(mCol);
+            return true;
+        } else {
+            return false;
+        }
+    }
 
     /**
      * Retrieving and creating models

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -1259,12 +1259,12 @@ public class Models {
      * @throws ConfirmModSchemaException **********************************************************************************************
      */
 
-    public static JSONObject addBasicModel(Collection col) throws ConfirmModSchemaException {
-        return addBasicModel(col, "Basic");
+    private static JSONObject _newBasicModel(Collection col) throws ConfirmModSchemaException {
+        return _newBasicModel(col, "Basic");
     }
 
 
-    public static JSONObject addBasicModel(Collection col, String name) throws ConfirmModSchemaException {
+    private static JSONObject _newBasicModel(Collection col, String name) throws ConfirmModSchemaException {
         Models mm = col.getModels();
         JSONObject m = mm.newModel(name);
         JSONObject fm = mm.newField("Front");
@@ -1279,7 +1279,16 @@ public class Models {
             throw new RuntimeException(e);
         }
         mm.addTemplate(m, t);
-        mm.add(m);
+        return m;
+    }
+
+    public static JSONObject addBasicModel(Collection col) {
+        return addBasicModel(col, "Basic");
+    }
+
+    public static JSONObject addBasicModel(Collection col, String name) {
+        JSONObject m = _newBasicModel(col, name);
+        col.getModels().add(m);
         return m;
     }
 
@@ -1288,13 +1297,14 @@ public class Models {
     public static JSONObject addForwardReverse(Collection col) throws ConfirmModSchemaException {
     	String name = "Basic (and reversed card)";
         Models mm = col.getModels();
-        JSONObject m = addBasicModel(col);
+        JSONObject m = _newBasicModel(col);
         try {
             m.put("name", name);
             JSONObject t = mm.newTemplate("Card 2");
             t.put("qfmt", "{{Back}}");
             t.put("afmt", "{{FrontSide}}\n\n<hr id=answer>\n\n{{Front}}");
             mm.addTemplate(m, t);
+            mm.add(m);
         } catch (JSONException e) {
             throw new RuntimeException(e);
         }
@@ -1307,7 +1317,7 @@ public class Models {
     public static JSONObject addForwardOptionalReverse(Collection col) throws ConfirmModSchemaException {
     	String name = "Basic (optional reversed card)";
         Models mm = col.getModels();
-        JSONObject m = addBasicModel(col);
+        JSONObject m = _newBasicModel(col);
         try {
             m.put("name", name);
             JSONObject fm = mm.newField("Add Reverse");
@@ -1316,6 +1326,7 @@ public class Models {
             t.put("qfmt", "{{#Add Reverse}}{{Back}}{{/Add Reverse}}");
             t.put("afmt", "{{FrontSide}}\n\n<hr id=answer>\n\n{{Front}}");
             mm.addTemplate(m, t);
+            mm.add(m);
         } catch (JSONException e) {
             throw new RuntimeException(e);
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -1302,18 +1302,18 @@ public class Models {
      * @throws ConfirmModSchemaException **********************************************************************************************
      */
 
-    private static JSONObject _newBasicModel(Collection col) throws ConfirmModSchemaException {
+    private static JSONObject _newBasicModel(Collection col) {
         return _newBasicModel(col, "Basic");
     }
 
 
-    private static JSONObject _newBasicModel(Collection col, String name) throws ConfirmModSchemaException {
+    private static JSONObject _newBasicModel(Collection col, String name) {
         Models mm = col.getModels();
         JSONObject m = mm.newModel(name);
         JSONObject fm = mm.newField("Front");
-        mm.addField(m, fm);
+        mm.addFieldInNewModel(m, fm);
         fm = mm.newField("Back");
-        mm.addField(m, fm);
+        mm.addFieldInNewModel(m, fm);
         JSONObject t = mm.newTemplate("Card 1");
         try {
             t.put("qfmt", "{{Front}}");
@@ -1321,7 +1321,7 @@ public class Models {
         } catch (JSONException e) {
             throw new RuntimeException(e);
         }
-        mm.addTemplate(m, t);
+        mm.addTemplateInNewModel(m, t);
         return m;
     }
 
@@ -1337,7 +1337,7 @@ public class Models {
 
     /* Forward & Reverse */
 
-    public static JSONObject addForwardReverse(Collection col) throws ConfirmModSchemaException {
+    public static JSONObject addForwardReverse(Collection col) {
     	String name = "Basic (and reversed card)";
         Models mm = col.getModels();
         JSONObject m = _newBasicModel(col);
@@ -1346,7 +1346,7 @@ public class Models {
             JSONObject t = mm.newTemplate("Card 2");
             t.put("qfmt", "{{Back}}");
             t.put("afmt", "{{FrontSide}}\n\n<hr id=answer>\n\n{{Front}}");
-            mm.addTemplate(m, t);
+            mm.addTemplateInNewModel(m, t);
             mm.add(m);
         } catch (JSONException e) {
             throw new RuntimeException(e);
@@ -1357,18 +1357,18 @@ public class Models {
 
     /* Forward & Optional Reverse */
 
-    public static JSONObject addForwardOptionalReverse(Collection col) throws ConfirmModSchemaException {
+    public static JSONObject addForwardOptionalReverse(Collection col) {
     	String name = "Basic (optional reversed card)";
         Models mm = col.getModels();
         JSONObject m = _newBasicModel(col);
         try {
             m.put("name", name);
             JSONObject fm = mm.newField("Add Reverse");
-            mm.addField(m, fm);
+            mm.addFieldInNewModel(m, fm);
             JSONObject t = mm.newTemplate("Card 2");
             t.put("qfmt", "{{#Add Reverse}}{{Back}}{{/Add Reverse}}");
             t.put("afmt", "{{FrontSide}}\n\n<hr id=answer>\n\n{{Front}}");
-            mm.addTemplate(m, t);
+            mm.addTemplateInNewModel(m, t);
             mm.add(m);
         } catch (JSONException e) {
             throw new RuntimeException(e);
@@ -1377,22 +1377,22 @@ public class Models {
     }
 
 
-    public static JSONObject addClozeModel(Collection col) throws ConfirmModSchemaException {
+    public static JSONObject addClozeModel(Collection col) {
         Models mm = col.getModels();
         JSONObject m = mm.newModel("Cloze");
         try {
             m.put("type", Consts.MODEL_CLOZE);
             String txt = "Text";
             JSONObject fm = mm.newField(txt);
-            mm.addField(m, fm);
+            mm.addFieldInNewModel(m, fm);
             fm = mm.newField("Extra");
-            mm.addField(m, fm);
+            mm.addFieldInNewModel(m, fm);
             JSONObject t = mm.newTemplate("Cloze");
             String fmt = "{{cloze:" + txt + "}}";
             m.put("css", m.getString("css") + ".cloze {" + "font-weight: bold;" + "color: blue;" + "}");
             t.put("qfmt", fmt);
             t.put("afmt", fmt + "<br>\n{{Extra}}");
-            mm.addTemplate(m, t);
+            mm.addTemplateInNewModel(m, t);
             mm.add(m);
         } catch (JSONException e) {
             throw new RuntimeException(e);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -186,7 +186,7 @@ public class Models {
                 m.put("mod", Utils.intTime());
                 m.put("usn", mCol.usn());
                 // TODO: fix empty id problem on _updaterequired (needed for model adding)
-                if (m.getLong("id") != 0) {
+                if (!isModelNew(m)) {
                     _updateRequired(m);
                 }
                 if (templates) {
@@ -324,6 +324,14 @@ public class Models {
         return m;
     }
 
+    // not in anki
+    public static boolean isModelNew(JSONObject m) {
+        try {
+            return m.getLong("id") == 0;
+        } catch (JSONException e) {
+            throw new RuntimeException(e);
+        }
+    }
 
     /** Delete model, and all its cards/notes. 
      * @throws ConfirmModSchemaException */
@@ -530,7 +538,7 @@ public class Models {
     public void addField(JSONObject m, JSONObject field) throws ConfirmModSchemaException {
         // only mod schema if model isn't new
         try {
-            if (m.getLong("id") != 0) {
+            if (!isModelNew(m)) {
                 mCol.modSchema(true);
             }
             JSONArray ja = m.getJSONArray("flds");
@@ -715,7 +723,7 @@ public class Models {
     public void _transformFields(JSONObject m, TransformFieldVisitor fn) {
         // model hasn't been added yet?
         try {
-            if (m.getLong("id") == 0) {
+            if (isModelNew(m)) {
                 return;
             }
             ArrayList<Object[]> r = new ArrayList<>();
@@ -761,7 +769,7 @@ public class Models {
      * @throws ConfirmModSchemaException */
     public void addTemplate(JSONObject m, JSONObject template) throws ConfirmModSchemaException {
         try {
-            if (m.getLong("id") != 0) {
+            if (!isModelNew(m)) {
                 mCol.modSchema(true);
             }
             JSONArray ja = m.getJSONArray("tmpls");

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Storage.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Storage.java
@@ -67,16 +67,11 @@ public class Storage {
             } else if (ver > Consts.SCHEMA_VERSION) {
                 throw new RuntimeException("This file requires a newer version of Anki.");
             } else if (create) {
-                try {
-                    // add in reverse order so basic is default
-                    Models.addClozeModel(col);
-                    Models.addForwardOptionalReverse(col);
-                    Models.addForwardReverse(col);
-                    Models.addBasicModel(col);
-                } catch (ConfirmModSchemaException e) {
-                    // This should never reached as we've just created a new database
-                    throw new RuntimeException(e);
-                }
+                // add in reverse order so basic is default
+                Models.addClozeModel(col);
+                Models.addForwardOptionalReverse(col);
+                Models.addForwardReverse(col);
+                Models.addBasicModel(col);
                 col.save();
             }
             return col;

--- a/AnkiDroid/src/main/java/com/ichi2/utils/Assert.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/Assert.java
@@ -1,0 +1,26 @@
+/****************************************************************************************
+ * Copyright (c) 2009 Bitonator                                                         *
+ * https://stackoverflow.com/questions/6176441/how-to-use-assert-in-android/47267127#47267127 * 
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+
+package com.ichi2.utils;
+
+public class Assert {
+    public static void that(boolean condition, String message) {
+        if (!condition) {
+            throw new AssertionError(message);
+        }
+    }
+}


### PR DESCRIPTION
## Purpose / Description
The initial purpose, as stated in Anki's git is to: "ensure the list of note types is not empty". dae/anki@8497da27cf47f395a8288c47d9ff3ba32e95cfc4

I.e. during fixIntegrity, if it is detected that there are no note type, then the standard note types are added. Similarly, during any change to note type (i.e. modelManager), the non-emptiness is also checked. 

I also ensured that adding the standard model would not state that the mod need to be changed. However, standard models should be added when collection is created; in which case a full upload is already required, or when there are no model, which should never occur.

Doing so, I did realize that the type of addField and addTemplate state that an exception may be thrown. Which actually is not the case if either the model is new or the mod value is already changed. In order to avoid adding try/catch when I know they are useless, I instead created variant of the methods, not throwing exceptions, which check that the model is indeed new/mod is already changed.
I used those methods instead of addTemplate/addField when it made sens. 


## Approach
The initial purpose is done as in anki.

adding field/template without sending exception in type is done by asserting that model is new/mod is changed.
A method to check whether model is new was added for the sake of factorization.

In order to ensure that a model is really new while adding standard model, I add to separate the creation of the basic model, and adding the basic model to the collection. 

## How Has This Been Tested?

gradlew. And I expect it to be tested by travis here. 

I don't really see how to test it; indeed the main change would only occur if there was no model in the model manager. I can't atteint this state in ankidroid, since I can't add/remove any model in it. And I can't do this by synchronization, since this would be corrected by anki on computer, and probably by ankiweb. 

However; I was still able to check that I could still add template.
Since it's impossible to add a field from ankidroid, it was not possible to test the new addField either. 

Note however that creating a new collection (i.e. starting ankidroid for the first time) works fine

Concerning insert in CardContentProvider, I can't figure out where this is called in the code. This class seems to be mentionned in string, but never imported or added in the remaining of the code. So it seems impossible to test it.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code