### PR TITLE
Add strip html process text escape text

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.java
@@ -38,6 +38,7 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -58,6 +59,20 @@ class Exporter {
         mCol = col;
         mDid = did;
     }
+
+	/**"Escape newlines, tabs, CSS and quotechar."*/
+	public String escapeText(String text){
+		// fixme: we should probably quote fields with newlines
+		// instead of converting them to spaces
+		text = text.replace("\n", " ");
+		text = text.replace("\t", "        ");
+		text = Pattern.compile("(?i)<style>.*?</style>").matcher(text).replaceAll("");
+		text = Pattern.compile("\\[\\[type:[^]]+\\]\\]").matcher(text).replaceAll("");
+		if (text.contains("\"")) {
+			text = "\"" + text.replace("\"", "\"\"") + "\"";
+		}
+		return text;
+	}
 }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.java
@@ -47,6 +47,10 @@ import timber.log.Timber;
 class Exporter {
     protected Collection mCol;
     protected Long mDid;
+	// mayIncludeHTML = false corresponds to includeHTML = None in Python.
+	protected boolean mayIncludeHTML = false;
+	// includeHTML is used only if mayIncludeHTML is true.
+	protected boolean includeHTML;
 
 
     public Exporter(Collection col) {
@@ -72,6 +76,25 @@ class Exporter {
 			text = "\"" + text.replace("\"", "\"\"") + "\"";
 		}
 		return text;
+	}
+
+	public String processText(String text) {
+		if (!includeHTML){
+			text = stripHTML(text);
+		}
+		text = escapeText(text);
+		return text;
+	}
+
+	public String stripHTML(String text) {
+		// very basic conversion to text
+		String s = text;
+		s = Pattern.compile("(?i)<(br ?/?|div|p)>").matcher(s).replaceAll("");
+		s = Pattern.compile("\\[sound:[^]]+\\]").matcher(s).replaceAll("");
+		s = Utils.stripHTML(s);
+		s = Pattern.compile("[ \n\t]+").matcher(s).replaceAll("");
+		s = s.trim();
+		return s;
 	}
 }
 


### PR DESCRIPTION
## Purpose / Description
Main purpose: having libanki similar to Anki's folder Anki.

More precisely, having methods which allow to obtain more beautiful notes when they are exported directly as a text file.
I should note that, since ankidroid only allows to export as apkg, those methods are useless right now; until exporting cards/notes as text is implemented.


## Approach
As in Anki

## How Has This Been Tested?

gradlew. And I expect it to be tested by travis here. 

Until exporting cards/notes as text is allowed, this method can't be directly tested in ankidroid.


## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code