### PR TITLE
Fix crash related to escaping html entites

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
@@ -26,6 +26,8 @@ import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.content.res.Resources;
 import android.net.Uri;
+import android.text.Spanned;
+
 import androidx.annotation.NonNull;
 
 import com.ichi2.anki.AnkiFont;
@@ -255,7 +257,9 @@ public class Utils {
         Matcher htmlEntities = htmlEntitiesPattern.matcher(html);
         StringBuffer sb = new StringBuffer();
         while (htmlEntities.find()) {
-            htmlEntities.appendReplacement(sb, CompatHelper.getCompat().fromHtml(htmlEntities.group()).toString());
+            final Spanned spanned = CompatHelper.getCompat().fromHtml(htmlEntities.group());
+            final String replacement = Matcher.quoteReplacement(spanned.toString());
+            htmlEntities.appendReplacement(sb, replacement);
         }
         htmlEntities.appendTail(sb);
         return sb.toString();


### PR DESCRIPTION
## Purpose / Description
The [Matcher.appendReplacement()](https://docs.oracle.com/javase/7/docs/api/java/util/regex/Matcher.html#appendReplacement\(java.lang.StringBuffer,%20java.lang.String\)) method used when escaping html entities treats backslashes (\\) and dollar signs ($) differently than the rest of the replacement string. Due to the input not being properly escaped, certain sequences (f.i. "&bsop;") lead to crashes.

## Fixes
This fixes issue #5638.

## Approach
We use the [Matcher.quoteReplacement()](https://docs.oracle.com/javase/7/docs/api/java/util/regex/Matcher.html#quoteReplacement\(java.lang.String\)) helper method to escape the string.

## How Has This Been Tested?
I've tested the fix multiple times using an Android 28 emulator.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
