### PR TITLE
Manually grant permissions <= Lollipop to avoid camera crash

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
@@ -20,13 +20,16 @@
 package com.ichi2.anki.multimediacard.fields;
 
 import android.Manifest;
+import android.annotation.SuppressLint;
 import android.app.Activity;
+import android.content.ClipData;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.database.Cursor;
 import android.graphics.Bitmap;
 import android.net.Uri;
+import android.os.Build;
 import android.provider.MediaStore;
 import android.provider.MediaStore.MediaColumns;
 import androidx.core.content.ContextCompat;
@@ -75,7 +78,8 @@ public class BasicImageFieldController extends FieldControllerBase implements IF
         return (int) Math.min(height * 0.4, width * 0.6);
     }
 
-
+    // The NewApi deprecation should be removed with API21. UnsupportedChromeOsCameraSystemFeature can be fixed in API16
+    @SuppressLint( {"UnsupportedChromeOsCameraSystemFeature", "NewApi"})
     @Override
     public void createUI(Context context, LinearLayout layout) {
         mImagePreview = new ImageView(mActivity);
@@ -117,6 +121,16 @@ public class BasicImageFieldController extends FieldControllerBase implements IF
                         image);
 
                 cameraIntent.putExtra(MediaStore.EXTRA_OUTPUT, uriSavedImage);
+
+                // Until Android API21 (maybe 22) you must manually handle permissions for image capture w/FileProvider
+                // It does not exist on API15 so they will still crash sadly. This can be removed once minSDK is >= 22
+                // https://medium.com/@quiro91/sharing-files-through-intents-part-2-fixing-the-permissions-before-lollipop-ceb9bb0eec3a
+                if (CompatHelper.getSdkVersion() <= Build.VERSION_CODES.LOLLIPOP &&
+                    CompatHelper.getSdkVersion() >= Build.VERSION_CODES.JELLY_BEAN) {
+                    cameraIntent.setClipData(ClipData.newRawUri("", uriSavedImage));
+                    cameraIntent.addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION | Intent.FLAG_GRANT_READ_URI_PERMISSION);
+                }
+
                 if (cameraIntent.resolveActivity(context.getPackageManager()) != null) {
                     mActivity.startActivityForResultWithoutAnimation(cameraIntent, ACTIVITY_TAKE_PICTURE);
                 }


### PR DESCRIPTION

## Pull Request template

## Purpose / Description

There were complaints of camera crashing but I'd never seen it, in working on another issue
that required use of an old emulator I noticed that indeed the camera is crashing on image
capture for Android API <= 21 (maybe 22)!

That's no good. This should fix it in the internet-recommended way.

https://medium.com/@quiro91/sharing-files-through-intents-part-2-fixing-the-permissions-before-lollipop-ceb9bb0eec3a


## Fixes
Related #4871, #4799 - both of those look like they were likely this bug

## Approach

Pursue any crash I see in testing to it's stackoverflow-directed conclusion, basically. Then test it.

## How Has This Been Tested?

I checked it on API18 emulators (reproducible crash without this patch) and an API28 emulator (worked fine before and after)

## Learning (optional, can help others)

I believe the root cause is the conversion to FileProvider for use in Android >= 7, which was part of the forward-porting from 2.8 to 2.9. No good deed unpunished

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
