### PR TITLE
Import out of space fixes

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
@@ -652,6 +652,7 @@ public class Utils {
                 success = true;
             } catch (IOException e) {
                 if (retryCnt == retries) {
+                    Timber.e("IOException while writing to file, out of retries.");
                     throw e;
                 } else {
                     Timber.e("IOException while writing to file, retrying...");

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
@@ -102,6 +102,7 @@ public class Anki2Importer extends Importer {
             }
         } catch (RuntimeException e) {
             Timber.e(e, "RuntimeException while importing");
+            throw new ImportExportException(e.getMessage());
         }
     }
 
@@ -636,8 +637,16 @@ public class Anki2Importer extends Importer {
             // Mark file addition to media db (see note in Media.java)
             mDst.getMedia().markFileAdd(fname);
         } catch (IOException e) {
+
             // the user likely used subdirectories
             Timber.e(e, "Error copying file %s.", fname);
+
+            // If we are out of space, we should re-throw
+            if (e.getCause() != null && e.getCause().getMessage().contains("No space left on device")) {
+                // we need to let the user know why we are failing
+                Timber.e("We are out of space, bubbling up the file copy exception");
+                throw new RuntimeException(e);
+            }
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
@@ -76,7 +76,7 @@ public class ImportUtils {
             } else if (filename != null) {
                 // Copy to temporary file
                 String tempOutDir = Uri.fromFile(new File(context.getCacheDir(), filename)).getEncodedPath();
-                errorMessage = ImportUtils.copyFileToCache(context, intent, tempOutDir) ? null : "copyFileToCache() failed";
+                errorMessage = ImportUtils.copyFileToCache(context, intent, tempOutDir) ? null : "copyFileToCache() failed (possibly out of storage space)";
                 // Show import dialog
                 if (errorMessage == null) {
                     ImportUtils.sendShowImportFileDialogMsg(tempOutDir);


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Running out of space on import creates a lot of crash reports and also a fair bit of user support. I investigated and found that the messaging in general is terrible:

1. if we run out of space on cache copy from file provider it says "invalid package" (!)
1. if cache copy works but import runs out of space it silently fails to import media

## Fixes
https://couchdb.ankidroid.org/acralyzer/_design/acralyzer/index.html#/report-details/7395b0d7-e9b6-4ae3-a57b-c42b464dc8f1

```

003-02 21:08:45.253 E/AnkiDroid(26719): ImportUtils/ Could not copy file to /data/user/0/com.ichi2.anki/cache/550_Phrasal_Verbs_-_Part_1_Ingls_-_Portugus.apkg103-02 21:08:45.253 E/AnkiDroid(26719): java.io.IOException: write failed: ENOSPC (No space left on device)203-02 21:08:45.253 E/AnkiDroid(26719): at libcore.io.IoBridge.write(IoBridge.java:501)303-02 21:08:45.253 E/AnkiDroid(26719): at java.io.FileOutputStream.write(FileOutputStream.java:316)403-02 21:08:45.253 E/AnkiDroid(26719): at com.ichi2.compat.CompatV15.copyFile(CompatV15.java:16)503-02 21:08:45.253 E/AnkiDroid(26719): at com.ichi2.compat.CompatV15.copyFile(CompatV15.java:9)603-02 21:08:45.253 E/AnkiDroid(26719): at com.ichi2.utils.ImportUtils.copyFileToCache(ImportUtils.java:2)703-02 21:08:45.253 E/AnkiDroid(26719): at com.ichi2.utils.ImportUtils.handleFileImport(ImportUtils.java:16)803-02 21:08:45.253 E/AnkiDroid(26719): at com.ichi2.anki.IntentHandler.onCreate(IntentHandler.java:10)903-02 21:08:45.253 E/AnkiDroid(26719): at android.app.Activity.performCreate(Activity.java:6666)1003-02 21:08:45.253 E/AnkiDroid(26719): at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1118)1103-02 21:08:45.253 E/AnkiDroid(26719): at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2677)1203-02 21:08:45.253 E/AnkiDroid(26719): at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2789)1303-02 21:08:45.253 E/AnkiDroid(26719): at android.app.ActivityThread.-wrap12(ActivityThread.java)1403-02 21:08:45.253 E/AnkiDroid(26719): at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1527)1503-02 21:08:45.253 E/AnkiDroid(26719): at android.os.Handler.dispatchMessage(Handler.java:110)1603-02 21:08:45.253 E/AnkiDroid(26719): at android.os.Looper.loop(Looper.java:203)1703-02 21:08:45.253 E/AnkiDroid(26719): at android.app.ActivityThread.main(ActivityThread.java:6251)1803-02 21:08:45.253 E/AnkiDroid(26719): at java.lang.reflect.Method.invoke(Native Method)1903-02 21:08:45.253 E/AnkiDroid(26719): at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1063)2003-02 21:08:45.253 E/AnkiDroid(26719): at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:924)2103-02 21:08:45.253 E/AnkiDroid(26719): Caused by: android.system.ErrnoException: write failed: ENOSPC (No space left on device)2203-02 21:08:45.253 E/AnkiDroid(26719): at libcore.io.Posix.writeBytes(Native Method)2303-02 21:08:45.253 E/AnkiDroid(26719): at libcore.io.Posix.write(Posix.java:273)2403-02 21:08:45.253 E/AnkiDroid(26719): at libcore.io.BlockGuardOs.write(BlockGuardOs.java:319)2503-02 21:08:45.253 E/AnkiDroid(26719): at libcore.io.IoBridge.write(IoBridge.java:496)2603-02 21:08:45.253 E/AnkiDroid(26719): ... 18 more2703-02 21:08:45.253 E/AnkiDroid(26719):2803-02 21:08:45.253 E/AnkiDroid(26719): java.io.IOException: write failed: ENOSPC (No space left on device)2903-02 21:08:45.253 E/AnkiDroid(26719): at libcore.io.IoBridge.write(IoBridge.java:501)3003-02 21:08:45.253 E/AnkiDroid(26719): at java.io.FileOutputStream.write(FileOutputStream.java:316)3103-02 21:08:45.253 E/AnkiDroid(26719): at com.ichi2.compat.CompatV15.copyFile(CompatV15.java:16)3203-02 21:08:45.253 E/AnkiDroid(26719): at com.ichi2.compat.CompatV15.copyFile(CompatV15.java:9)3303-02 21:08:45.253 E/AnkiDroid(26719): at com.ichi2.utils.ImportUtils.copyFileToCache(ImportUtils.java:2)3403-02 21:08:45.253 E/AnkiDroid(26719): at com.ichi2.utils.ImportUtils.handleFileImport(ImportUtils.java:16)3503-02 21:08:45.253 E/AnkiDroid(26719): at com.ichi2.anki.IntentHandler.onCreate(IntentHandler.java:10)3603-02 21:08:45.253 E/AnkiDroid(26719): at android.app.Activity.performCreate(Activity.java:6666)3703-02 21:08:45.253 E/AnkiDroid(26719): at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1118)3803-02 21:08:45.253 E/AnkiDroid(26719): at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2677)3903-02 21:08:45.253 E/AnkiDroid(26719): at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2789)4003-02 21:08:45.253 E/AnkiDroid(26719): at android.app.ActivityThread.-wrap12(ActivityThread.java)4103-02 21:08:45.253 E/AnkiDroid(26719): at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1527)4203-02 21:08:45.253 E/AnkiDroid(26719): at android.os.Handler.dispatchMessage(Handler.java:110)4303-02 21:08:45.253 E/AnkiDroid(26719): at android.os.Looper.loop(Looper.java:203)4403-02 21:08:45.253 E/AnkiDroid(26719): at android.app.ActivityThread.main(ActivityThread.java:6251)4503-02 21:08:45.253 E/AnkiDroid(26719): at java.lang.reflect.Method.invoke(Native Method)4603-02 21:08:45.253 E/AnkiDroid(26719): at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1063)4703-02 21:08:45.253 E/AnkiDroid(26719): at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:924)4803-02 21:08:45.253 E/AnkiDroid(26719): Caused by: android.system.ErrnoException: write failed: ENOSPC (No space left on device)4903-02 21:08:45.253 E/AnkiDroid(26719): at libcore.io.Posix.writeBytes(Native Method)5003-02 21:08:45.253 E/AnkiDroid(26719): at libcore.io.Posix.write(Posix.java:273)5103-02 21:08:45.253 E/AnkiDroid(26719): at libcore.io.BlockGuardOs.write(BlockGuardOs.java:319)5203-02 21:08:45.253 E/AnkiDroid(26719): at libcore.io.IoBridge.write(IoBridge.java:496)5303-02 21:08:45.253 E/AnkiDroid(26719): ... 18 more5403-02 21:08:46.050 E/AnkiDroid(26719): AcraAnalyticsInteraction/ ACRA handling crash, sending analytics exception report5503-02 21:08:48.201 E/AnkiDroid(26719): ImportUtils/ showImportUnsuccessfulDialog() message copyFileToCache() failed5603-02 21:12:01.979 E/AnkiDroid(26719): ImportUtils/ Could not open input stream to intent data5703-02 21:12:01.979 E/AnkiDroid(26719): java.io.FileNotFoundException: No such file or directory5803-02 21:12:01.979 E/AnkiDroid(26719): at android.database.DatabaseUtils.readExceptionWithFileNotFoundExceptionFromParcel(DatabaseUtils.java:149)5903-02 21:12:01.979 E/AnkiDroid(26719): at android.content.ContentProviderProxy.openTypedAssetFile(ContentProviderNative.java:692)6003-02 21:12:01.979 E/AnkiDroid(26719): at android.content.ContentResolver.openTypedAssetFileDescriptor(ContentResolver.java:1179)6103-02 21:12:01.979 E/AnkiDroid(26719): at android.content.ContentResolver.openAssetFileDescriptor(ContentResolver.java:998)6203-02 21:12:01.979 E/AnkiDroid(26719): at android.content.ContentResolver.openInputStream(ContentResolver.java:718)6303-02 21:12:01.979 E/AnkiDroid(26719): at com.ichi2.utils.ImportUtils.copyFileToCache(ImportUtils.java:1)6403-02 21:12:01.979 E/AnkiDroid(26719): at com.ichi2.utils.ImportUtils.handleFileImport(ImportUtils.java:16)6503-02 21:12:01.979 E/AnkiDroid(26719): at com.ichi2.anki.IntentHandler.onCreate(IntentHandler.java:10) | 0 | 03-02 21:08:45.253 E/AnkiDroid(26719): ImportUtils/ Could not copy file to /data/user/0/com.ichi2.anki/cache/550_Phrasal_Verbs_-_Part_1_Ingls_-_Portugus.apkg | 1 | 03-02 21:08:45.253 E/AnkiDroid(26719): java.io.IOException: write failed: ENOSPC (No space left on device) | 2 | 03-02 21:08:45.253 E/AnkiDroid(26719): at libcore.io.IoBridge.write(IoBridge.java:501) | 3 | 03-02 21:08:45.253 E/AnkiDroid(26719): at java.io.FileOutputStream.write(FileOutputStream.java:316) | 4 | 03-02 21:08:45.253 E/AnkiDroid(26719): at com.ichi2.compat.CompatV15.copyFile(CompatV15.java:16) | 5 | 03-02 21:08:45.253 E/AnkiDroid(26719): at com.ichi2.compat.CompatV15.copyFile(CompatV15.java:9) | 6 | 03-02 21:08:45.253 E/AnkiDroid(26719): at com.ichi2.utils.ImportUtils.copyFileToCache(ImportUtils.java:2) | 7 | 03-02 21:08:45.253 E/AnkiDroid(26719): at com.ichi2.utils.ImportUtils.handleFileImport(ImportUtils.java:16) | 8 | 03-02 21:08:45.253 E/AnkiDroid(26719): at com.ichi2.anki.IntentHandler.onCreate(IntentHandler.java:10) | 9 | 03-02 21:08:45.253 E/AnkiDroid(26719): at android.app.Activity.performCreate(Activity.java:6666) | 10 | 03-02 21:08:45.253 E/AnkiDroid(26719): at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1118) | 11 | 03-02 21:08:45.253 E/AnkiDroid(26719): at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2677) | 12 | 03-02 21:08:45.253 E/AnkiDroid(26719): at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2789) | 13 | 03-02 21:08:45.253 E/AnkiDroid(26719): at android.app.ActivityThread.-wrap12(ActivityThread.java) | 14 | 03-02 21:08:45.253 E/AnkiDroid(26719): at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1527) | 15 | 03-02 21:08:45.253 E/AnkiDroid(26719): at android.os.Handler.dispatchMessage(Handler.java:110) | 16 | 03-02 21:08:45.253 E/AnkiDroid(26719): at android.os.Looper.loop(Looper.java:203) | 17 | 03-02 21:08:45.253 E/AnkiDroid(26719): at android.app.ActivityThread.main(ActivityThread.java:6251) | 18 | 03-02 21:08:45.253 E/AnkiDroid(26719): at java.lang.reflect.Method.invoke(Native Method) | 19 | 03-02 21:08:45.253 E/AnkiDroid(26719): at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1063) | 20 | 03-02 21:08:45.253 E/AnkiDroid(26719): at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:924) | 21 | 03-02 21:08:45.253 E/AnkiDroid(26719): Caused by: android.system.ErrnoException: write failed: ENOSPC (No space left on device) | 22 | 03-02 21:08:45.253 E/AnkiDroid(26719): at libcore.io.Posix.writeBytes(Native Method) | 23 | 03-02 21:08:45.253 E/AnkiDroid(26719): at libcore.io.Posix.write(Posix.java:273) | 24 | 03-02 21:08:45.253 E/AnkiDroid(26719): at libcore.io.BlockGuardOs.write(BlockGuardOs.java:319) | 25 | 03-02 21:08:45.253 E/AnkiDroid(26719): at libcore.io.IoBridge.write(IoBridge.java:496) | 26 | 03-02 21:08:45.253 E/AnkiDroid(26719): ... 18 more | 27 | 03-02 21:08:45.253 E/AnkiDroid(26719): | 28 | 03-02 21:08:45.253 E/AnkiDroid(26719): java.io.IOException: write failed: ENOSPC (No space left on device) | 29 | 03-02 21:08:45.253 E/AnkiDroid(26719): at libcore.io.IoBridge.write(IoBridge.java:501) | 30 | 03-02 21:08:45.253 E/AnkiDroid(26719): at java.io.FileOutputStream.write(FileOutputStream.java:316) | 31 | 03-02 21:08:45.253 E/AnkiDroid(26719): at com.ichi2.compat.CompatV15.copyFile(CompatV15.java:16) | 32 | 03-02 21:08:45.253 E/AnkiDroid(26719): at com.ichi2.compat.CompatV15.copyFile(CompatV15.java:9) | 33 | 03-02 21:08:45.253 E/AnkiDroid(26719): at com.ichi2.utils.ImportUtils.copyFileToCache(ImportUtils.java:2) | 34 | 03-02 21:08:45.253 E/AnkiDroid(26719): at com.ichi2.utils.ImportUtils.handleFileImport(ImportUtils.java:16) | 35 | 03-02 21:08:45.253 E/AnkiDroid(26719): at com.ichi2.anki.IntentHandler.onCreate(IntentHandler.java:10) | 36 | 03-02 21:08:45.253 E/AnkiDroid(26719): at android.app.Activity.performCreate(Activity.java:6666) | 37 | 03-02 21:08:45.253 E/AnkiDroid(26719): at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1118) | 38 | 03-02 21:08:45.253 E/AnkiDroid(26719): at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2677) | 39 | 03-02 21:08:45.253 E/AnkiDroid(26719): at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2789) | 40 | 03-02 21:08:45.253 E/AnkiDroid(26719): at android.app.ActivityThread.-wrap12(ActivityThread.java) | 41 | 03-02 21:08:45.253 E/AnkiDroid(26719): at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1527) | 42 | 03-02 21:08:45.253 E/AnkiDroid(26719): at android.os.Handler.dispatchMessage(Handler.java:110) | 43 | 03-02 21:08:45.253 E/AnkiDroid(26719): at android.os.Looper.loop(Looper.java:203) | 44 | 03-02 21:08:45.253 E/AnkiDroid(26719): at android.app.ActivityThread.main(ActivityThread.java:6251) | 45 | 03-02 21:08:45.253 E/AnkiDroid(26719): at java.lang.reflect.Method.invoke(Native Method) | 46 | 03-02 21:08:45.253 E/AnkiDroid(26719): at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1063) | 47 | 03-02 21:08:45.253 E/AnkiDroid(26719): at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:924) | 48 | 03-02 21:08:45.253 E/AnkiDroid(26719): Caused by: android.system.ErrnoException: write failed: ENOSPC (No space left on device) | 49 | 03-02 21:08:45.253 E/AnkiDroid(26719): at libcore.io.Posix.writeBytes(Native Method) | 50 | 03-02 21:08:45.253 E/AnkiDroid(26719): at libcore.io.Posix.write(Posix.java:273) | 51 | 03-02 21:08:45.253 E/AnkiDroid(26719): at libcore.io.BlockGuardOs.write(BlockGuardOs.java:319) | 52 | 03-02 21:08:45.253 E/AnkiDroid(26719): at libcore.io.IoBridge.write(IoBridge.java:496) | 53 | 03-02 21:08:45.253 E/AnkiDroid(26719): ... 18 more | 54 | 03-02 21:08:46.050 E/AnkiDroid(26719): AcraAnalyticsInteraction/ ACRA handling crash, sending analytics exception report | 55 | 03-02 21:08:48.201 E/AnkiDroid(26719): ImportUtils/ showImportUnsuccessfulDialog() message copyFileToCache() failed | 56 | 03-02 21:12:01.979 E/AnkiDroid(26719): ImportUtils/ Could not open input stream to intent data | 57 | 03-02 21:12:01.979 E/AnkiDroid(26719): java.io.FileNotFoundException: No such file or directory | 58 | 03-02 21:12:01.979 E/AnkiDroid(26719): at android.database.DatabaseUtils.readExceptionWithFileNotFoundExceptionFromParcel(DatabaseUtils.java:149) | 59 | 03-02 21:12:01.979 E/AnkiDroid(26719): at android.content.ContentProviderProxy.openTypedAssetFile(ContentProviderNative.java:692) | 60 | 03-02 21:12:01.979 E/AnkiDroid(26719): at android.content.ContentResolver.openTypedAssetFileDescriptor(ContentResolver.java:1179) | 61 | 03-02 21:12:01.979 E/AnkiDroid(26719): at android.content.ContentResolver.openAssetFileDescriptor(ContentResolver.java:998) | 62 | 03-02 21:12:01.979 E/AnkiDroid(26719): at android.content.ContentResolver.openInputStream(ContentResolver.java:718) | 63 | 03-02 21:12:01.979 E/AnkiDroid(26719): at com.ichi2.utils.ImportUtils.copyFileToCache(ImportUtils.java:1) | 64 | 03-02 21:12:01.979 E/AnkiDroid(26719): at com.ichi2.utils.ImportUtils.handleFileImport(ImportUtils.java:16) | 65 | 03-02 21:12:01.979 E/AnkiDroid(26719): at com.ichi2.anki.IntentHandler.onCreate(IntentHandler.java:10)
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
0 | 03-02 21:08:45.253 E/AnkiDroid(26719): ImportUtils/ Could not copy file to /data/user/0/com.ichi2.anki/cache/550_Phrasal_Verbs_-_Part_1_Ingls_-_Portugus.apkg
1 | 03-02 21:08:45.253 E/AnkiDroid(26719): java.io.IOException: write failed: ENOSPC (No space left on device)
2 | 03-02 21:08:45.253 E/AnkiDroid(26719): at libcore.io.IoBridge.write(IoBridge.java:501)
3 | 03-02 21:08:45.253 E/AnkiDroid(26719): at java.io.FileOutputStream.write(FileOutputStream.java:316)
4 | 03-02 21:08:45.253 E/AnkiDroid(26719): at com.ichi2.compat.CompatV15.copyFile(CompatV15.java:16)
5 | 03-02 21:08:45.253 E/AnkiDroid(26719): at com.ichi2.compat.CompatV15.copyFile(CompatV15.java:9)
6 | 03-02 21:08:45.253 E/AnkiDroid(26719): at com.ichi2.utils.ImportUtils.copyFileToCache(ImportUtils.java:2)
7 | 03-02 21:08:45.253 E/AnkiDroid(26719): at com.ichi2.utils.ImportUtils.handleFileImport(ImportUtils.java:16)
8 | 03-02 21:08:45.253 E/AnkiDroid(26719): at com.ichi2.anki.IntentHandler.onCreate(IntentHandler.java:10)
9 | 03-02 21:08:45.253 E/AnkiDroid(26719): at android.app.Activity.performCreate(Activity.java:6666)
10 | 03-02 21:08:45.253 E/AnkiDroid(26719): at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1118)
11 | 03-02 21:08:45.253 E/AnkiDroid(26719): at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2677)
12 | 03-02 21:08:45.253 E/AnkiDroid(26719): at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2789)
13 | 03-02 21:08:45.253 E/AnkiDroid(26719): at android.app.ActivityThread.-wrap12(ActivityThread.java)
14 | 03-02 21:08:45.253 E/AnkiDroid(26719): at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1527)
15 | 03-02 21:08:45.253 E/AnkiDroid(26719): at android.os.Handler.dispatchMessage(Handler.java:110)
16 | 03-02 21:08:45.253 E/AnkiDroid(26719): at android.os.Looper.loop(Looper.java:203)
17 | 03-02 21:08:45.253 E/AnkiDroid(26719): at android.app.ActivityThread.main(ActivityThread.java:6251)
18 | 03-02 21:08:45.253 E/AnkiDroid(26719): at java.lang.reflect.Method.invoke(Native Method)
19 | 03-02 21:08:45.253 E/AnkiDroid(26719): at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1063)
20 | 03-02 21:08:45.253 E/AnkiDroid(26719): at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:924)
21 | 03-02 21:08:45.253 E/AnkiDroid(26719): Caused by: android.system.ErrnoException: write failed: ENOSPC (No space left on device)
22 | 03-02 21:08:45.253 E/AnkiDroid(26719): at libcore.io.Posix.writeBytes(Native Method)
23 | 03-02 21:08:45.253 E/AnkiDroid(26719): at libcore.io.Posix.write(Posix.java:273)
24 | 03-02 21:08:45.253 E/AnkiDroid(26719): at libcore.io.BlockGuardOs.write(BlockGuardOs.java:319)
25 | 03-02 21:08:45.253 E/AnkiDroid(26719): at libcore.io.IoBridge.write(IoBridge.java:496)
26 | 03-02 21:08:45.253 E/AnkiDroid(26719): ... 18 more
27 | 03-02 21:08:45.253 E/AnkiDroid(26719):
28 | 03-02 21:08:45.253 E/AnkiDroid(26719): java.io.IOException: write failed: ENOSPC (No space left on device)
29 | 03-02 21:08:45.253 E/AnkiDroid(26719): at libcore.io.IoBridge.write(IoBridge.java:501)
30 | 03-02 21:08:45.253 E/AnkiDroid(26719): at java.io.FileOutputStream.write(FileOutputStream.java:316)
31 | 03-02 21:08:45.253 E/AnkiDroid(26719): at com.ichi2.compat.CompatV15.copyFile(CompatV15.java:16)
32 | 03-02 21:08:45.253 E/AnkiDroid(26719): at com.ichi2.compat.CompatV15.copyFile(CompatV15.java:9)
33 | 03-02 21:08:45.253 E/AnkiDroid(26719): at com.ichi2.utils.ImportUtils.copyFileToCache(ImportUtils.java:2)
34 | 03-02 21:08:45.253 E/AnkiDroid(26719): at com.ichi2.utils.ImportUtils.handleFileImport(ImportUtils.java:16)
35 | 03-02 21:08:45.253 E/AnkiDroid(26719): at com.ichi2.anki.IntentHandler.onCreate(IntentHandler.java:10)
36 | 03-02 21:08:45.253 E/AnkiDroid(26719): at android.app.Activity.performCreate(Activity.java:6666)
37 | 03-02 21:08:45.253 E/AnkiDroid(26719): at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1118)
38 | 03-02 21:08:45.253 E/AnkiDroid(26719): at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2677)
39 | 03-02 21:08:45.253 E/AnkiDroid(26719): at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2789)
40 | 03-02 21:08:45.253 E/AnkiDroid(26719): at android.app.ActivityThread.-wrap12(ActivityThread.java)
41 | 03-02 21:08:45.253 E/AnkiDroid(26719): at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1527)
42 | 03-02 21:08:45.253 E/AnkiDroid(26719): at android.os.Handler.dispatchMessage(Handler.java:110)
43 | 03-02 21:08:45.253 E/AnkiDroid(26719): at android.os.Looper.loop(Looper.java:203)
44 | 03-02 21:08:45.253 E/AnkiDroid(26719): at android.app.ActivityThread.main(ActivityThread.java:6251)
45 | 03-02 21:08:45.253 E/AnkiDroid(26719): at java.lang.reflect.Method.invoke(Native Method)
46 | 03-02 21:08:45.253 E/AnkiDroid(26719): at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1063)
47 | 03-02 21:08:45.253 E/AnkiDroid(26719): at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:924)
48 | 03-02 21:08:45.253 E/AnkiDroid(26719): Caused by: android.system.ErrnoException: write failed: ENOSPC (No space left on device)
49 | 03-02 21:08:45.253 E/AnkiDroid(26719): at libcore.io.Posix.writeBytes(Native Method)
50 | 03-02 21:08:45.253 E/AnkiDroid(26719): at libcore.io.Posix.write(Posix.java:273)
51 | 03-02 21:08:45.253 E/AnkiDroid(26719): at libcore.io.BlockGuardOs.write(BlockGuardOs.java:319)
52 | 03-02 21:08:45.253 E/AnkiDroid(26719): at libcore.io.IoBridge.write(IoBridge.java:496)
53 | 03-02 21:08:45.253 E/AnkiDroid(26719): ... 18 more
54 | 03-02 21:08:46.050 E/AnkiDroid(26719): AcraAnalyticsInteraction/ ACRA handling crash, sending analytics exception report
55 | 03-02 21:08:48.201 E/AnkiDroid(26719): ImportUtils/ showImportUnsuccessfulDialog() message copyFileToCache() failed
56 | 03-02 21:12:01.979 E/AnkiDroid(26719): ImportUtils/ Could not open input stream to intent data
57 | 03-02 21:12:01.979 E/AnkiDroid(26719): java.io.FileNotFoundException: No such file or directory
58 | 03-02 21:12:01.979 E/AnkiDroid(26719): at android.database.DatabaseUtils.readExceptionWithFileNotFoundExceptionFromParcel(DatabaseUtils.java:149)
59 | 03-02 21:12:01.979 E/AnkiDroid(26719): at android.content.ContentProviderProxy.openTypedAssetFile(ContentProviderNative.java:692)
60 | 03-02 21:12:01.979 E/AnkiDroid(26719): at android.content.ContentResolver.openTypedAssetFileDescriptor(ContentResolver.java:1179)
61 | 03-02 21:12:01.979 E/AnkiDroid(26719): at android.content.ContentResolver.openAssetFileDescriptor(ContentResolver.java:998)
62 | 03-02 21:12:01.979 E/AnkiDroid(26719): at android.content.ContentResolver.openInputStream(ContentResolver.java:718)
63 | 03-02 21:12:01.979 E/AnkiDroid(26719): at com.ichi2.utils.ImportUtils.copyFileToCache(ImportUtils.java:1)
64 | 03-02 21:12:01.979 E/AnkiDroid(26719): at com.ichi2.utils.ImportUtils.handleFileImport(ImportUtils.java:16)
65 | 03-02 21:12:01.979 E/AnkiDroid(26719): at com.ichi2.anki.IntentHandler.onCreate(IntentHandler.java:10)

```

## Approach

I investigated the stack trace above, following the error handling, and where possible I guide the user by showing a message that includes out of storage space - either by adding it as a possibility in a hard-coded string (better than nothing) or by bubbling up that specific exception and displaying the localized message to the user


## How Has This Been Tested?

I ran this a bunch of times on an API28 emulator where I specifically constrained the space by creating zerofill files (`dd if=/dev/zero of=1.dat bs=1024000 count=100`) to run different scenarios (either initial cache copy failure, or cache copy success but import failure) along with the 78MB Spanish Top 5000 deck as my test

I was able to reliably reproduce errors, and then reliable get good messaging with these changes

This is a big user pain point and I'd like to cherry-pick this 2.9.5

## Checklist

_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
