### PR TITLE
Deck Description: Handle Newlines

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
@@ -44,6 +44,7 @@ import com.ichi2.compat.CompatHelper;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Utils;
 import com.ichi2.themes.StyledProgressDialog;
+import com.ichi2.utils.HtmlUtils;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -711,7 +712,9 @@ public class StudyOptionsFragment extends Fragment implements Toolbar.OnMenuItem
         //#5715: In deck description, ignore what is in style and script tag
         //Since we don't currently execute the JS/CSS, it's not worth displaying.
         String withStrippedTags = Utils.stripHTMLScriptAndStyleTags(desc);
-        return CompatHelper.getCompat().fromHtml(withStrippedTags);
+        //#5188 - fromHtml displays newlines as " "
+        String withFixedNewlines = HtmlUtils.convertNewlinesToHtml(withStrippedTags);
+        return CompatHelper.getCompat().fromHtml(withFixedNewlines);
     }
 
     private Collection getCol() {

--- a/AnkiDroid/src/main/java/com/ichi2/utils/HtmlUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/HtmlUtils.java
@@ -1,0 +1,16 @@
+package com.ichi2.utils;
+
+import androidx.annotation.Nullable;
+
+public class HtmlUtils {
+    //#5188 - compat.fromHtml converts newlines into spaces.
+    @Nullable
+    public static String convertNewlinesToHtml(@Nullable String html) {
+        if (html == null) {
+            return null;
+        }
+        String withoutWindowsLineEndings = html.replace("\r\n", "<br/>");
+        //replace unix line endings
+        return withoutWindowsLineEndings.replace("\n", "<br/>");
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/StudyOptionsFragmentTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/StudyOptionsFragmentTest.java
@@ -55,4 +55,26 @@ public class StudyOptionsFragmentTest {
         Spanned result = StudyOptionsFragment.formatDescription("a<style type=\"text/css\">a:1</style>a");
         assertEquals("aa", result.toString());
     }
+
+    /** Begin #5188 - newlines weren't displayed */
+
+    @Test //This was originally correct
+    public void brIsDisplayedAsNewline() {
+        Spanned result = StudyOptionsFragment.formatDescription("a<br/>a");
+        assertEquals("a\na", result.toString());
+    }
+
+    @Test
+    public void windowsNewlinesAreNewlines() {
+        Spanned result = StudyOptionsFragment.formatDescription("a\r\na");
+        assertEquals("a\na", result.toString());
+    }
+
+    @Test
+    public void unixNewlinesAreNewlines() {
+        Spanned result = StudyOptionsFragment.formatDescription("a\na");
+        assertEquals("a\na", result.toString());
+    }
+
+    /** end #5188 */
 }


### PR DESCRIPTION
## Purpose / Description
Previously, a newline was converted into a space, whereas Anki Desktop handles a newline as a newline.

## Fixes
Fixes #5188

## Approach
We convert newlines to `<br/>` tags, so `context.fromHtml` converts them to newlines.

## How Has This Been Tested?

Unit tested and tested on my Android.

Before: 
![image](https://user-images.githubusercontent.com/62114487/77515797-1c194780-6e71-11ea-8bc0-bcb7325e36dd.png)

After:
![image](https://user-images.githubusercontent.com/62114487/77515806-20ddfb80-6e71-11ea-9113-fef46e8318d2.png)

After matches Anki Desktop.

It has a scrollbar if necessary.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code