### PR TITLE
Gracefully handle WebView Crashes

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1599,10 +1599,12 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
                     Timber.e("Web Renderer crash loop on card: %d", mCurrentCard.getId());
                     displayRenderLoopDialog(mCurrentCard, detail);
                     return true;
-                } else {
-                    // This logic may need to be better defined. The card could have changed by the time we get here.
-                    lastCrashingCardId = mCurrentCard.getId();
                 }
+
+                // If we get here, the error is non-fatal and we should re-render the WebView
+                // This logic may need to be better defined. The card could have changed by the time we get here.
+                lastCrashingCardId = mCurrentCard.getId();
+
 
                 String nonFatalError = getResources().getString(R.string.webview_crash_nonfatal, errorCauseString);
                 UIUtils.showThemedToast(AbstractFlashcardViewer.this, nonFatalError, false);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1581,7 +1581,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
                 //I'll keep this line unless I see another crash, which would point to another underlying issue.
                 System.gc();
 
-                //We only want to show one toast message per branch.
+                //We only want to show one message per branch.
 
                 //It's not necessarily an OOM crash, false implies a general code which is for "system terminated".
                 int errorCauseId = detail.didCrash() ? R.string.webview_crash_unknown : R.string.webview_crash_oom;
@@ -2155,6 +2155,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
 
     protected void displayCardAnswer() {
         Timber.d("displayCardAnswer()");
+        crashWebViewRenderer();
 
         // prevent answering (by e.g. gestures) before card is loaded
         if (mCurrentCard == null) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -2155,7 +2155,6 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
 
     protected void displayCardAnswer() {
         Timber.d("displayCardAnswer()");
-        crashWebViewRenderer();
 
         // prevent answering (by e.g. gestures) before card is loaded
         if (mCurrentCard == null) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1594,11 +1594,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
 
                 if (webViewRendererLastCrashedOnCard(mCurrentCard.getId())) {
                     Timber.e("Web Renderer crash loop on card: %d", mCurrentCard.getId());
-                    String cardInformation = Long.toString(mCurrentCard.getId());
-                    String errorMessage = getResources().getString(
-                            R.string.webview_crash_loop, cardInformation, errorCauseString);
-                    UIUtils.showThemedToast(AbstractFlashcardViewer.this, errorMessage, false);
-                    finishWithoutAnimation();
+                    displayRenderLoopDialog(mCurrentCard, detail);
                     return true;
                 } else {
                     // This logic may need to be better defined. The card could have changed by the time we get here.
@@ -1617,6 +1613,23 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
 
                 //We handled the crash and can continue.
                 return true;
+            }
+
+
+            @TargetApi(Build.VERSION_CODES.O)
+            private void displayRenderLoopDialog(Card mCurrentCard, RenderProcessGoneDetail detail) {
+                String cardInformation = Long.toString(mCurrentCard.getId());
+                Resources res = getResources();
+
+                String errorDetails = detail.didCrash()
+                        ? res.getString(R.string.webview_crash_unknwon_detailed)
+                        : res.getString(R.string.webview_crash_oom_details);
+                new MaterialDialog.Builder(AbstractFlashcardViewer.this)
+                        .title(res.getString(R.string.webview_crash_loop_dialog_title))
+                        .content(res.getString(R.string.webview_crash_loop_dialog_content, cardInformation, errorDetails))
+                        .positiveText(R.string.dialog_ok)
+                        .onPositive((materialDialog, dialogAction) -> finishWithoutAnimation())
+                        .show();
             }
         });
         // Set transparent color to prevent flashing white when night mode enabled

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1561,9 +1561,10 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
             public boolean onRenderProcessGone(WebView view, RenderProcessGoneDetail detail) {
 
                 if (mCard == null || !mCard.equals(view)) {
-                    //A view crashed that wasn't ours. Unexpected.
-                    Timber.wtf("Unexpected WebView Renderer terminated. Crashed: %b",  detail.didCrash());
-                    return false;
+                    //A view crashed that wasn't ours.
+                    //We have nothing to handle. Returning false is a desire to crash, so return true.
+                    Timber.i("Unrelated WebView Renderer terminated. Crashed: %b",  detail.didCrash());
+                    return true;
                 }
 
                 Timber.e("WebView Renderer process terminated. Crashed: %b",  detail.didCrash());

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1577,6 +1577,9 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
                 parent.removeView(mCardFrame);
                 mCard = null;
                 mCardFrame = null;
+                //Even with the above, I occasionally saw the above error. Manually trigger the GC.
+                //I'll keep this line unless I see another crash, which would point to another underlying issue.
+                System.gc();
 
                 //We only want to show one toast message per branch.
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -39,6 +39,10 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Message;
 import android.os.SystemClock;
+
+import androidx.annotation.IdRes;
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 import androidx.core.content.ContextCompat;
 import androidx.core.view.GestureDetectorCompat;
 import androidx.appcompat.app.ActionBar;
@@ -50,6 +54,7 @@ import android.text.style.UnderlineSpan;
 import android.util.TypedValue;
 import android.view.GestureDetector.SimpleOnGestureListener;
 import android.view.KeyEvent;
+import android.view.LayoutInflater;
 import android.view.MenuItem;
 import android.view.MotionEvent;
 import android.view.View;
@@ -59,6 +64,7 @@ import android.view.WindowManager;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputMethodManager;
 import android.webkit.JsResult;
+import android.webkit.RenderProcessGoneDetail;
 import android.webkit.WebChromeClient;
 import android.webkit.WebResourceRequest;
 import android.webkit.WebView;
@@ -330,6 +336,13 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
     private Sound mSoundPlayer = new Sound();
 
     private long mUseTimerDynamicMS;
+
+    /**
+     * Last card that the WebView Renderer crashed on.
+     * If we get 2 crashes on the same card, then we likely have an infinite loop and want to exit gracefully.
+     */
+    @Nullable
+    private Long lastCrashingCardId = null;
 
     // private int zEase;
 
@@ -1541,10 +1554,105 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
                 drawMark();
                 view.loadUrl("javascript:onPageFinished();");
             }
