### PR TITLE
Add flag and mark in top of the reviewer as in anki

### DIFF
--- a/AnkiDroid/src/main/assets/card_template.html
+++ b/AnkiDroid/src/main/assets/card_template.html
@@ -14,6 +14,10 @@
         <script src="file:///android_asset/scripts/card.js" type="text/javascript"> </script>
     </head>
     <body class="::class::">
+      <div id="_mark_flag">
+        <div id="_mark">&#x2605;</div>
+        <div id="_flag">&#x2691;</div>
+      </div>
         <div id="content">
         ::content::
         </div>

--- a/AnkiDroid/src/main/assets/flashcard.css
+++ b/AnkiDroid/src/main/assets/flashcard.css
@@ -118,3 +118,24 @@ scale up, but not down.  */
 .night_mode .replaybutton svg {
   fill: white;
 }
+
+#_mark_flag {
+  top: 0;
+  font-size: 30px;
+  display: block;
+  -webkit-text-stroke-width: 1px;
+  -webkit-text-stroke-color: black;
+  margin: 10px;
+}
+
+#_flag {
+  right: 10px;
+  float:right;
+}
+
+#_mark {
+  left: 10px;
+  float:left;
+  color: yellow;
+}
+

--- a/AnkiDroid/src/main/assets/scripts/card.js
+++ b/AnkiDroid/src/main/assets/scripts/card.js
@@ -130,3 +130,29 @@ var onPageFinished = function() {
         }
     }
 }
+
+function _drawMark(mark) {
+    var elem = document.getElementById("_mark");
+    if (!mark) {
+        elem.style.display = "none";
+    } else {
+        elem.style.display = "inline";
+    }
+}
+
+function _drawFlag(flag) {
+    var elem = document.getElementById("_flag");
+
+    var _flagColours = [
+        "#ff6666",
+        "#ff9900",
+        "#77ff77",
+        "#77aaff"];
+
+    if (flag === 0) {
+        elem.style.display = "none";
+        return;
+    }
+    elem.style.display = "inline";
+    elem.style.color = _flagColours[flag-1];
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1530,6 +1530,8 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
             @Override
             public void onPageFinished(WebView view, String url) {
                 Timber.d("onPageFinished triggered");
+                drawFlag();
+                drawMark();
                 view.loadUrl("javascript:onPageFinished();");
             }
         });
@@ -2836,6 +2838,10 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
         }
     }
 
+    private void drawMark() {
+        mCard.loadUrl("javascript:_drawMark("+mCurrentCard.note().hasTag("marked")+");");
+    }
+
     protected void onMark(Card card) {
         Note note = card.note();
         if (note.hasTag("marked")) {
@@ -2845,12 +2851,18 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
         }
         note.flush();
         refreshActionBar();
+        drawMark();
+    }
+
+    private void drawFlag() {
+        mCard.loadUrl("javascript:_drawFlag("+mCurrentCard.getUserFlag()+");");
     }
 
     protected void onFlag(Card card, int flag) {
         card.setUserFlag(flag);
         card.flush();
         refreshActionBar();
+        drawFlag();
         /* Following code would allow to update value of {{cardFlag}}.
            Anki does not update this value when a flag is changed, so
            currently this code would do something that anki itself


### PR DESCRIPTION
## Fixes
As requested in https://github.com/ankidroid/Anki-Android/pull/5571#issuecomment-570105143 , anki cards now have flag/marked status as in Anki.

## How Has This Been Tested?

I opened ankidroid. I tried to add the marked status, and a flag. Both did appear. I left the card and reloaded it, the flag and star are still here. I tried to remove them, and they leave. Furthermore, in all cases, the icons are not on top of text.

![2020-01-01-230212_540x864_scrot](https://user-images.githubusercontent.com/357361/71655506-eb02fe00-2ceb-11ea-9e22-a6f56a82e6df.png)
![2020-01-01-233216_540x864_scrot](https://user-images.githubusercontent.com/357361/71656133-028fb600-2cef-11ea-8323-91dc5674085c.png)
![2020-01-01-233210_540x864_scrot](https://user-images.githubusercontent.com/357361/71656134-03284c80-2cef-11ea-835d-2b5ac659a53a.png)
![2020-01-01-233003_540x864_scrot](https://user-images.githubusercontent.com/357361/71656135-03284c80-2cef-11ea-8a55-96c4d06516ae.png)


## Learning (optional, can help others)
java is simple. Having correct css is a nightmare.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
