### PR TITLE
JaCoCo coverage upgrade / fixes

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -134,14 +134,14 @@ task jacocoTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest', 'crea
     }
 
     def fileFilter = ['**/R.class', '**/R$*.class', '**/BuildConfig.*', '**/Manifest*.*', '**/*Test*.*', 'android/**/*.*']
-    def debugTree = fileTree(dir: "$project.buildDir/intermediates/javac/debug/compileDebugJavaWithJavac/classes", excludes: fileFilter)
+    def debugTree = fileTree(dir: "$project.buildDir/intermediates/javac/debug/classes", excludes: fileFilter)
     def mainSrc = "$project.projectDir/src/main/java"
 
     sourceDirectories.from = files([mainSrc])
     classDirectories.from = files([debugTree])
     executionData.from = fileTree(dir: project.buildDir, includes: [
-            'jacoco/testDebugUnitTest.exec',
-            'outputs/code-coverage/connected/**/*.ec'
+            '**/*.exec',
+            '**/*.ec'
     ])
 }
 
@@ -153,7 +153,7 @@ task jacocoUnitTestReport(type: JacocoReport, dependsOn: ['testDebugUnitTest']) 
     }
 
     def fileFilter = ['**/R.class', '**/R$*.class', '**/BuildConfig.*', '**/Manifest*.*', '**/*Test*.*', 'android/**/*.*']
-    def debugTree = fileTree(dir: "$project.buildDir/intermediates/javac/debug/compileDebugJavaWithJavac/classes", excludes: fileFilter)
+    def debugTree = fileTree(dir: "$project.buildDir/intermediates/javac/debug/classes", excludes: fileFilter)
     def mainSrc = "$project.projectDir/src/main/java"
 
     sourceDirectories.from = files([mainSrc])

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -1,3 +1,5 @@
+import com.android.ddmlib.DdmPreferences
+
 plugins {
  // Gradle plugin portal 
  id 'com.github.triplet.play' version '2.4.2'
@@ -21,6 +23,7 @@ android {
     defaultConfig {
         applicationId "com.ichi2.anki"
         minSdkVersion 15
+        //noinspection OldTargetApi
         targetSdkVersion 28
         testApplicationId "com.ichi2.anki.tests"
         vectorDrawables.useSupportLibrary = true
@@ -30,7 +33,7 @@ android {
         adbOptions {
             //logLevel verbose // let's try to see what is happening
             timeOutInMs 20 * 60 * 1000  // 20 minutes
-            com.android.ddmlib.DdmPreferences.setTimeOut(120000) // apparently if not multidex you do this
+            DdmPreferences.setTimeOut(120000) // apparently if not multidex you do this
         }
     }
     lintOptions {
@@ -166,6 +169,7 @@ dependencies {
     annotationProcessor "com.google.auto.service:auto-service:1.0-rc6"
 
     implementation fileTree(dir: 'libs', include: ['*.jar'])
+    //noinspection GradleDependency
     implementation 'androidx.appcompat:appcompat:1.1.0-rc01'
     // Note: the design support library can be quite buggy, so test everything thoroughly before updating it
     implementation 'com.google.android.material:material:1.0.0'
@@ -186,6 +190,7 @@ dependencies {
     implementation'ch.acra:acra-limiter:5.2.1'
 
     implementation 'net.mikehardy:google-analytics-java7:2.0.10'
+    //noinspection GradleDependency
     implementation 'com.squareup.okhttp3:okhttp:3.12.6'
     implementation 'com.arcao:slf4j-timber:3.1'
 

--- a/AnkiDroid/src/main/resources/jacoco-agent.properties
+++ b/AnkiDroid/src/main/resources/jacoco-agent.properties
@@ -1,0 +1,1 @@
+output=none

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
 
 ext {
 
-    jacocoVersion = "0.8.4"
+    jacocoVersion = "0.8.5"
 
     travisBuild = System.getenv("TRAVIS") == "true"
     // allows for -Dpre-dex=false to be set


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

Coverage reports were broken, and jacoco upgrades were failing.

This updates the jacoco plugin, and in the process fixes all the entropy discovered in the area

## Fixes

No logged issue, but if codacy was working I would have noticed coverage went to zero as the reports were no longer referencing build classes (gradle moved them, I think with android studio 3.4 -> 3.5) or referencing instrumented test output (also moved)

Plus jacoco made a breaking change from 0.8.4 to 0.8.5 so it fixes that

I took the opportunity to de-lint the file as well, just taking Android Studio suggestions to quiet warnings as they seemed sensible.

## Approach

This includes a new resources file in androidTest only, that directs jacoco to not try writing to the filesystem on startup, that fixes the upgrade.

I changed paths in other places in order to fix report generation once jacoco was running again

## How Has This Been Tested?

Ran `./gradlew jacocoTestReport` locally and carefully examined output in `Anki-Android/AnkiDroid/build/reports/jacoco/jacocoTestReport/html/` (index.html and jacoco-sessions.html) until I was sure I had coverage data, and it was coming from all the emulators and unit tests combined

## Learning (optional, can help others)

Entropy doesn't sleep - @pkubowicz  might be interested in the solution as well

I logged this advisory issue on jacoco for future intrepid explorers: https://github.com/jacoco/jacoco/issues/968

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
