### PR TITLE
fixIntegrity Refactor / Instrument+continue if field count fix fails

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1634,7 +1634,8 @@ public class Collection {
             mDb.getDatabase().beginTransaction();
             save();
             notifyProgress.run();
-            if (!"ok".equals(mDb.queryString("PRAGMA integrity_check"))) {
+
+            if (!mDb.getDatabase().isDatabaseIntegrityOk()) {
                 return -1;
             }
             mDb.getDatabase().setTransactionSuccessful();

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1632,8 +1632,7 @@ public class Collection {
                 rebuildTags(notifyProgress);
                 updateFieldCache(notifyProgress);
                 fixNewCardDuePositionOverflow(notifyProgress);
-                // new card position
-                mConf.put("nextPos", mDb.queryScalar("SELECT max(due) + 1 FROM cards WHERE type = 0"));
+                resetNewCardInsertionPosition();
                 // reviews should have a reasonable due #
                 notifyProgress.run();
                 ids = mDb.queryColumn(Long.class, "SELECT id FROM cards WHERE queue = 2 AND due > 100000", 0);
@@ -1690,6 +1689,13 @@ public class Collection {
         }
         logProblems(problems);
         return (oldSize - newSize) / 1024;
+    }
+
+
+    private void resetNewCardInsertionPosition() throws JSONException {
+        // TODO: we should probably do a progress callback here
+        // new card position
+        mConf.put("nextPos", mDb.queryScalar("SELECT max(due) + 1 FROM cards WHERE type = 0"));
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1628,30 +1628,30 @@ public class Collection {
                 if (!"ok".equals(mDb.queryString("PRAGMA integrity_check"))) {
                     return -1;
                 }
-                executeIntegrityTask.consume(this::deleteNotesWithMissingModel);
-                // for each model
-                for (JSONObject m : mModels.all()) {
-                    executeIntegrityTask.consume((callback) -> deleteCardsWithInvalidModelOrdinals(callback, m));
-                    executeIntegrityTask.consume((callback) -> deleteNotesWithWrongFieldCounts(callback, m));
-                }
-                executeIntegrityTask.consume(this::deleteNotesWithMissingCards);
-                executeIntegrityTask.consume(this::deleteCardsWithMissingNotes);
-                executeIntegrityTask.consume(this::removeOriginalDuePropertyWhereInvalid);
-                executeIntegrityTask.consume(this::removeDynamicPropertyFromNonDynamicDecks);
-                executeIntegrityTask.consume(this::removeDeckOptionsFromDynamicDecks);
-                executeIntegrityTask.consume(this::rebuildTags);
-                executeIntegrityTask.consume(this::updateFieldCache);
-                executeIntegrityTask.consume(this::fixNewCardDuePositionOverflow);
-                executeIntegrityTask.consume((callback) -> resetNewCardInsertionPosition());
-                executeIntegrityTask.consume(this::fixExcessiveReviewDueDates);
-                // v2 sched had a bug that could create decimal intervals
-                executeIntegrityTask.consume(this::fixDecimalCardsData);
-                executeIntegrityTask.consume(this::fixDecimalRevLogData);
                 mDb.getDatabase().setTransactionSuccessful();
-                executeIntegrityTask.consume(this::restoreMissingDatabaseIndices);
             } finally {
                 mDb.getDatabase().endTransaction();
             }
+            executeIntegrityTask.consume(this::deleteNotesWithMissingModel);
+            // for each model
+            for (JSONObject m : mModels.all()) {
+                executeIntegrityTask.consume((callback) -> deleteCardsWithInvalidModelOrdinals(callback, m));
+                executeIntegrityTask.consume((callback) -> deleteNotesWithWrongFieldCounts(callback, m));
+            }
+            executeIntegrityTask.consume(this::deleteNotesWithMissingCards);
+            executeIntegrityTask.consume(this::deleteCardsWithMissingNotes);
+            executeIntegrityTask.consume(this::removeOriginalDuePropertyWhereInvalid);
+            executeIntegrityTask.consume(this::removeDynamicPropertyFromNonDynamicDecks);
+            executeIntegrityTask.consume(this::removeDeckOptionsFromDynamicDecks);
+            executeIntegrityTask.consume(this::rebuildTags);
+            executeIntegrityTask.consume(this::updateFieldCache);
+            executeIntegrityTask.consume(this::fixNewCardDuePositionOverflow);
+            executeIntegrityTask.consume((callback) -> resetNewCardInsertionPosition());
+            executeIntegrityTask.consume(this::fixExcessiveReviewDueDates);
+            // v2 sched had a bug that could create decimal intervals
+            executeIntegrityTask.consume(this::fixDecimalCardsData);
+            executeIntegrityTask.consume(this::fixDecimalRevLogData);
+            executeIntegrityTask.consume(this::restoreMissingDatabaseIndices);
         } catch (RuntimeException e) {
             Timber.e(e, "doInBackgroundCheckDatabase - RuntimeException on marking card");
             AnkiDroidApp.sendExceptionReport(e, "doInBackgroundCheckDatabase");

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1686,6 +1686,7 @@ public class Collection {
 
 
     private ArrayList<String> ensureModelsAreNotEmpty() {
+        Timber.d("ensureModelsAreNotEmpty()");
         ArrayList<String> problems = new ArrayList<>();
         if (mModels.ensureNotEmpty()) {
             problems.add("Added missing note type.");
@@ -1695,6 +1696,7 @@ public class Collection {
 
 
     private ArrayList<String> restoreMissingDatabaseIndices(Runnable notifyProgress) {
+        Timber.d("restoreMissingDatabaseIndices");
         ArrayList<String> problems = new ArrayList<>();
         // DB must have indices. Older versions of AnkiDroid didn't create them for new collections.
         notifyProgress.run();
@@ -1707,6 +1709,7 @@ public class Collection {
     }
 
     private ArrayList<String> fixDecimalCardsData(Runnable notifyProgress) {
+        Timber.d("fixDecimalCardsData");
         ArrayList<String> problems = new ArrayList<>();
         notifyProgress.run();
         SupportSQLiteStatement s = mDb.getDatabase().compileStatement(
@@ -1720,6 +1723,7 @@ public class Collection {
 
 
     private ArrayList<String> fixDecimalRevLogData(Runnable notifyProgress) {
+        Timber.d("fixDecimalRevLogData()");
         ArrayList<String> problems = new ArrayList<>();
         notifyProgress.run();
         SupportSQLiteStatement s = mDb.getDatabase().compileStatement(
@@ -1733,10 +1737,11 @@ public class Collection {
 
 
     private ArrayList<String> fixExcessiveReviewDueDates(Runnable notifyProgress) {
+        Timber.d("fixExcessiveReviewDueDates()");
         ArrayList<String> problems = new ArrayList<>();
-        ArrayList<Long> ids;// reviews should have a reasonable due #
         notifyProgress.run();
-        ids = mDb.queryColumn(Long.class, "SELECT id FROM cards WHERE queue = 2 AND due > 100000", 0);
+        // reviews should have a reasonable due #
+        ArrayList<Long> ids = mDb.queryColumn(Long.class, "SELECT id FROM cards WHERE queue = 2 AND due > 100000", 0);
         notifyProgress.run();
         if (ids.size() > 0) {
             problems.add("Reviews had incorrect due date.");
@@ -1748,6 +1753,7 @@ public class Collection {
 
 
     private List<String> resetNewCardInsertionPosition() throws JSONException {
+        Timber.d("resetNewCardInsertionPosition");
         // TODO: we should probably do a progress callback here
         // new card position
         mConf.put("nextPos", mDb.queryScalar("SELECT max(due) + 1 FROM cards WHERE type = 0"));
@@ -1756,6 +1762,7 @@ public class Collection {
 
 
     private List<String> fixNewCardDuePositionOverflow(Runnable notifyProgress) {
+        Timber.d("fixNewCardDuePositionOverflow");
         // new cards can't have a due position > 32 bits
         notifyProgress.run();
         mDb.execute("UPDATE cards SET due = 1000000, mod = " + Utils.intTime() + ", usn = " + usn()
@@ -1765,6 +1772,7 @@ public class Collection {
 
 
     private List<String> updateFieldCache(Runnable notifyProgress) {
+        Timber.d("updateFieldCache");
         // field cache
         for (JSONObject m : mModels.all()) {
             notifyProgress.run();
@@ -1775,6 +1783,7 @@ public class Collection {
 
 
     private List<String> rebuildTags(Runnable notifyProgress) {
+        Timber.d("rebuildTags");
         // tags
         notifyProgress.run();
         mTags.registerNotes();
@@ -1783,6 +1792,7 @@ public class Collection {
 
 
     private ArrayList<String> removeDeckOptionsFromDynamicDecks(Runnable notifyProgress) {
+        Timber.d("removeDeckOptionsFromDynamicDecks()");
         ArrayList<String> problems = new ArrayList<>();
         //#5708 - a dynamic deck should not have "Deck Options"
         notifyProgress.run();
@@ -1806,8 +1816,8 @@ public class Collection {
 
 
     private ArrayList<String> removeDynamicPropertyFromNonDynamicDecks(Runnable notifyProgress) {
+        Timber.d("removeDynamicPropertyFromNonDynamicDecks()");
         ArrayList<String> problems = new ArrayList<>();
-        ArrayList<Long> ids;// cards with odid set when not in a dyn deck
         ArrayList<Long> dids = new ArrayList<>();
         for (long id : mDecks.allIds()) {
             if (!mDecks.isDyn(id)) {
@@ -1815,7 +1825,8 @@ public class Collection {
             }
         }
         notifyProgress.run();
-        ids = mDb.queryColumn(Long.class,
+        // cards with odid set when not in a dyn deck
+        ArrayList<Long> ids = mDb.queryColumn(Long.class,
                 "select id from cards where odid > 0 and did in " + Utils.ids2str(dids), 0);
         notifyProgress.run();
         if (ids.size() != 0) {
@@ -1827,10 +1838,11 @@ public class Collection {
 
 
     private ArrayList<String> removeOriginalDuePropertyWhereInvalid(Runnable notifyProgress) {
+        Timber.d("removeOriginalDuePropertyWhereInvalid()");
         ArrayList<String> problems = new ArrayList<>();
-        ArrayList<Long> ids;// cards with odue set when it shouldn't be
         notifyProgress.run();
-        ids = mDb.queryColumn(Long.class,
+        // cards with odue set when it shouldn't be
+        ArrayList<Long> ids = mDb.queryColumn(Long.class,
                 "select id from cards where odue > 0 and (type=1 or queue=2) and not odid", 0);
         notifyProgress.run();
         if (ids.size() != 0) {
@@ -1842,6 +1854,7 @@ public class Collection {
 
 
     private ArrayList<String> deleteCardsWithMissingNotes(Runnable notifyProgress) {
+        Timber.d("deleteCardsWithMissingNotes()");
         ArrayList<String> problems = new ArrayList<>();
         ArrayList<Long> ids;// cards with missing notes
         notifyProgress.run();
@@ -1857,6 +1870,7 @@ public class Collection {
 
 
     private ArrayList<String> deleteNotesWithMissingCards(Runnable notifyProgress) {
+        Timber.d("deleteNotesWithMissingCards()");
         ArrayList<String> problems = new ArrayList<>();
         ArrayList<Long> ids;
         notifyProgress.run();
@@ -1929,8 +1943,8 @@ public class Collection {
 
 
     private ArrayList<String> deleteCardsWithInvalidModelOrdinals(Runnable notifyProgress, JSONObject m) throws JSONException {
+        Timber.d("deleteCardsWithInvalidModelOrdinals()");
         ArrayList<String> problems = new ArrayList<>();
-        ArrayList<Long> ids;// cards with invalid ordinal
         notifyProgress.run();
         if (m.getInt("type") == Consts.MODEL_STD) {
             ArrayList<Integer> ords = new ArrayList<>();
@@ -1938,9 +1952,10 @@ public class Collection {
             for (int t = 0; t < tmpls.length(); t++) {
                 ords.add(tmpls.getJSONObject(t).getInt("ord"));
             }
-            ids = mDb.queryColumn(Long.class,
+            // cards with invalid ordinal
+            ArrayList<Long> ids = mDb.queryColumn(Long.class,
                     "SELECT id FROM cards WHERE ord NOT IN " + Utils.ids2str(ords) + " AND nid IN ( " +
-                    "SELECT id FROM notes WHERE mid = " + m.getLong("id") + ")", 0);
+                            "SELECT id FROM notes WHERE mid = " + m.getLong("id") + ")", 0);
             if (ids.size() > 0) {
                 problems.add("Deleted " + ids.size() + " card(s) with missing template.");
                 remCards(Utils.arrayList2array(ids));
@@ -1951,6 +1966,7 @@ public class Collection {
 
 
     private ArrayList<String> deleteNotesWithMissingModel(Runnable notifyProgress) {
+        Timber.d("deleteNotesWithMissingModel()");
         ArrayList<String> problems = new ArrayList<>();
         // note types with a missing model
         notifyProgress.run();

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1634,21 +1634,7 @@ public class Collection {
                 fixNewCardDuePositionOverflow(notifyProgress);
                 resetNewCardInsertionPosition();
                 fixExcessiveReviewDueDates(problems, notifyProgress);
-                // v2 sched had a bug that could create decimal intervals
-                notifyProgress.run();
-                SupportSQLiteStatement s = mDb.getDatabase().compileStatement(
-                        "update cards set ivl=round(ivl),due=round(due) where ivl!=round(ivl) or due!=round(due)");
-                int rowCount = s.executeUpdateDelete();
-                if (rowCount > 0) {
-                    problems.add("Fixed " + rowCount + " cards with v2 scheduler bug.");
-                }
-                notifyProgress.run();
-                s = mDb.getDatabase().compileStatement(
-                        "update revlog set ivl=round(ivl),lastIvl=round(lastIvl) where ivl!=round(ivl) or lastIvl!=round(lastIvl)");
-                rowCount = s.executeUpdateDelete();
-                if (rowCount > 0) {
-                    problems.add("Fixed " + rowCount + " review history entries with v2 scheduler bug.");
-                }
+                fixDecimalIntervals(problems, notifyProgress);
                 mDb.getDatabase().setTransactionSuccessful();
                 // DB must have indices. Older versions of AnkiDroid didn't create them for new collections.
                 notifyProgress.run();
@@ -1681,6 +1667,25 @@ public class Collection {
         }
         logProblems(problems);
         return (oldSize - newSize) / 1024;
+    }
+
+
+    private void fixDecimalIntervals(ArrayList<String> problems, Runnable notifyProgress) {
+        // v2 sched had a bug that could create decimal intervals
+        notifyProgress.run();
+        SupportSQLiteStatement s = mDb.getDatabase().compileStatement(
+                "update cards set ivl=round(ivl),due=round(due) where ivl!=round(ivl) or due!=round(due)");
+        int rowCount = s.executeUpdateDelete();
+        if (rowCount > 0) {
+            problems.add("Fixed " + rowCount + " cards with v2 scheduler bug.");
+        }
+        notifyProgress.run();
+        s = mDb.getDatabase().compileStatement(
+                "update revlog set ivl=round(ivl),lastIvl=round(lastIvl) where ivl!=round(ivl) or lastIvl!=round(lastIvl)");
+        rowCount = s.executeUpdateDelete();
+        if (rowCount > 0) {
+            problems.add("Fixed " + rowCount + " review history entries with v2 scheduler bug.");
+        }
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1657,7 +1657,7 @@ public class Collection {
             AnkiDroidApp.sendExceptionReport(e, "doInBackgroundCheckDatabase");
             return -1;
         }
-        problems.addAll(ensureModelsAreNotEmpty());
+        executeIntegrityTask.consume((callback) -> ensureModelsAreNotEmpty());
         // and finally, optimize
         executeIntegrityTask.consume(this::optimize);
         file = new File(mPath);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1614,10 +1614,19 @@ public class Collection {
         FunctionalInterfaces.Consumer<FunctionalInterfaces.FunctionThrowable<Runnable, List<String>, JSONException>> executeIntegrityTask =
                 (FunctionalInterfaces.FunctionThrowable<Runnable, List<String>, JSONException> function) -> {
                     try {
+                        mDb.getDatabase().beginTransaction();
                         problems.addAll(function.apply(notifyProgress));
+                        mDb.getDatabase().setTransactionSuccessful();
                     } catch (Exception e) {
                         Timber.e(e, "Failed to execute integrity check");
                         AnkiDroidApp.sendExceptionReport(e, "fixIntegrity");
+                    } finally {
+                        try {
+                            mDb.getDatabase().endTransaction();
+                        } catch (Exception e) {
+                            Timber.e(e, "Failed to end integrity check transaction");
+                            AnkiDroidApp.sendExceptionReport(e, "fixIntegrity - endTransaction");
+                        }
                     }
                 };
         try {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1627,21 +1627,7 @@ public class Collection {
                 deleteNotesWithMissingCards(problems, notifyProgress);
                 deleteCardsWithMissingNotes(problems, notifyProgress);
                 removeOriginalDuePropertyWhereInvalid(problems, notifyProgress);
-                // cards with odid set when not in a dyn deck
-                ArrayList<Long> dids = new ArrayList<>();
-                for (long id : mDecks.allIds()) {
-                    if (!mDecks.isDyn(id)) {
-                        dids.add(id);
-                    }
-                }
-                notifyProgress.run();
-                ids = mDb.queryColumn(Long.class,
-                        "select id from cards where odid > 0 and did in " + Utils.ids2str(dids), 0);
-                notifyProgress.run();
-                if (ids.size() != 0) {
-                    problems.add("Fixed " + ids.size() + " card(s) with invalid properties.");
-                    mDb.execute("update cards set odid=0, odue=0 where id in " + Utils.ids2str(ids));
-                }
+                removeDynamicPropertyFromNonDynamicDecks(problems, notifyProgress);
                 {
                     //#5708 - a dynamic deck should not have "Deck Options"
                     notifyProgress.run();
@@ -1731,6 +1717,25 @@ public class Collection {
         }
         logProblems(problems);
         return (oldSize - newSize) / 1024;
+    }
+
+
+    private void removeDynamicPropertyFromNonDynamicDecks(ArrayList<String> problems, Runnable notifyProgress) {
+        ArrayList<Long> ids;// cards with odid set when not in a dyn deck
+        ArrayList<Long> dids = new ArrayList<>();
+        for (long id : mDecks.allIds()) {
+            if (!mDecks.isDyn(id)) {
+                dids.add(id);
+            }
+        }
+        notifyProgress.run();
+        ids = mDb.queryColumn(Long.class,
+                "select id from cards where odid > 0 and did in " + Utils.ids2str(dids), 0);
+        notifyProgress.run();
+        if (ids.size() != 0) {
+            problems.add("Fixed " + ids.size() + " card(s) with invalid properties.");
+            mDb.execute("update cards set odid=0, odue=0 where id in " + Utils.ids2str(ids));
+        }
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1636,13 +1636,7 @@ public class Collection {
                 fixExcessiveReviewDueDates(problems, notifyProgress);
                 fixDecimalIntervals(problems, notifyProgress);
                 mDb.getDatabase().setTransactionSuccessful();
-                // DB must have indices. Older versions of AnkiDroid didn't create them for new collections.
-                notifyProgress.run();
-                int ixs = mDb.queryScalar("select count(name) from sqlite_master where type = 'index'");
-                if (ixs < 7) {
-                    problems.add("Indices were missing.");
-                    Storage.addIndices(mDb);
-                }
+                restoreMissingDatabaseIndices(problems, notifyProgress);
             } catch (JSONException e) {
                 throw new RuntimeException(e);
             } finally {
@@ -1667,6 +1661,17 @@ public class Collection {
         }
         logProblems(problems);
         return (oldSize - newSize) / 1024;
+    }
+
+
+    private void restoreMissingDatabaseIndices(ArrayList<String> problems, Runnable notifyProgress) {
+        // DB must have indices. Older versions of AnkiDroid didn't create them for new collections.
+        notifyProgress.run();
+        int ixs = mDb.queryScalar("select count(name) from sqlite_master where type = 'index'");
+        if (ixs < 7) {
+            problems.add("Indices were missing.");
+            Storage.addIndices(mDb);
+        }
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1628,25 +1628,7 @@ public class Collection {
                 deleteCardsWithMissingNotes(problems, notifyProgress);
                 removeOriginalDuePropertyWhereInvalid(problems, notifyProgress);
                 removeDynamicPropertyFromNonDynamicDecks(problems, notifyProgress);
-                {
-                    //#5708 - a dynamic deck should not have "Deck Options"
-                    notifyProgress.run();
-                    int fixCount = 0;
-                    for (long id : mDecks.allDynamicDeckIds()) {
-                        try {
-                            if (mDecks.hasDeckOptions(id)) {
-                                mDecks.removeDeckOptions(id);
-                                fixCount++;
-                            }
-                        } catch (NoSuchDeckException e) {
-                            Timber.e("Unable to find dynamic deck %d", id);
-                        }
-                    }
-                    if (fixCount > 0) {
-                        mDecks.save();
-                        problems.add(String.format(Locale.US, "%d dynamic deck(s) had deck options.", fixCount));
-                    }
-                }
+                removeDeckOptionsFromDynamicDecks(problems, notifyProgress);
                 // tags
                 notifyProgress.run();
                 mTags.registerNotes();
@@ -1717,6 +1699,27 @@ public class Collection {
         }
         logProblems(problems);
         return (oldSize - newSize) / 1024;
+    }
+
+
+    private void removeDeckOptionsFromDynamicDecks(ArrayList<String> problems, Runnable notifyProgress) {
+        //#5708 - a dynamic deck should not have "Deck Options"
+        notifyProgress.run();
+        int fixCount = 0;
+        for (long id : mDecks.allDynamicDeckIds()) {
+            try {
+                if (mDecks.hasDeckOptions(id)) {
+                    mDecks.removeDeckOptions(id);
+                    fixCount++;
+                }
+            } catch (NoSuchDeckException e) {
+                Timber.e("Unable to find dynamic deck %d", id);
+            }
+        }
+        if (fixCount > 0) {
+            mDecks.save();
+            problems.add(String.format(Locale.US, "%d dynamic deck(s) had deck options.", fixCount));
+        }
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1630,11 +1630,7 @@ public class Collection {
                 removeDynamicPropertyFromNonDynamicDecks(problems, notifyProgress);
                 removeDeckOptionsFromDynamicDecks(problems, notifyProgress);
                 rebuildTags(notifyProgress);
-                // field cache
-                for (JSONObject m : mModels.all()) {
-                    notifyProgress.run();
-                    updateFieldCache(Utils.arrayList2array(mModels.nids(m)));
-                }
+                updateFieldCache(notifyProgress);
                 // new cards can't have a due position > 32 bits
                 notifyProgress.run();
                 mDb.execute("UPDATE cards SET due = 1000000, mod = " + Utils.intTime() + ", usn = " + usn()
@@ -1697,6 +1693,15 @@ public class Collection {
         }
         logProblems(problems);
         return (oldSize - newSize) / 1024;
+    }
+
+
+    private void updateFieldCache(Runnable notifyProgress) {
+        // field cache
+        for (JSONObject m : mModels.all()) {
+            notifyProgress.run();
+            updateFieldCache(Utils.arrayList2array(mModels.nids(m)));
+        }
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1647,10 +1647,7 @@ public class Collection {
             AnkiDroidApp.sendExceptionReport(e, "doInBackgroundCheckDatabase");
             return -1;
         }
-        // models
-        if (mModels.ensureNotEmpty()) {
-            problems.add("Added missing note type.");
-        }
+        ensureModelsAreNotEmpty(problems);
         // and finally, optimize
         optimize(notifyProgress);
         file = new File(mPath);
@@ -1661,6 +1658,13 @@ public class Collection {
         }
         logProblems(problems);
         return (oldSize - newSize) / 1024;
+    }
+
+
+    private void ensureModelsAreNotEmpty(ArrayList<String> problems) {
+        if (mModels.ensureNotEmpty()) {
+            problems.add("Added missing note type.");
+        }
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1631,10 +1631,7 @@ public class Collection {
                 removeDeckOptionsFromDynamicDecks(problems, notifyProgress);
                 rebuildTags(notifyProgress);
                 updateFieldCache(notifyProgress);
-                // new cards can't have a due position > 32 bits
-                notifyProgress.run();
-                mDb.execute("UPDATE cards SET due = 1000000, mod = " + Utils.intTime() + ", usn = " + usn()
-                        + " WHERE due > 1000000 AND type = 0");
+                fixNewCardDuePositionOverflow(notifyProgress);
                 // new card position
                 mConf.put("nextPos", mDb.queryScalar("SELECT max(due) + 1 FROM cards WHERE type = 0"));
                 // reviews should have a reasonable due #
@@ -1693,6 +1690,14 @@ public class Collection {
         }
         logProblems(problems);
         return (oldSize - newSize) / 1024;
+    }
+
+
+    private void fixNewCardDuePositionOverflow(Runnable notifyProgress) {
+        // new cards can't have a due position > 32 bits
+        notifyProgress.run();
+        mDb.execute("UPDATE cards SET due = 1000000, mod = " + Utils.intTime() + ", usn = " + usn()
+                + " WHERE due > 1000000 AND type = 0");
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1884,7 +1884,12 @@ public class Collection {
                     }
                 } catch (IllegalStateException ex) {
                     // DEFECT: Theory that is this an OOM is discussed in #5852
-                    AnkiDroidApp.sendExceptionReport(ex, "deleteNotesWithWrongFieldCounts");
+                    // We might not deduplicate if details are different, but we should hopefully be able to
+                    // track this down before the full release is out.
+                    String details = String.format(Locale.ROOT, "deleteNotesWithWrongFieldCounts row: %d col: %d",
+                                    rowCount,
+                            cur.getColumnCount());
+                    AnkiDroidApp.sendExceptionReport(ex, details);
                 }
                 rowCount++;
             }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1626,15 +1626,7 @@ public class Collection {
                 }
                 deleteNotesWithMissingCards(problems, notifyProgress);
                 deleteCardsWithMissingNotes(problems, notifyProgress);
-                // cards with odue set when it shouldn't be
-                notifyProgress.run();
-                ids = mDb.queryColumn(Long.class,
-                        "select id from cards where odue > 0 and (type=1 or queue=2) and not odid", 0);
-                notifyProgress.run();
-                if (ids.size() != 0) {
-                    problems.add("Fixed " + ids.size() + " card(s) with invalid properties.");
-                    mDb.execute("update cards set odue=0 where id in " + Utils.ids2str(ids));
-                }
+                removeOriginalDuePropertyWhereInvalid(problems, notifyProgress);
                 // cards with odid set when not in a dyn deck
                 ArrayList<Long> dids = new ArrayList<>();
                 for (long id : mDecks.allIds()) {
@@ -1739,6 +1731,19 @@ public class Collection {
         }
         logProblems(problems);
         return (oldSize - newSize) / 1024;
+    }
+
+
+    private void removeOriginalDuePropertyWhereInvalid(ArrayList<String> problems, Runnable notifyProgress) {
+        ArrayList<Long> ids;// cards with odue set when it shouldn't be
+        notifyProgress.run();
+        ids = mDb.queryColumn(Long.class,
+                "select id from cards where odue > 0 and (type=1 or queue=2) and not odid", 0);
+        notifyProgress.run();
+        if (ids.size() != 0) {
+            problems.add("Fixed " + ids.size() + " card(s) with invalid properties.");
+            mDb.execute("update cards set odue=0 where id in " + Utils.ids2str(ids));
+        }
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1617,15 +1617,8 @@ public class Collection {
                 if (!"ok".equals(mDb.queryString("PRAGMA integrity_check"))) {
                     return -1;
                 }
-                // note types with a missing model
-                notifyProgress.run();
-                ArrayList<Long> ids = mDb.queryColumn(Long.class,
-                        "SELECT id FROM notes WHERE mid NOT IN " + Utils.ids2str(mModels.ids()), 0);
-                notifyProgress.run();
-                if (ids.size() != 0) {
-                	problems.add("Deleted " + ids.size() + " note(s) with missing note type.");
-	                _remNotes(Utils.arrayList2array(ids));
-                }
+                deleteNotesWithMissingModel(problems, notifyProgress);
+                ArrayList<Long> ids;
                 // for each model
                 for (JSONObject m : mModels.all()) {
                     // cards with invalid ordinal
@@ -1805,6 +1798,19 @@ public class Collection {
         }
         logProblems(problems);
         return (oldSize - newSize) / 1024;
+    }
+
+
+    private void deleteNotesWithMissingModel(ArrayList<String> problems, Runnable notifyProgress) {
+        // note types with a missing model
+        notifyProgress.run();
+        ArrayList<Long> ids = mDb.queryColumn(Long.class,
+                "SELECT id FROM notes WHERE mid NOT IN " + Utils.ids2str(mModels.ids()), 0);
+        notifyProgress.run();
+        if (ids.size() != 0) {
+            problems.add("Deleted " + ids.size() + " note(s) with missing note type.");
+            _remNotes(Utils.arrayList2array(ids));
+        }
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1656,7 +1656,7 @@ public class Collection {
         }
         problems.addAll(ensureModelsAreNotEmpty());
         // and finally, optimize
-        optimize(notifyProgress);
+        executeIntegrityTask.consume(this::optimize);
         file = new File(mPath);
         long newSize = file.length();
         // if any problems were found, force a full sync
@@ -1933,13 +1933,14 @@ public class Collection {
     }
 
 
-    public void optimize(Runnable progressCallback) {
+    public List<String> optimize(Runnable progressCallback) {
         Timber.i("executing VACUUM statement");
         progressCallback.run();
         mDb.execute("VACUUM");
         Timber.i("executing ANALYZE statement");
         progressCallback.run();
         mDb.execute("ANALYZE");
+        return Collections.emptyList();
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1852,6 +1852,7 @@ public class Collection {
 
 
     private ArrayList<String> deleteNotesWithWrongFieldCounts(Runnable notifyProgress, JSONObject m) throws JSONException {
+        Timber.d("deleteNotesWithWrongFieldCounts");
         ArrayList<String> problems = new ArrayList<>();
         ArrayList<Long> ids;// notes with invalid field counts
         ids = new ArrayList<>();
@@ -1859,8 +1860,11 @@ public class Collection {
         try {
             notifyProgress.run();
             cur = mDb.getDatabase().query("select id, flds from notes where mid = " + m.getLong("id"), null);
+            Timber.d("cursor size: %d", cur.getCount());
+            int rowCount = 0;
             while (cur.moveToNext()) {
                 try {
+                    Timber.d("Handling row: %d. Columns: %d", rowCount, cur.getColumnCount());
                     String flds = cur.getString(1);
                     long id = cur.getLong(0);
                     int fldsCount = 0;
@@ -1876,6 +1880,7 @@ public class Collection {
                     // DEFECT: Theory that is this an OOM is discussed in #5852
                     AnkiDroidApp.sendExceptionReport(ex, "deleteNotesWithWrongFieldCounts");
                 }
+                rowCount++;
             }
             notifyProgress.run();
             if (ids.size() > 0) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1624,15 +1624,7 @@ public class Collection {
                     deleteCardsWithInvalidModelOrdinals(problems, notifyProgress, m);
                     deleteNotesWithWrongFieldCounts(problems, notifyProgress, m);
                 }
-                notifyProgress.run();
-                // delete any notes with missing cards
-                ids = mDb.queryColumn(Long.class,
-                        "SELECT id FROM notes WHERE id NOT IN (SELECT DISTINCT nid FROM cards)", 0);
-                notifyProgress.run();
-                if (ids.size() != 0) {
-                	problems.add("Deleted " + ids.size() + " note(s) with missing no cards.");
-	                _remNotes(Utils.arrayList2array(ids));
-                }
+                deleteNotesWithMissingCards(problems, notifyProgress);
                 // cards with missing notes
                 notifyProgress.run();
                 ids = mDb.queryColumn(Long.class,
@@ -1755,6 +1747,20 @@ public class Collection {
         }
         logProblems(problems);
         return (oldSize - newSize) / 1024;
+    }
+
+
+    private void deleteNotesWithMissingCards(ArrayList<String> problems, Runnable notifyProgress) {
+        ArrayList<Long> ids;
+        notifyProgress.run();
+        // delete any notes with missing cards
+        ids = mDb.queryColumn(Long.class,
+                "SELECT id FROM notes WHERE id NOT IN (SELECT DISTINCT nid FROM cards)", 0);
+        notifyProgress.run();
+        if (ids.size() != 0) {
+            problems.add("Deleted " + ids.size() + " note(s) with missing no cards.");
+            _remNotes(Utils.arrayList2array(ids));
+        }
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1633,15 +1633,7 @@ public class Collection {
                 updateFieldCache(notifyProgress);
                 fixNewCardDuePositionOverflow(notifyProgress);
                 resetNewCardInsertionPosition();
-                // reviews should have a reasonable due #
-                notifyProgress.run();
-                ids = mDb.queryColumn(Long.class, "SELECT id FROM cards WHERE queue = 2 AND due > 100000", 0);
-                notifyProgress.run();
-                if (ids.size() > 0) {
-                	problems.add("Reviews had incorrect due date.");
-                    mDb.execute("UPDATE cards SET due = " + mSched.getToday() + ", ivl = 1, mod = " +  Utils.intTime() +
-                            ", usn = " + usn() + " WHERE id IN " + Utils.ids2str(Utils.arrayList2array(ids)));
-                }
+                fixExcessiveReviewDueDates(problems, notifyProgress);
                 // v2 sched had a bug that could create decimal intervals
                 notifyProgress.run();
                 SupportSQLiteStatement s = mDb.getDatabase().compileStatement(
@@ -1689,6 +1681,19 @@ public class Collection {
         }
         logProblems(problems);
         return (oldSize - newSize) / 1024;
+    }
+
+
+    private void fixExcessiveReviewDueDates(ArrayList<String> problems, Runnable notifyProgress) {
+        ArrayList<Long> ids;// reviews should have a reasonable due #
+        notifyProgress.run();
+        ids = mDb.queryColumn(Long.class, "SELECT id FROM cards WHERE queue = 2 AND due > 100000", 0);
+        notifyProgress.run();
+        if (ids.size() > 0) {
+            problems.add("Reviews had incorrect due date.");
+            mDb.execute("UPDATE cards SET due = " + mSched.getToday() + ", ivl = 1, mod = " +  Utils.intTime() +
+                    ", usn = " + usn() + " WHERE id IN " + Utils.ids2str(Utils.arrayList2array(ids)));
+        }
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1625,15 +1625,7 @@ public class Collection {
                     deleteNotesWithWrongFieldCounts(problems, notifyProgress, m);
                 }
                 deleteNotesWithMissingCards(problems, notifyProgress);
-                // cards with missing notes
-                notifyProgress.run();
-                ids = mDb.queryColumn(Long.class,
-                        "SELECT id FROM cards WHERE nid NOT IN (SELECT id FROM notes)", 0);
-                notifyProgress.run();
-                if (ids.size() != 0) {
-                    problems.add("Deleted " + ids.size() + " card(s) with missing note.");
-                    remCards(Utils.arrayList2array(ids));
-                }
+                deleteCardsWithMissingNotes(problems, notifyProgress);
                 // cards with odue set when it shouldn't be
                 notifyProgress.run();
                 ids = mDb.queryColumn(Long.class,
@@ -1747,6 +1739,19 @@ public class Collection {
         }
         logProblems(problems);
         return (oldSize - newSize) / 1024;
+    }
+
+
+    private void deleteCardsWithMissingNotes(ArrayList<String> problems, Runnable notifyProgress) {
+        ArrayList<Long> ids;// cards with missing notes
+        notifyProgress.run();
+        ids = mDb.queryColumn(Long.class,
+                "SELECT id FROM cards WHERE nid NOT IN (SELECT id FROM notes)", 0);
+        notifyProgress.run();
+        if (ids.size() != 0) {
+            problems.add("Deleted " + ids.size() + " card(s) with missing note.");
+            remCards(Utils.arrayList2array(ids));
+        }
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -50,6 +50,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -1633,9 +1634,9 @@ public class Collection {
                 executeIntegrityTask.consume(this::removeOriginalDuePropertyWhereInvalid);
                 executeIntegrityTask.consume(this::removeDynamicPropertyFromNonDynamicDecks);
                 executeIntegrityTask.consume(this::removeDeckOptionsFromDynamicDecks);
-                rebuildTags(notifyProgress);
-                updateFieldCache(notifyProgress);
-                fixNewCardDuePositionOverflow(notifyProgress);
+                executeIntegrityTask.consume(this::rebuildTags);
+                executeIntegrityTask.consume(this::updateFieldCache);
+                executeIntegrityTask.consume(this::fixNewCardDuePositionOverflow);
                 resetNewCardInsertionPosition();
                 executeIntegrityTask.consume(this::fixExcessiveReviewDueDates);
                 executeIntegrityTask.consume(this::fixDecimalIntervals);
@@ -1730,27 +1731,30 @@ public class Collection {
     }
 
 
-    private void fixNewCardDuePositionOverflow(Runnable notifyProgress) {
+    private List<String> fixNewCardDuePositionOverflow(Runnable notifyProgress) {
         // new cards can't have a due position > 32 bits
         notifyProgress.run();
         mDb.execute("UPDATE cards SET due = 1000000, mod = " + Utils.intTime() + ", usn = " + usn()
                 + " WHERE due > 1000000 AND type = 0");
+        return Collections.emptyList();
     }
 
 
-    private void updateFieldCache(Runnable notifyProgress) {
+    private List<String> updateFieldCache(Runnable notifyProgress) {
         // field cache
         for (JSONObject m : mModels.all()) {
             notifyProgress.run();
             updateFieldCache(Utils.arrayList2array(mModels.nids(m)));
         }
+        return Collections.emptyList();
     }
 
 
-    private void rebuildTags(Runnable notifyProgress) {
+    private List<String> rebuildTags(Runnable notifyProgress) {
         // tags
         notifyProgress.run();
         mTags.registerNotes();
+        return Collections.emptyList();
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1618,7 +1618,6 @@ public class Collection {
                     return -1;
                 }
                 deleteNotesWithMissingModel(problems, notifyProgress);
-                ArrayList<Long> ids;
                 // for each model
                 for (JSONObject m : mModels.all()) {
                     deleteCardsWithInvalidModelOrdinals(problems, notifyProgress, m);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1629,9 +1629,7 @@ public class Collection {
                 removeOriginalDuePropertyWhereInvalid(problems, notifyProgress);
                 removeDynamicPropertyFromNonDynamicDecks(problems, notifyProgress);
                 removeDeckOptionsFromDynamicDecks(problems, notifyProgress);
-                // tags
-                notifyProgress.run();
-                mTags.registerNotes();
+                rebuildTags(notifyProgress);
                 // field cache
                 for (JSONObject m : mModels.all()) {
                     notifyProgress.run();
@@ -1699,6 +1697,13 @@ public class Collection {
         }
         logProblems(problems);
         return (oldSize - newSize) / 1024;
+    }
+
+
+    private void rebuildTags(Runnable notifyProgress) {
+        // tags
+        notifyProgress.run();
+        mTags.registerNotes();
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1614,6 +1614,7 @@ public class Collection {
         Runnable notifyProgress = () -> fixIntegrityProgress(progressCallback, currentTask[0]++, totalTasks);
         FunctionalInterfaces.Consumer<FunctionalInterfaces.FunctionThrowable<Runnable, List<String>, JSONException>> executeIntegrityTask =
                 (FunctionalInterfaces.FunctionThrowable<Runnable, List<String>, JSONException> function) -> {
+                    //DEFECT: notifyProgress will lag if an exception is thrown.
                     try {
                         mDb.getDatabase().beginTransaction();
                         problems.addAll(function.apply(notifyProgress));

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1860,16 +1860,21 @@ public class Collection {
             notifyProgress.run();
             cur = mDb.getDatabase().query("select id, flds from notes where mid = " + m.getLong("id"), null);
             while (cur.moveToNext()) {
-                String flds = cur.getString(1);
-                long id = cur.getLong(0);
-                int fldsCount = 0;
-                for (int i = 0; i < flds.length(); i++) {
-                    if (flds.charAt(i) == 0x1f) {
-                        fldsCount++;
+                try {
+                    String flds = cur.getString(1);
+                    long id = cur.getLong(0);
+                    int fldsCount = 0;
+                    for (int i = 0; i < flds.length(); i++) {
+                        if (flds.charAt(i) == 0x1f) {
+                            fldsCount++;
+                        }
                     }
-                }
-                if (fldsCount + 1 != m.getJSONArray("flds").length()) {
-                    ids.add(id);
+                    if (fldsCount + 1 != m.getJSONArray("flds").length()) {
+                        ids.add(id);
+                    }
+                } catch (IllegalStateException ex) {
+                    // DEFECT: Theory that is this an OOM is discussed in #5852
+                    AnkiDroidApp.sendExceptionReport(ex, "deleteNotesWithWrongFieldCounts");
                 }
             }
             notifyProgress.run();

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1621,22 +1621,7 @@ public class Collection {
                 ArrayList<Long> ids;
                 // for each model
                 for (JSONObject m : mModels.all()) {
-                    // cards with invalid ordinal
-                    notifyProgress.run();
-                    if (m.getInt("type") == Consts.MODEL_STD) {
-                        ArrayList<Integer> ords = new ArrayList<>();
-                        JSONArray tmpls = m.getJSONArray("tmpls");
-                        for (int t = 0; t < tmpls.length(); t++) {
-                            ords.add(tmpls.getJSONObject(t).getInt("ord"));
-                        }
-                        ids = mDb.queryColumn(Long.class,
-                                "SELECT id FROM cards WHERE ord NOT IN " + Utils.ids2str(ords) + " AND nid IN ( " +
-                                "SELECT id FROM notes WHERE mid = " + m.getLong("id") + ")", 0);
-                        if (ids.size() > 0) {
-                            problems.add("Deleted " + ids.size() + " card(s) with missing template.");
-                            remCards(Utils.arrayList2array(ids));
-                        }
-                    }
+                    deleteCardsWithInvalidModelOrdinals(problems, notifyProgress, m);
                     // notes with invalid field counts
                     ids = new ArrayList<>();
                     Cursor cur = null;
@@ -1798,6 +1783,26 @@ public class Collection {
         }
         logProblems(problems);
         return (oldSize - newSize) / 1024;
+    }
+
+
+    private void deleteCardsWithInvalidModelOrdinals(ArrayList<String> problems, Runnable notifyProgress, JSONObject m) throws JSONException {
+        ArrayList<Long> ids;// cards with invalid ordinal
+        notifyProgress.run();
+        if (m.getInt("type") == Consts.MODEL_STD) {
+            ArrayList<Integer> ords = new ArrayList<>();
+            JSONArray tmpls = m.getJSONArray("tmpls");
+            for (int t = 0; t < tmpls.length(); t++) {
+                ords.add(tmpls.getJSONObject(t).getInt("ord"));
+            }
+            ids = mDb.queryColumn(Long.class,
+                    "SELECT id FROM cards WHERE ord NOT IN " + Utils.ids2str(ords) + " AND nid IN ( " +
+                    "SELECT id FROM notes WHERE mid = " + m.getLong("id") + ")", 0);
+            if (ids.size() > 0) {
+                problems.add("Deleted " + ids.size() + " card(s) with missing template.");
+                remCards(Utils.arrayList2array(ids));
+            }
+        }
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1617,6 +1617,7 @@ public class Collection {
                         problems.addAll(function.apply(notifyProgress));
                     } catch (Exception e) {
                         Timber.e(e, "Failed to execute integrity check");
+                        AnkiDroidApp.sendExceptionReport(e, "fixIntegrity");
                     }
                 };
         try {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -229,6 +229,7 @@ public class Models {
 
     public boolean ensureNotEmpty() {
         if (mModels.isEmpty()) {
+            // TODO: Maybe we want to restore all models if we don't have any
             addBasicModel(mCol);
             return true;
         } else {

--- a/AnkiDroid/src/main/java/com/ichi2/utils/FunctionalInterfaces.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/FunctionalInterfaces.java
@@ -18,4 +18,9 @@ public final class FunctionalInterfaces {
     public interface Function<TIn, TOut> {
         TOut apply(TIn item);
     }
+
+    @FunctionalInterface
+    public interface FunctionThrowable<TIn, TOut, TEx extends Throwable> {
+        TOut apply(TIn item) throws TEx;
+    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/FunctionalInterfaces.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/FunctionalInterfaces.java
@@ -13,4 +13,9 @@ public final class FunctionalInterfaces {
     public interface Consumer<T> {
         void consume(T item);
     }
+
+    @FunctionalInterface
+    public interface Function<TIn, TOut> {
+        TOut apply(TIn item);
+    }
 }


### PR DESCRIPTION
## Purpose / Description

We added an additional database check inside `fixIntegrity`, which required that all users perform a database check.

This flagged that there were crash bugs in `fixIntegrity`

## Fixes
Fixes #5852 

## Approach

We modify each check into tasks, and perform each task in its own transaction, rather than running all in the same transaction.

## How Has This Been Tested?

* Check Integrity still works for me

* Added in an additional task which threw an exception. Exception was caught, logged and the process continued as expected.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code