### PR TITLE
Okhttp interrupted crash

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
@@ -19,6 +19,7 @@
 package com.ichi2.async;
 
 import android.Manifest;
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.pm.PackageManager;
 import android.net.ConnectivityManager;
@@ -122,6 +123,7 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
     /*
      * Runs on GUI thread
      */
+    @SuppressLint("WakelockTimeout")
     @Override
     protected void onPreExecute() {
         super.onPreExecute();
@@ -213,7 +215,7 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
             return data;
         } catch (Exception e2) {
             // Ask user to report all bugs which aren't timeout errors
-            if (!timeoutOccured(e2)) {
+            if (!timeoutOccurred(e2)) {
                 AnkiDroidApp.sendExceptionReport(e2, "doInBackgroundLogin");
             }
             data.success = false;
@@ -249,7 +251,7 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
     }
 
 
-    private boolean timeoutOccured(Exception e) {
+    private boolean timeoutOccurred(Exception e) {
         String msg = e.getMessage();
         return msg.contains("UnknownHostException") ||
                 msg.contains("HttpHostConnectException") ||
@@ -366,7 +368,7 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
                     data.result = new Object[] { "OutOfMemoryError" };
                     return data;
                 } catch (RuntimeException e) {
-                    if (timeoutOccured(e)) {
+                    if (timeoutOccurred(e)) {
                         data.result = new Object[] {"connectionError" };
                     } else if (e.getMessage().equals("UserAbortedSync")) {
                         data.result = new Object[] {"UserAbortedSync" };
@@ -411,7 +413,7 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
                         }
                     }
                 } catch (RuntimeException e) {
-                    if (timeoutOccured(e)) {
+                    if (timeoutOccurred(e)) {
                         data.result = new Object[] {"connectionError" };
                     } else if (e.getMessage().equals("UserAbortedSync")) {
                         data.result = new Object[] {"UserAbortedSync" };
@@ -438,7 +440,7 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
             Timber.e("doInBackgroundSync -- unknown response code error");
             e.printStackTrace();
             data.success = false;
-            Integer code = e.getResponseCode();
+            int code = e.getResponseCode();
             String msg = e.getLocalizedMessage();
             data.result = new Object[] { "error", code , msg };
             return data;
@@ -448,7 +450,7 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
             Timber.e("doInBackgroundSync error");
             e.printStackTrace();
             data.success = false;
-            if (timeoutOccured(e)) {
+            if (timeoutOccurred(e)) {
                 data.result = new Object[]{"connectionError"};
             } else if (e.getMessage().equals("UserAbortedSync")) {
                 data.result = new Object[] {"UserAbortedSync" };
@@ -510,7 +512,7 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
     }
 
     public static class Payload {
-        public int taskType;
+        private int taskType;
         public Object[] data;
         public Object result;
         public boolean success;

--- a/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
@@ -260,6 +260,7 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
                 msg.contains("ClientProtocolException") ||
                 msg.contains("deadline reached") ||
                 msg.contains("interrupted") ||
+                msg.contains("Failed to connect") ||
                 msg.contains("TimeoutException");
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
@@ -256,6 +256,8 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
                 msg.contains("SSLException while building HttpClient") ||
                 msg.contains("SocketTimeoutException") ||
                 msg.contains("ClientProtocolException") ||
+                msg.contains("deadline reached") ||
+                msg.contains("interrupted") ||
                 msg.contains("TimeoutException");
     }
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

https://couchdb.ankidroid.org/acralyzer/_design/acralyzer/index.html#/report-details/950f7ab5-1e97-44a2-b58a-e56f15d08e72

OkHTTP uses slightly different errors to percolate timeouts and connection interruptions vs the apache-http library, so we are now misinterpreting relatively harmless errors has something we should crash on


## Approach

I added the two okio (okhttp underlying library) messages to our connection error logic

https://github.com/square/okio/blob/1bed1bc104c19a673ad86fbe7e8eed859131a5ee/okio/src/main/java/okio/Timeout.java#L220-L226

## How Has This Been Tested?

Installed and used on API28 and API29 emulators to do a conflict full sync, a no-op sync, then to sync the results of a small review between them, it all still worked. I also checked interrupting data while a full sync was happening and it threw an error message instead of crashing

After the one commit with what should be the crash fix there is a second separate one which delints the file a bit. Look at the commits separately for easy review

## Learning (optional, can help others)

googled for the error present in the stack trace after stepping through the control flow in our connection code to see how the error was circulating

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
