### PR TITLE
Allow .zip after colpkg/apkg

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
@@ -141,11 +141,11 @@ public class ImportUtils {
     }
 
     public static boolean isCollectionPackage(String filename) {
-        return filename != null && (filename.toLowerCase().endsWith(".colpkg") || filename.equals("collection.apkg"));
+        return filename != null && (filename.toLowerCase().endsWith(".colpkg") || filename.toLowerCase().endsWith(".colpkg.zip") || (filename.equals("collection.apkg") || filename.equals("collection.apkg.zip")));
     }
 
     private static boolean isDeckPackage(String filename) {
-        return filename != null && filename.toLowerCase().endsWith(".apkg") && !filename.equals("collection.apkg");
+        return filename != null && (filename.toLowerCase().endsWith(".apkg") || filename.toLowerCase().endsWith(".apkg.zip")) && !(filename.equals("collection.apkg") || filename.equals("collection.apkg.zip"));
     }
 
     public static boolean isValidPackageName(String filename) {


### PR DESCRIPTION
## Purpose / Description

When downloading an apkg, some browser adds a .zip to the name of the
file (because it's detected as a zip). This leads to .apkg.zip and
.colpkg.zip files.

This commit ensure that in those cases, the file can be imported
without being renamed. This is extremly useful to test other commits,
especially the ones related to the import package.

Since it only accepts .zip if they are preceded by apkg or colpkg, the
risk is relatively small. Even if there is always the risk that
someone tries to zip a file foo.apkg, which becomes foo.apkg, and
should not be read by ankidroid.


## Fixes
I didn't find any similar issue in github. I'm honestly surprised

## Approach
By allowing .zip only when it follows one of the two expected extension.

## How Has This Been Tested?

I opened this version in a VM. I did download milchior.fr/tmp/im.apkg (or any other deck), I then clicked on it to open it Anki's list of event. Ankidroid did open it correctly.
Without this PR, anki states that it can't open it, because it's not the correct extension.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
