### PR TITLE
Fix Fullscreen (No Answer Buttons) Reviewer Gestures

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -2937,6 +2937,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
     };
 
     protected void delayedHide(int delayMillis) {
+        Timber.d("Fullscreen delayed hide in %dms", delayMillis);
         mFullScreenHandler.removeMessages(0);
         mFullScreenHandler.sendEmptyMessageDelayed(0, delayMillis);
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -2826,9 +2826,21 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
     }
 
     class MyGestureDetector extends SimpleOnGestureListener {
+        //Android design spec for the size of the status bar.
+        private final int NO_GESTURE_BORDER_DIP = 24;
 
         @Override
         public boolean onFling(MotionEvent e1, MotionEvent e2, float velocityX, float velocityY) {
+            Timber.d("onFling");
+
+            //#5741 - A swipe from the top caused delayedHide to be triggered,
+            //accepting a gesture and quickly disabling the status bar, which wasn't ideal.
+            //it would be lovely to use e1.getEdgeFlags(), but alas, it doesn't work.
+            if (isTouchingEdge(e1)) {
+                Timber.d("ignoring edge fling");
+                return false;
+            }
+
             // Go back to immersive mode if the user had temporarily exited it (and then execute swipe gesture)
             if (mPrefFullscreenReview > 0 &&
                     CompatHelper.getCompat().isImmersiveSystemUiVisible(AbstractFlashcardViewer.this)) {
@@ -2872,6 +2884,15 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
             }
             return false;
         }
+
+
+        private boolean isTouchingEdge(MotionEvent e1) {
+            int height = mTouchLayer.getHeight();
+            int width = mTouchLayer.getWidth();
+            float margin = NO_GESTURE_BORDER_DIP * getResources().getDisplayMetrics().density + 0.5f;
+            return e1.getX() < margin || e1.getY() < margin || height - e1.getY() < margin || width - e1.getX() < margin;
+        }
+
 
 
         @Override

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -686,8 +686,9 @@ public class Reviewer extends AbstractFlashcardViewer {
         fl.addView(mWhiteboard);
 
         mWhiteboard.setOnTouchListener((v, event) -> {
-            if (!mShowWhiteboard || (mPrefFullscreenReview
-                    && CompatHelper.getCompat().isImmersiveSystemUiVisible(Reviewer.this))) {
+            //If the whiteboard is currently drawing, and triggers the system UI to show, we want to continue drawing.
+            if (!mWhiteboard.isCurrentlyDrawing() && (!mShowWhiteboard || (mPrefFullscreenReview
+                    && CompatHelper.getCompat().isImmersiveSystemUiVisible(Reviewer.this)))) {
                 // Bypass whiteboard listener when it's hidden or fullscreen immersive mode is temporarily suspended
                 v.performClick();
                 return getGestureDetector().onTouchEvent(event);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.java
@@ -403,4 +403,8 @@ public class Whiteboard extends View {
             invalidate();
         }
     }
+
+    public boolean isCurrentlyDrawing() {
+        return mCurrentlyDrawing;
+    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV19.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV19.java
@@ -6,6 +6,8 @@ import android.animation.AnimatorListenerAdapter;
 import android.annotation.TargetApi;
 import android.content.SharedPreferences;
 import androidx.appcompat.widget.Toolbar;
+import timber.log.Timber;
+
 import android.view.View;
 import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
@@ -52,6 +54,7 @@ public class CompatV19 extends CompatV18 implements Compat {
                         // Note that system bars will only be "visible" if none of the
                         // LOW_PROFILE, HIDE_NAVIGATION, or FULLSCREEN flags are set.
                         boolean visible = (flags & View.SYSTEM_UI_FLAG_HIDE_NAVIGATION) == 0;
+                        Timber.d("System UI visibility change. Visible: %b", visible);
                         if (visible) {
                             showViewWithAnimation(toolbar);
                             if (fullscreenMode >= FULLSCREEN_ALL_GONE) {


### PR DESCRIPTION
## Purpose / Description
This fixes two issues, both when Fullscreen (No Buttons) is active.

Firstly: A swipe down from the status bar first triggered the Anki UI, and then was registered as a fling. This fling assumes "I'm a fling when the Anki UI is active, I should close the Anki UI and process a gesture".

Secondly: When drawing from the top and the whiteboard, the Anki UI is shown. The Reviewer logic assumes "I'm handling a touch event when the Anki UI is shown", this stops the draw event, and starts a fling from wherever the cursor is at the current moment, which closes the Anki UI and performs a gesture.

## Fixes
Fixes #5741

## Approach

* We define a margin, and assume it's not a gesture if it's within the margin of the edge of the screen.
* A whiteboard draw event continues after it shows the Anki UI.

## How Has This Been Tested?

On my Android

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code

## Review Goals

* Grill me on the hardcoded 24dip for the status bar, I felt it was fine given that we previously used a hardcoded value of 20dip.
* Should the whiteboard also have a margin? If the user draws from the top of the screen, do they want to draw, or get the navigation bar?