### PR TITLE
ensure the list of note types is not empty

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1714,6 +1714,10 @@ public class Collection {
             AnkiDroidApp.sendExceptionReport(e, "doInBackgroundCheckDatabase");
             return -1;
         }
+		// models
+        if (mModels.ensureNotEmpty()) {
+            problems.add("Added missing note type.");
+        }
         // and finally, optimize
         optimize(progressCallback, currentTask, totalTasks);
         file = new File(mPath);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -207,6 +207,7 @@ public class Models {
      */
     public void flush() {
         if (mChanged) {
+			ensureNotEmpty();
             JSONObject array = new JSONObject();
             try {
                 for (Map.Entry<Long, JSONObject> o : mModels.entrySet()) {
@@ -222,6 +223,14 @@ public class Models {
         }
     }
 
+	public boolean ensureNotEmpty() {
+		if (mModels.isEmpty()) {
+			addBasicModel(mCol);
+			return true;
+		} else {
+			return false;
+		}
+	}
 
     /**
      * Retrieving and creating models


### PR DESCRIPTION
## Purpose / Description
Main purpose: having libanki similar to Anki's folder Anki.

## Fixes
By accident, all notes type may be deleted in old version of anki
dae/anki@8497da2

## Approach
As in Anki

## How Has This Been Tested?

gradlew. And I expect it to be tested by travis here. 

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code