### PR TITLE
All missing columns in browser

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -73,6 +73,7 @@ import com.ichi2.libanki.Utils;
 import com.ichi2.themes.Themes;
 import com.ichi2.upgrade.Upgrade;
 import com.ichi2.utils.IntentTop;
+import com.ichi2.utils.LanguageUtil;
 import com.ichi2.widget.WidgetStatus;
 
 import org.json.JSONException;
@@ -1358,15 +1359,16 @@ public class CardBrowser extends NavigationDrawerActivity implements
         // database
         item.put("answer", formatQA(a));
         item.put("card", c.template().optString("name"));
-        // item.put("changed",strftime("%Y-%m-%d", localtime(c.getMod())));
-        // item.put("created",strftime("%Y-%m-%d", localtime(c.note().getId()/1000)));
         item.put("due", c.getDueString());
         if (c.getType() == 0) {
             item.put("ease", context.getString(R.string.card_browser_ease_new_card));
         } else {
             item.put("ease", (c.getFactor()/10)+"%");
         }
-        // item.put("edited",strftime("%Y-%m-%d", localtime(c.note().getMod())));
+
+        item.put("changed", LanguageUtil.getShortDateFormatFromMs(c.getMod() * 1000L));
+        item.put("created", LanguageUtil.getShortDateFormatFromMs(c.note().getId()));
+        item.put("edited", LanguageUtil.getShortDateFormatFromMs(c.note().getMod() * 1000L));
         // interval
         int type = c.getType();
         if (type == 0) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -151,10 +151,10 @@ public class CardBrowser extends NavigationDrawerActivity implements
         "lapses",
         "reviews",
         "interval",
+        "ease",
         "changed",
         "created",
         "due",
-        "ease",
         "edited",
     };
     private long mLastRenderStart = 0;
@@ -1362,7 +1362,11 @@ public class CardBrowser extends NavigationDrawerActivity implements
         // item.put("changed",strftime("%Y-%m-%d", localtime(c.getMod())));
         // item.put("created",strftime("%Y-%m-%d", localtime(c.note().getId()/1000)));
         // item.put("due",getDueString(c));
-        // item.put("ease","");
+        if (c.getType() == 0) {
+            item.put("ease", context.getString(R.string.card_browser_ease_new_card));
+        } else {
+            item.put("ease", (c.getFactor()/10)+"%");
+        }
         // item.put("edited",strftime("%Y-%m-%d", localtime(c.note().getMod())));
         // interval
         int type = c.getType();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -152,9 +152,9 @@ public class CardBrowser extends NavigationDrawerActivity implements
         "reviews",
         "interval",
         "ease",
+        "due",
         "changed",
         "created",
-        "due",
         "edited",
     };
     private long mLastRenderStart = 0;
@@ -1334,7 +1334,6 @@ public class CardBrowser extends NavigationDrawerActivity implements
         }
     };
 
