### PR TITLE
Bump Gradle from 5.6.1 to 5.6.3, JaCoCo to 0.8.4

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -7,7 +7,7 @@ apply plugin: 'com.android.application'
 apply plugin: 'jacoco'
 
 jacoco {
-    toolVersion = "$rootProject.ext.jacocoVersion"
+    toolVersion = jacocoVersion
 
 }
 repositories {
@@ -70,7 +70,7 @@ android {
     }
 
     jacoco {
-        version = "$rootProject.ext.jacocoVersion"
+        version = jacocoVersion
     }
     dexOptions {
         // Skip pre-dexing when running on Travis CI or when disabled via -Dpre-dex=false.

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,12 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-
     repositories {
         google()
         jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.5.1'
-        classpath "org.jacoco:org.jacoco.core:0.8.4"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
@@ -16,7 +14,7 @@ buildscript {
 
 ext {
 
-    jacocoVersion = "0.8.3"
+    jacocoVersion = "0.8.4"
 
     travisBuild = System.getenv("TRAVIS") == "true"
     // allows for -Dpre-dex=false to be set

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,11 +11,6 @@
 # The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx1536m
 
-# When configured, Gradle will run in incubating parallel mode.
-# This option should only be used with decoupled projects. More details, visit
-# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-# org.gradle.parallel=true
-
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app's APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
@@ -30,5 +25,3 @@ org.gradle.parallel=true
 
 # The default in the future, let's true the future now...
 org.gradle.caching=true
-
-org.gradle.jvmargs=-Xmx1g

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
The are [known issues](https://docs.gradle.org/5.6.2/release-notes.html#fixed-issues) in currently used Gradle 5.6.1

## Fixes
Also fix some clumsy Gradle usages:
- duplicate keys in gradle.properties
- casting string jacocoVersion property to string

## Approach

## How Has This Been Tested?

CI run would be enough


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
