### PR TITLE
Strip HTML comments in card browser

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1331,7 +1331,9 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
     private static String formatQA(String txt) {
         /* Strips all formatting from the string txt for use in displaying question/answer in browser */
-        String s = txt.replace("<br>", " ");
+        String s = txt;
+        s = s.replaceAll("<!--.*?-->", "");
+        s = s.replace("<br>", " ");
         s = s.replace("<br />", " ");
         s = s.replace("<div>", " ");
         s = s.replace("\n", " ");


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
https://github.com/ankidroid/Anki-Android/blob/bcc13aaf374725af69159bc4c7f68ea0d2fa3ea9/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java#L101

The tagPattern regexp does not properly handle tags which contain a ">" character within them, such as an HTML comment like `<!-- the <b> tag -->`

## Fixes
Fix #5395

## Approach
Since HTML is not "regular", trying to fix the regular expression to handle such cases seems futile. Instead, HTML comments are stripped prior to calling `stripHTMLMedia`.

## How Has This Been Tested?

Tested on physical device.

## Learning (optional, can help others)
According to the HTML spec, comments cannot contain `-->`, so if somebody writes `<!-- a <!-- nested --> comment -->` we are under no obligation to honor it.

https://www.w3.org/TR/html4/intro/sgmltut.html#h-3.2.4 indicates that the comment closing may contain whitespace, e.g. `--  >`. However the HTML5 spec does not mention that, and Chrome didn't seem to understand it, so I left it out.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
