### PR TITLE
fix crash on app startup with uninitialized collection

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.java
@@ -33,6 +33,11 @@ public class BootService extends BroadcastReceiver {
         if (!CollectionHelper.hasStorageAccessPermission(context)) {
             return;
         }
+        // There are cases where the app is installed, and we have access, but nothing exist yet
+        if (CollectionHelper.getInstance().getCol(context) == null
+                || CollectionHelper.getInstance().getCol(context).getDecks() == null) {
+            return;
+        }
 
         scheduleDeckReminder(context);
         scheduleNotification(context);


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

There is a state where the application is installed and storage permission is granted, but the collection is not actually initialized with decks

The BootService assumes a collection always has decks, counter to this possible state, and null pointer's attempting to access them and schedule reminders

## Fixes
Fixes #5503 - our top crash by far at the moment for 2.9.x

## Approach

I inspected the code a bit to see when the "collection accessible, but no decks" state occurs but must admit I didn't see it. At the same time it's clear that it happens a *lot* and reminders are more of an add-on vs having a crash bug on app startup, so it seemed simply acknowledging the state was possible by evidence, and handling it in the same way we handle other "can't schedule reminders yet" states was reasonable

## How Has This Been Tested?

Ran the full suite of tests, also ran the app in API29 simulator

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
