### PR TITLE
Bump Gradle to 3.6.1 to match Android Studio stable release

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -2,7 +2,7 @@ import com.android.ddmlib.DdmPreferences
 
 plugins {
  // Gradle plugin portal 
- id 'com.github.triplet.play' version '2.6.2'
+ id 'com.github.triplet.play' version '2.7.2'
 }
 
 apply plugin: 'com.android.application'

--- a/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/ContentProviderTest.java
+++ b/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/ContentProviderTest.java
@@ -71,7 +71,7 @@ public class ContentProviderTest {
     @Rule
     public GrantPermissionRule mRuntimePermissionRule =
             GrantPermissionRule.grant(Manifest.permission.WRITE_EXTERNAL_STORAGE,
-                    com.ichi2.anki.Manifest.permission.READ_WRITE_DATABASE);
+                    FlashCardsContract.READ_WRITE_PERMISSION);
 
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.java
@@ -1,6 +1,7 @@
 
 package com.ichi2.compat;
 
+import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.res.TypedArray;
@@ -13,8 +14,6 @@ import android.view.Window;
 import android.webkit.CookieManager;
 
 import com.ichi2.anki.AnkiDroidApp;
-
-import java.util.HashMap;
 
 import timber.log.Timber;
 
@@ -48,6 +47,7 @@ public class CompatV21 extends CompatV19 implements Compat {
     }
 
     @Override
+    @SuppressLint("NewApi")
     public int getCameraCount() {
         CameraManager cameraManager = (CameraManager)AnkiDroidApp.getInstance().getApplicationContext()
                 .getSystemService(Context.CAMERA_SERVICE);

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.android.tools.build:gradle:3.6.1'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Note that ContentProviderTest needed a tweak as Manifest class
is no longer generated correctly, we are using the second method
to handle it, as described here:

https://developer.android.com/studio/releases/gradle-plugin#agp-missing-manifest

Also, lint in 3.6 is apparently a little stricter on NewApi checks.
For the CameraException I verified that the camera enumerated fine
on API18 which is below the API19 warning they emitted where things might
crash just from attempting to touch the class
