### PR TITLE
some html regexps should be case insensitive

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
@@ -96,10 +96,10 @@ public class Utils {
     private Utils() { }
 
     // Regex pattern used in removing tags from text before diff
-    private static final Pattern stylePattern = Pattern.compile("(?s)<style.*?>.*?</style>");
-    private static final Pattern scriptPattern = Pattern.compile("(?s)<script.*?>.*?</script>");
+    private static final Pattern stylePattern = Pattern.compile("(?si)<style.*?>.*?</style>");
+    private static final Pattern scriptPattern = Pattern.compile("(?si)<script.*?>.*?</script>");
     private static final Pattern tagPattern = Pattern.compile("<.*?>");
-    private static final Pattern imgPattern = Pattern.compile("<img src=[\\\"']?([^\\\"'>]+)[\\\"']? ?/?>");
+    private static final Pattern imgPattern = Pattern.compile("(?i)<img src=[\\\"']?([^\\\"'>]+)[\\\"']? ?/?>");
     private static final Pattern htmlEntitiesPattern = Pattern.compile("&#?\\w+;");
 
     private static final String ALL_CHARACTERS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";


### PR DESCRIPTION
dae/anki@27c23c01d6193c4fdae6854f27972956deb0bb12

## Purpose / Description
Main purpose: having libanki similar to Anki's folder Anki.

## Fixes
Theoretical problem in case of upper cap in HTML in fields.

## Approach
As in Anki

## How Has This Been Tested?

gradlew. And I expect it to be tested by travis here. 

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code