### PR TITLE
Make heavy check mark and down arrow styleable

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -716,7 +716,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
         if (mUseInputTag) {
             // These functions are defined in the JavaScript file assets/scripts/card.js. We get the text back in
             // shouldOverrideUrlLoading() in createWebView() in this file.
-            sb.append("<center>\n<input type=text name=typed id=typeans onfocus=\"taFocus();\" " +
+            sb.append("<center>\n<input type=\"text\" name=\"typed\" id=\"typeans\" onfocus=\"taFocus();\" " +
                     "onblur=\"taBlur(this);\" onKeyPress=\"return taKey(this, event)\" autocomplete=\"off\" ");
             // We have to watch out. For the preview we don’t know the font or font size. Skip those there. (Anki
             // desktop just doesn’t show the input tag there. Do it with standard values here instead.)
@@ -726,7 +726,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
             }
             sb.append(">\n</center>\n");
         } else {
-            sb.append("<span id=typeans class=\"typePrompt");
+            sb.append("<span id=\"typeans\" class=\"typePrompt");
             if (mUseInputTag) {
                 sb.append(" typeOff");
             }
@@ -748,8 +748,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
         Matcher m = sTypeAnsPat.matcher(buf);
         DiffEngine diffEngine = new DiffEngine();
         StringBuilder sb = new StringBuilder();
-        sb.append("<div");
-        sb.append("><code id=typeans>");
+        sb.append("<div><code id=\"typeans\">");
 
         // We have to use Matcher.quoteReplacement because the inputs here might have $ or \.
 
@@ -758,7 +757,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
             if (userAnswer.equals(correctAnswer)) {
                 // and it was right.
                 sb.append(Matcher.quoteReplacement(DiffEngine.wrapGood(correctAnswer)));
-                sb.append("\u2714"); // Heavy check mark
+                sb.append("<span id=\"typecheckmark\">\u2714</span>"); // Heavy check mark
             } else {
                 // Answer not correct.
                 // Only use the complex diff code when needed, that is when we have some typed text that is not
@@ -766,7 +765,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
                 String[] diffedStrings = diffEngine.diffedHtmlStrings(correctAnswer, userAnswer);
                 // We know we get back two strings.
                 sb.append(Matcher.quoteReplacement(diffedStrings[0]));
-                sb.append("<br>&darr;<br>");
+                sb.append("<br><span id=\"typearrow\">&darr;</span><br>");
                 sb.append(Matcher.quoteReplacement(diffedStrings[1]));
             }
         } else {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.java
@@ -53,7 +53,7 @@ public class AbstractFlashcardViewerTest extends RobolectricTest {
                 " background-color: white;\n" +
                 "}\n" +
                 "</style>Type in hello\n" +
-                "<div><code id=typeans><span class=\"typeGood\">hello</span>✔</code></div>\n" +
+                "<div><code id=\"typeans\"><span class=\"typeGood\">hello</span><span id=\"typecheckmark\">✔</span></code></div>\n" +
                 "\n" +
                 "<hr id=answer>\n" +
                 "\n" +
@@ -86,7 +86,7 @@ public class AbstractFlashcardViewerTest extends RobolectricTest {
                 " background-color: white;\n" +
                 "}\n" +
                 "</style>Type in hello\n" +
-                "<div><code id=typeans><span class=\"typeBad\">hello</span><br>&darr;<br><span class=\"typeMissed\">xyzzy$$$22</span></code></div>\n" +
+                "<div><code id=\"typeans\"><span class=\"typeBad\">hello</span><br><span id=\"typearrow\">&darr;</span><br><span class=\"typeMissed\">xyzzy$$$22</span></code></div>\n" +
                 "\n" +
                 "<hr id=answer>\n" +
                 "\n" +
@@ -119,7 +119,7 @@ public class AbstractFlashcardViewerTest extends RobolectricTest {
                 " background-color: white;\n" +
                 "}\n" +
                 "</style>Type in hello\n" +
-                "<div><code id=typeans><span class=\"typeMissed\">hello</span></code></div>\n" +
+                "<div><code id=\"typeans\"><span class=\"typeMissed\">hello</span></code></div>\n" +
                 "\n" +
                 "<hr id=answer>\n" +
                 "\n" +
@@ -152,7 +152,7 @@ public class AbstractFlashcardViewerTest extends RobolectricTest {
                 " background-color: white;\n" +
                 "}\n" +
                 "</style>Type in $!\n" +
-                "<div><code id=typeans><span class=\"typeGood\">$!</span>✔</code></div>\n" +
+                "<div><code id=\"typeans\"><span class=\"typeGood\">$!</span><span id=\"typecheckmark\">✔</span></code></div>\n" +
                 "\n" +
                 "<hr id=answer>\n" +
                 "\n" +
@@ -185,7 +185,7 @@ public class AbstractFlashcardViewerTest extends RobolectricTest {
                 " background-color: white;\n" +
                 "}\n" +
                 "</style>Type in $!\n" +
-                "<div><code id=typeans><span class=\"typeBad\">$!</span><br>&darr;<br><span class=\"typeMissed\">hello</span></code></div>\n" +
+                "<div><code id=\"typeans\"><span class=\"typeBad\">$!</span><br><span id=\"typearrow\">&darr;</span><br><span class=\"typeMissed\">hello</span></code></div>\n" +
                 "\n" +
                 "<hr id=answer>\n" +
                 "\n" +
@@ -218,7 +218,7 @@ public class AbstractFlashcardViewerTest extends RobolectricTest {
                 " background-color: white;\n" +
                 "}\n" +
                 "</style>Type in $!\n" +
-                "<div><code id=typeans><span class=\"typeMissed\">$!</span></code></div>\n" +
+                "<div><code id=\"typeans\"><span class=\"typeMissed\">$!</span></code></div>\n" +
                 "\n" +
                 "<hr id=answer>\n" +
                 "\n" +


### PR DESCRIPTION
Changes to make heavy check mark and Down Arrow in type cards styleable
line 740 taken from anki desktop


## Fixes
Fixes 
https://github.com/ankidroid/Anki-Android/issues/4841#issuecomment-604230121

## How Has This Been Tested?
Testet by my own on all aviable versions untill 2.9alpha56 + on Android 7 an 10

- [x ] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x ] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x ] You have commented your code, particularly in hard-to-understand areas
- [x ] You have performed a self-review of your own code
![PR](https://user-images.githubusercontent.com/1220916/77699029-f051ab00-6fb1-11ea-812b-0919127b7be3.jpg)