### PR TITLE
cap filename length when attaching media to cards

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Media.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Media.java
@@ -40,7 +40,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -573,7 +572,7 @@ public class Media {
         int pathmax = 1024; // 240 for windows
 
         // cap namemax based on absolute path
-        int dirlen = Paths.get(fname).normalize().toString().length();
+        int dirlen = fname.length();// ideally, name should be normalized. Without access to nio.Paths library, it's hard to do it really correctly. This is still a better approximation than nothing.
         int remaining = pathmax - dirlen;
         namemax = min(remaining, namemax);
         Assert.that(namemax>0, "The media directory is maximally long. There is no more length available for file name.");


### PR DESCRIPTION
## Purpose / Description
Main purpose: having libanki similar to Anki's folder Anki.

## Fixes
Avoid a potential risk when media name added through android are extremly long.

Note that I believe that dae's code itself does not make sens here. Indeed, the same collection can be synchronized on any device. So the same constraints should apply to all devices. Otherwise, we risks to have media which can be used on android and not on windows. 

However, here, I'm only porting anki's code to ankidroid and thus don't intend to correct it

## Approach
As in Anki

## How Has This Been Tested?

gradlew. 
I fail to test this, because I fail to produce the bug it's supposed to avoid. When I try to use a virtual machine, I can't rename a file to give it more than 1024 characters. Mostly because typing a single character takes seconds. Which means that I can actually have a file name long enough to ensure that current ankidroid have a problem and that this droid solve it.

However I tested that we can still add normal files in ankidroid, and that it works perfectly.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code