### PR TITLE
Adds constant string before equal

### DIFF
--- a/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/libanki/ImportTest.java
+++ b/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/libanki/ImportTest.java
@@ -281,9 +281,9 @@ public class ImportTest {
 //        i.initMapping();
 //        i.run();
 //        n.load();
-//        assertTrue(n.getItem("Front").equals("1"));
-//        assertTrue(n.getItem("Back").equals("x"));
-//        assertTrue(n.getItem("Three").equals("3"));
+//        assertTrue("1".equals(n.getItem("Front")));
+//        assertTrue("x".equals(n.getItem("Back")));
+//        assertTrue("3".equals(n.getItem("Three")));
 //    }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1714,7 +1714,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
         mPrefShowETA = preferences.getBoolean("showETA", true);
         mUseInputTag = preferences.getBoolean("useInputTag", false);
         // On newer Androids, ignore this setting, which should be hidden in the prefs anyway.
-        mDisableClipboard = preferences.getString("dictionary", "0").equals("0");
+        mDisableClipboard = "0".equals(preferences.getString("dictionary", "0"));
         // mDeckFilename = preferences.getString("deckFilename", "");
         mNightMode = preferences.getBoolean("invertedColors", false);
         mPrefFullscreenReview = Integer.parseInt(preferences.getString("fullscreenMode", "0"));
@@ -1997,7 +1997,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
      * @return The correct answer text, with actual HTML and media references removed, and HTML entities unescaped.
      */
     protected String cleanCorrectAnswer(String answer) {
-        if (answer == null || answer.equals("")) {
+        if (answer == null || "".equals(answer)) {
             return "";
         }
         Matcher matcher = sSpanPattern.matcher(Utils.stripHTMLMedia(answer.trim()));
@@ -2017,7 +2017,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
      * @return The typed answer text, cleaned up.
      */
     protected String cleanTypedAnswer(String answer) {
-        if (answer == null || answer.equals("")) {
+        if (answer == null || "".equals(answer)) {
             return "";
         }
         return Utils.nfcNormalized(answer.trim());

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -440,7 +440,7 @@ public class AnkiDroidApp extends Application {
      */
     private static boolean isCurrentLanguage(String l) {
         String pref = getSharedPrefs(sInstance).getString(Preferences.LANGUAGE, "");
-        return pref.equals(l) || pref.equals("") && Locale.getDefault().getLanguage().equals(l);
+        return pref.equals(l) || "".equals(pref) && Locale.getDefault().getLanguage().equals(l);
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiFont.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiFont.java
@@ -96,7 +96,7 @@ public class AnkiFont {
         // determine if override font or default font
         SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(ctx);
         String defaultFont = preferences.getString("defaultFont", "");
-        boolean overrideFont = preferences.getString("overrideFontBehavior", "0").equals("1");
+        boolean overrideFont = "1".equals(preferences.getString("overrideFontBehavior", "0"));
         if (defaultFont.equalsIgnoreCase(name)) {
             if (overrideFont) {
                 createdFont.setAsOverride();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -201,7 +201,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
                                 .commit();
                     }
                     // default to descending for non-text fields
-                    if (fSortTypes[mOrder].equals("noteFld")) {
+                    if ("noteFld".equals(fSortTypes[mOrder])) {
                         mOrderAsc = true;
                     }
                     getCol().getConf().put("sortBackwards", mOrderAsc);
@@ -470,7 +470,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
             //conf saved may still have this bug.
             mOrderAsc = Upgrade.upgradeJSONIfNecessary(getCol(), getCol().getConf(), "sortBackwards", false);
             // default to descending for non-text fields
-            if (fSortTypes[mOrder].equals("noteFld")) {
+            if ("noteFld".equals(fSortTypes[mOrder])) {
                 mOrderAsc = !mOrderAsc;
             }
         } catch (JSONException e) {
@@ -1338,12 +1338,12 @@ public class CardBrowser extends NavigationDrawerActivity implements
         // render question and answer
         Map<String, String> qa = c._getQA(true, true);
         // Render full question / answer if the bafmt (i.e. "browser appearance") setting forced blank result
-        if (qa.get("q").equals("") || qa.get("a").equals("")) {
+        if ("".equals(qa.get("q")) || "".equals(qa.get("a"))) {
             HashMap<String, String> qaFull = c._getQA(true, false);
-            if (qa.get("q").equals("")) {
+            if ("".equals(qa.get("q"))) {
                 qa.put("q", qaFull.get("q"));
             }
-            if (qa.get("a").equals("")) {
+            if ("".equals(qa.get("a"))) {
                 qa.put("a", qaFull.get("a"));
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
@@ -98,7 +98,7 @@ public class CardTemplateEditor extends AnkiActivity {
                 } catch (JSONException e) {
                     throw new RuntimeException(e);
                 }
-            } else if (result.getString() != null && result.getString().equals("removeTemplateFailed")) {
+            } else if (result.getString() != null && "removeTemplateFailed".equals(result.getString())) {
                 // Failed to remove template
                 String message = getResources().getString(R.string.card_template_editor_would_delete_note);
                 UIUtils.showThemedToast(CardTemplateEditor.this, message, false);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -897,7 +897,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
             // No space left
             showDialogFragment(DeckPickerBackupNoSpaceLeftDialog.newInstance());
             preferences.edit().remove("noSpaceLeft").apply();
-        } else if (preferences.getString("lastVersion", "").equals("")) {
+        } else if ("".equals(preferences.getString("lastVersion", ""))) {
             // Fresh install
             preferences.edit().putString("lastVersion", VersionUtils.getPkgVersionName()).apply();
             onFinishedStartup();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FilteredDeckOptions.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FilteredDeckOptions.java
@@ -129,21 +129,21 @@ public class FilteredDeckOptions extends AppCompatPreferenceActivity implements 
                 try {
                     for (Entry<String, Object> entry : mUpdate.valueSet()) {
                         Timber.i("Change value for key '" + entry.getKey() + "': " + entry.getValue());
-                        if (entry.getKey().equals("search")) {
+                        if ("search".equals(entry.getKey())) {
                             JSONArray ar = mDeck.getJSONArray("terms");
                             ar.getJSONArray(0).put(0, entry.getValue());
                             mDeck.put("terms", ar);
-                        } else if (entry.getKey().equals("limit")) {
+                        } else if ("limit".equals(entry.getKey())) {
                             JSONArray ar = mDeck.getJSONArray("terms");
                             ar.getJSONArray(0).put(1, entry.getValue());
                             mDeck.put("terms", ar);
-                        } else if (entry.getKey().equals("order")) {
+                        } else if ("order".equals(entry.getKey())) {
                             JSONArray ar = mDeck.getJSONArray("terms");
                             ar.getJSONArray(0).put(2, Integer.parseInt((String) entry.getValue()));
                             mDeck.put("terms", ar);
-                        } else if (entry.getKey().equals("resched")) {
+                        } else if ("resched".equals(entry.getKey())) {
                             mDeck.put("resched", entry.getValue());
-                        } else if (entry.getKey().equals("stepsOn")) {
+                        } else if ("stepsOn".equals(entry.getKey())) {
                             boolean on = (Boolean) entry.getValue();
                             if (on) {
                                 JSONArray steps =  StepsPreference.convertToJSON(mValues.get("steps"));
@@ -153,19 +153,19 @@ public class FilteredDeckOptions extends AppCompatPreferenceActivity implements 
                             } else {
                                 mDeck.put("delays", JSONObject.NULL);
                             }
-                        } else if (entry.getKey().equals("steps")) {
+                        } else if ("steps".equals(entry.getKey())) {
                             mDeck.put("delays", StepsPreference.convertToJSON((String) entry.getValue()));
-                        } else if (entry.getKey().equals("preset")) {
+                        } else if ("preset".equals(entry.getKey())) {
                             int i = Integer.parseInt((String) entry.getValue());
                             if (i > 0) {
                                 JSONObject presetValues = new JSONObject(dynExamples[i]);
                                 JSONArray ar = presetValues.names();
                                 for (int j = 0; j < ar.length(); j++) {
                                     String name = ar.getString(j);
-                                    if (name.equals("steps")) {
+                                    if ("steps".equals(name)) {
                                         mUpdate.put("stepsOn", true);
                                     }
-                                    if (name.equals("resched")) {
+                                    if ("resched".equals(name)) {
                                         mUpdate.put(name, presetValues.getBoolean(name));
                                         mValues.put(name, Boolean.toString(presetValues.getBoolean(name)));
                                     } else {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -411,7 +411,7 @@ public class NoteEditor extends AnkiActivity {
                     finishWithoutAnimation();
                     return;
                 }
-                if (mSourceText[0].equals("Aedict Notepad") && addFromAedict(mSourceText[1])) {
+                if ("Aedict Notepad".equals(mSourceText[0]) && addFromAedict(mSourceText[1])) {
                     finishWithoutAnimation();
                     return;
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -203,7 +203,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                         screen.findPreference("fullscreenMode");
                 fullscreenPreference.setOnPreferenceChangeListener((preference, newValue) -> {
                     SharedPreferences prefs = AnkiDroidApp.getSharedPrefs(Preferences.this);
-                    if (prefs.getBoolean("gestures", false) || !newValue.equals("2")) {
+                    if (prefs.getBoolean("gestures", false) || !"2".equals(newValue)) {
                         return true;
                     } else {
                         Toast.makeText(getApplicationContext(),
@@ -490,7 +490,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                     getCol().setMod();
                     break;
                 case "useCurrent":
-                    getCol().getConf().put("addToCur", ((ListPreference) pref).getValue().equals("0"));
+                    getCol().getConf().put("addToCur", "0".equals(((ListPreference) pref).getValue()));
                     getCol().setMod();
                     break;
                 case "dayOffset": {
@@ -673,11 +673,11 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
         // Get summary text
         String oldSummary = mOriginalSumarries.get(pref.getKey());
         // Replace summary text with value according to some rules
-        if (oldSummary.equals("")) {
+        if ("".equals(oldSummary)) {
             pref.setSummary(value);
-        } else if (value.equals("")) {
+        } else if ("".equals(value)) {
             pref.setSummary(oldSummary);
-        } else if (pref.getKey().equals("minimumCardsDueForNotification")) {
+        } else if ("minimumCardsDueForNotification".equals(pref.getKey())) {
             pref.setSummary(replaceStringIfNumeric(oldSummary, value));
         } else {
             pref.setSummary(replaceString(oldSummary, value));

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.java
@@ -123,7 +123,7 @@ public class ReadText {
                                 speak(mTextToSpeak, locale, TextToSpeech.QUEUE_FLUSH);
                             }
                             String language = getLanguage(mDid, mOrd, mQuestionAnswer);
-                            if (language.equals("")) { // No language stored
+                            if ("".equals(language)) { // No language stored
                                 MetaDB.storeLanguage(mReviewer.get(), mDid, mOrd, mQuestionAnswer, locale);
                             } else {
                                 MetaDB.updateLanguage(mReviewer.get(), mDid, mOrd, mQuestionAnswer, locale);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ConfirmationDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ConfirmationDialog.java
@@ -50,7 +50,7 @@ import com.ichi2.anki.R;
             Resources res = getActivity().getResources();
             String title = getArguments().getString("title");
             return new MaterialDialog.Builder(getActivity())
-                    .title(title.equals("") ? res.getString(R.string.app_name) : title)
+                .title("".equals(title) ? res.getString(R.string.app_name) : title)
                     .content(getArguments().getString("message"))
                     .positiveText(res.getString(R.string.dialog_ok))
                     .negativeText(res.getString(R.string.dialog_cancel))

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
@@ -243,7 +243,7 @@ public class BasicImageFieldController extends FieldControllerBase implements IF
 
 
     private void setPreviewImage(String imagePath, int maxsize) {
-        if (imagePath != null && !imagePath.equals("")) {
+        if (imagePath != null && !"".equals(imagePath)) {
             File f = new File(imagePath);
             Bitmap b = BitmapUtil.decodeFile(f, maxsize);
             b = ExifUtil.rotateFromCamera(f, b);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
@@ -328,11 +328,11 @@ public class CardContentProvider extends ContentProvider {
                         String[] keyAndValue = arg.split("="); //split arguments into key ("limit") and value ("?")
                         try {
                             //check if value is a placeholder ("?"), if so replace with the next value of selectionArgs
-                            String value = keyAndValue[1].trim().equals("?") ? selectionArgs[selectionArgIndex++] :
+                            String value = "?".equals(keyAndValue[1].trim()) ? selectionArgs[selectionArgIndex++] :
                                     keyAndValue[1];
-                            if (keyAndValue[0].trim().equals("limit")) {
+                            if ("limit".equals(keyAndValue[0].trim())) {
                                 limit = Integer.valueOf(value);
-                            } else if (keyAndValue[0].trim().equals("deckID")) {
+                            } else if ("deckID".equals(keyAndValue[0].trim())) {
                                 deckIdOfTemporarilySelectedDeck = Long.valueOf(value);
                                 if(!selectDeckWithCheck(col, deckIdOfTemporarilySelectedDeck)){
                                     return rv; //if the provided deckID is wrong, return empty cursor.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/CustomFontsReviewerExt.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/CustomFontsReviewerExt.java
@@ -117,7 +117,7 @@ public class CustomFontsReviewerExt implements ReviewerExt {
         if (mOverrideFontStyle == null) {
             SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(context);
             AnkiFont defaultFont = customFontsMap.get(preferences.getString("defaultFont", null));
-            boolean overrideFont = preferences.getString("overrideFontBehavior", "0").equals("1");
+            boolean overrideFont = "1".equals(preferences.getString("overrideFontBehavior", "0"));
             if (defaultFont != null && overrideFont) {
                 mOverrideFontStyle = "BODY, .card, * { " + defaultFont.getCSS(true) + " }\n";
             } else {

--- a/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
@@ -283,7 +283,7 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
 
         boolean colCorruptFullSync = false;
         if (!CollectionHelper.getInstance().colIsOpen() || !ok) {
-            if (conflictResolution != null && conflictResolution.equals("download")) {
+            if (conflictResolution != null && "download".equals(conflictResolution)) {
                 colCorruptFullSync = true;
             } else {
                 data.success = false;
@@ -309,11 +309,11 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
                     return data;
                 }
                 String retCode = (String) ret[0];
-                if (!retCode.equals("noChanges") && !retCode.equals("success")) {
+                if (!"noChanges".equals(retCode) && !"success".equals(retCode)) {
                     data.success = false;
                     data.result = ret;
                     // Check if there was a sanity check error
-                    if (retCode.equals("sanityCheckError")) {
+                    if ("sanityCheckError".equals(retCode)) {
                         // Force full sync next time
                         col.modSchemaNoCheck();
                         col.save();
@@ -321,7 +321,7 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
                     return data;
                 }
                 // save and note success state
-                if (retCode.equals("noChanges")) {
+                if ("noChanges".equals(retCode)) {
                     // publishProgress(R.string.sync_no_changes_message);
                     noChanges = true;
                 }
@@ -330,7 +330,7 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
                     // Disable sync cancellation for full-sync
                     sIsCancellable = false;
                     server = new FullSyncer(col, hkey, this);
-                    if (conflictResolution.equals("upload")) {
+                    if ("upload".equals(conflictResolution)) {
                         Timber.i("Sync - fullsync - upload collection");
                         publishProgress(R.string.sync_preparing_full_sync_message);
                         Object[] ret = server.upload();
@@ -345,7 +345,7 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
                             data.result = ret;
                             return data;
                         }
-                    } else if (conflictResolution.equals("download")) {
+                    } else if ("download".equals(conflictResolution)) {
                         Timber.i("Sync - fullsync - download collection");
                         publishProgress(R.string.sync_downloading_message);
                         Object[] ret = server.download();
@@ -354,11 +354,11 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
                             data.result = new Object[] { "genericError" };
                             return data;
                         }
-                        if (ret[0].equals("success")) {
+                        if ("success".equals(ret[0])) {
                             data.success = true;
                             col.reopen();
                         }
-                        if (!ret[0].equals("success")) {
+                        if (!"success".equals(ret[0])) {
                             data.success = false;
                             data.result = ret;
                             if (!colCorruptFullSync) {
@@ -375,7 +375,7 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
                 } catch (RuntimeException e) {
                     if (timeoutOccurred(e)) {
                         data.result = new Object[] {"connectionError", e};
-                    } else if (e.getMessage().equals("UserAbortedSync")) {
+                    } else if ("UserAbortedSync".equals(e.getMessage())) {
                         data.result = new Object[] {"UserAbortedSync", e};
                     } else {
                         AnkiDroidApp.sendExceptionReport(e, "doInBackgroundSync-fullSync");
@@ -407,11 +407,11 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
                             mediaError = AnkiDroidApp.getAppResources().getString(R.string.sync_media_db_error);
                             noMediaChanges = true;
                         }
-                        if (ret.equals("noChanges")) {
+                        if ("noChanges".equals(ret)) {
                             publishProgress(R.string.sync_media_no_changes);
                             noMediaChanges = true;
                         }
-                        if (ret.equals("sanityFailed")) {
+                        if ("sanityFailed".equals(ret)) {
                             mediaError = AnkiDroidApp.getAppResources().getString(R.string.sync_media_sanity_failed);
                         } else {
                             publishProgress(R.string.sync_media_success);
@@ -420,7 +420,7 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
                 } catch (RuntimeException e) {
                     if (timeoutOccurred(e)) {
                         data.result = new Object[] {"connectionError", e};
-                    } else if (e.getMessage().equals("UserAbortedSync")) {
+                    } else if ("UserAbortedSync".equals(e.getMessage())) {
                         data.result = new Object[] {"UserAbortedSync", e};
                     }
                     mediaError = AnkiDroidApp.getAppResources().getString(R.string.sync_media_error) + "\n\n" + e.getLocalizedMessage();
@@ -455,7 +455,7 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
             data.success = false;
             if (timeoutOccurred(e)) {
                 data.result = new Object[]{"connectionError", e};
-            } else if (e.getMessage().equals("UserAbortedSync")) {
+            } else if ("UserAbortedSync".equals(e.getMessage())) {
                 data.result = new Object[] {"UserAbortedSync", e};
             } else {
                 AnkiDroidApp.sendExceptionReport(e, "doInBackgroundSync");

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatHelper.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatHelper.java
@@ -87,7 +87,7 @@ public class CompatHelper {
 
     private boolean isNookHdPlus() {
         return "NOOK".equals(Build.BRAND) && "HDplus".equals(Build.PRODUCT)
-                && android.os.Build.DEVICE.equals("ovation");
+            && "ovation".equals(android.os.Build.DEVICE);
     }
 
     private boolean isNookHd () {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.java
@@ -181,7 +181,7 @@ class AnkiExporter extends Exporter {
         }
         JSONObject dconfs = new JSONObject();
         for (JSONObject d : mSrc.getDecks().all()) {
-            if (d.getString("id").equals("1")) {
+            if ("1".equals(d.getString("id"))) {
                 continue;
             }
             if (mDid != null && !dids.contains(d.getLong("id"))) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Media.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Media.java
@@ -949,7 +949,7 @@ public class Media {
             // then loop through all files
             int cnt = 0;
             for (ZipEntry i : Collections.list(z.entries())) {
-                if (i.getName().equals("_meta")) {
+                if ("_meta".equals(i.getName())) {
                     // ignore previously-retrieved meta
                     continue;
                 } else {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.java
@@ -277,7 +277,7 @@ public class Sound {
         Timber.d("Playing %s has listener? %b", soundPath, playAllListener != null);
         Uri soundUri = Uri.parse(soundPath);
 
-        if (soundPath.substring(0, 3).equals("tts")) {
+        if ("tts".equals(soundPath.substring(0, 3))) {
             // TODO: give information about did
 //            ReadText.textToSpeech(soundPath.substring(4, soundPath.length()),
 //                    Integer.parseInt(soundPath.substring(3, 4)));

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/FullSyncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/FullSyncer.java
@@ -106,7 +106,7 @@ public class FullSyncer extends HttpSyncer {
         try {
             super.writeToFile(cont, tpath);
             FileInputStream fis = new FileInputStream(tpath);
-            if (super.stream2String(fis, 15).equals("upgradeRequired")) {
+            if ("upgradeRequired".equals(super.stream2String(fis, 15))) {
                 return new Object[]{"upgradeRequired"};
             }
         } catch (FileNotFoundException e) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/template/Template.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/template/Template.java
@@ -316,7 +316,7 @@ public class Template {
                 buf = m.group(2);
             }
 
-            if (m.group(1).equals("c")) {
+            if ("c".equals(m.group(1))) {
                 buf = String.format("<span class=cloze>%s</span>", buf);
             }
 

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
@@ -42,7 +42,7 @@ public class ImportUtils {
         Timber.i("IntentHandler/ User requested to view a file");
         String errorMessage = null;
         // If the file is being sent from a content provider we need to read the content before we can open the file
-        if (intent.getData().getScheme().equals("content")) {
+        if ("content".equals(intent.getData().getScheme())) {
             // Get the original filename from the content provider URI
             String filename = null;
             Cursor cursor = null;
@@ -59,7 +59,7 @@ public class ImportUtils {
 
             // Hack to fix bug where ContentResolver not returning filename correctly
             if (filename == null) {
-                if (intent.getType() != null && (intent.getType().equals("application/apkg") || ImportUtils.hasValidZipFile(context, intent))) {
+                if (intent.getType() != null && ("application/apkg".equals(intent.getType()) || ImportUtils.hasValidZipFile(context, intent))) {
                     // Set a dummy filename if MIME type provided or is a valid zip file
                     filename = "unknown_filename.apkg";
                     Timber.w("Could not retrieve filename from ContentProvider, but was valid zip file so we try to continue");
@@ -84,7 +84,7 @@ public class ImportUtils {
                     AnkiDroidApp.sendExceptionReport(new RuntimeException("Error importing apkg file"), "IntentHandler.java", "apkg import failed");
                 }
             }
-        } else if (intent.getData().getScheme().equals("file")) {
+        } else if ("file".equals(intent.getData().getScheme())) {
             // When the VIEW intent is sent as a file, we can open it directly without copying from content provider
             String filename = intent.getData().getPath();
             Timber.d("Importing regular file: %s", filename);
@@ -141,11 +141,11 @@ public class ImportUtils {
     }
 
     public static boolean isCollectionPackage(String filename) {
-        return filename != null && (filename.toLowerCase().endsWith(".colpkg") || filename.equals("collection.apkg"));
+        return filename != null && (filename.toLowerCase().endsWith(".colpkg") || "collection.apkg".equals(filename));
     }
 
     private static boolean isDeckPackage(String filename) {
-        return filename != null && filename.toLowerCase().endsWith(".apkg") && !filename.equals("collection.apkg");
+        return filename != null && filename.toLowerCase().endsWith(".apkg") && !"collection.apkg".equals(filename);
     }
 
     public static boolean isValidPackageName(String filename) {


### PR DESCRIPTION
## Purpose / Description

Codacy rejected a PR because I did `var.equals("constant")`
It explains that I must do `"constant".equals(var)` so that instead of
having a nullPointerException, it justs returns false when var is
null.

I decided to follow this advice and create a script reversing equality everywhere

## How Has This Been Tested?

Ensuring that no catch NullPointerException were surrounding the reversed tests. And installing it on my phone (which means I'm not testing JSON anymore)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
