### PR TITLE
Fix add audio crashes

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.java
@@ -182,9 +182,9 @@ public class ModelFieldEditor extends AnkiActivity {
                             .replaceAll("[\'\"\\n\\r\\[\\]\\(\\)]", "");
 
                     if (fieldName.length() == 0) {
-                        showToast(getResources().getString(R.string.toast_empty_name));
+                        UIUtils.showThemedToast(this, getResources().getString(R.string.toast_empty_name), true);
                     } else if (containsField(fieldName)) {
-                        showToast(getResources().getString(R.string.toast_duplicate_field));
+                        UIUtils.showThemedToast(this, getResources().getString(R.string.toast_duplicate_field), true);
                     } else {
                         //Name is valid, now field is added
                         try {
@@ -235,7 +235,7 @@ public class ModelFieldEditor extends AnkiActivity {
 
 
         if (mFieldLabels.size() < 2) {
-            showToast(getResources().getString(R.string.toast_last_field));
+            UIUtils.showThemedToast(this, getResources().getString(R.string.toast_last_field), true);
         } else {
             try {
                 mCol.modSchema();
@@ -282,9 +282,9 @@ public class ModelFieldEditor extends AnkiActivity {
                         String fieldLabel = mFieldNameInput.getText().toString()
                                 .replaceAll("[\'\"\\n\\r\\[\\]\\(\\)]", "");
                         if (fieldLabel.length() == 0) {
-                            showToast(getResources().getString(R.string.toast_empty_name));
+                            UIUtils.showThemedToast(this, getResources().getString(R.string.toast_empty_name), true);
                         } else if (containsField(fieldLabel)) {
-                            showToast(getResources().getString(R.string.toast_duplicate_field));
+                            UIUtils.showThemedToast(this, getResources().getString(R.string.toast_duplicate_field), true);
                         } else {
                             //Field is valid, now rename
                             try {
@@ -332,12 +332,12 @@ public class ModelFieldEditor extends AnkiActivity {
                         try {
                             pos = Integer.parseInt(newPosition);
                         } catch (NumberFormatException n) {
-                            showToast(getResources().getString(R.string.toast_out_of_range));
+                            UIUtils.showThemedToast(this, getResources().getString(R.string.toast_out_of_range), true);
                             return;
                         }
 
                         if (pos < 1 || pos > mFieldLabels.size()) {
-                            showToast(getResources().getString(R.string.toast_out_of_range));
+                            UIUtils.showThemedToast(this, getResources().getString(R.string.toast_out_of_range), true);
                         } else {
                             // Input is valid, now attempt to modify
                             try {
@@ -461,13 +461,6 @@ public class ModelFieldEditor extends AnkiActivity {
             }
         }
         return false;
-    }
-
-
-    private void showToast(CharSequence text) {
-        int duration = Toast.LENGTH_SHORT;
-        Toast toast = Toast.makeText(this, text, duration);
-        toast.show();
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicAudioClipFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicAudioClipFieldController.java
@@ -1,3 +1,18 @@
+/****************************************************************************************
+ * Copyright (c) 2020 Mike Hardy <github@mikehardy.net>                                 *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
 package com.ichi2.anki.multimediacard.fields;
 
 import android.app.Activity;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicAudioClipFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicAudioClipFieldController.java
@@ -87,15 +87,31 @@ public class BasicAudioClipFieldController extends FieldControllerBase implement
         if ((resultCode != Activity.RESULT_CANCELED) && (requestCode == ACTIVITY_SELECT_AUDIO_CLIP)) {
 
             Uri selectedClip = data.getData();
-            Timber.d(selectedClip.toString());
 
             // Get information about the selected document
-            String[] queryColumns = { MediaStore.MediaColumns.DISPLAY_NAME, MediaStore.MediaColumns.SIZE };
+            String[] queryColumns = { MediaStore.MediaColumns.DISPLAY_NAME, MediaStore.MediaColumns.SIZE, MediaStore.MediaColumns.MIME_TYPE };
             Cursor cursor = mActivity.getContentResolver().query(selectedClip, queryColumns, null, null, null);
+
+            if (cursor == null) {
+                 UIUtils.showThemedToast(AnkiDroidApp.getInstance().getApplicationContext(),
+                         AnkiDroidApp.getInstance().getString(R.string.multimedia_editor_something_wrong), true);
+                return;
+            }
+
             cursor.moveToFirst();
+            Timber.d("got name/size/type: %s/%s/%s", cursor.getString(0), cursor.getLong(1), cursor.getString(2));
             String audioClipFullName = cursor.getString(0);
-            // Note this could be unsafe, null name, or name without standard extension etc, go off mime types instead?
             String[] audioClipFullNameParts = audioClipFullName.split("\\.");
+            if (audioClipFullNameParts.length < 2) {
+                try {
+                    Timber.d("Audio clip name does not have extension, using second half of mime type");
+                    audioClipFullNameParts = new String[] {audioClipFullName, cursor.getString(2).split("\\/")[1]};
+                } catch (Exception e) {
+                    UIUtils.showThemedToast(AnkiDroidApp.getInstance().getApplicationContext(),
+                            AnkiDroidApp.getInstance().getString(R.string.multimedia_editor_something_wrong), true);
+                    return;
+                }
+            }
             cursor.close();
 
             // We may receive documents we can't access directly, we have to copy to a temp file


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

Add audio clips was a highly requested feature, and it worked structurally but failed when confronted with unexpected audio clip names or unexpected content resolver states (like, no results - it always expected one)

Also the error handling and implementation of file copies were non-standard

## Fixes
Fixes #5509 

## Approach

Best to review each commit separately as they are discrete and independently useful

1. generalize the ability to show toasts (so we can inform users of audio clip issues)
1. standardize the content file copy and error handling using existing helper function
1. improve content resolver results handling in case results are empty or contain an audio clip with no file extensions


## How Has This Been Tested?

I used an API29 emulator attached to a google play account so I could use my Google Drive as a source of audio files that would not be resolved to file paths.

I added two audio files, one with extension and one without to my google drive

I verified crashes when attempting to add the audio file without an extension

I verified everything works for both files after all the changes


## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
