### PR TITLE
Made image HTML identical to AnkiDesktop when inserting

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/ImageField.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/ImageField.java
@@ -25,6 +25,9 @@ import java.io.File;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
+
 /**
  * Field with an image.
  */
@@ -132,8 +135,15 @@ public class ImageField extends FieldBase implements IField {
     @Override
     public String getFormattedValue() {
         File file = new File(getImagePath());
+        return formatImageFileName(file);
+    }
+
+
+    @NonNull
+    @VisibleForTesting
+    static String formatImageFileName(@NonNull File file) {
         if (file.exists()) {
-            return String.format("<img src='%s'/>", file.getName());
+            return String.format("<img src=\"%s\">", file.getName());
         } else {
             return "";
         }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/fields/ImageFieldTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/fields/ImageFieldTest.java
@@ -1,0 +1,35 @@
+package com.ichi2.anki.multimediacard.fields;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+
+import java.io.File;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+@RunWith(AndroidJUnit4.class)
+public class ImageFieldTest {
+
+    /** #5237 - quotation marks on Android differed from Windows */
+    @Test
+    public void imageValueIsConsistentWithAnkiDesktop() {
+        //Arrange
+        File mockedFile = Mockito.mock(File.class);
+        Mockito.when(mockedFile.exists()).thenReturn(true);
+        Mockito.when(mockedFile.getName()).thenReturn("paste-abc.jpg");
+
+        //Act
+        String actual = ImageField.formatImageFileName(mockedFile);
+
+        //Assert
+        //This differs between AnkDesktop Version 2.0.51 and 2.1.22
+        //2.0:  "<img src=\"paste-abc.jpg\" />";
+        //2.1: (note: no trailing slash or space)
+        String expected = "<img src=\"paste-abc.jpg\">";
+        assertThat(actual, equalTo(expected));
+    }
+}


### PR DESCRIPTION
## Purpose / Description
We previously used single quotes for inserting images, which caused issues when quoting the output in JavaScript.

## Fixes
Fixes #5237

## Approach

We use single quotes and no trailing slash, which is the same as AnkiDesktop.

## How Has This Been Tested?

Unit Tests.  
Image insertion still works.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code