### PR TITLE
Correct due of new card whose all siblings are not new

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -769,11 +769,16 @@ public class Collection {
                 JSONObject model = mModels.get(mid);
                 ArrayList<Integer> avail = mModels.availOrds(model, flds);
                 long did = dids.get(nid);
-                long due = dues.get(nid);
+                // use sibling due if there is one, else use a new id
+                long due;
+                if (dues.containsKey(nid)) {
+                    due = dues.get(nid);
+                } else {
+                    due = nextID("pos");
+                }
                 if (did == 0) {
                     did = model.getLong("did");
                 }
-                due = dues.get(nid);
                 // add any missing cards
                 for (JSONObject t : _tmplsFromOrds(model, avail)) {
                     int tord = t.getInt("ord");
@@ -794,10 +799,6 @@ public class Collection {
                         }
                         // if the deck doesn't exist, use default instead
                         did = mDecks.get(did).getLong("id");
-                        // use sibling due if there is one, else use a new id
-                        if (due == 0) {
-                            due = nextID("pos");
-                        }
                         // give it a new id instead
                         data.add(new Object[] { ts, nid, did, tord, now, usn, due});
                         ts += 1;


### PR DESCRIPTION
## Purpose / Description
Using the alpha version of Anki, I received a null pointer exception and corrected it. 


Here is a silly problem with porting Python code to Java. Sometimes,
it does not work the same way at all. When I committed
504d96a99d31f35cfb48d94af1e7b282603b9bb6 I didn't pay attention to was
the value of dues.get(nid) when nid is not in dues. And actually, the
value is None. Which means that it can't be converted to a long. And
thus raised an exception.

I also realized that the line `due = dues.get(nid);` was present twice
in the code, which makes no sens in the first place. So this second
occurrence is now removed.

## Approach
Checking whether the value is in the mapping before accessing it.

## How Has This Been Tested?

Trying to edit a note without new cards. Seeing it now works


_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
