### PR TITLE
Gracefully handle any exception while building reminder

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/ReminderService.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/ReminderService.java
@@ -108,20 +108,18 @@ public class ReminderService extends BroadcastReceiver {
                     return node;
                 }
             }
-        } catch (IllegalStateException e) {
-            if (!CollectionHelper.getInstance().colIsOpen()) {
-                if (recur) {
-                    Timber.i(e, "Database closed while working. Probably auto-sync. Will re-try after sleep.");
-                    try {
-                        Thread.sleep(1000);
-                    } catch (InterruptedException ex) {
-                        Timber.i(ex, "Thread interrupted while waiting to retry. Likely unimportant.");
-                        Thread.currentThread().interrupt();
-                    }
-                    return getDeckDue(context, deckId, false);
-                } else {
-                    Timber.w(e, "Database closed while working. No re-tries left.");
+        } catch (Exception e) {
+            if (recur) {
+                Timber.i(e, "getDeckDue exception - likely database re-initialization from auto-sync. Will re-try after sleep.");
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException ex) {
+                    Timber.i(ex, "Thread interrupted while waiting to retry. Likely unimportant.");
+                    Thread.currentThread().interrupt();
                 }
+                return getDeckDue(context, deckId, false);
+            } else {
+                Timber.w(e, "Database unavailable while working. No re-tries left.");
             }
         }
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
#5748 attempted to gracefully handle database re-init from startup auto-sync while the reminder service was running but did not go far enough

That PR handled IllegalStateException but it turns out NullPointerException can also happen in this case.

This widens the exception handling to all exceptions (we really should never crash the app because the reminder had a problem - it's not core reviewing functionality) and should hopefully finally stabilize this area of the code?


## Fixes
https://couchdb.ankidroid.org/acralyzer/_design/acralyzer/index.html#/report-details/4ae96958-29b2-4a24-88d7-d0fdc8facc55

```
java.lang.RuntimeException: Unable to start receiver com.ichi2.anki.services.ReminderService: java.lang.NullPointerException: Attempt to invoke virtual method 'int com.ichi2.libanki.DB.queryScalar(java.lang.String)' on a null object reference
at android.app.ActivityThread.handleReceiver(ActivityThread.java:3541)
at android.app.ActivityThread.access$1200(ActivityThread.java:208)
at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1707)
at android.os.Handler.dispatchMessage(Handler.java:106)
at android.os.Looper.loop(Looper.java:205)
at android.app.ActivityThread.main(ActivityThread.java:6991)
at java.lang.reflect.Method.invoke(Native Method)
at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:884)
Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'int com.ichi2.libanki.DB.queryScalar(java.lang.String)' on a null object reference
at com.ichi2.libanki.SchedV2._newForDeck(SchedV2.java:2)
at com.ichi2.libanki.SchedV2.deckDueList(SchedV2.java:12)
at com.ichi2.libanki.SchedV2.deckDueTree(SchedV2.java:1)
at com.ichi2.anki.services.ReminderService.getDeckDue(ReminderService.java:1)
at com.ichi2.anki.services.ReminderService.onReceive(ReminderService.java:8)
at android.app.ActivityThread.handleReceiver(ActivityThread.java:3528)
```

## Approach
Catches any exception instead of just one kind, and don't depend (for error handling) on whether the collection was open or not, just re-try once no matter what, and gracefully move on if it doesn't work out.

## How Has This Been Tested?

Same as the original PR, checked reminders and startup with auto-sync on an emulator. This is racy though so it's hard to trigger


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
