### PR TITLE
Having star/flag bottom

### DIFF
--- a/AnkiDroid/src/main/assets/flashcard.css
+++ b/AnkiDroid/src/main/assets/flashcard.css
@@ -1,6 +1,7 @@
 body {
   margin: 0px;
   padding: 0px;
+  margin-bottom: 30px;
 }
 
 body.night_mode {
@@ -120,22 +121,26 @@ scale up, but not down.  */
 }
 
 #_mark_flag {
-  top: 0;
+  position: absolute;
+  bottom: 0;
   font-size: 30px;
   display: block;
   -webkit-text-stroke-width: 1px;
   -webkit-text-stroke-color: black;
   margin: 10px;
+  bottom: 23px;
 }
 
 #_flag {
-  display: none;
+  position: fixed;
+  display: block;
   right: 10px;
   float:right;
 }
 
 #_mark {
-  display: none;
+  position: fixed;
+  display: block;
   left: 10px;
   float:left;
   color: yellow;


### PR DESCRIPTION
@ijgnd suggested that flag and star be at the bottom of the card reviewer instead of being at the top. This way, there is no interaction between them and the content; unless the card is full. In which case anyway, the user has to scroll.

I do not state that this PR should be merged. But that's one nice way to solve many related problem at once.

When a card is long, flag/star are above the bottom line. However, you can scroll, there is enough bottom margin, so that you can always see the bottom line without having anything on top of it

![image](https://user-images.githubusercontent.com/357361/71785731-f8540d00-2fb7-11ea-95f4-c9f698d0c23b.png)
![image](https://user-images.githubusercontent.com/357361/71785909-0440ce80-2fba-11ea-80ef-072c9946fc40.png)
![image](https://user-images.githubusercontent.com/357361/71785911-099e1900-2fba-11ea-842e-5d4f0a03dcd2.png)

