### PR TITLE
remove dupeOnSchemaChange

### DIFF
--- a/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/libanki/ImportTest.java
+++ b/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/libanki/ImportTest.java
@@ -178,40 +178,7 @@ public class ImportTest {
         assertEquals(2, new File(testCol.getMedia().dir()).list().length);
     }
 
-    @Test
-    public void testAnki2Diffmodels() throws IOException, ImportExportException {
-        // create a new empty deck
-        // import the 1 card version of the model
-        String tmp = Shared.getTestFilePath(InstrumentationRegistry.getInstrumentation().getTargetContext(), "diffmodels2-1.apkg");
-        AnkiPackageImporter imp = new AnkiPackageImporter(testCol, tmp);
-        imp.setDupeOnSchemaChange(true);
-        imp.run();
-        int before = testCol.noteCount();
-        // repeating the process should do nothing
-        imp = new AnkiPackageImporter(testCol, tmp);
-        imp.setDupeOnSchemaChange(true);
-        imp.run();
-        assertEquals(before, testCol.noteCount());
-        // then the 2 card version
-        tmp = Shared.getTestFilePath(InstrumentationRegistry.getInstrumentation().getTargetContext(), "diffmodels2-2.apkg");
-        imp = new AnkiPackageImporter(testCol, tmp);
-        imp.setDupeOnSchemaChange(true);
-        imp.run();
-        int after = testCol.noteCount();
-        // as the model schemas differ, should have been imported as new model
-        assertEquals(before + 1, after);
-        // and the new model should have both cards
-        assertEquals(3, testCol.cardCount());
-        // repeating the process should do nothing
-        imp = new AnkiPackageImporter(testCol, tmp);
-        imp.setDupeOnSchemaChange(true);
-        imp.run();
-        after = testCol.noteCount();
-        assertEquals(before + 1, after);
-        assertEquals(3, testCol.cardCount());
-    }
-
-    @Test
+    @Test		
     public void testAnki2DiffmodelTemplates() throws IOException, JSONException, ImportExportException {
         // different from the above as this one tests only the template text being
         // changed, not the number of cards/fields

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
@@ -184,9 +184,8 @@ public class Anki2Importer extends Importer {
         // we may need to rewrite the guid if the model schemas don't match,
         // so we need to keep track of the changes for the card import stage
         mChangedGuids = new HashMap<>();
-        // apart from upgrading from anki1 decks, we ignore updates to changed
-        // schemas. we need to note the ignored guids, so we avoid importing
-        // invalid cards
+        // we ignore updates to changed schemas. we need to note the ignored
+        // guids, so we avoid importing invalid cards
         mIgnoredGuids = new HashMap<>();
         // iterate over source collection
         ArrayList<Object[]> add = new ArrayList<>();
@@ -303,23 +302,9 @@ public class Anki2Importer extends Importer {
         if (!mNotes.containsKey(origGuid)) {
             return true;
         }
-        // as the schemas differ and we already have a note with a different
-        // note type, this note needs a new guid
-        if (!mDupeOnSchemaChange) {
-            return false;
-        }
-        while (true) {
-            note[GUID] = Utils.incGuid((String) note[GUID]);
-            mChangedGuids.put(origGuid, (String) note[GUID]);
-            // if we don't have an existing guid, we can add
-            if (!mNotes.containsKey(note[GUID])) {
-                return true;
-            }
-            // if the existing guid shares the same mid, we can reuse
-            if (dstMid == (Long) mNotes.get(note[GUID])[MID]) {
-                return false;
-            }
-        }
+		// schema changed; don't import
+		mIgnoredGuids.put(origGuid, true);
+		return false;
     }
 
 


### PR DESCRIPTION
## Purpose / Description
Main purpose: having libanki similar to Anki's folder Anki.

Drop supporting anki 1

## Approach
As in Anki

## How Has This Been Tested?

gradlew. And I expect it to be tested by travis here. 

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code