### PR TITLE
Fix #5450

### DIFF
--- a/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/ContentProviderTest.java
+++ b/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/ContentProviderTest.java
@@ -105,7 +105,8 @@ public class ContentProviderTest {
         mCreatedNotes = new ArrayList<>();
         final Collection col = CollectionHelper.getInstance().getCol(InstrumentationRegistry.getInstrumentation().getTargetContext());
         // Add a new basic model that we use for testing purposes (existing models could potentially be corrupted)
-        JSONObject model = Models.addBasicModel(col, BASIC_MODEL_NAME);
+        JSONObject model = Models.addBasicModel(col);
+        model.put("name", BASIC_MODEL_NAME);
         mModelId = model.getLong("id");
         ArrayList<String> flds = col.getModels().fieldNames(model);
         // Use the names of the fields as test values for the notes which will be added
@@ -217,7 +218,8 @@ public class ContentProviderTest {
         final ContentResolver cr = InstrumentationRegistry.getInstrumentation().getTargetContext().getContentResolver();
         Collection col = CollectionHelper.getInstance().getCol(InstrumentationRegistry.getInstrumentation().getTargetContext());
         // Add a new basic model that we use for testing purposes (existing models could potentially be corrupted)
-        JSONObject model = Models.addBasicModel(col, BASIC_MODEL_NAME);
+        JSONObject model = Models.addBasicModel(col);
+        model.put("name", BASIC_MODEL_NAME);
         long modelId = model.getLong("id");
         // Add the note
         Uri modelUri = ContentUris.withAppendedId(FlashCardsContract.Model.CONTENT_URI, modelId);
@@ -252,7 +254,9 @@ public class ContentProviderTest {
         // Get required objects for test
         final ContentResolver cr = InstrumentationRegistry.getInstrumentation().getTargetContext().getContentResolver();
         Collection col = CollectionHelper.getInstance().getCol(InstrumentationRegistry.getInstrumentation().getTargetContext());
-        JSONObject model = Models.addBasicModel(col, BASIC_MODEL_NAME);
+        JSONObject model = Models.addBasicModel(col);
+        model.put("name", BASIC_MODEL_NAME);
+
         long modelId = model.getLong("id");
         JSONArray initialFldsArr = model.getJSONArray("flds");
         int initialFieldCount = initialFldsArr.length();

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -1251,12 +1251,7 @@ public class Models {
      * @throws ConfirmModSchemaException **********************************************************************************************
      */
 
-    public static JSONObject addBasicModel(Collection col) throws ConfirmModSchemaException {
-        return addBasicModel(col, "Basic");
-    }
-
-
-    public static JSONObject addBasicModel(Collection col, String name) throws ConfirmModSchemaException {
+    public static JSONObject createBasicModel(Collection col, String name) throws ConfirmModSchemaException {
         Models mm = col.getModels();
         JSONObject m = mm.newModel(name);
         JSONObject fm = mm.newField("Front");
@@ -1271,6 +1266,13 @@ public class Models {
             throw new RuntimeException(e);
         }
         mm.addTemplate(m, t);
+        return m;
+    }
+
+    public static JSONObject addBasicModel(Collection col) throws ConfirmModSchemaException {
+        String name = "Basic";
+        Models mm = col.getModels();
+        JSONObject m = createBasicModel(col, name);
         mm.add(m);
         return m;
     }
@@ -1280,13 +1282,13 @@ public class Models {
     public static JSONObject addForwardReverse(Collection col) throws ConfirmModSchemaException {
     	String name = "Basic (and reversed card)";
         Models mm = col.getModels();
-        JSONObject m = addBasicModel(col);
+        JSONObject m = createBasicModel(col, name);
         try {
-            m.put("name", name);
             JSONObject t = mm.newTemplate("Card 2");
             t.put("qfmt", "{{Back}}");
             t.put("afmt", "{{FrontSide}}\n\n<hr id=answer>\n\n{{Front}}");
             mm.addTemplate(m, t);
+            mm.add(m);
         } catch (JSONException e) {
             throw new RuntimeException(e);
         }
@@ -1299,15 +1301,15 @@ public class Models {
     public static JSONObject addForwardOptionalReverse(Collection col) throws ConfirmModSchemaException {
     	String name = "Basic (optional reversed card)";
         Models mm = col.getModels();
-        JSONObject m = addBasicModel(col);
+        JSONObject m = createBasicModel(col, name);
         try {
-            m.put("name", name);
             JSONObject fm = mm.newField("Add Reverse");
             mm.addField(m, fm);
             JSONObject t = mm.newTemplate("Card 2");
             t.put("qfmt", "{{#Add Reverse}}{{Back}}{{/Add Reverse}}");
             t.put("afmt", "{{FrontSide}}\n\n<hr id=answer>\n\n{{Front}}");
             mm.addTemplate(m, t);
+            mm.add(m);
         } catch (JSONException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
After a full sync, cloning the _Basic (and reversed card)_ or _Basic (optional reversed card)_ note types failed to honor the input name and did not display the new type in the list.

The code to add a _Basic_ type both created a new model and added that model to the collection. The code to add these reversed types reused the code to add the basic type, but then attempted to add a template after the new note type was added to the collection, which threw an incorrectly handled exception.

## Fixes
#5450

## Approach
The code was refactored so that all three types use a single method to create the basic model, and then may add extra templates before adding the model to the collection.

## How Has This Been Tested?

Tested on a physical device.

1. Force an overwrite sync.
2. Manage note types. Add any of the first four types listed; verify that the chosen name appears in the list.

**IMPORTANT: The three changes in ContentProviderTest have NOT been tested. Before merging, verify that setting the model name after creation still functions as intended.**

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
