### PR TITLE
Don't open twice the same activity

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -90,6 +90,8 @@ import com.ichi2.libanki.template.Template;
 import com.ichi2.themes.HtmlColors;
 import com.ichi2.themes.Themes;
 import com.ichi2.utils.DiffEngine;
+import com.ichi2.utils.IntentTop;
+import com.ichi2.utils.IntentTopNewTask;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -1129,7 +1131,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
 
 
     protected boolean editCard() {
-        Intent editCard = new Intent(AbstractFlashcardViewer.this, NoteEditor.class);
+        Intent editCard = new IntentTop(AbstractFlashcardViewer.this, NoteEditor.class);
         editCard.putExtra(NoteEditor.EXTRA_CALLER, NoteEditor.CALLER_REVIEWER);
         sEditorCard = mCurrentCard;
         startActivityForResultWithAnimation(editCard, EDIT_CURRENT_CARD, ActivityTransitionAnimation.LEFT);
@@ -1765,9 +1767,8 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
             throw new RuntimeException();
         } catch (NullPointerException npe) {
             // NPE on collection only happens if the Collection is broken, follow AnkiActivity example
-            Intent deckPicker = new Intent(this, DeckPicker.class);
+            Intent deckPicker = new IntentTopNewTask(this, DeckPicker.class);
             deckPicker.putExtra("collectionLoadError", true); // don't currently do anything with this
-            deckPicker.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
             startActivityWithAnimation(deckPicker, ActivityTransitionAnimation.LEFT);
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
@@ -34,6 +34,8 @@ import com.ichi2.compat.CompatHelper;
 import com.ichi2.compat.customtabs.CustomTabActivityHelper;
 import com.ichi2.libanki.Collection;
 import com.ichi2.themes.Themes;
+import com.ichi2.utils.IntentTop;
+import com.ichi2.utils.IntentTopNewTask;
 
 import timber.log.Timber;
 
@@ -267,9 +269,8 @@ public class AnkiActivity extends AppCompatActivity implements SimpleMessageDial
             if (col != null) {
                 onCollectionLoaded(col);
             } else {
-                Intent deckPicker = new Intent(this, DeckPicker.class);
+                Intent deckPicker = new IntentTopNewTask(this, DeckPicker.class);
                 deckPicker.putExtra("collectionLoadError", true); // don't currently do anything with this
-                deckPicker.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
                 startActivityWithAnimation(deckPicker, ActivityTransitionAnimation.LEFT);
             }
         });
@@ -425,8 +426,8 @@ public class AnkiActivity extends AppCompatActivity implements SimpleMessageDial
                 builder.setLights(Color.BLUE, 1000, 1000);
             }
             // Creates an explicit intent for an Activity in your app
-            Intent resultIntent = new Intent(this, DeckPicker.class);
-            resultIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
+            Intent resultIntent = new IntentTopNewTask(this, DeckPicker.class);
+            resultIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK);
             PendingIntent resultPendingIntent = PendingIntent.getActivity(this, 0, resultIntent, PendingIntent.FLAG_UPDATE_CURRENT);
             builder.setContentIntent(resultPendingIntent);
             NotificationManager notificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
@@ -445,8 +446,7 @@ public class AnkiActivity extends AppCompatActivity implements SimpleMessageDial
     public void dismissSimpleMessageDialog(boolean reload) {
         dismissAllDialogFragments();
         if (reload) {
-            Intent deckPicker = new Intent(this, DeckPicker.class);
-            deckPicker.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
+            Intent deckPicker = new IntentTopNewTask(this, DeckPicker.class);
             startActivityWithoutAnimation(deckPicker);
         }
     }
