### PR TITLE
One due by note

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -744,7 +744,7 @@ public class Collection {
                 if (odid != 0) {
                     due = odue;
                 }
-                if (!dues.containsKey(nid)) {
+                if (!dues.containsKey(nid) && type == 0) {
                     dues.put(nid, due);
                 }
             }


### PR DESCRIPTION
## Purpose / Description
_Describe the problem or feature and motivation_

## Fixes
This fix issue #5456 (by me). The first commit copies Anki behavior. As I reported, this behavior is bugged, so the second commit fix Anki bug the same way I just fixed it in anki's code. See https://github.com/dae/anki/pull/339

## Approach
As in Anki (and in my Anki's PR).
Edit: it's not a PR anymore, but it is dae/anki@c2a6c3e47a9d88d28d5dbdd129db97a28f044c49.

## How Has This Been Tested?

I tried to reproduce both bugs in ankidroid, and saw that with this PR, all dues are correct. #5456 did disappear and Anki's bug did not appear.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
