### PR TITLE
Correcting #5518

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1129,6 +1129,10 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
 
 
     protected boolean editCard() {
+        if (mCurrentCard == null) {
+            // This should never occurs. It means the review button was pressed while there is no more card in the reviewer.
+            return true;
+        }
         Intent editCard = new Intent(AbstractFlashcardViewer.this, NoteEditor.class);
         editCard.putExtra(NoteEditor.EXTRA_CALLER, NoteEditor.CALLER_REVIEWER);
         sEditorCard = mCurrentCard;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1030,7 +1030,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
                 // content of note was changed so update the note and current card
                 Timber.i("AbstractFlashcardViewer:: Saving card...");
                 DeckTask.launchDeckTask(DeckTask.TASK_TYPE_UPDATE_FACT, mUpdateCardHandler,
-                        new DeckTask.TaskData(mCurrentCard, true));
+                        new DeckTask.TaskData(sEditorCard, true));
             } else if (resultCode == RESULT_CANCELED && !(data!=null && data.hasExtra("reloadRequired"))) {
                 // nothing was changed by the note editor so just redraw the card
                 fillFlashcard();


### PR DESCRIPTION
## Purpose / Description
_Describe the problem or feature and motivation_

## Fixes
Fixes #5518 

## Approach
Ensuring that the card sent to be updated is the card which has been edited. This is theoretically always the case, unless the user review a card so quickly after the end of edition that onActivityResult is called after nextCardHandler and not before it.

## How Has This Been Tested?

Putting this code in a VM. Opening the reviewer, opening the editor, editing a card, seeing that the change are saved into the collection.

I didn't test that the original problem does not occur again because it seems hard to reproduce it in the first place voluntarily. 

## Research
-------------
doInBackgroundUpdateNote is called in a single place, doInBacground,
when the type is TASK_TYPE_UPDATE_FACT. This type is actually used in
two places, both cases in `onActivityResult`. I'll first explain why
CardBrowser can't be the problem.

Card Browser
------------
The task data is created with sCardBrowserCard. It's sent only if the
activity is EDIT_CARD. This activity is sent only once in the code,
just after setting sCardBrowserCard to
getCol().getCard(mCurrentCardId); which is a value which can't be
null.

sCardBrowserCard is not edited anywhere else in the code.
So we have both a garantee that this variable as been set once and
that it's not set to null anywhere else.

AbstractFlashcardReviewer
-------------------------

The task data used to be created with variable `mCurrentCard`. It's
sent only if the activity is EDIT_CURRENT_CARD. This activity is sent
only once, after `sEditorCard` is set to `mCurrentCard`.

It should be noted that `mCurrentCard` is set in multiple places. In
particular in nextCardHandler, where it may becomes null. This would
be the case if for some reason, Ankidroid asks for the next card
before the activity has time to tells the viewer that it did
ends. While it seems hard to reproduce voluntarily, I do imagine it
may occurs on a really slow smartphone.

Note that if I'm right, if `mCurrentCard` is set to another card, it
means that the activity `TASK_TYPE_UPDATE_FACT` will be applied to the
wrong card (which is not really a problem. It means that the correct
updating will simply be delayed until next time there is a db check or
an "empty card" check)

Since `sEditorCard` is not set anywhere else, appart before calling
the activity, there is no more risk in using `sEditorCard` than in
using `mCurrentCard`. In normal usage, they should both have the same
value. In case of trouble because the activity is slow to call
onActivityResult, then this is the variable having the card we care
about.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
