### PR TITLE
Fix #5778 - Scheduling doesn't respect max intervals

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sched.java
@@ -1500,8 +1500,16 @@ public class Sched {
 
 
     private void _updateRevIvl(Card card, int ease) {
-        int idealIvl = _nextRevIvl(card, ease);
-        card.setIvl(_adjRevIvl(card, idealIvl));
+        try{
+            int idealIvl = _nextRevIvl(card, ease);
+            JSONObject conf = _revConf(card);
+            card.setIvl(Math.min(
+                    Math.max(_adjRevIvl(card, idealIvl), card.getIvl() + 1),
+                    conf.getInt("maxIvl")));
+        } catch (JSONException e) {
+            throw new RuntimeException(e);
+        }
+
     }
 
     @SuppressWarnings("PMD.UnusedFormalParameter") // it's unused upstream as well

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sched.java
@@ -1500,7 +1500,7 @@ public class Sched {
 
 
     private void _updateRevIvl(Card card, int ease) {
-        try{
+        try {
             int idealIvl = _nextRevIvl(card, ease);
             JSONObject conf = _revConf(card);
             card.setIvl(Math.min(


### PR DESCRIPTION
## Purpose / Description
This PR brings in changes in the function at line 695 of the desktop Anki scheduler that aren't in Anki-Android: https://github.com/ankitects/anki/blob/master/pylib/anki/sched.py#L695

In other words, this is a minor code change to fix a scheduling bug where cards would be given a smaller interval than shown on the review buttons. This could occur because having a low maximum interval changes the new ivl level that is updated in the database (despite a different interval being shown to the user on the "again/hard/okay/easy" buttons during review, because the calculation logic is separate).

## Fixes
Fixes #5778

## Approach
I copied over changes from the desktop Anki repository that updates the card's new Ivl from just being an idealIvl calculation to also checking if the maxIvl sets a different level (else Anki changes the interval at some other point). This is the same URL linked above from the desktop repo.

## How Has This Been Tested?
For a given deck that has mature cards that need to be reviewed, change the deck's maximum interval period to 22 days. Then, review a card (the review buttons should all say 22 days). After review, check the card's new interval to make sure it is 22 days, and not a lower number like 19.

Note: This assumes your interval modifier is at 100%. If it is not, change it to that.

Tested on a Samsung Galaxy S10E, Android 10, latest master as of writing.

## Learning (optional, can help others)
I originally noticed a bug in a previous deck (a writeup of the problem is in https://github.com/ankidroid/Anki-Android/issues/5778). Upon further investigation, I noticed that it was only cards near my deck's maximum interval limit of 22 days that were randomly getting changed to lower intervals (despite all review buttons saying 22 days): 

![image](https://user-images.githubusercontent.com/6107544/76693153-ec22a680-661d-11ea-819c-3fd0cef11952.png)
 
Further testing revealed that it wasn't rating dependent - any rating lower, equal, or higher than the previous intervals were still getting corrupted intervals. Because the intervals shown to me on the buttons _were_ the correct intervals, and the desktop clients were all fine, I became suspicious that Anki Android (and also AnkiMobile iOS, incidentally which has the same bug) might have some different calculation logic occurring at interval update (suggesting the intervals are calculated twice).

Checking the desktop logic [here](https://github.com/ankitects/anki/blob/master/pylib/anki/sched.py#L695
) (line 695) and comparing it to the Anki-Android equivalent function (see the diff for this PR) indeed confirmed that the logic for calculating intervals at _update time_ had not been updated; hence this explained why desktop and AnkiWeb clients weren't having issues, while the mobile app was.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code

Descriptive commit message: Intend to squash commits and use this PR as title.