### PR TITLE
make sure exporting ignores subfolders

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.java
@@ -207,11 +207,18 @@ class AnkiExporter extends Exporter {
                     "select flds from notes where id in " + strnids, 0);
             for (int idx = 0; idx < mid.size(); idx++) {
                 for (String file : mSrc.getMedia().filesInStr(mid.get(idx), flds.get(idx))) {
+                    // skip files in subdirs
+                    if (file.contains(File.separator)) {
+                        continue;
+                    }
                     media.put(file, true);
                 }
             }
             if (mMediaDir != null) {
                 for (File f : new File(mMediaDir).listFiles()) {
+                    if (f.isDirectory()) {
+                        continue;
+                    }
                     String fname = f.getName();
                     if (fname.startsWith("_")) {
                         // Loop through every model that will be exported, and check if it contains a reference to f


### PR DESCRIPTION
## Purpose / Description
Main purpose: having libanki similar to Anki's folder Anki.

## Fixes
Theoretical risk in case of trouble with media folder

## Approach
As in Anki

## How Has This Been Tested?

gradlew.
I tried to export a deck with a media in it. It did work

I can't really test the problem this is supposed to solve since it's hard to reproduce without hacking a collection. Indeed, it supposes that I succeed in adding a folder in a collection.

Since this prevent exporting a folder, this is not a security risk, as could be allowing to import a deck with a folder in the medias. So I believe that trying to hack ankidroid in unusual way to check how much this correction really corrects entirely the theoretical risk is not worth the time of anyone.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code