### PR TITLE
Fix card browser text scaling

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1722,7 +1722,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
             }
             // do nothing when pref is 100% and apply scaling only once
             if (mFontSizeScalePcent != 100 && Math.abs(mOriginalTextSize - currentSize) < 0.1) {
-                v.setTextSize(TypedValue.COMPLEX_UNIT_SP, mOriginalTextSize * (mFontSizeScalePcent / 100.0f));
+                // getTextSize returns value in absolute PX so use that in the setter
+                v.setTextSize(TypedValue.COMPLEX_UNIT_PX, mOriginalTextSize * (mFontSizeScalePcent / 100.0f));
             }
 
             if (mCustomTypeface != null) {


### PR DESCRIPTION
## Purpose / Description
Update setTextSize to use absolute pixels when scaling font size because that's what getTextSize returns the value as

## Fixes
Fixes #5544 

## How Has This Been Tested?

Verified on Android API 25 and 29 VMs

## Learning (optional, can help others)
Confirm in this StackOverflow
https://stackoverflow.com/questions/5032355/android-textview-settextsize-incorrectly-increases-text-size

## Checklist
_Please, go through these checks before submitting the PR._

- [ x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ x] You have commented your code, particularly in hard-to-understand areas
- [x ] You have performed a self-review of your own code
