### PR TITLE
Fix "No notifications after update 2.9 and 2.9.1" (#5535)

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -22,6 +22,7 @@ import android.annotation.SuppressLint;
 import android.app.Application;
 import android.content.Context;
 import android.content.Intent;
+import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.content.res.Resources;
@@ -29,6 +30,8 @@ import android.os.Environment;
 import android.preference.PreferenceManager;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
+
 import android.util.Log;
 import android.view.ViewConfiguration;
 import android.webkit.CookieManager;
@@ -36,6 +39,7 @@ import android.webkit.CookieManager;
 import com.ichi2.anki.analytics.AnkiDroidCrashReportDialog;
 import com.ichi2.anki.exception.StorageAccessException;
 import com.ichi2.anki.services.BootService;
+import com.ichi2.anki.services.NotificationService;
 import com.ichi2.compat.CompatHelper;
 import com.ichi2.utils.LanguageUtil;
 import com.ichi2.anki.analytics.UsageAnalytics;
@@ -245,6 +249,11 @@ public class AnkiDroidApp extends Application {
             }
         }
         new BootService().onReceive(this, new Intent(this, BootService.class));
+
+        // Register BroadcastReceiver NotificationService
+        NotificationService ns = new NotificationService();
+        LocalBroadcastManager lbm = LocalBroadcastManager.getInstance(this);
+        lbm.registerReceiver(ns, new IntentFilter(NotificationService.INTENT_ACTION));
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.java
@@ -89,7 +89,7 @@ public class BootService extends BroadcastReceiver {
     public static void scheduleNotification(Context context) {
         AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
         SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(context);
-        if (Integer.parseInt(sp.getString("minimumCardsDueForNotification", "1000001")) <= 1000000) {
+        if (Integer.parseInt(sp.getString("minimumCardsDueForNotification", "1000001")) >= 1000000) {
             return;
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/NotificationService.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/NotificationService.java
@@ -37,6 +37,8 @@ public class NotificationService extends BroadcastReceiver {
     /** The id of the notification for due cards. */
     private static final int WIDGET_NOTIFY_ID = 1;
 
+    public static final String INTENT_ACTION = "com.ichi2.anki.intent.action.SHOW_NOTIFICATION";
+
     @Override
     public void onReceive(Context context, Intent intent) {
         Timber.i("NotificationService: OnStartCommand");

--- a/AnkiDroid/src/main/java/com/ichi2/widget/WidgetStatus.java
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/WidgetStatus.java
@@ -37,6 +37,7 @@ import timber.log.Timber;
 public final class WidgetStatus {
 
     private static boolean sSmallWidgetEnabled = false;
+    private static boolean sNotificationEnabled = false;
     private static AsyncTask<Context, Void, Context> sUpdateDeckStatusAsyncTask;
 
 
@@ -54,8 +55,9 @@ public final class WidgetStatus {
     public static void update(Context context) {
         SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(context);
         sSmallWidgetEnabled = preferences.getBoolean("widgetSmallEnabled", false);
-        if (sSmallWidgetEnabled &&
-                ((sUpdateDeckStatusAsyncTask == null) || (sUpdateDeckStatusAsyncTask.getStatus() == AsyncTask.Status.FINISHED))) {
+        sNotificationEnabled = Integer.parseInt(preferences.getString("minimumCardsDueForNotification", "1000001")) < 1000000;
+        boolean canExecuteTask = ((sUpdateDeckStatusAsyncTask == null) || (sUpdateDeckStatusAsyncTask.getStatus() == AsyncTask.Status.FINISHED));
+        if ((sSmallWidgetEnabled || sNotificationEnabled) && canExecuteTask) {
             Timber.d("WidgetStatus.update(): updating");
             sUpdateDeckStatusAsyncTask = new UpdateDeckStatusAsyncTask();
             sUpdateDeckStatusAsyncTask.execute(context);

--- a/AnkiDroid/src/main/java/com/ichi2/widget/WidgetStatus.java
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/WidgetStatus.java
@@ -20,9 +20,12 @@ import android.content.SharedPreferences;
 import android.os.AsyncTask;
 import android.util.Pair;
 
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
+
 import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.CollectionHelper;
 import com.ichi2.anki.MetaDB;
+import com.ichi2.anki.services.NotificationService;
 import com.ichi2.async.BaseAsyncTask;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Sched;
@@ -108,6 +111,9 @@ public final class WidgetStatus {
             if (sSmallWidgetEnabled) {
                 new AnkiDroidWidgetSmall.UpdateService().doUpdate(context);
             }
+            Intent intent = new Intent(NotificationService.INTENT_ACTION);
+            Context appContext = context.getApplicationContext();
+            LocalBroadcastManager.getInstance(appContext).sendBroadcast(intent);
         }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.2'
+        classpath 'com.android.tools.build:gradle:3.5.3'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
An attempt to fix issue "No notifications after update 2.9 and 2.9.1" #5535 

## Fixes
Fix #5535 

## Approach
From my experience with AnkiDroid, there are 2 types of notifications  in the app:
(1) The general notification which has the form "%d AnkiDroid cards due"  
(2) The reminder (specific to each deck) which has the form "%d cards to review in <DeckName>"  
For convenience, in the following text, I regard (1) as notification, and (2) as reminder.  
 
I ran some tests. It turned out that the notification only works when the widget is enabled.

Steps to reproduce this phenomenon:
1. Install AnkiDroid.
2. Download and import a shared deck with more than 10 cards.  
3. Enable widget (the AnkiDroid Small Widget).
(by "enable widget" I mean add the AnkiDroid's widget onto the Home Screen of the phone)
4. Choose Settings -> AnkiDroid General Settings -> Notifications -> Notify When More than 10 cards due.

If all of these steps are done, then AnkiDroid shows the notification (*).
But if we omit step 3 (which means the widget is not enabled), then AnkiDroid does not show the notification.

(*) We might have to wait some minutes before the notification is shown.
  
The above mentioned behavior is unexpected, since AnkiDroid should show the notification regardless of the widget's state.  
In my opinion, the normal behaviour should be: After the user chooses a certain due threshold in Settings, and if the user has more due cards than this threshold, the notification should be displayed. The user doesn't have to enable the widget. 
 
I see 2 problems in the code which are probably the culprits.

Problem 1:
Class NotificationService uses a method of class WidgetStatus to get the due value.  
The problem is, this method only works correctly if the widget is enabled.  
if widget is enabled, this method returns the correct due value.  
if widget is not enabled, this method always returns 0.  
One solution to this (I think) is to allow NotificationService to get the due value directly from Collection.  
 And since getting due from Collection might not be quick, NotificationService should use an AsyncTask to do the job. 

Problem 2:
In class BootService, method scheduleNotification(), statement if, the comparison operator is currently <=.   
I think it should be >=  .

The patch I provided in this PR is an attempt to solve our notification problem. It implements my aforementioned suggestions.

## How Has This Been Tested?

I tested this patch in both the emulator (API 28) and a physical phone, and AnkiDroid worked as expected (ie. the notification, once enabled in Settings, was shown correctly regardless of the state of the widget).  
I also ran all unit tests and instrumentation tests (on emulator) and this patch didn't break any of them.  

## Learning (optional, can help others)


## Checklist
_Please, go through these checks before submitting the PR._

- [x ] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x ] You have a descriptive commit message with a short title.
- [x ] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x ] You have commented your code, particularly in hard-to-understand areas
- [x ] You have performed a self-review of your own code
