### PR TITLE
Allow Travis CI macOS failures temporarily

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,7 @@ jobs:
       script: echo finalize codacy coverage uploads
   allow_failures:
     - env: API=24 JDK="1.11" # non-default JDKs should not hold up success reporting
+    - os: osx # Until macos is stable we must ignore https://travis-ci.community/t/macos-build-an-error-occurred-while-generating-the-build-script/7684/15
     - env: FINALIZE_COVERAGE=TRUE API=NONE # finalizing coverage should not hold up success reporting
 
 before_install:


### PR DESCRIPTION

## Pull Request template

## Purpose / Description
Travis has started having intermittent (but mostly failure) results on osx builds, we need to temporarily ignore them so that CI doesn't fail so frequently requiring manual intervention

## Fixes
Upstream macOS instability issue tracked here:
https://travis-ci.community/t/macos-build-an-error-occurred-while-generating-the-build-script/7684/15

## Approach
Just allowing the failure for now

## How Has This Been Tested?
I have a personal Travis CI instance I use to develop the CI infrastructure for Anki-Android among others, I checked it and it's working: https://travis-ci.com/github/mikehardy/Anki-Android/builds/154483510

## Learning (optional, can help others)
Entropy is inevitable

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
