### PR TITLE
Card browser accepts empty answer string

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -519,6 +519,9 @@ public class CardBrowser extends NavigationDrawerActivity implements
                             .putInt("cardBrowserColumn2", mColumn2Index).commit();
                     String[] fromMap = mCardsAdapter.getFromMapping();
                     fromMap[1] = COLUMN2_KEYS[mColumn2Index];
+                    if (fromMap[1] == null) {
+                        fromMap[1] = "";
+                    }
                     mCardsAdapter.setFromMapping(fromMap);
                 }
             }
@@ -531,11 +534,15 @@ public class CardBrowser extends NavigationDrawerActivity implements
         // get the font and font size from the preferences
         int sflRelativeFontSize = preferences.getInt("relativeCardBrowserFontSize", DEFAULT_FONT_SIZE_RATIO);
         String sflCustomFont = preferences.getString("browserEditorFont", "");
+        String[] columnsContent = {COLUMN1_KEYS[mColumn1Index], COLUMN2_KEYS[mColumn2Index]};
+        if (columnsContent[1] == null) {
+            columnsContent[1] = "";
+        }
         // make a new list adapter mapping the data in mCards to column1 and column2 of R.layout.card_item_browser
         mCardsAdapter = new MultiColumnListAdapter(
                 this,
                 R.layout.card_item_browser,
-                new String[] {COLUMN1_KEYS[mColumn1Index], COLUMN2_KEYS[mColumn2Index]},
+                columnsContent,
                 new int[] {R.id.card_sfld, R.id.card_column2},
                 sflRelativeFontSize,
                 sflCustomFont);
@@ -1579,7 +1586,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 String firstAns = getCards().get(firstVisibleItem).get("answer");
                 // Note: max value of lastVisibleItem is totalItemCount, so need to subtract 1
                 String lastAns = getCards().get(lastVisibleItem - 1).get("answer");
-                if ("".equals(firstAns) || "".equals(lastAns)) {
+                if (firstAns == null || lastAns == null) {
                     showProgressBar();
                     // Also start rendering the items on the screen every 300ms while scrolling
                     long currentTime = SystemClock.elapsedRealtime ();

--- a/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
@@ -887,7 +887,7 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
 
         // for each specified card in the browser list
         for (int i = startPos; i < startPos + n; i++) {
-            if (i >= 0 && i < items.size() && items.get(i).get("answer").equals("")) {
+            if (i >= 0 && i < items.size() && items.get(i).get("answer") == null) {
                 // Extract card item
                 Card c = col.getCard(Long.parseLong(items.get(i).get("id"), 10));
                 // Update item

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
@@ -1115,8 +1115,8 @@ public class Finder {
                 card.put("tags", tags);
                 res.add(card);
                 // add placeholder for question and answer
-                card.put("question", "");
-                card.put("answer", "");
+                card.put("question", null);
+                card.put("answer", null);
                 card.put("flags", (new Integer(Card.intToFlag(cur.getInt(5)))).toString());
                 card.put("suspended", queue == Card.QUEUE_SUSP ? "True": "False");
                 card.put("marked", (tags.matches(".*[Mm]arked.*"))?"marked": null);


### PR DESCRIPTION
It partially corrects #5694. The browser does not seems to be loading
anymore when the answer is an empty string. (E.g. if the answer
consists only of a music file, or anything else which was deleted
because it can't be rendered)
![2020-01-05-054837_757x1242_scrot](https://user-images.githubusercontent.com/357361/71781068-384ace00-2f7f-11ea-9d7c-4fd75155068a.png)
