### PR TITLE
Fixes #5810 - Beolingus search case insensitivity

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/beolingus/parsing/BeolingusParser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/beolingus/parsing/BeolingusParser.java
@@ -41,7 +41,10 @@ public class BeolingusParser {
     public static String getPronunciationAddressFromTranslation(String html, String wordToSearchFor) {
         Matcher m = PRONUNC_PATTERN.matcher(html);
         while (m.find()) {
-            if (m.group(2).contains(wordToSearchFor)) {
+            //Perform .contains() due to #5376 (a "%20{noun}" suffix).
+            //Perform .toLowerCase() due to #5810 ("hello" should match "Hello").
+            //See #5810 for discussion on Locale complexities. Currently unhandled.
+            if (m.group(2).toLowerCase().contains(wordToSearchFor.toLowerCase())) {
                 Timber.d("pronunciation URL is https://dict.tu-chemnitz.de%s", m.group(1));
                 return "https://dict.tu-chemnitz.de" + m.group(1);
             }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/beolingus/parsing/BeolingusParserTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/beolingus/parsing/BeolingusParserTest.java
@@ -19,6 +19,47 @@ public class BeolingusParserTest {
     }
 
     @Test
+    public void testHaystackCaseInsensitivity() {
+        //#5810 - a search for "hello" did not match "Hello".
+        String html = ""
+                + "<a href=\"/dings.cgi?speak=en/2/0/zQbP7qZh_u2;text=Hello\" "
+                + "onclick=\"return s(this)\" onmouseover=\"return u('Hello')\">"
+                + "<img src=\"/pics/s1.png\" width=\"16\" height=\"16\" "
+                + "alt=\"[listen]\" title=\"Hello\" border=\"0\" align=\"top\" /></a>";
+
+        String pronunciationUrl = BeolingusParser.getPronunciationAddressFromTranslation(html, "hello");
+        assertEquals("https://dict.tu-chemnitz.de/dings.cgi?speak=en/2/0/zQbP7qZh_u2;text=Hello", pronunciationUrl);
+    }
+
+    @Test
+    public void testNeedleCaseInsensitivity() {
+        //#5810 - confirm "HELLO" matches "Hello"
+        String html = ""
+                + "<a href=\"/dings.cgi?speak=en/2/0/zQbP7qZh_u2;text=Hello\" "
+                + "onclick=\"return s(this)\" onmouseover=\"return u('Hello')\">"
+                + "<img src=\"/pics/s1.png\" width=\"16\" height=\"16\" "
+                + "alt=\"[listen]\" title=\"Hello\" border=\"0\" align=\"top\" /></a>";
+
+        String pronunciationUrl = BeolingusParser.getPronunciationAddressFromTranslation(html, "HELLO");
+        assertEquals("https://dict.tu-chemnitz.de/dings.cgi?speak=en/2/0/zQbP7qZh_u2;text=Hello", pronunciationUrl);
+    }
+
+
+    @Test
+    public void testEszettCasing() {
+        // Some transformations lose the Eszett: "ß".toUpperCase() == "SS".
+        // Ensure that we don't do this.
+        String html = ""
+                + "<a href=\"/dings.cgi?speak=de/8/9/5wbPa4jy41_;text=Straße\" "
+                + "onclick=\"return s(this)\" onmouseover=\"return u('Straße')\">"
+                + "<img src=\"/pics/s1.png\" width=\"16\" height=\"16\" "
+                + "alt=\"[listen]\" title=\"Straße\" border=\"0\" align=\"top\" /></a>";
+
+        String pronunciationUrl = BeolingusParser.getPronunciationAddressFromTranslation(html, "straße");
+        assertEquals("https://dict.tu-chemnitz.de/dings.cgi?speak=de/8/9/5wbPa4jy41_;text=Straße", pronunciationUrl);
+    }
+
+    @Test
     public void testMp3() {
         String html = "<td><a href=\"/speak-de/0/7/52qA5FttGIU.mp3\">Mit Ihrem";
 


### PR DESCRIPTION
## Purpose / Description

Previously, a search of "hello" failed to find a pronunciation on Beolingus named "Hello". This fixes the issue.

## Fixes

Fixes #5810

## Approach

`.toLowerCase()` is used to compare both the needle and the haystack when string comparing.

## How Has This Been Tested?

Via Unit Tests

Ran pronunciation searches on my personal Android phone. All successful.

* `text` (to test regression from a previous issue).
* `hello`
* `HELLO`
* `Hello`
* `straße` (German)

## Checklist
- [ x ] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [ x ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ x ] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ x ] You have commented your code, particularly in hard-to-understand areas
- [ x ] You have performed a self-review of your own code