### PR TITLE
Display Interval on Reschedule Dialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -973,10 +973,23 @@ public class CardBrowser extends NavigationDrawerActivity implements
             case R.id.action_reschedule_cards: {
                 Timber.i("CardBrowser:: Reschedule button pressed");
                 IntegerDialog rescheduleDialog = new IntegerDialog();
+
+                String content = null;
+                if (getSelectedCardIds().length == 1) {
+                    long cardId = getSelectedCardIds()[0];
+                    Card selectedCard = getCol().getCard(cardId);
+                    if (selectedCard.isReview() && !selectedCard.isDynamic()) {
+                        //#5595 - Help a user reschedule cards by showing them the current interval.
+                        //DEFECT: We should be able to calculate this for all card types.
+                        content = getResources().getString(R.string.reschedule_card_dialog_interval, selectedCard.getIvl());
+                    }
+                }
+
                 rescheduleDialog.setArgs(
                         getString(R.string.reschedule_card_dialog_title),
                         getString(R.string.reschedule_card_dialog_message),
-                        4);
+                        4,
+                        content);
                 rescheduleDialog.setCallbackRunnable(rescheduleDialog.new IntRunnable() {
                     public void run() {
                         DeckTask.launchDeckTask(DeckTask.TASK_TYPE_DISMISS_MULTI, mRescheduleCardHandler,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -987,7 +987,9 @@ public class CardBrowser extends NavigationDrawerActivity implements
                     Card selected = getCol().getCard(cardId);
                     rescheduleDialog = RescheduleDialog.rescheduleSingleCard(getResources(), selected, consumer);
                 } else {
-                    rescheduleDialog = RescheduleDialog.rescheduleMultipleCards(getResources(), consumer);
+                    rescheduleDialog = RescheduleDialog.rescheduleMultipleCards(getResources(),
+                            consumer,
+                            selectedCardIds.length);
                 }
                 showDialogFragment(rescheduleDialog);
                 return true;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -73,6 +73,7 @@ import com.ichi2.libanki.Note;
 import com.ichi2.libanki.Utils;
 import com.ichi2.themes.Themes;
 import com.ichi2.upgrade.Upgrade;
+import com.ichi2.utils.FunctionalInterfaces;
 import com.ichi2.utils.IntentTop;
 import com.ichi2.utils.LanguageUtil;
 import com.ichi2.widget.WidgetStatus;
@@ -975,20 +976,18 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 Timber.i("CardBrowser:: Reschedule button pressed");
 
                 long[] selectedCardIds = getSelectedCardIds();
-                IntegerDialog.IntRunnable runnable = new IntegerDialog.IntRunnable() {
-                    public void run() {
-                        DeckTask.launchDeckTask(DeckTask.TASK_TYPE_DISMISS_MULTI, mRescheduleCardHandler,
-                                new DeckTask.TaskData(new Object[]{selectedCardIds, Collection.DismissType.RESCHEDULE_CARDS, this.getInt()}));
-                    }
-                };
+                FunctionalInterfaces.Consumer<Integer> consumer = newDays ->
+                    DeckTask.launchDeckTask(DeckTask.TASK_TYPE_DISMISS_MULTI,
+                        mRescheduleCardHandler,
+                        new TaskData(new Object[]{selectedCardIds, Collection.DismissType.RESCHEDULE_CARDS, newDays}));
 
                 RescheduleDialog rescheduleDialog;
                 if (selectedCardIds.length == 1) {
                     long cardId = selectedCardIds[0];
                     Card selected = getCol().getCard(cardId);
-                    rescheduleDialog = RescheduleDialog.rescheduleSingleCard(getResources(), selected, runnable);
+                    rescheduleDialog = RescheduleDialog.rescheduleSingleCard(getResources(), selected, consumer);
                 } else {
-                    rescheduleDialog = RescheduleDialog.rescheduleMultipleCards(getResources(), runnable);
+                    rescheduleDialog = RescheduleDialog.rescheduleMultipleCards(getResources(), consumer);
                 }
                 showDialogFragment(rescheduleDialog);
                 return true;
@@ -1014,12 +1013,10 @@ public class CardBrowser extends NavigationDrawerActivity implements
                         getString(R.string.reposition_card_dialog_title),
                         getString(R.string.reposition_card_dialog_message),
                         5);
-                repositionDialog.setCallbackRunnable(new IntegerDialog.IntRunnable() {
-                    public void run() {
-                        DeckTask.launchDeckTask(DeckTask.TASK_TYPE_DISMISS_MULTI, mRepositionCardHandler,
-                                new DeckTask.TaskData(new Object[] {cardIds, Collection.DismissType.REPOSITION_CARDS, this.getInt()}));
-                    }
-                });
+                repositionDialog.setCallbackRunnable(days ->
+                    DeckTask.launchDeckTask(DeckTask.TASK_TYPE_DISMISS_MULTI, mRepositionCardHandler,
+                        new DeckTask.TaskData(new Object[] {cardIds, Collection.DismissType.REPOSITION_CARDS, days}))
+                );
                 showDialogFragment(repositionDialog);
                 return true;
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -39,6 +39,7 @@ import android.widget.FrameLayout;
 import com.ichi2.anim.ActivityTransitionAnimation;
 import com.ichi2.anki.dialogs.ConfirmationDialog;
 import com.ichi2.anki.dialogs.IntegerDialog;
+import com.ichi2.anki.dialogs.RescheduleDialog;
 import com.ichi2.async.DeckTask;
 import com.ichi2.compat.CompatHelper;
 import com.ichi2.libanki.Card;
@@ -319,28 +320,15 @@ public class Reviewer extends AbstractFlashcardViewer {
     }
 
     private void showRescheduleCardDialog() {
-        IntegerDialog rescheduleDialog = new IntegerDialog();
-
-        String content = null;
-        if (mCurrentCard.isReview() && !mCurrentCard.isDynamic()) {
-            //#5595 - Help a user reschedule cards by showing them the current interval.
-            //DEFECT: We should be able to calculate this for all card types.
-            content = getResources().getString(R.string.reschedule_card_dialog_interval, mCurrentCard.getIvl());
-        }
-
-        rescheduleDialog.setArgs(
-                getResources().getString(R.string.reschedule_card_dialog_title),
-                getResources().getString(R.string.reschedule_card_dialog_message),
-                4,
-                content);
-
-        rescheduleDialog.setCallbackRunnable(rescheduleDialog.new IntRunnable() {
+        IntegerDialog.IntRunnable runnable = new IntegerDialog.IntRunnable() {
             public void run() {
                 DeckTask.launchDeckTask(DeckTask.TASK_TYPE_DISMISS_MULTI, mRescheduleCardHandler,
                         new DeckTask.TaskData(new Object[]{new long[]{mCurrentCard.getId()}, Collection.DismissType.RESCHEDULE_CARDS, this.getInt()}));
             }
-        });
-        showDialogFragment(rescheduleDialog);
+        };
+        RescheduleDialog dialog = RescheduleDialog.rescheduleSingleCard(getResources(), mCurrentCard, runnable);
+
+        showDialogFragment(dialog);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -320,10 +320,20 @@ public class Reviewer extends AbstractFlashcardViewer {
 
     private void showRescheduleCardDialog() {
         IntegerDialog rescheduleDialog = new IntegerDialog();
+
+        String content = null;
+        if (mCurrentCard.isReview() && !mCurrentCard.isDynamic()) {
+            //#5595 - Help a user reschedule cards by showing them the current interval.
+            //DEFECT: We should be able to calculate this for all card types.
+            content = getResources().getString(R.string.reschedule_card_dialog_interval, mCurrentCard.getIvl());
+        }
+
         rescheduleDialog.setArgs(
                 getResources().getString(R.string.reschedule_card_dialog_title),
                 getResources().getString(R.string.reschedule_card_dialog_message),
-                4);
+                4,
+                content);
+
         rescheduleDialog.setCallbackRunnable(rescheduleDialog.new IntRunnable() {
             public void run() {
                 DeckTask.launchDeckTask(DeckTask.TASK_TYPE_DISMISS_MULTI, mRescheduleCardHandler,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -38,7 +38,6 @@ import android.widget.FrameLayout;
 
 import com.ichi2.anim.ActivityTransitionAnimation;
 import com.ichi2.anki.dialogs.ConfirmationDialog;
-import com.ichi2.anki.dialogs.IntegerDialog;
 import com.ichi2.anki.dialogs.RescheduleDialog;
 import com.ichi2.async.DeckTask;
 import com.ichi2.compat.CompatHelper;
@@ -46,6 +45,7 @@ import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Collection.DismissType;
 import com.ichi2.themes.Themes;
+import com.ichi2.utils.FunctionalInterfaces.Consumer;
 import com.ichi2.utils.IntentTop;
 import com.ichi2.widget.WidgetStatus;
 
@@ -320,12 +320,11 @@ public class Reviewer extends AbstractFlashcardViewer {
     }
 
     private void showRescheduleCardDialog() {
-        IntegerDialog.IntRunnable runnable = new IntegerDialog.IntRunnable() {
-            public void run() {
-                DeckTask.launchDeckTask(DeckTask.TASK_TYPE_DISMISS_MULTI, mRescheduleCardHandler,
-                        new DeckTask.TaskData(new Object[]{new long[]{mCurrentCard.getId()}, Collection.DismissType.RESCHEDULE_CARDS, this.getInt()}));
-            }
-        };
+        Consumer<Integer> runnable = days ->
+            DeckTask.launchDeckTask(DeckTask.TASK_TYPE_DISMISS_MULTI, mRescheduleCardHandler,
+                    new DeckTask.TaskData(new Object[]{new long[]{mCurrentCard.getId()},
+                    Collection.DismissType.RESCHEDULE_CARDS, days})
+            );
         RescheduleDialog dialog = RescheduleDialog.rescheduleSingleCard(getResources(), mCurrentCard, runnable);
 
         showDialogFragment(dialog);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/IntegerDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/IntegerDialog.java
@@ -15,7 +15,8 @@ public class IntegerDialog extends AnalyticsDialogFragment {
 
     private IntRunnable callbackRunnable;
 
-    public abstract class IntRunnable implements Runnable {
+    //TODO: Why isn't this a consumer accepting an int?
+    public static abstract class IntRunnable implements Runnable {
         private int mInt;
         public void setInt(int intArg) {
             mInt = intArg;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/IntegerDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/IntegerDialog.java
@@ -9,6 +9,7 @@ import com.ichi2.anki.R;
 import com.ichi2.anki.analytics.AnalyticsDialogFragment;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 public class IntegerDialog extends AnalyticsDialogFragment {
 
@@ -30,17 +31,22 @@ public class IntegerDialog extends AnalyticsDialogFragment {
     }
 
     public void setArgs(String title, String prompt, int digits) {
+        setArgs(title, prompt, digits, null);
+    }
+
+    public void setArgs(String title, String prompt, int digits, @Nullable String content) {
         Bundle args = new Bundle();
         args.putString("title", title);
         args.putString("prompt", prompt);
         args.putInt("digits", digits);
+        args.putString("content", content);
         setArguments(args);
     }
 
     @Override
     public @NonNull MaterialDialog onCreateDialog(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        return new MaterialDialog.Builder(getActivity())
+        MaterialDialog.Builder builder = new MaterialDialog.Builder(getActivity())
                 .title(getArguments().getString("title"))
                 .positiveText(getResources().getString(R.string.dialog_ok))
                 .negativeText(R.string.cancel)
@@ -49,7 +55,13 @@ public class IntegerDialog extends AnalyticsDialogFragment {
                 .input(getArguments().getString("prompt"), "", (dialog, text) -> {
                     callbackRunnable.setInt(Integer.parseInt(text.toString()));
                     callbackRunnable.run();
-                })
-                .show();
+                });
+        //content is marked as @NotNull
+        //We can't use "" as that creates padding, and want to respect the contract, so only set if not null
+        String content = getArguments().getString("content");
+        if (content != null) {
+            builder = builder.content(content);
+        }
+        return builder.show();
     }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/IntegerDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/IntegerDialog.java
@@ -7,28 +7,17 @@ import android.text.InputType;
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.ichi2.anki.R;
 import com.ichi2.anki.analytics.AnalyticsDialogFragment;
+import com.ichi2.utils.FunctionalInterfaces.Consumer;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 public class IntegerDialog extends AnalyticsDialogFragment {
 
-    private IntRunnable callbackRunnable;
+    private Consumer<Integer> consumer;
 
-    //TODO: Why isn't this a consumer accepting an int?
-    public static abstract class IntRunnable implements Runnable {
-        private int mInt;
-        public void setInt(int intArg) {
-            mInt = intArg;
-        }
-        public int getInt() {
-            return mInt;
-        }
-        public abstract void run();
-    }
-
-    public void setCallbackRunnable(IntRunnable callbackRunnable) {
-        this.callbackRunnable = callbackRunnable;
+    public void setCallbackRunnable(Consumer<Integer> consumer) {
+        this.consumer = consumer;
     }
 
     public void setArgs(String title, String prompt, int digits) {
@@ -53,10 +42,8 @@ public class IntegerDialog extends AnalyticsDialogFragment {
                 .negativeText(R.string.cancel)
                 .inputType(InputType.TYPE_CLASS_NUMBER)
                 .inputRange(1, getArguments().getInt("digits"))
-                .input(getArguments().getString("prompt"), "", (dialog, text) -> {
-                    callbackRunnable.setInt(Integer.parseInt(text.toString()));
-                    callbackRunnable.run();
-                });
+                .input(getArguments().getString("prompt"), "",
+                        (dialog, text) -> consumer.consume(Integer.parseInt(text.toString())));
         //content is marked as @NotNull
         //We can't use "" as that creates padding, and want to respect the contract, so only set if not null
         String content = getArguments().getString("content");

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/IntegerDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/IntegerDialog.java
@@ -44,7 +44,7 @@ public class IntegerDialog extends AnalyticsDialogFragment {
                 .inputRange(1, getArguments().getInt("digits"))
                 .input(getArguments().getString("prompt"), "",
                         (dialog, text) -> consumer.consume(Integer.parseInt(text.toString())));
-        //content is marked as @NotNull
+        //builder.content's argument is marked as @NotNull
         //We can't use "" as that creates padding, and want to respect the contract, so only set if not null
         String content = getArguments().getString("content");
         if (content != null) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/RescheduleDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/RescheduleDialog.java
@@ -1,0 +1,68 @@
+package com.ichi2.anki.dialogs;
+
+import android.content.res.Resources;
+
+import com.ichi2.anki.R;
+import com.ichi2.libanki.Card;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import androidx.annotation.CheckResult;
+
+public class RescheduleDialog extends IntegerDialog {
+    private RescheduleDialog() {
+        super();
+    }
+
+    @NotNull
+    @CheckResult
+    public static RescheduleDialog rescheduleSingleCard(Resources resources, Card currentCard, IntRunnable callbackRunnable) {
+        RescheduleDialog rescheduleDialog = new RescheduleDialog();
+
+        String content = getContentString(resources, currentCard);
+
+        rescheduleDialog.setArgs(
+                resources.getString(R.string.reschedule_card_dialog_title),
+                resources.getString(R.string.reschedule_card_dialog_message),
+                4,
+                content);
+
+        if (callbackRunnable != null) {
+            rescheduleDialog.setCallbackRunnable(callbackRunnable);
+        }
+
+        return rescheduleDialog;
+    }
+
+    @NotNull
+    @CheckResult
+    public static RescheduleDialog rescheduleMultipleCards(Resources resources, IntRunnable callbackRunnable) {
+        RescheduleDialog rescheduleDialog = new RescheduleDialog();
+
+        rescheduleDialog.setArgs(
+                resources.getString(R.string.reschedule_card_dialog_title),
+                resources.getString(R.string.reschedule_card_dialog_message),
+                4);
+
+        if (callbackRunnable != null) {
+            rescheduleDialog.setCallbackRunnable(callbackRunnable);
+        }
+
+        return rescheduleDialog;
+    }
+
+
+    @Nullable
+    private static String getContentString(Resources resources, Card currentCard) {
+        //#5595 - Help a user reschedule cards by showing them the current interval.
+
+        if (!currentCard.isReview() || currentCard.isDynamic()) {
+            //DEFECT: We should be able to calculate this for all card types.
+            return null;
+        }
+
+        return resources.getString(R.string.reschedule_card_dialog_interval, currentCard.getIvl());
+    }
+
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/RescheduleDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/RescheduleDialog.java
@@ -4,6 +4,7 @@ import android.content.res.Resources;
 
 import com.ichi2.anki.R;
 import com.ichi2.libanki.Card;
+import com.ichi2.utils.FunctionalInterfaces.Consumer;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -17,7 +18,8 @@ public class RescheduleDialog extends IntegerDialog {
 
     @NotNull
     @CheckResult
-    public static RescheduleDialog rescheduleSingleCard(Resources resources, Card currentCard, IntRunnable callbackRunnable) {
+    public static RescheduleDialog rescheduleSingleCard(Resources resources, Card currentCard,
+                                                        Consumer<Integer> consumer) {
         RescheduleDialog rescheduleDialog = new RescheduleDialog();
 
         String content = getContentString(resources, currentCard);
@@ -28,8 +30,8 @@ public class RescheduleDialog extends IntegerDialog {
                 4,
                 content);
 
-        if (callbackRunnable != null) {
-            rescheduleDialog.setCallbackRunnable(callbackRunnable);
+        if (consumer != null) {
+            rescheduleDialog.setCallbackRunnable(consumer);
         }
 
         return rescheduleDialog;
@@ -37,7 +39,7 @@ public class RescheduleDialog extends IntegerDialog {
 
     @NotNull
     @CheckResult
-    public static RescheduleDialog rescheduleMultipleCards(Resources resources, IntRunnable callbackRunnable) {
+    public static RescheduleDialog rescheduleMultipleCards(Resources resources, Consumer<Integer> consumer) {
         RescheduleDialog rescheduleDialog = new RescheduleDialog();
 
         rescheduleDialog.setArgs(
@@ -45,8 +47,8 @@ public class RescheduleDialog extends IntegerDialog {
                 resources.getString(R.string.reschedule_card_dialog_message),
                 4);
 
-        if (callbackRunnable != null) {
-            rescheduleDialog.setCallbackRunnable(callbackRunnable);
+        if (consumer != null) {
+            rescheduleDialog.setCallbackRunnable(consumer);
         }
 
         return rescheduleDialog;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/RescheduleDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/RescheduleDialog.java
@@ -25,7 +25,7 @@ public class RescheduleDialog extends IntegerDialog {
         String content = getContentString(resources, currentCard);
 
         rescheduleDialog.setArgs(
-                resources.getString(R.string.reschedule_card_dialog_title),
+                resources.getQuantityString(R.plurals.reschedule_cards_dialog_title, 1),
                 resources.getString(R.string.reschedule_card_dialog_message),
                 4,
                 content);
@@ -39,11 +39,11 @@ public class RescheduleDialog extends IntegerDialog {
 
     @NotNull
     @CheckResult
-    public static RescheduleDialog rescheduleMultipleCards(Resources resources, Consumer<Integer> consumer) {
+    public static RescheduleDialog rescheduleMultipleCards(Resources resources, Consumer<Integer> consumer, int cardCount) {
         RescheduleDialog rescheduleDialog = new RescheduleDialog();
 
         rescheduleDialog.setArgs(
-                resources.getString(R.string.reschedule_card_dialog_title),
+                resources.getQuantityString(R.plurals.reschedule_cards_dialog_title, cardCount),
                 resources.getString(R.string.reschedule_card_dialog_message),
                 4);
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/RescheduleDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/RescheduleDialog.java
@@ -62,7 +62,7 @@ public class RescheduleDialog extends IntegerDialog {
             return null;
         }
 
-        return resources.getString(R.string.reschedule_card_dialog_interval, currentCard.getIvl());
+        return resources.getQuantityString(R.plurals.reschedule_card_dialog_interval, currentCard.getIvl(), currentCard.getIvl());
     }
 
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.java
@@ -723,4 +723,15 @@ public class Card implements Cloneable {
         }
         return LanguageUtil.getShortDateFormatFromS(date);
     }
+
+    /** Non libAnki */
+    public boolean isDynamic() {
+        //I have cards in my collection with oDue <> 0 and oDid = 0.
+        //These are not marked as dynamic.
+        return this.getODid() != 0;
+    }
+
+    public boolean isReview() {
+        return this.getType() == 2 && this.getQueue() == 2;
+    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceExtensions.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceExtensions.java
@@ -2,7 +2,7 @@ package com.ichi2.preferences;
 
 import android.content.SharedPreferences;
 
-import com.ichi2.utils.FunctionalInterfaces.*;
+import com.ichi2.utils.FunctionalInterfaces.Supplier;
 
 import androidx.annotation.CheckResult;
 import androidx.annotation.NonNull;

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceExtensions.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceExtensions.java
@@ -2,6 +2,8 @@ package com.ichi2.preferences;
 
 import android.content.SharedPreferences;
 
+import com.ichi2.utils.FunctionalInterfaces.*;
+
 import androidx.annotation.CheckResult;
 import androidx.annotation.NonNull;
 
@@ -22,11 +24,5 @@ public class PreferenceExtensions {
         String supplied = supplier.get();
         target.edit().putString(key, supplied).apply();
         return supplied;
-    }
-
-    /** TODO: Move this to Supplier in API 24 */
-    @FunctionalInterface
-    public interface Supplier<T> {
-        T get();
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/FunctionalInterfaces.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/FunctionalInterfaces.java
@@ -1,0 +1,10 @@
+package com.ichi2.utils;
+
+public final class FunctionalInterfaces {
+
+    /** TODO: Move this to Supplier in API 24 */
+    @FunctionalInterface
+    public interface Supplier<T> {
+        T get();
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/utils/FunctionalInterfaces.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/FunctionalInterfaces.java
@@ -1,10 +1,16 @@
 package com.ichi2.utils;
 
+
+/** TODO: Move this to standard library in API 24 */
 public final class FunctionalInterfaces {
 
-    /** TODO: Move this to Supplier in API 24 */
     @FunctionalInterface
     public interface Supplier<T> {
         T get();
+    }
+
+    @FunctionalInterface
+    public interface Consumer<T> {
+        void consume(T item);
     }
 }

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -58,6 +58,10 @@
         <item quantity="other">%d cards reset</item>
     </plurals>
     <string name="reschedule_card_dialog_title">Reschedule card</string>
+    <plurals name="reschedule_cards_dialog_title">
+        <item quantity="one">Reschedule card</item>
+        <item quantity="other">Reschedule cards</item>
+    </plurals>
     <plurals name="reschedule_card_dialog_interval">
         <item quantity="one">Current interval: %d day</item>
         <item quantity="other">Current interval: %d days</item>

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -58,6 +58,7 @@
         <item quantity="other">%d cards reset</item>
     </plurals>
     <string name="reschedule_card_dialog_title">Reschedule card</string>
+    <string name="reschedule_card_dialog_interval">Current interval: %d days</string>
     <string name="reschedule_card_dialog_message">Reschedule for review in x days</string>
     <plurals name="reschedule_cards_dialog_acknowledge">
         <item quantity="one">%d card rescheduled</item>

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -58,7 +58,10 @@
         <item quantity="other">%d cards reset</item>
     </plurals>
     <string name="reschedule_card_dialog_title">Reschedule card</string>
-    <string name="reschedule_card_dialog_interval">Current interval: %d days</string>
+    <plurals name="reschedule_card_dialog_interval">
+        <item quantity="one">Current interval: %d day</item>
+        <item quantity="other">Current interval: %d days</item>
+    </plurals>
     <string name="reschedule_card_dialog_message">Reschedule for review in x days</string>
     <plurals name="reschedule_cards_dialog_acknowledge">
         <item quantity="one">%d card rescheduled</item>

--- a/AnkiDroid/src/test/java/com/ichi2/preferences/PreferenceExtensionsTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/preferences/PreferenceExtensionsTest.java
@@ -10,6 +10,7 @@ import org.mockito.Mockito;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import static com.ichi2.testutils.AnkiAssert.assertDoesNotThrow;
+import static com.ichi2.utils.FunctionalInterfaces.*;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -19,8 +20,8 @@ import static org.mockito.ArgumentMatchers.eq;
 @RunWith(PowerMockRunner.class)
 public class PreferenceExtensionsTest {
 
-    private static PreferenceExtensions.Supplier<String> UNUSED_SUPPLIER = () -> { throw new UnexpectedException();};
-    private static PreferenceExtensions.Supplier<String> EXCEPTION_SUPPLIER = () -> { throw new ExpectedException();};
+    private static Supplier<String> UNUSED_SUPPLIER = () -> { throw new UnexpectedException();};
+    private static Supplier<String> EXCEPTION_SUPPLIER = () -> { throw new ExpectedException();};
 
     private static final String VALID_KEY = "VALID";
     private static final String VALID_RESULT = "WAS VALID KEY";
@@ -33,7 +34,7 @@ public class PreferenceExtensionsTest {
     @Mock
     private SharedPreferences.Editor mockEditor;
 
-    private String getOrSetString(String key, PreferenceExtensions.Supplier<String> supplier) {
+    private String getOrSetString(String key, Supplier<String> supplier) {
         return PreferenceExtensions.getOrSetString(mMockReferences, key, supplier);
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/preferences/PreferenceExtensionsTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/preferences/PreferenceExtensionsTest.java
@@ -10,7 +10,7 @@ import org.mockito.Mockito;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import static com.ichi2.testutils.AnkiAssert.assertDoesNotThrow;
-import static com.ichi2.utils.FunctionalInterfaces.*;
+import static com.ichi2.utils.FunctionalInterfaces.Supplier;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;


### PR DESCRIPTION
## Purpose / Description
User requested interval data in dialog to assist them in selecting a new interval

## Fixes
Fixes #5595 

## Approach

We only handle interval data for review cards in a non-dynamic deck.

We add the interval data unconditionally on review, and if there is a single card selected in the card browser.

## How Has This Been Tested?

Tested on my device

<a href="https://user-images.githubusercontent.com/62114487/77094321-3764fc80-6a04-11ea-95dc-40b254c6f365.jpg">Review: Review Queue</a>
<a href="https://user-images.githubusercontent.com/62114487/77094316-3633cf80-6a04-11ea-8bed-5b0a5fc725b1.jpg">Review: Non Review Queue</a>
<a href="https://user-images.githubusercontent.com/62114487/77095974-9297ee80-6a06-11ea-9314-215cf315e048.png">Review: 1 day</a>
<a href="https://user-images.githubusercontent.com/62114487/77094314-359b3900-6a04-11ea-81f6-e5b8e41f185e.jpg">Browser: 1 selection</a>
<a href="https://user-images.githubusercontent.com/62114487/77094325-37fd9300-6a04-11ea-8f66-c48581582d65.jpg">Browser: 2 selections</a>

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code

## Review Goals

* A bug in "[Browser: 2 selections](https://user-images.githubusercontent.com/62114487/77094325-37fd9300-6a04-11ea-8f66-c48581582d65.jpg)" was discovered: the title is non-plural.
  * How do you convert a string to a plural while keeping CrowdSource happy?