### PR TITLE
Mathjax wrong api crash

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ env:
     # PATH order is incredibly important. e.g. the 'emulator' script exists in more than one place!
     - PATH=${ANDROID_HOME}:${ANDROID_HOME}/emulator:${TOOLS}:${TOOLS}/bin:${ANDROID_HOME}/platform-tools:${PATH}
     - UNIT_TEST=FALSE # by default we don't run the unit tests, they are run only in specific builds
+    - LINT=FALSE # by default we don't lint, they are run only in specific builds
     - FINALIZE_COVERAGE=FALSE # by default we don't finalize coverage, it is done in one specific build
   matrix:
    #- API=15 # only runs locally. Create+Start once from AndroidStudio to init sdcard. Then only from command-line w/-engine classic
@@ -56,6 +57,10 @@ jobs:
       os: osx
     - stage: unit_test
       env: UNIT_TEST=TRUE API=NONE
+      install: skip
+      os: linux
+    - stage: unit_test
+      env: LINT=TRUE API=NONE
       install: skip
       os: linux
     - stage: finalize_coverage
@@ -121,6 +126,7 @@ install:
 
 script:
   - if [ "$UNIT_TEST" = "TRUE" ]; then ./gradlew jacocoUnitTestReport; fi
+  - if [ "$LINT" = "TRUE" ]; then ./gradlew lint; fi
   - if [ "$API" != "NONE" ]; then ./gradlew jacocoAndroidTestReport; fi
 
 after_success:

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -93,6 +93,10 @@ android {
             manifest.srcFile 'src/test/AndroidManifest.xml'
         }
     }
+    lintOptions {
+        check 'NewApi'
+        abortOnError true
+    }
 }
 
 play {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/template/Template.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/template/Template.java
@@ -379,14 +379,11 @@ public class Template {
         // flags in middle of expression deprecated
         boolean in_mathjax = false;
 
-        // The following regex matches one of:
-        //  -  MathJax opening
-        //  -  MathJax close
-        //  -  Cloze deletion number `ord`
+        // The following regex matches one of 3 things, noted below:
         String regex = new StringBuilder("(?si)")
-            .append("(?<mathjaxopen>\\\\[(\\[])|")
-            .append("(?<mathjaxclose>\\\\[\\])])|")
-            .append("(?<cloze>")
+            .append("(\\\\[(\\[])|")  // group 1, MathJax opening
+            .append("(\\\\[\\])])|")  // group 2, MathJax close
+            .append("(")              // group 3, Cloze deletion number `ord`
             .append(String.format(Locale.US, creg, ord))
             .append(")")
             .toString();
@@ -395,17 +392,17 @@ public class Template {
 
         StringBuffer repl = new StringBuffer();
         while (m.find()) {
-            if (m.group("mathjaxopen") != null) {
+            if (m.group(1) != null) {
                 if (in_mathjax) {
                     Log.d(TAG, "MathJax opening found while already in MathJax");
                 }
                 in_mathjax = true;
-            } else if (m.group("mathjaxclose") != null) {
+            } else if (m.group(2) != null) {
                 if (!in_mathjax) {
                     Log.d(TAG, "MathJax close found while not in MathJax");
                 }
                 in_mathjax = false;
-            } else if (m.group("cloze") != null) {
+            } else if (m.group(3) != null) {
                 if (in_mathjax) {
                     // appendReplacement has an issue with backslashes, so...
                     m.appendReplacement(


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

The crash database had a good number of crashes like this:

```
java.lang.RuntimeException: An error occurred while executing doInBackground()
at android.os.AsyncTask$3.done(AsyncTask.java:309)
at java.util.concurrent.FutureTask.finishCompletion(FutureTask.java:354)
at java.util.concurrent.FutureTask.setException(FutureTask.java:223)
at java.util.concurrent.FutureTask.run(FutureTask.java:242)
at android.os.AsyncTask$SerialExecutor$1.run(AsyncTask.java:234)
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1113)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:588)
at java.lang.Thread.run(Thread.java:818)
Caused by: java.lang.NoSuchMethodError: No virtual method group(Ljava/lang/String;)Ljava/lang/String; in class Ljava/util/regex/Matcher; or its super classes (declaration of 'java.util.regex.Matcher' appears in /system/framework/core-libart.jar)
at com.ichi2.libanki.template.Template.removeFormattingFromMathjax(Template.java:12)
at com.ichi2.libanki.template.Template.clozeText(Template.java:2)
```

Turns out PR #5673 used an API26 regex API and I/we did not catch it


## Approach
I added a lint job that will fail NewApi lint violations
I modified the regex API usage to use numbered matches

## How Has This Been Tested?

I demonstrated the NewApi failure first: https://travis-ci.com/mikehardy/Anki-Android/jobs/286172124
There is a unit test for the mathjax code, which is very helpful, so I verified that failed modifying the regex in a deliberately incorrect way, then verified it worked after what I believe is the appropriate edit to use numbered groups

@agentydragon - it would be nice if you looked at the modified regex to make sure I didn't do anything braindead, I'm handy enough with regex to know that I am no master