### PR TITLE
Cloze menu

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -71,6 +71,7 @@ import com.ichi2.async.DeckTask;
 import com.ichi2.compat.CompatHelper;
 import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
+import com.ichi2.libanki.Consts;
 import com.ichi2.libanki.Note;
 import com.ichi2.libanki.Utils;
 import com.ichi2.themes.StyledProgressDialog;
@@ -1712,8 +1713,17 @@ public class NoteEditor extends AnkiActivity {
         @Override
         public boolean onPrepareActionMode(ActionMode mode, Menu menu) {
             // Adding the cloze deletion floating context menu item, but only once.
-            if (menu.findItem(mMenuId) == null) {
-                menu.add(Menu.NONE, mMenuId, Menu.NONE, R.string.multimedia_editor_popup_cloze);
+            boolean isClozeType, itemExists;
+            int noteModelType;
+            try {
+                noteModelType = getCol().getModels().current().getInt("type");
+            } catch (JSONException e) {
+                throw new RuntimeException(e);
+            }
+            isClozeType = noteModelType == Consts.MODEL_CLOZE;
+            itemExists = menu.findItem(mMenuId) != null;
+            if (isClozeType && !itemExists) {
+                menu.add(Menu.NONE, mMenuId, 0, R.string.multimedia_editor_popup_cloze);
                 return true;
             } else {
                 return false;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1713,7 +1713,7 @@ public class NoteEditor extends AnkiActivity {
         @Override
         public boolean onPrepareActionMode(ActionMode mode, Menu menu) {
             // Adding the cloze deletion floating context menu item, but only once.
-			int noteModelType;
+            int noteModelType;
             try {
                 noteModelType = getCurrentlySelectedModel().getInt("type");
             } catch (JSONException e) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1713,15 +1713,13 @@ public class NoteEditor extends AnkiActivity {
         @Override
         public boolean onPrepareActionMode(ActionMode mode, Menu menu) {
             // Adding the cloze deletion floating context menu item, but only once.
-            boolean isClozeType, itemExists;
-            int noteModelType;
             try {
-                noteModelType = getCurrentlySelectedModel().getInt("type");
+                int noteModelType = getCurrentlySelectedModel().getInt("type");
             } catch (JSONException e) {
                 throw new RuntimeException(e);
             }
-            isClozeType = noteModelType == Consts.MODEL_CLOZE;
-            itemExists = menu.findItem(mMenuId) != null;
+            boolean isClozeType = noteModelType == Consts.MODEL_CLOZE;
+            boolean itemExists = menu.findItem(mMenuId) != null;
             if (isClozeType && !itemExists) {
                 menu.add(Menu.NONE, mMenuId, 0, R.string.multimedia_editor_popup_cloze);
                 return true;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1713,8 +1713,9 @@ public class NoteEditor extends AnkiActivity {
         @Override
         public boolean onPrepareActionMode(ActionMode mode, Menu menu) {
             // Adding the cloze deletion floating context menu item, but only once.
+			int noteModelType;
             try {
-                int noteModelType = getCurrentlySelectedModel().getInt("type");
+                noteModelType = getCurrentlySelectedModel().getInt("type");
             } catch (JSONException e) {
                 throw new RuntimeException(e);
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1716,7 +1716,7 @@ public class NoteEditor extends AnkiActivity {
             boolean isClozeType, itemExists;
             int noteModelType;
             try {
-                noteModelType = getCol().getModels().current().getInt("type");
+                noteModelType = getCurrentlySelectedModel().getInt("type");
             } catch (JSONException e) {
                 throw new RuntimeException(e);
             }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
The Cloze deletion floating menu item appeared on all note types, and in an inconsistent position.

## Fixes
#5532 

## Approach
Fix to always be on the left, and only on Cloze types.

## How Has This Been Tested?

Tested manually on a physical Samsung Galaxy Note 9.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
