### PR TITLE
Port MathJax-Cloze bugfix from Anki

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/template/Template.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/template/Template.java
@@ -17,6 +17,7 @@
 package com.ichi2.libanki.template;
 
 import android.text.TextUtils;
+import android.util.Log;
 
 import com.ichi2.libanki.Utils;
 import com.ichi2.libanki.hooks.Hooks;
@@ -48,6 +49,7 @@ public class Template {
     public static final String clozeReg = "(?si)\\{\\{(c)%s::(.*?)(::(.*?))?\\}\\}";
     private static final Pattern fHookFieldMod = Pattern.compile("^(.*?)(?:\\((.*)\\))?$");
     private static final Pattern fClozeSection = Pattern.compile("c[qa]:(\\d+):(.+)");
+    private static final String TAG = Template.class.getName();
 
     // The regular expression used to find a #section
     private Pattern sSection_re = null;
@@ -354,46 +356,72 @@ public class Template {
         return false;
     }
 
+    /**
+     * Marks all clozes within MathJax to prevent formatting them.
+     *
+     * Active Cloze deletions within MathJax should not be wrapped inside
+     * a Cloze <span>, as that would interfere with MathJax. This method finds
+     * all Cloze deletions number `ord` in `txt` which are inside MathJax inline
+     * or display formulas, and replaces their opening '{{c123' with a '{{C123'.
+     * The clozeText method interprets the upper-case C as "don't wrap this
+     * Cloze in a <span>".
+     */
     public static String removeFormattingFromMathjax(String txt, String ord) {
-        // look for clozes wrapped in mathjax, and change {{cx to {{Cx
-
         String creg = clozeReg.replace("(?si)", "");
-        StringBuilder regex = new StringBuilder("(?si)(\\\\[");
-        regex.append(Pattern.quote("(["));
-        regex.append("])(.*?)");
-        regex.append(String.format(Locale.US, creg, ord));
-        regex.append("(.*?)(\\\\[");
-        regex.append(Pattern.quote("])"));
-        regex.append("])");
+        // Scan the string left to right.
+        // After a MathJax opening - \( or \[ - flip in_mathjax to True.
+        // After a MathJax closing - \) or \] - flip in_mathjax to False.
+        // When a Cloze pattern number `ord` is found and we are in MathJax,
+        // replace its '{{c' with '{{C'.
+        //
+        // TODO: Report mismatching opens/closes - e.g. '\(\]'
+        // TODO: Report errors in this method better than printing to stdout.
+        // flags in middle of expression deprecated
+        boolean in_mathjax = false;
 
-        Matcher m = Pattern.compile(regex.toString()).matcher(txt);
+        // The following regex matches one of:
+        //  -  MathJax opening
+        //  -  MathJax close
+        //  -  Cloze deletion number `ord`
+        String regex = new StringBuilder("(?si)")
+            .append("(?<mathjaxopen>\\\\[(\\[])|")
+            .append("(?<mathjaxclose>\\\\[\\])])|")
+            .append("(?<cloze>")
+            .append(String.format(Locale.US, creg, ord))
+            .append(")")
+            .toString();
+
+        Matcher m = Pattern.compile(regex).matcher(txt);
 
         StringBuffer repl = new StringBuffer();
         while (m.find()) {
-            boolean enclosed = true;
-
-            for (String closing : sMathJaxClosings) {
-                if (m.group(1).contains(closing)) {
-                    enclosed = false;
+            if (m.group("mathjaxopen") != null) {
+                if (in_mathjax) {
+                    Log.d(TAG, "MathJax opening found while already in MathJax");
                 }
-            }
-
-            for (String opening : sMathJaxOpenings) {
-                if (m.group(7).contains(opening)) {
-                    enclosed = false;
+                in_mathjax = true;
+            } else if (m.group("mathjaxclose") != null) {
+                if (!in_mathjax) {
+                    Log.d(TAG, "MathJax close found while not in MathJax");
                 }
-            }
-
-            if (!enclosed) {
-                String f = m.group(0);
-                // appendReplacement has an issue with backslashes, so...
-                m.appendReplacement(repl, Matcher.quoteReplacement(m.group(0)));
+                in_mathjax = false;
+            } else if (m.group("cloze") != null) {
+                if (in_mathjax) {
+                    // appendReplacement has an issue with backslashes, so...
+                    m.appendReplacement(
+                        repl,
+                        m.quoteReplacement(
+                            m.group(0).replaceAll(
+                                "{{" + ord + "::", "{{C" + ord + "::")));
+                    continue;
+                }
             } else {
-                m.appendReplacement(repl, Matcher.quoteReplacement(m.group(0).replace("{{c", "{{C")));
+                Log.d(TAG, "Unexpected: no expected capture group is present");
             }
+            // appendReplacement has an issue with backslashes, so...
+            m.appendReplacement(repl, Matcher.quoteReplacement(m.group(0)));
         }
-        txt = m.appendTail(repl).toString();
-        return txt;
+        return m.appendTail(repl).toString();
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/template/Template.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/template/Template.java
@@ -411,8 +411,8 @@ public class Template {
                     m.appendReplacement(
                         repl,
                         m.quoteReplacement(
-                            m.group(0).replaceAll(
-                                "{{" + ord + "::", "{{C" + ord + "::")));
+                            m.group(0).replace(
+                                "{{c" + ord + "::", "{{C" + ord + "::")));
                     continue;
                 }
             } else {

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/MathJaxClozeTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/MathJaxClozeTest.java
@@ -36,7 +36,7 @@ public class MathJaxClozeTest extends RobolectricTest {
         assertEquals(original_s, Template.removeFormattingFromMathjax(original_s, "4"));
         assertEquals(original_s, Template.removeFormattingFromMathjax(original_s, "5"));
 
-        final String escaped_s = "{{c1::ok}} \\(2^2\\) {{C2::not ok}} \\(2^{{C3::2}}\\) \\(x^3\\) {{c4::blah}} {{c5::text with \\(x^2\\) jax}}";
+        final String escaped_s = "{{c1::ok}} \\(2^2\\) {{c2::not ok}} \\(2^{{C3::2}}\\) \\(x^3\\) {{c4::blah}} {{c5::text with \\(x^2\\) jax}}";
         assertEquals(escaped_s, Template.removeFormattingFromMathjax(original_s, "3"));
 
         final String original_s2 = "\\(a\\) {{c1::b}} \\[ {{c1::c}} \\]";

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/MathJaxClozeTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/MathJaxClozeTest.java
@@ -39,6 +39,9 @@ public class MathJaxClozeTest extends RobolectricTest {
         final String escaped_s = "{{c1::ok}} \\(2^2\\) {{C2::not ok}} \\(2^{{C3::2}}\\) \\(x^3\\) {{c4::blah}} {{c5::text with \\(x^2\\) jax}}";
         assertEquals(escaped_s, Template.removeFormattingFromMathjax(original_s, "3"));
 
+        final String original_s2 = "\\(a\\) {{c1::b}} \\[ {{c1::c}} \\]";
+        final String escaped_s2 = "\\(a\\) {{c1::b}} \\[ {{C1::c}} \\]";
+        assertEquals(escaped_s2, Template.removeFormattingFromMathjax(original_s2, "1"));
     }
 
     @Test
@@ -66,17 +69,29 @@ public class MathJaxClozeTest extends RobolectricTest {
         final Context context = ApplicationProvider.getApplicationContext();
 
         Collection c = getCol();
-        Note f = c.newNote(c.getModels().byName("Cloze"));
-        f.setItem("Text", "\\(1 \\div 2 =\\){{c1::\\(\\frac{1}{2}\\)}}");
-        c.addNote(f);
+	{
+            Note f = c.newNote(c.getModels().byName("Cloze"));
+            f.setItem("Text", "\\(1 \\div 2 =\\){{c1::\\(\\frac{1}{2}\\)}}");
+            c.addNote(f);
 
-        ArrayList<Card> cards = f.cards();
-        Card c2 = cards.get(0);
-        String q = c2.q();
-        String a = c2.a();
-        assertTrue(q.contains("\\(1 \\div 2 =\\)"));
-        assertTrue(a.contains("\\(1 \\div 2 =\\)"));
-        assertTrue(a.contains("<span class=cloze>\\(\\frac{1}{2}\\)</span>"));
+            ArrayList<Card> cards = f.cards();
+            Card c2 = cards.get(0);
+            String q = c2.q();
+            String a = c2.a();
+            assertTrue(q.contains("\\(1 \\div 2 =\\)"));
+            assertTrue(a.contains("\\(1 \\div 2 =\\)"));
+            assertTrue(a.contains("<span class=cloze>\\(\\frac{1}{2}\\)</span>"));
+	}
+
+	{
+            Note f = c.newNote(c.getModels().byName("Cloze"));
+            f.setItem("Text", "\\(a\\) {{c1::b}} \\[ {{c1::c}} \\]");
+            c.addNote(f);
+            ArrayList<Card> cards = f.cards();
+            Card c2 = cards.get(0);
+            String q = c2.q();
+            assertTrue(q.contains("\\(a\\) <span class=cloze>[...]</span> \\[ [...] \\]"));
+	}
     }
 
     @Test


### PR DESCRIPTION
See https://github.com/dae/anki/pull/374 for upstream fix.

## Pull Request template

## Purpose / Description
I fixed a parsing issue in MathJax with Clozes in upstream Anki, this is a port of the fix to Ankidroid.

## Fixes
See https://github.com/dae/anki/pull/374

## Approach
Straightforward port of my rewrite of the `_removeFormattingFromMathjax` function in original Python.

## How Has This Been Tested?
CI tests should be sufficient, since this code is covered by unit tests. I am also adding unit tests for my minimum reproduction of the parsing error.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
