### PR TITLE
Categorize more okhttp connection errors as harmless

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
@@ -261,6 +261,9 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
                 msg.contains("deadline reached") ||
                 msg.contains("interrupted") ||
                 msg.contains("Failed to connect") ||
+                msg.contains("InterruptedIOException") ||
+                msg.contains("stream was reset") ||
+                msg.contains("ConnectionShutdownException") ||
                 msg.contains("TimeoutException");
     }
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

OkHTTP has a slightly different way of reporting connection errors than the Apache HTTP library did, and while these don't cause application crashes they do clutter the crash reporting database because we send non-fatal error reports for them.

## Fixes
This adds 3 new string matches to the connection error handling to categorize the matched exception messages as harmless

## How Has This Been Tested?

Difficult to reproduce, but on emulators account syncing still works after these chanes
