### PR TITLE
Gracefully handle deck deletion while building reminders

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/ReminderService.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/ReminderService.java
@@ -95,6 +95,13 @@ public class ReminderService extends BroadcastReceiver {
 
     // getDeckDue information, will recur one time to workaround collection close if recur is true
     private Sched.DeckDueTreeNode getDeckDue(Context context, long deckId, boolean recur) {
+
+        // Avoid crashes if the deck is deleted while we are working
+        if (CollectionHelper.getInstance().getCol(context).getDecks().get(deckId, false) == null) {
+            Timber.d("Deck %s deleted while ReminderService was working. Ignoring", deckId);
+            return null;
+        }
+
         try {
             for (Sched.DeckDueTreeNode node : CollectionHelper.getInstance().getCol(context).getSched().deckDueTree()) {
                 if (node.did == deckId) {


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
If you delete a deck while building reminders, the app will crash because the scheduler will throw out a NullPointerException if asked to find cards due for a missing deck

If this seems okay, I'll cherry-pick this in 2.9.5 as a targetted crash fix, after marinating on 2.10alpha


## Fixes
https://couchdb.ankidroid.org/acralyzer/_design/acralyzer/index.html#/report-details/b772e271-82de-4945-a600-51eca6db7daa

```
Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'boolean org.json.JSONObject.has(java.lang.String)' on a null object reference
at com.ichi2.libanki.Decks.confForDid(Decks.java:2)
at com.ichi2.libanki.Sched._deckNewLimitSingle(Sched.java:3)
at com.ichi2.libanki.Sched.deckDueList(Sched.java:8)
at com.ichi2.libanki.Sched.deckDueTree(Sched.java:1)
at com.ichi2.anki.services.ReminderService.getDeckDue(ReminderService.java:1)
at com.ichi2.anki.services.ReminderService.onReceive(ReminderService.java:8)
at android.app.ActivityThread.handleReceiver(ActivityThread.java:3380)
```

## Approach

Follow the code through plus the logcat (which showed a deck was deleted just before the crash), put the two together to realize the reminder service was trying to work on the deleted deck and 

## How Has This Been Tested?
API29 emulator - reminders still appear to work, it's a race condition so hard to trigger but it doesn't mess up normal functionality

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
