### PR TITLE
Fixes #5756 - Crash on Template Preview when adding Note with Dynamic Deck selected

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1731,92 +1731,13 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
         }
     }
 
+    protected boolean shouldShowNextReviewTime() {
+        return mShowNextReviewTime;
+    }
 
     protected void displayAnswerBottomBar() {
         // hide flipcard button
         mFlipCardLayout.setVisibility(View.GONE);
-
-        int buttonCount;
-        try {
-            buttonCount = mSched.answerButtons(mCurrentCard);
-        } catch (RuntimeException e) {
-            AnkiDroidApp.sendExceptionReport(e, "AbstractReviewer-showEaseButtons");
-            closeReviewer(DeckPicker.RESULT_DB_ERROR, true);
-            return;
-        }
-
-        // Set correct label and background resource for each button
-        // Note that it's necessary to set the resource dynamically as the ease2 / ease3 buttons
-        // (which libanki expects ease to be 2 and 3) can either be hard, good, or easy - depending on num buttons shown
-        final int[] background = Themes.getResFromAttr(this, new int [] {
-                R.attr.againButtonRef,
-                R.attr.hardButtonRef,
-                R.attr.goodButtonRef,
-                R.attr.easyButtonRef});
-        final int[] textColor = Themes.getColorFromAttr(this, new int [] {
-                R.attr.againButtonTextColor,
-                R.attr.hardButtonTextColor,
-                R.attr.goodButtonTextColor,
-                R.attr.easyButtonTextColor});
-        mEase1Layout.setVisibility(View.VISIBLE);
-        mEase1Layout.setBackgroundResource(background[0]);
-        mEase4Layout.setBackgroundResource(background[3]);
-        switch (buttonCount) {
-            case 2:
-                // Ease 2 is "good"
-                mEase2Layout.setVisibility(View.VISIBLE);
-                mEase2Layout.setBackgroundResource(background[2]);
-                mEase2.setText(R.string.ease_button_good);
-                mEase2.setTextColor(textColor[2]);
-                mNext2.setTextColor(textColor[2]);
-                mEase2Layout.requestFocus();
-                break;
-            case 3:
-                // Ease 2 is good
-                mEase2Layout.setVisibility(View.VISIBLE);
-                mEase2Layout.setBackgroundResource(background[2]);
-                mEase2.setText(R.string.ease_button_good);
-                mEase2.setTextColor(textColor[2]);
-                mNext2.setTextColor(textColor[2]);
-                // Ease 3 is easy
-                mEase3Layout.setVisibility(View.VISIBLE);
-                mEase3Layout.setBackgroundResource(background[3]);
-                mEase3.setText(R.string.ease_button_easy);
-                mEase3.setTextColor(textColor[3]);
-                mNext3.setTextColor(textColor[3]);
-                mEase2Layout.requestFocus();
-                break;
-            default:
-                mEase2Layout.setVisibility(View.VISIBLE);
-                // Ease 2 is "hard"
-                mEase2Layout.setVisibility(View.VISIBLE);
-                mEase2Layout.setBackgroundResource(background[1]);
-                mEase2.setText(R.string.ease_button_hard);
-                mEase2.setTextColor(textColor[1]);
-                mNext2.setTextColor(textColor[1]);
-                mEase2Layout.requestFocus();
-                // Ease 3 is good
-                mEase3Layout.setVisibility(View.VISIBLE);
-                mEase3Layout.setBackgroundResource(background[2]);
-                mEase3.setText(R.string.ease_button_good);
-                mEase3.setTextColor(textColor[2]);
-                mNext3.setTextColor(textColor[2]);
-                mEase4Layout.setVisibility(View.VISIBLE);
-                mEase3Layout.requestFocus();
-                break;
-        }
-
-        // Show next review time
-        if (mShowNextReviewTime) {
-            mNext1.setText(mSched.nextIvlStr(this, mCurrentCard, 1));
-            mNext2.setText(mSched.nextIvlStr(this, mCurrentCard, 2));
-            if (buttonCount > 2) {
-                mNext3.setText(mSched.nextIvlStr(this, mCurrentCard, 3));
-            }
-            if (buttonCount > 3) {
-                mNext4.setText(mSched.nextIvlStr(this, mCurrentCard, 4));
-            }
-        }
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1732,7 +1732,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
     }
 
 
