### PR TITLE
Give users more connection error information, handle cleartext failure

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -1542,6 +1542,9 @@ public class DeckPicker extends NavigationDrawerActivity implements
                         showSyncErrorMessage(joinSyncMessages(dialogMessage, syncMessage));
                     } else if ("connectionError".equals(resultType)) {
                         dialogMessage = res.getString(R.string.sync_connection_error);
+                        if (result.length >= 1 && result[1] instanceof Exception) {
+                            dialogMessage += "\n\n" + ((Exception)result[1]).getLocalizedMessage();
+                        }
                         showSyncErrorMessage(joinSyncMessages(dialogMessage, syncMessage));
                     } else if ("IOException".equals(resultType)) {
                         handleDbError();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.java
@@ -200,11 +200,17 @@ public class MyAccount extends AnkiActivity {
                     switchToState(STATE_LOGGED_IN);
                 }
             } else {
-                Timber.e("Login failed, error code %d",data.returnType);
+                Timber.e("Login failed, error code %d", data.returnType);
                 if (data.returnType == 403) {
                     UIUtils.showSimpleSnackbar(MyAccount.this, R.string.invalid_username_password, true);
                 } else {
-                    UIUtils.showSimpleSnackbar(MyAccount.this, R.string.connection_error_message, true);
+                    String message = getResources().getString(R.string.connection_error_message);
+                    Object[] result = (Object [])data.result;
+                    if (result.length > 1 && result[1] instanceof Exception) {
+                        showSimpleMessageDialog(message, ((Exception)result[1]).getLocalizedMessage(), false);
+                    } else {
+                        UIUtils.showSimpleSnackbar(MyAccount.this, message, false);
+                    }
                 }
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
@@ -219,7 +219,7 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
                 AnkiDroidApp.sendExceptionReport(e2, "doInBackgroundLogin");
             }
             data.success = false;
-            data.result = new Object[] {"connectionError" };
+            data.result = new Object[] {"connectionError", e2};
             return data;
         }
         String hostkey = null;
@@ -264,6 +264,7 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
                 msg.contains("InterruptedIOException") ||
                 msg.contains("stream was reset") ||
                 msg.contains("ConnectionShutdownException") ||
+                msg.contains("CLEARTEXT communication") ||
                 msg.contains("TimeoutException");
     }
 
@@ -373,12 +374,12 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
                     return data;
                 } catch (RuntimeException e) {
                     if (timeoutOccurred(e)) {
-                        data.result = new Object[] {"connectionError" };
+                        data.result = new Object[] {"connectionError", e};
                     } else if (e.getMessage().equals("UserAbortedSync")) {
-                        data.result = new Object[] {"UserAbortedSync" };
+                        data.result = new Object[] {"UserAbortedSync", e};
                     } else {
                         AnkiDroidApp.sendExceptionReport(e, "doInBackgroundSync-fullSync");
-                        data.result = new Object[] { "IOException" };
+                        data.result = new Object[] {"IOException", e};
                     }
                     data.success = false;
                     return data;
@@ -418,9 +419,9 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
                     }
                 } catch (RuntimeException e) {
                     if (timeoutOccurred(e)) {
-                        data.result = new Object[] {"connectionError" };
+                        data.result = new Object[] {"connectionError", e};
                     } else if (e.getMessage().equals("UserAbortedSync")) {
-                        data.result = new Object[] {"UserAbortedSync" };
+                        data.result = new Object[] {"UserAbortedSync", e};
                     }
                     mediaError = AnkiDroidApp.getAppResources().getString(R.string.sync_media_error) + "\n\n" + e.getLocalizedMessage();
                 }
@@ -437,12 +438,11 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
         } catch (MediaSyncException e) {
             Timber.e("Media sync rejected by server");
             data.success = false;
-            data.result = new Object[] {"mediaSyncServerError"};
+            data.result = new Object[] {"mediaSyncServerError", e};
             AnkiDroidApp.sendExceptionReport(e, "doInBackgroundSync");
             return data;
         } catch (UnknownHttpResponseException e) {
-            Timber.e("doInBackgroundSync -- unknown response code error");
-            e.printStackTrace();
+            Timber.e(e, "doInBackgroundSync -- unknown response code error");
             data.success = false;
             int code = e.getResponseCode();
             String msg = e.getLocalizedMessage();
@@ -451,16 +451,15 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
         } catch (Exception e) {
             // Global error catcher.
             // Try to give a human readable error, otherwise print the raw error message
-            Timber.e("doInBackgroundSync error");
-            e.printStackTrace();
+            Timber.e(e, "doInBackgroundSync error");
             data.success = false;
             if (timeoutOccurred(e)) {
-                data.result = new Object[]{"connectionError"};
+                data.result = new Object[]{"connectionError", e};
             } else if (e.getMessage().equals("UserAbortedSync")) {
-                data.result = new Object[] {"UserAbortedSync" };
+                data.result = new Object[] {"UserAbortedSync", e};
             } else {
                 AnkiDroidApp.sendExceptionReport(e, "doInBackgroundSync");
-                data.result = new Object[] {e.getLocalizedMessage()};
+                data.result = new Object[] {e.getLocalizedMessage(), e};
             }
             return data;
         } finally {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HttpSyncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HttpSyncer.java
@@ -229,7 +229,7 @@ public class HttpSyncer {
                 return httpResponse;
             } catch (SSLException e) {
                 Timber.e(e, "SSLException while building HttpClient");
-                throw new RuntimeException("SSLException while building HttpClient");
+                throw new RuntimeException("SSLException while building HttpClient", e);
             }
         } catch (UnsupportedEncodingException | JSONException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Connection error information is largely eaten by the app so users don't have a good chance to help themselves if they configure things wrong or there is a sync problem

This gives users more info they can use to self-help, and categorizes cleartext protocol failures as harmless

## Fixes
https://couchdb.ankidroid.org/acralyzer/_design/acralyzer/index.html#/report-details/69ac5da1-bb3f-48cf-ba63-6cef9bc7bf4d

```
java.lang.RuntimeException: java.net.UnknownServiceException: CLEARTEXT communication to 220.208.39.208 not permitted by network security policy
at com.ichi2.libanki.sync.HttpSyncer.req(HttpSyncer.java:62)
at com.ichi2.libanki.sync.HttpSyncer.req(HttpSyncer.java:4)
at com.ichi2.libanki.sync.HttpSyncer.req(HttpSyncer.java:2)
at com.ichi2.libanki.sync.RemoteServer.meta(RemoteServer.java:9)
at com.ichi2.libanki.sync.Syncer.sync(Syncer.java:4)
at com.ichi2.async.Connection.doInBackgroundSync(Connection.java:15)
at com.ichi2.async.Connection.doOneInBackground(Connection.java:2)
at com.ichi2.async.Connection.doInBackground(Connection.java:4)
at com.ichi2.async.Connection.doInBackground(Connection.java:1)
```

## Approach
I classify 'CLEARTEXT' HTTP problems as harmless via the existing classification style
I pass along the exception to the AsyncTask consumer, so it may be inspected
On login and sync failures that are connection failures, I look to see if the async result has an exception, and if it does I add the exception message to what we show the user

This will just go for 2.10 it's not frequent enough to pull in to 2.9 and isn't a crash anyway, just user help

## How Has This Been Tested?

On an API28 emulator I tried 

- a regular sync to ankiweb (works)
- I tried logging in to the cleartext custom sync server from the error link above (did not work) - had a useless message before, now contains the cleartext fail information which is actionable
- I tried logging in to AnkiWeb then changing to the custom sync server above (did not work) - had a useless message before, now contains the cleartext fail information which is actionable

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
