### PR TITLE
Fix permission handling in Multimedia editor

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -43,6 +43,7 @@ import com.ichi2.anki.services.NotificationService;
 import com.ichi2.compat.CompatHelper;
 import com.ichi2.utils.LanguageUtil;
 import com.ichi2.anki.analytics.UsageAnalytics;
+import com.ichi2.utils.Permissions;
 
 import org.acra.ACRA;
 import org.acra.ReportField;
@@ -235,7 +236,7 @@ public class AnkiDroidApp extends Application {
         CardBrowser.clearLastDeckId();
 
         // Create the AnkiDroid directory if missing. Send exception report if inaccessible.
-        if (CollectionHelper.hasStorageAccessPermission(this)) {
+        if (Permissions.hasStorageAccessPermission(this)) {
             try {
                 String dir = CollectionHelper.getCurrentAnkiDroidDirectory(this);
                 CollectionHelper.initializeAnkiDroidDirectory(dir);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
@@ -225,13 +225,4 @@ public class CollectionHelper {
         return new File(path).getParentFile().getAbsolutePath();
     }
 
-    /**
-     * Check if we have permission to access the external storage
-     * @param context
-     * @return
-     */
-    public static boolean hasStorageAccessPermission(Context context) {
-        return ContextCompat.checkSelfPermission(context, Manifest.permission.WRITE_EXTERNAL_STORAGE)
-                == PackageManager.PERMISSION_GRANTED;
-    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -105,6 +105,7 @@ import com.ichi2.libanki.Utils;
 import com.ichi2.libanki.importer.AnkiPackageImporter;
 import com.ichi2.themes.StyledProgressDialog;
 import com.ichi2.utils.ImportUtils;
+import com.ichi2.utils.Permissions;
 import com.ichi2.utils.VersionUtils;
 import com.ichi2.widget.WidgetStatus;
 
@@ -435,7 +436,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
             showStartupScreensAndDialogs(preferences, 0);
         } else {
             // Show error dialogs
-            if (CollectionHelper.hasStorageAccessPermission(this)) {
+            if (Permissions.hasStorageAccessPermission(this)) {
                 if (!AnkiDroidApp.isSdCardMounted()) {
                     // SD card not mounted
                     onSdCardNotMounted();
@@ -456,7 +457,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
      * @return whether or not we were successful
      */
     private boolean firstCollectionOpen() {
-        if (CollectionHelper.hasStorageAccessPermission(this)) {
+        if (Permissions.hasStorageAccessPermission(this)) {
             // Show error dialog if collection could not be opened
             return CollectionHelper.getInstance().getColSafe(this) != null;
         } else if (mClosedWelcomeMessage) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/AudioView.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/AudioView.java
@@ -30,6 +30,7 @@ import android.widget.LinearLayout;
 
 import com.ichi2.anki.R;
 import com.ichi2.anki.UIUtils;
+import com.ichi2.anki.multimediacard.utils.Permissions;
 
 import timber.log.Timber;
 
@@ -329,6 +330,15 @@ public class AudioView extends LinearLayout {
             public void onClick(View v) {
                 // Since mAudioPath is not compulsory, we check if it exists
                 if (mAudioPath == null) {
+                    return;
+                }
+
+                //We can get to this screen without permissions through the "Pronunciation" feature.
+                if (!Permissions.canRecordAudio(mContext)) {
+                    Timber.w("Audio recording permission denied.");
+                    UIUtils.showThemedToast(mContext,
+                            getResources().getString(R.string.multimedia_editor_audio_permission_denied),
+                            true);
                     return;
                 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/AudioView.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/AudioView.java
@@ -30,7 +30,7 @@ import android.widget.LinearLayout;
 
 import com.ichi2.anki.R;
 import com.ichi2.anki.UIUtils;
-import com.ichi2.anki.multimediacard.utils.Permissions;
+import com.ichi2.utils.Permissions;
 
 import timber.log.Timber;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
@@ -125,6 +125,14 @@ public class MultimediaEditFieldActivity extends AnkiActivity
         return false;
     }
 
+    /** Sets various properties required for IFieldController to be in a valid state */
+    private void setupUIController(IFieldController fieldController) {
+        fieldController.setField(mField);
+        fieldController.setFieldIndex(mFieldIndex);
+        fieldController.setNote(mNote);
+        fieldController.setEditingActivity(this);
+    }
+
     private void recreateEditingUi() {
         Timber.d("recreateEditingUi()");
 
@@ -141,10 +149,7 @@ public class MultimediaEditFieldActivity extends AnkiActivity
             return;
         }
 
-        mFieldController.setField(mField);
-        mFieldController.setFieldIndex(mFieldIndex);
-        mFieldController.setNote(mNote);
-        mFieldController.setEditingActivity(this);
+        setupUIController(mFieldController);
 
         LinearLayout linearLayout = findViewById(R.id.LinearLayoutInScrollViewFieldEdit);
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
@@ -115,6 +115,7 @@ public class MultimediaEditFieldActivity extends AnkiActivity
     private boolean performPermissionRequest(IField field) {
         // Request permission to record if audio field
         if (field instanceof AudioRecordingField && !Permissions.canRecordAudio(this)) {
+            Timber.d("Requesting Audio Permissions");
             ActivityCompat.requestPermissions(this, new String[] {Manifest.permission.RECORD_AUDIO},
                     REQUEST_AUDIO_PERMISSION);
             return true;
@@ -122,6 +123,7 @@ public class MultimediaEditFieldActivity extends AnkiActivity
 
         // Request permission to use the camera if image field
         if (field instanceof ImageField && !Permissions.canUseCamera(this)) {
+            Timber.d("Requesting Camera Permissions");
             ActivityCompat.requestPermissions(this, new String[] {Manifest.permission.CAMERA},
                     REQUEST_CAMERA_PERMISSION);
             return true;
@@ -315,6 +317,7 @@ public class MultimediaEditFieldActivity extends AnkiActivity
 
 
     private void recreateEditingUIUsingCachedRequest() {
+        Timber.d("recreateEditingUIUsingCachedRequest()");
         if (mCurrentChangeRequest == null) {
             throw new IllegalStateException("mCurrentChangeRequest should be set before using cached request");
         }
@@ -326,6 +329,7 @@ public class MultimediaEditFieldActivity extends AnkiActivity
             throw new IllegalStateException("mCurrentChangeRequest should be set before requesting permissions");
         }
 
+        Timber.d("onRequestPermissionsResult. Code: %d", requestCode);
         if (requestCode == REQUEST_AUDIO_PERMISSION && permissions.length == 1) {
 
             if (grantResults[0] == PackageManager.PERMISSION_GRANTED) {
@@ -429,6 +433,7 @@ public class MultimediaEditFieldActivity extends AnkiActivity
 
         /** Raised just before the field controller is replaced */
         private static void onPreFieldControllerReplacement(IFieldController previousFieldController) {
+            Timber.d("onPreFieldControllerReplacement");
             //on init, we don't need to do anything
             if (previousFieldController == null) {
                 return;
@@ -443,6 +448,7 @@ public class MultimediaEditFieldActivity extends AnkiActivity
          * Currently: We used a field for which we didn't know how to generate the UI
          * */
         private static void onControllerCreationFailed(ChangeUIRequest request, MultimediaEditFieldActivity activity) {
+            Timber.d("onControllerCreationFailed. State: %d", request.getState());
             switch (request.getState()) {
                 case ChangeUIRequest.ACTIVITY_LOAD:
                 case ChangeUIRequest.EXTERNAL_FIELD_CHANGE:
@@ -458,6 +464,7 @@ public class MultimediaEditFieldActivity extends AnkiActivity
         }
 
         private static void onPostUICreation(ChangeUIRequest request, MultimediaEditFieldActivity activity) {
+            Timber.d("onPostUICreation. State: %d", request.getState());
             switch (request.getState()) {
                 case ChangeUIRequest.UI_CHANGE:
                 case ChangeUIRequest.EXTERNAL_FIELD_CHANGE:
@@ -472,6 +479,7 @@ public class MultimediaEditFieldActivity extends AnkiActivity
         }
 
         private static void onRequiredPermissionDenied(ChangeUIRequest request, MultimediaEditFieldActivity activity) {
+            Timber.d("onRequiredPermissionDenied. State: %d", request.getState());
             switch (request.state) {
                 case ChangeUIRequest.ACTIVITY_LOAD:
                     activity.finishCancel();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
@@ -146,7 +146,7 @@ public class MultimediaEditFieldActivity extends AnkiActivity
 
         //If we went through the permission check once, we don't need to do it again.
         //As we only get here a second time if we have the required permissions
-        if (newUI.doesRequirePermissionCheck() && performPermissionRequest(newUI.getField())) {
+        if (newUI.getRequiresPermissionCheck() && performPermissionRequest(newUI.getField())) {
             newUI.markAsPermissionRequested();
             return;
         }
@@ -378,7 +378,7 @@ public class MultimediaEditFieldActivity extends AnkiActivity
     private final static class ChangeUIRequest {
         private final IField newField;
         private final int state;
-        private boolean requiresPermissionCheck = true;
+        private boolean mRequiresPermissionCheck = true;
 
         /** Initial request when activity is created */
         public static final int ACTIVITY_LOAD = 0;
@@ -408,12 +408,12 @@ public class MultimediaEditFieldActivity extends AnkiActivity
             return new ChangeUIRequest(field, EXTERNAL_FIELD_CHANGE);
         }
 
-        private boolean doesRequirePermissionCheck() {
-            return requiresPermissionCheck;
+        private boolean getRequiresPermissionCheck() {
+            return mRequiresPermissionCheck;
         }
 
         private void markAsPermissionRequested() {
-            requiresPermissionCheck = false;
+            mRequiresPermissionCheck = false;
         }
 
         private int getState() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
@@ -381,42 +381,42 @@ public class MultimediaEditFieldActivity extends AnkiActivity
         private boolean requiresPermissionCheck = true;
 
         /** Initial request when activity is created */
-        static final int ACTIVITY_LOAD = 0;
+        public static final int ACTIVITY_LOAD = 0;
         /** A change in UI via the menu options. Cancellable */
-        static final int UI_CHANGE = 1;
+        public static final int UI_CHANGE = 1;
         /** A change in UI via access to the activity. Not (yet) cancellable */
-        static final int EXTERNAL_FIELD_CHANGE = 2;
+        public static final int EXTERNAL_FIELD_CHANGE = 2;
 
         private ChangeUIRequest(IField field, int state) {
             this.newField = field;
             this.state = state;
         }
 
-        public IField getField() {
+        private IField getField() {
             return newField;
         }
 
-        static ChangeUIRequest init(IField field) {
+        private static ChangeUIRequest init(IField field) {
             return new ChangeUIRequest(field, ACTIVITY_LOAD);
         }
 
-        static ChangeUIRequest uiChange(IField field) {
+        private static ChangeUIRequest uiChange(IField field) {
             return new ChangeUIRequest(field, UI_CHANGE);
         }
 
-        static ChangeUIRequest fieldChange(IField field) {
+        private static ChangeUIRequest fieldChange(IField field) {
             return new ChangeUIRequest(field, EXTERNAL_FIELD_CHANGE);
         }
 
-        boolean doesRequirePermissionCheck() {
+        private boolean doesRequirePermissionCheck() {
             return requiresPermissionCheck;
         }
 
-        void markAsPermissionRequested() {
+        private void markAsPermissionRequested() {
             requiresPermissionCheck = false;
         }
 
-        int getState() {
+        private int getState() {
             return state;
         }
     }
@@ -428,7 +428,7 @@ public class MultimediaEditFieldActivity extends AnkiActivity
     private static final class UIRecreationLogic {
 
         /** Raised just before the field controller is replaced */
-        static void onPreFieldControllerReplacement(IFieldController previousFieldController) {
+        private static void onPreFieldControllerReplacement(IFieldController previousFieldController) {
             //on init, we don't need to do anything
             if (previousFieldController == null) {
                 return;
@@ -442,7 +442,7 @@ public class MultimediaEditFieldActivity extends AnkiActivity
          * Raised when we were supplied with a field that could not generate a UI controller
          * Currently: We used a field for which we didn't know how to generate the UI
          * */
-        static void onControllerCreationFailed(ChangeUIRequest request, MultimediaEditFieldActivity activity) {
+        private static void onControllerCreationFailed(ChangeUIRequest request, MultimediaEditFieldActivity activity) {
             switch (request.getState()) {
                 case ChangeUIRequest.ACTIVITY_LOAD:
                 case ChangeUIRequest.EXTERNAL_FIELD_CHANGE:
@@ -457,7 +457,7 @@ public class MultimediaEditFieldActivity extends AnkiActivity
             }
         }
 
-        static void onPostUICreation(ChangeUIRequest request, MultimediaEditFieldActivity activity) {
+        private static void onPostUICreation(ChangeUIRequest request, MultimediaEditFieldActivity activity) {
             switch (request.getState()) {
                 case ChangeUIRequest.UI_CHANGE:
                 case ChangeUIRequest.EXTERNAL_FIELD_CHANGE:
@@ -471,7 +471,7 @@ public class MultimediaEditFieldActivity extends AnkiActivity
             }
         }
 
-        static void onRequiredPermissionDenied(ChangeUIRequest request, MultimediaEditFieldActivity activity) {
+        private static void onRequiredPermissionDenied(ChangeUIRequest request, MultimediaEditFieldActivity activity) {
             switch (request.state)
             {
                 case ChangeUIRequest.ACTIVITY_LOAD:

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
@@ -319,14 +319,16 @@ public class MultimediaEditFieldActivity extends AnkiActivity
     private void recreateEditingUIUsingCachedRequest() {
         Timber.d("recreateEditingUIUsingCachedRequest()");
         if (mCurrentChangeRequest == null) {
-            throw new IllegalStateException("mCurrentChangeRequest should be set before using cached request");
+            cancelActivityWithAssertionFailure("mCurrentChangeRequest should be set before using cached request");
+            return;
         }
         recreateEditingUi(mCurrentChangeRequest);
     }
 
     public void onRequestPermissionsResult (int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
         if (mCurrentChangeRequest == null) {
-            throw new IllegalStateException("mCurrentChangeRequest should be set before requesting permissions");
+            cancelActivityWithAssertionFailure("mCurrentChangeRequest should be set before requesting permissions");
+            return;
         }
 
         Timber.d("onRequestPermissionsResult. Code: %d", requestCode);
@@ -355,6 +357,14 @@ public class MultimediaEditFieldActivity extends AnkiActivity
             recreateEditingUIUsingCachedRequest();
         }
     }
+
+
+    private void cancelActivityWithAssertionFailure(String logMessage) {
+        Timber.wtf(logMessage);
+        UIUtils.showThemedToast(this, getString(R.string.mutimedia_editor_assertion_failed), false);
+        finishCancel();
+    }
+
 
     public void handleFieldChanged(IField newField) {
         recreateEditingUi(ChangeUIRequest.fieldChange(newField));

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
@@ -107,6 +107,23 @@ public class MultimediaEditFieldActivity extends AnkiActivity
         finishWithoutAnimation();
     }
 
+    private boolean performPermissionRequest(IField field) {
+        // Request permission to record if audio field
+        if (field instanceof AudioRecordingField && !Permissions.canRecordAudio(this)) {
+            ActivityCompat.requestPermissions(this, new String[] {Manifest.permission.RECORD_AUDIO},
+                    REQUEST_AUDIO_PERMISSION);
+            return true;
+        }
+
+        // Request permission to use the camera if image field
+        if (field instanceof ImageField && !Permissions.canUseCamera(this)) {
+            ActivityCompat.requestPermissions(this, new String[] {Manifest.permission.CAMERA},
+                    REQUEST_CAMERA_PERMISSION);
+            return true;
+        }
+
+        return false;
+    }
 
     private void recreateEditingUi() {
         Timber.d("recreateEditingUi()");
@@ -120,19 +137,10 @@ public class MultimediaEditFieldActivity extends AnkiActivity
             return;
         }
 
-        // Request permission to record if audio field
-        if (mField instanceof AudioRecordingField && !Permissions.canRecordAudio(this)) {
-            ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.RECORD_AUDIO},
-                    REQUEST_AUDIO_PERMISSION);
+        if (performPermissionRequest(mField)) {
             return;
         }
 
-        // Request permission to use the camera if image field
-        if (mField instanceof ImageField && !Permissions.canUseCamera(this)) {
-            ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.CAMERA},
-                    REQUEST_CAMERA_PERMISSION);
-            return;
-        }
         mFieldController.setField(mField);
         mFieldController.setFieldIndex(mFieldIndex);
         mFieldController.setNote(mNote);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
@@ -45,6 +45,7 @@ import com.ichi2.anki.multimediacard.fields.IField;
 import com.ichi2.anki.multimediacard.fields.IFieldController;
 import com.ichi2.anki.multimediacard.fields.ImageField;
 import com.ichi2.anki.multimediacard.fields.TextField;
+import com.ichi2.anki.multimediacard.utils.Permissions;
 
 import java.io.File;
 
@@ -120,16 +121,14 @@ public class MultimediaEditFieldActivity extends AnkiActivity
         }
 
         // Request permission to record if audio field
-        if (mField instanceof AudioRecordingField && ContextCompat.checkSelfPermission(this, Manifest.permission.RECORD_AUDIO) !=
-                PackageManager.PERMISSION_GRANTED) {
+        if (mField instanceof AudioRecordingField && !Permissions.canRecordAudio(this)) {
             ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.RECORD_AUDIO},
                     REQUEST_AUDIO_PERMISSION);
             return;
         }
 
         // Request permission to use the camera if image field
-        if (mField instanceof ImageField && ContextCompat.checkSelfPermission(this, Manifest.permission.CAMERA) !=
-                PackageManager.PERMISSION_GRANTED) {
+        if (mField instanceof ImageField && !Permissions.canUseCamera(this)) {
             ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.CAMERA},
                     REQUEST_CAMERA_PERMISSION);
             return;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
@@ -45,7 +45,7 @@ import com.ichi2.anki.multimediacard.fields.IField;
 import com.ichi2.anki.multimediacard.fields.IFieldController;
 import com.ichi2.anki.multimediacard.fields.ImageField;
 import com.ichi2.anki.multimediacard.fields.TextField;
-import com.ichi2.anki.multimediacard.utils.Permissions;
+import com.ichi2.utils.Permissions;
 
 import java.io.File;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
@@ -157,11 +157,11 @@ public class MultimediaEditFieldActivity extends AnkiActivity
 
         if (fieldController == null) {
             Timber.d("Field controller creation failed");
-            UIRecreationLogic.onControllerCreationFailed(newUI, this);
+            UIRecreationHandler.onControllerCreationFailed(newUI, this);
             return;
         }
 
-        UIRecreationLogic.onPreFieldControllerReplacement(mFieldController);
+        UIRecreationHandler.onPreFieldControllerReplacement(mFieldController);
 
         mFieldController = fieldController;
         mField = newUI.getField();
@@ -174,7 +174,7 @@ public class MultimediaEditFieldActivity extends AnkiActivity
 
         mFieldController.createUI(this, linearLayout);
 
-        UIRecreationLogic.onPostUICreation(newUI, this);
+        UIRecreationHandler.onPostUICreation(newUI, this);
     }
 
 
@@ -337,7 +337,7 @@ public class MultimediaEditFieldActivity extends AnkiActivity
                     getResources().getString(R.string.multimedia_editor_audio_permission_refused),
                     true);
 
-            UIRecreationLogic.onRequiredPermissionDenied(mCurrentChangeRequest, this);
+            UIRecreationHandler.onRequiredPermissionDenied(mCurrentChangeRequest, this);
 
         }
         if (requestCode == REQUEST_CAMERA_PERMISSION && permissions.length == 1) {
@@ -425,7 +425,7 @@ public class MultimediaEditFieldActivity extends AnkiActivity
      * Class to contain logic relating to decisions made when recreating a UI.
      * Can later be converted to a non-static class to allow testing of the logic.
      * */
-    private static final class UIRecreationLogic {
+    private static final class UIRecreationHandler {
 
         /** Raised just before the field controller is replaced */
         private static void onPreFieldControllerReplacement(IFieldController previousFieldController) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
@@ -143,7 +143,10 @@ public class MultimediaEditFieldActivity extends AnkiActivity
         //Permissions are checked async, save our current state to allow continuation
         mCurrentChangeRequest = newUI;
 
-        if (performPermissionRequest(newUI.getField())) {
+        //If we went through the permission check once, we don't need to do it again.
+        //As we only get here a second time if we have the required permissions
+        if (newUI.doesRequirePermissionCheck() && performPermissionRequest(newUI.getField())) {
+            newUI.markAsPermissionRequested();
             return;
         }
 
@@ -381,6 +384,7 @@ public class MultimediaEditFieldActivity extends AnkiActivity
     private final static class ChangeUIRequest {
         private final IField newField;
         private final int state;
+        private boolean requiresPermissionCheck = true;
 
         /** Initial request when activity is created */
         static final int ACTIVITY_LOAD = 0;
@@ -408,6 +412,14 @@ public class MultimediaEditFieldActivity extends AnkiActivity
 
         static ChangeUIRequest fieldChange(IField field) {
             return new ChangeUIRequest(field, EXTERNAL_FIELD_CHANGE);
+        }
+
+        boolean doesRequirePermissionCheck() {
+            return requiresPermissionCheck;
+        }
+
+        void markAsPermissionRequested() {
+            requiresPermissionCheck = false;
         }
 
         int getState() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
@@ -472,8 +472,7 @@ public class MultimediaEditFieldActivity extends AnkiActivity
         }
 
         private static void onRequiredPermissionDenied(ChangeUIRequest request, MultimediaEditFieldActivity activity) {
-            switch (request.state)
-            {
+            switch (request.state) {
                 case ChangeUIRequest.ACTIVITY_LOAD:
                     activity.finishCancel();
                     break;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
@@ -19,7 +19,6 @@
 
 package com.ichi2.anki.multimediacard.fields;
 
-import android.Manifest;
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.ClipData;
@@ -32,7 +31,6 @@ import android.net.Uri;
 import android.os.Build;
 import android.provider.MediaStore;
 import android.provider.MediaStore.MediaColumns;
-import androidx.core.content.ContextCompat;
 import androidx.core.content.FileProvider;
 import android.util.DisplayMetrics;
 import android.view.View;
@@ -46,6 +44,7 @@ import com.ichi2.anki.R;
 import com.ichi2.compat.CompatHelper;
 import com.ichi2.utils.BitmapUtil;
 import com.ichi2.utils.ExifUtil;
+import com.ichi2.utils.Permissions;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -142,7 +141,7 @@ public class BasicImageFieldController extends FieldControllerBase implements IF
             }
         });
 
-        if (ContextCompat.checkSelfPermission(context, Manifest.permission.CAMERA) != PackageManager.PERMISSION_GRANTED) {
+        if (!Permissions.canUseCamera(context)) {
             mBtnCamera.setVisibility(View.INVISIBLE);
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/utils/Permissions.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/utils/Permissions.java
@@ -1,0 +1,24 @@
+package com.ichi2.anki.multimediacard.utils;
+
+import android.Manifest;
+import android.content.Context;
+import android.content.pm.PackageManager;
+
+import androidx.annotation.NonNull;
+import androidx.core.content.ContextCompat;
+
+public class Permissions {
+    private Permissions() { }
+
+    public static boolean canUseCamera(@NonNull Context context) {
+        return hasPermission(context, Manifest.permission.CAMERA);
+    }
+
+    public static boolean canRecordAudio(@NonNull Context context) {
+        return hasPermission(context, Manifest.permission.RECORD_AUDIO);
+    }
+
+    private static boolean hasPermission(@NonNull Context context, @NonNull String permission) {
+        return ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED;
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.java
@@ -11,6 +11,7 @@ import android.preference.PreferenceManager;
 import com.ichi2.anki.CollectionHelper;
 import com.ichi2.anki.Preferences;
 import com.ichi2.libanki.Collection;
+import com.ichi2.utils.Permissions;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -31,7 +32,7 @@ public class BootService extends BroadcastReceiver {
         if (sWasRun) {
             return;
         }
-        if (!CollectionHelper.hasStorageAccessPermission(context)) {
+        if (!Permissions.hasStorageAccessPermission(context)) {
             return;
         }
         // There are cases where the app is installed, and we have access, but nothing exist yet

--- a/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
@@ -40,6 +40,7 @@ import com.ichi2.libanki.sync.MediaSyncer;
 import com.ichi2.libanki.sync.RemoteMediaServer;
 import com.ichi2.libanki.sync.RemoteServer;
 import com.ichi2.libanki.sync.Syncer;
+import com.ichi2.utils.Permissions;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -128,8 +129,7 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
     protected void onPreExecute() {
         super.onPreExecute();
         // Acquire the wake lock before syncing to ensure CPU remains on until the sync completes.
-        if (ContextCompat.checkSelfPermission(AnkiDroidApp.getInstance().getApplicationContext(),
-                Manifest.permission.WAKE_LOCK) == PackageManager.PERMISSION_GRANTED) {
+        if (Permissions.canUseWakeLock(AnkiDroidApp.getInstance().getApplicationContext())) {
             mWakeLock.acquire();
         }
         if (mListener != null) {

--- a/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.java
@@ -1,4 +1,4 @@
-package com.ichi2.anki.multimediacard.utils;
+package com.ichi2.utils;
 
 import android.Manifest;
 import android.content.Context;

--- a/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.java
@@ -32,4 +32,9 @@ public class Permissions {
         return ContextCompat.checkSelfPermission(context, Manifest.permission.WRITE_EXTERNAL_STORAGE)
                 == PackageManager.PERMISSION_GRANTED;
     }
+
+
+    public static boolean canUseWakeLock(Context context) {
+        return ContextCompat.checkSelfPermission(context, Manifest.permission.WAKE_LOCK) == PackageManager.PERMISSION_GRANTED;
+    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.java
@@ -21,4 +21,15 @@ public class Permissions {
     private static boolean hasPermission(@NonNull Context context, @NonNull String permission) {
         return ContextCompat.checkSelfPermission(context, permission) == PackageManager.PERMISSION_GRANTED;
     }
+
+
+    /**
+     * Check if we have permission to access the external storage
+     * @param context
+     * @return
+     */
+    public static boolean hasStorageAccessPermission(Context context) {
+        return ContextCompat.checkSelfPermission(context, Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                == PackageManager.PERMISSION_GRANTED;
+    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.java
@@ -29,12 +29,11 @@ public class Permissions {
      * @return
      */
     public static boolean hasStorageAccessPermission(Context context) {
-        return ContextCompat.checkSelfPermission(context, Manifest.permission.WRITE_EXTERNAL_STORAGE)
-                == PackageManager.PERMISSION_GRANTED;
+        return hasPermission(context, Manifest.permission.WRITE_EXTERNAL_STORAGE);
     }
 
 
     public static boolean canUseWakeLock(Context context) {
-        return ContextCompat.checkSelfPermission(context, Manifest.permission.WAKE_LOCK) == PackageManager.PERMISSION_GRANTED;
+        return hasPermission(context, Manifest.permission.WAKE_LOCK);
     }
 }

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -140,6 +140,10 @@
     <string name="empty_cards_count">Cards to delete: %d</string>
     <string name="empty_cards_deleted">Cards deleted: %d</string>
 
+    <!-- Multimedia - Edit Field Activity -->
+    <string name="multimedia_editor_audio_permission_refused">Could not obtain permission to record audio.</string>
+    <string name="multimedia_editor_camera_permission_refused"> Could not obtain permissions for camera. Functionality has been disabled.</string>
+
     <!-- Multimedia - Audio View -->
     <string name="multimedia_editor_audio_permission_denied">Audio recording permission denied</string>
 

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -150,4 +150,5 @@
     <!-- Initial collection load -->
     <string name="collection_load_welcome_request_permissions_title">Welcome to AnkiDroid!</string>
     <string name="collection_load_welcome_request_permissions_details">AnkiDroid requires storage permission, which we use exclusively to store your AnkiDroid collection, flashcard media and backups. Our code is open-source, written by volunteers, and trusted by millions.\n\nIf you have any questions, please access our in-app manual or visit our support forums.\n\nThank you for trying AnkiDroid!\n—AnkiDroid Development Team</string>
+    <string name="mutimedia_editor_assertion_failed">Unknown error occurred displaying Advanced Editor</string>
 </resources>

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -140,6 +140,9 @@
     <string name="empty_cards_count">Cards to delete: %d</string>
     <string name="empty_cards_deleted">Cards deleted: %d</string>
 
+    <!-- Multimedia - Audio View -->
+    <string name="multimedia_editor_audio_permission_denied">Audio recording permission denied</string>
+
     <!-- Initial collection load -->
     <string name="collection_load_welcome_request_permissions_title">Welcome to AnkiDroid!</string>
     <string name="collection_load_welcome_request_permissions_details">AnkiDroid requires storage permission, which we use exclusively to store your AnkiDroid collection, flashcard media and backups. Our code is open-source, written by volunteers, and trusted by millions.\n\nIf you have any questions, please access our in-app manual or visit our support forums.\n\nThank you for trying AnkiDroid!\n—AnkiDroid Development Team</string>

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -141,7 +141,7 @@
     <string name="empty_cards_deleted">Cards deleted: %d</string>
 
     <!-- Multimedia - Edit Field Activity -->
-    <string name="multimedia_editor_audio_permission_refused">Could not obtain permission to record audio.</string>
+    <string name="multimedia_editor_audio_permission_refused">Could not obtain microphone permission.</string>
     <string name="multimedia_editor_camera_permission_refused">Could not obtain camera permission. Functionality has been disabled.</string>
 
     <!-- Multimedia - Audio View -->

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -142,7 +142,7 @@
 
     <!-- Multimedia - Edit Field Activity -->
     <string name="multimedia_editor_audio_permission_refused">Could not obtain permission to record audio.</string>
-    <string name="multimedia_editor_camera_permission_refused"> Could not obtain permissions for camera. Functionality has been disabled.</string>
+    <string name="multimedia_editor_camera_permission_refused">Could not obtain camera permission. Functionality has been disabled.</string>
 
     <!-- Multimedia - Audio View -->
     <string name="multimedia_editor_audio_permission_denied">Audio recording permission denied</string>


### PR DESCRIPTION
## Purpose / Description

Editing a note, selecting "Record Audio", with denied & remembered permissions would soft crash the app.

## Fixes
Fixes #5407 

## Approach

Explained in #5407

> Define 3 ***transitions*** (between Multimedia UIs):
>
> * Init - initial load
> * UI - Menu Item is clicked, (changing from "Record Audio" to "Insert Image").
>    * Treat this as cancellable
> * Activity - Pronunciation calls "Record Audio" with a known clip to allow for preview and pronunciation recreation. 
>   * This is invoked by the caller, so there's no way to know whether the previous UI is in a valid state. Treat this is non-cancellable.
>
> ----
>
> * Allow "Record Audio" to fail a transition
>   * UI - Failing will keep the application on the previous multimedia UI.
>     * Requires changes to avoid destroying the previous context until the new context validates.
>   * Init - Cancel the Activity
>   * Activity - Allow access to "Record Audio" without permissions
>* Save the state of a transition to allow the async `onRequestPermissionsResult` to reapply the context.
>* Mark the state as having "permissions requested", so they're not re-requested when calling `recreateEditingUi`
>* Show a toast notification on "Permission Denied"
>* Ensure "Record Audio" can be used without permissions.

## How Has This Been Tested?

* Deny permissions:
* Selecting from the attachment fails and takes you back to the main screen/
* A preview from pronunciation succeeds

Toasts are displayed on permissions issues.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code