### PR TITLE
CardBrowser: Multiple Selection Fixes

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -31,6 +31,8 @@ import android.os.Handler;
 import android.os.SystemClock;
 import androidx.annotation.NonNull;
 import com.google.android.material.snackbar.Snackbar;
+
+import androidx.annotation.VisibleForTesting;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.widget.SearchView;
 import android.text.TextUtils;
@@ -1921,5 +1923,10 @@ public class CardBrowser extends NavigationDrawerActivity implements
         supportInvalidateOptionsMenu();
         mActionBarSpinner.setVisibility(View.VISIBLE);
         mActionBarTitle.setVisibility(View.GONE);
+    }
+
+    @VisibleForTesting
+    boolean isInMultiSelectMode() {
+        return mInMultiSelectMode;
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -360,9 +360,11 @@ public class CardBrowser extends NavigationDrawerActivity implements
     }
 
     private long[] getSelectedCardIds() {
-        long[] ids = new long[mCheckedCardPositions.size()];
+        //copy to array to ensure threadsafe iteration
+        Integer[] checkedPositions = mCheckedCardPositions.toArray(new Integer[0]);
+        long[] ids = new long[checkedPositions.length];
         int count = 0;
-        for (int cardPosition : mCheckedCardPositions) {
+        for (int cardPosition : checkedPositions) {
             ids[count++] = Long.valueOf(mCards.get(cardPosition).get("id"));
         }
         return ids;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -445,7 +445,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
         mActionBarSpinner.setOnItemSelectedListener(new OnItemSelectedListener() {
             @Override
             public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
-                selectDropDownItem(position);
+                deckDropDownItemChanged(position);
             }
 
             @Override
@@ -1126,6 +1126,14 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
     public void selectDropDownItem(int position) {
         mActionBarSpinner.setSelection(position);
+        deckDropDownItemChanged(position);
+    }
+
+    /**
+     * Performs changes relating to the Deck DropDown Item changing
+     * Exists as mActionBarSpinner.setSelection() caused a loop in roboelectirc (calling onItemSelected())
+     */
+    private void deckDropDownItemChanged(int position) {
         if (position == 0) {
             mRestrictOnDeck = "";
             saveLastDeckId(ALL_DECKS_ID);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -774,13 +774,15 @@ public class CardBrowser extends NavigationDrawerActivity implements
                     new DeckTask.TaskData(new Object[]{mCheckedCardPositions, getCards()}));
         }
 
-        if (!hasSelectedAllCards()) {
-            mActionBarMenu.findItem(R.id.action_select_all).setTitle(R.string.card_browser_select_all);
-        } else {
-            mActionBarMenu.findItem(R.id.action_select_all).setTitle(R.string.card_browser_select_none);
-        }
+        mActionBarMenu.findItem(R.id.action_select_all).setVisible(!hasSelectedAllCards());
+        //Note: Theoretically should not happen, as this should kick us back to the menu
+        mActionBarMenu.findItem(R.id.action_select_none).setVisible(hasSelectedCards());
     }
 
+
+    private boolean hasSelectedCards() {
+        return mCheckedCardPositions.size() > 0;
+    }
 
     private boolean hasSelectedAllCards() {
         return mCheckedCardPositions.size() >= getCards().size();
@@ -943,8 +945,11 @@ public class CardBrowser extends NavigationDrawerActivity implements
                     DeckTask.launchDeckTask(DeckTask.TASK_TYPE_UNDO, mUndoHandler);
                 }
                 return true;
+            case R.id.action_select_none:
+                onSelectNone();
+                return true;
             case R.id.action_select_all:
-                onCheckAll();
+                onSelectAll();
                 return true;
 
             case R.id.action_preview: {
@@ -1825,19 +1830,24 @@ public class CardBrowser extends NavigationDrawerActivity implements
         }
     }
 
-    private void onCheckAll() {
-        boolean all = mCheckedCardPositions.size() < getCards().size();
-        if (all) {
-            for (int i = 0; i < mCards.size(); i++) {
-                mCheckedCardPositions.add(i);
-            }
-        } else {
-            mCheckedCardPositions.clear();
+    private void onSelectAll() {
+        for (int i = 0; i < mCards.size(); i++) {
+            mCheckedCardPositions.add(i);
         }
+        onSelectionChanged();
+    }
+
+    private void onSelectNone() {
+        mCheckedCardPositions.clear();
+        onSelectionChanged();
+    }
+
+    private void onSelectionChanged() {
         updateMultiselectMenu();
         mActionBarTitle.setText(Integer.toString(mCheckedCardPositions.size()));
         mCardsAdapter.notifyDataSetChanged();
     }
+
 
     private List<Map<String, String>> getCards() {
         if (mCards == null) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -774,12 +774,18 @@ public class CardBrowser extends NavigationDrawerActivity implements
                     new DeckTask.TaskData(new Object[]{mCheckedCardPositions, getCards()}));
         }
 
-        if (mCheckedCardPositions.size() < getCards().size()) {
+        if (!hasSelectedAllCards()) {
             mActionBarMenu.findItem(R.id.action_select_all).setTitle(R.string.card_browser_select_all);
         } else {
             mActionBarMenu.findItem(R.id.action_select_all).setTitle(R.string.card_browser_select_none);
         }
     }
+
+
+    private boolean hasSelectedAllCards() {
+        return mCheckedCardPositions.size() >= getCards().size();
+    }
+
 
     private void flagTask (int flag) {
         DeckTask.launchDeckTask(DeckTask.TASK_TYPE_DISMISS_MULTI,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -761,6 +761,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
     }
 
     private void updateMultiselectMenu() {
+        Timber.d("updateMultiselectMenu()");
         if (mActionBarMenu == null || mActionBarMenu.findItem(R.id.action_suspend_card) == null) {
             return;
         }
@@ -1883,6 +1884,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
         if (mInMultiSelectMode) {
             return;
         }
+        Timber.d("loadMultiSelectMode()");
         // set in multi-select mode
         mInMultiSelectMode = true;
         // show title and hide spinner
@@ -1897,6 +1899,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
      * Turn off Multi-Select Mode and return to normal state
      */
     private void endMultiSelectMode() {
+        Timber.d("endMultiSelectMode()");
         mCheckedCardPositions.clear();
         mInMultiSelectMode = false;
         // If view which was originally selected when entering multi-select is visible then maintain its position

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -168,7 +168,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
     private TextView mActionBarTitle;
     private boolean mReloadRequired = false;
     private boolean mInMultiSelectMode = false;
-    private Set<Integer> mCheckedCardPositions = new LinkedHashSet<>();
+    private Set<Integer> mCheckedCardPositions = Collections.synchronizedSet(new LinkedHashSet<>());
     private int mLastSelectedPosition;
     @Nullable
     private Menu mActionBarMenu;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -32,6 +32,7 @@ import android.os.SystemClock;
 import androidx.annotation.NonNull;
 import com.google.android.material.snackbar.Snackbar;
 
+import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.widget.SearchView;
@@ -169,6 +170,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
     private boolean mInMultiSelectMode = false;
     private Set<Integer> mCheckedCardPositions = new LinkedHashSet<>();
     private int mLastSelectedPosition;
+    @Nullable
     private Menu mActionBarMenu;
 
     private static final int SNACKBAR_DURATION = 8000;

--- a/AnkiDroid/src/main/res/menu/card_browser.xml
+++ b/AnkiDroid/src/main/res/menu/card_browser.xml
@@ -42,4 +42,7 @@
         android:id="@+id/action_preview"
         android:title="@string/card_editor_preview_card"/>
 
+    <item
+        android:id="@+id/action_select_all"
+        android:title="@string/card_browser_select_all"/>
 </menu>

--- a/AnkiDroid/src/main/res/menu/card_browser_multiselect.xml
+++ b/AnkiDroid/src/main/res/menu/card_browser_multiselect.xml
@@ -73,6 +73,13 @@
         android:title="@string/card_browser_select_all"
         android:icon="@drawable/ic_select_all_white_24dp"/>
 
+    <!-- For now: don't display 'select none' as action as we don't have an icon -->
+    <item
+        ankidroid:showAsAction="never"
+        android:id="@+id/action_select_none"
+        android:title="@string/card_browser_select_none"
+        android:icon="@drawable/ic_select_all_white_24dp"/>
+
     <item
         ankidroid:showAsAction="ifRoom"
         android:id="@+id/action_undo"

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
@@ -1,6 +1,8 @@
 package com.ichi2.anki;
 
 import android.content.Intent;
+import android.widget.AdapterView;
+import android.widget.ListView;
 
 import com.ichi2.libanki.Note;
 
@@ -8,13 +10,17 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.android.controller.ActivityController;
+import org.robolectric.shadows.ShadowActivity;
 
 import javax.annotation.CheckReturnValue;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+import timber.log.Timber;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.core.Is.is;
+import static org.robolectric.Shadows.shadowOf;
 
 @RunWith(AndroidJUnit4.class)
 public class CardBrowserTest extends RobolectricTest {
@@ -30,6 +36,92 @@ public class CardBrowserTest extends RobolectricTest {
         CardBrowser browser = getBrowserWithMultipleNotes();
         assertThat(browser.isInMultiSelectMode(), is(false));
     }
+
+    @Test
+    public void selectAllIsNotVisibleWhenNoCardsInDeck() {
+        CardBrowser browser = getBrowserWithNoCards();
+        assertThat(browser.isShowingSelectAll(), is(false));
+    }
+
+    @Test
+    public void selectAllIsVisibleWhenCardsInDeck() {
+        CardBrowser browser = getBrowserWithMultipleNotes();
+        assertThat(browser.cardCount(), greaterThan(0L));
+        assertThat(browser.isShowingSelectAll(), is(true));
+    }
+
+    @Test
+    public void selectAllIsNotVisibleOnceCalled() {
+        CardBrowser browser = getBrowserWithMultipleNotes();
+        selectMenuItem(browser, R.id.action_select_all);
+        assertThat(browser.isShowingSelectAll(), is(false));
+    }
+
+    @Test
+    public void selectNoneIsVisibleOnceSelectAllCalled() {
+        CardBrowser browser = getBrowserWithMultipleNotes();
+        selectMenuItem(browser, R.id.action_select_all);
+        assertThat(browser.isShowingSelectNone(), is(true));
+    }
+
+    @Test
+    public void selectNoneIsVisibleWhenSelectingOne() {
+        CardBrowser browser = getBrowserWithMultipleNotes();
+        selectOneOfManyCards(browser);
+        assertThat(browser.isShowingSelectNone(), is(true));
+    }
+
+    @Test
+    public void selectAllIsVisibleWhenSelectingOne() {
+        CardBrowser browser = getBrowserWithMultipleNotes();
+        selectOneOfManyCards(browser);
+        assertThat(browser.isShowingSelectAll(), is(true));
+    }
+
+    @Test
+    public void browserIsInMultiSelectModeWhenSelectingOne() {
+        CardBrowser browser = getBrowserWithMultipleNotes();
+        selectOneOfManyCards(browser);
+        assertThat(browser.isInMultiSelectMode(), is(true));
+    }
+
+    @Test
+    public void browserIsInMultiSelectModeWhenSelectingAll() {
+        CardBrowser browser = getBrowserWithMultipleNotes();
+        selectMenuItem(browser, R.id.action_select_all);
+        assertThat(browser.isInMultiSelectMode(), is(true));
+    }
+
+    @Test
+    public void browserIsNotInMultiSelectModeWhenSelectingNone() {
+        CardBrowser browser = getBrowserWithMultipleNotes();
+        selectMenuItem(browser, R.id.action_select_all);
+        selectMenuItem(browser, R.id.action_select_none);
+        assertThat(browser.isInMultiSelectMode(), is(false));
+    }
+
+    private void selectOneOfManyCards(CardBrowser browser) {
+        Timber.d("Selecting single card");
+        ShadowActivity shadowActivity = shadowOf(browser);
+        ListView toSelect = shadowActivity.getContentView().findViewById(R.id.card_browser_list);
+        int position = 0;
+
+        //roboelectric doesn't easily seem to allow us to fire an onItemLongClick
+        AdapterView.OnItemLongClickListener listener = toSelect.getOnItemLongClickListener();
+        if (listener == null)
+            throw new IllegalStateException("no listener found");
+        listener.onItemLongClick(null, toSelect.getChildAt(position),
+                position, toSelect.getItemIdAtPosition(position));
+    }
+
+
+    private void selectMenuItem(CardBrowser browser, int action_select_all) {
+        Timber.d("Selecting menu item");
+        //select seems to run an infinite loop :/
+        ShadowActivity shadowActivity = shadowOf(browser);
+        shadowActivity.clickMenuItem(action_select_all);
+    }
+
 
     private CardBrowser getBrowserWithMultipleNotes() {
         return getBrowserWithNotes(3);

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
@@ -1,0 +1,63 @@
+package com.ichi2.anki;
+
+import android.content.Intent;
+
+import com.ichi2.libanki.Note;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.android.controller.ActivityController;
+
+import javax.annotation.CheckReturnValue;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+@RunWith(AndroidJUnit4.class)
+public class CardBrowserTest extends RobolectricTest {
+
+    @Test
+    public void browserIsNotInitiallyInMultiSelectModeWithNoCards() {
+        CardBrowser browser = getBrowserWithNoCards();
+        assertThat(browser.isInMultiSelectMode(), is(false));
+    }
+
+    @Test
+    public void browserIsNotInitiallyInMultiSelectModeWithCards() {
+        CardBrowser browser = getBrowserWithMultipleNotes();
+        assertThat(browser.isInMultiSelectMode(), is(false));
+    }
+
+    private CardBrowser getBrowserWithMultipleNotes() {
+        return getBrowserWithNotes(3);
+    }
+
+
+    private CardBrowser getBrowserWithNotes(int count) {
+        for(int i = 0; i < count; i ++) {
+            addNote(Integer.toString(i));
+        }
+        ActivityController multimediaController = Robolectric.buildActivity(CardBrowser.class, new Intent())
+                .create().start().resume().visible();
+        return (CardBrowser) multimediaController.get();
+    }
+
+
+    private void addNote(String value) {
+        Note n = getCol().newNote();
+        n.setField(0, value);
+        if (getCol().addNote(n) != 1) {
+            throw new IllegalStateException("card was not added");
+        }
+    }
+
+    @CheckReturnValue
+    private CardBrowser getBrowserWithNoCards() {
+        ActivityController multimediaController = Robolectric.buildActivity(CardBrowser.class, new Intent())
+                .create().start().resume().visible();
+        return (CardBrowser) multimediaController.get();
+    }
+}


### PR DESCRIPTION
## Purpose / Description

The Card Browser could not display "Select All" and "Select None" at the same time

The Card Browser did not display "Select All" when no cards were selected

When "Select None" was clicked, the browser remained in Multi-Select Mode

When no cards are *available*, "Select All" should not be visible. *Edited*

## Fixes
Fixes #5464

## Approach

We add in additional items in the layout:

* New "Select All" in the unselected mode
* Differentiate "Select All" and "Select None" in mutliselect mode.

We combine all previous state changes into a function which takes the current state into account, and sets the "Selection Buttons" to the correct states.

## How Has This Been Tested?

Both on my device, and via unit test

* 0 item deck
* Normal Decks
* Deleting cards so they become 0 item decks
* Adding items to 0 item decks
* Moving items out of 1 item decks

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code