### PR TITLE
favour most recent modified when importing template changes

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/ImportTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/ImportTest.java
@@ -30,6 +30,7 @@ import com.ichi2.libanki.importer.AnkiPackageImporter;
 import com.ichi2.libanki.importer.Importer;
 
 import com.ichi2.utils.JSONException;
+import com.ichi2.utils.JSONObject;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -187,6 +188,10 @@ public class ImportTest {
         AnkiPackageImporter imp = new AnkiPackageImporter(testCol, tmp);
         imp.setDupeOnSchemaChange(true);
         imp.run();
+        JSONObject importedDeck = testCol.getDecks().get(1403973847422L);
+        importedDeck.put("mod", 1403978820L);
+        //During importation, the mod date is set to now. For the next test, we need the mod date to be older than the one in diffmodeltemplates-2. So we set it back to its previous value
+        testCol.getDecks().save(importedDeck);
         // then the version with updated template
         tmp = Shared.getTestFilePath(InstrumentationRegistry.getInstrumentation().getTargetContext(), "diffmodeltemplates-2.apkg");
         imp = new AnkiPackageImporter(testCol, tmp);

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/ImportTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/ImportTest.java
@@ -189,7 +189,7 @@ public class ImportTest {
         imp.setDupeOnSchemaChange(true);
         imp.run();
         JSONObject importedDeck = testCol.getDecks().get(1403973847422L);
-        importedDeck.put("mod", 1403978820L);
+        importedDeck.put("mod", 140320L);
         //During importation, the mod date is set to now. For the next test, we need the mod date to be older than the one in diffmodeltemplates-2. So we set it back to its previous value
         testCol.getDecks().save(importedDeck);
         // then the version with updated template

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
@@ -347,12 +347,14 @@ public class Anki2Importer extends Importer {
             JSONObject dstModel = mDst.getModels().get(mid);
             String dstScm = mDst.getModels().scmhash(dstModel);
             if (srcScm.equals(dstScm)) {
-                // they do; we can reuse this mid
-                JSONObject model = srcModel.deepClone();
-                model.put("id", mid);
-                model.put("mod", Utils.intTime());
-                model.put("usn", mCol.usn());
-                mDst.getModels().update(model);
+                // copy styling changes over if newer
+                if (srcModel.getLong("mod") > dstModel.getLong("mod")) {
+                    JSONObject model = srcModel.deepClone();
+                    model.put("id", mid);
+                    model.put("mod", Utils.intTime());
+                    model.put("usn", mCol.usn());
+                    mDst.getModels().update(model);
+                }
                 break;
             }
             // as they don't match, try next id


### PR DESCRIPTION
## Purpose / Description
Main purpose: having libanki similar to Anki's folder Anki.

## Fixes
If a model has been changed recently on ankidroid, don't import model

## Approach
As in Anki

## How Has This Been Tested?

1. Export a deck
2. change a card type's template
3. import the deck

Without this PR, you'll have the last version of the deck back. With this PR, you have the newest version of the deck.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code