### PR TITLE
Correcting: onMark/onFlag raises nullPointException

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -2839,6 +2839,9 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
     }
 
     private void drawMark() {
+        if (mCurrentCard == null) {
+            return;
+        }
         mCard.loadUrl("javascript:_drawMark("+mCurrentCard.note().hasTag("marked")+");");
     }
 
@@ -2858,6 +2861,9 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
     }
 
     private void drawFlag() {
+        if (mCurrentCard == null) {
+            return;
+        }
         mCard.loadUrl("javascript:_drawFlag("+mCurrentCard.getUserFlag()+");");
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -2843,6 +2843,9 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
     }
 
     protected void onMark(Card card) {
+        if (card == null) {
+            return;
+        }
         Note note = card.note();
         if (note.hasTag("marked")) {
             note.delTag("marked");
@@ -2859,6 +2862,9 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
     }
 
     protected void onFlag(Card card, int flag) {
+        if (card == null) {
+            return;
+        }
         card.setUserFlag(flag);
         card.flush();
         refreshActionBar();


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
When you click on mark/flag in the reviewer but the card is not yet
loaded, this used to lead to a nullPointException. This is now
corrected. 


## Approach
I believe that it's okay if those button does nothing while
we are waiting for the next card.
## How Has This Been Tested?

Takes a slow phone. Open the reviewer. Press the flag button immediately. There used to be an exception. There is none anymore 

## Learning (optional, can help others)
Note that this leaves the related problem: when you review a card and
then click on "mark" on a slow phone, it's not clear which card is
marked; indeed, it depends on whether the value of mCurrentCard did
change or not.

One solution would be to set "mCurrentCard" to null once the button 1, 2, 3 or 4 is pressed, to ensure that nothing occurs until next card is loaded.