### PR TITLE
Correct conf' when it's set.

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -468,6 +468,10 @@ public class CardBrowser extends NavigationDrawerActivity implements
             if (mOrder == 1 && preferences.getBoolean("cardBrowserNoSorting", false)) {
                 mOrder = 0;
             }
+            //This upgrade should already have been done during
+            //setConf. However older version of AnkiDroid didn't call
+            //upgradeJSONIfNecessary during setConf, which means the
+            //conf saved may still have this bug.
             mOrderAsc = Upgrade.upgradeJSONIfNecessary(getCol(), getCol().getConf(), "sortBackwards", false);
             // default to descending for non-text fields
             if (fSortTypes[mOrder].equals("noteFld")) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -34,6 +34,7 @@ import com.ichi2.async.DeckTask;
 import com.ichi2.compat.CompatHelper;
 import com.ichi2.libanki.hooks.Hooks;
 import com.ichi2.libanki.template.Template;
+import com.ichi2.upgrade.Upgrade;
 import com.ichi2.utils.VersionUtils;
 
 import org.json.JSONArray;
@@ -1908,6 +1909,14 @@ public class Collection {
 
 
     public void setConf(JSONObject conf) {
+        // Anki sometimes set sortBackward to 0/1 instead of
+        // False/True. This should be repaired before setting mConf;
+        // otherwise this may save a faulty value in mConf, and if
+        // it's done just before the value is read, this may lead to
+        // bug #5523. This bug should occur only for people using anki
+        // prior to version 2.16 and has been corrected with
+        // dae/anki#347
+        Upgrade.upgradeJSONIfNecessary(this, conf, "sortBackwards", false);
         mConf = conf;
     }
 


### PR DESCRIPTION
Currently, the conf is corrected only when accessed. Which I believe
may be the cause of bug #5523. Indeed, data is corrected, and then
accessed, while it is theoretically possible that data is changed back
to a faulty value during an asynchrone process after correction and
before access.

With this change, data is changed BEFORE conf' is saved; which means
that the value is never faulty.

This correction should become useless for people using Anki 2.16 or
latter, thanks to dae/anki#347.

I should note that currently, the method we use sends both 0 and 1 to False, instead of only 0. I do believe that setting the browser in the wrong order is not a problem that needs to be repaired, especially since the problem should soon disappear for everyone using anki 2.1.16

## Fixes
Fixes #5523

## How Has This Been Tested?

I only tested that sync still did works. Bug is hard to reproduce

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
