### PR TITLE
Abstract sched

### DIFF
--- a/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/ContentProviderTest.java
+++ b/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/ContentProviderTest.java
@@ -40,6 +40,7 @@ import com.ichi2.libanki.Decks;
 import com.ichi2.libanki.Models;
 import com.ichi2.libanki.Note;
 import com.ichi2.libanki.Sched;
+import com.ichi2.libanki.AbstractSched;
 import com.ichi2.libanki.Utils;
 
 import org.json.JSONArray;
@@ -705,7 +706,7 @@ public class ContentProviderTest {
     public void testQueryNextCard(){
         Collection col;
         col = CollectionHelper.getInstance().getCol(InstrumentationRegistry.getInstrumentation().getTargetContext());
-        Sched sched = col.getSched();
+        AbstractSched sched = col.getSched();
 
         Cursor reviewInfoCursor = InstrumentationRegistry.getInstrumentation().getTargetContext().getContentResolver().query(
                 FlashCardsContract.ReviewInfo.CONTENT_URI, null, null, null, null);
@@ -739,7 +740,7 @@ public class ContentProviderTest {
         String deckArguments[] = {Long.toString(deckToTest)};
         Collection col;
         col = CollectionHelper.getInstance().getCol(InstrumentationRegistry.getInstrumentation().getTargetContext());
-        Sched sched = col.getSched();
+        AbstractSched sched = col.getSched();
         long selectedDeckBeforeTest = col.getDecks().selected();
         col.getDecks().select(1); //select Default deck
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -79,6 +79,7 @@ import com.ichi2.anki.receiver.SdCardReceiver;
 import com.ichi2.anki.reviewer.ReviewerExtRegistry;
 import com.ichi2.async.DeckTask;
 import com.ichi2.compat.CompatHelper;
+import com.ichi2.libanki.AbstractSched;
 import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Consts;
@@ -311,7 +312,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
 
     private int mFadeDuration = 300;
 
-    protected Sched mSched;
+    protected AbstractSched mSched;
 
     private ReviewerExtRegistry mExtensions;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
@@ -42,6 +42,7 @@ import com.ichi2.anki.FlashCardsContract;
 import com.ichi2.anki.FlashCardsContract.CardTemplate;
 import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.compat.CompatHelper;
+import com.ichi2.libanki.AbstractSched;
 import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.DB;
@@ -1163,7 +1164,7 @@ public class CardContentProvider extends ContentProvider {
         }
     }
 
-    private void answerCard(Collection col, Sched sched, Card cardToAnswer, int ease, long timeTaken) {
+    private void answerCard(Collection col, AbstractSched sched, Card cardToAnswer, int ease, long timeTaken) {
         try {
             DB db = col.getDb();
             db.getDatabase().beginTransaction();
@@ -1186,7 +1187,7 @@ public class CardContentProvider extends ContentProvider {
     }
 
 
-    private void buryOrSuspendCard(Collection col, Sched sched, Card card, boolean bury) {
+    private void buryOrSuspendCard(Collection col, AbstractSched sched, Card card, boolean bury) {
         try {
             DB db = col.getDb();
             db.getDatabase().beginTransaction();

--- a/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
@@ -31,6 +31,7 @@ import com.ichi2.anki.CollectionHelper;
 import com.ichi2.anki.R;
 import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.anki.exception.ImportExportException;
+import com.ichi2.libanki.AbstractSched;
 import com.ichi2.libanki.AnkiPackageExporter;
 import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
@@ -410,7 +411,7 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
         Timber.d("doInBackgroundUpdateNote");
         // Save the note
         Collection col = CollectionHelper.getInstance().getCol(mContext);
-        Sched sched = col.getSched();
+        AbstractSched sched = col.getSched();
         Card editCard = params[0].getCard();
         Note editNote = editCard.note();
         boolean fromReviewer = params[0].getBoolean();
@@ -483,7 +484,7 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
 
     private TaskData doInBackgroundAnswerCard(TaskData... params) {
         Collection col = CollectionHelper.getInstance().getCol(mContext);
-        Sched sched = col.getSched();
+        AbstractSched sched = col.getSched();
         Card oldCard = params[0].getCard();
         int ease = params[0].getInt();
         Card newCard = null;
@@ -515,7 +516,7 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
     }
 
 
-    private Card getCard(Sched sched) {
+    private Card getCard(AbstractSched sched) {
         if (sHadCardQueue) {
             sched.reset();
             sHadCardQueue = false;
@@ -554,7 +555,7 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
 
     private TaskData doInBackgroundDismissNote(TaskData... params) {
         Collection col = CollectionHelper.getInstance().getCol(mContext);
-        Sched sched = col.getSched();
+        AbstractSched sched = col.getSched();
         Object[] data = params[0].getObjArray();
         Card card = (Card) data[0];
         Collection.DismissType type = (Collection.DismissType) data[1];
@@ -625,7 +626,7 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
 
     private TaskData doInBackgroundDismissNotes(TaskData... params) {
         Collection col = CollectionHelper.getInstance().getCol(mContext);
-        Sched sched = col.getSched();
+        AbstractSched sched = col.getSched();
         Object[] data = params[0].getObjArray();
         long[] cardIds = (long[]) data[0];
         // query cards
@@ -813,7 +814,7 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
 
     private TaskData doInBackgroundUndo(TaskData... params) {
         Collection col = CollectionHelper.getInstance().getCol(mContext);
-        Sched sched = col.getSched();
+        AbstractSched sched = col.getSched();
         try {
             col.getDb().getDatabase().beginTransaction();
             Card newCard = null;
@@ -931,7 +932,7 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
         Timber.d("doInBackgroundUpdateValuesFromDeck");
         try {
             Collection col = CollectionHelper.getInstance().getCol(mContext);
-            Sched sched = col.getSched();
+            AbstractSched sched = col.getSched();
             Object[] obj = params[0].getObjArray();
             boolean reset = (Boolean) obj[0];
             if (reset) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/AbstractSched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/AbstractSched.java
@@ -3,7 +3,6 @@ package com.ichi2.libanki;
 import android.app.Activity;
 import android.content.Context;
 
-import com.ichi2.libanki.Card;
 
 import org.json.JSONObject;
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/AbstractSched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/AbstractSched.java
@@ -1,0 +1,149 @@
+package com.ichi2.libanki;
+
+import android.app.Activity;
+import android.content.Context;
+
+import com.ichi2.libanki.Card;
+
+import org.json.JSONObject;
+
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+
+public abstract class AbstractSched {
+    public abstract Card getCard();
+    public abstract void reset();
+    public abstract void answerCard(Card card, int ease);
+    public abstract int[] counts();
+    public abstract int[] counts(Card card);
+    public abstract int dueForecast();
+    public abstract int dueForecast(int days);
+    public abstract int countIdx(Card card);
+    public abstract int answerButtons(Card card);
+    public abstract void unburyCards();
+    public abstract void unburyCardsForDeck();
+    public abstract void _updateStats(Card card, String type, long cnt);
+    public abstract void extendLimits(int newc, int rev);
+    public abstract List<DeckDueTreeNode> deckDueList();
+    public abstract List<DeckDueTreeNode> deckDueTree();
+    public abstract int _newForDeck(long did, int lim);
+    public abstract int _deckNewLimitSingle(JSONObject g);
+    public abstract int totalNewForCurrentDeck();
+    public abstract int totalRevForCurrentDeck();
+    public abstract int[] _fuzzedIvlRange(int ivl);
+    public abstract void rebuildDyn();
+    public abstract List<Long> rebuildDyn(long did);
+    public abstract void emptyDyn(long did);
+    public abstract void emptyDyn(long did, String lim);
+    public abstract void remFromDyn(long[] cids);
+    public abstract JSONObject _cardConf(Card card);
+    public abstract String _deckLimit();
+    public abstract void _checkDay();
+    public abstract CharSequence finishedMsg(Context context);
+    public abstract String _nextDueMsg(Context context);
+    public abstract boolean revDue();
+    public abstract boolean newDue();
+    public abstract boolean haveBuried();
+    public abstract String nextIvlStr(Context context, Card card, int ease);
+    public abstract long nextIvl(Card card, int ease);
+    public abstract void suspendCards(long[] ids);
+    public abstract void unsuspendCards(long[] ids);
+    public abstract void buryCards(long[] cids);
+    public abstract void buryNote(long nid);
+    public abstract void forgetCards(long[] ids);
+    public abstract void reschedCards(long[] ids, int imin, int imax);
+    public abstract void resetCards(Long[] ids);
+    public abstract void sortCards(long[] cids, int start);
+    public abstract void sortCards(long[] cids, int start, int step, boolean shuffle, boolean shift);
+    public abstract void randomizeCards(long did);
+    public abstract void orderCards(long did);
+    public abstract void resortConf(JSONObject conf);
+    public abstract void maybeRandomizeDeck();
+    public abstract void maybeRandomizeDeck(Long did);
+    public abstract boolean haveBuried(long did);
+    public abstract void unburyCardsForDeck(long did);
+    public abstract String getName();
+    public abstract int getToday();
+    public abstract void setToday(int today);
+    public abstract long getDayCutoff();
+    public abstract int getReps();
+    public abstract void setReps(int reps);
+    public abstract int cardCount();
+    public abstract int eta(int[] counts);
+    public abstract int eta(int[] counts, boolean reload);
+    public abstract void decrementCounts(Card card);
+    public abstract boolean leechActionSuspend(Card card);
+    public abstract void setContext(WeakReference<Activity> contextReference);
+
+
+    /**
+     * Holds the data for a single node (row) in the deck due tree (the user-visible list
+     * of decks and their counts). A node also contains a list of nodes that refer to the
+     * next level of sub-decks for that particular deck (which can be an empty list).
+     *
+     * The names field is an array of names that build a deck name from a hierarchy (i.e., a nested
+     * deck will have an entry for every level of nesting). While the python version interchanges
+     * between a string and a list of strings throughout processing, we always use an array for
+     * this field and use names[0] for those cases.
+     */
+    public class DeckDueTreeNode implements Comparable {
+        public String[] names;
+        public long did;
+        public int depth;
+        public int revCount;
+        public int lrnCount;
+        public int newCount;
+        public List<DeckDueTreeNode> children = new ArrayList<>();
+
+        public DeckDueTreeNode(String[] names, long did, int revCount, int lrnCount, int newCount) {
+            this.names = names;
+            this.did = did;
+            this.revCount = revCount;
+            this.lrnCount = lrnCount;
+            this.newCount = newCount;
+        }
+
+        public DeckDueTreeNode(String name, long did, int revCount, int lrnCount, int newCount) {
+            this(new String[]{name}, did, revCount, lrnCount, newCount);
+        }
+
+        public DeckDueTreeNode(String name, long did, int revCount, int lrnCount, int newCount,
+                               List<DeckDueTreeNode> children) {
+            this(new String[]{name}, did, revCount, lrnCount, newCount);
+            this.children = children;
+        }
+
+        /**
+         * Sort on the head of the node.
+         */
+        @Override
+        public int compareTo(Object other) {
+            DeckDueTreeNode rhs = (DeckDueTreeNode) other;
+            // Consider each subdeck name in the ordering
+            for (int i = 0; i < names.length && i < rhs.names.length; i++) {
+                int cmp = names[i].compareTo(rhs.names[i]);
+                if (cmp == 0) {
+                    continue;
+                }
+                return cmp;
+            }
+            // If we made it this far then the arrays are of different length. The longer one should
+            // always come after since it contains all of the sections of the shorter one inside it
+            // (i.e., the short one is an ancestor of the longer one).
+            if (rhs.names.length > names.length) {
+                return -1;
+            } else {
+                return 1;
+            }
+        }
+
+        @Override
+        public String toString() {
+            return String.format(Locale.US, "%s, %d, %d, %d, %d, %d, %s",
+                    Arrays.toString(names), did, depth, revCount, lrnCount, newCount, children);
+        }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -80,7 +80,7 @@ public class Collection {
     private Models mModels;
     private Tags mTags;
 
-    private Sched mSched;
+    private AbstractSched mSched;
 
     private double mStartTime;
     private int mStartReps;
@@ -1958,7 +1958,7 @@ public class Collection {
     }
 
 
-    public Sched getSched() {
+    public AbstractSched getSched() {
         return mSched;
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sched.java
@@ -55,7 +55,7 @@ import timber.log.Timber;
 @SuppressWarnings({"PMD.ExcessiveClassLength", "PMD.AvoidThrowingRawExceptionTypes","PMD.AvoidReassigningParameters",
                     "PMD.NPathComplexity","PMD.MethodNamingConventions","PMD.AvoidBranchingStatementAsLastInLoop",
                     "PMD.SwitchStmtsShouldHaveDefault","PMD.CollapsibleIfStatements","PMD.EmptyIfStmt"})
-public class Sched {
+public class Sched extends AbstractSched {
 
 
 
@@ -95,14 +95,6 @@ public class Sched {
 
     // Not in libanki
     private WeakReference<Activity> mContextReference;
-
-
-    /**
-     * This is a do-nothing constructor for descendants (ScedV2) to use.
-     */
-    public Sched() {
-
-    }
 
     /**
      * queue types: 0=new/cram, 1=lrn, 2=rev, 3=day lrn, -1=suspended, -2=buried
@@ -2481,74 +2473,5 @@ public class Sched {
 
     public void setContext(WeakReference<Activity> contextReference) {
         mContextReference = contextReference;
-    }
-
-
-    /**
-     * Holds the data for a single node (row) in the deck due tree (the user-visible list
-     * of decks and their counts). A node also contains a list of nodes that refer to the
-     * next level of sub-decks for that particular deck (which can be an empty list).
-     *
-     * The names field is an array of names that build a deck name from a hierarchy (i.e., a nested
-     * deck will have an entry for every level of nesting). While the python version interchanges
-     * between a string and a list of strings throughout processing, we always use an array for
-     * this field and use names[0] for those cases.
-     */
-    public class DeckDueTreeNode implements Comparable {
-        public String[] names;
-        public long did;
-        public int depth;
-        public int revCount;
-        public int lrnCount;
-        public int newCount;
-        public List<DeckDueTreeNode> children = new ArrayList<>();
-
-        public DeckDueTreeNode(String[] names, long did, int revCount, int lrnCount, int newCount) {
-            this.names = names;
-            this.did = did;
-            this.revCount = revCount;
-            this.lrnCount = lrnCount;
-            this.newCount = newCount;
-        }
-
-        public DeckDueTreeNode(String name, long did, int revCount, int lrnCount, int newCount) {
-            this(new String[]{name}, did, revCount, lrnCount, newCount);
-        }
-
-        public DeckDueTreeNode(String name, long did, int revCount, int lrnCount, int newCount,
-                               List<DeckDueTreeNode> children) {
-            this(new String[]{name}, did, revCount, lrnCount, newCount);
-            this.children = children;
-        }
-
-        /**
-         * Sort on the head of the node.
-         */
-        @Override
-        public int compareTo(Object other) {
-            DeckDueTreeNode rhs = (DeckDueTreeNode) other;
-            // Consider each subdeck name in the ordering
-            for (int i = 0; i < names.length && i < rhs.names.length; i++) {
-                int cmp = names[i].compareTo(rhs.names[i]);
-                if (cmp == 0) {
-                    continue;
-                }
-                return cmp;
-            }
-            // If we made it this far then the arrays are of different length. The longer one should
-            // always come after since it contains all of the sections of the shorter one inside it
-            // (i.e., the short one is an ancestor of the longer one).
-            if (rhs.names.length > names.length) {
-                return -1;
-            } else {
-                return 1;
-            }
-        }
-
-        @Override
-        public String toString() {
-            return String.format(Locale.US, "%s, %d, %d, %d, %d, %d, %s",
-                    Arrays.toString(names), did, depth, revCount, lrnCount, newCount, children);
-        }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sched.java
@@ -1143,7 +1143,7 @@ public class Sched {
     }
 
 
-    public void removeLrn() {
+    private void removeLrn() {
     	removeLrn(null);
     }
 
@@ -1207,7 +1207,7 @@ public class Sched {
     }
 
 
-    public int _revForDeck(long did, int lim) {
+    private int _revForDeck(long did, int lim) {
     	lim = Math.min(lim, mReportLimit);
     	return mCol.getDb().queryScalar("SELECT count() FROM (SELECT 1 FROM cards WHERE did = " + did + " AND queue = 2 AND due <= " + mToday + " LIMIT " + lim + ")");
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/SchedV2.java
@@ -65,7 +65,7 @@ public class SchedV2 extends AbstractSched {
     // Not in libanki
     private static final int[] FACTOR_ADDITION_VALUES = { -150, 0, 150 };
 
-    private String mName = "std";
+    private String mName = "std2";
     private boolean mHaveCustomStudy = true;
     private boolean mBurySiblingsOnAnswer = true;
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/SchedV2.java
@@ -1265,7 +1265,7 @@ public class SchedV2 extends Sched {
     }
 
 
-    public int _revForDeck(long did, int lim, HashMap<Long, HashMap> childMap) {
+    private int _revForDeck(long did, int lim, HashMap<Long, HashMap> childMap) {
         List<Long> dids = mCol.getDecks().childDids(did, childMap);
         dids.add(0, did);
         lim = Math.min(lim, mReportLimit);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/SchedV2.java
@@ -58,7 +58,7 @@ import timber.log.Timber;
 @SuppressWarnings({"PMD.ExcessiveClassLength", "PMD.AvoidThrowingRawExceptionTypes","PMD.AvoidReassigningParameters",
                     "PMD.NPathComplexity","PMD.MethodNamingConventions","PMD.AvoidBranchingStatementAsLastInLoop",
                     "PMD.SwitchStmtsShouldHaveDefault","PMD.CollapsibleIfStatements","PMD.EmptyIfStmt"})
-public class SchedV2 extends Sched {
+public class SchedV2 extends AbstractSched {
 
 
 


### PR DESCRIPTION
## Purpose / Description
The initial problem that I had was some automated test having unexpected result. Mostly because there is an empty constructor in Sched. And that actually, what it really meant is that SchedV2 should never have inherited from Sched. Indeed, it reuses absolutly no code and no variable from Sched, and it's not semantically a specific kind of Sched.

It also corrected the name of SchedV2, so that it's the same as in Anki. Which changes nothing as this name is never used here nor there.

## Approach
I simply created an abstract Sched class, from which both Sched and SchedV2 inherits. This abstract class declare as public abstract all public classes from Sched that are also in SchedV2. This way, we have in a proper java way what we already had in Python: no inheritance between both classes, but being able to use the same class name for both variables

I also did change to private some methods which were in one class and not the other, and which were never used outside of the Sched class. 

## How Has This Been Tested?
Started Ankidroid and checked that reviewing still happened correctly. 

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
