### PR TITLE
catch attempts to write outside the media folder

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/AnkiPackageImporter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/AnkiPackageImporter.java
@@ -89,6 +89,8 @@ public class AnkiPackageImporter extends Anki2Importer {
             // number to use during the import
             File mediaMapFile = new File(tempDir, "media");
             mNameToNum = new HashMap<>();
+            String dirPath = tmpCol.getMedia().dir();
+            File dir = new File(dirPath);
             // We need the opposite mapping in AnkiDroid since our extraction method requires it.
             Map<String, String> numToName = new HashMap<>();
             try {
@@ -99,6 +101,10 @@ public class AnkiPackageImporter extends Anki2Importer {
                 while (jr.hasNext()) {
                     num = jr.nextName();
                     name = jr.nextString();
+                    File file= new File(dir, name);
+                    if (!Utils.isInside(file, dir)) {
+                        throw (new RuntimeException("Invalid file"));
+                    }
                     mNameToNum.put(name, num);
                     numToName.put(num, name);
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/AnkiPackageImporter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/AnkiPackageImporter.java
@@ -105,6 +105,7 @@ public class AnkiPackageImporter extends Anki2Importer {
                     if (!Utils.isInside(file, dir)) {
                         throw (new RuntimeException("Invalid file"));
                     }
+                    Utils.nfcNormalized(num);
                     mNameToNum.put(name, num);
                     numToName.put(num, name);
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/AnkiPackageImporter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/AnkiPackageImporter.java
@@ -50,7 +50,7 @@ public class AnkiPackageImporter extends Anki2Importer {
     public void run() throws ImportExportException {
         publishProgress(0, 0, 0);
         File tempDir = new File(new File(mCol.getPath()).getParent(), "tmpzip");
-        Collection tmpCol;
+        Collection tmpCol; //self.col into Anki.
         try {
             // We extract the zip contents into a temporary directory and do a little more
             // validation than the desktop client to ensure the extracted collection is an apkg.
@@ -94,8 +94,8 @@ public class AnkiPackageImporter extends Anki2Importer {
             try {
                 JsonReader jr = new JsonReader(new FileReader(mediaMapFile));
                 jr.beginObject();
-                String name;
-                String num;
+                String name; // v in anki
+                String num; // k in anki
                 while (jr.hasNext()) {
                     num = jr.nextName();
                     name = jr.nextString();


### PR DESCRIPTION
## Purpose / Description
Main purpose: having libanki similar to Anki's folder Anki.

## Fixes
Theoretical risk in case of media name in cards not referring to media folder

## Approach
As in Anki

## How Has This Been Tested?

I tried to import a deck with an image. it did work.
I didn't check whether it really protects against a deck created especially to hack anki/ankidroid, since I don't even know exactly against which attack this is supposed to protect the user. I don't know how to create a zip file such that the normalized path of a string is above the top level of the folder.


## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code