### PR TITLE
Ignore android VM screen capture images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ Thumbs.db
 *.ipr
 *.iws
 /.idea/*
+/captures
 
 # IDEA/Android Studio Ignore exceptions - this lets you share things you specifically want all team members to use
 !/.idea/codeStyles/


### PR DESCRIPTION
## Purpose / Description
Screenshots taken with the Android VM appear in a 'captures' folder in the root directory of the project. Git will track there, but there shouldn't be a need to ever version control them.

## Fixes
I didn't create an issue - are they required for pull request?

## Approach
excludes folder in gitignore

## How Has This Been Tested?

Hides local screenshots I've taken from being tracked by git

## Checklist
_Please, go through these checks before submitting the PR._

- [x ] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [ x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ x] You have commented your code, particularly in hard-to-understand areas
- [ x] You have performed a self-review of your own code
