### PR TITLE
AdvancedStatistics: disregard suspended, etc. cards

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/hooks/AdvancedStatistics.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/hooks/AdvancedStatistics.java
@@ -588,6 +588,7 @@ public class AdvancedStatistics extends Hook  {
             query = "SELECT id, due, ivl, factor, type, reps " +
                     "FROM cards " +
                     "WHERE did IN (" + did + ") " +
+                    "AND queue != -1 " +   // ignore suspended cards
                     "order by id;";
             Timber.d("Forecast query: %s", query);
             cur = db.query(query, null);


### PR DESCRIPTION
## Fixes
Fixes #5289 
Suspended cards are ignored by prediction algorithm.