### PR TITLE
find&replace should not be case sensitive on field

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
@@ -855,7 +855,7 @@ public class Finder {
                     JSONArray flds = m.getJSONArray("flds");
                     for (int fi = 0; fi < flds.length(); ++fi) {
                         JSONObject f = flds.getJSONObject(fi);
-                        if (f.getString("name").equals(field)) {
+                        if (f.getString("name").equalsIgnoreCase(field)) {
                             mmap.put(m.getLong("id"), f.getInt("ord"));
                         }
                     }


### PR DESCRIPTION
## Purpose / Description
Main purpose: having libanki similar to Anki's folder Anki.


## Approach
As in Anki

## How Has This Been Tested?

gradlew. 
ordForMid is used only in findDupes. findDupes is used only in other method findDupes. So essentially, this method is not used at all currently. 

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code