### PR TITLE
Localize standard models

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.java
@@ -300,10 +300,10 @@ public class ModelBrowser extends AnkiActivity {
         String clone = getResources().getString(R.string.model_browser_add_clone);
 
         // AnkiDroid doesn't have stdmodels class or model name localization, this could be much cleaner if implemented
-        final String basicName = "Basic";
-        final String addForwardReverseName = "Basic (and reversed card)";
-        final String addForwardOptionalReverseName = "Basic (optional reversed card)";
-        final String addClozeModelName = "Cloze";
+        final String basicName = getResources().getString(R.string.basic_model_name);
+        final String addForwardReverseName = getResources().getString(R.string.forward_reverse_model_name);
+        final String addForwardOptionalReverseName = getResources().getString(R.string.forward_optional_reverse_model_name);
+        final String addClozeModelName = getResources().getString(R.string.cloze_model_name);
 
         //Populates arrayadapters listing the mModels (includes prefixes/suffixes)
         mNewModelLabels = new ArrayList<>();

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -23,6 +23,8 @@ import android.content.ContentValues;
 import android.database.Cursor;
 import android.util.Pair;
 
+import com.ichi2.anki.AnkiDroidApp;
+import com.ichi2.anki.R;
 import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.utils.Assert;
 
@@ -1311,21 +1313,25 @@ public class Models {
      */
 
     private static JSONObject _newBasicModel(Collection col) {
-        return _newBasicModel(col, "Basic");
+        String name = AnkiDroidApp.getAppResources().getString(R.string.basic_model_name);
+        return _newBasicModel(col, name);
     }
 
 
     private static JSONObject _newBasicModel(Collection col, String name) {
         Models mm = col.getModels();
         JSONObject m = mm.newModel(name);
-        JSONObject fm = mm.newField("Front");
+        String frontName = AnkiDroidApp.getAppResources().getString(R.string.front_field_name);
+        JSONObject fm = mm.newField(frontName);
         mm.addFieldInNewModel(m, fm);
-        fm = mm.newField("Back");
+        String backName = AnkiDroidApp.getAppResources().getString(R.string.back_field_name);
+        fm = mm.newField(backName);
         mm.addFieldInNewModel(m, fm);
-        JSONObject t = mm.newTemplate("Card 1");
+        String cardOneName = AnkiDroidApp.getAppResources().getString(R.string.card_one_name);
+        JSONObject t = mm.newTemplate(cardOneName);
         try {
-            t.put("qfmt", "{{Front}}");
-            t.put("afmt", "{{FrontSide}}\n\n<hr id=answer>\n\n{{Back}}");
+            t.put("qfmt", "{{"+frontName+"}}");
+            t.put("afmt", "{{FrontSide}}\n\n<hr id=answer>\n\n{{" + backName + "}}");
         } catch (JSONException e) {
             throw new RuntimeException(e);
         }
@@ -1334,7 +1340,8 @@ public class Models {
     }
 
     public static JSONObject addBasicModel(Collection col) {
-        return addBasicModel(col, "Basic");
+        String name = AnkiDroidApp.getAppResources().getString(R.string.basic_model_name);
+        return addBasicModel(col, name);
     }
 
     public static JSONObject addBasicModel(Collection col, String name) {
@@ -1345,16 +1352,20 @@ public class Models {
 
     /* Forward & Reverse */
     private static JSONObject _newForwardReverse(Collection col) {
-        return _newForwardReverse(col, "Basic (and reversed card)");
+        String name = AnkiDroidApp.getAppResources().getString(R.string.forward_reverse_model_name);
+        return _newForwardReverse(col, name);
     }
 
     private static JSONObject _newForwardReverse(Collection col, String name) {
         Models mm = col.getModels();
         JSONObject m = _newBasicModel(col, name);
         try {
-            JSONObject t = mm.newTemplate("Card 2");
-            t.put("qfmt", "{{Back}}");
-            t.put("afmt", "{{FrontSide}}\n\n<hr id=answer>\n\n{{Front}}");
+            String frontName = m.getJSONArray("flds").getJSONObject(0).getString("name");
+            String backName = m.getJSONArray("flds").getJSONObject(1).getString("name");
+            String cardTwoName = AnkiDroidApp.getAppResources().getString(R.string.card_two_name);
+            JSONObject t = mm.newTemplate(cardTwoName);
+            t.put("qfmt", "{{" + backName + "}}");
+            t.put("afmt", "{{FrontSide}}\n\n<hr id=answer>\n\n{{"+frontName+"}}");
             mm.addTemplateInNewModel(m, t);
         } catch (JSONException e) {
             throw new RuntimeException(e);
@@ -1371,11 +1382,11 @@ public class Models {
     /* Forward & Optional Reverse */
 
     private static JSONObject _newForwardOptionalReverse(Collection col) {
-    	String name = "Basic (optional reversed card)";
+        String name = AnkiDroidApp.getAppResources().getString(R.string.forward_optional_reverse_model_name);
         Models mm = col.getModels();
         JSONObject m = _newForwardReverse(col, name);
         try {
-            String av = "Add Reverse";
+            String av = AnkiDroidApp.getAppResources().getString(R.string.field_to_ask_front_name);
             JSONObject fm = mm.newField(av);
             mm.addFieldInNewModel(m, fm);
             JSONObject t = m.getJSONArray("tmpls").getJSONObject(1);
@@ -1394,19 +1405,22 @@ public class Models {
 
     public static JSONObject addClozeModel(Collection col) {
         Models mm = col.getModels();
-        JSONObject m = mm.newModel("Cloze");
+        String name = AnkiDroidApp.getAppResources().getString(R.string.cloze_model_name);
+        JSONObject m = mm.newModel(name);
         try {
             m.put("type", Consts.MODEL_CLOZE);
-            String txt = "Text";
+            String txt = AnkiDroidApp.getAppResources().getString(R.string.text_field_name);
             JSONObject fm = mm.newField(txt);
             mm.addFieldInNewModel(m, fm);
-            fm = mm.newField("Extra");
+            String fieldExtraName = AnkiDroidApp.getAppResources().getString(R.string.extra_field_name);
+            fm = mm.newField(fieldExtraName);
             mm.addFieldInNewModel(m, fm);
-            JSONObject t = mm.newTemplate("Cloze");
+            String cardTypeClozeName = AnkiDroidApp.getAppResources().getString(R.string.card_cloze_name);
+            JSONObject t = mm.newTemplate(cardTypeClozeName);
             String fmt = "{{cloze:" + txt + "}}";
             m.put("css", m.getString("css") + ".cloze {" + "font-weight: bold;" + "color: blue;" + "}");
             t.put("qfmt", fmt);
-            t.put("afmt", fmt + "<br>\n{{Extra}}");
+            t.put("afmt", fmt + "<br>\n{{" + fieldExtraName + "}}");
             mm.addTemplateInNewModel(m, t);
             mm.add(m);
         } catch (JSONException e) {

--- a/AnkiDroid/src/main/res/values/18-standard-models.xml
+++ b/AnkiDroid/src/main/res/values/18-standard-models.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!--Fields-->
+    <string name="front_field_name">Front</string>
+    <string name="back_field_name">Back</string>
+    <string name="text_field_name">Text</string>
+    <string name="extra_field_name">Extra</string>
+    <string name="field_to_ask_front_name">Add Reverse</string>
+
+
+    <!--Card type-->
+    <string name="card_one_name">Card 1</string>
+    <string name="card_two_name">Card 2</string>
+    <string name="card_cloze_name">Cloze</string>
+
+
+    <!--Note type-->
+    <string name="basic_model_name">Basic</string>
+    <string name="cloze_model_name">Cloze</string>
+    <string name="basic_typing_model_name">Basic (type in the answer)</string>
+    <string name="forward_reverse_model_name">Basic (and reversed card)</string>
+    <string name="forward_optional_reverse_model_name">Basic (optional reversed card)</string>
+</resources>

--- a/tools/manage-crowdin.py
+++ b/tools/manage-crowdin.py
@@ -29,7 +29,7 @@ PROJECT_IDENTIFIER = 'ankidroid'
 
 path = './AnkiDroid/src/main/res/values/'
 
-files = ['01-core', '02-strings', '03-dialogs', '04-network', '05-feedback', '06-statistics', '07-cardbrowser', '08-widget', '09-backup', '10-preferences', '11-arrays', '14-marketdescription', '16-multimedia-editor', '17-model-manager']
+files = ['01-core', '02-strings', '03-dialogs', '04-network', '05-feedback', '06-statistics', '07-cardbrowser', '08-widget', '09-backup', '10-preferences', '11-arrays', '14-marketdescription', '16-multimedia-editor', '17-model-manager', '18-standard-models']
 alllang = ['ar', 'ca', 'cs', 'de', 'el', 'es-AR', 'es-ES', 'fa', 'fi', 'fr', 'hu', 'id', 'it', 'ja', 'ko', 'nl', 'pl', 'pt-PT', 'pt-BR', 'ro', 'ru', 'sr', 'sv-SE', 'th', 'tr', 'vi', 'zh-CN', 'zh-TW']
 
 

--- a/tools/update-localizations.py
+++ b/tools/update-localizations.py
@@ -27,7 +27,7 @@ languages = ['ar', 'bg', 'ca', 'cs', 'de', 'el', 'es-AR', 'es-ES', 'et', 'fa', '
 # languages which are localized for more than one region
 localizedRegions = ['es', 'pt', 'zh']
 
-fileNames = ['01-core', '02-strings', '03-dialogs', '04-network', '05-feedback', '06-statistics', '07-cardbrowser', '08-widget', '09-backup', '10-preferences', '11-arrays', '14-marketdescription', '15-markettitle', '16-multimedia-editor', '17-model-manager']
+fileNames = ['01-core', '02-strings', '03-dialogs', '04-network', '05-feedback', '06-statistics', '07-cardbrowser', '08-widget', '09-backup', '10-preferences', '11-arrays', '14-marketdescription', '15-markettitle', '16-multimedia-editor', '17-model-manager', '18-standard-models']
 anyError = False
 titleFile = 'docs/marketing/localized_description/ankidroid-titles.txt'
 titleString = 'AnkiDroid Flashcards'


### PR DESCRIPTION
## Purpose / Description
    
In Anki, standard models are localized. More precisely, there are translations of field names, card name and model names. I ported this to ankidroid.

## Approach
Using resources

## How Has This Been Tested?

Starting anki in a VM, changing the language to French, trying to add a note type, seing that all names are translated to french.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
