### PR TITLE
Replace apache http remnant / Beolingus parse fix

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/LoadPronounciationActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/LoadPronounciationActivity.java
@@ -370,7 +370,7 @@ public class LoadPronounciationActivity extends Activity implements OnCancelList
 
     private String computeAddressOfTranslationPage() {
         // Service name has to be replaced from the language lister.
-        String address = "http://dict.tu-chemnitz.de/dings.cgi?lang=en&service=SERVICE&opterrors=0&optpro=0&query=Welt";
+        String address = "https://dict.tu-chemnitz.de/dings.cgi?lang=en&service=SERVICE&opterrors=0&optpro=0&query=Welt";
 
         String strFrom = mSpinnerFrom.getSelectedItem().toString();
         String langCodeFrom = mLanguageLister.getCodeFor(strFrom);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/TranslationActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/TranslationActivity.java
@@ -215,7 +215,7 @@ public class TranslationActivity extends FragmentActivity implements DialogInter
 
 
     private String computeAddress() {
-        String address = "http://glosbe.com/gapi/translate?from=FROMLANG&dest=TOLANG&format=json&phrase=SOURCE&pretty=true";
+        String address = "https://glosbe.com/gapi/translate?from=FROMLANG&dest=TOLANG&format=json&phrase=SOURCE&pretty=true";
 
         String strFrom = mSpinnerFrom.getSelectedItem().toString();
         // Conversion to iso, lister created before.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/beolingus/parsing/BeolingusParser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/beolingus/parsing/BeolingusParser.java
@@ -41,11 +41,12 @@ public class BeolingusParser {
     public static String getPronunciationAddressFromTranslation(String html, String wordToSearchFor) {
         Matcher m = PRONUNC_PATTERN.matcher(html);
         while (m.find()) {
-            if (m.group(2).equals(wordToSearchFor)) {
+            if (m.group(2).contains(wordToSearchFor)) {
                 Timber.d("pronunciation URL is https://dict.tu-chemnitz.de%s", m.group(1));
                 return "https://dict.tu-chemnitz.de" + m.group(1);
             }
         }
+        Timber.d("Unable to find pronunciation URL");
         return "no";
     }
 
@@ -61,6 +62,7 @@ public class BeolingusParser {
             Timber.d("MP3 address is https://dict.tu-chemnitz.de%s", m.group(1));
             return "https://dict.tu-chemnitz.de" + m.group(1);
         }
+        Timber.d("Unable to find MP3 file address");
         return "no";
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/web/HttpFetcher.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/web/HttpFetcher.java
@@ -3,6 +3,7 @@
  * Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
  * Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
  * Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
+ * Copyright (c) 2020 Mike Hardy <github@mikehardy.net>                                 *
  *                                                                                      *
  * This program is free software; you can redistribute it and/or modify it under        *
  * the terms of the GNU General Public License as published by the Free Software        *
@@ -21,22 +22,29 @@ package com.ichi2.anki.web;
 
 import android.content.Context;
 
+import com.ichi2.async.Connection;
 import com.ichi2.compat.CompatHelper;
+import com.ichi2.libanki.sync.Tls12SocketFactory;
 
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.Charset;
+import java.util.concurrent.TimeUnit;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import timber.log.Timber;
 
 /**
  * Helper class to download from web.
  * <p>
  * Used in AsyncTasks in Translation and Pronunciation activities, and more...
  */
-@SuppressWarnings("deprecation") // tracking HTTP transport change in github already
 public class HttpFetcher {
 
     public static String fetchThroughHttp(String address) {
@@ -46,24 +54,34 @@ public class HttpFetcher {
 
     public static String fetchThroughHttp(String address, String encoding) {
 
+        Timber.d("fetching %s", address);
+        Response response = null;
+
         try {
-            org.apache.http.client.HttpClient httpClient = new org.apache.http.impl.client.DefaultHttpClient();
-            org.apache.http.params.HttpParams params = httpClient.getParams();
-            org.apache.http.params.HttpConnectionParams.setConnectionTimeout(params, 10000);
-            org.apache.http.params.HttpConnectionParams.setSoTimeout(params, 60000);
-            org.apache.http.protocol.HttpContext localContext = new org.apache.http.protocol.BasicHttpContext();
-            org.apache.http.client.methods.HttpGet httpGet = new org.apache.http.client.methods.HttpGet(address);
-            org.apache.http.HttpResponse response = httpClient.execute(httpGet, localContext);
-            if (response.getStatusLine().getStatusCode() != 200) {
+            Request.Builder requestBuilder = new Request.Builder();
+            requestBuilder.url(address).get();
+            Request httpGet = requestBuilder.build();
+
+            OkHttpClient.Builder clientBuilder = new OkHttpClient.Builder();
+            Tls12SocketFactory.enableTls12OnPreLollipop(clientBuilder)
+                    .connectTimeout(Connection.CONN_TIMEOUT, TimeUnit.SECONDS)
+                    .writeTimeout(Connection.CONN_TIMEOUT, TimeUnit.SECONDS)
+                    .readTimeout(Connection.CONN_TIMEOUT, TimeUnit.SECONDS);
+            OkHttpClient client = clientBuilder.build();
+            response = client.newCall(httpGet).execute();
+
+
+            if (response.code() != 200) {
+                Timber.d("Response code was %s, returning failure", response.code());
                 return "FAILED";
             }
 
-            BufferedReader reader = new BufferedReader(new InputStreamReader(response.getEntity().getContent(),
+            BufferedReader reader = new BufferedReader(new InputStreamReader(response.body().byteStream(),
                     Charset.forName(encoding)));
 
             StringBuilder stringBuilder = new StringBuilder();
 
-            String line = null;
+            String line;
             while ((line = reader.readLine()) != null) {
                 stringBuilder.append(line);
             }
@@ -71,48 +89,15 @@ public class HttpFetcher {
             return stringBuilder.toString();
 
         } catch (Exception e) {
+            Timber.d(e, "Failed with an exception");
             return "FAILED with exception: " + e.getMessage();
+        } finally {
+            if (response != null && response.body() != null) {
+                response.body().close();
+            }
         }
-
     }
 
-
-    // public static String downloadFileToCache(String UrlToFile, Context context, String prefix)
-    // {
-    // try
-    // {
-    // URL url = new URL(UrlToFile);
-    //
-    // String extension = UrlToFile.substring(UrlToFile.length() - 4);
-    //
-    // HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection();
-    // urlConnection.setRequestMethod("GET");
-    // urlConnection.setDoOutput(true);
-    // urlConnection.connect();
-    //
-    // File outputDir = context.getCacheDir();
-    // File file = File.createTempFile(prefix, extension, outputDir);
-    //
-    // FileOutputStream fileOutput = new FileOutputStream(file);
-    // InputStream inputStream = urlConnection.getInputStream();
-    //
-    // byte[] buffer = new byte[1024];
-    // int bufferLength = 0;
-    //
-    // while ((bufferLength = inputStream.read(buffer)) > 0)
-    // {
-    // fileOutput.write(buffer, 0, bufferLength);
-    // }
-    // fileOutput.close();
-    //
-    // return file.getAbsolutePath();
-    //
-    // }
-    // catch (Exception e)
-    // {
-    // return "FAILED " + e.getMessage();
-    // }
-    // }
 
     public static String downloadFileToSdCard(String UrlToFile, Context context, String prefix) {
         String str = downloadFileToSdCardMethod(UrlToFile, context, prefix, "GET");
@@ -125,28 +110,51 @@ public class HttpFetcher {
 
 
     public static String downloadFileToSdCardMethod(String UrlToFile, Context context, String prefix, String method) {
+
+        Response response = null;
+
         try {
             URL url = new URL(UrlToFile);
 
             String extension = UrlToFile.substring(UrlToFile.length() - 4);
 
-            HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection();
-            urlConnection.setRequestMethod(method);
-            urlConnection.setRequestProperty("Referer", "com.ichi2.anki");
-            urlConnection.setRequestProperty("User-Agent", "Mozilla/5.0 ( compatible ) ");
-            urlConnection.setRequestProperty("Accept", "*/*");
-			urlConnection.setConnectTimeout(10000);
-			urlConnection.setReadTimeout(60000);
-            urlConnection.connect();
+            Request.Builder requestBuilder = new Request.Builder();
+            requestBuilder.url(url);
+            if ("GET".equals(method)) {
+                requestBuilder.get();
+            } else {
+                requestBuilder.post(RequestBody.create(null, new byte[0]));
+            }
+            Request request = requestBuilder.build();
+
+            OkHttpClient.Builder clientBuilder = new OkHttpClient.Builder();
+            clientBuilder.addNetworkInterceptor(chain -> chain.proceed(
+                    chain.request()
+                            .newBuilder()
+                            .header("Referer", "com.ichi2.anki")
+                            .header("User-Agent", "Mozilla/5.0 ( compatible ) ")
+                            .header("Accept", "*/*")
+                            .build()
+            ));
+            Tls12SocketFactory.enableTls12OnPreLollipop(clientBuilder)
+                    .connectTimeout(Connection.CONN_TIMEOUT, TimeUnit.SECONDS)
+                    .writeTimeout(Connection.CONN_TIMEOUT, TimeUnit.SECONDS)
+                    .readTimeout(Connection.CONN_TIMEOUT, TimeUnit.SECONDS);
+            OkHttpClient client = clientBuilder.build();
+            response = client.newCall(request).execute();
 
             File file = File.createTempFile(prefix, extension, context.getCacheDir());
-            InputStream inputStream = urlConnection.getInputStream();
+            InputStream inputStream = response.body().byteStream();
             CompatHelper.getCompat().copyFile(inputStream, file.getCanonicalPath());
             inputStream.close();
             return file.getAbsolutePath();
 
         } catch (Exception e) {
             return "FAILED " + e.getMessage();
+        } finally {
+            if (response != null && response.body() != null) {
+                response.body().close();
+            }
         }
     }
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

I noticed a crash in 2.9 related to Apache HTTP client and it led me to discover there was one more Apache HTTP remnant in the HttpFetcher used to download pronunciation and translations.

https://couchdb.ankidroid.org/acralyzer/_design/acralyzer/index.html#/report-details/33a4184e-c3d7-4b60-af73-ca68b02fdfbb

```
java.lang.RuntimeException: An error occurred while executing doInBackground()
at android.os.AsyncTask$3.done(AsyncTask.java:354)
at java.util.concurrent.FutureTask.finishCompletion(FutureTask.java:383)
at java.util.concurrent.FutureTask.setException(FutureTask.java:252)
at java.util.concurrent.FutureTask.run(FutureTask.java:271)
at android.os.AsyncTask$SerialExecutor$1.run(AsyncTask.java:245)
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
at java.lang.Thread.run(Thread.java:764)
Caused by: java.lang.IncompatibleClassChangeError: Class 'org.apache.http.conn.ssl.SSLSocketFactory' does not implement interface 'org.apache.http.conn.scheme.SchemeSocketFactory' in call to 'java.net.Socket org.apache.http.conn.scheme.SchemeSocketFactory.createSocket(org.apache.http.params.HttpParams)' (declaration of 'org.apache.http.impl.conn.DefaultClientConnectionOperator' appears in base.apk)
at org.apache.http.impl.conn.DefaultClientConnectionOperator.openConnection(DefaultClientConnectionOperator.java:13)
at org.apache.http.impl.conn.ManagedClientConnectionImpl.open(ManagedClientConnectionImpl.java:11)
at org.apache.http.impl.client.DefaultRequestDirector.tryConnect(DefaultRequestDirector.java:5)
at org.apache.http.impl.client.DefaultRequestDirector.execute(DefaultRequestDirector.java:31)
at org.apache.http.impl.client.AbstractHttpClient.doExecute(AbstractHttpClient.java:29)
at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:7)
at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:4)
at com.ichi2.anki.web.HttpFetcher.fetchThroughHttp(HttpFetcher.java:8)
at com.ichi2.anki.multimediacard.activity.LoadPronounciationActivity$BackgroundPost.doInBackground(LoadPronounciationActivity.java:2)
at com.ichi2.anki.multimediacard.activity.LoadPronounciationActivity$BackgroundPost.doInBackground(LoadPronounciationActivity.java:1)
at android.os.AsyncTask$2.call(AsyncTask.java:333)
at java.util.concurrent.FutureTask.run(FutureTask.java:266)
```

I additionally discovered, while testing, that Beolingus had changed their response text to include extra information after the word, so our pronunciation downloader was no longer matching it correctly, so no pronunciations were ever found for words that definitely had matches

## Fixes
Fixes #5376 by altering beolingus match to "contains" vs "equals"

## Approach
Converts HttpFetcher to OkHTTP
Converts online requests to HTTPS
Fixes the matcher so beolingus works

## How Has This Been Tested?
API28 emulator, it easily reproduced all the problems, and worked after making these changes

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
