### PR TITLE
catch and report TTS errors

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.java
@@ -293,8 +293,14 @@ public class ReadText {
                         }
                         @Override
                         @Deprecated
-                        public void onError(String arg0) {
-                            // do nothing
+                        public void onError(String utteranceId) {
+                            Timber.v("Andoid TTS failed. Check logcat for error. Indicates a problem with Android TTS engine.");
+                            new Handler(mReviewer.get().getMainLooper()).post(new Runnable() {
+                                @Override
+                                public void run() {
+                                    Toast.makeText(mReviewer.get(), "TTS failed. Check Android settings.", Toast.LENGTH_LONG).show();
+                                }
+                            });
                         }
                         @Override
                         public void onStart(String arg0) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.java
@@ -18,6 +18,7 @@ package com.ichi2.anki;
 
 import android.content.Context;
 import android.content.res.Resources;
+import android.net.Uri;
 import android.os.Handler;
 import android.speech.tts.TextToSpeech;
 import android.speech.tts.UtteranceProgressListener;
@@ -26,6 +27,7 @@ import android.view.View;
 import android.widget.Toast;
 
 import com.afollestad.materialdialogs.MaterialDialog;
+import com.google.android.material.snackbar.Snackbar;
 import com.ichi2.compat.Compat;
 import com.ichi2.compat.CompatHelper;
 
@@ -295,12 +297,13 @@ public class ReadText {
                         @Deprecated
                         public void onError(String utteranceId) {
                             Timber.v("Andoid TTS failed. Check logcat for error. Indicates a problem with Android TTS engine.");
-                            new Handler(mReviewer.get().getMainLooper()).post(new Runnable() {
-                                @Override
-                                public void run() {
-                                    Toast.makeText(mReviewer.get(), "TTS failed. Check Android settings.", Toast.LENGTH_LONG).show();
-                                }
-                            });
+
+                            final Uri helpUrl = Uri.parse(mReviewer.get().getString(R.string.link_faq_tts));
+                            final AnkiActivity ankiActivity = (AnkiActivity) mReviewer.get();
+                            ankiActivity.mayOpenUrl(helpUrl);
+                            UIUtils.showSnackbar(ankiActivity, R.string.no_tts_available_message, false, R.string.help,
+                                    v -> ankiActivity.openUrl(helpUrl), ankiActivity.findViewById(R.id.root_layout),
+                                    new Snackbar.Callback());
                         }
                         @Override
                         public void onStart(String arg0) {

--- a/AnkiDroid/src/main/res/values/constants.xml
+++ b/AnkiDroid/src/main/res/values/constants.xml
@@ -134,6 +134,7 @@
     <string name="link_manual_zh">https://docs.ankidroid.org/manual-zh.html</string>
     <string name="link_manual_getting_started">https://docs.ankidroid.org/manual.html#gettingStarted</string>
     <string name="link_hebrew_font">https://github.com/ankidroid/Anki-Android/releases/download/tohu-font/Tohu.ttf</string>
+    <string name="link_faq_tts">https://github.com/ankidroid/Anki-Android/wiki/FAQ#tts--text-to-speech-is-not-speaking</string>
     <string name="shared_decks_url">https://ankiweb.net/shared/decks/</string>
     <string name="repair_deck">http://ankisrs.net/docs/manual.html#corrupt-collections</string>
     <string name="resetpw_url">http://ankiweb.net/account/resetpw</string>


### PR DESCRIPTION
## Purpose / Description
implement onError() to report a Toast with some hints to the user
in case the TTS engine returns an error.

From API 21 upwards we would also have the error code available
for further details on what happened.

## Fixes
fixes #5468

## Approach
report a Toast

## How Has This Been Tested?
Tested on emulator

## Checklist
- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
