### PR TITLE
Fix #5715: Hide style/script tag content in deck description

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
@@ -20,6 +20,8 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.res.Resources;
 import android.os.Bundle;
+
+import androidx.annotation.VisibleForTesting;
 import androidx.fragment.app.Fragment;
 import androidx.appcompat.widget.Toolbar;
 
@@ -688,11 +690,12 @@ public class StudyOptionsFragment extends Fragment implements Toolbar.OnMenuItem
         };
     }
 
+    @VisibleForTesting()
     static Spanned formatDescription(String desc) {
         //#5715: In deck description, ignore what is in style and script tag
         //Since we don't currently execute the JS/CSS, it's not worth displaying.
-        desc = Utils.stripHTMLScriptAndStyleTags(desc);
-        return CompatHelper.getCompat().fromHtml(desc);
+        String withStrippedTags = Utils.stripHTMLScriptAndStyleTags(desc);
+        return CompatHelper.getCompat().fromHtml(withStrippedTags);
     }
 
     private Collection getCol() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
@@ -22,6 +22,8 @@ import android.content.res.Resources;
 import android.os.Bundle;
 import androidx.fragment.app.Fragment;
 import androidx.appcompat.widget.Toolbar;
+
+import android.text.Spanned;
 import android.text.method.LinkMovementMethod;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -618,7 +620,7 @@ public class StudyOptionsFragment extends Fragment implements Toolbar.OnMenuItem
                         desc = getCol().getDecks().getActualDescription();
                     }
                     if (desc.length() > 0) {
-                        mTextDeckDescription.setText(CompatHelper.getCompat().fromHtml(desc));
+                        mTextDeckDescription.setText(formatDescription(desc));
                         mTextDeckDescription.setVisibility(View.VISIBLE);
                     } else {
                         mTextDeckDescription.setVisibility(View.GONE);
@@ -684,6 +686,13 @@ public class StudyOptionsFragment extends Fragment implements Toolbar.OnMenuItem
                 }
             }
         };
+    }
+
+    static Spanned formatDescription(String desc) {
+        //#5715: In deck description, ignore what is in style and script tag
+        //Since we don't currently execute the JS/CSS, it's not worth displaying.
+        desc = Utils.stripHTMLScriptAndStyleTags(desc);
+        return CompatHelper.getCompat().fromHtml(desc);
     }
 
     private Collection getCol() {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
@@ -223,13 +223,22 @@ public class Utils {
      * @return The text without the aforementioned tags.
      */
     public static String stripHTML(String s) {
+        s = stripHTMLScriptAndStyleTags(s);
+        Matcher htmlMatcher = tagPattern.matcher(s);
+        s = htmlMatcher.replaceAll("");
+        return entsToTxt(s);
+    }
+
+    /**
+     * Strips <style>...</style> and <script>...</script> HTML tags and content from a string.
+     * @param s The HTML text to be cleaned.
+     * @return The text without the aforementioned tags.
+     */
+    public static String stripHTMLScriptAndStyleTags(String s) {
         Matcher htmlMatcher = stylePattern.matcher(s);
         s = htmlMatcher.replaceAll("");
         htmlMatcher = scriptPattern.matcher(s);
-        s = htmlMatcher.replaceAll("");
-        htmlMatcher = tagPattern.matcher(s);
-        s = htmlMatcher.replaceAll("");
-        return entsToTxt(s);
+        return htmlMatcher.replaceAll("");
     }
 
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/StudyOptionsFragmentTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/StudyOptionsFragmentTest.java
@@ -1,0 +1,58 @@
+package com.ichi2.anki;
+
+import android.text.Spanned;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(AndroidJUnit4.class) //required for String -> Spannable conversion in formatDescription
+public class StudyOptionsFragmentTest {
+
+    //Fixes for #5715: In deck description, ignore what is in style and script tag
+
+    @Test
+    public void spanTagsAreNotRemoved() {
+        Spanned result = StudyOptionsFragment.formatDescription("a<span style=\"color:red\">a=1</span>a");
+        assertEquals("aa=1a", result.toString()); //Note: This is coloured red on the screen
+    }
+
+    @Test
+    public void scriptTagContentsAreRemoved() {
+        Spanned result = StudyOptionsFragment.formatDescription("a<script>a=1</script>a");
+        assertEquals("aa", result.toString());
+    }
+
+    @Test
+    public void upperCaseScriptTagContentsAreRemoved() {
+        Spanned result = StudyOptionsFragment.formatDescription("a<SCRIPT>a=1</script>a");
+        assertEquals("aa", result.toString());
+    }
+
+    @Test
+    public void scriptTagWithAttributesContentsAreRemoved() {
+        Spanned result = StudyOptionsFragment.formatDescription("a<script type=\"application/javascript\">a=1</script>a");
+        assertEquals("aa", result.toString());
+    }
+
+    @Test
+    public void styleTagContentsAreRemoved() {
+        Spanned result = StudyOptionsFragment.formatDescription("a<style>a=1</style>a");
+        assertEquals("aa", result.toString());
+    }
+
+    @Test
+    public void upperCaseStyleTagContentsAreRemoved() {
+        Spanned result = StudyOptionsFragment.formatDescription("a<STYLE>a:1</style>a");
+        assertEquals("aa", result.toString());
+    }
+
+    @Test
+    public void styleTagWithAttributesContentsAreRemoved() {
+        Spanned result = StudyOptionsFragment.formatDescription("a<style type=\"text/css\">a:1</style>a");
+        assertEquals("aa", result.toString());
+    }
+}


### PR DESCRIPTION
## Purpose / Description

Previously, the android libraries handled converting most HTML into a `Spanned`, but `<script>` and `<style>` displayed their inner text as a string.

## Fixes
Fixes #5715

## Approach
Now, we Regex replace the two tags out of the HTML before we use the Android libraries to convert the string into a `Spanned`.

This removes the tags and their content to provide a better description.

## How Has This Been Tested?

* Unit Tested

----

* Tested on my local Android against the test string: `a<script>a=1</script>a <span style="color:red">red</span>`

Result: As expected
<img src="https://user-images.githubusercontent.com/62114487/76631447-a2609000-6539-11ea-97eb-4b7c7e48c01f.png" height="200" />


## Learning (optional, can help others)

It's likely that we don't need pure HTML parsing for this and we can reuse the converted regex from Anki Desktop. A `<script>` can't contain `</script>` in a string: https://stackoverflow.com/a/22488867.

## Checklist

- [ x ] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [ x ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ x ] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ x ] You have commented your code, particularly in hard-to-understand areas
- [ x ] You have performed a self-review of your own code