### PR TITLE
Render flag as inline SVG for old API compatibility

### DIFF
--- a/AnkiDroid/src/main/assets/card_template.html
+++ b/AnkiDroid/src/main/assets/card_template.html
@@ -16,7 +16,17 @@
     <body class="::class::">
       <div id="_mark_flag">
         <div id="_mark">&#x2605;</div>
-        <div id="_flag">&#x2691;</div>
+        <div id="_flag">
+            <svg id="_flag_svg" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+                 width="35.834px" height="35.834px" viewBox="0 0 35.834 35.834" style="enable-background:new 0 0 35.834 35.834;"
+                 xml:space="preserve">
+                <g>
+	                <path id="_flag_svg_path" d="M32.959,6.666c0,5.111,0,10.223,0,15.334c-8.223-6.134-16.444,6.134-24.667,0c0-5.111,0-10.223,0-15.334
+                        C16.515,12.799,24.736,0.532,32.959,6.666z M5.792,0C4.181,0,2.875,1.306,2.875,2.917c0,1.162,0.685,2.156,1.667,2.625v30.292h2.5
+		                V5.542c0.982-0.469,1.667-1.463,1.667-2.625C8.709,1.305,7.404,0,5.792,0z"/>
+                </g>
+            </svg>
+        </div>
       </div>
         <div id="content">
         ::content::

--- a/AnkiDroid/src/main/assets/flashcard.css
+++ b/AnkiDroid/src/main/assets/flashcard.css
@@ -123,21 +123,20 @@ scale up, but not down.  */
   top: 0;
   font-size: 30px;
   display: block;
-  -webkit-text-stroke-width: 1px;
-  -webkit-text-stroke-color: black;
+  -webkit-text-stroke: 1px black;
   margin: 10px;
 }
 
 #_flag {
   display: none;
   right: 10px;
-  float:right;
+  float: right;
 }
 
 #_mark {
   display: none;
   left: 10px;
-  float:left;
+  float: left;
   color: yellow;
 }
 

--- a/AnkiDroid/src/main/assets/scripts/card.js
+++ b/AnkiDroid/src/main/assets/scripts/card.js
@@ -142,6 +142,8 @@ function _drawMark(mark) {
 
 function _drawFlag(flag) {
     var elem = document.getElementById("_flag");
+    var flag_svg = document.getElementById("_flag_svg");
+    var flag_svg_path = document.getElementById("_flag_svg_path");
 
     var _flagColours = [
         "#ff6666",
@@ -155,4 +157,6 @@ function _drawFlag(flag) {
     }
     elem.style.display = "inline";
     elem.style.color = _flagColours[flag-1];
+    flag_svg.style.fill = _flagColours[flag-1];
+    flag_svg_path.style.fill = _flagColours[flag-1];
 }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
The Flags in the WebView weren't rendering on API<23

This replaces the partially supported emoji with an inline SVG image


## Fixes
https://github.com/ankidroid/Anki-Android/pull/5768#issuecomment-596112068

## Approach
There was no font on old APIs that had the unicode support necessary to show the flag emoji

## How Has This Been Tested?
I tested this on 6 emulators - all the ones mentioned in the comment here: https://github.com/ankidroid/Anki-Android/pull/5768#issuecomment-596121839

to make sure I got the compatibility right

## Learning (optional, can help others)

Support really old devices is difficult 🤷‍♂ 

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
