### PR TITLE
Gracefully handle MediaRecorder.stop exceptions

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/AudioView.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/AudioView.java
@@ -27,8 +27,9 @@ import android.media.MediaRecorder;
 import androidx.appcompat.widget.AppCompatImageButton;
 import android.view.View;
 import android.widget.LinearLayout;
-import android.widget.Toast;
+
 import com.ichi2.anki.R;
+import com.ichi2.anki.UIUtils;
 
 import timber.log.Timber;
 
@@ -88,13 +89,6 @@ public class AudioView extends LinearLayout {
 
         mStop = new StopButton(context);
         addView(mStop, new LinearLayout.LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT));
-    }
-
-
-    private void showToast(String msg) {
-        int duration = Toast.LENGTH_SHORT;
-        Toast toast = Toast.makeText(mContext, msg, duration);
-        toast.show();
     }
 
 
@@ -165,7 +159,12 @@ public class AudioView extends LinearLayout {
 
     public void notifyStopRecord() {
         if (mRecorder != null && mStatus == Status.RECORDING) {
-            mRecorder.stop();
+            try {
+                mRecorder.stop();
+            } catch (RuntimeException e) {
+                Timber.i(e, "Recording stop failed, this happens if stop was hit immediately after start");
+                UIUtils.showThemedToast(mContext, gtxt(R.string.multimedia_editor_audio_view_recording_failed), true);
+            }
             mStatus = Status.IDLE;
             if (mOnRecordingFinishEventListener != null) {
                 mOnRecordingFinishEventListener.onRecordingFinish(AudioView.this);
@@ -210,7 +209,7 @@ public class AudioView extends LinearLayout {
                             notifyPlay();
                         } catch (Exception e) {
                             Timber.e(e);
-                            showToast(gtxt(R.string.multimedia_editor_audio_view_playing_failed));
+                            UIUtils.showThemedToast(mContext, gtxt(R.string.multimedia_editor_audio_view_playing_failed), true);
                             mStatus = Status.IDLE;
                         }
                         break;
@@ -366,7 +365,7 @@ public class AudioView extends LinearLayout {
                             } catch (Exception e) {
                                 // either output file failed or codec didn't work, in any case fail out
                                 Timber.e("RecordButton.onClick() :: error recording to " + mAudioPath + "\n" +e.getMessage());
-                                showToast(gtxt(R.string.multimedia_editor_audio_view_recording_failed));
+                                UIUtils.showThemedToast(mContext, gtxt(R.string.multimedia_editor_audio_view_recording_failed), true);
                                 mStatus = Status.STOPPED;
                                 break;
                             }


### PR DESCRIPTION
MediaRecorder.stop is documented to throw a RuntimeException on purpose
in the case where stop is hit immediately after start:
https://developer.android.com/reference/android/media/MediaRecorder#stop()

## Fixes

There are a lot of crashes like this: https://couchdb.ankidroid.org/acralyzer/_design/acralyzer/index.html#/report-details/09bef5fb-2f04-4cc8-8856-31f9c78dee9e

```
java.lang.RuntimeException: stop failed.
at android.media.MediaRecorder.native_stop(Native Method)
at android.media.MediaRecorder.stop(MediaRecorder.java:919)
at com.ichi2.anki.multimediacard.AudioView.notifyStopRecord(AudioView.java:2)
at com.ichi2.anki.multimediacard.AudioView$RecordButton$1.onClick(AudioView.java:4)
at android.view.View.performClick(View.java:5661)
at android.view.View$PerformClick.run(View.java:22682)
at android.os.Handler.handleCallback(Handler.java:751)
at android.os.Handler.dispatchMessage(Handler.java:95)
at android.os.Looper.loop(Looper.java:154)
at android.app.ActivityThread.main(ActivityThread.java:6351)
at java.lang.reflect.Method.invoke(Native Method)
at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:896)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:786)
```

## Approach

Handle the documented exception

## How Has This Been Tested?

API28 emulator recording

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
