### PR TITLE
Correct assertEquals parameter order

### DIFF
--- a/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/ContentProviderTest.java
+++ b/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/ContentProviderTest.java
@@ -425,7 +425,7 @@ public class ContentProviderTest {
             assertEquals("Check field length", TEST_MODEL_FIELDS.length, model.getJSONArray("flds").length());
             JSONArray flds = model.getJSONArray("flds");
             for (int i = 0; i < flds.length(); i++) {
-                assertEquals("Check name of fields", flds.getJSONObject(i).getString("name"), TEST_MODEL_FIELDS[i]);
+                assertEquals("Check name of fields", TEST_MODEL_FIELDS[i], flds.getJSONObject(i).getString("name"));
             }
             // Test updating the model CSS (to test updating MODELS_ID Uri)
             cv = new ContentValues();

--- a/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/libanki/ImportTest.java
+++ b/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/libanki/ImportTest.java
@@ -153,7 +153,7 @@ public class ImportTest {
         expected = Collections.singletonList("foo.wav");
         actual = Arrays.asList(new File(tmp.getMedia().dir()).list());
         actual.retainAll(expected);
-        assertEquals(actual.size(), expected.size());
+        assertEquals(expected.size(), actual.size());
         // but if the local file has different data, it will rename
         tmp.remCards(Utils.arrayList2array(tmp.getDb().queryColumn(Long.class, "select id from cards", 0)));
         FileOutputStream os;
@@ -162,7 +162,7 @@ public class ImportTest {
         os.close();
         imp = new AnkiPackageImporter(tmp, apkg);
         imp.run();
-        assertEquals(new File(tmp.getMedia().dir()).list().length, 2);
+        assertEquals(2, new File(tmp.getMedia().dir()).list().length);
     }
 
     @Test
@@ -187,16 +187,16 @@ public class ImportTest {
         imp.run();
         int after = dst.noteCount();
         // as the model schemas differ, should have been imported as new model
-        assertEquals(after, before + 1);
+        assertEquals(before + 1, after);
         // and the new model should have both cards
-        assertEquals(dst.cardCount(), 3);
+        assertEquals(3, dst.cardCount());
         // repeating the process should do nothing
         imp = new AnkiPackageImporter(dst, tmp);
         imp.setDupeOnSchemaChange(true);
         imp.run();
         after = dst.noteCount();
-        assertEquals(after, before + 1);
-        assertEquals(dst.cardCount(), 3);
+        assertEquals(before + 1, after);
+        assertEquals(3, dst.cardCount());
     }
 
     @Test
@@ -215,7 +215,7 @@ public class ImportTest {
         imp.setDupeOnSchemaChange(true);
         imp.run();
         // collection should contain the note we imported
-        assertEquals(dst.noteCount(), 1);
+        assertEquals(1, dst.noteCount());
         // the front template should contain the text added in the 2nd package
         Long tcid = dst.findCards("").get(0);
         Note tnote = dst.getCard(tcid).note();
@@ -229,24 +229,24 @@ public class ImportTest {
         String tmp = Shared.getTestFilePath(InstrumentationRegistry.getInstrumentation().getTargetContext(), "update1.apkg");
         AnkiPackageImporter imp = new AnkiPackageImporter(dst, tmp);
         imp.run();
-        assertEquals(imp.getDupes(), 0);
-        assertEquals(imp.getAdded(), 1);
-        assertEquals(imp.getUpdated(), 0);
+        assertEquals(0, imp.getDupes());
+        assertEquals(1, imp.getAdded());
+        assertEquals(0, imp.getUpdated());
         // importing again should be idempotent
         imp = new AnkiPackageImporter(dst, tmp);
         imp.run();
-        assertEquals(imp.getDupes(), 1);
-        assertEquals(imp.getAdded(), 0);
-        assertEquals(imp.getUpdated(), 0);
+        assertEquals(1, imp.getDupes());
+        assertEquals(0, imp.getAdded());
+        assertEquals(0, imp.getUpdated());
         // importing a newer note should update
-        assertEquals(dst.noteCount(), 1);
+        assertEquals(1, dst.noteCount());
         assertTrue(dst.getDb().queryString("select flds from notes").startsWith("hello"));
         tmp = Shared.getTestFilePath(InstrumentationRegistry.getInstrumentation().getTargetContext(), "update2.apkg");
         imp = new AnkiPackageImporter(dst, tmp);
         imp.run();
-        assertEquals(imp.getDupes(), 1);
-        assertEquals(imp.getAdded(), 0);
-        assertEquals(imp.getUpdated(), 1);
+        assertEquals(1, imp.getDupes());
+        assertEquals(0, imp.getAdded());
+        assertEquals(1, imp.getUpdated());
         assertTrue(dst.getDb().queryString("select flds from notes").startsWith("goodbye"));
     }
 
@@ -328,8 +328,8 @@ public class ImportTest {
         imp = new AnkiPackageImporter(dst, tmp);
         imp.run();
         // there is a dupe, but it was ignored
-        assertEquals(imp.getDupes(), 1);
-        assertEquals(imp.getAdded(), 0);
-        assertEquals(imp.getUpdated(), 0);
+        assertEquals(1, imp.getDupes());
+        assertEquals(0, imp.getAdded());
+        assertEquals(0, imp.getUpdated());
     }
 }

--- a/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/libanki/MediaTest.java
+++ b/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/libanki/MediaTest.java
@@ -184,8 +184,8 @@ public class MediaTest {
     public void testChanges() throws IOException {
         Collection d = Shared.getEmptyCol(InstrumentationRegistry.getInstrumentation().getTargetContext());
         assertNotNull(d.getMedia()._changed());
-        assertEquals(added(d).size(), 0);
-        assertEquals(removed(d).size(), 0);
+        assertEquals(0, added(d).size());
+        assertEquals(0, removed(d).size());
         // add a file
         File dir = Shared.getTestDir(InstrumentationRegistry.getInstrumentation().getTargetContext());
         File path = new File(dir, "foo.jpg");
@@ -197,26 +197,26 @@ public class MediaTest {
         // should have been logged
         d.getMedia().findChanges();
         assertTrue(added(d).size() > 0);
-        assertEquals(removed(d).size(), 0);
+        assertEquals(0, removed(d).size());
         // if we modify it, the cache won't notice
         os = new FileOutputStream(path, true);
         os.write("world".getBytes());
         os.close();
-        assertEquals(added(d).size(), 1);
-        assertEquals(removed(d).size(), 0);
+        assertEquals(1, added(d).size());
+        assertEquals(0, removed(d).size());
         // but if we add another file, it will
         path = new File(path.getAbsolutePath()+"2");
         os = new FileOutputStream(path, true);
         os.write("yo".getBytes());
         os.close();
         d.getMedia().findChanges(true);
-        assertEquals(added(d).size(), 2);
-        assertEquals(removed(d).size(), 0);
+        assertEquals(2, added(d).size());
+        assertEquals(0, removed(d).size());
         // deletions should get noticed too
         assertTrue(path.delete());
         d.getMedia().findChanges(true);
-        assertEquals(added(d).size(), 1);
-        assertEquals(removed(d).size(), 1);
+        assertEquals(1, added(d).size());
+        assertEquals(1, removed(d).size());
     }
 
 
@@ -225,14 +225,14 @@ public class MediaTest {
         Collection d = Shared.getEmptyCol(InstrumentationRegistry.getInstrumentation().getTargetContext());
         String aString = "a:b|cd\\e/f\0g*h";
         String good = "abcdefgh";
-        assertEquals(d.getMedia().stripIllegal(aString), good);
+        assertEquals(good, d.getMedia().stripIllegal(aString));
         for (int i = 0; i < aString.length(); i++) {
             char c = aString.charAt(i);
             boolean bad = d.getMedia().hasIllegal("something" + c + "morestring");
             if (bad) {
-                assertEquals(good.indexOf(c), -1);
+                assertEquals(-1, good.indexOf(c));
             } else {
-                assertNotEquals(good.indexOf(c), -1);
+                assertNotEquals(-1, good.indexOf(c));
             }
         }
     }


### PR DESCRIPTION
## Purpose / Description
According to
http://junit.sourceforge.net/javadoc/org/junit/Assert.html , in
assertEquals, the expected value should be given before the value
tested. Otherwise, it leads to messages such as
>Error in testAnki2Updates(com.ichi2.anki.tests.libanki.ImportTest): java.lang.AssertionError: expected:<0> but was:<1>
where the expected value is 1 and the value actually tested is 0.

While it certainly does not change any test result, it makes the
debugging process slightly more complex, since the error messages are
misleading.

## Approach
I did read the 130 assertEquals found by grep, and changed
the order of arguments when it seems to make sens. More precisely, I
assumed that:
* if one value compared is either a literal, or a constant (as L438 of
  ContentProviderTest.java), then it is the expected value
* if two variables are compared, I assume that the one which has been
  set the most recently is the one tested. (For example
  `assertEquals(after, before + 1)`; becomes `assertEquals(before + 1,
  after);` l198 of ImportTest.java. Indeed, `before` was set L177 (and
  even tested L182) while `after` was set L197)
* if a value is named «expected» then it is the expected value. For
  example L156 of ImportTest.java

## How Has This Been Tested?

Gradlew

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