@@ -461,7 +461,7 @@ public class AnkiActivity extends AppCompatActivity implements SimpleMessageDial
     // Restart the activity
     public void restartActivity() {
         Timber.i("AnkiActivity -- restartActivity()");
-        Intent intent = new Intent();
+        Intent intent = new IntentTop();
         intent.setClass(this, this.getClass());
         intent.putExtras(new Bundle());
         this.startActivityWithoutAnimation(intent);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -72,6 +72,7 @@ import com.ichi2.libanki.Note;
 import com.ichi2.libanki.Utils;
 import com.ichi2.themes.Themes;
 import com.ichi2.upgrade.Upgrade;
+import com.ichi2.utils.IntentTop;
 import com.ichi2.widget.WidgetStatus;
 
 import org.json.JSONException;
@@ -567,7 +568,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
                     mCurrentCardId = Long.parseLong(getCards().get(position).get("id"));
                     sCardBrowserCard = getCol().getCard(mCurrentCardId);
                     // start note editor using the card we just loaded
-                    Intent editCard = new Intent(CardBrowser.this, NoteEditor.class);
+                    Intent editCard = new IntentTop(CardBrowser.this, NoteEditor.class);
                     editCard.putExtra(NoteEditor.EXTRA_CALLER, NoteEditor.CALLER_CARDBROWSER_EDIT);
                     editCard.putExtra(NoteEditor.EXTRA_CARD_ID, sCardBrowserCard.getId());
                     startActivityForResultWithAnimation(editCard, EDIT_CARD, ActivityTransitionAnimation.LEFT);
@@ -786,7 +787,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 endMultiSelectMode();
                 return true;
             case R.id.action_add_card_from_card_browser: {
-                Intent intent = new Intent(CardBrowser.this, NoteEditor.class);
+                Intent intent = new IntentTop(CardBrowser.this, NoteEditor.class);
                 intent.putExtra(NoteEditor.EXTRA_CALLER, NoteEditor.CALLER_CARDBROWSER_ADD);
                 startActivityForResultWithAnimation(intent, ADD_NOTE, ActivityTransitionAnimation.LEFT);
                 return true;
@@ -905,7 +906,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 return true;
 
             case R.id.action_preview: {
-                Intent previewer = new Intent(CardBrowser.this, Previewer.class);
+                Intent previewer = new IntentTop(CardBrowser.this, Previewer.class);
                 if (mInMultiSelectMode && mCheckedCardPositions.size() > 1) {
                     // Multiple cards have been explicitly selected, so preview only those cards
                     previewer.putExtra("index", 0);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
@@ -48,6 +48,7 @@ import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Models;
 import com.ichi2.libanki.Note;
 import com.ichi2.ui.SlidingTabLayout;
+import com.ichi2.utils.IntentTop;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -488,7 +489,7 @@ public class CardTemplateEditor extends AnkiActivity {
                         col.getModels().save(model, false);
                     }
                     // Create intent for the previewer and add some arguments
-                    Intent i = new Intent(getActivity(), Previewer.class);
+                    Intent i = new IntentTop(getActivity(), Previewer.class);
                     int pos = getArguments().getInt("position");
                     long cid;
                     if (getArguments().getLong("noteId") != -1L && pos <

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -103,6 +103,7 @@ import com.ichi2.libanki.Utils;
 import com.ichi2.libanki.importer.AnkiPackageImporter;
 import com.ichi2.themes.StyledProgressDialog;
 import com.ichi2.utils.ImportUtils;
+import com.ichi2.utils.IntentTop;
 import com.ichi2.utils.VersionUtils;
 import com.ichi2.widget.WidgetStatus;
 
@@ -593,7 +594,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
             case R.id.action_model_browser_open: {
                 Timber.i("DeckPicker:: Model browser button pressed");
-                Intent noteTypeBrowser = new Intent(this, ModelBrowser.class);
+                Intent noteTypeBrowser = new IntentTop(this, ModelBrowser.class);
                 startActivityForResultWithAnimation(noteTypeBrowser, 0, ActivityTransitionAnimation.LEFT);
                 return true;
             }
@@ -882,7 +883,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
     }
 
     public void addNote() {
-        Intent intent = new Intent(DeckPicker.this, NoteEditor.class);
+        Intent intent = new IntentTop(DeckPicker.this, NoteEditor.class);
         intent.putExtra(NoteEditor.EXTRA_CALLER, NoteEditor.CALLER_DECKPICKER);
         startActivityForResultWithAnimation(intent, ADD_NOTE, ActivityTransitionAnimation.LEFT);
     }
@@ -1017,7 +1018,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
                 // If no changes are required we go to the new features activity
                 // There the "lastVersion" is set, so that this code is not reached again
                 if (VersionUtils.isReleaseVersion()) {
-                    Intent infoIntent = new Intent(this, Info.class);
+                    Intent infoIntent = new IntentTop(this, Info.class);
                     infoIntent.putExtra(Info.TYPE_EXTRA, Info.TYPE_NEW_VERSION);
 
                     if (skip != 0) {
@@ -1670,7 +1671,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
     @Override
     public void loginToSyncServer() {
-        Intent myAccount = new Intent(this, MyAccount.class);
+        Intent myAccount = new IntentTop(this, MyAccount.class);
         myAccount.putExtra("notLoggedIn", true);
         startActivityForResultWithAnimation(myAccount, LOG_IN_FOR_SYNC, ActivityTransitionAnimation.FADE);
     }
@@ -1849,7 +1850,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
             // The fragment will show the study options screen instead of launching a new activity.
             loadStudyOptionsFragment(withDeckOptions);
         } else {
-            Intent intent = new Intent();
+            Intent intent = new IntentTop();
             intent.putExtra("withDeckOptions", withDeckOptions);
             intent.setClass(this, StudyOptionsActivity.class);
             startActivityForResultWithAnimation(intent, SHOW_STUDYOPTIONS, ActivityTransitionAnimation.LEFT);
@@ -2015,12 +2016,12 @@ public class DeckPicker extends NavigationDrawerActivity implements
         // open deck options
         if (getCol().getDecks().isDyn(mContextMenuDid)) {
             // open cram options if filtered deck
-            Intent i = new Intent(DeckPicker.this, FilteredDeckOptions.class);
+            Intent i = new IntentTop(DeckPicker.this, FilteredDeckOptions.class);
             i.putExtra("did", mContextMenuDid);
             startActivityWithAnimation(i, ActivityTransitionAnimation.FADE);
         } else {
             // otherwise open regular options
-            Intent i = new Intent(DeckPicker.this, DeckOptions.class);
+            Intent i = new IntentTop(DeckPicker.this, DeckOptions.class);
             i.putExtra("did", mContextMenuDid);
             startActivityWithAnimation(i, ActivityTransitionAnimation.FADE);
         }
@@ -2224,7 +2225,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
 
     private void openReviewer() {
-        Intent reviewer = new Intent(this, Reviewer.class);
+        Intent reviewer = new IntentTop(this, Reviewer.class);
         startActivityForResultWithAnimation(reviewer, REQUEST_REVIEW, ActivityTransitionAnimation.LEFT);
         getCol().startTimebox();
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.java
@@ -8,6 +8,7 @@ import android.os.Message;
 import com.ichi2.anki.dialogs.DialogHandler;
 import com.ichi2.anki.services.ReminderService;
 import com.ichi2.utils.ImportUtils;
+import com.ichi2.utils.IntentTop;
 
 import timber.log.Timber;
 
@@ -27,7 +28,7 @@ public class IntentHandler extends Activity {
         setContentView(R.layout.progress_bar);
         Intent intent = getIntent();
         Timber.v(intent.toString());
-        Intent reloadIntent = new Intent(this, DeckPicker.class);
+        Intent reloadIntent = new IntentTop(this, DeckPicker.class);
         reloadIntent.setDataAndType(getIntent().getData(), getIntent().getType());
         String action = intent.getAction();
         if (Intent.ACTION_VIEW.equals(action)) {
@@ -52,6 +53,9 @@ public class IntentHandler extends Activity {
             startActivity(reloadIntent);
             AnkiActivity.finishActivityWithFade(this);
         } else if (intent.hasExtra(ReminderService.EXTRA_DECK_ID)) {
+            // Intent and not IntentTop, because you may want to
+            // actually review the remainded deck and then go back to
+            // current deck.
             final Intent reviewIntent = new Intent(this, Reviewer.class);
 
             CollectionHelper.getInstance().getCol(this).getDecks().select(intent.getLongExtra(ReminderService.EXTRA_DECK_ID, 0));

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.java
@@ -47,6 +47,7 @@ import com.ichi2.async.DeckTask;
 import com.ichi2.async.DeckTask.TaskData;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Models;
+import com.ichi2.utils.IntentTop;
 import com.ichi2.widget.WidgetStatus;
 
 import org.json.JSONException;
@@ -261,7 +262,7 @@ public class ModelBrowser extends AnkiActivity {
             public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
                 long noteTypeID = mModelIds.get(position);
                 mModelListPosition = position;
-                Intent noteOpenIntent = new Intent(ModelBrowser.this, ModelFieldEditor.class);
+                Intent noteOpenIntent = new IntentTop(ModelBrowser.this, ModelFieldEditor.class);
                 noteOpenIntent.putExtra("title", mModelDisplayList.get(position).getName());
                 noteOpenIntent.putExtra("noteTypeID", noteTypeID);
                 startActivityForResultWithAnimation(noteOpenIntent, 0, ActivityTransitionAnimation.LEFT);
@@ -530,7 +531,7 @@ public class ModelBrowser extends AnkiActivity {
      * the user to edit the current note's templates.
      */
     private void openTemplateEditor() {
-        Intent intent = new Intent(this, CardTemplateEditor.class);
+        Intent intent = new IntentTop(this, CardTemplateEditor.class);
         intent.putExtra("modelId", mCurrentID);
         startActivityForResultWithAnimation(intent, REQUEST_TEMPLATE_EDIT, ActivityTransitionAnimation.LEFT);
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
@@ -36,6 +36,8 @@ import android.view.View;
 import com.ichi2.anim.ActivityTransitionAnimation;
 import com.ichi2.compat.CompatHelper;
 import com.ichi2.themes.Themes;
+import com.ichi2.utils.IntentTop;
+import com.ichi2.utils.IntentTopNewTask;
 
 import timber.log.Timber;
 
@@ -278,8 +280,8 @@ public abstract class NavigationDrawerActivity extends AnkiActivity implements N
             // Take action if a different item selected
             switch (item.getItemId()) {
                 case R.id.nav_decks: {
-                    Intent deckPicker = new Intent(NavigationDrawerActivity.this, DeckPicker.class);
-                    deckPicker.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);    // opening DeckPicker should clear back history
+                    Intent deckPicker = new IntentTopNewTask(NavigationDrawerActivity.this, DeckPicker.class);
+                    // opening DeckPicker should clear back history
                     startActivityWithAnimation(deckPicker, ActivityTransitionAnimation.RIGHT);
                     break;
                 }
@@ -287,7 +289,7 @@ public abstract class NavigationDrawerActivity extends AnkiActivity implements N
                     openCardBrowser();
                     break;
                 case R.id.nav_stats: {
-                    Intent intent = new Intent(NavigationDrawerActivity.this, Statistics.class);
+                    Intent intent = new IntentTop(NavigationDrawerActivity.this, Statistics.class);
                     startActivityForResultWithAnimation(intent, REQUEST_STATISTICS, ActivityTransitionAnimation.LEFT);
                     break;
                 }
@@ -298,7 +300,7 @@ public abstract class NavigationDrawerActivity extends AnkiActivity implements N
                     mOldColPath = CollectionHelper.getCurrentAnkiDroidDirectory(NavigationDrawerActivity.this);
                     // Remember the theme we started with so we can restart the Activity if it changes
                     mOldTheme = Themes.getCurrentTheme(getApplicationContext());
-                    startActivityForResultWithAnimation(new Intent(NavigationDrawerActivity.this, Preferences.class), REQUEST_PREFERENCES_UPDATE, ActivityTransitionAnimation.FADE);
+                    startActivityForResultWithAnimation(new IntentTop(NavigationDrawerActivity.this, Preferences.class), REQUEST_PREFERENCES_UPDATE, ActivityTransitionAnimation.FADE);
                     break;
                 case R.id.nav_help:
                     openUrl(Uri.parse(AnkiDroidApp.getManualUrl()));
@@ -316,7 +318,7 @@ public abstract class NavigationDrawerActivity extends AnkiActivity implements N
     }
 
     protected void openCardBrowser() {
-        Intent intent = new Intent(NavigationDrawerActivity.this, CardBrowser.class);
+        Intent intent = new IntentTop(NavigationDrawerActivity.this, CardBrowser.class);
         Long currentCardId = getCurrentCardId();
         if (currentCardId != null) {
             intent.putExtra("currentCard", currentCardId);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -77,6 +77,7 @@ import com.ichi2.libanki.Utils;
 import com.ichi2.themes.StyledProgressDialog;
 import com.ichi2.themes.Themes;
 import com.ichi2.anki.widgets.PopupMenuWithIcons;
+import com.ichi2.utils.IntentTop;
 import com.ichi2.widget.WidgetStatus;
 
 import org.json.JSONArray;
@@ -886,6 +887,8 @@ public class NoteEditor extends AnkiActivity {
             case R.id.action_add_card_from_card_editor:
             case R.id.action_copy_card: {
                 Timber.i("NoteEditor:: Copy or add card button pressed");
+                // Intent and not IntentTop, because we want to return here after the copy.
+                // This open an "add note" window, but still use NoteEditor
                 Intent intent = new Intent(NoteEditor.this, NoteEditor.class);
                 intent.putExtra(EXTRA_CALLER, CALLER_CARDEDITOR);
                 // intent.putExtra(EXTRA_DECKPATH, mDeckPath);
@@ -1011,7 +1014,7 @@ public class NoteEditor extends AnkiActivity {
     }
 
     private void showCardTemplateEditor() {
-        Intent intent = new Intent(this, CardTemplateEditor.class);
+        Intent intent = new IntentTop(this, CardTemplateEditor.class);
         // Pass the model ID
         try {
             intent.putExtra("modelId", getCurrentlySelectedModel().getLong("id"));
@@ -1272,7 +1275,7 @@ public class NoteEditor extends AnkiActivity {
 
 
     private void startMultimediaFieldEditor(final int index, IMultimediaEditableNote mNote, IField field) {
-        Intent editCard = new Intent(NoteEditor.this, MultimediaEditFieldActivity.class);
+        Intent editCard = new IntentTop(NoteEditor.this, MultimediaEditFieldActivity.class);
         editCard.putExtra(MultimediaEditFieldActivity.EXTRA_FIELD_INDEX, index);
         editCard.putExtra(MultimediaEditFieldActivity.EXTRA_FIELD, field);
         editCard.putExtra(MultimediaEditFieldActivity.EXTRA_WHOLE_NOTE, mNote);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -62,6 +62,7 @@ import com.ichi2.themes.Themes;
 import com.ichi2.ui.AppCompatPreferenceActivity;
 import com.ichi2.ui.ConfirmationPreference;
 import com.ichi2.ui.SeekBarPreference;
+import com.ichi2.utils.IntentTop;
 import com.ichi2.utils.LanguageUtil;
 import com.ichi2.anki.analytics.UsageAnalytics;
 import com.ichi2.utils.VersionUtils;
@@ -174,7 +175,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
     // ----------------------------------------------------------------------------
 
     public static Intent getPreferenceSubscreenIntent(Context context, String subscreen) {
-        Intent i = new Intent(context, Preferences.class);
+        Intent i = new IntentTop(context, Preferences.class);
         i.putExtra(PreferenceActivity.EXTRA_SHOW_FRAGMENT, "com.ichi2.anki.Preferences$SettingsFragment");
         Bundle extras = new Bundle();
         extras.putString("subscreen", subscreen);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -45,6 +45,7 @@ import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Collection.DismissType;
 import com.ichi2.themes.Themes;
+import com.ichi2.utils.IntentTop;
 import com.ichi2.widget.WidgetStatus;
 
 import org.json.JSONException;
@@ -277,7 +278,7 @@ public class Reviewer extends AbstractFlashcardViewer {
                 break;
 
             case R.id.action_open_deck_options:
-                Intent i = new Intent(this, DeckOptions.class);
+                Intent i = new IntentTop(this, DeckOptions.class);
                 startActivityForResultWithAnimation(i, DECK_OPTIONS, ActivityTransitionAnimation.FADE);
                 break;
 
@@ -332,7 +333,7 @@ public class Reviewer extends AbstractFlashcardViewer {
 
 
     private void addNote() {
-        Intent intent = new Intent(this, NoteEditor.class);
+        Intent intent = new IntentTop(this, NoteEditor.class);
         intent.putExtra(NoteEditor.EXTRA_CALLER, NoteEditor.CALLER_REVIEWER_ADD);
         startActivityForResultWithAnimation(intent, ADD_NOTE, ActivityTransitionAnimation.LEFT);
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
@@ -39,6 +39,7 @@ import com.ichi2.compat.CompatHelper;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Utils;
 import com.ichi2.themes.StyledProgressDialog;
+import com.ichi2.utils.IntentTop;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -148,7 +149,7 @@ public class StudyOptionsFragment extends Fragment implements Toolbar.OnMenuItem
      *                      set of values.
      */
     private void openFilteredDeckOptions(boolean defaultConfig) {
-        Intent i = new Intent(getActivity(), FilteredDeckOptions.class);
+        Intent i = new IntentTop(getActivity(), FilteredDeckOptions.class);
         i.putExtra("defaultConfig", defaultConfig);
         getActivity().startActivityForResult(i, DECK_OPTIONS);
         ActivityTransitionAnimation.slide(getActivity(), ActivityTransitionAnimation.FADE);
@@ -226,7 +227,7 @@ public class StudyOptionsFragment extends Fragment implements Toolbar.OnMenuItem
 
 
     private void openReviewer() {
-        Intent reviewer = new Intent(getActivity(), Reviewer.class);
+        Intent reviewer = new IntentTop(getActivity(), Reviewer.class);
         if (mFragmented) {
             getActivity().startActivityForResult(reviewer, AnkiActivity.REQUEST_REVIEW);
         } else {
@@ -297,7 +298,7 @@ public class StudyOptionsFragment extends Fragment implements Toolbar.OnMenuItem
                 if (getCol().getDecks().isDyn(getCol().getDecks().selected())) {
                     openFilteredDeckOptions();
                 } else {
-                    Intent i = new Intent(getActivity(), DeckOptions.class);
+                    Intent i = new IntentTop(getActivity(), DeckOptions.class);
                     getActivity().startActivityForResult(i, DECK_OPTIONS);
                     ActivityTransitionAnimation.slide(getActivity(), ActivityTransitionAnimation.FADE);
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
@@ -41,6 +41,7 @@ import com.ichi2.anki.analytics.AnalyticsDialogFragment;
 import com.ichi2.async.DeckTask;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Consts;
+import com.ichi2.utils.IntentTop;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -125,7 +126,7 @@ public class CustomStudyDialog extends AnalyticsDialogFragment {
                         switch (view.getId()) {
                             case DECK_OPTIONS: {
                                 // User asked to permanently change the deck options
-                                Intent i = new Intent(activity, DeckOptions.class);
+                                Intent i = new IntentTop(activity, DeckOptions.class);
                                 i.putExtra("did", getArguments().getLong("did"));
                                 getActivity().startActivity(i);
                                 break;
@@ -492,7 +493,7 @@ public class CustomStudyDialog extends AnalyticsDialogFragment {
     private void onLimitsExtended(boolean jumpToReviewer) {
         AnkiActivity activity = (AnkiActivity) getActivity();
         if (jumpToReviewer) {
-            activity.startActivityForResultWithoutAnimation(new Intent(activity, Reviewer.class), AnkiActivity.REQUEST_REVIEW);
+            activity.startActivityForResultWithoutAnimation(new IntentTop(activity, Reviewer.class), AnkiActivity.REQUEST_REVIEW);
             CollectionHelper.getInstance().getCol(activity).startTimebox();
         } else {
             ((CustomStudyListener) activity).onExtendStudyLimits();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicTextFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicTextFieldController.java
@@ -37,6 +37,7 @@ import com.ichi2.anki.multimediacard.activity.LoadPronounciationActivity;
 import com.ichi2.anki.multimediacard.activity.PickStringDialogFragment;
 import com.ichi2.anki.multimediacard.activity.TranslationActivity;
 import com.ichi2.compat.CompatHelper;
+import com.ichi2.utils.IntentTop;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -120,7 +121,7 @@ public class BasicTextFieldController extends FieldControllerBase implements IFi
                 return;
             }
 
-            Intent intent = new Intent(mActivity, LoadPronounciationActivity.class);
+            Intent intent = new IntentTop(mActivity, LoadPronounciationActivity.class);
             intent.putExtra(LoadPronounciationActivity.EXTRA_SOURCE, source);
             mActivity.startActivityForResultWithoutAnimation(intent, REQUEST_CODE_PRONOUNCIATION);
         });
@@ -368,7 +369,7 @@ public class BasicTextFieldController extends FieldControllerBase implements IFi
     private void startTranslationWithGlosbe() {
         String source = mEditText.getText().toString();
 
-        Intent intent = new Intent(mActivity, TranslationActivity.class);
+        Intent intent = new IntentTop(mActivity, TranslationActivity.class);
         intent.putExtra(TranslationActivity.EXTRA_SOURCE, source);
         mActivity.startActivityForResultWithoutAnimation(intent, REQUEST_CODE_TRANSLATE_GLOSBE);
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/NotificationService.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/NotificationService.java
@@ -28,6 +28,7 @@ import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.DeckPicker;
 import com.ichi2.anki.NotificationChannels;
 import com.ichi2.anki.R;
+import com.ichi2.utils.IntentTopNewTask;
 import com.ichi2.widget.WidgetStatus;
 
 import timber.log.Timber;
@@ -68,8 +69,8 @@ public class NotificationService extends BroadcastReceiver {
                 builder.setLights(Color.BLUE, 1000, 1000);
             }
             // Creates an explicit intent for an Activity in your app
-            Intent resultIntent = new Intent(context, DeckPicker.class);
-            resultIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
+            Intent resultIntent = new IntentTopNewTask(context, DeckPicker.class);
+            resultIntent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK);
             PendingIntent resultPendingIntent = PendingIntent.getActivity(context, 0, resultIntent,
                     PendingIntent.FLAG_UPDATE_CURRENT);
             builder.setContentIntent(resultPendingIntent);

--- a/AnkiDroid/src/main/java/com/ichi2/utils/IntentTop.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/IntentTop.java
@@ -1,0 +1,37 @@
+package com.ichi2.utils;
+
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+
+public class IntentTop extends Intent {
+    public IntentTop() {
+        super();
+        defaultFlags();
+    }
+    public IntentTop(Intent o) {
+        super(o);
+        defaultFlags();
+    }
+    public IntentTop(String action) {
+        super(action);
+        defaultFlags();
+    }
+    public IntentTop(String action, Uri uri) {
+        super(action, uri);
+        defaultFlags();
+    }
+    public IntentTop(Context packageContext, Class<?> cls) {
+        super(packageContext, cls);
+        defaultFlags();
+    }
+    public IntentTop(String action, Uri uri, Context packageContext, Class<?> cls) {
+        super(action, uri, packageContext, cls);
+        defaultFlags();
+    }
+
+    protected void defaultFlags() {
+        addFlags(FLAG_ACTIVITY_SINGLE_TOP);
+        addFlags(FLAG_ACTIVITY_CLEAR_TOP);
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/utils/IntentTopNewTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/IntentTopNewTask.java
@@ -1,0 +1,38 @@
+package com.ichi2.utils;
+
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+
+public class IntentTopNewTask extends IntentTop {
+    public IntentTopNewTask() {
+        super();
+        defaultFlags();
+    }
+    public IntentTopNewTask(Intent o) {
+        super(o);
+        defaultFlags();
+    }
+    public IntentTopNewTask(String action) {
+        super(action);
+        defaultFlags();
+    }
+    public IntentTopNewTask(String action, Uri uri) {
+        super(action, uri);
+        defaultFlags();
+    }
+    public IntentTopNewTask(Context packageContext, Class<?> cls) {
+        super(packageContext, cls);
+        defaultFlags();
+    }
+    public IntentTopNewTask(String action, Uri uri, Context packageContext, Class<?> cls) {
+        super(action, uri, packageContext, cls);
+        defaultFlags();
+    }
+
+
+    protected void defaultFlags() {
+        super.defaultFlags();
+        addFlags(FLAG_ACTIVITY_NEW_TASK);
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/widget/AddNoteWidget.java
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/AddNoteWidget.java
@@ -24,6 +24,7 @@ import android.widget.RemoteViews;
 import com.ichi2.anki.NoteEditor;
 import com.ichi2.anki.R;
 import com.ichi2.anki.analytics.UsageAnalytics;
+import com.ichi2.utils.IntentTop;
 
 import timber.log.Timber;
 
@@ -50,7 +51,7 @@ public class AddNoteWidget extends AppWidgetProvider {
         Timber.d("onUpdate");
 
         final RemoteViews remoteViews = new RemoteViews(context.getPackageName(), R.layout.widget_add_note);
-        final Intent intent = new Intent(context, NoteEditor.class);
+        final Intent intent = new IntentTop(context, NoteEditor.class);
 
         intent.putExtra(NoteEditor.EXTRA_CALLER, NoteEditor.CALLER_DECKPICKER);
 


### PR DESCRIPTION
## Fixes
If you click twice clickly on a button which opens an activity, this activity will be opened twice. This is the case for example when clicking on a deck name to review it. When clicking on edit from the editor. When clicking on «add note» from the deck browser window. When clicking on «card browser» on the side menu...

This is a problem in particular when you edit notes, because when you ends editing the note, the activity close, and you'll see the previous activity, which is also card edition, with the data of the previous version of the note. If you simply cancel, nothing is saved, and the actual new version of the note is kept, but it's not clear at all to any normal user.

In other cases, it's not a huge problem, it's just slightly confusing to see again card to review when you clicked «back» in the reviewer. 

I should note that fixing the problem of registering two clicks instead of one should still be fixed; e.g. when you click twice on "undo" you may query "undo" twice, even if there is a single thing to undo. So that's only a partial solution to the real problem that I do in this PR.

## Approach
Intents use FLAG_ACTIVITY_SINGLE_TOP and FLAG_ACTIVITY_CLEAR_TOP to ensure that a single activity is used when we don't want two activities. I don't add those flags when either: 
* it calls an activity from outside of ankidroid (I believe that if we want to add a media, the media app will deal itself with the fact that it's opened twice)
* we actually want twice the same activity (the only example I have being in «Edit note» when we want to copy the current note. This open the same activity with a new note; and then we want to come back to the edited note.

More precisely, I created a class inheriting Intent, having those flags by default. This allows to avoid doing a copy paste where we add them in 16 files.

## How Has This Been Tested?

Installing ankidroid on my phone, and testing many of the features mentioned above. Trying to click twice clickly, and seeing I don't have the same bug as before.

## Learning (optional, can help others)
_Links to blog posts, patterns, libraries or addons used to solve this problem_
https://stackoverflow.com/a/44433420/414269

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