+
+            /** Fix: #5780 - WebView Renderer OOM crashes reviewer */
+            @Override
+            @TargetApi(Build.VERSION_CODES.O)
+            public boolean onRenderProcessGone(WebView view, RenderProcessGoneDetail detail) {
+
+                if (mCard == null || !mCard.equals(view)) {
+                    //A view crashed that wasn't ours. Unexpected.
+                    Timber.wtf("Unexpected WebView Renderer terminated. Crashed: %b",  detail.didCrash());
+                    return false;
+                }
+
+                Timber.e("WebView Renderer process terminated. Crashed: %b",  detail.didCrash());
+
+                //Destroy the current WebView (to ensure WebView is GCed).
+                //Otherwise, we get the following error:
+                //"crash wasn't handled by all associated webviews, triggering application crash"
+                destroyWebView(mCard);
+                ViewGroup parent = (ViewGroup) mCardFrame.getParent();
+                parent.removeView(mCardFrame);
+                mCard = null;
+                mCardFrame = null;
+
+                //We only want to show one toast message per branch.
+
+                //It's not necessarily an OOM crash, false implies a general code which is for "system terminated".
+                int errorCauseId = detail.didCrash() ? R.string.webview_crash_unknown : R.string.webview_crash_oom;
+                String errorCauseString = getResources().getString(errorCauseId);
+
+                if (!canRecoverFromWebViewRendererCrash()) {
+                    Timber.e("Unrecoverable WebView Render crash");
+                    String errorMessage = getResources().getString(R.string.webview_crash_fatal, errorCauseString);
+                    UIUtils.showThemedToast(AbstractFlashcardViewer.this, errorMessage, false);
+                    finishWithoutAnimation();
+                    return true;
+                }
+
+                if (webViewRendererLastCrashedOnCard(mCurrentCard.getId())) {
+                    Timber.e("Web Renderer crash loop on card: %d", mCurrentCard.getId());
+                    String cardInformation = Long.toString(mCurrentCard.getId());
+                    String errorMessage = getResources().getString(
+                            R.string.webview_crash_loop, cardInformation, errorCauseString);
+                    UIUtils.showThemedToast(AbstractFlashcardViewer.this, errorMessage, false);
+                    finishWithoutAnimation();
+                    return true;
+                } else {
+                    // This logic may need to be better defined. The card could have changed by the time we get here.
+                    lastCrashingCardId = mCurrentCard.getId();
+                }
+
+                String nonFatalError = getResources().getString(R.string.webview_crash_nonfatal, errorCauseString);
+                UIUtils.showThemedToast(AbstractFlashcardViewer.this, nonFatalError, false);
+
+                //inflate a new instance of mCardFrame
+                mCardFrame = inflateNewView(R.id.flashcard);
+                parent.addView(mCardFrame);
+
+                recreateWebView();
+                displayCardQuestion();
+
+                //We handled the crash and can continue.
+                return true;
+            }
         });
         // Set transparent color to prevent flashing white when night mode enabled
         webView.setBackgroundColor(Color.argb(1, 0, 0, 0));
         return webView;
