### PR TITLE
Revert "Bump appcompat from 1.1.0-rc01 to 1.1.0"

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -166,7 +166,7 @@ dependencies {
     annotationProcessor "com.google.auto.service:auto-service:1.0-rc6"
 
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.appcompat:appcompat:1.1.0-rc01'
     // Note: the design support library can be quite buggy, so test everything thoroughly before updating it
     implementation 'com.google.android.material:material:1.0.0'
     implementation 'androidx.browser:browser:1.0.0'


### PR DESCRIPTION
## Purpose / Description

This reverts commit 2cc4c46125223595edbab6c4a24877551dd620e2.

WebView crashes on all Android 5.x versions, and Android 6-7.1 versions with old WebViews and no Play Services when using appcompat-1.1.0

Upstream bug to track is https://issuetracker.google.com/issues/141132133

## Fixes

#5507 - and should be cherry-picked and released as 2.9.1 as soon as possible

## Approach

Most discussion is here: https://stackoverflow.com/questions/41025200/android-view-inflateexception-error-inflating-class-android-webkit-webview

Workarounds are to:

1. drop appcompat below 1.1.0 (since between rc01 and final they actually made changes, terrible release engineering: https://developer.android.com/jetpack/androidx/releases/appcompat#1.1.0)
2. wrap WebView (we use it in maybe 5 places and it breaks touch actions, a no-go)
3. override a WebView method (we use it in 5 places, and the linked changelog above indicates we aren't missing much, so I went for option 1)

## How Has This Been Tested?

API21 and API22 emulators reproduced the crash and associated stack trace easily on master with appcompat-1.1.0, and with appcompat-1.1.0-rc01 they work fine

## Learning (optional, can help others)

Never make changes from rc01 to full release, this was most unexpected.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
