### PR TITLE
Gracefully handle dialog show failures

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.java
@@ -24,6 +24,7 @@ import android.speech.tts.TextToSpeech;
 import android.speech.tts.UtteranceProgressListener;
 import android.view.View;
 
+import android.view.WindowManager;
 import android.widget.Toast;
 
 import com.afollestad.materialdialogs.MaterialDialog;
@@ -138,7 +139,11 @@ public class ReadText {
         handler.postDelayed(new Runnable() {
             @Override
             public void run() {
-                builder.build().show();
+                try {
+                    builder.build().show();
+                } catch (WindowManager.BadTokenException e) {
+                    Timber.w("Activity invalidated before TTS language dialog could display");
+                }
             }
         }, delay);
     }


### PR DESCRIPTION

## Pull Request template

## Purpose / Description

There are two frequent crashes that show up when AnkiDroid attempts
to show a dialog but the Activity is no longer there. Both have the same
root cause in that when you attempt to show a dialog you have to check
whether it failed to show, and if it did, either notify user / clean up
or (if not necessary) ignore versus crashing

## Fixes
Fixes #5138

## Approach
For the ReadText crash (which happens on preview mostly) I just ignore it. If they've moved on they don't care about selecting a TTS language

For the sync dialog crash (which happens on auto-sync on startup as a race, I believe) I cancel the task (better than crashing!) and notify the user it was cancelled. If they want to sync they can take action with the new information, and if they don't then it will try again later as I moved the timestamp update below the error handling

## How Has This Been Tested?

These are race conditions and I can't reproduce either of them but thinking logically through the cleanup is the important part. Review is important for that reason
