### PR TITLE
Allow correct translation of 'x cards to review in y minutes'

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -554,7 +554,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
                 // it to the user.
                 int nCards = elapsed[1].intValue() - 1;
                 int nMins = elapsed[0].intValue() / 60;
-                String mins = res.getQuantityString(R.plurals.timebox_reached_minutes, nMins, nMins);
+                String mins = res.getQuantityString(R.plurals.in_minutes, nMins, nMins);
                 String timeboxMessage = res.getQuantityString(R.plurals.timebox_reached, nCards, nCards, mins);
                 UIUtils.showThemedToast(AbstractFlashcardViewer.this, timeboxMessage, true);
                 getCol().startTimebox();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/stats/AnkiStatsTaskHandler.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/stats/AnkiStatsTaskHandler.java
@@ -227,7 +227,7 @@ public class AnkiStatsTaskHandler {
                     }
                 }
                 Resources res = collection.getContext().getResources();
-                final String span = res.getQuantityString(R.plurals.time_span_minutes, minutes, minutes);
+                final String span = res.getQuantityString(R.plurals.in_minutes, minutes, minutes);
                 return res.getQuantityString(R.plurals.studied_cards_today, cards, cards, span);
             } finally {
                 sLock.unlock();

--- a/AnkiDroid/src/main/res/values-ar/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-ar/02-strings.xml
@@ -122,7 +122,7 @@
         <item quantity="many">%1$d cards studied in %2$s</item>
         <item quantity="other">%1$d cards studied in %2$s</item>
     </plurals>
-    <plurals name="timebox_reached_minutes">
+    <plurals name="in_minutes">
         <item quantity="zero">%1$d دقيقة</item>
         <item quantity="one">%1$d دقيقة</item>
         <item quantity="two">%1$d دقيقتان</item>

--- a/AnkiDroid/src/main/res/values-bg/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-bg/02-strings.xml
@@ -118,7 +118,7 @@
         <item quantity="one">%1$d карта изучена за %2$s</item>
         <item quantity="other">%1$d карти изучени за %2$s</item>
     </plurals>
-    <plurals name="timebox_reached_minutes">
+    <plurals name="in_minutes">
         <item quantity="one">%1$d минута</item>
         <item quantity="other">%1$d минути</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-ca/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-ca/02-strings.xml
@@ -118,7 +118,7 @@
         <item quantity="one">%1$d carta estudiada en %2$s</item>
         <item quantity="other">%1$d cartes estudiades en %2$s</item>
     </plurals>
-    <plurals name="timebox_reached_minutes">
+    <plurals name="in_minutes">
         <item quantity="one">%1$d minut</item>
         <item quantity="other">%1$d minuts</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-cs/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-cs/02-strings.xml
@@ -120,7 +120,7 @@
         <item quantity="many">%1$d cards studied in %2$s</item>
         <item quantity="other">%1$d karet studováno za %2$s</item>
     </plurals>
-    <plurals name="timebox_reached_minutes">
+    <plurals name="in_minutes">
         <item quantity="one">%1$d minuta</item>
         <item quantity="few">%1$d minuty</item>
         <item quantity="many">%1$d minutes</item>

--- a/AnkiDroid/src/main/res/values-de/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-de/02-strings.xml
@@ -118,7 +118,7 @@
         <item quantity="one">%1$d Karte gelernt in %2$s</item>
         <item quantity="other">%1$d Karten gelernt in %2$s</item>
     </plurals>
-    <plurals name="timebox_reached_minutes">
+    <plurals name="in_minutes">
         <item quantity="one">%1$d Minute</item>
         <item quantity="other">%1$d Minuten</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-el/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-el/02-strings.xml
@@ -118,7 +118,7 @@
         <item quantity="one">%1$d card studied in %2$s</item>
         <item quantity="other">%1$d cards studied in %2$s</item>
     </plurals>
-    <plurals name="timebox_reached_minutes">
+    <plurals name="in_minutes">
         <item quantity="one">%1$d minute</item>
         <item quantity="other">%1$d minutes</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-eo/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-eo/02-strings.xml
@@ -118,7 +118,7 @@
         <item quantity="one">Lernis %1$d karton dum %2$s</item>
         <item quantity="other">Lernis %1$d kartojn dum %2$s</item>
     </plurals>
-    <plurals name="timebox_reached_minutes">
+    <plurals name="in_minutes">
         <item quantity="one">%1$d minuto</item>
         <item quantity="other">%1$d minutoj</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-es-rAR/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-es-rAR/02-strings.xml
@@ -118,7 +118,7 @@
         <item quantity="one">%1$d tarjeta estudiada en %2$s</item>
         <item quantity="other">%1$d tarjetas estudiadas en %2$s</item>
     </plurals>
-    <plurals name="timebox_reached_minutes">
+    <plurals name="in_minutes">
         <item quantity="one">%1$d minuto</item>
         <item quantity="other">%1$d minutos</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-es-rES/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-es-rES/02-strings.xml
@@ -118,7 +118,7 @@
         <item quantity="one">%1$d tarjeta estudiada en %2$s</item>
         <item quantity="other">%1$d tarjetas estudiadas en %2$s</item>
     </plurals>
-    <plurals name="timebox_reached_minutes">
+    <plurals name="in_minutes">
         <item quantity="one">%1$d minuto</item>
         <item quantity="other">%1$d minutos</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-et/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-et/02-strings.xml
@@ -118,7 +118,7 @@
         <item quantity="one">%1$d card studied in %2$s</item>
         <item quantity="other">%1$d cards studied in %2$s</item>
     </plurals>
-    <plurals name="timebox_reached_minutes">
+    <plurals name="in_minutes">
         <item quantity="one">%1$d minut</item>
         <item quantity="other">%1$d minutit</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-fa/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-fa/02-strings.xml
@@ -118,7 +118,7 @@
         <item quantity="one">%1$d کارت در %2$s مطالعه شد</item>
         <item quantity="other">%1$d کارت در %2$s مطالعه شد</item>
     </plurals>
-    <plurals name="timebox_reached_minutes">
+    <plurals name="in_minutes">
         <item quantity="one">%1$d دقیقه</item>
         <item quantity="other">%1$d دقیقه</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-fi/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-fi/02-strings.xml
@@ -118,7 +118,7 @@
         <item quantity="one">%1$d korttia opiskeltu ajassa %2$s</item>
         <item quantity="other">%1$d korttia opiskeltu ajassa %2$s</item>
     </plurals>
-    <plurals name="timebox_reached_minutes">
+    <plurals name="in_minutes">
         <item quantity="one">%1$d minuutti</item>
         <item quantity="other">%1$d minuuttia</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-fr/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-fr/02-strings.xml
@@ -118,7 +118,7 @@
         <item quantity="one">%1$d carte étudiée en %2$s</item>
         <item quantity="other">%1$d cartes étudiées en %2$s</item>
     </plurals>
-    <plurals name="timebox_reached_minutes">
+    <plurals name="in_minutes">
         <item quantity="one">%1$d minute</item>
         <item quantity="other">%1$d minutes</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-gl/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-gl/02-strings.xml
@@ -118,7 +118,7 @@
         <item quantity="one">%1$d cartón estudado en %2$s</item>
         <item quantity="other">%1$d cartóns estudados en %2$s</item>
     </plurals>
-    <plurals name="timebox_reached_minutes">
+    <plurals name="in_minutes">
         <item quantity="one">%1$d minuto</item>
         <item quantity="other">%1$d minutos</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-go/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-go/02-strings.xml
@@ -118,7 +118,7 @@
         <item quantity="one">%1$d card studied in %2$s</item>
         <item quantity="other">%1$d cards studied in %2$s</item>
     </plurals>
-    <plurals name="timebox_reached_minutes">
+    <plurals name="in_minutes">
         <item quantity="one">%1$d minute</item>
         <item quantity="other">%1$d minutes</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-he/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-he/02-strings.xml
@@ -120,7 +120,7 @@
         <item quantity="many">%1$d כרטסיות נלמדו ב%2$s</item>
         <item quantity="other">%1$d כרטסיות נלמדו ב%2$s</item>
     </plurals>
-    <plurals name="timebox_reached_minutes">
+    <plurals name="in_minutes">
         <item quantity="one">%1$d דקה</item>
         <item quantity="two">%1$d דקה</item>
         <item quantity="many">%1$d דקה</item>

--- a/AnkiDroid/src/main/res/values-hi/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-hi/02-strings.xml
@@ -118,7 +118,7 @@
         <item quantity="one">%1$d कार्ड में अध्ययन किया %2$s</item>
         <item quantity="other">%1$d कार्ड में अध्ययन किया %2$s</item>
     </plurals>
-    <plurals name="timebox_reached_minutes">
+    <plurals name="in_minutes">
         <item quantity="one">%1$d मिनट</item>
         <item quantity="other">%1$d मिनट</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-hu/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-hu/02-strings.xml
@@ -118,7 +118,7 @@
         <item quantity="one">%1$d kártyát tanultál %2$s alatt</item>
         <item quantity="other">%1$d kártyát tanultál %2$s alatt</item>
     </plurals>
-    <plurals name="timebox_reached_minutes">
+    <plurals name="in_minutes">
         <item quantity="one">%1$d perc</item>
         <item quantity="other">%1$d perc</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-id/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-id/02-strings.xml
@@ -117,7 +117,7 @@
     <plurals name="timebox_reached">
         <item quantity="other">%1$d kartu dipelajari di%2$s</item>
     </plurals>
-    <plurals name="timebox_reached_minutes">
+    <plurals name="in_minutes">
         <item quantity="other">%1$d menit</item>
     </plurals>
     <string name="studyoptions_welcome_title">Selamat Datang ke AnkiDroid</string>

--- a/AnkiDroid/src/main/res/values-it/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-it/02-strings.xml
@@ -118,7 +118,7 @@
         <item quantity="one">%1$d carta studiata in %2$s</item>
         <item quantity="other">%1$d carte studiate in %2$s</item>
     </plurals>
-    <plurals name="timebox_reached_minutes">
+    <plurals name="in_minutes">
         <item quantity="one">%1$d minuto</item>
         <item quantity="other">%1$d minuti</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-ja/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-ja/02-strings.xml
@@ -117,7 +117,7 @@
     <plurals name="timebox_reached">
         <item quantity="other">%1$d枚のカードを%2$sで学習しました</item>
     </plurals>
-    <plurals name="timebox_reached_minutes">
+    <plurals name="in_minutes">
         <item quantity="other">%1$d分</item>
     </plurals>
     <string name="studyoptions_welcome_title">AnkiDroidへようこそ</string>

--- a/AnkiDroid/src/main/res/values-ko/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-ko/02-strings.xml
@@ -117,7 +117,7 @@
     <plurals name="timebox_reached">
         <item quantity="other">%1$d 카드가 %2$s에 학습됨</item>
     </plurals>
-    <plurals name="timebox_reached_minutes">
+    <plurals name="in_minutes">
         <item quantity="other">%1$d분</item>
     </plurals>
     <string name="studyoptions_welcome_title">AnkiDroid에 오신 것을 환영합니다</string>

--- a/AnkiDroid/src/main/res/values-lt/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-lt/02-strings.xml
@@ -120,7 +120,7 @@
         <item quantity="many">Per %2$s išmokote %1$d kortelių</item>
         <item quantity="other">Per %2$s išmokote %1$d kort.</item>
     </plurals>
-    <plurals name="timebox_reached_minutes">
+    <plurals name="in_minutes">
         <item quantity="one">%1$d minutę</item>
         <item quantity="few">%1$d minutes</item>
         <item quantity="many">%1$d minučių</item>

--- a/AnkiDroid/src/main/res/values-lv/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-lv/02-strings.xml
@@ -119,7 +119,7 @@
         <item quantity="one">%1$d card studied in %2$s</item>
         <item quantity="other">%1$d cards studied in %2$s</item>
     </plurals>
-    <plurals name="timebox_reached_minutes">
+    <plurals name="in_minutes">
         <item quantity="zero">%1$d minutes</item>
         <item quantity="one">%1$d minute</item>
         <item quantity="other">%1$d minutes</item>

--- a/AnkiDroid/src/main/res/values-nl/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-nl/02-strings.xml
@@ -118,7 +118,7 @@
         <item quantity="one">%1$d kaart geoefend in %2$s</item>
         <item quantity="other">%1$d kaarten geoefend in %2$s</item>
     </plurals>
-    <plurals name="timebox_reached_minutes">
+    <plurals name="in_minutes">
         <item quantity="one">%1$d minuut</item>
         <item quantity="other">%1$d minuten</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-no/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-no/02-strings.xml
@@ -118,7 +118,7 @@
         <item quantity="one">%1$d kort studert i %2$s</item>
         <item quantity="other">%1$d kort studert i %2$s</item>
     </plurals>
-    <plurals name="timebox_reached_minutes">
+    <plurals name="in_minutes">
         <item quantity="one">%1$d minutt</item>
         <item quantity="other">%1$d minutter</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-pl/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-pl/02-strings.xml
@@ -120,7 +120,7 @@
         <item quantity="many">%1$d cards studied in %2$s</item>
         <item quantity="other">%1$d kart przerobione w %2$s</item>
     </plurals>
-    <plurals name="timebox_reached_minutes">
+    <plurals name="in_minutes">
         <item quantity="one">%1$d minutę</item>
         <item quantity="few">%1$d minut</item>
         <item quantity="many">%1$d minutes</item>

--- a/AnkiDroid/src/main/res/values-pt-rBR/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-pt-rBR/02-strings.xml
@@ -118,7 +118,7 @@
         <item quantity="one">%1$d cartão estudado em %2$s</item>
         <item quantity="other">%1$d cartões estudados em %2$s</item>
     </plurals>
-    <plurals name="timebox_reached_minutes">
+    <plurals name="in_minutes">
         <item quantity="one">%1$d minuto</item>
         <item quantity="other">%1$d minutos</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-pt-rPT/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-pt-rPT/02-strings.xml
@@ -118,7 +118,7 @@
         <item quantity="one">%1$d ficha estudada em %2$s</item>
         <item quantity="other">%1$d fichas estudadas em %2$s</item>
     </plurals>
-    <plurals name="timebox_reached_minutes">
+    <plurals name="in_minutes">
         <item quantity="one">%1$d minuto</item>
         <item quantity="other">%1$d minutos</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-ro/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-ro/02-strings.xml
@@ -119,7 +119,7 @@
         <item quantity="few">%1$d cards studied in %2$s</item>
         <item quantity="other">%1$d cards studied in %2$s</item>
     </plurals>
-    <plurals name="timebox_reached_minutes">
+    <plurals name="in_minutes">
         <item quantity="one">%1$d minute</item>
         <item quantity="few">%1$d minutes</item>
         <item quantity="other">%1$d minutes</item>

--- a/AnkiDroid/src/main/res/values-ru/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-ru/02-strings.xml
@@ -120,7 +120,7 @@
         <item quantity="many">%1$d карточек изучено за %2$s</item>
         <item quantity="other">%1$d карточек изучено за %2$s</item>
     </plurals>
-    <plurals name="timebox_reached_minutes">
+    <plurals name="in_minutes">
         <item quantity="one">%1$d минута</item>
         <item quantity="few">%1$d минуты</item>
         <item quantity="many">%1$d минут</item>

--- a/AnkiDroid/src/main/res/values-sk/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-sk/02-strings.xml
@@ -120,7 +120,7 @@
         <item quantity="many">%1$d preštudovaných kartičiek za %2$s</item>
         <item quantity="other">%1$d preštudovaných kartičiek za %2$s</item>
     </plurals>
-    <plurals name="timebox_reached_minutes">
+    <plurals name="in_minutes">
         <item quantity="one">%1$d minútu</item>
         <item quantity="few">%1$d minúty</item>
         <item quantity="many">%1$d minút</item>

--- a/AnkiDroid/src/main/res/values-sl/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-sl/02-strings.xml
@@ -120,7 +120,7 @@
         <item quantity="few">%1$d kartice preučene v %2$s</item>
         <item quantity="other">%1$d kartic preučenih v %2$s</item>
     </plurals>
-    <plurals name="timebox_reached_minutes">
+    <plurals name="in_minutes">
         <item quantity="one">%1$d minuta</item>
         <item quantity="two">%1$d minuti</item>
         <item quantity="few">%1$d minute</item>

--- a/AnkiDroid/src/main/res/values-sr/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-sr/02-strings.xml
@@ -119,7 +119,7 @@
         <item quantity="few">%1$d карата проучено у %2$s</item>
         <item quantity="other">%1$d cards studied in %2$s</item>
     </plurals>
-    <plurals name="timebox_reached_minutes">
+    <plurals name="in_minutes">
         <item quantity="one">%1$d минут</item>
         <item quantity="few">%1$d минута</item>
         <item quantity="other">%1$d minutes</item>

--- a/AnkiDroid/src/main/res/values-sv/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-sv/02-strings.xml
@@ -118,7 +118,7 @@
         <item quantity="one">Studera %1$d kort i %2$s</item>
         <item quantity="other">Studera %1$d kort i %2$s</item>
     </plurals>
-    <plurals name="timebox_reached_minutes">
+    <plurals name="in_minutes">
         <item quantity="one">%1$d minut</item>
         <item quantity="other">%1$d minuter</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-th/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-th/02-strings.xml
@@ -117,7 +117,7 @@
     <plurals name="timebox_reached">
         <item quantity="other">%1$d cards studied in %2$s</item>
     </plurals>
-    <plurals name="timebox_reached_minutes">
+    <plurals name="in_minutes">
         <item quantity="other">%1$d minutes</item>
     </plurals>
     <string name="studyoptions_welcome_title">Welcome to AnkiDroid</string>

--- a/AnkiDroid/src/main/res/values-tr/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-tr/02-strings.xml
@@ -118,7 +118,7 @@
         <item quantity="one">%2$s %1$d kart çalışıldı</item>
         <item quantity="other">%2$s %1$d kart çalışıldı</item>
     </plurals>
-    <plurals name="timebox_reached_minutes">
+    <plurals name="in_minutes">
         <item quantity="one">%1$d dakikada</item>
         <item quantity="other">%1$d dakikada</item>
     </plurals>

--- a/AnkiDroid/src/main/res/values-uk/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-uk/02-strings.xml
@@ -120,7 +120,7 @@
         <item quantity="many">%1$d карток вивчено за %2$s</item>
         <item quantity="other">%1$d картки вивчені за %2$s</item>
     </plurals>
-    <plurals name="timebox_reached_minutes">
+    <plurals name="in_minutes">
         <item quantity="one">%1$d хвилина</item>
         <item quantity="few">%1$d хвилини</item>
         <item quantity="many">%1$d хвилин</item>

--- a/AnkiDroid/src/main/res/values-vi/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-vi/02-strings.xml
@@ -117,7 +117,7 @@
     <plurals name="timebox_reached">
         <item quantity="other">Đã học %1$d thẻ trong %2$s</item>
     </plurals>
-    <plurals name="timebox_reached_minutes">
+    <plurals name="in_minutes">
         <item quantity="other">%1$d phút</item>
     </plurals>
     <string name="studyoptions_welcome_title">Chào mừng đến với AnkiDroid</string>

--- a/AnkiDroid/src/main/res/values-zh-rCN/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-zh-rCN/02-strings.xml
@@ -117,7 +117,7 @@
     <plurals name="timebox_reached">
         <item quantity="other">在%2$s内学习了%1$d张卡片</item>
     </plurals>
-    <plurals name="timebox_reached_minutes">
+    <plurals name="in_minutes">
         <item quantity="other">%1$d分钟</item>
     </plurals>
     <string name="studyoptions_welcome_title">欢迎进入 AnkiDroid</string>

--- a/AnkiDroid/src/main/res/values-zh-rTW/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-zh-rTW/02-strings.xml
@@ -117,7 +117,7 @@
     <plurals name="timebox_reached">
         <item quantity="other">使用 %2$s 學習共 %1$d 張卡片</item>
     </plurals>
-    <plurals name="timebox_reached_minutes">
+    <plurals name="in_minutes">
         <item quantity="other">%1$d 分鐘</item>
     </plurals>
     <string name="studyoptions_welcome_title">歡迎使用 AnkiDroid</string>

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -105,7 +105,8 @@
         <item quantity="one">%1$d card studied in %2$s</item>
         <item quantity="other">%1$d cards studied in %2$s</item>
     </plurals>
-    <plurals name="timebox_reached_minutes">
+    <!-- minutes used in '[studied in] x minutes' context, causing inflexion in some languages -->
+    <plurals name="in_minutes">
         <item quantity="one">%1$d minute</item>
         <item quantity="other">%1$d minutes</item>
     </plurals>


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Currently the translation string is 'y minutes', which does not
give enough context to the translator. In Slavic languages
'y minutes' and 'in y minutes' are completely different things.
I checked Polish, Czech and Russian translations and everywhere
the translator made a mistake due to lack of information.

## Approach
I just changed the string without changing the code.

## How Has This Been Tested?

I haven't tested this change. It will be clear if it works once you open the main screen.

## Learning (optional, can help others)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
