### PR TITLE
Order by creation of note

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sched.java
@@ -2264,7 +2264,7 @@ public class Sched {
 
 
     public void orderCards(long did) {
-        List<Long> cids = mCol.getDb().queryColumn(Long.class, "SELECT id FROM cards WHERE did = " + did + " ORDER BY id", 0);
+        List<Long> cids = mCol.getDb().queryColumn(Long.class, "SELECT id FROM cards WHERE did = " + did + " ORDER BY nid", 0);
         sortCards(Utils.toPrimitive(cids), 1, 1, false, false);
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/SchedV2.java
@@ -2463,7 +2463,7 @@ public class SchedV2 extends Sched {
 
 
     public void orderCards(long did) {
-        List<Long> cids = mCol.getDb().queryColumn(Long.class, "SELECT id FROM cards WHERE did = " + did + " ORDER BY id", 0);
+        List<Long> cids = mCol.getDb().queryColumn(Long.class, "SELECT id FROM cards WHERE did = " + did + " ORDER BY nid", 0);
         sortCards(Utils.toPrimitive(cids), 1, 1, false, false);
     }
 


### PR DESCRIPTION
Porting ankitects@d9b5a1da891a2b61e7d5b8ba4e4fe59185696a91
Ankidroid had the exact same bug than anki. I didn't actually try to reproduce it on my ankidroid, because that's a long process (see the commit for details). I just checked that, with this trivial change, you can still change order of new cards in a standard deck's option