### PR TITLE
Use application-level resources for Async fragments

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportDialog.java
@@ -125,12 +125,12 @@ public class ImportDialog extends AsyncDialogFragment {
 
     @Override
     public String getNotificationMessage() {
-        return getResources().getString(R.string.import_interrupted);
+        return res().getString(R.string.import_interrupted);
     }
 
     @Override
     public String getNotificationTitle() {
-        return getResources().getString(R.string.import_title);
+        return res().getString(R.string.import_title);
     }
     
     public void dismissAllDialogFragments() {


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

ImportDialog was still crashing after #5743 

https://couchdb.ankidroid.org/acralyzer/_design/acralyzer/index.html#/report-details/4a0ab280-d1bc-4265-bba5-2fd175004c3d

```
java.lang.IllegalStateException: Fragment ImportDialog{59c7f45 (0ccc9642-1fda-4aed-b165-c4fdd4b1ee02) dialog} not attached to a context.
at androidx.fragment.app.Fragment.requireContext(Fragment.java:2)
at androidx.fragment.app.Fragment.getResources(Fragment.java:1)
at com.ichi2.anki.dialogs.ImportDialog.getNotificationTitle(ImportDialog.java:1)
at com.ichi2.anki.AnkiActivity.showAsyncDialogFragment(AnkiActivity.java:4)
at com.ichi2.anki.AnkiActivity.showAsyncDialogFragment(AnkiActivity.java:1)
at com.ichi2.anki.DeckPicker.showImportDialog(DeckPicker.java:13)
at com.ichi2.anki.dialogs.DialogHandler.handleMessage(DialogHandler.java:6)
at android.os.Handler.dispatchMessage(Handler.java:107)
at android.os.Looper.loop(Looper.java:237)
at android.app.ActivityThread.main(ActivityThread.java:7811)
at java.lang.reflect.Method.invoke(Native Method)
at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1076)
```

Turns out my initial fix was *almost* correct but not quite. I was accessing the resources non-idiomatically compared with the other AsyncDialogFragments. 

Now I use the built-in function as opposed to attempting to access the resources via the context


## Approach
Use the methods that exist - they exist for a reason of course. Learning they exist so I use them is on me

## How Has This Been Tested?

local jacocoTestReport to make sure it worked, then an import of a deck on an API28 emulator. Everything is still fine on the happy path but this is an exception fix of course

I will continue watching acralyzer until I nail this one, it's our most frequent crash at the moment.
