### PR TITLE
Change the img regex tag to match Anki desktop

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
@@ -99,7 +99,7 @@ public class Utils {
     private static final Pattern stylePattern = Pattern.compile("(?si)<style.*?>.*?</style>");
     private static final Pattern scriptPattern = Pattern.compile("(?si)<script.*?>.*?</script>");
     private static final Pattern tagPattern = Pattern.compile("<.*?>");
-    private static final Pattern imgPattern = Pattern.compile("(?i)<img src=[\\\"']?([^\\\"'>]+)[\\\"']? ?/?>");
+    private static final Pattern imgPattern = Pattern.compile("(?i)<img[^>]+src=[\\\"']?([^\\\"'>]+)[\\\"']?[^>]*>");
     private static final Pattern htmlEntitiesPattern = Pattern.compile("&#?\\w+;");
 
     private static final String ALL_CHARACTERS = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";


### PR DESCRIPTION
## Purpose / Description

The img tag detection was incorrect which caused conditional field replacements using just img tags with differently ordered attributes to break the regex. More concretely:

```html
<!-- This used to break -->
<img height="400px" src="imgrc0068910127.jpg" width="400px">
<!-- This doesn't -->
<img src="imgrc0068910127.jpg">
```

## Fixes

This should fix #5166

## Approach

Similar to the issue linked I updated the regex to match the one used by Anki desktop which doesn't have this issue. The template code still differs from upstream Anki but I thought this was out of scope for the PR.

## How Has This Been Tested?

I admit I haven't tested this but the regex should be correct since I tested it on regex101.com

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
