### PR TITLE
add type-in-the-answer note type

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.java
@@ -303,6 +303,7 @@ public class ModelBrowser extends AnkiActivity {
         final String basicName = getResources().getString(R.string.basic_model_name);
         final String addForwardReverseName = getResources().getString(R.string.forward_reverse_model_name);
         final String addForwardOptionalReverseName = getResources().getString(R.string.forward_optional_reverse_model_name);
+        final String addTypingName = getResources().getString(R.string.basic_typing_model_name);
         final String addClozeModelName = getResources().getString(R.string.cloze_model_name);
 
         //Populates arrayadapters listing the mModels (includes prefixes/suffixes)
@@ -314,11 +315,13 @@ public class ModelBrowser extends AnkiActivity {
         mNewModelLabels.add(String.format(add, basicName));
         mNewModelLabels.add(String.format(add, addForwardReverseName));
         mNewModelLabels.add(String.format(add, addForwardOptionalReverseName));
+        mNewModelLabels.add(String.format(add, addTypingName));
         mNewModelLabels.add(String.format(add, addClozeModelName));
 
         mNewModelNames.add(basicName);
         mNewModelNames.add(addForwardReverseName);
         mNewModelNames.add(addForwardOptionalReverseName);
+        mNewModelNames.add(addTypingName);
         mNewModelNames.add(addClozeModelName);
 
         final int numStdModels = mNewModelLabels.size();
@@ -404,14 +407,17 @@ public class ModelBrowser extends AnkiActivity {
                     case (2):
                         model = Models.addForwardOptionalReverse(col);
                         break;
-                    //Close model
                     case (3):
+                        model = Models.addBasicTypingModel(col);
+                        break;
+                    //Close model
+                    case (4):
                         model = Models.addClozeModel(col);
                         break;
                     default:
                         //New model
                         //Model that is being cloned
-                        JSONObject oldModel = new JSONObject(mModels.get(position - 4).toString());
+                        JSONObject oldModel = new JSONObject(mModels.get(position - 5).toString());
                         JSONObject newModel = Models.addBasicModel(col);
                         oldModel.put("id", newModel.get("id"));
                         model = oldModel;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -1350,6 +1350,37 @@ public class Models {
         return m;
     }
 
+    /* Basic w/ typing */
+
+    private static JSONObject _newBasicTypingModel(Collection col) {
+        String name = AnkiDroidApp.getAppResources().getString(R.string.basic_typing_model_name);
+        return _newBasicTypingModel(col, name);
+    }
+
+    private static JSONObject _newBasicTypingModel(Collection col, String name) {
+        //addField and addTemplate can't actually throw an exception, since we add new field/template.
+        JSONObject m = _newBasicModel(col, name);
+        try {
+            JSONObject t = m.getJSONArray("tmpls").getJSONObject(0);
+            t.put("afmt", "{{"+"Front"+"}}\n\n<hr id=answer>\n\n{{type:"+"Back"+"}}");
+        } catch (JSONException e) {
+            throw new RuntimeException(e);
+        }
+        return m;
+    }
+
+    public static JSONObject addBasicTypingModel(Collection col, String name) {
+        JSONObject m = _newBasicTypingModel(col, name);
+        col.getModels().add(m);
+        return m;
+    }
+
+    public static JSONObject addBasicTypingModel(Collection col) {
+        JSONObject m = _newBasicTypingModel(col);
+        col.getModels().add(m);
+        return m;
+    }
+
     /* Forward & Reverse */
     private static JSONObject _newForwardReverse(Collection col) {
         String name = AnkiDroidApp.getAppResources().getString(R.string.forward_reverse_model_name);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Storage.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Storage.java
@@ -69,6 +69,7 @@ public class Storage {
             } else if (create) {
                 // add in reverse order so basic is default
                 Models.addClozeModel(col);
+                Models.addBasicTypingModel(col);
                 Models.addForwardOptionalReverse(col);
                 Models.addForwardReverse(col);
                 Models.addBasicModel(col);


### PR DESCRIPTION
## Purpose / Description
Main purpose: having libanki similar to Anki's folder Anki.

This default note type was missing from ankidroid

## Approach
As in Anki.
The rebase onto main, to take into account last change which did conflict in this PR. In particular 1193ecfaf7f18b03a14e1f897951cde4d64c4521 by myself; because now names are localized.

## How Has This Been Tested?

gradlew/travis.

I started a fresh ankidroid on a virtual machine, checked that «Basic (type in the answer)», created a note, and tested it. It did work.


## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code