### PR TITLE
Enable toggle sticky feature on fields in field editor

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.java
@@ -441,6 +441,24 @@ public class ModelFieldEditor extends AnkiActivity {
         }
     }
 
+    /*
+     * Toggle the "Remember last input" setting AKA the "Sticky" setting
+     */
+    private void toggleStickyField() {
+        try {
+            // Get the current field
+            JSONObject field = (JSONObject) mNoteFields.get(mCurrentPos);
+            // If the sticky setting is enabled then disable it, otherwise enable it
+            if (field.getBoolean("sticky")){
+                field.put("sticky", false);
+            } else {
+                field.put("sticky", true);
+            }
+        } catch (JSONException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
 
     /*
      * Reloads everything
@@ -552,6 +570,9 @@ public class ModelFieldEditor extends AnkiActivity {
                 break;
             case ModelEditorContextMenu.FIELD_RENAME:
                 renameFieldDialog();
+                break;
+            case ModelEditorContextMenu.FIELD_TOGGLE_STICKY:
+                toggleStickyField();
                 break;
         }
     };

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.java
@@ -445,17 +445,13 @@ public class ModelFieldEditor extends AnkiActivity {
      * Toggle the "Remember last input" setting AKA the "Sticky" setting
      */
     private void toggleStickyField() {
-        try {
-            // Get the current field
-            JSONObject field = (JSONObject) mNoteFields.get(mCurrentPos);
-            // If the sticky setting is enabled then disable it, otherwise enable it
-            if (field.getBoolean("sticky")){
-                field.put("sticky", false);
-            } else {
-                field.put("sticky", true);
-            }
-        } catch (JSONException e) {
-            throw new RuntimeException(e);
+        // Get the current field
+        JSONObject field = (JSONObject) mNoteFields.get(mCurrentPos);
+        // If the sticky setting is enabled then disable it, otherwise enable it
+        if (field.getBoolean("sticky")) {
+            field.put("sticky", false);
+        } else {
+            field.put("sticky", true);
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ModelEditorContextMenu.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ModelEditorContextMenu.java
@@ -13,6 +13,7 @@ public class ModelEditorContextMenu extends AnalyticsDialogFragment {
     public final static int SORT_FIELD = 1;
     public final static int FIELD_RENAME = 2;
     public final static int FIELD_DELETE = 3;
+    public final static int FIELD_TOGGLE_STICKY = 4;
 
 
     private static MaterialDialog.ListCallback mContextMenuListener;
@@ -31,11 +32,12 @@ public class ModelEditorContextMenu extends AnalyticsDialogFragment {
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        String[] entries = new String[4];
+        String[] entries = new String[5];
         entries[FIELD_REPOSITION] = getResources().getString(R.string.model_field_editor_reposition_menu);
         entries[SORT_FIELD] = getResources().getString(R.string.model_field_editor_sort_field);
         entries[FIELD_RENAME] = getResources().getString(R.string.model_field_editor_rename);
         entries[FIELD_DELETE] = getResources().getString(R.string.model_field_editor_delete);
+        entries[FIELD_TOGGLE_STICKY] = getResources().getString(R.string.model_field_editor_toggle_sticky);
 
         return new MaterialDialog.Builder(getActivity())
                 .title(getArguments().getString("label"))

--- a/AnkiDroid/src/main/res/values/17-model-manager.xml
+++ b/AnkiDroid/src/main/res/values/17-model-manager.xml
@@ -51,6 +51,7 @@
     <string name="model_field_editor_rename">Rename field</string>
     <string name="model_field_editor_reposition_menu">Reposition field</string>
     <string name="model_field_editor_reposition">Reposition field (enter a value %1$d–%2$d)</string>
+    <string name="model_field_editor_toggle_sticky">Remember last input when adding</string>
     <string name="model_field_editor_changing">Updating fields</string>
     <string name="model_field_editor_sort_field">Sort by this field</string>
     <string name="model_clone_suffix">copy</string>


### PR DESCRIPTION
## Purpose / Description
Allows user to enable/disable the "Remember last input" setting of an Anki field. This is known as the "sticky" value in the Anki database structure. This PR adds a button on the "Edit Fields" screen, though there is no visual indication of the current value of the setting. 

## Fixes
Fixes #5353 

## Approach
When the context menu item is tapped, it checks the current boolean value and changes it to the other. Possible enhancements for this PR:
1. A visual indicator (checkbox? other icon?) could be used to indicate the current value of "sticky"
2. Call toggleStickyField() from the "paperclip menu" that is to the right of a field when adding a field (similar to the "Frozen Fields" add-on on desktop Anki

## How Has This Been Tested?
On device: LG L33L Android 5.0.1

## Learning (optional, can help others)
1. [Anki Database Structure](https://github.com/ankidroid/Anki-Android/wiki/Database-Structure)
2. [setting JSON values in java](https://www.tutorialspoint.com/json/json_java_example.htm)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
