### PR TITLE
Fix ImportDialog IllegalStateException crash

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -1180,8 +1180,8 @@ public class DeckPicker extends NavigationDrawerActivity implements
                 || (id == ImportDialog.DIALOG_IMPORT_ADD_CONFIRM)
                 || (id == ImportDialog.DIALOG_IMPORT_REPLACE_CONFIRM)) {
             Timber.d("showImportDialog() delegating to ImportDialog");
-            DialogFragment newFragment = ImportDialog.newInstance(id, message);
-            showDialogFragment(newFragment);
+            AsyncDialogFragment newFragment = ImportDialog.newInstance(id, message);
+            showAsyncDialogFragment(newFragment);
         } else {
             Timber.d("showImportDialog() delegating to file picker intent");
             Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportDialog.java
@@ -15,7 +15,7 @@ import com.ichi2.utils.ImportUtils;
 import java.io.File;
 import java.util.List;
 
-public class ImportDialog extends AnalyticsDialogFragment {
+public class ImportDialog extends AsyncDialogFragment {
 
     public static final int DIALOG_IMPORT_HINT = 0;
     public static final int DIALOG_IMPORT_SELECT = 1;
@@ -121,6 +121,16 @@ public class ImportDialog extends AnalyticsDialogFragment {
             default:
                 return null;
         }
+    }
+
+    @Override
+    public String getNotificationMessage() {
+        return getResources().getString(R.string.import_interrupted);
+    }
+
+    @Override
+    public String getNotificationTitle() {
+        return getResources().getString(R.string.import_title);
     }
     
     public void dismissAllDialogFragments() {

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -149,6 +149,7 @@
     <string name="import_error_not_apkg_extension">Filename “%s” doesn’t have .apkg or .colpkg extension</string>
     <string name="import_error_content_provider">The selected file couldn’t be imported automatically by AnkiDroid. Please see the user manual for how to manually import anki files: \n%s</string>
     <string name="import_replacing">Replacing collection…</string>
+    <string name="import_interrupted">Import interrupted</string>
     <string name="export_include_schedule">Include scheduling</string>
     <string name="export_include_media">Include media</string>
     <string name="confirm_apkg_export">Export collection as Anki package?</string>


### PR DESCRIPTION

```
java.lang.IllegalStateException: Can not perform this action after onSaveInstanceState
at androidx.fragment.app.FragmentManagerImpl.checkStateLoss(FragmentManagerImpl.java:2)
at androidx.fragment.app.FragmentManagerImpl.enqueueAction(FragmentManagerImpl.java:1)
at androidx.fragment.app.BackStackRecord.commitInternal(BackStackRecord.java:12)
at androidx.fragment.app.BackStackRecord.commit(BackStackRecord.java:1)
at androidx.fragment.app.DialogFragment.show(DialogFragment.java:10)
at com.ichi2.anki.AnkiActivity.showDialogFragment(AnkiActivity.java:5)
at com.ichi2.anki.DeckPicker.showImportDialog(DeckPicker.java:13)
at com.ichi2.anki.dialogs.DialogHandler.handleMessage(DialogHandler.java:6)
at android.os.Handler.dispatchMessage(Handler.java:106)
at android.os.Looper.loop(Looper.java:201)
at android.app.ActivityThread.main(ActivityThread.java:6820)
```

It appears ImportDialog can be requested in an async manner now from the
system file picker, and attempting to show the dialog when the Activity
has gone away results in a crash.

This is a simple conversion to an AsyncDialogFragment so we can gracefully
toast a message instead of crashing

I am unable to reproduce this but the crash reporting system is littered with it, and all the async infrastructure exists, so it seems sensible to fix

## How Has This Been Tested?

On an API28 emulator I exported and imported a bunch of times to make sure normal imports still worked.
