### PR TITLE
Catch corrupt media db fix it in check media

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
@@ -394,6 +394,10 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
                     if (ret == null) {
                         mediaError = AnkiDroidApp.getAppResources().getString(R.string.sync_media_error);
                     } else {
+                        if ("corruptMediaDB".equals(ret)) {
+                            mediaError = AnkiDroidApp.getAppResources().getString(R.string.sync_media_db_error);
+                            noMediaChanges = true;
+                        }
                         if (ret.equals("noChanges")) {
                             publishProgress(R.string.sync_media_no_changes);
                             noMediaChanges = true;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Media.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Media.java
@@ -203,6 +203,12 @@ public class Media {
         mDb = null;
     }
 
+    private void _deleteDB() {
+        String path = mDb.getPath();
+        close();
+        (new File(path)).delete();
+        connect();
+    }
 
     public String dir() {
         return mDir;
@@ -496,6 +502,12 @@ public class Media {
             if (!x.startsWith("_")) {
                 nohave.add(x);
             }
+        }
+        // make sure the media DB is valid
+        try {
+            findChanges();
+        } catch (SQLException ignored) {
+            _deleteDB();
         }
         List<List<String>> result = new ArrayList<>();
         result.add(nohave);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/MediaSyncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/MediaSyncer.java
@@ -17,6 +17,7 @@
 
 package com.ichi2.libanki.sync;
 
+import android.database.SQLException;
 import android.text.TextUtils;
 import android.util.Pair;
 
@@ -89,7 +90,11 @@ public class MediaSyncer {
             if (mCol.getMedia().needScan()) {
                 mCon.publishProgress(R.string.sync_media_find);
                 mCol.log("findChanges");
-                mCol.getMedia().findChanges();
+                try {
+                    mCol.getMedia().findChanges();
+                } catch (SQLException ignored) {
+                    return "corruptMediaDB";
+                }
             }
 
             // begin session and check if in sync

--- a/AnkiDroid/src/main/res/values/04-network.xml
+++ b/AnkiDroid/src/main/res/values/04-network.xml
@@ -95,6 +95,7 @@
     <string name="sync_media_downloaded_count">%d media files downloaded</string>
     <string name="sync_sanity_failed">After syncing, the collection was in an inconsistent state. To fix this problem, AnkiDroid will force a full sync. Choose which side you would like to keep.</string>
     <string name="sync_media_sanity_failed">Media sync completed, but the media count doesn’t agree with the server. The next media sync will be full to correct any error.</string>
+    <string name="sync_media_db_error">Media sync failed because current database is corrupt. A media check is recommended.</string>
     <string name="sync_media_error">Error syncing media data</string>
     <string name="sync_media_error_check">Error while syncing media. A media check is recommended.</string>
     <string name="sync_sanity_local">Local</string>


### PR DESCRIPTION
## Purpose / Description
Main purpose: having libanki similar to Anki's folder Anki.

## Fixes
Theoretical risk in case of corrupted media database

## Approach
As in Anki

## How Has This Been Tested?

gradlew. And I expect it to be tested by travis here. 

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code