+    }
+
+    private boolean webViewRendererLastCrashedOnCard(long cardId) {
+        return lastCrashingCardId != null && lastCrashingCardId == cardId;
+    }
+
+
+    private boolean canRecoverFromWebViewRendererCrash() {
+        // DEFECT
+        // If we don't have a card to render, we're in a bad state. The class doesn't currently track state
+        // well enough to be able to know exactly where we are in the initialisation pipeline.
+        // so it's best to mark the crash as non-recoverable.
+        // We should fix this, but it's very unlikely that we'll ever get here. Logs will tell
+
+        // Revisit webViewCrashedOnCard() if changing this. Logic currently assumes we have a card.
+        return mCurrentCard != null;
+    }
+
+    //#5780 - Users could OOM the WebView Renderer. This triggers the same symptoms
+    @VisibleForTesting()
+    @SuppressWarnings("unused")
+    public void crashWebViewRenderer() {
+        mCard.loadUrl("chrome://crash");
+    }
+
+    private <T extends View> T inflateNewView(@IdRes int id) {
+        int layoutId = getContentViewAttr(mPrefFullscreenReview);
+        ViewGroup content = (ViewGroup) LayoutInflater.from(AbstractFlashcardViewer.this).inflate(layoutId, null, false);
+        T ret = content.findViewById(id);
+        ((ViewGroup) ret.getParent()).removeView(ret); //detach the view from its parent
+        content.removeAllViews();
+        return ret;
     }
 
     private void destroyWebView(WebView webView) {
@@ -1801,6 +1909,10 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
         if (mCurrentCard == null) {
             return;
         }
+        recreateWebView();
+    }
+
+    private void recreateWebView() {
         if (mCard == null) {
             mCard = createWebView();
             // On your desktop use chrome://inspect to connect to emulator WebViews

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -51,6 +51,11 @@
     <string name="leech_suspend_notification">Card marked as leech and suspended</string>
     <string name="leech_notification">Card marked as leech</string>
     <string name="corrupt_font">Corrupt font file %s</string>
+    <string name="webview_crash_unknown">Unknown error</string>
+    <string name="webview_crash_oom">Out of Memory</string>
+    <string name="webview_crash_nonfatal">WebView renderer crashed. Cause: %s</string>
+    <string name="webview_crash_fatal">Fatal Error: WebView renderer crashed. Cause: %s</string>
+    <string name="webview_crash_loop">Fatal Error: Crash loop rendering card \'%s\'. Cause: %s</string>
 
     <!-- Browser -->
     <string-array name="browser_column1_headings">

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -52,10 +52,13 @@
     <string name="leech_notification">Card marked as leech</string>
     <string name="corrupt_font">Corrupt font file %s</string>
     <string name="webview_crash_unknown">Unknown error</string>
+    <string name="webview_crash_unknwon_detailed">This was caused by an internal error in the WebView</string>
     <string name="webview_crash_oom">Out of Memory</string>
+    <string name="webview_crash_oom_details">The WebView was terminated by the system. This typically happens when the application runs out of memory, often due to large fonts or media.</string>
     <string name="webview_crash_nonfatal">WebView renderer crashed. Cause: %s</string>
     <string name="webview_crash_fatal">Fatal Error: WebView renderer crashed. Cause: %s</string>
-    <string name="webview_crash_loop">Fatal Error: Crash loop rendering card \'%s\'. Cause: %s</string>
+    <string name="webview_crash_loop_dialog_title">System WebView Rendering Failure</string>
+    <string name="webview_crash_loop_dialog_content">System WebView failed to render card \'%s\'.\n %s</string>
 
     <!-- Browser -->
     <string-array name="browser_column1_headings">


### PR DESCRIPTION
## Purpose / Description
Out of Memory issues in the WebView Renderer (e.g. large fonts) were causing the application to crash and restart, going to the deck browser. This was listed as a soft crash in the bug report, but was actually killing the PID.

If a card fails once, we reset the WebView and try to render the card again.

If a card has not been rendered, or if the same card fails twice, we fail gracefully and return to the deck browser. We show a Toast to the user explaining that an OOM occurred.

## Fixes
Fixes #5780

## Approach

We catch the OOM using `onRenderProcessGone()` (API >= 26) and recreate the WebView to allow the application to continue with minor disruption.

## How Has This Been Tested?

Locally on my Android device (Android 9). Placing `crashWebViewRenderer()` inside `displayCardAnswer()`

* A single failure recreates the WebView
* A second failure on the same card takes the user to the Deck Browser.
* A failure on a different card recreates the WebView.

## Learning (optional, can help others)

StackOverflow example: https://stackoverflow.com/questions/46737984/onrenderprocessgonewebview-view-renderprocessgonedetail-detail-example

API: https://developer.android.com/reference/android/webkit/WebViewClient#onRenderProcessGone(android.webkit.WebView,%20android.webkit.RenderProcessGoneDetail)

https://developer.android.com/guide/webapps/managing-webview#termination-handle

## Checklist

- [ x ] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [ x ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ x ] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ x ] You have commented your code, particularly in hard-to-understand areas
- [ x ] You have performed a self-review of your own code

## Review Goals

* I'm unfamiliar with internationalisation. May have screwed up
* Do we need to do anything more to handle lower API levels?
* `inflateNewView` - doesn't feel like good code.
* We currently use Toasts because they're easy, but they don't stay on the screen for long or have much room.
* lastCrashingCardId - may not be a perfect test.
* We only report the failing card ID to the user. We could do better (not sure if out of scope).