### PR TITLE
Change copy-related terms from "card" to "note"

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -785,7 +785,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
             case android.R.id.home:
                 endMultiSelectMode();
                 return true;
-            case R.id.action_add_card_from_card_browser: {
+            case R.id.action_add_note_from_card_browser: {
                 Intent intent = new Intent(CardBrowser.this, NoteEditor.class);
                 intent.putExtra(NoteEditor.EXTRA_CALLER, NoteEditor.CALLER_CARDBROWSER_ADD);
                 startActivityForResultWithAnimation(intent, ADD_NOTE, ActivityTransitionAnimation.LEFT);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -852,17 +852,17 @@ public class NoteEditor extends AnkiActivity {
     public boolean onCreateOptionsMenu(Menu menu) {
         getMenuInflater().inflate(R.menu.note_editor, menu);
         if (mAddNote) {
-            menu.findItem(R.id.action_copy_card).setVisible(false);
+            menu.findItem(R.id.action_copy_note).setVisible(false);
         } else {
-            menu.findItem(R.id.action_add_card_from_card_editor).setVisible(true);
+            menu.findItem(R.id.action_add_note_from_note_editor).setVisible(true);
         }
         if (mEditFields != null) {
             for (int i = 0; i < mEditFields.size(); i++) {
                 if (mEditFields.get(i).getText().length() > 0) {
-                    menu.findItem(R.id.action_copy_card).setEnabled(true);
+                    menu.findItem(R.id.action_copy_note).setEnabled(true);
                     break;
                 } else if (i == mEditFields.size() - 1) {
-                    menu.findItem(R.id.action_copy_card).setEnabled(false);
+                    menu.findItem(R.id.action_copy_note).setEnabled(false);
                 }
             }
         }
@@ -883,13 +883,13 @@ public class NoteEditor extends AnkiActivity {
                 saveNote();
                 return true;
 
-            case R.id.action_add_card_from_card_editor:
-            case R.id.action_copy_card: {
+            case R.id.action_add_note_from_note_editor:
+            case R.id.action_copy_note: {
                 Timber.i("NoteEditor:: Copy or add card button pressed");
                 Intent intent = new Intent(NoteEditor.this, NoteEditor.class);
                 intent.putExtra(EXTRA_CALLER, CALLER_CARDEDITOR);
                 // intent.putExtra(EXTRA_DECKPATH, mDeckPath);
-                if (item.getItemId() == R.id.action_copy_card) {
+                if (item.getItemId() == R.id.action_copy_note) {
                     intent.putExtra(EXTRA_CONTENTS, getFieldsText());
                 }
                 startActivityForResultWithAnimation(intent, REQUEST_ADD, ActivityTransitionAnimation.LEFT);

--- a/AnkiDroid/src/main/res/menu/card_browser.xml
+++ b/AnkiDroid/src/main/res/menu/card_browser.xml
@@ -2,9 +2,9 @@
     xmlns:ankidroid="http://schemas.android.com/apk/res-auto" >
 
     <item
-        android:id="@+id/action_add_card_from_card_browser"
+        android:id="@+id/action_add_note_from_card_browser"
         android:icon="@drawable/ic_add_white_24dp"
-        android:title="@string/card_editor_add_card"
+        android:title="@string/note_editor_add_note"
         ankidroid:showAsAction="ifRoom"/>
     <item
         android:id="@+id/action_search"

--- a/AnkiDroid/src/main/res/menu/note_editor.xml
+++ b/AnkiDroid/src/main/res/menu/note_editor.xml
@@ -7,11 +7,11 @@
         android:title="@string/save"
         ankidroid:showAsAction="always"/>
     <item
-        android:id="@+id/action_add_card_from_card_editor"
-        android:title="@string/card_editor_add_card"
+        android:id="@+id/action_add_note_from_note_editor"
+        android:title="@string/note_editor_add_note"
         android:visible="false"/>
     <item
-        android:id="@+id/action_copy_card"
+        android:id="@+id/action_copy_note"
         android:enabled="false"
-        android:title="@string/card_editor_copy_card"/>
+        android:title="@string/note_editor_copy_note"/>
 </menu>

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -113,7 +113,8 @@
 
     <string name="studyoptions_welcome_title">Welcome to AnkiDroid</string>
     <string name="fact_adder_intent_title">AnkiDroid card</string>
-    <string name="card_editor_add_card">Add note</string>
+    <string name="note_editor_add_note">Add note</string>
+    <string name="note_editor_copy_note">Copy note</string>
     <string name="card_editor_copy_card">Copy card</string>
     <string name="card_editor_reposition_card">Reposition</string>
     <string name="card_editor_reset_card">Reset progress</string>


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
The note editor has a "Copy card" option which actually copies the note. Both that option and the "Add note" option use action and string resource names which say "card" instead of "note".

Now with less mess-with-translated-strings action!

## Fixes
Fixes #5553 

## Approach
Global find/replace of the incorrect action names.
Added a new string resource for "Copy note" text.

## How Has This Been Tested?

Tested on a physical device. Can only confirm correct string for English language.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
