### PR TITLE
Allow to search for cards with some flag

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
@@ -306,6 +306,8 @@ public class Finder {
                     s.add(_findTemplate(val));
                 } else if ("deck".equals(cmd)) {
                     s.add(_findDeck(val));
+                } else if ("flag".equals(cmd)) {
+                    s.add(_findFlag(val));
                 } else if ("mid".equals(cmd)) {
                     s.add(_findMid(val));
                 } else if ("nid".equals(cmd)) {
@@ -472,6 +474,30 @@ public class Finder {
         }
     }
 
+    private String _findFlag(String val) {
+        int flag;
+        switch (val) {
+        case "0":
+            flag = 0;
+            break;
+        case "1":
+            flag = 1;
+            break;
+        case "2":
+            flag = 2;
+            break;
+        case "3":
+            flag = 3;
+            break;
+        case "4":
+            flag = 4;
+            break;
+        default:
+            return null;
+        }
+        int mask = 0b111; // 2**3 -1 in Anki
+        return "(c.flags & "+mask+") == " + flag;
+    }
 
     private String _findRated(String val) {
         // days(:optional_ease)


### PR DESCRIPTION
## Purpose / Description
Anki allows to use flag to search cards, both in Browser and in Filtered deck.
This commit allows to do the same thing.

## Fixes
Fixes #5444

## Approach
Mostly as in Anki (so, sorry Mike, there is a little bit of binary computation).
With the exception that I had to deal with type conversion as in Java and not as in Python. So I decided to simply check whether the string is "0", "1", "2", "3", or "4" using a switch case. This avoid to try a conversion and deal with a potential exception. 


## How Has This Been Tested?

Creating a deck with a due card with flag 2 (on computer, as you still didn't merge my PR related to flags). Creating a filtered deck with search "flag:2". Emptying the deck. Synchronizing from computer onto ankidroid.  Seing that when I build the filtered deck on ankidroid, it find the above mentionned card and nothing else.


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
