### PR TITLE
#5708 Fix Dynamic Deck with Options defined

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -157,7 +157,7 @@ public class AnkiDroidApp extends Application {
      * collections being upgraded to (or after) this version must run an integrity check as it will contain fixes that
      * all collections should have.
      */
-    public static final int CHECK_DB_AT_VERSION = 21000150;
+    public static final int CHECK_DB_AT_VERSION = 21000151;
 
     /**
      * The latest package version number that included changes to the preferences that requires handling. All

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -157,7 +157,7 @@ public class AnkiDroidApp extends Application {
      * collections being upgraded to (or after) this version must run an integrity check as it will contain fixes that
      * all collections should have.
      */
-    public static final int CHECK_DB_AT_VERSION = 20900148;
+    public static final int CHECK_DB_AT_VERSION = 21000150;
 
     /**
      * The latest package version number that included changes to the preferences that requires handling. All

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1607,7 +1607,7 @@ public class Collection {
         ArrayList<String> problems = new ArrayList<>();
         long oldSize = file.length();
         int currentTask = 1;
-        int totalTasks = (mModels.all().size() * 4) + 21; // 4 things are in all-models loops, 20 things are one-offs
+        int totalTasks = (mModels.all().size() * 4) + 21; // a few fixes are in all-models loops, the rest are one-offs
         try {
             mDb.getDatabase().beginTransaction();
             try {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -26,6 +26,7 @@ import android.text.TextUtils;
 
 import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.anki.exception.DeckRenameException;
+import com.ichi2.libanki.exception.NoSuchDeckException;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -448,7 +449,7 @@ public class Decks {
         return mDecks.size();
     }
 
-
+    /** Obtains the deck from the DeckID, or default if the deck was not found */
     public @NonNull JSONObject get(long did) {
         return get(did, true);
     }
@@ -1152,5 +1153,32 @@ public class Decks {
 
     public HashMap<Long, JSONObject> getDecks() {
         return mDecks;
+    }
+
+    public Long[] allDynamicDeckIds() {
+        ArrayList<Long> validValues = new ArrayList<>();
+        for (Long did : allIds()) {
+            if (isDyn(did)) {
+                validValues.add(did);
+            }
+        }
+        return validValues.toArray(new Long[0]);
+    }
+
+    private JSONObject getDeckOrFail(long deckId) throws NoSuchDeckException {
+        JSONObject deck = get(deckId, false);
+        if (deck == null) {
+            throw new NoSuchDeckException(deckId);
+        }
+        return deck;
+    }
+
+    public boolean hasDeckOptions(long deckId) throws NoSuchDeckException {
+        return getDeckOrFail(deckId).has("conf");
+    }
+
+
+    public void removeDeckOptions(long deckId) throws NoSuchDeckException {
+        getDeckOrFail(deckId).remove("conf");
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/exception/NoSuchDeckException.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/exception/NoSuchDeckException.java
@@ -1,0 +1,19 @@
+package com.ichi2.libanki.exception;
+
+/**
+ * A deck was accessed which did not exist.
+ * <br/>
+ * Remarks: We use this checked exception to mimic an Optional before Java 1.8.
+ */
+public class NoSuchDeckException extends Exception {
+    private final long mDeckId;
+
+    public NoSuchDeckException(long deckId) {
+        this.mDeckId = deckId;
+    }
+
+    /** The ID of the accessed deck */
+    public long getDeckId() {
+        return mDeckId;
+    }
+}


### PR DESCRIPTION
## Purpose / Description
A dynamic deck with `conf` (Deck Options) defined will crash the reviewer.

A dynamic deck should not have deck options, therefore we want to remove them.

## Fixes
Fixes #5708. But I'd either like to avoid closing the issue, or raise some other issues.

* We can improve the exception thrown in the reviewer
* We should try to track down how this happened

## Approach

This adds a task to "Check Database" to remove Deck Options from any dynamic decks.

## How Has This Been Tested?

1. Force Sync + Download corrupt collection
2. Select corrupt custom study deck and flip card (FAIL).
3. Select Check Database
4. Select same custom study deck and flip card (PASS)

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code