### PR TITLE
Adding missing line

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -866,33 +866,32 @@ public class Decks {
 
         for (JSONObject deck: decks) {
             // two decks with the same name?
-            String deckName = null;
-            try {
-                deckName = deck.getString("name");
+             try {
+                if (names.contains(deck.getString("name"))) {
+                    Timber.i("fix duplicate deck name %s", deck.getString("name"));
+                    deck.put("name", deck.getString("name") + Utils.intTime(1000));
+                    save(deck);
+                }
+
+                // ensure no sections are blank
+                if (deck.getString("name").indexOf("::::") != -1) {
+                    Timber.i("fix deck with missing sections %s", deck.getString("name"));
+                    deck.put("name", "recovered"+Utils.intTime(1000));
+                    save(deck);
+                }
+
+                // immediate parent must exist
+                String immediateParent = parent(deck.getString("name"));
+                if (immediateParent != null) {
+                    if (!names.contains(immediateParent)) {
+                        Timber.i("fix deck with missing parent %s", deck.getString("name"));
+                        _ensureParents(deck.getString("name"));
+                        names.add(immediateParent);
+                    }
+                }
+            names.add(deck.getString("name"));
             } catch (JSONException e) {
                 throw new RuntimeException(e);
-            }
-            if (names.contains(deckName)) {
-                Timber.i("fix duplicate deck name %s", deckName);
-                deckName += Utils.intTime(1000);
-                save(deck);
-            }
-
-            // ensure no sections are blank
-            if (deckName.indexOf("::::") != -1) {
-                Timber.i("fix deck with missing sections %s", deckName);
-                deckName = "recovered"+Utils.intTime(1000);
-                save(deck);
-            }
-
-            // immediate parent must exist
-            String immediateParent = parent(deckName);
-            if (immediateParent != null) {
-                if (!names.contains(immediateParent)) {
-                    Timber.i("fix deck with missing parent %s", deckName);
-                    _ensureParents(deckName);
-                    names.add(immediateParent);
-                }
             }
         }
     }


### PR DESCRIPTION
It seems when I ported the method from anki to ankidroid, I forgot:
1. to add the name of the deck in the set of name of decks.
Here it is. It'll remove timbers.

2. to save the new names in the deck objects once they were computed.

I should note that this did not create any problem. Indeed, it only
meant that:
* duplicates were not found (unless the first duplicate is a parent of
  another deck). This is not really a problem, they should not exists
  in the first place, and can always be corrected later.
* some decks were seen as missing, but then anki would try to add
  them, and then _ensureParents would find all parents and actually do
  no work.


## How Has This Been Tested?

I'm using this version of master (to try to understand another problem actually). So I'm seeing whether it works by checking that there is less timber messages now

## Learning (optional, can help others)
I should really stick as close as possible to anki code. I'm really prone of making silly mistake otherwise

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
