### PR TITLE
Fix _checkDeckTree

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -894,6 +894,7 @@ public class Decks {
                     names.add(immediateParent);
                 }
             }
+            names.add(deckName);
         }
     }
 


### PR DESCRIPTION
## Purpose / Description
I did forgot to add deck names in the name list. Which means that each
subdeck thought they don't have parents.
Parents were not created since _ensureParents founds the parents. And
it didn't made ankidroid really slower. However, it means that
duplicates were not found; and worse, it sent a lot of useless data to
the debugger, making it harder to read than what it was before


Honestly, this branch was created months ago. And it seems I just forgot to transform it into a PR. 
## Approach
By adding the name into the set of deck name

## How Has This Been Tested?
Started ankidroid, and checked that actually I didn't have timbers related to deck name.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
