### PR TITLE
Revert "Allow Travis CI macOS failures temporarily"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,6 @@ jobs:
       script: echo finalize codacy coverage uploads
   allow_failures:
     - env: API=24 JDK="1.11" # non-default JDKs should not hold up success reporting
-    - os: osx # Until macos is stable we must ignore https://travis-ci.community/t/macos-build-an-error-occurred-while-generating-the-build-script/7684/15
     - env: FINALIZE_COVERAGE=TRUE API=NONE # finalizing coverage should not hold up success reporting
 
 before_install:


### PR DESCRIPTION
This reverts commit 17aa22017092ba601aa67759884a996d68706d79.

The upstream issue we were working around has been resolved.
macOS builds are functional again and should be required
