### PR TITLE
support {{CardFlag}}

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.java
@@ -293,7 +293,7 @@ public class Card implements Cloneable {
             Object[] data;
             try {
                 data = new Object[] { mId, f.getId(), m.getLong("id"), mODid != 0L ? mODid : mDid, mOrd,
-                        f.stringTags(), f.joinedFields() };
+                        f.stringTags(), f.joinedFields(), mFlags};
             } catch (JSONException e) {
                 throw new RuntimeException(e);
             }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1062,7 +1062,7 @@ public class Collection {
 
 
     public HashMap<String, String> _renderQA(Object[] data, String qfmt, String afmt) {
-        // data is [cid, nid, mid, did, ord, tags, flds]
+        // data is [cid, nid, mid, did, ord, tags, flds, cardFlags]
         // unpack fields and create dict
         String[] flist = Utils.splitFields((String) data[6]);
         Map<String, String> fields = new HashMap<>();
@@ -1078,6 +1078,7 @@ public class Collection {
             fields.put("Deck", mDecks.name((Long) data[3]));
             String[] parents = fields.get("Deck").split("::", -1);
             fields.put("Subdeck", parents[parents.length-1]);
+            fields.put("CardFlag", _flagNameFromCardFlags((Integer) data[7]));
             JSONObject template;
             if (model.getInt("type") == Consts.MODEL_STD) {
                 template = model.getJSONArray("tmpls").getJSONObject((Integer) data[4]);
@@ -1122,7 +1123,7 @@ public class Collection {
 
 
     /**
-     * Return [cid, nid, mid, did, ord, tags, flds] db query
+     * Return [cid, nid, mid, did, ord, tags, flds, flags] db query
      */
     public ArrayList<Object[]> _qaData() {
         return _qaData("");
@@ -1135,10 +1136,10 @@ public class Collection {
         try {
             cur = mDb.getDatabase().query(
                     "SELECT c.id, n.id, n.mid, c.did, c.ord, "
-                            + "n.tags, n.flds FROM cards c, notes n WHERE c.nid == n.id " + where, null);
+                            + "n.tags, n.flds, c.flags FROM cards c, notes n WHERE c.nid == n.id " + where, null);
             while (cur.moveToNext()) {
                 data.add(new Object[] { cur.getLong(0), cur.getLong(1), cur.getLong(2), cur.getLong(3), cur.getInt(4),
-                        cur.getString(5), cur.getString(6) });
+                        cur.getString(5), cur.getString(6), cur.getInt(7)});
             }
         } finally {
             if (cur != null && !cur.isClosed()) {
@@ -1148,6 +1149,13 @@ public class Collection {
         return data;
     }
 
+	public String _flagNameFromCardFlags(int flags){
+		int flag = flags & 0b111;
+		if (flag == 0) {
+			return "";
+		}
+		return "flag"+flag;
+	}
 
     /**
      * Finding cards ************************************************************ ***********************************

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -1078,10 +1078,10 @@ public class Models {
             }
             Object[] data;
             data = new Object[] {1L, 1L, m.getLong("id"), 1L, t.getInt("ord"), "",
-                    Utils.joinFields(a.toArray(new String[a.size()])) };
+                    Utils.joinFields(a.toArray(new String[a.size()])), 0};
             String full = mCol._renderQA(data).get("q");
             data = new Object[] {1L, 1L, m.getLong("id"), 1L, t.getInt("ord"), "",
-                    Utils.joinFields(b.toArray(new String[b.size()])) };
+                    Utils.joinFields(b.toArray(new String[b.size()])), 0};
             String empty = mCol._renderQA(data).get("q");
             // if full and empty are the same, the template is invalid and there is no way to satisfy it
             if (full.equals(empty)) {


### PR DESCRIPTION
## Purpose / Description
Main purpose: having libanki similar to Anki's folder Anki.

## Fixes
This tag was set in anki, not in ankidroid. It's no longer the case

I should note that {{CardFlag}} in anki is replaced by the empty string or by Flagi, with i a number. It's absurd; the flag should be a color, as in the browser. However, I stay close to anki code and keep the absurd action instead of doing sensible thing.

## Approach
As in Anki

## How Has This Been Tested?

Gradlew. Travis.

I created a new profile on computer. I edited the basic note so that it's front template is:
```HTML
{{Front}}<br/>
Card flag is :{{CardFlag}}
```
I then created 5 cards. In the browser, I set their flags to the four colours. (As far as I know, ankidroid doesn't allow to set flags yet)
I synchronized on a throwaway account on ankiserver. 
On a virtual device, I synchronized with this throwaway account and downloaded the collection.
I then saw the five cards. 
In the first one {{CardFlag}} was replaced by the empty string. On the other ones, by Flagi, with i a number between 1 and 4; as in anki. 

On a virtual device without this PR, {{CardFlag}} is replaced by a message stating that this field is not known.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code