### PR TITLE
Correcting #5515 hopefully

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
@@ -1069,7 +1069,7 @@ public class Finder {
                 // cancel if the launching task was cancelled. 
                 if (task.isCancelled()){
                     Timber.i("_findCardsForCardBrowser() cancelled...");
-                    return null;
+                    return new ArrayList<>();
                 }                
                 Map<String, String> map = new HashMap<>();
                 map.put("id", cur.getString(0));


### PR DESCRIPTION
The error was sent in this line:
https://github.com/ankidroid/Anki-Android/blob/7235a5bc667a6c9def934d85764cedc6594814b3/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java#L857
where searchResult is null.
It's value is the result of col.findCardsForCardBrowser
this method simply returns the  value returned by the Finder#findCardsForCardBrowser

The value returned by the finder itself findCardsForCardBrowser sends
null if the task was cancelled. However, the value returned is still
used by findCardsForCardBrowser. So I ensure that it's not null, but
an empty list.

## Purpose / Description
_Describe the problem or feature and motivation_

## Fixes
 #5515

## Approach
Returning empty list is as quick as returning null, and does not lead to null pointer exception.

## How Has This Been Tested?

Searching cards and verifying that it still works.
I didn't try to reproduce the bug, and cancel during a search; seems hard to reproduce actually. So I can't test whether the bug can't be reproduced.

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
