### PR TITLE
Removing flashing of stars/flag

### DIFF
--- a/AnkiDroid/src/main/assets/flashcard.css
+++ b/AnkiDroid/src/main/assets/flashcard.css
@@ -129,11 +129,13 @@ scale up, but not down.  */
 }
 
 #_flag {
+  display: none;
   right: 10px;
   float:right;
 }
 
 #_mark {
+  display: none;
   left: 10px;
   float:left;
   color: yellow;


### PR DESCRIPTION
This is a partial solution to #5695. Seems to work on my VM.

CSS hides star by default. That is actually what anki does. But since I didn't see the point (since the star is hidden by JS) I didn't copy this part of the CSS. Now I see the point, thank you