### PR TITLE
Fix #5811 - Clicking hint field blocks key input

### DIFF
--- a/AnkiDroid/src/main/assets/scripts/card.js
+++ b/AnkiDroid/src/main/assets/scripts/card.js
@@ -58,6 +58,17 @@ var resizeImages = function() {
     resizeDone = true;
 };
 
+/* Tell the app that we no longer want to focus the WebView and should instead return keyboard
+ * focus to a native answer input method.
+ * Naming subject to change.
+ */
+function _relinquishFocus() {
+    // Clicking on a hint set the Android mouse cursor to a text entry bar, even after navigating
+    // away. This fixes the issue.
+    document.body.style.cursor = "default";
+    window.location.href = "signal:relinquishFocus";
+}
+
 /* Tell the app that the input box got focus. See also
  * AbstractFlashcardViewer and CompatV15 */
 function taFocus() {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/hooks/HintFilter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/hooks/HintFilter.java
@@ -37,7 +37,7 @@ public class HintFilter {
             // random id
             String domid = "hint" + txt.hashCode();
             return "<a class=hint href=\"#\" onclick=\"this.style.display='none';document.getElementById('" +
-                    domid + "').style.display='block';return false;\">" +
+                    domid + "').style.display='block';_relinquishFocus();return false;\">" +
                     res.getString(R.string.show_hint, (String) args[2]) + "</a><div id=\"" +
                     domid + "\" class=hint style=\"display: none\">" + txt + "</div>";
         }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.java
@@ -8,6 +8,7 @@ import java.lang.reflect.Method;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
+import static com.ichi2.anki.AbstractFlashcardViewer.WebViewSignalParserUtils.*;
 import static org.junit.Assert.*;
 
 @RunWith(AndroidJUnit4.class)
@@ -224,5 +225,51 @@ public class AbstractFlashcardViewerTest extends RobolectricTest {
                 "$!";
         // Make sure $! as typed shows up as $!
         assertEquals(expectedOutput, typeAnsAnswerFilter(buf, "", "$!"));
+    }
+
+    @Test
+    public void relinquishFocusIsParsedFromSignal() {
+        String url = "signal:relinquishFocus"; //confirmed data from JS transition via debugger.
+        assertEquals(RELINQUISH_FOCUS, getSignalFromUrl(url));
+    }
+
+    @Test
+    public void typeFocusIsParsedFromSignal() {
+        String url = "signal:typefocus";
+        assertEquals(TYPE_FOCUS, getSignalFromUrl(url));
+    }
+
+    @Test
+    public void showAnswerIsParsedFromSignal() {
+        String url = "signal:show_answer";
+        assertEquals(SHOW_ANSWER, getSignalFromUrl(url));
+    }
+
+    //I'd love to turn these int parameterised tests, but it feels like more overhead for just 4 tests.
+    @Test
+    public void ease1IsParsedFromSignal() {
+        String url = "signal:answer_ease1";
+        assertEquals(ANSWER_ORDINAL_1, getSignalFromUrl(url));
+    }
+    @Test
+    public void ease2IsParsedFromSignal() {
+        String url = "signal:answer_ease2";
+        assertEquals(ANSWER_ORDINAL_2, getSignalFromUrl(url));
+    }
+    @Test
+    public void ease3IsParsedFromSignal() {
+        String url = "signal:answer_ease3";
+        assertEquals(ANSWER_ORDINAL_3, getSignalFromUrl(url));
+    }
+    @Test
+    public void ease4IsParsedFromSignal() {
+        String url = "signal:answer_ease4";
+        assertEquals(ANSWER_ORDINAL_4, getSignalFromUrl(url));
+    }
+
+    @Test
+    public void invalidEaseIsParsedFromSignal() {
+        String url = "signal:answer_ease0";
+        assertEquals(SIGNAL_NOOP, getSignalFromUrl(url));
     }
 }


### PR DESCRIPTION
## Review Goals

* Confirm whether selecting the Text Input Field, rather than "Show Answer" on a note type with both `{{hint:}}` and `{{type:}}` is correct. 
* Normally, a `{{type:}}` field does not have this focus initially.
  * But, even with focus on the text input field, `ENTER` displays the new card.

* `_relinquishFocus()` is appropriate in cards.js, named correctly (and marked well as unstable). 
* Whether the extraction of some parsing logic is a good first step in taming the complexity of `filterUrl(String url)`, or if there's a better design.

## Purpose / Description

After clicking on a `{{hint:}}` field with the mouse, the WebView took focus and KeyEvents were not sent to the Activity.

The mouse cursor was stuck as a text entry bar when hovering over the WebView

## Fixes
Fixes #5811

## Approach

* We define a JavaScript function: `_relinquishFocus`. This navigates to a URL which we capture from the Activity.
* We call the above function onClick of the Hint field.
* We handle the signal in `AbstractFlashcardViewer` and remove focus from the WebVew
* We abstract out the concern of parsing the URL
  * Slightly reduces mental load when looking at the function. Readers now see the "What", not the "How".
  * Testability, and allows us to store known good values to call URL parsing.

## How Has This Been Tested?

Unit Tested

* Tested via Keyboard & Mouse with Template: 

```
{{Front}}
{{hint:Front}}
```

**Input:** Click the hint. Press "Enter"

**Output:** Show Answer is pressed.

* Tested via Keyboard & Mouse with Template:
* "Type answer into the card" is disabled

```
{{type:Front}}

{{hint:Back}}
```

**Input:** Click the hint. Press "A"

**Outcome:** "A" appears in the Android TextView.

## Learning

The WebView only appears to allows focus from touch events when "Type answer into the card" (via HTML input) is checked.

Even though this is the case, the WebView can be focused from other inputs, and this will need to be more closely looked at in future.

## Checklist
- [ X ] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [ X ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ X ] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ X ] You have commented your code, particularly in hard-to-understand areas
- [ X ] You have performed a self-review of your own code