### PR TITLE
Added review options related to the automatic showing of answer specific to a group of decks

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1967,11 +1967,11 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
         hideEaseButtons();
 
         // Check if it should use the general 'Timeout settings' or the ones specific to this deck
-        if (mOptUseGeneralTimerSettings){
+        if (mOptUseGeneralTimerSettings) {
             mUseTimer = mPrefUseTimer;
             mWaitAnswerSecond = mPrefWaitAnswerSecond;
             mWaitQuestionSecond = mPrefWaitQuestionSecond;
-        }else{
+        } else {
             mUseTimer = mOptUseTimer;
             mWaitAnswerSecond = mOptWaitAnswerSecond;
             mWaitQuestionSecond = mOptWaitQuestionSecond;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1728,7 +1728,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
         mRelativeButtonSize = preferences.getInt("answerButtonSize", 100);
         mSpeakText = preferences.getBoolean("tts", false);
         mPrefUseTimer = preferences.getBoolean("timeoutAnswer", false);
-        mPrefWaitAnswerSecond = preferences.getInt("timeoutAnswerSeconds", 6);
+        mPrefWaitAnswerSecond = preferences.getInt("timeoutAnswerSeconds", 20);
         mPrefWaitQuestionSecond = preferences.getInt("timeoutQuestionSeconds", 60);
         mScrollingButtons = preferences.getBoolean("scrolling_buttons", false);
         mDoubleScrolling = preferences.getBoolean("double_scrolling", false);
@@ -1778,11 +1778,12 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
             mShowNextReviewTime = getCol().getConf().getBoolean("estTimes");
             mShowRemainingCardCount = getCol().getConf().getBoolean("dueCounts");
 
+            // Get the review options for this group
             JSONObject revOptions = getCol().getDecks().confForDid(getCol().getDecks().current().getLong("id")).getJSONObject("rev");
 
             mOptUseGeneralTimerSettings = revOptions.optBoolean("useGeneralTimeoutSettings", true);
             mOptUseTimer = revOptions.optBoolean("timeoutAnswer", false);
-            mOptWaitAnswerSecond = revOptions.optInt("timeoutAnswerSeconds", 6);
+            mOptWaitAnswerSecond = revOptions.optInt("timeoutAnswerSeconds", 20);
             mOptWaitQuestionSecond = revOptions.optInt("timeoutQuestionSeconds", 60);
         } catch (JSONException e) {
             throw new RuntimeException();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
@@ -124,6 +124,12 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
                 mValues.put("revIvlFct", Integer.toString((int) (revOptions.getDouble("ivlFct") * 100)));
                 mValues.put("revMaxIvl", revOptions.getString("maxIvl"));
                 mValues.put("revBury", Boolean.toString(revOptions.optBoolean("bury", true)));
+
+                mValues.put("revUseGeneralTimeoutSettings", Boolean.toString(revOptions.optBoolean("useGeneralTimeoutSettings", true)));
+                mValues.put("revTimeoutAnswer", Boolean.toString(revOptions.optBoolean("timeoutAnswer", false)));
+                mValues.put("revTimeoutAnswerSeconds", Integer.toString(revOptions.optInt("timeoutAnswerSeconds", 6)));
+                mValues.put("revTimeoutQuestionSeconds", Integer.toString(revOptions.optInt("timeoutQuestionSeconds", 60)));
+
                 // lapse
                 JSONObject lapOptions = mOptions.getJSONObject("lapse");
                 mValues.put("lapSteps", StepsPreference.convertFromJSON(lapOptions.getJSONArray("delays")));
@@ -227,6 +233,18 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
                                 break;
                             case "revBury":
                                 mOptions.getJSONObject("rev").put("bury", value);
+                                break;
+                            case "revUseGeneralTimeoutSettings":
+                                mOptions.getJSONObject("rev").put("useGeneralTimeoutSettings", value);
+                                break;
+                            case "revTimeoutAnswer":
+                                mOptions.getJSONObject("rev").put("timeoutAnswer", value);
+                                break;
+                            case "revTimeoutAnswerSeconds":
+                                mOptions.getJSONObject("rev").put("timeoutAnswerSeconds", value);
+                                break;
+                            case "revTimeoutQuestionSeconds":
+                                mOptions.getJSONObject("rev").put("timeoutQuestionSeconds", value);
                                 break;
                             case "lapMinIvl":
                                 mOptions.getJSONObject("lapse").put("minInt", value);

--- a/AnkiDroid/src/main/res/values-pt-rPT/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-pt-rPT/10-preferences.xml
@@ -221,6 +221,8 @@
     <string name="deck_conf_new_bury_summ">As fichas novas relacionadas são ocultadas até ao dia seguinte</string>
     <string name="deck_conf_rev_bury">Ocultar revisões relacionadas</string>
     <string name="deck_conf_rev_bury_summ">As revisões relacionadas são ocultadas até ao dia seguinte</string>
+    <string name="deck_conf_use_general_timeout_settings">Utilizar as definições gerais para \'Mostrar resposta automaticamente\'</string>
+    <string name="deck_conf_use_general_timeout_settings_summ">Utilizar as definições gerais para \'Mostrar resposta automaticamente\' em vez de utilizar as definições deste grupo</string>
     <string name="deck_conf_easy_bonus">Bónus de facilidade</string>
     <string name="deck_conf_ivl_fct">Modificador de intervalo</string>
     <string name="deck_conf_max_ivl">Intervalo máximo</string>

--- a/AnkiDroid/src/main/res/values-pt-rPT/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-pt-rPT/10-preferences.xml
@@ -221,8 +221,6 @@
     <string name="deck_conf_new_bury_summ">As fichas novas relacionadas são ocultadas até ao dia seguinte</string>
     <string name="deck_conf_rev_bury">Ocultar revisões relacionadas</string>
     <string name="deck_conf_rev_bury_summ">As revisões relacionadas são ocultadas até ao dia seguinte</string>
-    <string name="deck_conf_use_general_timeout_settings">Utilizar as definições gerais para \'Mostrar resposta automaticamente\'</string>
-    <string name="deck_conf_use_general_timeout_settings_summ">Utilizar as definições gerais para \'Mostrar resposta automaticamente\' em vez de utilizar as definições deste grupo</string>
     <string name="deck_conf_easy_bonus">Bónus de facilidade</string>
     <string name="deck_conf_ivl_fct">Modificador de intervalo</string>
     <string name="deck_conf_max_ivl">Intervalo máximo</string>

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -17,7 +17,7 @@
 ~
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
---><resources>
+--><resources xmlns:tools="http://schemas.android.com/tools">
     <!-- generic strings -->
     <string name="disabled">Disabled</string>
     <string name="enabled">Enabled</string>
@@ -204,6 +204,8 @@
     <string name="deck_conf_new_bury_summ">Related new cards are buried until the next day</string>
     <string name="deck_conf_rev_bury">Bury related reviews</string>
     <string name="deck_conf_rev_bury_summ">Related reviews are buried until the next day</string>
+    <string name="deck_conf_use_general_timeout_settings" tools:ignore="MissingTranslation">Use general \'Automatic display answer\' settings</string>
+    <string name="deck_conf_use_general_timeout_settings_summ" tools:ignore="MissingTranslation">Use general \'Automatic display answer\' settings instead of using the settings for this group</string>
     <string name="deck_conf_easy_bonus">Easy bonus</string>
     <string name="deck_conf_ivl_fct">Interval modifier</string>
     <string name="deck_conf_max_ivl">Maximum interval</string>

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -17,7 +17,7 @@
 ~
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
---><resources xmlns:tools="http://schemas.android.com/tools">
+--><resources>
     <!-- generic strings -->
     <string name="disabled">Disabled</string>
     <string name="enabled">Enabled</string>
@@ -204,8 +204,8 @@
     <string name="deck_conf_new_bury_summ">Related new cards are buried until the next day</string>
     <string name="deck_conf_rev_bury">Bury related reviews</string>
     <string name="deck_conf_rev_bury_summ">Related reviews are buried until the next day</string>
-    <string name="deck_conf_use_general_timeout_settings" tools:ignore="MissingTranslation">Use general \'Automatic display answer\' settings</string>
-    <string name="deck_conf_use_general_timeout_settings_summ" tools:ignore="MissingTranslation">Use general \'Automatic display answer\' settings instead of using the settings for this group</string>
+    <string name="deck_conf_use_general_timeout_settings">Use general \'Automatic display answer\' settings</string>
+    <string name="deck_conf_use_general_timeout_settings_summ">Use general \'Automatic display answer\' settings instead of using the settings for this group.</string>
     <string name="deck_conf_easy_bonus">Easy bonus</string>
     <string name="deck_conf_ivl_fct">Interval modifier</string>
     <string name="deck_conf_max_ivl">Maximum interval</string>

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -204,7 +204,7 @@
     <string name="deck_conf_new_bury_summ">Related new cards are buried until the next day</string>
     <string name="deck_conf_rev_bury">Bury related reviews</string>
     <string name="deck_conf_rev_bury_summ">Related reviews are buried until the next day</string>
-    <string name="deck_conf_use_general_timeout_settings">Use general \'Automatic display answer\' settings</string>
+    <string name="deck_conf_use_general_timeout_settings">Use general settings</string>
     <string name="deck_conf_use_general_timeout_settings_summ">Use general \'Automatic display answer\' settings instead of using the settings for this group.</string>
     <string name="deck_conf_easy_bonus">Easy bonus</string>
     <string name="deck_conf_ivl_fct">Interval modifier</string>

--- a/AnkiDroid/src/main/res/xml/deck_options.xml
+++ b/AnkiDroid/src/main/res/xml/deck_options.xml
@@ -135,6 +135,33 @@
                 android:key="revBury"
                 android:summary="@string/deck_conf_rev_bury_summ"
                 android:title="@string/deck_conf_rev_bury" />
+
+            <CheckBoxPreference
+                android:defaultValue="true"
+                android:disableDependentsState="true"
+                android:key="revUseGeneralTimeoutSettings"
+                android:title="Use general 'Automatic display answer' settings" />
+            <CheckBoxPreference
+                android:defaultValue="false"
+                android:disableDependentsState="false"
+                android:dependency="revUseGeneralTimeoutSettings"
+                android:key="revTimeoutAnswer"
+                android:summary="@string/timeout_answer_summ"
+                android:title="@string/timeout_answer_text" />
+            <com.ichi2.ui.SeekBarPreference
+                android:defaultValue="6"
+                android:dependency="revTimeoutAnswer"
+                android:key="revTimeoutAnswerSeconds"
+                android:max="30"
+                android:summary="@string/timeout_answer_seconds_summ"
+                android:title="@string/timeout_answer_seconds" />
+            <com.ichi2.ui.SeekBarPreference
+                android:defaultValue="60"
+                android:dependency="revTimeoutAnswer"
+                android:key="revTimeoutQuestionSeconds"
+                android:max="60"
+                android:summary="@string/timeout_question_seconds_summ"
+                android:title="@string/timeout_question_seconds" />
         </PreferenceScreen>
         <PreferenceScreen android:title="@string/deck_conf_lps_cards" >
             <com.ichi2.preferences.StepsPreference

--- a/AnkiDroid/src/main/res/xml/deck_options.xml
+++ b/AnkiDroid/src/main/res/xml/deck_options.xml
@@ -136,32 +136,35 @@
                 android:summary="@string/deck_conf_rev_bury_summ"
                 android:title="@string/deck_conf_rev_bury" />
 
-            <CheckBoxPreference
-                android:defaultValue="true"
-                android:disableDependentsState="true"
-                android:key="revUseGeneralTimeoutSettings"
-                android:title="Use general 'Automatic display answer' settings" />
-            <CheckBoxPreference
-                android:defaultValue="false"
-                android:disableDependentsState="false"
-                android:dependency="revUseGeneralTimeoutSettings"
-                android:key="revTimeoutAnswer"
-                android:summary="@string/timeout_answer_summ"
-                android:title="@string/timeout_answer_text" />
-            <com.ichi2.ui.SeekBarPreference
-                android:defaultValue="6"
-                android:dependency="revTimeoutAnswer"
-                android:key="revTimeoutAnswerSeconds"
-                android:max="30"
-                android:summary="@string/timeout_answer_seconds_summ"
-                android:title="@string/timeout_answer_seconds" />
-            <com.ichi2.ui.SeekBarPreference
-                android:defaultValue="60"
-                android:dependency="revTimeoutAnswer"
-                android:key="revTimeoutQuestionSeconds"
-                android:max="60"
-                android:summary="@string/timeout_question_seconds_summ"
-                android:title="@string/timeout_question_seconds" />
+            <PreferenceCategory android:title="@string/pref_cat_automatic_display" >
+                <CheckBoxPreference
+                    android:defaultValue="true"
+                    android:disableDependentsState="true"
+                    android:key="revUseGeneralTimeoutSettings"
+                    android:title="@string/deck_conf_use_general_timeout_settings"
+                    android:summary="@string/deck_conf_use_general_timeout_settings_summ" />
+                <CheckBoxPreference
+                    android:defaultValue="false"
+                    android:disableDependentsState="false"
+                    android:dependency="revUseGeneralTimeoutSettings"
+                    android:key="revTimeoutAnswer"
+                    android:summary="@string/timeout_answer_summ"
+                    android:title="@string/timeout_answer_text" />
+                <com.ichi2.ui.SeekBarPreference
+                    android:defaultValue="20"
+                    android:dependency="revTimeoutAnswer"
+                    android:key="revTimeoutAnswerSeconds"
+                    android:max="30"
+                    android:summary="@string/timeout_answer_seconds_summ"
+                    android:title="@string/timeout_answer_seconds" />
+                <com.ichi2.ui.SeekBarPreference
+                    android:defaultValue="60"
+                    android:dependency="revTimeoutAnswer"
+                    android:key="revTimeoutQuestionSeconds"
+                    android:max="60"
+                    android:summary="@string/timeout_question_seconds_summ"
+                    android:title="@string/timeout_question_seconds" />
+            </PreferenceCategory>
         </PreferenceScreen>
         <PreferenceScreen android:title="@string/deck_conf_lps_cards" >
             <com.ichi2.preferences.StepsPreference

--- a/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
@@ -141,7 +141,7 @@
             android:summary="@string/timeout_answer_summ"
             android:title="@string/timeout_answer_text" />
         <com.ichi2.ui.SeekBarPreference
-            android:defaultValue="6"
+            android:defaultValue="20"
             android:dependency="timeoutAnswer"
             android:key="timeoutAnswerSeconds"
             android:max="30"


### PR DESCRIPTION
## Purpose / Description
The 'Automatic display answer' settings are very useful for increasing the speed of review. Nonetheless, different decks have different needs and, as a user, I always felt that having a single set of settings for all decks was not enough.  As such, I decided to search for a way to solve this. I did not find a solution, only a related issue. For a while now, I've changing the settings between decks, which is cumbersome.

This commit adds 'Automatic display answer' to the group options, allowing for the user to use either the specific settings of a group or use the general ones.

## Fixes
An issue I found related to this: https://github.com/ankidroid/Anki-Android/issues/3838

## Approach
This commit adds 'Automatic display answer' to the group options, allowing for the user to use either the specific settings of a group or use the general ones.

## How Has This Been Tested?

I've used an emulator and created different decks, on different groups. Changed the options of one of the groups to use specific settings and tested them to make sure they were using the correct settings.
