### PR TITLE
allow the following characters for field, note type, and deck names: ' " [ ] ( and )

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.java
@@ -493,7 +493,8 @@ public class ModelBrowser extends AnkiActivity {
                                 .onPositive((dialog, which) -> {
                                         JSONObject model = mModels.get(mModelListPosition);
                                         String deckName = mModelNameInput.getText().toString()
-                                                .replaceAll("[\'\"\\n\\r\\[\\]\\(\\)]", "");
+                                                // Anki desktop doesn't allow double quote characters in deck names
+                                                .replaceAll("[\"\\n\\r]", "");
                                         getCol().getDecks().id(deckName, false);
                                         if (deckName.length() > 0) {
                                             try {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.java
@@ -179,7 +179,7 @@ public class ModelFieldEditor extends AnkiActivity {
                 .customView(mFieldNameInput, true)
                 .onPositive((dialog, which) -> {
                     String fieldName = mFieldNameInput.getText().toString()
-                            .replaceAll("[\'\"\\n\\r\\[\\]\\(\\)]", "");
+                            .replaceAll("[\\n\\r]", "");
 
                     if (fieldName.length() == 0) {
                         showToast(getResources().getString(R.string.toast_empty_name));
@@ -199,7 +199,7 @@ public class ModelFieldEditor extends AnkiActivity {
                             Runnable confirm = () -> {
                                 mCol.modSchemaNoCheck();
                                 String fieldName1 = mFieldNameInput.getText().toString()
-                                        .replaceAll("[\'\"\\n\\r\\[\\]\\(\\)]", "");
+                                        .replaceAll("[\\n\\r]", "");
                                 DeckTask.launchDeckTask(DeckTask.TASK_TYPE_ADD_FIELD, mChangeFieldHandler,
                                         new DeckTask.TaskData(new Object[]{mMod, fieldName1}));
                                 dismissContextMenu();
@@ -280,7 +280,7 @@ public class ModelFieldEditor extends AnkiActivity {
                 .onPositive((dialog, which) -> {
 
                         String fieldLabel = mFieldNameInput.getText().toString()
-                                .replaceAll("[\'\"\\n\\r\\[\\]\\(\\)]", "");
+                                .replaceAll("[\\n\\r]", "");
                         if (fieldLabel.length() == 0) {
                             showToast(getResources().getString(R.string.toast_empty_name));
                         } else if (containsField(fieldLabel)) {
@@ -406,7 +406,7 @@ public class ModelFieldEditor extends AnkiActivity {
     private void renameField() throws ConfirmModSchemaException {
         try {
             String fieldLabel = mFieldNameInput.getText().toString()
-                    .replaceAll("[\'\"\\n\\r\\[\\]\\(\\)]", "");
+                    .replaceAll("[\\n\\r]", "");
             JSONObject field = (JSONObject) mNoteFields.get(mCurrentPos);
             mCol.getModels().renameField(mMod, field, fieldLabel);
             mCol.getModels().save();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.java
@@ -166,8 +166,7 @@ public class ModelFieldEditor extends AnkiActivity {
 
 
     /*
-    * Creates a dialog to rename the currently selected field, short loading ti
-    * Processing time scales with number of items
+    * Creates a dialog to create a field
     */
     private void addFieldDialog() {
         mFieldNameInput = new EditText(this);
@@ -219,8 +218,7 @@ public class ModelFieldEditor extends AnkiActivity {
 
 
     /*
-     * Creates a dialog to rename the currently selected field, short loading ti
-     * Processing time scales with number of items
+     * Creates a dialog to delete the currently selected field
      */
     private void deleteFieldDialog() {
         Runnable confirm = () -> {
@@ -265,7 +263,7 @@ public class ModelFieldEditor extends AnkiActivity {
 
 
     /*
-     * Creates a dialog to rename the currently selected field, short loading ti
+     * Creates a dialog to rename the currently selected field
      * Processing time is constant
      */
     private void renameFieldDialog() {


### PR DESCRIPTION


## Pull Request template

## Purpose / Description
Anki desktop allows for the following characters in the names of fields and note types:
' " [ ] ( )
The following characters are allowed for decks:
' [ ] ( )

Ankidroid current strips these characters when creating or renaming fields, note types, and decks. This is somewhat annoying when renaming one of these items: even the "Basic (and reversed card)" note type becomes: "Basic and reversed card" with the parenthesis removed.

## Fixes
#5352 


## Approach
changes the regex used for replacement of characters in the field names, note type names, and deck names. This goes further than #5460 does.


## How Has This Been Tested?
tested on device: Android 5.0.1 LG L33L.

I looked at what characters are currently replaced by the regex and I tested to see which are valid characters as of Anki desktop version 2.1.15.

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
I messed this part up
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
