### PR TITLE
Remove method onSaveInstanceState in FieldEditText, fix #5660

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.java
@@ -3,6 +3,7 @@ package com.ichi2.anki;
 
 import android.content.Context;
 import android.graphics.drawable.Drawable;
+import android.os.Parcelable;
 import android.util.AttributeSet;
 import android.widget.TextView;
 import androidx.appcompat.widget.AppCompatEditText;
@@ -31,6 +32,14 @@ public class FieldEditText extends AppCompatEditText {
 
     public FieldEditText(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
+    }
+
+
+    @Override
+    public Parcelable onSaveInstanceState() {
+        // content text has been saved in NoteEditor.java, restore twice caused issue#5660
+        super.onSaveInstanceState();
+        return null;
     }
 
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Don't duplicate the text in Front EditText after split screen operation (activity destroy/recreate)

## Fixes
Fixes #5660 

## Approach
Activity recreated after split screen. The code in NoteEditor handles onSaveInstanceState correctly including saving/restoring FieldEditText contents but FieldEditText saves text automatically itself unless you override and cutout the behavior.

## How Has This Been Tested?

manually tested with cases in issue

## Learning (optional, can help others)

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
