### PR TITLE
Re-enable CI emulator API15 via canary for that API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ env:
     - ANDROID_HOME=${HOME}/android-sdk
     - ANDROID_TOOLS_URL="https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip"
     - EMU_FLAVOR=default # use google_apis flavor if no default flavor emulator
+    - EMU_CHANNEL="" # use default / stable emulator channel normally
     - GRAVIS="https://raw.githubusercontent.com/DanySK/Gravis-CI/master/"
     - JDK="1.8"
     - TOOLS=${ANDROID_HOME}/tools
@@ -25,7 +26,7 @@ env:
     - UNIT_TEST=FALSE # by default we don't run the unit tests, they are run only in specific builds
     - FINALIZE_COVERAGE=FALSE # by default we don't finalize coverage, it is done in one specific build
   matrix:
-   #- API=15 # only runs locally. Create+Start once from AndroidStudio to init sdcard. Then only from command-line w/-engine classic
+   - API=15 ABI=x86 EMU_CHANNEL="--channel=4" # Canaries of API15 are working again, google fixed their issues
    - API=16 ABI=x86 AUDIO=-no-audio
    - API=17 ABI=x86
    #- API=18 ABI=x86 # frequently flaky: test run failed: 'Instrumentation run failed due to 'java.lang.SecurityException''
@@ -93,7 +94,7 @@ install:
   # That only happens currently on linux, so this section can assume linux + emulator is desired
   # Download required emulator tools
   - echo y | sdkmanager --no_https "platforms;android-$API" >/dev/null # We need the API of the emulator we will run
-  - echo y | sdkmanager --no_https "emulator" >/dev/null
+  - echo y | sdkmanager --no_https $EMU_CHANNEL "emulator" >/dev/null
   - echo y | sdkmanager --no_https "system-images;android-$API;$EMU_FLAVOR;$ABI" >/dev/null # install our emulator
 
   # Set up KVM on linux for hardware acceleration. Manually here so it only happens for emulator tests, takes ~30s
@@ -107,7 +108,12 @@ install:
     EMU_PARAMS="-verbose -no-snapshot -no-window -camera-back none -camera-front none -selinux permissive -qemu -m 2048"
     EMU_COMMAND="emulator"
     if [[ $ABI =~ "x86" ]]; then
-      EMU_COMMAND="emulator-headless"
+      if [ $API != "15" ]; then
+        # API15 is using the canary channel right now, and emulator-headless is command not found?
+        # this may break in the future when the current canaries are promoted but until now it works
+        # for all but API15 on the canary channel
+        EMU_COMMAND="emulator-headless"
+      fi
     fi
     # This double "sudo" monstrosity is used to have Travis execute the
     # emulator with its new group permissions and help preserve the rule


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

Our lowest supported API - API15 - has been a broken emulator for a long time. Since it's the end of our supported range it's important to verify it works.

But Google's emulator team has been on the job the last year. The improvements have been great.

They've just fixed the last issue I was tracking, and API15 works again in latest canaries
https://issuetracker.google.com/issues/37138030#comment17

## Approach

I add the ability to specify what emulator channel to pick up in Travis. Default to stable, but for API15 I use the canary to get this enabled.

## How Has This Been Tested?

Travis CI runs on my own fork https://travis-ci.com/mikehardy/Anki-Android/builds/135278687

Still works even with hardware acceleration though the command-line we are using to start the emulator seems to change with the canary, indicating a future emulator release might need a modification for the command line used everywhere.

## Learning (optional, can help others)

The emulator project inside google has been staffed up it seems and is receiving a great deal of focus. They are adding major features every quarter and resolving old bugs, consistently over a year. So keep an eye out for change in the area.

## Checklist


- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
