### PR TITLE
Avoid crash on browser QA render if cancelled

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
@@ -887,19 +887,18 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
 
         // for each specified card in the browser list
         for (int i = startPos; i < startPos + n; i++) {
+            // Stop if cancelled
+            if (isCancelled()) {
+                Timber.d("doInBackgroundRenderBrowserQA was aborted");
+                return null;
+            }
             if (i >= 0 && i < items.size() && items.get(i).get("answer") == null) {
                 // Extract card item
                 Card c = col.getCard(Long.parseLong(items.get(i).get("id"), 10));
                 // Update item
                 CardBrowser.updateSearchItemQA(mContext, items.get(i), c);
-                // Stop if cancelled
-                if (isCancelled()) {
-                    Timber.d("doInBackgroundRenderBrowserQA was aborted");
-                    return null;
-                } else {
-                    float progress = (float) i / n * 100;
-                    publishProgress(new TaskData((int) progress));
-                }
+                float progress = (float) i / n * 100;
+                publishProgress(new TaskData((int) progress));
             }
         }
         return new TaskData(items);


### PR DESCRIPTION

## Pull Request template

## Purpose / Description
Avoid crash on browser QA render if cancelled

## Fixes
https://couchdb.ankidroid.org/acralyzer/_design/acralyzer/index.html#/report-details/32165275-1bc3-46d7-8611-5e381d2b7bde

```
java.lang.RuntimeException: An error occurred while executing doInBackground()
at android.os.AsyncTask$3.done(AsyncTask.java:354)
at java.util.concurrent.FutureTask.finishCompletion(FutureTask.java:383)
at java.util.concurrent.FutureTask.setException(FutureTask.java:252)
at java.util.concurrent.FutureTask.run(FutureTask.java:271)
at android.os.AsyncTask$SerialExecutor$1.run(AsyncTask.java:245)
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
at java.lang.Thread.run(Thread.java:764)
Caused by: java.lang.IndexOutOfBoundsException: Index: 257, Size: 0
at java.util.ArrayList.get(ArrayList.java:437)
at com.ichi2.async.DeckTask.doInBackgroundRenderBrowserQA(DeckTask.java:9)
at com.ichi2.async.DeckTask.doInBackground(DeckTask.java:29)
at com.ichi2.async.DeckTask.doInBackground(DeckTask.java:1)
at android.os.AsyncTask$2.call(AsyncTask.java:333)
at java.util.concurrent.FutureTask.run(FutureTask.java:266)
```

in combination with logcat

```
30 | 03-02 17:23:00.988 I/AnkiDroid(31033): Cancelled task 37
31 | 03-02 17:23:01.006 I/AnkiDroid(31033): Cancelled task 37
32 | 03-02 17:23:01.006 I/AnkiDroid(31033): Cancelled task 37
33 | 03-02 17:23:01.023 I/AnkiDroid(31033): Cancelled task 37
34 | 03-02 17:23:01.024 I/AnkiDroid(31033): Cancelled task 37
35 | 03-02 17:23:01.041 I/AnkiDroid(31033): Cancelled task 37
36 | 03-02 17:23:01.041 I/AnkiDroid(31033): Cancelled task 37
37 | 03-02 17:23:01.042 I/AnkiDroid(31033): NoteEditor:: Save note button pressed
38 | 03-02 17:23:01.066 I/AnkiDroid(31033): Cancelled task 37
39 | 03-02 17:23:01.067 I/AnkiDroid(31033): Cancelled task 37
40 | 03-02 17:23:01.067 I/AnkiDroid(31033): Creating notification channel with id/name: General Notifications/AnkiDroid
41 | 03-02 17:23:01.067 I/AnkiDroid(31033): Creating notification channel with id/name: Synchronization/Synchronization
42 | 03-02 17:23:01.069 I/AnkiDroid(31033): Creating notification channel with id/name: Global Reminders/Cards due
43 | 03-02 17:23:01.071 I/AnkiDroid(31033): Creating notification channel with id/name: Deck Reminders/Reminders
44 | 03-02 17:23:01.073 I/AnkiDroid(31033): CardBrowser:: CardBrowser: Saving card...
45 | 03-02 17:23:01.073 I/AnkiDroid(31033): Cancelled task 37
46 | --------- beginning of crash


```

## Approach
The mCards array is shared via TaskData into the async render DeckTask,
and in the render there is logic listening for a possible cancel, but
not until after it already attempted to touch the (possibly concurrently
mutated) mCards array, resulting in IndexOutOfBoundsException

This puts the cancel check above any usage of the shared mCards array
which should hopefully solve the race and avoid overrunning mutated mCards

If this receives positive review and marinates well on alphas, I'll cherry pick for a 2.9.5

## How Has This Been Tested?

API29 emulator - could not reproduce crash (it is racy) but moving to a short-circuit style with cancel check on top should be low-risk, and I verified scrolling and changing search terms (including to zero items shown) worked fine in the card browser after the change

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
