### PR TITLE
Subtitle in DeckPicker indicates hours if more than 60 minutes

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1845,7 +1845,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
             }
             if (mPrefShowETA) {
                 int eta = mSched.eta(counts, false);
-                actionBar.setSubtitle(getResources().getQuantityString(R.plurals.reviewer_window_title, eta, eta));
+                actionBar.setSubtitle(Utils.remainingTime(AnkiDroidApp.getInstance(), eta * 60));
             }
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -2006,7 +2006,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
                     if (getCol().cardCount() != -1) {
                         String time = "-";
                         if (eta != -1) {
-                            time = res.getString(R.string.time_quantity_minutes, eta);
+                            time = Utils.timeQuantity(AnkiDroidApp.getInstance(), eta*60);
                         }
                         if (getSupportActionBar() != null) {
                             getSupportActionBar().setSubtitle(res.getQuantityString(R.plurals.deckpicker_title, due, due, time));

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
@@ -132,7 +132,8 @@ public class Utils {
      *
      * @param context The application's environment.
      * @param time_s The time to format, in seconds
-     * @return The time quantity string. Something like "3 s" or "1.7 yr".
+     * @return The time quantity string. Something like "3 s" or "1.7
+     * yr". Only months and year have a number after the decimal.
      */
     public static String timeQuantity(Context context, long time_s) {
         Resources res = context.getResources();

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
@@ -80,6 +80,9 @@ public class Utils {
 
     public static final int CHUNK_SIZE = 32768;
 
+    private static final long TIME_MINUTE_LONG = 60;  // seconds
+    private static final long TIME_HOUR_LONG = 60 * TIME_MINUTE_LONG;
+    private static final long TIME_DAY_LONG = 24 * TIME_HOUR_LONG;
     // These are doubles on purpose because we want a rounded, not integer result later.
     private static final double TIME_MINUTE = 60.0;  // seconds
     private static final double TIME_HOUR = 60 * TIME_MINUTE;
@@ -151,6 +154,37 @@ public class Utils {
             return res.getString(R.string.time_quantity_months, time_s/TIME_MONTH);
         } else {
             return res.getString(R.string.time_quantity_years, time_s/TIME_YEAR);
+        }
+    }
+
+    /**
+     * Return a string representing how much time remains
+     *
+     * @param context The application's environment.
+     * @param time_s The time to format, in seconds
+     * @return The time quantity string. Something like "3 minutes left" or "2 hours left".
+     */
+    public static String remainingTime(Context context, long time_s) {
+        int time_x;  // Time in unit x
+        int remaining_seconds; // Time not counted in the number in unit x
+        int remaining; // Time in the unit smaller than x
+        Resources res = context.getResources();
+        if (time_s < TIME_HOUR_LONG) {
+            time_x = (int) Math.round(time_s / TIME_MINUTE);
+            return res.getQuantityString(R.plurals.reviewer_window_title, time_x, time_x);
+            //It used to be minutes only. So the word "minutes" is not
+            //explicitly written in the ressource name.
+        } else if (time_s < TIME_DAY_LONG) {
+            time_x = (int) (time_s / TIME_HOUR_LONG);
+            remaining_seconds = (int) (time_s % TIME_HOUR_LONG);
+            remaining = (int) Math.round((float) remaining_seconds / TIME_MINUTE);
+            return res.getQuantityString(R.plurals.reviewer_window_title_hours, time_x, time_x, remaining);
+
+        } else {
+            time_x = (int) (time_s / TIME_DAY_LONG);
+            remaining_seconds = (int) ((float) time_s % TIME_DAY_LONG);
+            remaining = (int) Math.round(remaining_seconds / TIME_HOUR);
+            return res.getQuantityString(R.plurals.reviewer_window_title_days, time_x, time_x, remaining);
         }
     }
 

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -45,6 +45,14 @@
         <item quantity="one">%d minute left</item>
         <item quantity="other">%d minutes left</item>
     </plurals>
+    <plurals name="reviewer_window_title_hours">
+        <item quantity="one">%d hour %d left</item>
+        <item quantity="other">%d hours %d left</item>
+    </plurals>
+    <plurals name="reviewer_window_title_days">
+        <item quantity="one">%d day %d left</item>
+        <item quantity="other">%d days %d left</item>
+    </plurals>
 
     <!-- The deck picker via AnkiStatsTaskHandler.java -->
     <plurals name="studied_cards_today">


### PR DESCRIPTION
![2019-11-14-144759_539x825_scrot](https://user-images.githubusercontent.com/357361/68863107-ff187f00-06ee-11ea-9982-888dcb921c6d.png)
![2019-11-16-155812_540x864_scrot](https://user-images.githubusercontent.com/357361/68995082-1d66b200-088a-11ea-9bc2-2592cf953b5a.png)


## Purpose / Description
When I am late and have a lot of review to due, seeing 907 minutes is less clear than seeing 14 hours. So this PR simply simplifies the message to show hours (or days...) instead.
It does so in the deck picker and in the reviewer. In the deck picker, it can show up to (2 y), but I really hope for every one sanity that it will never occurs to anyone. It's implemented only because I used a function which already exists
In the reviewer, it will show potentially "868 days", instead of "2 years". Not because it's hard to implement, but because I really wish that this code would be useless in the entire future of ankidroid users. 

## Approach
Using the method Utils.timeQuantity instead of directly showing the number of minutes. And creating as similar method for the reviewer.

## How Has This Been Tested?

Create a collection with a lot of due cards. Open it. See that "hours" are shown instead of "minutes". Click on a deck with a lot of cards. See you see "2 hours" instead of "150 minutes".

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
