### PR TITLE
Dependency updates 20200213

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -154,7 +154,7 @@ dependencies {
     api project(":api")
 
     testImplementation 'org.junit.vintage:junit-vintage-engine:5.6.0'
-    testImplementation 'org.mockito:mockito-core:3.2.4'
+    testImplementation 'org.mockito:mockito-core:3.3.0'
     testImplementation 'org.powermock:powermock-core:2.0.5'
     testImplementation 'org.powermock:powermock-module-junit4:2.0.5'
     testImplementation 'org.powermock:powermock-api-mockito2:2.0.5'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -156,7 +156,7 @@ dependencies {
     testImplementation 'org.junit.vintage:junit-vintage-engine:5.6.0'
     testImplementation 'org.mockito:mockito-core:3.2.4'
     testImplementation 'org.powermock:powermock-core:2.0.5'
-    testImplementation 'org.powermock:powermock-module-junit4:2.0.4'
+    testImplementation 'org.powermock:powermock-module-junit4:2.0.5'
     testImplementation 'org.powermock:powermock-api-mockito2:2.0.4'
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
     testImplementation 'net.lachlanmckee:timber-junit-rule:1.0.1'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -150,7 +150,7 @@ dependencies {
 
     implementation 'com.jakewharton.timber:timber:4.7.1'
     implementation 'com.google.code.gson:gson:2.8.6'
-    implementation 'org.jsoup:jsoup:1.12.1'
+    implementation 'org.jsoup:jsoup:1.12.2'
     api project(":api")
 
     testImplementation 'org.junit.vintage:junit-vintage-engine:5.6.0'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -130,7 +130,7 @@ dependencies {
     implementation 'androidx.browser:browser:1.0.0'
     implementation 'androidx.exifinterface:exifinterface:1.1.0'
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
-    implementation 'io.requery:sqlite-android:3.30.1'
+    implementation 'io.requery:sqlite-android:3.31.0'
     implementation 'android.arch.persistence:db-framework:1.1.1'
     implementation 'com.afollestad.material-dialogs:core:0.9.6.0'
     implementation 'com.getbase:floatingactionbutton:1.10.1'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -126,7 +126,7 @@ dependencies {
     //noinspection GradleDependency
     implementation 'androidx.appcompat:appcompat:1.1.0-rc01'
     // Note: the design support library can be quite buggy, so test everything thoroughly before updating it
-    implementation 'com.google.android.material:material:1.0.0'
+    implementation 'com.google.android.material:material:1.1.0'
     implementation 'androidx.browser:browser:1.0.0'
     implementation 'androidx.exifinterface:exifinterface:1.1.0'
     implementation 'androidx.recyclerview:recyclerview:1.1.0'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -155,7 +155,7 @@ dependencies {
 
     testImplementation 'org.junit.vintage:junit-vintage-engine:5.6.0'
     testImplementation 'org.mockito:mockito-core:3.2.4'
-    testImplementation 'org.powermock:powermock-core:2.0.4'
+    testImplementation 'org.powermock:powermock-core:2.0.5'
     testImplementation 'org.powermock:powermock-module-junit4:2.0.4'
     testImplementation 'org.powermock:powermock-api-mockito2:2.0.4'
     testImplementation 'org.hamcrest:hamcrest-all:1.3'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -157,7 +157,7 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:3.2.4'
     testImplementation 'org.powermock:powermock-core:2.0.5'
     testImplementation 'org.powermock:powermock-module-junit4:2.0.5'
-    testImplementation 'org.powermock:powermock-api-mockito2:2.0.4'
+    testImplementation 'org.powermock:powermock-api-mockito2:2.0.5'
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
     testImplementation 'net.lachlanmckee:timber-junit-rule:1.0.1'
     testImplementation "org.robolectric:robolectric:4.2.1"


### PR DESCRIPTION
Typical batch of dependency updates
In this one we have sqlite, material and jsoup for release changes

The rest are internal testing items (powermock)

They pass CI, and because material could affect visible items I also spot-checked it on an emulator and nothing appears visually different. Should be okay, but still targeting for 2.10 not a 2.9 merge