### PR TITLE
Avoid crashing on import even if collection not found

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
@@ -847,14 +847,11 @@ public class Utils {
     public static List<File> getImportableDecks(Context context) {
         String deckPath = CollectionHelper.getCurrentAnkiDroidDirectory(context);
         File dir = new File(deckPath);
-        int deckCount = 0;
-        File[] deckList = null;
-        if (dir.exists() && dir.isDirectory()) {
-            deckList = dir.listFiles(pathname -> pathname.isFile() && ImportUtils.isValidPackageName(pathname.getName()));
-            deckCount = deckList.length;
-        }
         List<File> decks = new ArrayList<>();
-        decks.addAll(Arrays.asList(deckList).subList(0, deckCount));
+        if (dir.exists() && dir.isDirectory()) {
+            File[] deckList = dir.listFiles(pathname -> pathname.isFile() && ImportUtils.isValidPackageName(pathname.getName()));
+            decks.addAll(Arrays.asList(deckList).subList(0, deckList.length));
+        }
         return decks;
     }
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
It is possible to crash on import if the collection isn't found

## Fixes
https://couchdb.ankidroid.org/acralyzer/_design/acralyzer/index.html#/report-details/77140843-8f1a-404b-a2ec-2d752b9dde1c

```
java.lang.NullPointerException
at java.util.Objects.requireNonNull(Objects.java:203)
at java.util.Arrays$ArrayList.<init>(Arrays.java:3741)
at java.util.Arrays.asList(Arrays.java:3728)
at com.ichi2.libanki.Utils.getImportableDecks(Utils.java:917)
at com.ichi2.anki.dialogs.ImportDialog.onCreateDialog(ImportDialog.java:88)
at com.ichi2.anki.dialogs.ImportDialog.onCreateDialog(ImportDialog.java:20)
at android.support.v4.app.DialogFragment.getLayoutInflater(DialogFragment.java:312)
at android.support.v4.app.FragmentManagerImpl.moveToState(FragmentManager.java:1298)
at android.support.v4.app.FragmentManagerImpl.moveFragmentsToInvisible(FragmentManager.java:2323)
at android.support.v4.app.FragmentManagerImpl.executeOpsTogether(FragmentManager.java:2136)
at android.support.v4.app.FragmentManagerImpl.optimizeAndExecuteOps(FragmentManager.java:2092)
at android.support.v4.app.FragmentManagerImpl.execPendingActions(FragmentManager.java:1998)
at android.support.v4.app.FragmentManagerImpl.executePendingTransactions(FragmentManager.java:762)
at com.ichi2.anki.AnkiActivity.showDialogFragment(AnkiActivity.java:349)
at com.ichi2.anki.DeckPicker.showImportDialog(DeckPicker.java:1114)
at com.ichi2.anki.DeckPicker.showImportDialog(DeckPicker.java:1107)
at com.ichi2.anki.dialogs.ImportDialog$1.onPositive(ImportDialog.java:76)
at com.afollestad.materialdialogs.MaterialDialog.onClick(MaterialDialog.java:340)
```

## Approach

I think this is a little far-fetched but we get crash reports and it's a simple fix to avoid the crash here, so I just re-arranged variable access / initialization such that we will always at least return an empty list vs crashing

## How Has This Been Tested?
I revoked permissions on an API28 emulator then attempted to import a file while denying storage permission during import, and we get a fail error message and app quit vs a crash

Regular imports still work fine as well

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
