### PR TITLE
escape backslash in find&replace

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
@@ -870,6 +870,7 @@ public class Finder {
         // find and gather replacements
         if (!isRegex) {
             src = Pattern.quote(src);
+            dst = dst.replace("\\", "\\\\");
         }
         if (fold) {
             src = "(?i)" + src;


### PR DESCRIPTION
https://anki.tenderapp.com/discussions/ankidesktop/35903-bug-find-and-replace-breaks-when-replacing-with-latexmathjax-commands
dae/anki@6b784ae42e767413798acfbff34968d2d984db52

## Purpose / Description
Main purpose: having libanki similar to Anki's folder Anki.

## Approach
As in Anki

## How Has This Been Tested?

gradlew. And I expect it to be tested by travis here. 

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code