### PR TITLE
Allow special characters to be escaped

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
@@ -440,11 +440,11 @@ public class Finder {
         if (!val.startsWith("%")) {
             val = "% " + val;
         }
-        if (!val.endsWith("%")) {
+        if (!val.endsWith("%") || val.endsWith("\\%")) {
             val += " %";
         }
         args.add(val);
-        return "n.tags like ?";
+        return "n.tags like ? escape '\\'";
     }
 
 


### PR DESCRIPTION
dae/anki@491b8ea63fdf049dae122a0bc905e0eac3c7451f

## Purpose / Description
Main purpose: having libanki similar to Anki's folder Anki.

## Fixes
Allow to deal with search of tags when there are multiple tags

## Approach
As in Anki

## How Has This Been Tested?

gradlew.
Create a collection with two notes. one with tag "tag%". One with tag "tag". 
Open the browser. Enter search "tag:tag\%". You'll find only the first note, as in anki.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code