### PR TITLE
Update google-analytics library for Android 11 compatibility

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -143,7 +143,7 @@ dependencies {
     implementation'ch.acra:acra-toast:5.2.1'
     implementation'ch.acra:acra-limiter:5.2.1'
 
-    implementation 'net.mikehardy:google-analytics-java7:2.0.12'
+    implementation 'net.mikehardy:google-analytics-java7:2.0.13'
     //noinspection GradleDependency
     implementation 'com.squareup.okhttp3:okhttp:3.12.8'
     implementation 'com.arcao:slf4j-timber:3.1'


### PR DESCRIPTION
One more dependency update before generating next alpha - this prevents crashes for 11 preview people

Tested in API16 and API28 emulator via choosing to opt-in for feature sharing then setting analytics to dev mode in advanced preferences and scanning logcat to verify analytics post successes