### PR TITLE
Add method card ids to exporter

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.java
@@ -109,12 +109,7 @@ class AnkiExporter extends Exporter {
         Collection dst = Storage.Collection(context, path);
         mSrc = mCol;
         // find cards
-        Long[] cids;
-        if (mDid == null) {
-            cids = Utils.list2ObjectArray(mSrc.getDb().queryColumn(Long.class, "SELECT id FROM cards", 0));
-        } else {
-            cids = mSrc.getDecks().cids(mDid, true);
-        }
+        Long[] cids = cardIds();
         // attach dst to src so we can copy data between them. This isn't done in original libanki as Python more
         // flexible
         dst.close();

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.java
@@ -46,6 +46,7 @@ import timber.log.Timber;
 class Exporter {
     protected Collection mCol;
     protected Long mDid;
+    protected int mCount;
 
 
     public Exporter(Collection col) {
@@ -58,6 +59,18 @@ class Exporter {
         mCol = col;
         mDid = did;
     }
+
+    /** card ids of cards in deck self.did if it is set, all ids otherwise. */
+    public Long[] cardIds() {
+        Long[] cids;
+        if (mDid == null) {
+            cids = Utils.list2ObjectArray(mCol.getDb().queryColumn(Long.class, "select id from cards", 0));
+        } else {
+            cids = mCol.getDecks().cids(mDid, true);
+        }
+        mCount = cids.length;
+        return cids;
+    }
 }
 
 
@@ -69,7 +82,6 @@ class AnkiExporter extends Exporter {
     protected boolean mIncludeMedia;
     private Collection mSrc;
     String mMediaDir;
-    int mCount;
     ArrayList<String> mMediaFiles = new ArrayList<>();
     boolean _v2sched;
 


### PR DESCRIPTION
## Purpose / Description
Main purpose: having libanki similar to Anki's folder Anki.

When there are more exporter, allows to factorize code

## Approach
As in Anki

## How Has This Been Tested?

gradlew. And I expect it to be tested by travis here. 

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code