### PR TITLE
New model can be edited without full sync

### DIFF
--- a/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/ContentProviderTest.java
+++ b/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/ContentProviderTest.java
@@ -160,7 +160,7 @@ public class ContentProviderTest {
         col.getDecks().flush();
         assertEquals("Check that all created decks have been deleted", mNumDecksBeforeTest, col.getDecks().count());
         // Delete test model
-        col.modSchema(false);
+        col.modSchemaNoCheck();
 
         removeAllModelsByName(col, BASIC_MODEL_NAME);
         removeAllModelsByName(col, TEST_MODEL_NAME);
@@ -453,8 +453,8 @@ public class ContentProviderTest {
             }
         } finally {
             // Delete the model (this will force a full-sync)
+            col.modSchemaNoCheck();
             try {
-                col.modSchema(false);
                 col.getModels().rem(col.getModels().get(mid));
             } catch (ConfirmModSchemaException e) {
                 // This will never happen

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
@@ -658,12 +658,13 @@ public class CardTemplateEditor extends AnkiActivity {
 
         /**
          * Launch background task to delete tmpl from model
+         *
+         * Assuming schema is already modified if necessary
          * @param tmpl template to remove
          * @param model model to remove from
          */
         private void deleteTemplate(JSONObject tmpl, JSONObject model) {
             CardTemplateEditor activity = ((CardTemplateEditor) getActivity());
-            activity.getCol().modSchemaNoCheck();
             Object [] args = new Object[] {model, tmpl};
             DeckTask.launchDeckTask(DeckTask.TASK_TYPE_REMOVE_TEMPLATE,
                     activity.mAddRemoveTemplateHandler,  new DeckTask.TaskData(args));
@@ -696,11 +697,13 @@ public class CardTemplateEditor extends AnkiActivity {
 
         /**
          * Launch background task to add new template to model
+         *
+         * assume schema is already changed if necessary.
+         *
          * @param model model to add new template to
          */
         private void addNewTemplate(JSONObject model) {
             CardTemplateEditor activity = ((CardTemplateEditor) getActivity());
-            activity.getCol().modSchemaNoCheck();
             Models mm = activity.getCol().getModels();
             // Build new template
             JSONObject newTemplate;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
@@ -640,7 +640,7 @@ public class CardTemplateEditor extends AnkiActivity {
          */
         private void deleteTemplateWithCheck(final JSONObject tmpl, final JSONObject model) {
             try {
-                ((CardTemplateEditor) getActivity()).getCol().modSchema(true);
+                ((CardTemplateEditor) getActivity()).getCol().getModels()._modSchemaIfRequired(model);
                 deleteTemplate(tmpl, model);
             } catch (ConfirmModSchemaException e) {
                 ConfirmationDialog d = new ConfirmationDialog();
@@ -677,7 +677,7 @@ public class CardTemplateEditor extends AnkiActivity {
          */
         private void addNewTemplateWithCheck(final JSONObject model) {
             try {
-                ((CardTemplateEditor) getActivity()).getCol().modSchema(true);
+                ((CardTemplateEditor) getActivity()).getCol().getModels()._modSchemaIfRequired(model);
                 addNewTemplate(model);
             } catch (ConfirmModSchemaException e) {
                 ConfirmationDialog d = new ConfirmationDialog();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.java
@@ -68,6 +68,7 @@ public class ModelBrowser extends AnkiActivity {
     // Of the currently selected model
     private long mCurrentID;
     private int mModelListPosition;
+    private JSONObject mMod;
 
     //Used exclusively to display model name
     private ArrayList<JSONObject> mModels;
@@ -272,6 +273,7 @@ public class ModelBrowser extends AnkiActivity {
             public boolean onItemLongClick(AdapterView<?> parent, View view, int position, long id) {
                 String cardName = mModelDisplayList.get(position).getName();
                 mCurrentID = mModelIds.get(position);
+                mMod = mModels.get(position);
                 mModelListPosition = position;
                 mContextMenu = ModelBrowserContextMenu.newInstance(cardName, mContextMenuListener);
                 showDialogFragment(mContextMenu);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.java
@@ -437,8 +437,8 @@ public class ModelBrowser extends AnkiActivity {
             Runnable confirm = new Runnable() {
                 @Override
                 public void run() {
+                    col.modSchemaNoCheck();
                     try {
-                        col.modSchema(false);
                         deleteModel();
                     } catch (ConfirmModSchemaException e) {
                         //This should never be reached because modSchema() didn't throw an exception

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.java
@@ -394,29 +394,28 @@ public class ModelBrowser extends AnkiActivity {
                 switch (position) {
                     //Basic Model
                     case (0):
-                        model = Models.addBasicModel(col);
+                        model = Models.addBasicModel(col, modelName);
                         break;
                     //Add forward reverse model
                     case (1):
-                        model = Models.addForwardReverse(col);
+                        model = Models.addForwardReverse(col, modelName);
                         break;
                     //Add forward optional reverse model
                     case (2):
-                        model = Models.addForwardOptionalReverse(col);
+                        model = Models.addForwardOptionalReverse(col, modelName);
                         break;
                     //Close model
                     case (3):
-                        model = Models.addClozeModel(col);
+                        model = Models.addClozeModel(col, modelName);
                         break;
                     default:
                         //New model
                         //Model that is being cloned
                         JSONObject oldModel = new JSONObject(mModels.get(position - 4).toString());
-                        model = col.getModels().copy(oldModel);
+                        model = col.getModels().copy(oldModel, modelName);
                         break;
 
                 }
-                model.put("name", modelName);
                 col.getModels().update(model);
                 fullRefresh();
             } else {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.java
@@ -438,11 +438,7 @@ public class ModelBrowser extends AnkiActivity {
                 @Override
                 public void run() {
                     col.modSchemaNoCheck();
-                    try {
-                        deleteModel();
-                    } catch (ConfirmModSchemaException e) {
-                        //This should never be reached because modSchema() didn't throw an exception
-                    }
+                    deleteModel();
                     dismissContextMenu();
                 }
             };
@@ -557,7 +553,7 @@ public class ModelBrowser extends AnkiActivity {
     /*
      * Deletes the currently selected model
      */
-    private void deleteModel() throws ConfirmModSchemaException {
+    private void deleteModel() {
         DeckTask.launchDeckTask(DeckTask.TASK_TYPE_DELETE_MODEL, mDeleteModelHandler,
                 new DeckTask.TaskData(mCurrentID));
         mModels.remove(mModelListPosition);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.java
@@ -454,7 +454,7 @@ public class ModelBrowser extends AnkiActivity {
             };
 
             try {
-                col.modSchema();
+                col.getModels()._modSchemaIfRequired(mMod);
                 ConfirmationDialog d = new ConfirmationDialog();
                 d.setArgs(getResources().getString(R.string.model_delete_warning));
                 d.setConfirm(confirm);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.java
@@ -412,9 +412,7 @@ public class ModelBrowser extends AnkiActivity {
                         //New model
                         //Model that is being cloned
                         JSONObject oldModel = new JSONObject(mModels.get(position - 4).toString());
-                        JSONObject newModel = Models.addBasicModel(col);
-                        oldModel.put("id", newModel.get("id"));
-                        model = oldModel;
+                        model = col.getModels().copy(oldModel);
                         break;
 
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.java
@@ -224,12 +224,8 @@ public class ModelFieldEditor extends AnkiActivity {
      */
     private void deleteFieldDialog() {
         Runnable confirm = () -> {
-            try {
-                mCol.modSchema(false);
-                deleteField();
-            } catch (ConfirmModSchemaException e) {
-                //This should never be reached because modSchema() didn't throw an exception
-            }
+            mCol.modSchemaNoCheck();
+            deleteField();
             dismissContextMenu();
         };
 
@@ -295,8 +291,8 @@ public class ModelFieldEditor extends AnkiActivity {
                                 ConfirmationDialog c = new ConfirmationDialog();
                                 c.setArgs(getResources().getString(R.string.full_sync_confirmation));
                                 Runnable confirm = () -> {
+                                    mCol.modSchemaNoCheck();
                                     try {
-                                        mCol.modSchema(false);
                                         renameField();
                                     } catch (ConfirmModSchemaException e1) {
                                         //This should never be thrown

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.java
@@ -188,7 +188,7 @@ public class ModelFieldEditor extends AnkiActivity {
                     } else {
                         //Name is valid, now field is added
                         try {
-                            mCol.modSchema();
+                            mCol.getModels()._modSchemaIfRequired(mMod);
                             DeckTask.launchDeckTask(DeckTask.TASK_TYPE_ADD_FIELD, mChangeFieldHandler,
                                     new DeckTask.TaskData(new Object[]{mMod, fieldName}));
                         } catch (ConfirmModSchemaException e) {
@@ -238,7 +238,7 @@ public class ModelFieldEditor extends AnkiActivity {
             showToast(getResources().getString(R.string.toast_last_field));
         } else {
             try {
-                mCol.modSchema();
+                mCol.getModels()._modSchemaIfRequired(mMod);
                 ConfirmationDialog d = new ConfirmationDialog();
                 d.setArgs(getResources().getString(R.string.field_delete_warning));
                 d.setConfirm(confirm);
@@ -341,7 +341,7 @@ public class ModelFieldEditor extends AnkiActivity {
                         } else {
                             // Input is valid, now attempt to modify
                             try {
-                                mCol.modSchema();
+                                mCol.getModels()._modSchemaIfRequired(mMod);
                                 DeckTask.launchDeckTask(DeckTask.TASK_TYPE_REPOSITION_FIELD, mChangeFieldHandler,
                                         new DeckTask.TaskData(new Object[]{mMod,
                                                 mNoteFields.getJSONObject(mCurrentPos), pos - 1}));
@@ -422,7 +422,7 @@ public class ModelFieldEditor extends AnkiActivity {
      */
     private void sortByField() {
         try {
-            mCol.modSchema();
+            mCol.getModels()._modSchemaIfRequired(mMod);
             DeckTask.launchDeckTask(DeckTask.TASK_TYPE_CHANGE_SORT_FIELD, mChangeFieldHandler,
                     new DeckTask.TaskData(new Object[]{mMod, mCurrentPos}));
         } catch (ConfirmModSchemaException e) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.java
@@ -283,6 +283,7 @@ public class ModelFieldEditor extends AnkiActivity {
                         } else {
                             //Field is valid, now rename
                             try {
+                                mCol.getModels()._modSchemaIfRequired(mMod);
                                 renameField();
                             } catch (ConfirmModSchemaException e) {
 
@@ -291,11 +292,7 @@ public class ModelFieldEditor extends AnkiActivity {
                                 c.setArgs(getResources().getString(R.string.full_sync_confirmation));
                                 Runnable confirm = () -> {
                                     mCol.modSchemaNoCheck();
-                                    try {
-                                        renameField();
-                                    } catch (ConfirmModSchemaException e1) {
-                                        //This should never be thrown
-                                    }
+                                    renameField();
                                     dismissContextMenu();
                                 };
                                 c.setConfirm(confirm);
@@ -395,15 +392,17 @@ public class ModelFieldEditor extends AnkiActivity {
     }
 
 
-    /*
+    /**
      * Renames the current field
+     *
+     * assume no need to change schema for the current model.
      */
-    private void renameField() throws ConfirmModSchemaException {
+    private void renameField() {
         try {
             String fieldLabel = mFieldNameInput.getText().toString()
                     .replaceAll("[\'\"\\n\\r\\[\\]\\(\\)]", "");
             JSONObject field = (JSONObject) mNoteFields.get(mCurrentPos);
-            mCol.getModels().renameField(mMod, field, fieldLabel);
+            mCol.getModels().renameFieldNoSchemaChangeRequired(mMod, field, fieldLabel);
             mCol.getModels().save();
             fullRefreshList();
         } catch (JSONException e) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.java
@@ -224,7 +224,6 @@ public class ModelFieldEditor extends AnkiActivity {
      */
     private void deleteFieldDialog() {
         Runnable confirm = () -> {
-            mCol.modSchemaNoCheck();
             deleteField();
             dismissContextMenu();
         };

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
@@ -901,7 +901,7 @@ public class CardContentProvider extends ContentProvider {
                     // Add the fields
                     String[] allFields = Utils.splitFields(fieldNames);
                     for (String f: allFields) {
-                        mm.addFieldInNewModel(newModel, mm.newField(f));
+                        mm.addFieldNoSchemaChangeRequired(newModel, mm.newField(f));
                     }
                     // Add some empty card templates
                     for (int idx = 0; idx < numCards; idx++) {
@@ -912,7 +912,7 @@ public class CardContentProvider extends ContentProvider {
                             answerField = allFields[1];
                         }
                         t.put("afmt",String.format("{{FrontSide}}\\n\\n<hr id=answer>\\n\\n{{%s}}", answerField));
-                        mm.addTemplateInNewModel(newModel, t);
+                        mm.addTemplateNoSchemaChangeRequired(newModel, t);
                     }
                     // Add the CSS if specified
                     if (css != null) {

--- a/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
@@ -1426,7 +1426,7 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
     }
 
     /**
-     * Adds a field of with name in given model
+     * Adds a field with name in given model
      */
     private TaskData doInBackGroundAddField(TaskData... params){
         Timber.d("doInBackgroundRepositionField");

--- a/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
@@ -1279,7 +1279,7 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
         JSONObject model = (JSONObject) args[0];
         JSONObject template = (JSONObject) args[1];
         // add the new template
-        col.getModels().addTemplateModChanged(model, template);
+        col.getModels().addTemplateNoSchemaChangeRequired(model, template);
         col.save();
         return new TaskData(true);
     }
@@ -1436,7 +1436,7 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
         String fieldName = (String) objects[1];
 
         Collection col = CollectionHelper.getInstance().getCol(mContext);
-        col.getModels().addFieldModChanged(model, col.getModels().newField(fieldName));
+        col.getModels().addFieldNoSchemaChangeRequired(model, col.getModels().newField(fieldName));
         col.save();
         return new TaskData(true);
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -434,12 +434,8 @@ public class Collection {
      * This is a convenience method which doesn't throw ConfirmModSchemaException
      */
     public void modSchemaNoCheck() {
-        try {
-            modSchema(false);
-        } catch (ConfirmModSchemaException e) {
-            // This will never be reached as we disable confirmation via the "false" argument
-            throw new RuntimeException(e);
-        }
+        mScm = Utils.intTime(1000);
+        setMod();
     }
 
     /** Mark schema modified to force a full sync.
@@ -470,8 +466,7 @@ public class Collection {
                 throw new ConfirmModSchemaException();
             }
         }
-        mScm = Utils.intTime(1000);
-        setMod();
+        modSchemaNoCheck();
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -457,6 +457,12 @@ public class Collection {
      * @throws ConfirmModSchemaException
      */
     public void modSchema(boolean check) throws ConfirmModSchemaException {
+        // modSchema(false) is equivalent to modSchemaNoCheck.
+        // modSchema is never called with a variable in parameter in
+        // the code currently.  the only reason to use a parameter in
+        // modSchema is to follow Anki's code.  in this code, there is
+        // no static type indicating that exceptions are potentially
+        // thrown, so modSchemaNoCheck is useless.
         if (!schemaChanged()) {
             if (check) {
                 /* In Android we can't show a dialog which blocks the main UI thread

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -440,7 +440,7 @@ public class Collection {
 
     /** Mark schema modified to force a full sync.
      * ConfirmModSchemaException will be thrown if the user needs to be prompted to confirm the action.
-     * If the user chooses to confirm then modSchema(false) should be called, after which the exception can
+     * If the user chooses to confirm then modSchemaNoCheck should be called, after which the exception can
      * be safely ignored, and the outer code called again.
      *
      * @throws ConfirmModSchemaException */
@@ -450,7 +450,7 @@ public class Collection {
 
     /** Mark schema modified to force a full sync.
      * If check==true and the schema has not already been marked modified then ConfirmModSchemaException will be thrown.
-     * If the user chooses to confirm then modSchema(false) should be called, after which the exception can
+     * If the user chooses to confirm then modSchemaNoCheck should be called, after which the exception can
      * be safely ignored, and the outer code called again.
      *
      * @param check

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -466,9 +466,11 @@ public class Models {
     /** Copy, save and return. */
     public JSONObject copy(JSONObject m) {
         JSONObject m2 = null;
+        String clone = AnkiDroidApp.getAppResources().getString(R.string.model_browser_add_clone);
         try {
+            String name = String.format(clone, m2.getString("name"));
             m2 = new JSONObject(Utils.jsonToString(m));
-            m2.put("name", m2.getString("name") + " copy");
+            m2.put("name", name);
         } catch (JSONException e) {
             throw new RuntimeException(e);
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -584,19 +584,11 @@ public class Models {
         _addField(m, field);
     }
 
-    public void addFieldInNewModel(JSONObject m, JSONObject field) {
-        // similar to Anki's addField; but thanks to assumption that
-        // model is new, it never has to throw
-        // ConfirmModSchemaException.
-        Assert.that(isModelNew(m), "Model was assumed to be new, but is not");
-        _addField(m, field);
-    }
-
-    public void addFieldModChanged(JSONObject m, JSONObject field) {
+    public void addFieldNoSchemaChangeRequired(JSONObject m, JSONObject field) {
         // similar to Anki's addField; but thanks to assumption that
         // mod is already changed, it never has to throw
         // ConfirmModSchemaException.
-        Assert.that(mCol.schemaChanged(), "Mod was assumed to be already changed, but is not");
+        Assert.that(!isModSchemaRequired(m), "Can't add a field in a model without requiring full sync. But we believed it was not required to ask it.");
         _addField(m, field);
     }
 
@@ -835,17 +827,9 @@ public class Models {
         _addTemplate(m, template);
     }
 
-    public void addTemplateInNewModel(JSONObject m, JSONObject template)  {
+    public void addTemplateNoSchemaChangeRequired(JSONObject m, JSONObject template)  {
         // similar to addTemplate, but doesn't throw exception;
-        // asserting the model is new.
-        Assert.that(isModelNew(m), "Model was assumed to be new, but is not");
-        _addTemplate(m, template);
-    }
-
-    public void addTemplateModChanged(JSONObject m, JSONObject template)  {
-        // similar to addTemplate, but doesn't throw exception;
-        // asserting the model is new.
-        Assert.that(mCol.schemaChanged(), "Mod was assumed to be already changed, but is not");
+        Assert.that(!isModSchemaRequired(m), "Can't add a template in a model without requiring full sync. But we believed it was not required to ask it.");
         _addTemplate(m, template);
     }
 
@@ -1359,10 +1343,10 @@ public class Models {
         JSONObject m = mm.newModel(name);
         String frontName = AnkiDroidApp.getAppResources().getString(R.string.front_field_name);
         JSONObject fm = mm.newField(frontName);
-        mm.addFieldInNewModel(m, fm);
+        mm.addFieldNoSchemaChangeRequired(m, fm);
         String backName = AnkiDroidApp.getAppResources().getString(R.string.back_field_name);
         fm = mm.newField(backName);
-        mm.addFieldInNewModel(m, fm);
+        mm.addFieldNoSchemaChangeRequired(m, fm);
         String cardOneName = AnkiDroidApp.getAppResources().getString(R.string.card_one_name);
         JSONObject t = mm.newTemplate(cardOneName);
         try {
@@ -1371,7 +1355,7 @@ public class Models {
         } catch (JSONException e) {
             throw new RuntimeException(e);
         }
-        mm.addTemplateInNewModel(m, t);
+        mm.addTemplateNoSchemaChangeRequired(m, t);
         return m;
     }
 
@@ -1403,7 +1387,7 @@ public class Models {
             JSONObject t = mm.newTemplate(cardTwoName);
             t.put("qfmt", "{{" + backName + "}}");
             t.put("afmt", "{{FrontSide}}\n\n<hr id=answer>\n\n{{"+frontName+"}}");
-            mm.addTemplateInNewModel(m, t);
+            mm.addTemplateNoSchemaChangeRequired(m, t);
         } catch (JSONException e) {
             throw new RuntimeException(e);
         }
@@ -1435,7 +1419,7 @@ public class Models {
         try {
             String av = AnkiDroidApp.getAppResources().getString(R.string.field_to_ask_front_name);
             JSONObject fm = mm.newField(av);
-            mm.addFieldInNewModel(m, fm);
+            mm.addFieldNoSchemaChangeRequired(m, fm);
             JSONObject t = m.getJSONArray("tmpls").getJSONObject(1);
             t.put("qfmt", "{{#" + av +"}}" + t.get("qfmt") + "{{/" + av +"}}");
         } catch (JSONException e) {
@@ -1468,17 +1452,17 @@ public class Models {
             m.put("type", Consts.MODEL_CLOZE);
             String txt = AnkiDroidApp.getAppResources().getString(R.string.text_field_name);
             JSONObject fm = mm.newField(txt);
-            mm.addFieldInNewModel(m, fm);
+            mm.addFieldNoSchemaChangeRequired(m, fm);
             String fieldExtraName = AnkiDroidApp.getAppResources().getString(R.string.extra_field_name);
             fm = mm.newField(fieldExtraName);
-            mm.addFieldInNewModel(m, fm);
+            mm.addFieldNoSchemaChangeRequired(m, fm);
             String cardTypeClozeName = AnkiDroidApp.getAppResources().getString(R.string.card_cloze_name);
             JSONObject t = mm.newTemplate(cardTypeClozeName);
             String fmt = "{{cloze:" + txt + "}}";
             m.put("css", m.getString("css") + ".cloze {" + "font-weight: bold;" + "color: blue;" + "}");
             t.put("qfmt", fmt);
             t.put("afmt", fmt + "<br>\n{{" + fieldExtraName + "}}");
-            mm.addTemplateInNewModel(m, t);
+            mm.addTemplateNoSchemaChangeRequired(m, t);
         } catch (JSONException e) {
             throw new RuntimeException(e);
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -1085,6 +1085,17 @@ public class Models {
         mCol.remCards(Utils.toPrimitive(deleted));
     }
 
+    /**
+        Mod the schema only if it's required
+     */
+    public void _modSchemaIfRequired(JSONObject m) throws ConfirmModSchemaException {
+        // ideally it would be private. But ModelFieldEditor needs to access it
+        // because it wants to mod the schema before it add fields in it.
+        if (isModSchemaRequired(m)) {
+                mCol.modSchema();
+        }
+    }
+
     /** checks whether a mod of schema is required when m is edited.*/
     private boolean isModSchemaRequired(JSONObject m) {
         try {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -1340,8 +1340,9 @@ public class Models {
     }
 
     public static JSONObject addBasicModel(Collection col) {
-        String name = AnkiDroidApp.getAppResources().getString(R.string.basic_model_name);
-        return addBasicModel(col, name);
+        JSONObject m = _newBasicModel(col);
+        col.getModels().add(m);
+        return m;
     }
 
     public static JSONObject addBasicModel(Collection col, String name) {
@@ -1379,10 +1380,20 @@ public class Models {
         return m;
     }
 
+    public static JSONObject addForwardReverse(Collection col, String name) {
+        JSONObject m = _newForwardReverse(col, name);
+        col.getModels().add(m);
+        return m;
+    }
+
     /* Forward & Optional Reverse */
 
     private static JSONObject _newForwardOptionalReverse(Collection col) {
         String name = AnkiDroidApp.getAppResources().getString(R.string.forward_optional_reverse_model_name);
+        return _newForwardOptionalReverse(col, name);
+    }
+
+    private static JSONObject _newForwardOptionalReverse(Collection col, String name) {
         Models mm = col.getModels();
         JSONObject m = _newForwardReverse(col, name);
         try {
@@ -1403,9 +1414,19 @@ public class Models {
         return m;
     }
 
-    public static JSONObject addClozeModel(Collection col) {
-        Models mm = col.getModels();
+    public static JSONObject addForwardOptionalReverse(Collection col, String name) {
+        JSONObject m = _newForwardOptionalReverse(col, name);
+        col.getModels().add(m);
+        return m;
+    }
+
+    private static JSONObject _newClozeModel(Collection col) {
         String name = AnkiDroidApp.getAppResources().getString(R.string.cloze_model_name);
+        return _newClozeModel(col, name);
+    }
+
+    private static JSONObject _newClozeModel(Collection col, String name) {
+        Models mm = col.getModels();
         JSONObject m = mm.newModel(name);
         try {
             m.put("type", Consts.MODEL_CLOZE);
@@ -1422,10 +1443,21 @@ public class Models {
             t.put("qfmt", fmt);
             t.put("afmt", fmt + "<br>\n{{" + fieldExtraName + "}}");
             mm.addTemplateInNewModel(m, t);
-            mm.add(m);
         } catch (JSONException e) {
             throw new RuntimeException(e);
         }
+        return m;
+    }
+
+    public static JSONObject addClozeModel(Collection col) {
+        JSONObject m = _newClozeModel(col);
+        col.getModels().add(m);
+        return m;
+    }
+
+    public static JSONObject addClozeModel(Collection col, String name) {
+        JSONObject m = _newClozeModel(col, name);
+        col.getModels().add(m);
         return m;
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -465,10 +465,18 @@ public class Models {
 
     /** Copy, save and return. */
     public JSONObject copy(JSONObject m) {
-        JSONObject m2 = null;
-        String clone = AnkiDroidApp.getAppResources().getString(R.string.model_browser_add_clone);
         try {
-            String name = String.format(clone, m2.getString("name"));
+            String clone = AnkiDroidApp.getAppResources().getString(R.string.model_browser_add_clone);
+            String name = String.format(clone, m.getString("name"));
+            return copy(m, name);
+        } catch (JSONException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public JSONObject copy(JSONObject m, String name) {
+        JSONObject m2 = null;
+        try {
             m2 = new JSONObject(Utils.jsonToString(m));
             m2.put("name", name);
         } catch (JSONException e) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -331,6 +331,7 @@ public class Models {
             m.put("tmpls", new JSONArray());
             m.put("tags", new JSONArray());
             m.put("id", 0);
+            m.put("usn", mCol.usn());
         } catch (JSONException e) {
             throw new RuntimeException(e);
         }
@@ -479,6 +480,7 @@ public class Models {
         try {
             m2 = new JSONObject(Utils.jsonToString(m));
             m2.put("name", name);
+            m2.put("usn", mCol.usn());
         } catch (JSONException e) {
             throw new RuntimeException(e);
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -350,7 +350,7 @@ public class Models {
     /** Delete model, and all its cards/notes. 
      * @throws ConfirmModSchemaException */
     public void rem(JSONObject m) throws ConfirmModSchemaException {
-        mCol.modSchema(true);
+        _modSchemaIfRequired(m);
         try {
             long id = m.getLong("id");
             boolean current = current().getLong("id") == id;
@@ -550,7 +550,7 @@ public class Models {
 
     public void setSortIdx(JSONObject m, int idx) throws ConfirmModSchemaException{
         try {
-            mCol.modSchema(true);
+            _modSchemaIfRequired(m);
             m.put("sortf", idx);
             mCol.updateFieldCache(Utils.toPrimitive(nids(m)));
             save(m);
@@ -576,11 +576,7 @@ public class Models {
     }
 
     public void addField(JSONObject m, JSONObject field) throws ConfirmModSchemaException {
-        // only mod schema if model isn't new
-        // this is Anki's addField.
-        if (!isModelNew(m)) {
-            mCol.modSchema(true);
-        }
+        _modSchemaIfRequired(m);
         _addField(m, field);
     }
 
@@ -604,7 +600,7 @@ public class Models {
 
 
     public void remField(JSONObject m, JSONObject field) throws ConfirmModSchemaException {
-        mCol.modSchema(true);
+        _modSchemaIfRequired(m);
         try {
             JSONArray ja = m.getJSONArray("flds");
             JSONArray ja2 = new JSONArray();
@@ -653,7 +649,7 @@ public class Models {
 
 
     public void moveField(JSONObject m, JSONObject field, int idx) throws ConfirmModSchemaException {
-        mCol.modSchema(true);
+        _modSchemaIfRequired(m);
         try {
             JSONArray ja = m.getJSONArray("flds");
             ArrayList<JSONObject> l = new ArrayList<>();
@@ -713,7 +709,7 @@ public class Models {
 
 
     public void renameField(JSONObject m, JSONObject field, String newName) throws ConfirmModSchemaException {
-        mCol.modSchema(true);
+        _modSchemaIfRequired();
         try {
             String pat = String.format("\\{\\{([^{}]*)([:#^/]|[^:#/^}][^:}]*?:|)%s\\}\\}",
                     Pattern.quote(field.getString("name")));
@@ -821,9 +817,7 @@ public class Models {
     /** @throws ConfirmModSchemaException */
     public void addTemplate(JSONObject m, JSONObject template) throws ConfirmModSchemaException {
         //That is Anki's addTemplate method
-        if (!isModelNew(m)) {
-            mCol.modSchema(true);
-        }
+        _modSchemaIfRequired(m);
         _addTemplate(m, template);
     }
 
@@ -861,7 +855,7 @@ public class Models {
                 return false;
             }
             // ok to proceed; remove cards
-            mCol.modSchema(true);
+            _modSchemaIfRequired(m);
             mCol.remCards(cids);
             // shift ordinals
             mCol.getDb()
@@ -961,7 +955,7 @@ public class Models {
      * @throws ConfirmModSchemaException 
      */
     public void change(JSONObject m, long[] nids, JSONObject newModel, Map<Integer, Integer> fmap, Map<Integer, Integer> cmap) throws ConfirmModSchemaException {
-        mCol.modSchema(true);
+        _modSchemaIfRequired(m);
         try {
             assert (newModel.getLong("id") == m.getLong("id")) || (fmap != null && cmap != null);
         } catch (JSONException e) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -350,7 +350,7 @@ public class Models {
     /** Delete model, and all its cards/notes. 
      * @throws ConfirmModSchemaException */
     public void rem(JSONObject m) throws ConfirmModSchemaException {
-        _modSchemaIfRequired(m);
+                _modSchemaIfRequired(m);
         try {
             long id = m.getLong("id");
             boolean current = current().getLong("id") == id;
@@ -623,7 +623,7 @@ public class Models {
                 // need to rebuild
                 mCol.updateFieldCache(Utils.toPrimitive(nids(m)));
             }
-            renameField(m, field, null);
+            renameFieldNoSchemaChangeRequired(m, field, null);
         } catch (JSONException e) {
             throw new RuntimeException(e);
         }
@@ -709,7 +709,21 @@ public class Models {
 
 
     public void renameField(JSONObject m, JSONObject field, String newName) throws ConfirmModSchemaException {
-        _modSchemaIfRequired();
+		// this method is not called anywhere. Still here only to remain consistent with Anki's code
+        _modSchemaIfRequired(m);
+        _renameField(m, field, newName);
+    }
+
+    /**
+        similar to _renameField, but does not throw an exception, by
+        asserting that it is useless.
+     */
+    public void renameFieldNoSchemaChangeRequired(JSONObject m, JSONObject field, String newName) {
+        assert(!isModSchemaRequired(m));
+        _renameField(m, field, newName);
+    }
+
+    private void _renameField(JSONObject m, JSONObject field, String newName) {
         try {
             String pat = String.format("\\{\\{([^{}]*)([:#^/]|[^:#/^}][^:}]*?:|)%s\\}\\}",
                     Pattern.quote(field.getString("name")));

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -1085,6 +1085,19 @@ public class Models {
         mCol.remCards(Utils.toPrimitive(deleted));
     }
 
+    /** checks whether a mod of schema is required when m is edited.*/
+    private boolean isModSchemaRequired(JSONObject m) {
+        try {
+            // usn is -1 either if th model is new or if the schema was already mared as modified.
+            // in the first case, no need to mark schema as modified
+            // in the second, modified schema was already accepted.
+            // in both case, no mark a modification anymore.
+            return !isModelNew(m) && m.getInt("usn") != -1 && !mCol.schemaChanged();
+        } catch (JSONException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     /**
      * Schema hash ***********************************************************************************************
      */

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/ClozeTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/ClozeTest.java
@@ -6,6 +6,7 @@ import com.ichi2.anki.RobolectricTest;
 import com.ichi2.libanki.template.Template;
 
 import org.json.JSONException;
+import org.json.JSONObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -17,6 +18,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
 @RunWith(AndroidJUnit4.class)
@@ -27,7 +29,9 @@ public class ClozeTest extends RobolectricTest {
         final Context context = ApplicationProvider.getApplicationContext();
 
         Collection d = getCol();
-        Note f = d.newNote(d.getModels().byName("Cloze"));
+		JSONObject m = d.getModels().byName("Cloze");
+		assertNotNull(m);
+        Note f = d.newNote(m);
 
         try {
             String name = f.model().getString("name");


### PR DESCRIPTION
## Purpose / Description

Keeping up to date with anki

dae/anki@0ffb3080043a9547fd041ca54c8f67a03c96e592,
dae/anki@9863b6f9ff2d75763bcc055395a35a8cb1f43a19 and
dae/anki@b78480fe5282fd54ed56b98252e197cfc2aaff10

Initially this commit solves a problem that I had many time in the past. When I
create a new model, I usually want to edit it. Clone of existing
models present no interest by themselves. And as soon as I edit it, I
need to do a full sync.

As far as I understand ankiweb (which is sadly closed source), the
full sync is required because ankiweb needs to know that the model
associated to note type on the server did change. But since the model
is new, it has no note type associated to on the server, so there is
no need to do a full sync immediatly. Since the model is new, it also
means there is no risk of the inconsistency with a change made in
another computer/smartphone.

However, because of the way ConfirmModSchemaException is handled directly in GUI, this needs to change a lot of things. So let me details you everything I did in the next section.

## Approach
In Models.java I dealt as I did in Anki in the commits linked above.

I created a method `isModSchemaRequired` which states whether, when a model is edited, this edition need to modify the schema. This would be the case if the model is not new, the schema is not modified, and the model is already synchronized in ankiweb.
I then created a method `modSchemaIfRequired` which throws `ConfirmModSchemaException` if the schema needs to be changed.
I then ensures that, instead of directly throwing the exception, each method of Models calls `modSchemaIfRequired`

Not that `isModschemaRequired` requires to access the USN to check whether it's modified or not. So creating and cloning a model should set the USN directly. I realized that cloning a model did not actually used the method `Models#Copy`; so I corrected that. I also ensured that the word "copy" is actually found using resources and not a direct string.
Since I was already working with all of this, I also ensured that one can directly give a name to the method copy, and to all methods creating standard models. 

I then add to deal with all actions which can be applied to note type. I add to ensure that schema was modified only if necessary  (i.e. changing `modSchema` to `modSchemaIfRequired`). I then add to ensure that each time the methods changing the model were applied, the schema was already changed if necessary. This was the case everywhere, except for renaming field, for some reason. So I did split `renameField` in distinct methods. One private doing the actual work, one public which may throws `ConfirmModSchemaException` if required. And one public, not throwing it, which assert that throwing the exception is useless. I then used this last one in the GUI, and before the call, I used a method to ensure that the schema is modified if necessary.

In other cases, I add to remove a call to a method which modified schema without checking. In the past, this method was useless, because it's call could be reached only if the schema was already modified. No it's actually harming, because it can be called when the note type is new, and thus when actually we may want not to have the schema modified.

Checking whether changing a model requires a full sync requires to have access to the model. So I added it as an instance variable in ModelBrowser.

Since I was dealing a lot with schema check, I also did refactorize modSchema and modSchemaNoCheck to avoid some useless try/catch. I also commented a method which is never called, but which is required to stay close to Anki's code.


### Multiple commits
As you can see, porting Anki's commit did actually show that a lot of thing had to change. Or at least that it would makes more sens if they did change.
That's why I did a 19 commits, so that each commit can deal with one particular change. I tried as much as possible to ensure that the code of each commit remains consistent; that you can run it and have a correct version of ankidroid.
Of course, some commit will be useless, because they only add a method without using it. And some would be quite pointless, because they do replace some code by some code having the same effect, but through distinct method call. It's only the last commits which ensure that this PR have sens by finally porting the new anki feature

## How Has This Been Tested?

Sync. Add a card of this note type. Create a new note type, add field and card type into it. Remove them, reorder fields. check that you can sync without doing a full sync. (It seems I can't reorder card type)
try to add more fields, see you can't without having to accept a full sync. 


## Learning (optional, can help others)
That if I have a PR accepted by DAE, then I'll have to do the same code edit twice, in python and then in Java. And that actually, the second time is not necessarily easier, since android code seems to be far more complex.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
