### PR TITLE
Fix for: Latest update plays audio file twice #5530

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -2812,7 +2812,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
             Matcher audioReferences = Sound.sSoundPattern.matcher(frontSideFormat);
             // remove the first instance of audio contained in "{{FrontSide}}"
             while (audioReferences.find()) {
-                newAnswerContent = answerContent.replaceFirst(Pattern.quote(audioReferences.group()), "");
+                newAnswerContent = newAnswerContent.replaceFirst(Pattern.quote(audioReferences.group()), "");
             }
         }
         return newAnswerContent;


### PR DESCRIPTION
## Purpose / Description
After updating to the latest version my question plays twice on the question side and once on the answer side.

## Fixes
Fixes #5530, #5730 

## Approach
In the function removeFrontSideAudio only the first occurrence of sound was stripped.
The similar bug occurred and was fixed in 2014 https://github.com/ankidroid/Anki-Android/pull/669 

## How Has This Been Tested?
I've built APK with this fix - after pressing "show answer" button question was not repeated again.

## Checklist
- [*] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [*] You have a descriptive commit message with a short title (first line, max 50 chars).
- [*] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [*] You have performed a self-review of your own code
