### PR TITLE
Fix incorrect filtered deck getting rebuilt on long-click

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/FilteredDeckOptions.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FilteredDeckOptions.java
@@ -434,7 +434,11 @@ public class FilteredDeckOptions extends AppCompatPreferenceActivity implements 
     private void closeDeckOptions() {
         if (mPrefChanged) {
             // Rebuild the filtered deck if a setting has changed
-            mCol.getSched().rebuildDyn(mCol.getDecks().selected());
+            try {
+                mCol.getSched().rebuildDyn(mDeck.getLong("id"));
+            } catch (JSONException e) {
+                Timber.e(e);
+            }
         }
         finish();
         ActivityTransitionAnimation.slide(this, ActivityTransitionAnimation.FADE);


### PR DESCRIPTION
## Fixes
Fixes #5091

## Approach
Use actual deck ID instead of libanki selected deck ID

## How Has This Been Tested?

On VM as per steps in original issue