### PR TITLE
Avoid crash on audio clip w/no extension or mime type

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicAudioClipFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicAudioClipFieldController.java
@@ -99,14 +99,17 @@ public class BasicAudioClipFieldController extends FieldControllerBase implement
             }
 
             cursor.moveToFirst();
-            Timber.d("got name/size/type: %s/%s/%s", cursor.getString(0), cursor.getLong(1), cursor.getString(2));
             String audioClipFullName = cursor.getString(0);
             String[] audioClipFullNameParts = audioClipFullName.split("\\.");
             if (audioClipFullNameParts.length < 2) {
                 try {
-                    Timber.d("Audio clip name does not have extension, using second half of mime type");
+                    Timber.i("Audio clip name does not have extension, using second half of mime type");
                     audioClipFullNameParts = new String[] {audioClipFullName, cursor.getString(2).split("\\/")[1]};
                 } catch (Exception e) {
+                    // This code is difficult to stabilize - it is not clear how to handle files with no extension
+                    // and apparently we may fail to get MIME_TYPE information - in that case we will gather information
+                    // about what people are experiencing in the real world and decide later, but without crashing at least
+                    AnkiDroidApp.sendExceptionReport(e, "Audio Clip addition failed. Name " + audioClipFullName + " / cursor mime type column type " + cursor.getType(2));
                     UIUtils.showThemedToast(AnkiDroidApp.getInstance().getApplicationContext(),
                             AnkiDroidApp.getInstance().getString(R.string.multimedia_editor_something_wrong), true);
                     return;


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
#5755 was a major improvement in audio clip handling but there was still a crash, this time related to my attempt to debug log the mime-type information

Turns out that can be null which will throw an exception in the Android implementation: https://developer.android.com/reference/android/database/Cursor.html#getString(int)

```
java.lang.RuntimeException: Failure delivering result ResultInfo{who=null, request=1, result=-1, data=Intent { dat=content://com.mi.android.globalFileexplorer.myprovider/external_files/Download/Cloakroom.mp3 flg=0x1 }} to activity {com.ichi2.anki/com.ichi2.anki.multimediacard.activity.MultimediaEditFieldActivity}: java.lang.IllegalStateException: Couldn't read row 0, col 2 from CursorWindow. Make sure the Cursor is initialized correctly before accessing data from it.
at android.app.ActivityThread.deliverResults(ActivityThread.java:4285)
at android.app.ActivityThread.handleSendResult(ActivityThread.java:4329)
at android.app.ActivityThread.-wrap20(Unknown Source:0)
at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1657)
at android.os.Handler.dispatchMessage(Handler.java:106)
at android.os.Looper.loop(Looper.java:164)
at android.app.ActivityThread.main(ActivityThread.java:6543)
at java.lang.reflect.Method.invoke(Native Method)
at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:438)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:807)
Caused by: java.lang.IllegalStateException: Couldn't read row 0, col 2 from CursorWindow. Make sure the Cursor is initialized correctly before accessing data from it.
at android.database.CursorWindow.nativeGetString(Native Method)
at android.database.CursorWindow.getString(CursorWindow.java:438)
at android.database.AbstractWindowedCursor.getString(AbstractWindowedCursor.java:51)
at android.database.CursorWrapper.getString(CursorWrapper.java:137)
at com.ichi2.anki.multimediacard.fields.BasicAudioClipFieldController.onActivityResult(BasicAudioClipFieldController.java:7)
at com.ichi2.anki.multimediacard.activity.MultimediaEditFieldActivity.onActivityResult(MultimediaEditFieldActivity.java:3)
at android.app.Activity.dispatchActivityResult(Activity.java:7290)
at android.app.ActivityThread.deliverResults(ActivityThread.java:4281)
```


## Approach
Hard to win on this one!
So I removed the debug logging which accessed the possibly-null-and-will-throw column
I added extra logging about what was happening and send an error report now so we can see how often it happens and with what kinds of data, but we will not crash anymore

## How Has This Been Tested?
Same as previous PR I tested a file that has an extension and one that has only a MIME type from google drive, but I don't know what content provider to use that won't provide mime type information so I can't reproduce the fail path yet. I can guarantee we don't crash on it now though at least

## Learning (optional, can help others)
You just never know when an API will throw a RuntimeException...

## Checklist
_Please, go through these checks before submitting the PR._

- [ ] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
