### PR TITLE
Preview progress

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.java
@@ -20,6 +20,9 @@ package com.ichi2.anki;
 
 import android.os.Bundle;
 import android.view.View;
+import android.widget.LinearLayout;
+import android.widget.SeekBar;
+import android.widget.TextView;
 
 import com.ichi2.libanki.Collection;
 import com.ichi2.themes.Themes;
@@ -35,6 +38,8 @@ public class Previewer extends AbstractFlashcardViewer {
     private long[] mCardList;
     private int mIndex;
     private boolean mShowingAnswer;
+    private SeekBar progressSeekBar;
+    private TextView progressText;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -58,7 +63,49 @@ public class Previewer extends AbstractFlashcardViewer {
         // Ensure navigation drawer can't be opened. Various actions in the drawer cause crashes.
         disableDrawerSwipe();
         startLoadingCollection();
+        initPreviewProgress();
     }
+
+
+    private void initPreviewProgress() {
+        LinearLayout progressLayout = findViewById(R.id.preview_progress_layout);
+        progressSeekBar = findViewById(R.id.preview_progress_seek_bar);
+        progressText = findViewById(R.id.preview_progress_text);
+        progressLayout.setVisibility(View.VISIBLE);
+        setSeekBar();
+        updateProgress();
+    }
+
+
+    private void setSeekBar() {
+        progressSeekBar.setMax(mCardList.length - 1);
+
+        progressSeekBar.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
+            @Override
+            public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {
+                if (fromUser) {
+                    mIndex = progress;
+                    updateProgress();
+                }
+            }
+
+
+            @Override
+            public void onStartTrackingTouch(SeekBar seekBar) {
+            }
+
+
+            @Override
+            public void onStopTrackingTouch(SeekBar seekBar) {
+                if (mIndex >= 0) {
+                    mCurrentCard = getCol().getCard(mCardList[mIndex]);
+                    displayCardQuestion();
+                    updateProgress();
+                }
+            }
+        });
+    }
+
 
     @Override
     protected void onCollectionLoaded(Collection col) {
@@ -132,6 +179,7 @@ public class Previewer extends AbstractFlashcardViewer {
                     mCurrentCard = getCol().getCard(mCardList[mIndex]);
                 }
                 displayCardQuestion();
+                updateProgress();
             } else {
                 // If we are showing the question, any click will show an answer...
                 if (view.getId() == R.id.flashcard_layout_ease1) {
@@ -143,6 +191,18 @@ public class Previewer extends AbstractFlashcardViewer {
             }
         }
     };
+
+
+    private void updateProgress() {
+        int correctIndex = mIndex + 1;
+        if (correctIndex > mCardList.length) {
+            correctIndex = mIndex;
+        }
+        progressSeekBar.setProgress(correctIndex);
+        String progress = correctIndex + "/" + mCardList.length;
+        progressText.setText(progress);
+    }
+
 
     private void updateButtonState() {
         // If we are in single-card mode, we show the "Show Answer" button on the question side

--- a/AnkiDroid/src/main/res/layout/reviewer_answer_buttons.xml
+++ b/AnkiDroid/src/main/res/layout/reviewer_answer_buttons.xml
@@ -20,6 +20,33 @@
     -->
 
     <LinearLayout
+        android:id="@+id/preview_progress_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:weightSum="100"
+        android:visibility="visible"
+        android:layout_marginEnd="4dp"
+        android:layout_marginRight="4dp"
+        android:paddingTop="8dp"
+        android:paddingBottom="8dp">
+
+        <SeekBar
+            android:id="@+id/preview_progress_seek_bar"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="75"
+            />
+        <TextView
+            android:id="@+id/preview_progress_text"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="25"
+            android:gravity="center_horizontal" />
+
+    </LinearLayout>
+
+    <LinearLayout
         android:id="@+id/answer_options_layout"
         android:layout_width="fill_parent"
         android:layout_height="fill_parent">

--- a/AnkiDroid/src/main/res/layout/reviewer_answer_buttons.xml
+++ b/AnkiDroid/src/main/res/layout/reviewer_answer_buttons.xml
@@ -25,7 +25,7 @@
         android:layout_height="wrap_content"
         android:orientation="horizontal"
         android:weightSum="100"
-        android:visibility="visible"
+        android:visibility="gone"
         android:layout_marginEnd="4dp"
         android:layout_marginRight="4dp"
         android:paddingTop="8dp"


### PR DESCRIPTION
## Purpose / Description
This feature allows the user to quickly preview all the cards using the seek bar to transition to a question in another position of the deck. Also the counter allows the user to know which position of the deck is being viewed.

## Fixes
https://github.com/ankidroid/Anki-Android/issues/5689

## Approach
Added a seek bar on the bottom of the previewer (above buttons) and a textview as card counter.

## How Has This Been Tested?

Tested on physical device (Android 8.0 - API level 26) for configuration changes and process death.
Also tried in different screen sizes.

## Possible changes
If the user has a very big collection the numbers may not fit in one line..(tested xxxx/xxxx on a 4 inch screen it was ok).  No style was added to the textview.

## Screenshots
#### Original - With Seekbar
<img src="https://user-images.githubusercontent.com/57217107/71806459-29d8e100-3069-11ea-8913-62d618935d54.png" width="200" alt="original"> <img src="https://user-images.githubusercontent.com/57217107/71806460-29d8e100-3069-11ea-8f46-a5651aa94ff4.png" width="200" alt="seekbar">

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
