### PR TITLE
Persist Whiteboard Visible State

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/MetaDB.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MetaDB.java
@@ -277,11 +277,7 @@ public class MetaDB {
         Cursor cur = null;
         try {
             cur = mMetaDb.rawQuery("SELECT state FROM whiteboardState" + " WHERE did = " + did, null);
-            if (cur.moveToNext()) {
-                return cur.getInt(0) > 0;
-            } else {
-                return false;
-            }
+            return DatabaseUtil.getScalarBoolean(cur);
         } catch (Exception e) {
             Timber.e(e, "Error retrieving whiteboard state from MetaDB ");
             return false;
@@ -446,6 +442,14 @@ public class MetaDB {
     }
 
     private static class DatabaseUtil {
+        private static boolean getScalarBoolean(Cursor cur) {
+            if (cur.moveToNext()) {
+                return cur.getInt(0) > 0;
+            } else {
+                return false;
+            }
+        }
+
         @SuppressWarnings("TryFinallyCanBeTryWithResources") //API LEVEL
         private static int getTableColumnCount(SQLiteDatabase mMetaDb, String tableName) {
             Cursor c = null;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/MetaDB.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MetaDB.java
@@ -87,7 +87,14 @@ public class MetaDB {
                 + "did INTEGER NOT NULL, " + "dictionary INTEGER)");
         mMetaDb.execSQL("CREATE TABLE IF NOT EXISTS smallWidgetStatus (" + "id INTEGER PRIMARY KEY AUTOINCREMENT, "
                 + "due INTEGER NOT NULL, eta INTEGER NOT NULL)");
-        // Use pragma to get info about widgetStatus.
+        updateWidgetStatus(mMetaDb);
+        mMetaDb.setVersion(databaseVersion);
+        Timber.i("MetaDB:: Upgrading Internal Database finished. New version: %d", databaseVersion);
+        return mMetaDb;
+    }
+
+
+    private static void updateWidgetStatus(SQLiteDatabase mMetaDb) {
         int columnCount = DatabaseUtil.getTableColumnCount(mMetaDb, "widgetStatus");
         if (columnCount > 0) {
             if (columnCount < 7) {
@@ -99,10 +106,8 @@ public class MetaDB {
                     + "deckName TEXT NOT NULL, " + "newCards INTEGER NOT NULL, " + "lrnCards INTEGER NOT NULL, "
                     + "dueCards INTEGER NOT NULL, " + "progress INTEGER NOT NULL, " + "eta INTEGER NOT NULL)");
         }
-        mMetaDb.setVersion(databaseVersion);
-        Timber.i("MetaDB:: Upgrading Internal Database finished. New version: %d", databaseVersion);
-        return mMetaDb;
     }
+
 
     /** Open the meta-db but only if it currently closed. */
     private static void openDBIfClosed(Context context) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -169,8 +169,10 @@ public class Reviewer extends AbstractFlashcardViewer {
 
         mPrefWhiteboard = MetaDB.getWhiteboardState(this, getParentDid());
         if (mPrefWhiteboard) {
+            //DEFECT: Slight inefficiency here, as we set the database using these methods
+            boolean whiteboardVisibility = MetaDB.getWhiteboardVisibility(this, getParentDid());
             setWhiteboardEnabledState(true);
-            setWhiteboardVisibility(true);
+            setWhiteboardVisibility(whiteboardVisibility);
         }
 
         col.getSched().reset();     // Reset schedule incase card had previous been loaded
@@ -267,6 +269,8 @@ public class Reviewer extends AbstractFlashcardViewer {
                 // toggle whiteboard enabled state (and show/hide whiteboard item in action bar)
                 mPrefWhiteboard = ! mPrefWhiteboard;
                 Timber.i("Reviewer:: Whiteboard enabled state set to %b", mPrefWhiteboard);
+                //Even though the visibility is now stored in its own setting, we want it to be dependent
+                //on the enabled status
                 setWhiteboardEnabledState(mPrefWhiteboard);
                 setWhiteboardVisibility(mPrefWhiteboard);
                 refreshActionBar();
@@ -615,6 +619,7 @@ public class Reviewer extends AbstractFlashcardViewer {
     // Show or hide the whiteboard
     private void setWhiteboardVisibility(boolean state) {
         mShowWhiteboard = state;
+        MetaDB.storeWhiteboardVisibility(this, getParentDid(), state);
         if (state) {
             mWhiteboard.setVisibility(View.VISIBLE);
             disableDrawerSwipe();


### PR DESCRIPTION
This review was borderline "I should split this into commits". If you'd prefer this, please let me know.

I'd also love to hear "You should abstract out the whiteboard logic from `Reviewer` and test it", but I doubt it's considered to be a good use of time. 

----


## Purpose / Description
Previously, the whiteboard visible state depended on the enabled state

This caused problems when switching from Night Mode, as it would forget the Visible setting.

## Fixes
Fixes #5065

## Approach

We now persist the visible state to the internal database, this still depends on the enabled flag.

## How Has This Been Tested?

Previously it did not work on my device.

Now when switching to night mode, the visible status is saved.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code