### PR TITLE
Add File Space Warning before Check Database

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.java
@@ -17,12 +17,13 @@
 package com.ichi2.anki;
 
 import android.content.SharedPreferences;
-import android.os.StatFs;
 
 
 import com.ichi2.compat.CompatHelper;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Utils;
+import com.ichi2.utils.FileUtil;
+
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -206,12 +207,7 @@ public class BackupManager {
 
 
     private static long getFreeDiscSpace(File file) {
-        try {
-            return CompatHelper.getCompat().getAvailableBytes(new StatFs(file.getParentFile().getPath()));
-        } catch (IllegalArgumentException e) {
-            Timber.e(e, "Free space could not be retrieved");
-            return MIN_FREE_SPACE * 1024 * 1024;
-        }
+        return FileUtil.getFreeDiskSpace(file, MIN_FREE_SPACE * 1024 * 1024);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
@@ -272,11 +272,17 @@ public class CollectionHelper {
             return new CollectionIntegrityStorageCheck(errorMessage);
         }
 
+        private static String defaultRequiredFreeSpace(Context context) {
+            long oneHundredFiftyMB = 150 * 1000 * 1000; //tested, 1024 displays 157MB. 1000 displays 150
+            return Formatter.formatShortFileSize(context, oneHundredFiftyMB);
+        }
+
         public static CollectionIntegrityStorageCheck createInstance(Context context) {
 
             Long maybeCurrentCollectionSizeInBytes = getCollectionSize(context);
             if (maybeCurrentCollectionSizeInBytes == null) {
-                return fromError(context.getResources().getString(R.string.integrity_check_error_colection_load_failed));
+                String requiredFreeSpace = defaultRequiredFreeSpace(context);
+                return fromError(context.getResources().getString(R.string.integrity_check_maybe_insufficient_space, requiredFreeSpace));
             }
 
             // This means that when VACUUMing a database, as much as twice the size of the original database file is
@@ -289,7 +295,7 @@ public class CollectionHelper {
 
             if (freeSpace == -1) {
                 String readableFileSize  = Formatter.formatFileSize(context, requiredSpaceInBytes);
-                return fromError(context.getResources().getString(R.string.integrity_check_error_remaining_filesystem_size_failed, readableFileSize));
+                return fromError(context.getResources().getString(R.string.integrity_check_maybe_insufficient_space, readableFileSize));
             }
 
             return new CollectionIntegrityStorageCheck(requiredSpaceInBytes, freeSpace);
@@ -315,7 +321,8 @@ public class CollectionHelper {
             }
             if (mFreeSpace == null || mRequiredSpace == null) {
                 Timber.e("CollectionIntegrityCheckStatus in an invalid state");
-                return context.getResources().getString(R.string.integrity_check_error_unknown_error);
+                String defaultRequiredFreeSpace = defaultRequiredFreeSpace(context);
+                return context.getResources().getString(R.string.integrity_check_maybe_insufficient_space, defaultRequiredFreeSpace);
             }
             String required = Formatter.formatShortFileSize(context, mRequiredSpace);
             String currentFree = Formatter.formatShortFileSize(context, mFreeSpace);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
@@ -302,7 +302,7 @@ public class CollectionHelper {
         private boolean fileSystemDoesNotHaveSpaceForBackup() {
             //only to be called when mErrorMessage == null
             if (mFreeSpace == null || mRequiredSpace == null) {
-                Timber.wtf("fileSystemDoesNotHaveSpaceForBackup called in invalid state.");
+                Timber.e("fileSystemDoesNotHaveSpaceForBackup called in invalid state.");
                 return true;
             }
             return mRequiredSpace > mFreeSpace;
@@ -314,7 +314,7 @@ public class CollectionHelper {
                 return mErrorMessage;
             }
             if (mFreeSpace == null || mRequiredSpace == null) {
-                Timber.wtf("CollectionIntegrityCheckStatus in an invalid state");
+                Timber.e("CollectionIntegrityCheckStatus in an invalid state");
                 return context.getResources().getString(R.string.integrity_check_error_unknown_error);
             }
             String required = Formatter.formatShortFileSize(context, mRequiredSpace);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
@@ -240,7 +240,7 @@ public class CollectionHelper {
     }
 
     /** Union: (required space * free space) | Error */
-    public static class CollectionIntegrityCheckStatus {
+    public static class CollectionIntegrityStorageCheck {
 
         @Nullable
         private final String mErrorMessage;
@@ -251,23 +251,23 @@ public class CollectionHelper {
         @Nullable
         private final Long mFreeSpace;
 
-        private CollectionIntegrityCheckStatus(long requiredSpace, long freeSpace) {
+        private CollectionIntegrityStorageCheck(long requiredSpace, long freeSpace) {
             this.mFreeSpace = freeSpace;
             this.mRequiredSpace = requiredSpace;
             this.mErrorMessage = null;
         }
 
-        private CollectionIntegrityCheckStatus(@NonNull String errorMessage) {
+        private CollectionIntegrityStorageCheck(@NonNull String errorMessage) {
             this.mRequiredSpace = null;
             this.mFreeSpace = null;
             this.mErrorMessage = errorMessage;
         }
 
-        private static CollectionIntegrityCheckStatus fromError(String errorMessage) {
-            return new CollectionIntegrityCheckStatus(errorMessage);
+        private static CollectionIntegrityStorageCheck fromError(String errorMessage) {
+            return new CollectionIntegrityStorageCheck(errorMessage);
         }
 
-        public static CollectionIntegrityCheckStatus createInstance(Context context) {
+        public static CollectionIntegrityStorageCheck createInstance(Context context) {
 
             Long maybeCurrentCollectionSizeInBytes = getCollectionSize(context);
             if (maybeCurrentCollectionSizeInBytes == null) {
@@ -287,7 +287,7 @@ public class CollectionHelper {
                 return fromError(context.getResources().getString(R.string.integrity_check_error_remaining_filesystem_size_failed, readableFileSize));
             }
 
-            return new CollectionIntegrityCheckStatus(requiredSpaceInBytes, freeSpace);
+            return new CollectionIntegrityStorageCheck(requiredSpaceInBytes, freeSpace);
         }
 
         public boolean shouldWarnOnIntegrityCheck() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
@@ -282,7 +282,7 @@ public class CollectionHelper {
             Long maybeCurrentCollectionSizeInBytes = getCollectionSize(context);
             if (maybeCurrentCollectionSizeInBytes == null) {
                 String requiredFreeSpace = defaultRequiredFreeSpace(context);
-                return fromError(context.getResources().getString(R.string.integrity_check_maybe_insufficient_space, requiredFreeSpace));
+                return fromError(context.getResources().getString(R.string.integrity_check_insufficient_space, requiredFreeSpace));
             }
 
             // This means that when VACUUMing a database, as much as twice the size of the original database file is
@@ -295,7 +295,7 @@ public class CollectionHelper {
 
             if (freeSpace == -1) {
                 String readableFileSize  = Formatter.formatFileSize(context, requiredSpaceInBytes);
-                return fromError(context.getResources().getString(R.string.integrity_check_maybe_insufficient_space, readableFileSize));
+                return fromError(context.getResources().getString(R.string.integrity_check_insufficient_space, readableFileSize));
             }
 
             return new CollectionIntegrityStorageCheck(requiredSpaceInBytes, freeSpace);
@@ -322,11 +322,18 @@ public class CollectionHelper {
             if (mFreeSpace == null || mRequiredSpace == null) {
                 Timber.e("CollectionIntegrityCheckStatus in an invalid state");
                 String defaultRequiredFreeSpace = defaultRequiredFreeSpace(context);
-                return context.getResources().getString(R.string.integrity_check_maybe_insufficient_space, defaultRequiredFreeSpace);
+                return context.getResources().getString(R.string.integrity_check_insufficient_space, defaultRequiredFreeSpace);
             }
+
             String required = Formatter.formatShortFileSize(context, mRequiredSpace);
+            String insufficientSpace = context.getResources().getString(
+                    R.string.integrity_check_insufficient_space, required);
+
+            //Also concat in the extra content showing the current free space.
             String currentFree = Formatter.formatShortFileSize(context, mFreeSpace);
-            return context.getResources().getString(R.string.integrity_check_insufficient_space, required, currentFree);
+            String insufficientSpaceCurrentFree = context.getResources().getString(
+                    R.string.integrity_check_insufficient_space_extra_content, currentFree);
+            return insufficientSpace + insufficientSpaceCurrentFree;
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
@@ -281,6 +281,7 @@ public class CollectionHelper {
 
             Long maybeCurrentCollectionSizeInBytes = getCollectionSize(context);
             if (maybeCurrentCollectionSizeInBytes == null) {
+                Timber.w("Error obtaining collection file size.");
                 String requiredFreeSpace = defaultRequiredFreeSpace(context);
                 return fromError(context.getResources().getString(R.string.integrity_check_insufficient_space, requiredFreeSpace));
             }
@@ -294,6 +295,7 @@ public class CollectionHelper {
             long freeSpace = FileUtil.getFreeDiskSpace(collectionFile, -1);
 
             if (freeSpace == -1) {
+                Timber.w("Error obtaining free space for '%s'", collectionFile.getPath());
                 String readableFileSize  = Formatter.formatFileSize(context, requiredSpaceInBytes);
                 return fromError(context.getResources().getString(R.string.integrity_check_insufficient_space, readableFileSize));
             }
@@ -311,6 +313,7 @@ public class CollectionHelper {
                 Timber.e("fileSystemDoesNotHaveSpaceForBackup called in invalid state.");
                 return true;
             }
+            Timber.d("Required Free Space: %d. Current: %d", mRequiredSpace, mFreeSpace);
             return mRequiredSpace > mFreeSpace;
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
@@ -239,7 +239,12 @@ public class CollectionHelper {
         return new File(path).getParentFile().getAbsolutePath();
     }
 
-    /** Union: (required space * free space) | Error */
+    /**
+     * This currently stores either:
+     * An error message stating the reason that a storage check must be performed
+     * OR
+     * The current storage requirements, and the current available storage.
+     */
     public static class CollectionIntegrityStorageCheck {
 
         @Nullable

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -71,6 +71,7 @@ import com.afollestad.materialdialogs.MaterialDialog;
 import com.getbase.floatingactionbutton.FloatingActionButton;
 import com.getbase.floatingactionbutton.FloatingActionsMenu;
 import com.ichi2.anim.ActivityTransitionAnimation;
+import com.ichi2.anki.CollectionHelper.CollectionIntegrityCheckStatus;
 import com.ichi2.anki.StudyOptionsFragment.StudyOptionsListener;
 import com.ichi2.anki.analytics.UsageAnalytics;
 import com.ichi2.anki.dialogs.AsyncDialogFragment;
@@ -1264,7 +1265,20 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
     // Callback method to handle database integrity check
     public void integrityCheck() {
-        performIntegrityCheck();
+        //#5852 - We were having issues with integrity checks where the users had run out of space.
+        //display a dialog box if we don't have the space
+        CollectionIntegrityCheckStatus status = CollectionIntegrityCheckStatus.createInstance(this);
+        if (status.shouldWarnOnIntegrityCheck()) {
+            new MaterialDialog.Builder(this)
+                    .title(R.string.check_db_title)
+                    .content(status.getWarningDetails(this))
+                    .positiveText(R.string.integrity_check_continue_anyway)
+                    .onPositive((dialog, which) -> performIntegrityCheck())
+                    .negativeText(R.string.dialog_cancel)
+                    .show();
+        } else {
+            performIntegrityCheck();
+        }
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -1040,7 +1040,21 @@ public class DeckPicker extends NavigationDrawerActivity implements
                 //noinspection ConstantConditions
                 if (!skipDbCheck && previous < upgradeDbVersion) {
                     Timber.i("showStartupScreensAndDialogs() running integrityCheck()");
-                    integrityCheck();
+                    //#5852 - since we may have a warning about disk space, we don't want to force a check database
+                    //and show a warning before the user knows what is happening.
+                    new MaterialDialog.Builder(this)
+                            .title(R.string.integrity_check_startup_title)
+                            .content(R.string.integrity_check_startup_content)
+                            .positiveText(R.string.integrity_check_positive)
+                            .negativeText(R.string.close)
+                            .onPositive((materialDialog, dialogAction) -> integrityCheck())
+                            .onNeutral((materialDialog, dialogAction) -> restartActivity())
+                            .onNegative((materialDialog, dialogAction) ->  restartActivity())
+                            .canceledOnTouchOutside(false)
+                            .cancelable(false)
+                            .build()
+                            .show();
+
                 } else if (previous < upgradePrefsVersion) {
                     // If integrityCheck() doesn't occur, but we did update preferences we should restart DeckPicker to
                     // proceed

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -71,7 +71,7 @@ import com.afollestad.materialdialogs.MaterialDialog;
 import com.getbase.floatingactionbutton.FloatingActionButton;
 import com.getbase.floatingactionbutton.FloatingActionsMenu;
 import com.ichi2.anim.ActivityTransitionAnimation;
-import com.ichi2.anki.CollectionHelper.CollectionIntegrityCheckStatus;
+import com.ichi2.anki.CollectionHelper.CollectionIntegrityStorageCheck;
 import com.ichi2.anki.StudyOptionsFragment.StudyOptionsListener;
 import com.ichi2.anki.analytics.UsageAnalytics;
 import com.ichi2.anki.dialogs.AsyncDialogFragment;
@@ -1267,7 +1267,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
     public void integrityCheck() {
         //#5852 - We were having issues with integrity checks where the users had run out of space.
         //display a dialog box if we don't have the space
-        CollectionIntegrityCheckStatus status = CollectionIntegrityCheckStatus.createInstance(this);
+        CollectionIntegrityStorageCheck status = CollectionIntegrityStorageCheck.createInstance(this);
         if (status.shouldWarnOnIntegrityCheck()) {
             new MaterialDialog.Builder(this)
                     .title(R.string.check_db_title)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -1283,6 +1283,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
         //display a dialog box if we don't have the space
         CollectionIntegrityStorageCheck status = CollectionIntegrityStorageCheck.createInstance(this);
         if (status.shouldWarnOnIntegrityCheck()) {
+            Timber.d("Displaying File Size confirmation");
             new MaterialDialog.Builder(this)
                     .title(R.string.check_db_title)
                     .content(status.getWarningDetails(this))
@@ -1297,6 +1298,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
 
     private void performIntegrityCheck() {
+        Timber.d("performIntegrityCheck()");
         DeckTask.launchDeckTask(DeckTask.TASK_TYPE_CHECK_DATABASE, new DeckTask.TaskListener() {
             @Override
             public void onPreExecute() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -1264,6 +1264,11 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
     // Callback method to handle database integrity check
     public void integrityCheck() {
+        performIntegrityCheck();
+    }
+
+
+    private void performIntegrityCheck() {
         DeckTask.launchDeckTask(DeckTask.TASK_TYPE_CHECK_DATABASE, new DeckTask.TaskListener() {
             @Override
             public void onPreExecute() {
@@ -1295,7 +1300,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
 
             @Override
-            public void onProgressUpdate(DeckTask.TaskData... values) {
+            public void onProgressUpdate(TaskData... values) {
                 mProgressDialog.setContent(values[0].getString());
             }
         });

--- a/AnkiDroid/src/main/java/com/ichi2/utils/FileUtil.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/FileUtil.java
@@ -1,0 +1,21 @@
+package com.ichi2.utils;
+
+import android.os.StatFs;
+
+import com.ichi2.compat.CompatHelper;
+
+import java.io.File;
+
+import timber.log.Timber;
+
+public class FileUtil {
+    /** Gets the free disk space given a file */
+    public static long getFreeDiskSpace(File file, long defaultValue) {
+        try {
+            return CompatHelper.getCompat().getAvailableBytes(new StatFs(file.getParentFile().getPath()));
+        } catch (IllegalArgumentException e) {
+            Timber.e(e, "Free space could not be retrieved");
+            return defaultValue;
+        }
+    }
+}

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -151,4 +151,13 @@
     <string name="collection_load_welcome_request_permissions_title">Welcome to AnkiDroid!</string>
     <string name="collection_load_welcome_request_permissions_details">AnkiDroid requires storage permission, which we use exclusively to store your AnkiDroid collection, flashcard media and backups. Our code is open-source, written by volunteers, and trusted by millions.\n\nIf you have any questions, please access our in-app manual or visit our support forums.\n\nThank you for trying AnkiDroid!\n—AnkiDroid Development Team</string>
     <string name="mutimedia_editor_assertion_failed">Unknown error occurred displaying Advanced Editor</string>
+
+    <!-- Database Integrity Check -->
+    <string name="integrity_check_continue_anyway">Continue Anyway</string>
+    <string name="integrity_check_insufficient_space">Check Database uses a large amount of temporary storage.\n\nIt is strongly recommended that you have at least %s free space on your device before continuing.\n\nYou currently have %s free.</string>
+
+    <string name="integrity_check_error_colection_load_failed">Check Database uses a large amount of temporary storage.\n\nIt is strongly recommended that you have at least 150MB free space on your device before continuing.</string>
+    <!-- This will likely never be shown to the user-->
+    <string name="integrity_check_error_unknown_error">Check Database uses a large amount of temporary storage.\n\nIt is strongly recommended that you have at least 150MB free space on your device before continuing.</string>
+    <string name="integrity_check_error_remaining_filesystem_size_failed">Check Database uses a large amount of temporary storage.\n\nIt is strongly recommended that you have at least %s free space on your device before continuing.</string>
 </resources>

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -154,10 +154,6 @@
 
     <!-- Database Integrity Check -->
     <string name="integrity_check_continue_anyway">Continue Anyway</string>
-    <string name="integrity_check_insufficient_space">Check Database uses a large amount of temporary storage.\n\nIt is strongly recommended that you have at least %s free space on your device before continuing.\n\nYou currently have %s free.</string>
-
-    <string name="integrity_check_error_colection_load_failed">Check Database uses a large amount of temporary storage.\n\nIt is strongly recommended that you have at least 150MB free space on your device before continuing.</string>
-    <!-- This will likely never be shown to the user-->
-    <string name="integrity_check_error_unknown_error">Check Database uses a large amount of temporary storage.\n\nIt is strongly recommended that you have at least 150MB free space on your device before continuing.</string>
-    <string name="integrity_check_error_remaining_filesystem_size_failed">Check Database uses a large amount of temporary storage.\n\nIt is strongly recommended that you have at least %s free space on your device before continuing.</string>
+    <string name="integrity_check_insufficient_space">Check Database uses a large amount of temporary storage.\n\nIt is strongly recommended that you have at least %s free space on your device before continuing.\n\nYou currently have %s free.</string>>
+    <string name="integrity_check_maybe_insufficient_space">Check Database uses a large amount of temporary storage.\n\nIt is strongly recommended that you have at least %s free space on your device before continuing.</string>
 </resources>

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -157,6 +157,6 @@
     <string name="integrity_check_startup_content">AnkiDroid has been upgraded. This upgrade includes fixes for possible database problems, and we advise you to run check database now.</string>
     <string name="integrity_check_positive">Check Database</string>
     <string name="integrity_check_continue_anyway">Continue Anyway</string>
-    <string name="integrity_check_insufficient_space">Check Database uses a large amount of temporary storage.\n\nIt is strongly recommended that you have at least %s free space on your device before continuing.\n\nYou currently have %s free.</string>>
-    <string name="integrity_check_maybe_insufficient_space">Check Database uses a large amount of temporary storage.\n\nIt is strongly recommended that you have at least %s free space on your device before continuing.</string>
+    <string name="integrity_check_insufficient_space">Check Database uses a large amount of temporary storage.\n\nIt is strongly recommended that you have at least %s free space on your device before continuing.</string>>
+    <string name="integrity_check_insufficient_space_extra_content">\n\nYou currently have %s free.</string>
 </resources>

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -154,7 +154,7 @@
 
     <!-- Database Integrity Check -->
     <string name="integrity_check_startup_title">AnkiDroid Upgraded</string>
-    <string name="integrity_check_startup_content">AnkiDroid has been upgraded. It is advised that you check and optimise your database to ensure an optimal user experience.</string>
+    <string name="integrity_check_startup_content">AnkiDroid has been upgraded. This upgrade includes fixes for possible database problems, and we advise you to run check database now.</string>
     <string name="integrity_check_positive">Check Database</string>
     <string name="integrity_check_continue_anyway">Continue Anyway</string>
     <string name="integrity_check_insufficient_space">Check Database uses a large amount of temporary storage.\n\nIt is strongly recommended that you have at least %s free space on your device before continuing.\n\nYou currently have %s free.</string>>

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -153,6 +153,9 @@
     <string name="mutimedia_editor_assertion_failed">Unknown error occurred displaying Advanced Editor</string>
 
     <!-- Database Integrity Check -->
+    <string name="integrity_check_startup_title">AnkiDroid Upgraded</string>
+    <string name="integrity_check_startup_content">AnkiDroid has been upgraded. It is advised that you check and optimise your database to ensure an optimal user experience.</string>
+    <string name="integrity_check_positive">Check Database</string>
     <string name="integrity_check_continue_anyway">Continue Anyway</string>
     <string name="integrity_check_insufficient_space">Check Database uses a large amount of temporary storage.\n\nIt is strongly recommended that you have at least %s free space on your device before continuing.\n\nYou currently have %s free.</string>>
     <string name="integrity_check_maybe_insufficient_space">Check Database uses a large amount of temporary storage.\n\nIt is strongly recommended that you have at least %s free space on your device before continuing.</string>


### PR DESCRIPTION
## Purpose / Description
We are having problems with users performing check database with insufficient file space. This causes a crash.

## Fixes
Partially #5852 

## Approach
We discourage the user from performing check database without enough file space.

## How Has This Been Tested?

Nothing normally. This when I reverse the condition,
![image](https://user-images.githubusercontent.com/62114487/77316187-d2a9ea80-6d00-11ea-8248-2defe31c11e0.png)

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code

## Review Goals

* Text - preamble feels too long without explaining the issue.
* UI flows  
  * Seeing this when immediately opening the app seems too strong and may scare users. Maybe we want a pre-dialog stating on this case stating that the update fixes some issues and it's advised to run it, rather than forcing a check.
 
## Notes

This appears on database error (also used by the manual check database button), and on startup.