### PR TITLE
Fix #5253 - Deck Options Corruption on Export

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.java
@@ -192,11 +192,13 @@ class AnkiExporter extends Exporter {
                     dconfs.put(Long.toString(d.getLong("conf")), true);
                 }
             }
+
+            JSONObject destinationDeck = JSONObjectUtils.slowDeepClone(d);
             if (!mIncludeSched) {
                 // scheduling not included, so reset deck settings to default
-                d.put("conf", 1);
+                destinationDeck.put("conf", 1);
             }
-            dst.getDecks().update(d);
+            dst.getDecks().update(destinationDeck);
         }
         // copy used deck confs
         Timber.d("Copy deck options");
@@ -312,6 +314,17 @@ class AnkiExporter extends Exporter {
 
     public void setDid(Long did) {
         mDid = did;
+    }
+
+    private static class JSONObjectUtils {
+        private JSONObjectUtils() {
+
+        }
+
+        /** Defect: Inefficient deep clone. We should find or write a faster method */
+        private static JSONObject slowDeepClone(JSONObject object) throws JSONException {
+            return new JSONObject(object.toString());
+        }
     }
 }
 


### PR DESCRIPTION
## Purpose / Description

User complaint that exporting a deck reset the deck options to 1.

This also appears to have been the cause of a dynamic deck having options, and therefore being corrupted. 

## Fixes
Fixes #5253
Fixes #5708

## Approach
We fix this via an inefficient deep clone.

## How Has This Been Tested?

1. New Collection - created on 2.10alpha46
2. Create New Deck
3. Create new options group and assign to new deck
4. Fails - new deck's option group is set to default
5. Load 2.10alpha51
5. Export
6. Passes - deck is still the same

Also tested with default deck and a custom study deck, both were corrupt (database errors on study).


## Learning (optional, can help others)

[stackOverflow: How do I clone an org.json.JSONObject in Java?](https://stackoverflow.com/questions/12809779/how-do-i-clone-an-org-json-jsonobject-in-java)

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code