### PR TITLE
Update CI for new emulator command lines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,6 @@ jobs:
       script: echo finalize codacy coverage uploads
   allow_failures:
     - env: API=24 JDK="1.11" # non-default JDKs should not hold up success reporting
-    - env: API=15 ABI=x86 EMU_CHANNEL="--channel=4" # API15 worked with 29.2.7 but 29.2.8 fails again?
     - env: FINALIZE_COVERAGE=TRUE API=NONE # finalizing coverage should not hold up success reporting
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -106,9 +106,6 @@ install:
   - |
     EMU_PARAMS="-verbose -no-snapshot -no-window -camera-back none -camera-front none -selinux permissive -qemu -m 2048"
     EMU_COMMAND="emulator"
-    if [[ $ABI =~ "x86" ]]; then
-      EMU_COMMAND="emulator-headless"
-    fi
     # This double "sudo" monstrosity is used to have Travis execute the
     # emulator with its new group permissions and help preserve the rule
     # of least privilege.

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ env:
     - ANDROID_HOME=${HOME}/android-sdk
     - ANDROID_TOOLS_URL="https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip"
     - EMU_FLAVOR=default # use google_apis flavor if no default flavor emulator
-    - EMU_CHANNEL="" # use default / stable emulator channel normally
     - GRAVIS="https://raw.githubusercontent.com/DanySK/Gravis-CI/master/"
     - JDK="1.8"
     - TOOLS=${ANDROID_HOME}/tools
@@ -26,7 +25,7 @@ env:
     - UNIT_TEST=FALSE # by default we don't run the unit tests, they are run only in specific builds
     - FINALIZE_COVERAGE=FALSE # by default we don't finalize coverage, it is done in one specific build
   matrix:
-   - API=15 ABI=x86 EMU_CHANNEL="--channel=4" # Canaries of API15 are working again, google fixed their issues
+   #- API=15 # only runs locally. Create+Start once from AndroidStudio to init sdcard. Then only from command-line w/-engine classic
    - API=16 ABI=x86 AUDIO=-no-audio
    - API=17 ABI=x86
    #- API=18 ABI=x86 # frequently flaky: test run failed: 'Instrumentation run failed due to 'java.lang.SecurityException''
@@ -94,7 +93,7 @@ install:
   # That only happens currently on linux, so this section can assume linux + emulator is desired
   # Download required emulator tools
   - echo y | sdkmanager --no_https "platforms;android-$API" >/dev/null # We need the API of the emulator we will run
-  - echo y | sdkmanager --no_https $EMU_CHANNEL "emulator" >/dev/null
+  - echo y | sdkmanager --no_https "emulator" >/dev/null
   - echo y | sdkmanager --no_https "system-images;android-$API;$EMU_FLAVOR;$ABI" >/dev/null # install our emulator
 
   # Set up KVM on linux for hardware acceleration. Manually here so it only happens for emulator tests, takes ~30s
@@ -108,12 +107,7 @@ install:
     EMU_PARAMS="-verbose -no-snapshot -no-window -camera-back none -camera-front none -selinux permissive -qemu -m 2048"
     EMU_COMMAND="emulator"
     if [[ $ABI =~ "x86" ]]; then
-      if [ $API != "15" ]; then
-        # API15 is using the canary channel right now, and emulator-headless is command not found?
-        # this may break in the future when the current canaries are promoted but until now it works
-        # for all but API15 on the canary channel
-        EMU_COMMAND="emulator-headless"
-      fi
+      EMU_COMMAND="emulator-headless"
     fi
     # This double "sudo" monstrosity is used to have Travis execute the
     # emulator with its new group permissions and help preserve the rule


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

The Google Android Emulator team continues with high velocity and sometimes breaking changes

There were a couple crash bugs that were fixed in recent emulator versions (allowing me to revert two temporary workarounds), but the recent one also collapsed 'emulator-headless' command to 'emulator -no-window', so this converts our emulator usage to the new command syntax

## Fixes
Fixes #5649 

## Approach
Adopt new command

## How Has This Been Tested?
Tested on personal Travis CI instance connected to my Anki-Android fork

## Learning (optional, can help others)
Google Android Emulator team continues to have high velocity, not all good, but I still like it.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
