### PR TITLE
Don't assume dynamic decks have review options

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1773,14 +1773,19 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
             mShowNextReviewTime = getCol().getConf().getBoolean("estTimes");
             mShowRemainingCardCount = getCol().getConf().getBoolean("dueCounts");
 
-            // Get the review options for this group
-            JSONObject revOptions = getCol().getDecks().confForDid(getCol().getDecks().selected()).getJSONObject("rev");
+            // Dynamic don't have review options; attempt to get deck-specific auto-advance options
+            // but be prepared to go with all default if it's a dynamic deck
+            JSONObject revOptions = new JSONObject();
+            if (!getCol().getDecks().isDyn(getCol().getDecks().current().getLong("id"))) {
+                revOptions = getCol().getDecks().confForDid(getCol().getDecks().current().getLong("id")).getJSONObject("rev");
+            }
 
             mOptUseGeneralTimerSettings = revOptions.optBoolean("useGeneralTimeoutSettings", true);
             mOptUseTimer = revOptions.optBoolean("timeoutAnswer", false);
             mOptWaitAnswerSecond = revOptions.optInt("timeoutAnswerSeconds", 20);
             mOptWaitQuestionSecond = revOptions.optInt("timeoutQuestionSeconds", 60);
         } catch (JSONException e) {
+            Timber.e(e, "Unable to restoreCollectionPreferences");
             throw new RuntimeException(e);
         } catch (NullPointerException npe) {
             // NPE on collection only happens if the Collection is broken, follow AnkiActivity example


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

Something is going on with regard to dynamic decks. At least the ones formed with a filter that is to preview ahead a certain number of days.

They don't contain all the items I would expect in the deck conf

One symptom is #5708 but #5756 is also happening.

I have fixed #5756 here by going to all default arguments if it is a dynamic deck, which is possible because we have sensible defaults for it. But I'm not sure how to fix #5708 yet

## Fixes
Fixes #5756

## Approach
Carefully attempt to access the decks "rev" object, only if the deck is not dynamic.

## How Has This Been Tested?

I was able to reproduce the google test lab pre-launch report crash by watching the video and clicking along on an API28 emulator.

I was able to avoid the same crash after adding this patch

