### PR TITLE
Wildcard tag deletion

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Tags.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Tags.java
@@ -251,6 +251,7 @@ public class Tags {
             if (lim.length() != 0) {
                 lim.append(" or ");
             }
+            t = t.replace("*", "%");
             lim.append(l).append("like '% ").append(t).append(" %'");
         }
         Cursor cur = null;
@@ -328,14 +329,19 @@ public class Tags {
         return join(canonify(currentTags));
     }
 
+    // submethod of remFromStr in anki
+    public boolean wildcard(String pat, String str) {
+        return (pat.contains("*") &&
+                Pattern.compile(pat.replace("*", ".*"), Pattern.CASE_INSENSITIVE|Pattern.UNICODE_CASE).matcher(str).matches());
+    }
 
-    /** Delete tags if they don't exist. */
+    /** Delete tags if they exist. */
     public String remFromStr(String deltags, String tags) {
         List<String> currentTags = split(tags);
         for (String tag : split(deltags)) {
             List<String> remove = new ArrayList<>();
             for (String tx: currentTags) {
-                if (tag.equalsIgnoreCase(tx)) {
+                if (tag.equalsIgnoreCase(tx) || wildcard(tag, tx)) {
                     remove.add(tx);
                 }
             }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Tags.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Tags.java
@@ -331,8 +331,9 @@ public class Tags {
 
     // submethod of remFromStr in anki
     public boolean wildcard(String pat, String str) {
-        return (pat.contains("*") &&
-                Pattern.compile(pat.replace("*", ".*"), Pattern.CASE_INSENSITIVE|Pattern.UNICODE_CASE).matcher(str).matches());
+        String pat_replaced = Pattern.quote(pat).replace("\\*", ".*");
+        return (pat_replaced.contains("*") &&
+                Pattern.compile(pat_replaced, Pattern.CASE_INSENSITIVE|Pattern.UNICODE_CASE).matcher(str).matches());
     }
 
     /** Delete tags if they exist. */

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Tags.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Tags.java
@@ -332,8 +332,7 @@ public class Tags {
     // submethod of remFromStr in anki
     public boolean wildcard(String pat, String str) {
         String pat_replaced = Pattern.quote(pat).replace("\\*", ".*");
-        return (pat_replaced.contains("*") &&
-                Pattern.compile(pat_replaced, Pattern.CASE_INSENSITIVE|Pattern.UNICODE_CASE).matcher(str).matches());
+        return Pattern.compile(pat_replaced, Pattern.CASE_INSENSITIVE|Pattern.UNICODE_CASE).matcher(str).matches();
     }
 
     /** Delete tags if they exist. */

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Tags.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Tags.java
@@ -236,7 +236,9 @@ public class Tags {
             return;
         }
         // cache tag names
-        register(newTags);
+        if (add) {
+            register(newTags);
+        }
         // find notes missing the tags
         String l;
         if (add) {


### PR DESCRIPTION
Allow wildcard tag deletion
dae/anki@9f37cddfdad8c7c7bab0e60b42e00eb50fd6161b

## Purpose / Description
Main purpose: having libanki similar to Anki's folder Anki.

## Approach
As in Anki

## How Has This Been Tested?

Gradlew only.
Currently, Tags#bulkRem is never called anywhere in the code. It's not accessible from the GUI. So there is no way to check whether the PR indeed correct this method since anyway this method currently can't be used, even if it's in the codebase.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code