### PR TITLE
Dealing with ":::" in deck name

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -1131,17 +1131,19 @@ public class Decks {
     * ***********************************************************
     */
 
-	public static String parent(String deckName) {
-		// method parent, from sched's method deckDueList in python
-		int index = deckName.lastIndexOf("::");
-		if (index == -1) {
-			return null;
-		}
-		return deckName.substring(0, index);
-	}
+    public static String parent(String deckName) {
+        // method parent, from sched's method deckDueList in python
+        List<String> parts = Arrays.asList(deckName.split("::", -1));
+        if (parts.size() < 2) {
+            return null;
+        } else {
+            parts = parts.subList(0, parts.size() - 1);
+            return TextUtils.join("::", parts);
+        }
+    }
 
     public String getActualDescription() {
-    	return current().optString("desc","");
+        return current().optString("desc","");
     }
 
 


### PR DESCRIPTION
## Purpose / Description
The method `parent` as I implemented it, does not deal with names
having ":::" in them. "::::" is impossible, but ":::" is totally
okay. So now it deals with it.

Anki believe that in this case, the first two colons are the
separators, the last one is part of the deck name.

## Fixes
#5603

## How Has This Been Tested?

Trying to reproduce the above-mentionned bug, and failing the reproduction.

## Learning (optional, can help others)
_Describe the research stage_
I did read the three commits during which the problems did appear, and which were listed by timrae

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
