### PR TITLE
Fix crash occurring when trying to open rating activity

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Info.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Info.java
@@ -86,12 +86,8 @@ public class Info extends AnkiActivity {
         Button marketButton = findViewById(R.id.market);
         marketButton.setOnClickListener(arg0 -> {
             if (mType == TYPE_ABOUT) {
-                final String intentUri;
-                if (CompatHelper.isKindle()) {
-                    intentUri = "http://www.amazon.com/gp/mas/dl/android?p=com.ichi2.anki";
-                } else {
-                    intentUri = "market://details?id=com.ichi2.anki";
-                }
+                final String intentUri = getString(
+                        CompatHelper.isKindle() ? R.string.link_market_kindle : R.string.link_market);
                 final Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(intentUri));
                 final PackageManager packageManager = getPackageManager();
                 if (intent.resolveActivity(packageManager) != null) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Info.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Info.java
@@ -21,6 +21,7 @@ package com.ichi2.anki;
 import android.content.ClipData;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.content.res.Resources;
 import android.net.Uri;
 import android.os.Build;
@@ -85,13 +86,19 @@ public class Info extends AnkiActivity {
         Button marketButton = findViewById(R.id.market);
         marketButton.setOnClickListener(arg0 -> {
             if (mType == TYPE_ABOUT) {
+                final String intentUri;
                 if (CompatHelper.isKindle()) {
-                    Intent intent = new Intent("android.intent.action.VIEW",
-                            Uri.parse("http://www.amazon.com/gp/mas/dl/android?p=com.ichi2.anki"));
+                    intentUri = "http://www.amazon.com/gp/mas/dl/android?p=com.ichi2.anki";
+                } else {
+                    intentUri = "market://details?id=com.ichi2.anki";
+                }
+                final Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(intentUri));
+                final PackageManager packageManager = getPackageManager();
+                if (intent.resolveActivity(packageManager) != null) {
                     startActivityWithoutAnimation(intent);
                 } else {
-                    Info.this.startActivityWithoutAnimation(new Intent(Intent.ACTION_VIEW, Uri
-                            .parse("market://details?id=com.ichi2.anki")));
+                    final String errorMsg = getString(R.string.feedback_no_suitable_app_found);
+                    UIUtils.showThemedToast(Info.this, errorMsg, true);
                 }
                 return;
             }

--- a/AnkiDroid/src/main/res/values/05-feedback.xml
+++ b/AnkiDroid/src/main/res/values/05-feedback.xml
@@ -31,4 +31,5 @@
     <string name="feedback_copy_debug">Copy debug info</string>
     <string name="feedback_report">Report</string>
     <string name="feedback_report_automatically">Send error reports automatically</string>
+    <string name="feedback_no_suitable_app_found">No suitable app found</string>
 </resources>

--- a/AnkiDroid/src/main/res/values/constants.xml
+++ b/AnkiDroid/src/main/res/values/constants.xml
@@ -123,6 +123,8 @@
     <string name="licence_wiki">http://www.gnu.org/licenses/gpl.html</string>
     <string name="link_source">https://github.com/ankidroid/Anki-Android</string>
     <string name="link_donation">http://ankisrs.net/support</string>
+    <string name="link_market">market://details?id=com.ichi2.anki</string>
+    <string name="link_market_kindle">http://www.amazon.com/gp/mas/dl/android?p=com.ichi2.anki</string>
     <string name="link_translation">http://crowdin.net/project/ankidroid</string>
     <string name="link_wikipedia_open_source">http://en.wikipedia.org/wiki/Open_source_software</string>
     <string name="link_contribution">https://github.com/ankidroid/Anki-Android/wiki/Contributing</string>


### PR DESCRIPTION
## Purpose / Description
When the user wants to rate the app, AnkiDroid launches an intent with a specific market uri and expects the device to handle it. In some situations, however, the intent can't be handled (like in issue #5653). AnkiDroid never assumes this situation and crashes.

## Fixes
This fixes issue #5653.

## Approach
We use the [Intent.resolveActivity()](https://developer.android.com/reference/android/content/Intent.html#resolveActivity\(android.content.pm.PackageManager\)) function to test whether the intent can be resolved or not.
If the intent can not be resolved, we notify the user using a Toast.

## How Has This Been Tested?
I've tested the fix multiple times using an Android API 28 emulator.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
