### PR TITLE
Calculate scheduler limits for sync using AnkiWeb limit

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -2022,4 +2022,17 @@ public class Collection {
         return mContext;
     }
 
+    /** Not in libAnki */
+
+    //This duplicates _loadScheduler (but returns the value and sets the report limit).
+    public Sched createScheduler(int reportLimit) {
+        int ver = schedVer();
+        if (ver == 1) {
+            mSched = new Sched(this);
+        } else if (ver == 2) {
+            mSched = new SchedV2(this);
+        }
+        mSched.setReportLimit(reportLimit);
+        return mSched;
+    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sched.java
@@ -2538,7 +2538,7 @@ public class Sched {
         }
     }
 
-    //not in libAnki. Added due to #5666 (
+    /** not in libAnki. Added due to #5666: inconsistent selected deck card counts on sync */
     public int[] recalculateCounts() {
         _resetLrnCount();
         _resetNewCount();
@@ -2546,10 +2546,11 @@ public class Sched {
         return new int[] { mNewCount, mLrnCount, mRevCount };
     }
 
-    //not in libAnki. Added due to #5666 (
     public void setReportLimit(int reportLimit) {
         this.mReportLimit = reportLimit;
     }
+
+    /** End #5666 */
 
 
     public void setContext(WeakReference<Activity> contextReference) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sched.java
@@ -2538,6 +2538,19 @@ public class Sched {
         }
     }
 
+    //not in libAnki. Added due to #5666 (
+    public int[] recalculateCounts() {
+        _resetLrnCount();
+        _resetNewCount();
+        _resetRevCount();
+        return new int[] { mNewCount, mLrnCount, mRevCount };
+    }
+
+    //not in libAnki. Added due to #5666 (
+    public void setReportLimit(int reportLimit) {
+        this.mReportLimit = reportLimit;
+    }
+
 
     public void setContext(WeakReference<Activity> contextReference) {
         mContextReference = contextReference;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/SchedV2.java
@@ -2796,4 +2796,19 @@ public class SchedV2 extends Sched {
         mContextReference = contextReference;
     }
 
+    /** not in libAnki. Added due to #5666: inconsistent selected deck card counts on sync */
+    @Override
+    public int[] recalculateCounts() {
+        _resetLrnCount();
+        _resetNewCount();
+        _resetRevCount();
+        return new int[] { mNewCount, mLrnCount, mRevCount };
+    }
+
+    @Override
+    public void setReportLimit(int reportLimit) {
+        this.mReportLimit = reportLimit;
+    }
+
+    /** End #5666 */
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.java
@@ -27,6 +27,7 @@ import com.ichi2.anki.exception.UnknownHttpResponseException;
 import com.ichi2.async.Connection;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Consts;
+import com.ichi2.libanki.Sched;
 import com.ichi2.libanki.Utils;
 
 import org.json.JSONArray;
@@ -56,6 +57,9 @@ public class Syncer {
     public static final int TYPE_FLOAT = 2;
     public static final int TYPE_STRING = 3;
     public static final int TYPE_BLOB = 4;
+
+    /** The libAnki value of `sched.mReportLimit` */
+    private static final int SYNC_SCHEDULER_REPORT_LIMIT = 1000;
 
     private Collection mCol;
     private HttpSyncer mServer;
@@ -377,7 +381,11 @@ public class Syncer {
             // return summary of deck
             JSONArray ja = new JSONArray();
             JSONArray sa = new JSONArray();
-            for (int c : mCol.getSched().counts()) {
+
+            //#5666 - not in libAnki
+            //We modified mReportLimit inside the scheduler, and this causes issues syncing dynamic decks.
+            Sched syncScheduler = mCol.createScheduler(SYNC_SCHEDULER_REPORT_LIMIT);
+            for (int c : syncScheduler.recalculateCounts()) {
                 sa.put(c);
             }
             ja.put(sa);


### PR DESCRIPTION
## Purpose / Description
We modified `mReportLimit` in #5326 to allow a user to see how many cards they had if there were more than 1000 in a queue.

This had an impact on calculating the number of cards in the current deck, which is required for a sync to ensure that the server and client are consistent.

This caused an inconsistency (as we calculate the proper value), and this meant that a full sync needed to occur if a dynamic deck with over 1000 cards in a queue was selected or a subdeck of the selected deck.

## Fixes
Fixes #5666 
Fixes #5672

## Approach

This fixes the issue by instantiating a new scheduler with the correct `mReportLimit` for calculating the number of cards in the selected deck.

## How Has This Been Tested?

I have a test collection (SchedV1).

1. Synced with normal deck from Android - worked.
2. On Desktop - filled dynamic deck with ~1700 cards on AnkiDesktop - `self.sched.counts() - (7, 0, 1000)`.
3. Sync to server and sync from Android
4. Review a card
5. Sync - Failure

---

After applying the fix, the sync worked, also works with a regular deck.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code