-    protected void showEaseButtons() {
+    protected void displayAnswerBottomBar() {
         // hide flipcard button
         mFlipCardLayout.setVisibility(View.GONE);
 
@@ -2250,7 +2250,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
 
         mIsSelecting = false;
         updateCard(enrichWithQADiv(answer, true));
-        showEaseButtons();
+        displayAnswerBottomBar();
         // If the user wants to show the next question automatically
         if (mUseTimer) {
             long delay = mWaitQuestionSecond * 1000 + mUseTimerDynamicMS;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -534,6 +534,91 @@ public class Reviewer extends AbstractFlashcardViewer {
         return super.onKeyUp(keyCode, event);
     }
 
+    @Override
+    protected void displayAnswerBottomBar() {
+        super.displayAnswerBottomBar();
+        int buttonCount;
+        try {
+            buttonCount = mSched.answerButtons(mCurrentCard);
+        } catch (RuntimeException e) {
+            AnkiDroidApp.sendExceptionReport(e, "AbstractReviewer-showEaseButtons");
+            closeReviewer(DeckPicker.RESULT_DB_ERROR, true);
+            return;
+        }
+
+        // Set correct label and background resource for each button
+        // Note that it's necessary to set the resource dynamically as the ease2 / ease3 buttons
+        // (which libanki expects ease to be 2 and 3) can either be hard, good, or easy - depending on num buttons shown
+        final int[] background = Themes.getResFromAttr(this, new int [] {
+                R.attr.againButtonRef,
+                R.attr.hardButtonRef,
+                R.attr.goodButtonRef,
+                R.attr.easyButtonRef});
+        final int[] textColor = Themes.getColorFromAttr(this, new int [] {
+                R.attr.againButtonTextColor,
+                R.attr.hardButtonTextColor,
+                R.attr.goodButtonTextColor,
+                R.attr.easyButtonTextColor});
+        mEase1Layout.setVisibility(View.VISIBLE);
+        mEase1Layout.setBackgroundResource(background[0]);
+        mEase4Layout.setBackgroundResource(background[3]);
+        switch (buttonCount) {
+            case 2:
+                // Ease 2 is "good"
+                mEase2Layout.setVisibility(View.VISIBLE);
+                mEase2Layout.setBackgroundResource(background[2]);
+                mEase2.setText(R.string.ease_button_good);
+                mEase2.setTextColor(textColor[2]);
+                mNext2.setTextColor(textColor[2]);
+                mEase2Layout.requestFocus();
+                break;
+            case 3:
+                // Ease 2 is good
+                mEase2Layout.setVisibility(View.VISIBLE);
+                mEase2Layout.setBackgroundResource(background[2]);
+                mEase2.setText(R.string.ease_button_good);
+                mEase2.setTextColor(textColor[2]);
+                mNext2.setTextColor(textColor[2]);
+                // Ease 3 is easy
+                mEase3Layout.setVisibility(View.VISIBLE);
+                mEase3Layout.setBackgroundResource(background[3]);
+                mEase3.setText(R.string.ease_button_easy);
+                mEase3.setTextColor(textColor[3]);
+                mNext3.setTextColor(textColor[3]);
+                mEase2Layout.requestFocus();
+                break;
+            default:
+                mEase2Layout.setVisibility(View.VISIBLE);
+                // Ease 2 is "hard"
+                mEase2Layout.setVisibility(View.VISIBLE);
+                mEase2Layout.setBackgroundResource(background[1]);
+                mEase2.setText(R.string.ease_button_hard);
+                mEase2.setTextColor(textColor[1]);
+                mNext2.setTextColor(textColor[1]);
+                mEase2Layout.requestFocus();
+                // Ease 3 is good
+                mEase3Layout.setVisibility(View.VISIBLE);
+                mEase3Layout.setBackgroundResource(background[2]);
+                mEase3.setText(R.string.ease_button_good);
+                mEase3.setTextColor(textColor[2]);
+                mNext3.setTextColor(textColor[2]);
+                mEase4Layout.setVisibility(View.VISIBLE);
+                mEase3Layout.requestFocus();
+                break;
+        }
+
+        // Show next review time
+        if (shouldShowNextReviewTime()) {
+            mNext1.setText(mSched.nextIvlStr(this, mCurrentCard, 1));
+            mNext2.setText(mSched.nextIvlStr(this, mCurrentCard, 2));
+            if (buttonCount > 2) {
+                mNext3.setText(mSched.nextIvlStr(this, mCurrentCard, 3));
+            }
+            if (buttonCount > 3) {
+                mNext4.setText(mSched.nextIvlStr(this, mCurrentCard, 4));
+            }
+        }
+    }
 
     @Override
     protected SharedPreferences restorePreferences() {


### PR DESCRIPTION
## Purpose / Description
Previewing a card currently performs `showEaseButtons` which requires an ease calculation. This crashes as there is a discrepancy between the "add deck" and the "libAnki sched deck"

## Fixes
Fixes #5756

But the issue contains another bug report (in Reviewer), which isn't fixed by this

## Approach
The ease calculation depends on the current deck, and is not necessary in the previewer as we don't show ease buttons, we get a crash as the scheduler is pointed at the wrong deck, so don't calculate either.

Note: This only fixes the crash, it doesn't touch the root cause:

We rely on libAnki to get cards for previews, which relies on the current deck for setting certain data.

This information is neither required, nor correct when previewing.

We can't change the scheduler while previewing as we may be previewing during a review session, which would cause a scheduler reset.

## How Has This Been Tested?

Checked review on my phone. No change (Passes)  
Checked Preview using the reproduction steps: Previously failed, now displays the back

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code