### PR TITLE
Fix #5141: Release resources on audio completion

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.java
@@ -46,6 +46,7 @@ import java.util.HashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import androidx.annotation.Nullable;
 import timber.log.Timber;
 
 /**
@@ -232,10 +233,10 @@ public class Sound {
     public void playSounds(int qa) {
         // If there are sounds to play for the current card, start with the first one
         if (mSoundPaths != null && mSoundPaths.containsKey(qa)) {
-            playSound(mSoundPaths.get(qa).get(0), new PlayAllCompletionListener(qa));
+            playSoundInternal(mSoundPaths.get(qa).get(0), new PlayAllCompletionListener(qa), null);
         } else if (mSoundPaths != null && qa == Sound.SOUNDS_QUESTION_AND_ANSWER) {
             if (makeQuestionAnswerList()) {
-                playSound(mSoundPaths.get(qa).get(0), new PlayAllCompletionListener(qa));
+                playSoundInternal(mSoundPaths.get(qa).get(0), new PlayAllCompletionListener(qa), null);
             }
         }
     }
@@ -272,8 +273,14 @@ public class Sound {
      * Plays the given sound or video and sets playAllListener if available on media player to start next media.
      * If videoView is null and the media is a video, then a request is sent to start the VideoPlayer Activity
      */
-    @SuppressWarnings({"PMD.EmptyIfStmt","PMD.CollapsibleIfStatements","deprecation"}) // audio API deprecation tracked on github as #5022
     public void playSound(String soundPath, OnCompletionListener playAllListener, final VideoView videoView) {
+        SingleSoundCompletionListener completionListener = new SingleSoundCompletionListener(playAllListener);
+        playSoundInternal(soundPath, completionListener, videoView);
+    }
+
+    /** Plays a sound without ensuring that the playAllListener will release the audio */
+    @SuppressWarnings({"PMD.EmptyIfStmt","PMD.CollapsibleIfStatements","deprecation"}) // audio API deprecation tracked on github as #5022
+    private void playSoundInternal(String soundPath, OnCompletionListener playAllListener, VideoView videoView) {
         Timber.d("Playing %s has listener? %b", soundPath, playAllListener != null);
         Uri soundUri = Uri.parse(soundPath);
 
@@ -363,6 +370,28 @@ public class Sound {
         }
     }
 
+    /** #5414 - Ensures playing a single sound performs cleanup */
+    private final class SingleSoundCompletionListener implements OnCompletionListener {
+        @Nullable
+        private final OnCompletionListener userCallback;
+
+        public SingleSoundCompletionListener(@Nullable OnCompletionListener userCallback) {
+            this.userCallback = userCallback;
+        }
+
+        @Override
+        public void onCompletion(MediaPlayer mp) {
+            try {
+                //We call onCompletion first, as we release the media player in releaseSound()
+                if (userCallback != null) {
+                    userCallback.onCompletion(mp);
+                }
+            } finally {
+                releaseSound();
+            }
+        }
+    }
+
     /**
      * Class used to play all sounds for a given card side
      */
@@ -400,6 +429,7 @@ public class Sound {
      */
     @SuppressWarnings("deprecation") // Tracked on github as #5022
     private void releaseSound() {
+        Timber.d("Releasing sounds and abandoning audio focus");
         if (mMediaPlayer != null) {
             mMediaPlayer.release();
             mMediaPlayer = null;


### PR DESCRIPTION
## Purpose / Description
Clicking an individual sound file did not abandon audio focus when it completed playing, leading to reduced audio volume if another sound is playing.

## Fixes
Fixes #5141

## Approach

We have two functions `playSound` and `playSounds`. We did not set a completion listener for `playSound`.

We fix this by adding a new completion listener, which will call `releaseSound()` after the optional user callback has completed.

## How Has This Been Tested?

Tested on my Android.

Played a tone, then clicked a "Play Audio" button on a card.

**Before:** Audio stayed at a decreased level after sound completion.

**After:** Audio returned to its original volume.

## Checklist
- [ x ] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [ x ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ x ] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ x ] You have commented your code, particularly in hard-to-understand areas
- [ x ] You have performed a self-review of your own code

## Review Goals

* We do not currently handle an errors in the callback (and did not before). Do we want to do this here, or is that for another issue/PR? 