### PR TITLE
Change copy-related terms from "card" to "note"

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -785,7 +785,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
             case android.R.id.home:
                 endMultiSelectMode();
                 return true;
-            case R.id.action_add_card_from_card_browser: {
+            case R.id.action_add_note_from_card_browser: {
                 Intent intent = new Intent(CardBrowser.this, NoteEditor.class);
                 intent.putExtra(NoteEditor.EXTRA_CALLER, NoteEditor.CALLER_CARDBROWSER_ADD);
                 startActivityForResultWithAnimation(intent, ADD_NOTE, ActivityTransitionAnimation.LEFT);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -852,17 +852,17 @@ public class NoteEditor extends AnkiActivity {
     public boolean onCreateOptionsMenu(Menu menu) {
         getMenuInflater().inflate(R.menu.note_editor, menu);
         if (mAddNote) {
-            menu.findItem(R.id.action_copy_card).setVisible(false);
+            menu.findItem(R.id.action_copy_note).setVisible(false);
         } else {
-            menu.findItem(R.id.action_add_card_from_card_editor).setVisible(true);
+            menu.findItem(R.id.action_add_note_from_note_editor).setVisible(true);
         }
         if (mEditFields != null) {
             for (int i = 0; i < mEditFields.size(); i++) {
                 if (mEditFields.get(i).getText().length() > 0) {
-                    menu.findItem(R.id.action_copy_card).setEnabled(true);
+                    menu.findItem(R.id.action_copy_note).setEnabled(true);
                     break;
                 } else if (i == mEditFields.size() - 1) {
-                    menu.findItem(R.id.action_copy_card).setEnabled(false);
+                    menu.findItem(R.id.action_copy_note).setEnabled(false);
                 }
             }
         }
@@ -883,13 +883,13 @@ public class NoteEditor extends AnkiActivity {
                 saveNote();
                 return true;
 
-            case R.id.action_add_card_from_card_editor:
-            case R.id.action_copy_card: {
+            case R.id.action_add_note_from_note_editor:
+            case R.id.action_copy_note: {
                 Timber.i("NoteEditor:: Copy or add card button pressed");
                 Intent intent = new Intent(NoteEditor.this, NoteEditor.class);
                 intent.putExtra(EXTRA_CALLER, CALLER_CARDEDITOR);
                 // intent.putExtra(EXTRA_DECKPATH, mDeckPath);
-                if (item.getItemId() == R.id.action_copy_card) {
+                if (item.getItemId() == R.id.action_copy_note) {
                     intent.putExtra(EXTRA_CONTENTS, getFieldsText());
                 }
                 startActivityForResultWithAnimation(intent, REQUEST_ADD, ActivityTransitionAnimation.LEFT);

--- a/AnkiDroid/src/main/res/menu/card_browser.xml
+++ b/AnkiDroid/src/main/res/menu/card_browser.xml
@@ -2,9 +2,9 @@
     xmlns:ankidroid="http://schemas.android.com/apk/res-auto" >
 
     <item
-        android:id="@+id/action_add_card_from_card_browser"
+        android:id="@+id/action_add_note_from_card_browser"
         android:icon="@drawable/ic_add_white_24dp"
-        android:title="@string/card_editor_add_card"
+        android:title="@string/note_editor_add_note"
         ankidroid:showAsAction="ifRoom"/>
     <item
         android:id="@+id/action_search"

--- a/AnkiDroid/src/main/res/menu/note_editor.xml
+++ b/AnkiDroid/src/main/res/menu/note_editor.xml
@@ -7,11 +7,11 @@
         android:title="@string/save"
         ankidroid:showAsAction="always"/>
     <item
-        android:id="@+id/action_add_card_from_card_editor"
-        android:title="@string/card_editor_add_card"
+        android:id="@+id/action_add_note_from_note_editor"
+        android:title="@string/note_editor_add_note"
         android:visible="false"/>
     <item
-        android:id="@+id/action_copy_card"
+        android:id="@+id/action_copy_note"
         android:enabled="false"
-        android:title="@string/card_editor_copy_card"/>
+        android:title="@string/note_editor_copy_note"/>
 </menu>

--- a/AnkiDroid/src/main/res/values-ar/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-ar/02-strings.xml
@@ -132,7 +132,7 @@
     </plurals>
     <string name="studyoptions_welcome_title">مرحباً بكم مع آنكيدرويد</string>
     <string name="fact_adder_intent_title">بطاقة آنكيدرويد</string>
-    <string name="card_editor_add_card">أضف ملاحظة</string>
+    <string name="note_editor_add_note">أضف ملاحظة</string>
     <string name="card_editor_copy_card">انسخ البطاقة</string>
     <string name="card_editor_reposition_card">Reposition</string>
     <string name="card_editor_reset_card">أعد تعيين التقدم</string>

--- a/AnkiDroid/src/main/res/values-bg/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-bg/02-strings.xml
@@ -124,7 +124,7 @@
     </plurals>
     <string name="studyoptions_welcome_title">Добре дошли в AnkiDroid</string>
     <string name="fact_adder_intent_title">AnkiDroid карта</string>
-    <string name="card_editor_add_card">Нова бележка</string>
+    <string name="note_editor_add_note">Нова бележка</string>
     <string name="card_editor_copy_card">копиране на карта</string>
     <string name="card_editor_reposition_card">Reposition</string>
     <string name="card_editor_reset_card">Начално състояние на напредъка</string>

--- a/AnkiDroid/src/main/res/values-ca/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-ca/02-strings.xml
@@ -124,7 +124,7 @@
     </plurals>
     <string name="studyoptions_welcome_title">Benvingut a l\'AnkiDroid</string>
     <string name="fact_adder_intent_title">Fitxa AnkiDroid</string>
-    <string name="card_editor_add_card">Afegeix una nota</string>
+    <string name="note_editor_add_note">Afegeix una nota</string>
     <string name="card_editor_copy_card">Còpia la fitxa</string>
     <string name="card_editor_reposition_card">Reposition</string>
     <string name="card_editor_reset_card">Reinicia</string>

--- a/AnkiDroid/src/main/res/values-cs/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-cs/02-strings.xml
@@ -128,7 +128,7 @@
     </plurals>
     <string name="studyoptions_welcome_title">Vítejte v AnkiDroid</string>
     <string name="fact_adder_intent_title">AnkiDroid karta</string>
-    <string name="card_editor_add_card">Přidat poznámku</string>
+    <string name="note_editor_add_note">Přidat poznámku</string>
     <string name="card_editor_copy_card">Kopírovat kartu</string>
     <string name="card_editor_reposition_card">Změnit pořadí</string>
     <string name="card_editor_reset_card">Obnovit proces učení</string>

--- a/AnkiDroid/src/main/res/values-de/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-de/02-strings.xml
@@ -124,7 +124,7 @@
     </plurals>
     <string name="studyoptions_welcome_title">Willkommen bei AnkiDroid</string>
     <string name="fact_adder_intent_title">AnkiDroid Karte</string>
-    <string name="card_editor_add_card">Notiz hinzufügen</string>
+    <string name="note_editor_add_note">Notiz hinzufügen</string>
     <string name="card_editor_copy_card">Karte kopieren</string>
     <string name="card_editor_reposition_card">Position ändern</string>
     <string name="card_editor_reset_card">Fortschritt zurücksetzen</string>

--- a/AnkiDroid/src/main/res/values-el/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-el/02-strings.xml
@@ -124,7 +124,7 @@
     </plurals>
     <string name="studyoptions_welcome_title">Καλώς ήρθατε στο AnkiDroid</string>
     <string name="fact_adder_intent_title">Κάρτα AnkiDroid</string>
-    <string name="card_editor_add_card">Προσθήκη σημείωσης</string>
+    <string name="note_editor_add_note">Προσθήκη σημείωσης</string>
     <string name="card_editor_copy_card">Αντιγραφή κάρτας</string>
     <string name="card_editor_reposition_card">Reposition</string>
     <string name="card_editor_reset_card">Διαγραφή προόδου</string>

--- a/AnkiDroid/src/main/res/values-eo/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-eo/02-strings.xml
@@ -124,7 +124,7 @@
     </plurals>
     <string name="studyoptions_welcome_title">Bonvenon al AnkiDroid</string>
     <string name="fact_adder_intent_title">AnkiDroid-karto</string>
-    <string name="card_editor_add_card">Aldoni noton</string>
+    <string name="note_editor_add_note">Aldoni noton</string>
     <string name="card_editor_copy_card">Kopii karton</string>
     <string name="card_editor_reposition_card">Repozicii</string>
     <string name="card_editor_reset_card">Nuligi progreson</string>

--- a/AnkiDroid/src/main/res/values-es-rAR/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-es-rAR/02-strings.xml
@@ -124,7 +124,7 @@
     </plurals>
     <string name="studyoptions_welcome_title">Bienvenido a AnkiDroid</string>
     <string name="fact_adder_intent_title">Tarjeta de AnkiDroid</string>
-    <string name="card_editor_add_card">Añadir nota</string>
+    <string name="note_editor_add_note">Añadir nota</string>
     <string name="card_editor_copy_card">Copiar tarjeta</string>
     <string name="card_editor_reposition_card">Reposicionamiento</string>
     <string name="card_editor_reset_card">Resetear progreso</string>

--- a/AnkiDroid/src/main/res/values-es-rES/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-es-rES/02-strings.xml
@@ -124,7 +124,7 @@
     </plurals>
     <string name="studyoptions_welcome_title">Bienvenido a AnkiDroid</string>
     <string name="fact_adder_intent_title">Tarjeta de AnkiDroid</string>
-    <string name="card_editor_add_card">Añadir nota</string>
+    <string name="note_editor_add_note">Añadir nota</string>
     <string name="card_editor_copy_card">Copiar tarjeta</string>
     <string name="card_editor_reposition_card">Reposición</string>
     <string name="card_editor_reset_card">Reiniciar el progreso</string>

--- a/AnkiDroid/src/main/res/values-et/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-et/02-strings.xml
@@ -124,7 +124,7 @@
     </plurals>
     <string name="studyoptions_welcome_title">Tere tulemast AnkiDroidi</string>
     <string name="fact_adder_intent_title">AnkiDroid kaart</string>
-    <string name="card_editor_add_card">Lisa märkus</string>
+    <string name="note_editor_add_note">Lisa märkus</string>
     <string name="card_editor_copy_card">Kopeeri kaart</string>
     <string name="card_editor_reposition_card">Reposition</string>
     <string name="card_editor_reset_card">Lähtestamise progress</string>

--- a/AnkiDroid/src/main/res/values-fa/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-fa/02-strings.xml
@@ -124,7 +124,7 @@
     </plurals>
     <string name="studyoptions_welcome_title">به آنکی دروید خوش آمدید</string>
     <string name="fact_adder_intent_title">کارت آنکی دروید</string>
-    <string name="card_editor_add_card">افزودن یادداشت</string>
+    <string name="note_editor_add_note">افزودن یادداشت</string>
     <string name="card_editor_copy_card">کپی کارت</string>
     <string name="card_editor_reposition_card">تغییر مکان</string>
     <string name="card_editor_reset_card">تنظیم مجدد پیشرفت</string>

--- a/AnkiDroid/src/main/res/values-fi/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-fi/02-strings.xml
@@ -124,7 +124,7 @@
     </plurals>
     <string name="studyoptions_welcome_title">Tervetuloa AnkiDroidiin</string>
     <string name="fact_adder_intent_title">AnkiDroid-kortti</string>
-    <string name="card_editor_add_card">Lisää merkintä</string>
+    <string name="note_editor_add_note">Lisää merkintä</string>
     <string name="card_editor_copy_card">Kopioi kortti</string>
     <string name="card_editor_reposition_card">Reposition</string>
     <string name="card_editor_reset_card">Tyhjennä edistyminen</string>

--- a/AnkiDroid/src/main/res/values-fr/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-fr/02-strings.xml
@@ -124,7 +124,7 @@
     </plurals>
     <string name="studyoptions_welcome_title">Bienvenue sur AnkiDroid</string>
     <string name="fact_adder_intent_title">Carte AnkiDroid</string>
-    <string name="card_editor_add_card">Ajouter une note</string>
+    <string name="note_editor_add_note">Ajouter une note</string>
     <string name="card_editor_copy_card">Copier la carte</string>
     <string name="card_editor_reposition_card">Repositionner</string>
     <string name="card_editor_reset_card">Remettre les compteurs à 0</string>

--- a/AnkiDroid/src/main/res/values-gl/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-gl/02-strings.xml
@@ -124,7 +124,7 @@
     </plurals>
     <string name="studyoptions_welcome_title">Benvido a AnkiDroid</string>
     <string name="fact_adder_intent_title">Cartón AnkiDroid</string>
-    <string name="card_editor_add_card">Engadir nota</string>
+    <string name="note_editor_add_note">Engadir nota</string>
     <string name="card_editor_copy_card">Copiar cartón</string>
     <string name="card_editor_reposition_card">Reposicionar</string>
     <string name="card_editor_reset_card">Reiniciar progreso</string>

--- a/AnkiDroid/src/main/res/values-go/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-go/02-strings.xml
@@ -124,7 +124,7 @@
     </plurals>
     <string name="studyoptions_welcome_title">Waila andanems du AnkiDroid</string>
     <string name="fact_adder_intent_title">AnkiDroid karta</string>
-    <string name="card_editor_add_card">Add note</string>
+    <string name="note_editor_add_note">Add note</string>
     <string name="card_editor_copy_card">Copy card</string>
     <string name="card_editor_reposition_card">Reposition</string>
     <string name="card_editor_reset_card">Reset progress</string>

--- a/AnkiDroid/src/main/res/values-he/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-he/02-strings.xml
@@ -128,7 +128,7 @@
     </plurals>
     <string name="studyoptions_welcome_title">ברוך בואך ל־AnkiDroid</string>
     <string name="fact_adder_intent_title">קלף AnkiDroid</string>
-    <string name="card_editor_add_card">הוסף הערה</string>
+    <string name="note_editor_add_note">הוסף הערה</string>
     <string name="card_editor_copy_card">העתקת קלף</string>
     <string name="card_editor_reposition_card">מיקום מחדש</string>
     <string name="card_editor_reset_card">איפוס התקדמות</string>

--- a/AnkiDroid/src/main/res/values-hi/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-hi/02-strings.xml
@@ -124,7 +124,7 @@
     </plurals>
     <string name="studyoptions_welcome_title">AnkiDroid में आपका स्वागत है</string>
     <string name="fact_adder_intent_title">AnkiDroid कार्ड</string>
-    <string name="card_editor_add_card">नोट जोड़ें</string>
+    <string name="note_editor_add_note">नोट जोड़ें</string>
     <string name="card_editor_copy_card">प्रति कार्ड</string>
     <string name="card_editor_reposition_card">Reposition</string>
     <string name="card_editor_reset_card">प्रगति को रीसेट</string>

--- a/AnkiDroid/src/main/res/values-hu/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-hu/02-strings.xml
@@ -124,7 +124,7 @@
     </plurals>
     <string name="studyoptions_welcome_title">Üdv az AnkiDroidban!</string>
     <string name="fact_adder_intent_title">AnkiDroid Kártya</string>
-    <string name="card_editor_add_card">Jegyzet hozzáadása</string>
+    <string name="note_editor_add_note">Jegyzet hozzáadása</string>
     <string name="card_editor_copy_card">Kártya másolása</string>
     <string name="card_editor_reposition_card">Áthelyezés</string>
     <string name="card_editor_reset_card">Reset folyamat</string>

--- a/AnkiDroid/src/main/res/values-id/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-id/02-strings.xml
@@ -122,7 +122,7 @@
     </plurals>
     <string name="studyoptions_welcome_title">Selamat Datang ke AnkiDroid</string>
     <string name="fact_adder_intent_title">Kad AnkiDroid</string>
-    <string name="card_editor_add_card">Tambahkan catatan</string>
+    <string name="note_editor_add_note">Tambahkan catatan</string>
     <string name="card_editor_copy_card">Salin kad</string>
     <string name="card_editor_reposition_card">Reposisi</string>
     <string name="card_editor_reset_card">Set semula aktivitas</string>

--- a/AnkiDroid/src/main/res/values-it/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-it/02-strings.xml
@@ -124,7 +124,7 @@
     </plurals>
     <string name="studyoptions_welcome_title">Benvenuto in AnkiDroid</string>
     <string name="fact_adder_intent_title">Carta AnkiDroid</string>
-    <string name="card_editor_add_card">Aggiungi nota</string>
+    <string name="note_editor_add_note">Aggiungi nota</string>
     <string name="card_editor_copy_card">Copia carta</string>
     <string name="card_editor_reposition_card">Riposiziona</string>
     <string name="card_editor_reset_card">Reimposta progresso</string>

--- a/AnkiDroid/src/main/res/values-ja/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-ja/02-strings.xml
@@ -122,7 +122,7 @@
     </plurals>
     <string name="studyoptions_welcome_title">AnkiDroidへようこそ</string>
     <string name="fact_adder_intent_title">AnkiDroid カード</string>
-    <string name="card_editor_add_card">ノートを追加</string>
+    <string name="note_editor_add_note">ノートを追加</string>
     <string name="card_editor_copy_card">カードをコピー</string>
     <string name="card_editor_reposition_card">新規カードの表示順序を変更</string>
     <string name="card_editor_reset_card">学習履歴をリセット</string>

--- a/AnkiDroid/src/main/res/values-ko/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-ko/02-strings.xml
@@ -122,7 +122,7 @@
     </plurals>
     <string name="studyoptions_welcome_title">AnkiDroid에 오신 것을 환영합니다</string>
     <string name="fact_adder_intent_title">AnkiDroid 카드</string>
-    <string name="card_editor_add_card">노트 추가</string>
+    <string name="note_editor_add_note">노트 추가</string>
     <string name="card_editor_copy_card">카드 복사</string>
     <string name="card_editor_reposition_card">위치 변경</string>
     <string name="card_editor_reset_card">학습 진도 재설정</string>

--- a/AnkiDroid/src/main/res/values-lt/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-lt/02-strings.xml
@@ -128,7 +128,7 @@
     </plurals>
     <string name="studyoptions_welcome_title">Sveiki apsilankę „AnkiDroid“ programoje</string>
     <string name="fact_adder_intent_title">„AnkiDroid“ kortelė</string>
-    <string name="card_editor_add_card">Pridėti užrašą</string>
+    <string name="note_editor_add_note">Pridėti užrašą</string>
     <string name="card_editor_copy_card">Kopijuoti kortelę</string>
     <string name="card_editor_reposition_card">Keisti išdėstymą</string>
     <string name="card_editor_reset_card">Atkurti pažangą</string>

--- a/AnkiDroid/src/main/res/values-lv/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-lv/02-strings.xml
@@ -126,7 +126,7 @@
     </plurals>
     <string name="studyoptions_welcome_title">Welcome to AnkiDroid</string>
     <string name="fact_adder_intent_title">AnkiDroid card</string>
-    <string name="card_editor_add_card">Add note</string>
+    <string name="note_editor_add_note">Add note</string>
     <string name="card_editor_copy_card">Copy card</string>
     <string name="card_editor_reposition_card">Reposition</string>
     <string name="card_editor_reset_card">Reset progress</string>

--- a/AnkiDroid/src/main/res/values-nl/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-nl/02-strings.xml
@@ -124,7 +124,7 @@
     </plurals>
     <string name="studyoptions_welcome_title">Welkom bij AnkiDroid</string>
     <string name="fact_adder_intent_title">Ankidroid kaart</string>
-    <string name="card_editor_add_card">Kaart toevoegen</string>
+    <string name="note_editor_add_note">Kaart toevoegen</string>
     <string name="card_editor_copy_card">Kopieer kaart</string>
     <string name="card_editor_reposition_card">Verplaatsen</string>
     <string name="card_editor_reset_card">Vooruitgang resetten</string>

--- a/AnkiDroid/src/main/res/values-no/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-no/02-strings.xml
@@ -124,7 +124,7 @@
     </plurals>
     <string name="studyoptions_welcome_title">Velkommen til AnkiDroid</string>
     <string name="fact_adder_intent_title">AnkiDroid-kort</string>
-    <string name="card_editor_add_card">Legg til notat</string>
+    <string name="note_editor_add_note">Legg til notat</string>
     <string name="card_editor_copy_card">Kopier kort</string>
     <string name="card_editor_reposition_card">Reposition</string>
     <string name="card_editor_reset_card">Tilbakestill fremdrift</string>

--- a/AnkiDroid/src/main/res/values-pl/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-pl/02-strings.xml
@@ -128,7 +128,7 @@
     </plurals>
     <string name="studyoptions_welcome_title">Witamy w AnkiDroidzie</string>
     <string name="fact_adder_intent_title">Karta AnkiDroida</string>
-    <string name="card_editor_add_card">Dodaj notatkę</string>
+    <string name="note_editor_add_note">Dodaj notatkę</string>
     <string name="card_editor_copy_card">Kopiuj kartę</string>
     <string name="card_editor_reposition_card">Przestawianie</string>
     <string name="card_editor_reset_card">Resetuj postępy</string>

--- a/AnkiDroid/src/main/res/values-pt-rBR/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-pt-rBR/02-strings.xml
@@ -124,7 +124,7 @@
     </plurals>
     <string name="studyoptions_welcome_title">Bem-vindo ao AnkiDroid</string>
     <string name="fact_adder_intent_title">Cartão AnkiDroid</string>
-    <string name="card_editor_add_card">Adicionar nota</string>
+    <string name="note_editor_add_note">Adicionar nota</string>
     <string name="card_editor_copy_card">Copiar cartão</string>
     <string name="card_editor_reposition_card">Reposicionar</string>
     <string name="card_editor_reset_card">Redefinir progresso</string>

--- a/AnkiDroid/src/main/res/values-pt-rPT/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-pt-rPT/02-strings.xml
@@ -124,7 +124,7 @@
     </plurals>
     <string name="studyoptions_welcome_title">Bem-vindo à AnkiDroid</string>
     <string name="fact_adder_intent_title">Ficha AnkiDroid</string>
-    <string name="card_editor_add_card">Adicionar nota</string>
+    <string name="note_editor_add_note">Adicionar nota</string>
     <string name="card_editor_copy_card">Copiar ficha</string>
     <string name="card_editor_reposition_card">Reposition</string>
     <string name="card_editor_reset_card">Reiniciar progresso</string>

--- a/AnkiDroid/src/main/res/values-ro/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-ro/02-strings.xml
@@ -126,7 +126,7 @@
     </plurals>
     <string name="studyoptions_welcome_title">Bine ati venit la AnkiDroid</string>
     <string name="fact_adder_intent_title">Card de AnkiDroid</string>
-    <string name="card_editor_add_card">Adauga nota</string>
+    <string name="note_editor_add_note">Adauga nota</string>
     <string name="card_editor_copy_card">Copie card</string>
     <string name="card_editor_reposition_card">Reposition</string>
     <string name="card_editor_reset_card">Resetare progres</string>

--- a/AnkiDroid/src/main/res/values-ru/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-ru/02-strings.xml
@@ -128,7 +128,7 @@
     </plurals>
     <string name="studyoptions_welcome_title">AnkiDroid приветствует вас</string>
     <string name="fact_adder_intent_title">Карточка AnkiDroid</string>
-    <string name="card_editor_add_card">Добавить запись</string>
+    <string name="note_editor_add_note">Добавить запись</string>
     <string name="card_editor_copy_card">Копировать карточку</string>
     <string name="card_editor_reposition_card">Переместить</string>
     <string name="card_editor_reset_card">Сбросить прогресс</string>

--- a/AnkiDroid/src/main/res/values-sk/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-sk/02-strings.xml
@@ -128,7 +128,7 @@
     </plurals>
     <string name="studyoptions_welcome_title">Vitajte v AnkiDroid</string>
     <string name="fact_adder_intent_title">AnkiDroid kartička</string>
-    <string name="card_editor_add_card">Pridať poznámku</string>
+    <string name="note_editor_add_note">Pridať poznámku</string>
     <string name="card_editor_copy_card">Kopírovať kartičku</string>
     <string name="card_editor_reposition_card">Premiestniť</string>
     <string name="card_editor_reset_card">Vynulovať pokrok</string>

--- a/AnkiDroid/src/main/res/values-sl/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-sl/02-strings.xml
@@ -128,7 +128,7 @@
     </plurals>
     <string name="studyoptions_welcome_title">Dobrodošli v AnkiDroid</string>
     <string name="fact_adder_intent_title">Kartica AnkiDroid</string>
-    <string name="card_editor_add_card">Dodaj zapisek</string>
+    <string name="note_editor_add_note">Dodaj zapisek</string>
     <string name="card_editor_copy_card">Kopiraj kartico</string>
     <string name="card_editor_reposition_card">Reposition</string>
     <string name="card_editor_reset_card">Ponastavi napredek</string>

--- a/AnkiDroid/src/main/res/values-sr/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-sr/02-strings.xml
@@ -126,7 +126,7 @@
     </plurals>
     <string name="studyoptions_welcome_title">Добро дошли у AnkiDroid</string>
     <string name="fact_adder_intent_title">AnkiDroid карта</string>
-    <string name="card_editor_add_card">Додај белешку</string>
+    <string name="note_editor_add_note">Додај белешку</string>
     <string name="card_editor_copy_card">Копирај карту</string>
     <string name="card_editor_reposition_card">Reposition</string>
     <string name="card_editor_reset_card">Ресетуј напредак</string>

--- a/AnkiDroid/src/main/res/values-sv/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-sv/02-strings.xml
@@ -124,7 +124,7 @@
     </plurals>
     <string name="studyoptions_welcome_title">Välkommen till AnkiDroid</string>
     <string name="fact_adder_intent_title">AnkiDroid-kort</string>
-    <string name="card_editor_add_card">Lägg till not</string>
+    <string name="note_editor_add_note">Lägg till not</string>
     <string name="card_editor_copy_card">Kopiera kort</string>
     <string name="card_editor_reposition_card">Reposition</string>
     <string name="card_editor_reset_card">Återställ framsteg</string>

--- a/AnkiDroid/src/main/res/values-th/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-th/02-strings.xml
@@ -122,7 +122,7 @@
     </plurals>
     <string name="studyoptions_welcome_title">Welcome to AnkiDroid</string>
     <string name="fact_adder_intent_title">AnkiDroid card</string>
-    <string name="card_editor_add_card">Add note</string>
+    <string name="note_editor_add_note">Add note</string>
     <string name="card_editor_copy_card">Copy card</string>
     <string name="card_editor_reposition_card">Reposition</string>
     <string name="card_editor_reset_card">Reset progress</string>

--- a/AnkiDroid/src/main/res/values-tr/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-tr/02-strings.xml
@@ -124,7 +124,7 @@
     </plurals>
     <string name="studyoptions_welcome_title">AnkiDroid\'e Hoşgeldiniz</string>
     <string name="fact_adder_intent_title">AnkiDroid Kartı</string>
-    <string name="card_editor_add_card">Not ekle</string>
+    <string name="note_editor_add_note">Not ekle</string>
     <string name="card_editor_copy_card">Kartı kopyala</string>
     <string name="card_editor_reposition_card">Yerini değiştir</string>
     <string name="card_editor_reset_card">İlerlemeyi sıfırla</string>

--- a/AnkiDroid/src/main/res/values-uk/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-uk/02-strings.xml
@@ -128,7 +128,7 @@
     </plurals>
     <string name="studyoptions_welcome_title">Ласкаво просимо в AnkiDroid</string>
     <string name="fact_adder_intent_title">Картка AnkiDroid</string>
-    <string name="card_editor_add_card">Додати примітку</string>
+    <string name="note_editor_add_note">Додати примітку</string>
     <string name="card_editor_copy_card">Копіювати картку</string>
     <string name="card_editor_reposition_card">Переставити</string>
     <string name="card_editor_reset_card">Скинути поступ</string>

--- a/AnkiDroid/src/main/res/values-vi/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-vi/02-strings.xml
@@ -122,7 +122,7 @@
     </plurals>
     <string name="studyoptions_welcome_title">Chào mừng đến với AnkiDroid</string>
     <string name="fact_adder_intent_title">Thẻ AnkiDroid</string>
-    <string name="card_editor_add_card">Thêm ghi chú</string>
+    <string name="note_editor_add_note">Thêm ghi chú</string>
     <string name="card_editor_copy_card">Sao chép thẻ</string>
     <string name="card_editor_reposition_card">Reposition</string>
     <string name="card_editor_reset_card">Thiết lập lại quá trình học</string>

--- a/AnkiDroid/src/main/res/values-zh-rCN/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-zh-rCN/02-strings.xml
@@ -122,7 +122,7 @@
     </plurals>
     <string name="studyoptions_welcome_title">欢迎进入 AnkiDroid</string>
     <string name="fact_adder_intent_title">AnkiDroid卡片</string>
-    <string name="card_editor_add_card">添加笔记</string>
+    <string name="note_editor_add_note">添加笔记</string>
     <string name="card_editor_copy_card">复制卡片</string>
     <string name="card_editor_reposition_card">更改位置</string>
     <string name="card_editor_reset_card">重设学习进度</string>

--- a/AnkiDroid/src/main/res/values-zh-rTW/02-strings.xml
+++ b/AnkiDroid/src/main/res/values-zh-rTW/02-strings.xml
@@ -122,7 +122,7 @@
     </plurals>
     <string name="studyoptions_welcome_title">歡迎使用 AnkiDroid</string>
     <string name="fact_adder_intent_title">AnkiDroid 卡片</string>
-    <string name="card_editor_add_card">增加筆記</string>
+    <string name="note_editor_add_note">增加筆記</string>
     <string name="card_editor_copy_card">複製卡片</string>
     <string name="card_editor_reposition_card">更改位置</string>
     <string name="card_editor_reset_card">重設卡片進度</string>

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -113,7 +113,8 @@
 
     <string name="studyoptions_welcome_title">Welcome to AnkiDroid</string>
     <string name="fact_adder_intent_title">AnkiDroid card</string>
-    <string name="card_editor_add_card">Add note</string>
+    <string name="note_editor_add_note">Add note</string>
+    <string name="note_editor_copy_note">Copy note</string>
     <string name="card_editor_copy_card">Copy card</string>
     <string name="card_editor_reposition_card">Reposition</string>
     <string name="card_editor_reset_card">Reset progress</string>


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
The note editor has a "Copy card" option which actually copies the note. Both that option and the "Add note" option use action and string resource names which say "card" instead of "note".

## Fixes
#5553 

## Approach
Global find/replace of the incorrect action names.
Added a new string resource for "Copy note" text.

## How Has This Been Tested?

Tested on a physical device. Can only confirm correct string for English language.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
