### PR TITLE
fix format string error in hu-HU import progress string

### DIFF
--- a/AnkiDroid/src/main/res/values-hu/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values-hu/03-dialogs.xml
@@ -100,7 +100,7 @@
     <string name="rebuild_custom_study_deck">Egyéni gyakorlópakli újraépítése.\nKérlek, várj...</string>
     <string name="importing_collection">Gyűjtemény importálása.\nKérlek, várj&#8230;</string>
     <string name="import_media_count">Média fájlok importálása %1$d%%\nKérlek, várj&#8230;</string>
-    <string name="import_progress">• Importált megjegyzések: %1$d%%\n• importált kártyák: %2$d%%\n• utómunka: %3$d% %</string>
+    <string name="import_progress">• Importált megjegyzések: %1$d%%\n• importált kártyák: %2$d%%\n• utómunka: %3$d%%</string>
     <string name="import_update_details">Frissített %1$d %2$d meglévő jegyzetek.</string>
     <string name="import_update_ignored">Néhány frissítést figyelmen kívül hagytak, mert a jegyzet típusa megváltozott</string>
     <string name="import_complete_count">Importált kártyák: %d</string>


### PR DESCRIPTION
Fixes #5501

I also fixed it on crowdin for future exports https://crowdin.com/translate/ankidroid/7303/en-hu#6534325

This should be cherry-picked for a 2.9.1 as soon as possible


## How Has This Been Tested?

Using an emulator set to hu-HU locale I was easily able to reproduce the exact crash I saw on ACRA by trying to import an .apkg

After fixing the format string (`% %` -> `%%`) it worked great. So I matched the local fix on crowdin and that's it
