### PR TITLE
make sure we normalize deck names on input

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -31,6 +31,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.text.Normalizer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -238,8 +239,11 @@ public class Decks {
     public Long id(String name, boolean create, String type) {
         try {
             name = name.replace("\"", "");
+            name = Normalizer.normalize(name, Normalizer.Form.NFC);
             for (Map.Entry<Long, JSONObject> g : mDecks.entrySet()) {
-                if (g.getValue().getString("name").equalsIgnoreCase(name)) {
+                String deckName = g.getValue().getString("name");
+                deckName = Normalizer.normalize(deckName, Normalizer.Form.NFC);
+                if (deckName.equalsIgnoreCase(name)) {
                     return g.getKey();
                 }
             }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
@@ -30,6 +30,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.text.Normalizer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -583,7 +584,9 @@ public class Finder {
         LinkedList<Long> ids = new LinkedList<>();
         try {
             for (JSONObject m : mCol.getModels().all()) {
-                if (m.getString("name").equalsIgnoreCase(val)) {
+                String modelName = m.getString("name");
+                modelName = Normalizer.normalize(modelName, Normalizer.Form.NFC);
+                if (modelName.equalsIgnoreCase(val)) {
                     ids.add(m.getLong("id"));
                 }
             }
@@ -628,7 +631,9 @@ public class Finder {
                 val = val.replace("*", ".*");
                 val = val.replace("+", "\\+");
                 for (JSONObject d : mCol.getDecks().all()) {
-                    if (d.getString("name").matches("(?i)" + val)) {
+                    String deckName = d.getString("name");
+                    deckName = Normalizer.normalize(deckName, Normalizer.Form.NFC);
+                    if (deckName.matches("(?i)" + val)) {
                         for (long id : dids(d.getLong("id"))) {
                             if (!ids.contains(id)) {
                                 ids.add(id);
@@ -666,7 +671,9 @@ public class Finder {
                 JSONArray tmpls = m.getJSONArray("tmpls");
                 for (int ti = 0; ti < tmpls.length(); ++ti) {
                     JSONObject t = tmpls.getJSONObject(ti);
-                    if (t.getString("name").equalsIgnoreCase(val)) {
+                    String templateName = t.getString("name");
+                    Normalizer.normalize(templateName, Normalizer.Form.NFC);
+                    if (templateName.equalsIgnoreCase(val)) {
                         if (m.getInt("type") == Consts.MODEL_CLOZE) {
                             // if the user has asked for a cloze card, we want
                             // to give all ordinals, so we just limit to the
@@ -715,7 +722,9 @@ public class Finder {
                 JSONArray flds = m.getJSONArray("flds");
                 for (int fi = 0; fi < flds.length(); ++fi) {
                     JSONObject f = flds.getJSONObject(fi);
-                    if (f.getString("name").equalsIgnoreCase(field)) {
+                    String fieldName = f.getString("name");
+                    fieldName = Normalizer.normalize(fieldName, Normalizer.Form.NFC);
+                    if (fieldName.equalsIgnoreCase(field)) {
                         mods.put(m.getLong("id"), new Object[] { m, f.getInt("ord") });
                     }
                 }


### PR DESCRIPTION
## Purpose / Description
Main purpose: having libanki similar to Anki's folder Anki.

## Fixes
Some theoretical risk in collision of non normalized name

## Approach
As in Anki

## How Has This Been Tested?

gradlew. 
I don't know how to have non normalized name on android. I'm not competent enough to test it

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code