### PR TITLE
Correcting due date of cards in learning

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1366,9 +1366,9 @@ public class CardBrowser extends NavigationDrawerActivity implements
             item.put("ease", (c.getFactor()/10)+"%");
         }
 
-        item.put("changed", LanguageUtil.getShortDateFormatFromMs(c.getMod() * 1000L));
+        item.put("changed", LanguageUtil.getShortDateFormatFromS(c.getMod()));
         item.put("created", LanguageUtil.getShortDateFormatFromMs(c.note().getId()));
-        item.put("edited", LanguageUtil.getShortDateFormatFromMs(c.note().getMod() * 1000L));
+        item.put("edited", LanguageUtil.getShortDateFormatFromS(c.note().getMod()));
         // interval
         int type = c.getType();
         if (type == 0) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.java
@@ -710,18 +710,17 @@ public class Card implements Cloneable {
         long due = getDue();
         if (getODid() != 0) {
             return AnkiDroidApp.getAppResources().getString(R.string.card_browser_due_filtered_card);
-        }
-        else if (getQueue() == 1) {
+        } else if (getQueue() == 1) {
             date = due;
         } else if (getQueue() == 0 || getType() == 0) {
             return (new Long(due)).toString();
-        } else if (getQueue() == 2 || getQueue() == 3 || (getType() == 2 && getQueue() <0)) {
+        } else if (getQueue() == 2 || getQueue() == 3 || (getType() == 2 && getQueue() < 0)) {
             long time = System.currentTimeMillis();
             long nbDaySinceCreation = (due - getCol().getSched().getToday());
-            date = time + (nbDaySinceCreation * 86400L * 1000L);
+            date = time + (nbDaySinceCreation * 86400L);
         } else {
             return "";
         }
-        return LanguageUtil.getShortDateFormatFromMs(date);
+        return LanguageUtil.getShortDateFormatFromS(date);
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/LanguageUtil.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/LanguageUtil.java
@@ -76,4 +76,8 @@ public class LanguageUtil {
         return DateFormat.getDateInstance(DateFormat.SHORT, getLocale()).format(new Date(ms));
     }
 
+    public static String getShortDateFormatFromS(long s) {
+        return DateFormat.getDateInstance(DateFormat.SHORT, getLocale()).format(new Date(s * 1000L));
+    }
+
 }


### PR DESCRIPTION
This solve
https://github.com/ankidroid/Anki-Android/pull/5592#issuecomment-600314471 (no
Bug report associated as far as I know)

The problem was that the anki function to display time uses uses input
in second while ankidroid uses it in miliseconds. So time was
incorrect.

I now have a function taking seconds and another taking milisecond,
and call the former instead of multiplying by 1000L in a lot of part
of the code
