### PR TITLE
Fix "AnkiDroid directory is inaccessible" Bug

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
@@ -27,6 +27,7 @@ import androidx.core.content.ContextCompat;
 import com.ichi2.anki.exception.StorageAccessException;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Storage;
+import com.ichi2.preferences.PreferenceExtensions;
 
 import java.io.File;
 import java.io.IOException;
@@ -209,7 +210,10 @@ public class CollectionHelper {
      */
     public static String getCurrentAnkiDroidDirectory(Context context) {
         SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context.getApplicationContext());
-        return preferences.getString("deckPath", getDefaultAnkiDroidDirectory());
+        return PreferenceExtensions.getOrSetString(
+                preferences,
+                "deckPath",
+                CollectionHelper::getDefaultAnkiDroidDirectory);
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceExtensions.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceExtensions.java
@@ -1,0 +1,32 @@
+package com.ichi2.preferences;
+
+import android.content.SharedPreferences;
+
+import androidx.annotation.CheckResult;
+import androidx.annotation.NonNull;
+
+/** Extension methods over the SharedPreferences class */
+public class PreferenceExtensions {
+
+    /**
+     * Returns the string value specified by the key, or sets key to the result of the lambda and returns it.<br/>
+     * This is not designed to be used when bulk editing preferences.<br/>
+     * Defect #5828 - This is potentially not thread safe and could cause another preference commit to fail.
+     */
+    @CheckResult //Not truly an error as this has a side effect, but you should use a "set" API for perf.
+    public static String getOrSetString(@NonNull SharedPreferences target, @NonNull String key, @NonNull Supplier<String> supplier) {
+        if (target.contains(key)) {
+            //the default Is never returned. The value might be able be optimised, but the Android API should be better.
+            return target.getString(key, "");
+        }
+        String supplied = supplier.get();
+        target.edit().putString(key, supplied).apply();
+        return supplied;
+    }
+
+    /** TODO: Move this to Supplier in API 24 */
+    @FunctionalInterface
+    public interface Supplier<T> {
+        T get();
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/preferences/PreferenceExtensionsTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/preferences/PreferenceExtensionsTest.java
@@ -1,0 +1,87 @@
+package com.ichi2.preferences;
+
+import android.content.SharedPreferences;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static com.ichi2.testutils.AnkiAssert.assertDoesNotThrow;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+
+//Unknown issue: @CheckResult should provide warnings on this class when return value is unused, but doesn't.
+//TODO: The preference mock is messy
+@RunWith(PowerMockRunner.class)
+public class PreferenceExtensionsTest {
+
+    private static PreferenceExtensions.Supplier<String> UNUSED_SUPPLIER = () -> { throw new UnexpectedException();};
+    private static PreferenceExtensions.Supplier<String> EXCEPTION_SUPPLIER = () -> { throw new ExpectedException();};
+
+    private static final String VALID_KEY = "VALID";
+    private static final String VALID_RESULT = "WAS VALID KEY";
+    private static final String MISSING_KEY = "INVALID";
+    private static final String LAMBDA_RETURN = "LAMBDA";
+
+    @Mock
+    private SharedPreferences mMockReferences;
+
+    @Mock
+    private SharedPreferences.Editor mockEditor;
+
+    private String getOrSetString(String key, PreferenceExtensions.Supplier<String> supplier) {
+        return PreferenceExtensions.getOrSetString(mMockReferences, key, supplier);
+    }
+
+    @Before
+    public void setUp() {
+        Mockito.when(mMockReferences.contains(VALID_KEY)).thenReturn(true);
+        Mockito.when(mMockReferences.getString(eq(VALID_KEY), anyString())).thenReturn(VALID_RESULT);
+        Mockito.when(mMockReferences.edit()).thenReturn(mockEditor);
+        Mockito.when(mockEditor.putString(anyString(), anyString())).thenReturn(mockEditor);
+    }
+
+    private String getForMissingKey() {
+        return getOrSetString(MISSING_KEY, () -> LAMBDA_RETURN);
+    }
+
+    @Test
+    public void existingKeyReturnsMappedValue() {
+        String ret = getOrSetString(VALID_KEY, UNUSED_SUPPLIER);
+        assertEquals(ret, VALID_RESULT);
+    }
+
+    @Test
+    public void missingKeyReturnsLambdaValue() {
+        String ret = getForMissingKey();
+        assertEquals(ret, LAMBDA_RETURN);
+    }
+
+    @SuppressWarnings("unused")
+    @Test
+    public void missingKeySetsPreference() {
+        getForMissingKey();
+        Mockito.verify(mockEditor).putString(MISSING_KEY, LAMBDA_RETURN);
+        Mockito.verify(mockEditor).apply();
+    }
+
+    @SuppressWarnings("unused")
+    public void noLambdaExceptionIfKeyExists() {
+         assertDoesNotThrow(() -> getOrSetString(VALID_KEY, EXCEPTION_SUPPLIER));
+    }
+
+    @SuppressWarnings("unused")
+    @Test(expected = ExpectedException.class)
+    public void rethrowLambdaExceptionIfKeyIsMissing() {
+        getOrSetString(MISSING_KEY, EXCEPTION_SUPPLIER);
+    }
+
+    private static class ExpectedException extends RuntimeException {
+    }
+    private static class UnexpectedException extends RuntimeException {
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/AnkiAssert.java
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/AnkiAssert.java
@@ -1,0 +1,18 @@
+package com.ichi2.testutils;
+
+import androidx.annotation.NonNull;
+
+import org.junit.Assert;
+
+/** Assertion methods that aren't currently supported by our dependencies */
+public class AnkiAssert {
+
+    /** Helper to sort out "JUnit tests should include assert() or fail()" quality check */
+    public static void assertDoesNotThrow(@NonNull Runnable runnable) {
+        try {
+            runnable.run();
+        } catch (Exception e) {
+            Assert.fail();
+        }
+    }
+}


### PR DESCRIPTION
## Purpose / Description

This bug has been pervasive for some time, and I logically believe that this change fixes it, although I haven't verified this empirically.

A user accessing "Advanced Settings" would obtain an error: `directory_inaccessible`

This was caused by entering the settings, which set a hardcoded default value `sdcard/AnkiDroid` without validation which did not match `getDefaultAnkiDroidDirectory()`

This immediately kicks the user out the app and leaves them in a crash loop. They don't know what the actual value is meant to be (as they never saw the UI, so they can't easily fix it)

## Fixes
Fixes #5097 
Fixes #5510

Partially Addresses #5346 (option can still be set if somehow preferences is the first entered screen, but I think that's logically impossible)

## Approach
We fix this by setting the preference when we try to access `deckPath` and the value is unset.

## How Has This Been Tested?

Not Tested 🛑 

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code