-
     public static void updateSearchItemQA(Context context, Map<String, String> item, Card c) {
         // render question and answer
         Map<String, String> qa = c._getQA(true, true);
@@ -1361,7 +1360,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
         item.put("card", c.template().optString("name"));
         // item.put("changed",strftime("%Y-%m-%d", localtime(c.getMod())));
         // item.put("created",strftime("%Y-%m-%d", localtime(c.note().getId()/1000)));
-        // item.put("due",getDueString(c));
+        item.put("due", c.getDueString());
         if (c.getType() == 0) {
             item.put("ease", context.getString(R.string.card_browser_ease_new_card));
         } else {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.java
@@ -23,6 +23,9 @@ import android.database.Cursor;
 import android.text.TextUtils;
 
 import com.ichi2.utils.Assert;
+import com.ichi2.anki.AnkiDroidApp;
+import com.ichi2.anki.R;
+import com.ichi2.utils.LanguageUtil;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -686,5 +689,35 @@ public class Card implements Cloneable {
 
     public void setUserFlag(int flag) {
         mFlags = setFlagInInt(mFlags, flag);
+    }
+
+    // not in Anki.
+    public String getDueString() {
+        String t = nextDue();
+        if (getQueue() < 0) {
+            t = "(" + t + ")";
+        }
+        return t;
+    }
+
+    // as in Anki aqt/browser.py
+    private String nextDue() {
+        long date;
+        long due = getDue();
+        if (getODid() != 0) {
+            return AnkiDroidApp.getAppResources().getString(R.string.card_browser_due_filtered_card);
+        }
+        else if (getQueue() == 1) {
+            date = due;
+        } else if (getQueue() == 0 || getType() == 0) {
+            return (new Long(due)).toString();
+        } else if (getQueue() == 2 || getQueue() == 3 || (getType() == 2 && getQueue() <0)) {
+            long time = System.currentTimeMillis();
+            long nbDaySinceCreation = (due - getCol().getSched().getToday());
+            date = time + (nbDaySinceCreation * 86400L * 1000L);
+        } else {
+            return "";
+        }
+        return LanguageUtil.getShortDateFormatFromMs(date);
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.java
@@ -452,6 +452,10 @@ public class Card implements Cloneable {
         mMod = mod;
     }
 
+    public long getMod() {
+        return mMod ;
+    }
+
 
     public void setUsn(int usn) {
         mUsn = usn;

--- a/AnkiDroid/src/main/java/com/ichi2/utils/LanguageUtil.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/LanguageUtil.java
@@ -70,4 +70,8 @@ public class LanguageUtil {
         return locale;
     }
 
+    public static String getShortDateFormatFromMs(long ms) {
+        return DateFormat.getDateInstance(DateFormat.SHORT, getLocale()).format(new Date(ms));
+    }
+
 }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/LanguageUtil.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/LanguageUtil.java
@@ -19,6 +19,8 @@ import android.text.TextUtils;
 import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.Preferences;
 
+import java.text.DateFormat;
+import java.util.Date;
 import java.util.Locale;
 
 /**

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -66,14 +66,14 @@
         <item>Tags</item>
         <item>Lapses</item>
         <item>Reviews</item>
+        <item>Interval</item>
         <item>Ease</item>
+        <item>Due</item>
         <!--
     <item>Changed</item>
     <item>Created</item>
-    <item>Due</item>
     <item>Edited</item>
         -->
-        <item>Interval</item>
     </string-array>
 
     <!-- Custom study options -->

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -69,11 +69,9 @@
         <item>Interval</item>
         <item>Ease</item>
         <item>Due</item>
-        <!--
-    <item>Changed</item>
-    <item>Created</item>
-    <item>Edited</item>
-        -->
+        <item>Changed</item>
+        <item>Created</item>
+        <item>Edited</item>
     </string-array>
 
     <!-- Custom study options -->

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -66,11 +66,11 @@
         <item>Tags</item>
         <item>Lapses</item>
         <item>Reviews</item>
+        <item>Ease</item>
         <!--
     <item>Changed</item>
     <item>Created</item>
     <item>Due</item>
-    <item>Ease</item>
     <item>Edited</item>
         -->
         <item>Interval</item>

--- a/AnkiDroid/src/main/res/values/07-cardbrowser.xml
+++ b/AnkiDroid/src/main/res/values/07-cardbrowser.xml
@@ -77,5 +77,6 @@
     <string name="card_browser_select_none">Select none</string>
     <string name="card_browser_interval_new_card">(new)</string>
     <string name="card_browser_ease_new_card">(new)</string>
+    <string name="card_browser_due_filtered_card">(filtered)</string>
     <string name="card_browser_interval_learning_card">(learning)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values/07-cardbrowser.xml
+++ b/AnkiDroid/src/main/res/values/07-cardbrowser.xml
@@ -76,5 +76,6 @@
     <string name="card_browser_select_all">Select all</string>
     <string name="card_browser_select_none">Select none</string>
     <string name="card_browser_interval_new_card">(new)</string>
+    <string name="card_browser_ease_new_card">(new)</string>
     <string name="card_browser_interval_learning_card">(learning)</string>
 </resources>


### PR DESCRIPTION
 ## Purpose / Description 
Adding in the browser all columns present in Anki.

## Fixes
I'm pretty sure someone asked for it, and I was mentioned because I did add interval. I can't find it anymore.

## Approach
As in Anki, with the following twists:
* the method to get due is in Cards.java. In anki it's in aqt/browser.py, but we don't literally have AQT, and anyway, it makes totally sens to decide that this is a method related to the card itself.
* the dates are localized. Anki didn't localize the date; I decided to use java DateFormat and let him localize date in Short format.

## How Has This Been Tested?

Open ankidroid with an existing used collection. Find a few cards (new, due, filtered), and ensure that each columns display the same values in Ankidroid and in Anki (assuming the collections are synchronized on both devices obviously) 

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
