### PR TITLE
Add preview in notes editor

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -878,6 +878,17 @@ public class NoteEditor extends AnkiActivity {
                 closeCardEditorWithCheck();
                 return true;
 
+            case R.id.action_preview:
+                Intent previewer = new Intent(NoteEditor.this, Previewer.class);
+                long[] cids = {mCurrentEditedCard.getId()};
+
+                previewer.putExtra("index", 0);
+                previewer.putExtra("cardList", cids);
+
+                startActivityWithoutAnimation(previewer);
+
+                return true;
+
             case R.id.action_save:
                 Timber.i("NoteEditor:: Save note button pressed");
                 saveNote();

--- a/AnkiDroid/src/main/res/menu/note_editor.xml
+++ b/AnkiDroid/src/main/res/menu/note_editor.xml
@@ -2,6 +2,12 @@
     xmlns:ankidroid="http://schemas.android.com/apk/res-auto" >
 
     <item
+        android:id="@+id/action_preview"
+        android:icon="@drawable/ic_remove_red_eye_white_24dp"
+        android:title="@string/card_editor_preview_card"
+        ankidroid:showAsAction="ifRoom"
+        android:visible="true"/>
+    <item
         android:id="@+id/action_save"
         android:icon="@drawable/ic_done_white_24dp"
         android:title="@string/save"


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Adds missing preview option in the notes editor.

## Fixes
Kinda fixes #5644 

"Kinda" because the current preview behaviour doesn't make much sense, since it will not preview the actual changes to the notes/cards but still the old card in the database. This should be somehow addressed in another PR since it involes changing how the Previwer itself works and which params are getting passed to it.

## Approach
Added the preview "eye" in the toolbar in notes editor. Clicking on it opens the previewer to preview the card that's beeing edited.

## How Has This Been Tested?
Testend on pixel 2 api 29 emulator.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
