### PR TITLE
#5643 - Filter Additional Media for Export

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.java
@@ -231,8 +231,8 @@ class AnkiExporter extends Exporter {
                     String fname = f.getName();
                     if (fname.startsWith("_")) {
                         // Loop through every model that will be exported, and check if it contains a reference to f
-                        for (int idx = 0; idx < mid.size(); idx++) {
-                            if (_modelHasMedia(mSrc.getModels().get(idx), fname)) {
+                        for (JSONObject model : mSrc.getModels().all()) {
+                            if (_modelHasMedia(model, fname)) {
                                 media.put(fname, true);
                                 break;
                             }


### PR DESCRIPTION
## Purpose / Description

Our code intends to find media beginning with "_" and only include it when it's valid in the CSS or a formatted answer. This was devised to ensure that we don't export massive and unused CJK fonts.

See: https://github.com/ankitects/anki/pull/114

This didn't work, as we passed in the index of the model, instead of the model ID, therefore we had a null model, which was assumed to return true.
## Fixes
Fixes #5643 

## Approach
We use a for loop

## How Has This Been Tested?

Tested on my phone. Custom collection with 2 files, one included in a deck, and one not, but with a leading "_".

Before: Deck export contained 2 files and was 3MB  
After: Deck export contained 1 file and was 400KB

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code

----

Original Anki Code: https://github.com/ankitects/anki/blob/862e2b48f06dadf414d171d2cfdc4ac3ad79e7da/pylib/anki/exporting.py#L270-L276