### PR TITLE
Avoid crash if unable to delegate to external app

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
@@ -4,6 +4,7 @@ package com.ichi2.anki;
 import android.app.Activity;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
+import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -171,20 +172,24 @@ public class AnkiActivity extends AppCompatActivity implements SimpleMessageDial
     @Deprecated
     @Override
     public void startActivityForResult(Intent intent, int requestCode) {
-        super.startActivityForResult(intent, requestCode);
+        try {
+            super.startActivityForResult(intent, requestCode);
+        } catch (ActivityNotFoundException e) {
+            UIUtils.showSimpleSnackbar(this, R.string.activity_start_failed,true);
+        }
     }
 
 
     public void startActivityForResultWithoutAnimation(Intent intent, int requestCode) {
         disableIntentAnimation(intent);
-        super.startActivityForResult(intent, requestCode);
+        startActivityForResult(intent, requestCode);
         disableActivityAnimation();
     }
 
 
     public void startActivityForResultWithAnimation(Intent intent, int requestCode, int animation) {
         enableIntentAnimation(intent);
-        super.startActivityForResult(intent, requestCode);
+        startActivityForResult(intent, requestCode);
         enableActivityAnimation(animation);
     }
 

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -233,4 +233,6 @@
     <string name="import_cannot_with_v2">V2 scheduler can not import V1 decks with scheduling included.</string>
     <string name="export_v2_dummy_note">This file requires a newer version of Anki.</string>
     <string name="export_v2_forbidden">Please switch to the V1 scheduler before exporting a single deck with scheduling information.</string>
+
+    <string name="activity_start_failed">The system does not have an app installed that can perform this action.</string>
 </resources>


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
It should not be frequent, but it is possible to crash if we try to start an external activity and it does not exist. Now if this happens we will notify the user instead of crashing

## Fixes
https://couchdb.ankidroid.org/acralyzer/_design/acralyzer/index.html#/report-details/a070f47e-d8b0-41c3-976a-1e797e4267d7

```
android.content.ActivityNotFoundException: No Activity found to handle Intent { act=android.intent.action.PICK dat=content://media/external/images/media flg=0x10000 }
at android.app.Instrumentation.checkStartActivityResult(Instrumentation.java:1809)
at android.app.Instrumentation.execStartActivity(Instrumentation.java:1523)
at android.app.Activity.startActivityForResult(Activity.java:4226)
at androidx.fragment.app.FragmentActivity.startActivityForResult(FragmentActivity.java:6)
at android.app.Activity.startActivityForResult(Activity.java:4185)
at androidx.fragment.app.FragmentActivity.startActivityForResult(FragmentActivity.java:3)
at com.ichi2.anki.AnkiActivity.startActivityForResultWithoutAnimation(AnkiActivity.java:2)
at com.ichi2.anki.multimediacard.fields.BasicImageFieldController.a(BasicImageFieldController.java:2)
at com.ichi2.anki.multimediacard.fields.d.onClick(lambda)
at android.view.View.performClick(View.java:5692)
```

## Approach
Have all external activity starts go through a try/catch

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration (SDK version(s), emulator or physical, etc)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
