### PR TITLE
Avoid RuntimeException crash in Sound

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.java
@@ -253,8 +253,8 @@ public class Sound {
                 try {
                     metaRetriever.setDataSource(AnkiDroidApp.getInstance().getApplicationContext(), soundUri);
                     length += Long.parseLong(metaRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION));
-                } catch (IllegalArgumentException iae) {
-                    Timber.e(iae, "metaRetriever - Error setting Data Source for mediaRetriever (media doesn't exist).");
+                } catch (Exception e) {
+                    Timber.e(e, "metaRetriever - Error setting Data Source for mediaRetriever (media doesn't exist or forbidden?).");
                 }
             }
         }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

It is not documented, but in AOSP source RuntimeException may be
thrown for a variety of reasons while retrieving media metadata

## Fixes
Not logged, but was brought up in play store review and has associated crash UUID URL https://couchdb.ankidroid.org/acralyzer/_design/acralyzer/index.html#/report-details/a572b30b-82d6-454d-b587-4e20b83a5d5e

## Approach

This fix expands the catch to handle those RuntimeExceptions, even
though we can't really recover from them. The method is only responsible
for returning the duration of the sound, and it will now default to 0
in these cases.

This media duration method itself is only used when AnkiDroid is
configured for auto-advancing review, to calculate the delay correctly.
Since the file is likely inaccessible anyway, waiting for 0 duration in
that case seems correct anyway

## How Has This Been Tested?

Local run of the app on simulator API28, plus CI should check it. That said, having a stack trace with only one possible way it can happen based on inspection of AOSP source gives me confidence

## Learning (optional, can help others)

Here's the source for the Java file, where RuntimeException is not documented, but you can see where the .setDataSource(Context, URI) code goes native:

https://github.com/aosp-mirror/platform_frameworks_base/blob/master/media/java/android/media/MediaMetadataRetriever.java

Here's the native code where it will chuck a RuntimeException if there are any problems: https://github.com/aosp-mirror/platform_frameworks_base/blob/master/media/jni/android_media_MediaMetadataRetriever.cpp#L189

Since it's obvious it can happen, and the consequence is light, seems best to catch it vs crashing.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
