### PR TITLE
Gracefully handle Bitmap Compression Failure

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/utils/BitmapUtil.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/BitmapUtil.java
@@ -26,6 +26,8 @@ import android.graphics.drawable.Drawable;
 
 import android.widget.ImageView;
 
+import com.ichi2.anki.AnkiDroidApp;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -71,7 +73,8 @@ public class BitmapUtil {
             }
 
         } catch (IOException e) {
-            // do nothing
+            //#5513 - We don't know the reason for the crash, let's find out.
+            AnkiDroidApp.sendExceptionReport(e, "BitmapUtil decodeFile");
         }
         return bmp;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/BitmapUtil.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/BitmapUtil.java
@@ -41,9 +41,15 @@ public class BitmapUtil {
             BitmapFactory.Options o = new BitmapFactory.Options();
             o.inJustDecodeBounds = true;
 
-            FileInputStream fis = new FileInputStream(theFile);
-            BitmapFactory.decodeStream(fis, null, o);
-            fis.close();
+            FileInputStream fis = null;
+            try {
+                fis = new FileInputStream(theFile);
+                BitmapFactory.decodeStream(fis, null, o);
+            } finally {
+                if (fis != null) {
+                    fis.close();
+                }
+            }
 
             int scale = 1;
             if (o.outHeight > IMAGE_MAX_SIZE || o.outWidth > IMAGE_MAX_SIZE) {
@@ -56,10 +62,14 @@ public class BitmapUtil {
             // Decode with inSampleSize
             BitmapFactory.Options o2 = new BitmapFactory.Options();
             o2.inSampleSize = scale;
-            fis = new FileInputStream(theFile);
-            bmp = BitmapFactory.decodeStream(fis, null, o2);
 
-            fis.close();
+            try {
+                fis = new FileInputStream(theFile);
+                bmp = BitmapFactory.decodeStream(fis, null, o2);
+            } finally {
+                fis.close(); //don't need a null check, as we reuse the variable.
+            }
+
         } catch (IOException e) {
             // do nothing
         }

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -241,4 +241,5 @@
     <string name="export_v2_forbidden">Please switch to the V1 scheduler before exporting a single deck with scheduling information.</string>
 
     <string name="activity_start_failed">The system does not have an app installed that can perform this action.</string>
+    <string name="multimedia_editor_image_compression_failed"><![CDATA[Camera images may be large. You may wish to compress & resize images in the media directory]]></string>
 </resources>


### PR DESCRIPTION
## Purpose / Description
Sometimes, the `rotateAndCompress` method could fail, causing a crash.

## Fixes
Fixes #5513

## Approach
Instead, we return the uncompressed image, and display both the file size and a warning that some images may require compression.

We do this, rather than displaying an error, as it's easier for a user to take action.

We unconditionally display the file size as it's a useful attribute.

## How Has This Been Tested?

On my Android, both with a sample failure via the debugger and with a normal image via camera.

Note: Compression increased the image size.

![image](https://user-images.githubusercontent.com/62114487/77236657-881d5680-6bb8-11ea-9dd1-fe57e05eef8c.png)
![image](https://user-images.githubusercontent.com/62114487/77236660-8b184700-6bb8-11ea-9bfd-611244dce931.png)

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code