### PR TITLE
Allow for a deck parameter when creating and previewing a card

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -813,6 +813,11 @@ public class Collection {
      * @return list of cards
 	 */
 	public List<Card> previewCards(Note note, int type) {
+        int did = 0;
+        return previewCards(note, type, did);
+    }
+
+    public List<Card> previewCards(Note note, int type, int did) {
 	    ArrayList<JSONObject> cms = null;
 	    if (type == 0) {
 	        cms = findTemplates(note);
@@ -837,7 +842,7 @@ public class Collection {
 	    }
 	    List<Card> cards = new ArrayList<>();
 	    for (JSONObject template : cms) {
-	        cards.add(_newCard(note, template, 1, false));
+	        cards.add(_newCard(note, template, 1, did, false));
 	    }
 	    return cards;
 	}


### PR DESCRIPTION
## Purpose / Description
Main purpose: having libanki similar to Anki's folder Anki.

I should note that the initial problem that dae/anki@20ff61e59eae6c32e4671c035a0d5438d169ab2f was supposed to solve exists in ankidroid. However, since ankidroid doesn't used previewCards to preview cards, this PR does not fix the bug. I should also note that my goal is to port anki to libanki, so actually correcting the bug is not something I intend to do in this PR. Even if having previewCards fixed may probably help solving this bug eventually.

## Approach
As in Anki

## How Has This Been Tested?

gradlew and Travis.

I should note that the method previewCards is not called anywhere in ankidroid code. Therefore, there is no way for me to test any change to previewCards. I have not yet looked at the way cards are previewed in ankidroid.

Regarding _newCard: this method is only called in addNote (and in other _newCard). So I only have to test adding cards and seeing whether they still goes to the correct deck.
I.e.:
On computer
* I create a deck «Front»
* I create a note type «TestDeck»
* I create a card «Front» whose override is «Front»
* I create a card «Current» without override
I synchronize
On virtual machine:
* I click on «add»
* I select deck «Default»
* I create a card with random content
* I check that the card «Front» went to «Front» and the card «current» went to deck «Default».

There is no way to test for a new feature, since this new feature would only be used by previewCards, which is not used in ankidroid (yet?)
For context:
Anki uses _newCard to create temporary note that are shown in the addCard window. Those notes becomes permanent if and when the «add» button is clicked. Since ankidroid use another method to add card, _newCard is almost useless here

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code