### PR TITLE
make sure we don't import cards into a filtered deck

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
@@ -390,6 +390,7 @@ public class Anki2Importer extends Importer {
 
     /** Given did in src col, return local id. */
     private long _did(long did) {
+        JSONObject deck;
         try {
             // already converted?
             if (mDecks.containsKey(did)) {
@@ -418,6 +419,11 @@ public class Anki2Importer extends Importer {
                 long idInSrc = mSrc.getDecks().id(head);
                 _did(idInSrc);
             }
+            // if target is a filtered deck, we'll need a new deck name
+            deck = mDst.getDecks().byName(name);
+            if (deck != null && deck.getBoolean("dyn")) {
+                name = String.format("%s %d", name, Utils.intTime());
+            }
             // create in local
             long newid = mDst.getDecks().id(name);
             // pull conf over
@@ -430,7 +436,7 @@ public class Anki2Importer extends Importer {
                 mDst.getDecks().save(g2);
             }
             // save desc
-            JSONObject deck = mDst.getDecks().get(newid);
+            deck = mDst.getDecks().get(newid);
             deck.put("desc", g.getString("desc"));
             mDst.getDecks().save(deck);
             // add to deck map and return


### PR DESCRIPTION
## Purpose / Description
Main purpose: having libanki similar to Anki's folder Anki.

## Fixes
Theoretical risks of importing card in filtered deck

## Approach
As in Anki

## How Has This Been Tested?

gradlew. And I expect it to be tested by travis here. 

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code