### PR TITLE
ImageField: Stop parsing images using Regex

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
@@ -32,6 +32,8 @@ import android.net.Uri;
 import android.os.Build;
 import android.provider.MediaStore;
 import android.provider.MediaStore.MediaColumns;
+
+import androidx.annotation.VisibleForTesting;
 import androidx.core.content.FileProvider;
 
 import android.text.format.Formatter;
@@ -293,12 +295,21 @@ public class BasicImageFieldController extends FieldControllerBase implements IF
     private void setPreviewImage(String imagePath, int maxsize) {
         if (imagePath != null && !"".equals(imagePath)) {
             File f = new File(imagePath);
-            Bitmap b = BitmapUtil.decodeFile(f, maxsize);
-            b = ExifUtil.rotateFromCamera(f, b);
-            mImagePreview.setImageBitmap(b);
-            mImageFileSize.setVisibility(View.VISIBLE);
-            mImageFileSize.setText(Formatter.formatFileSize(mActivity, f.length()));
+            setImagePreview(f, maxsize);
         }
+    }
+
+    @VisibleForTesting
+    void setImagePreview(File f, int maxsize) {
+        Bitmap b = BitmapUtil.decodeFile(f, maxsize);
+        if (b == null) {
+            Timber.i("Not displaying preview: Could not process image %s", f.getPath());
+            return;
+        }
+        b = ExifUtil.rotateFromCamera(f, b);
+        mImagePreview.setImageBitmap(b);
+        mImageFileSize.setVisibility(View.VISIBLE);
+        mImageFileSize.setText(Formatter.formatFileSize(mActivity, f.length()));
     }
 
 
@@ -306,5 +317,9 @@ public class BasicImageFieldController extends FieldControllerBase implements IF
     public void onDestroy() {
         ImageView imageView = mImagePreview;
         BitmapUtil.freeImageView(imageView);
+    }
+
+    public boolean isShowingPreview() {
+        return mImageFileSize.getVisibility() == View.VISIBLE;
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/ImageField.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/ImageField.java
@@ -153,10 +153,18 @@ public class ImageField extends FieldBase implements IField {
 
     @Override
     public void setFormattedString(Collection col, String value) {
+        setImagePath(getImageFullPath(col, value));
+    }
+
+
+    @NonNull
+    @VisibleForTesting
+    String getImageFullPath(Collection col, String value) {
         String path = parseImageSrcFromHtml(value);
         String mediaDir = col.getMedia().dir() + "/";
-        setImagePath(mediaDir + path);
+        return mediaDir + path;
     }
+
 
     @VisibleForTesting
     @CheckResult

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/ImageField.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/ImageField.java
@@ -159,8 +159,11 @@ public class ImageField extends FieldBase implements IField {
 
     @NonNull
     @VisibleForTesting
-    String getImageFullPath(Collection col, String value) {
+    static String getImageFullPath(Collection col, String value) {
         String path = parseImageSrcFromHtml(value);
+        if ("".equals(path)) {
+            return "";
+        }
         String mediaDir = col.getMedia().dir() + "/";
         return mediaDir + path;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/BitmapUtil.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/BitmapUtil.java
@@ -30,15 +30,20 @@ import com.ichi2.anki.AnkiDroidApp;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.IOException;
 
+import androidx.annotation.Nullable;
 import timber.log.Timber;
 
 public class BitmapUtil {
 
+    @Nullable
     public static Bitmap decodeFile(File theFile, int IMAGE_MAX_SIZE) {
         Bitmap bmp = null;
         try {
+            if (!theFile.exists()) {
+                Timber.i("not displaying preview - image does not exist: '%s'", theFile.getPath());
+                return null;
+            }
             // Decode image size
             BitmapFactory.Options o = new BitmapFactory.Options();
             o.inJustDecodeBounds = true;
@@ -71,8 +76,7 @@ public class BitmapUtil {
             } finally {
                 fis.close(); //don't need a null check, as we reuse the variable.
             }
-
-        } catch (IOException e) {
+        } catch (Exception e) {
             //#5513 - We don't know the reason for the crash, let's find out.
             AnkiDroidApp.sendExceptionReport(e, "BitmapUtil decodeFile");
         }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ExifUtil.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ExifUtil.java
@@ -21,12 +21,15 @@ package com.ichi2.utils;
 
 import android.graphics.Bitmap;
 import android.graphics.Matrix;
+
+import androidx.annotation.NonNull;
 import androidx.exifinterface.media.ExifInterface;
 
 import java.io.File;
 
 public class ExifUtil {
-    public static Bitmap rotateFromCamera(File theFile, Bitmap bmp) {
+    @NonNull
+    public static Bitmap rotateFromCamera(File theFile, @NonNull Bitmap bmp) {
         try {
             ExifInterface exif = new ExifInterface(theFile.getPath());
             int orientation = exif.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL);

--- a/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldControllerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldControllerTest.java
@@ -4,10 +4,17 @@ import com.ichi2.anki.multimediacard.activity.MultimediaEditFieldActivityTestBas
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
 import org.robolectric.RobolectricTestRunner;
+
+import java.io.File;
+
+import androidx.annotation.CheckResult;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.when;
 
 
 @RunWith(RobolectricTestRunner.class)
@@ -15,10 +22,7 @@ public class BasicImageFieldControllerTest extends MultimediaEditFieldActivityTe
 
     @Test
     public void constructionWithoutDataGivesNoError() {
-        grantCameraPermission();
-
-        IFieldController controller = getControllerForField(emptyImageField(), getEmptyNote(), 0);
-
+        IFieldController controller = getValidControllerNoImage();
         assertThat(controller, instanceOf(BasicImageFieldController.class));
     }
 
@@ -30,6 +34,44 @@ public class BasicImageFieldControllerTest extends MultimediaEditFieldActivityTe
 
         assertThat(controller, instanceOf(BasicImageFieldController.class));
     }
+
+    @Test
+    public void nonExistingFileDoesNotDisplayPreview() {
+        BasicImageFieldController controller = getValidControllerNoImage();
+        assertThat(controller.isShowingPreview(), is(false));
+
+        File f =  Mockito.mock(File.class);
+        when(f.exists()).thenReturn(false);
+
+        controller.setImagePreview(f, 100);
+
+        assertThat("A non existing file should not display a preview",
+                controller.isShowingPreview(),
+                is(false));
+    }
+
+    @Test
+    public void erroringFileDoesNotDisplayPreview() {
+        BasicImageFieldController controller = getValidControllerNoImage();
+        assertThat(controller.isShowingPreview(), is(false));
+
+        File f =  Mockito.mock(File.class);
+        when(f.exists()).thenReturn(true); //true, but it'll throw due to being a mock.
+
+        controller.setImagePreview(f, 100);
+
+        assertThat("A broken existing file should not display a preview",
+                controller.isShowingPreview(),
+                is(false));
+    }
+
+    @CheckResult
+    protected BasicImageFieldController getValidControllerNoImage() {
+        grantCameraPermission();
+
+        return (BasicImageFieldController) getControllerForField(emptyImageField(), getEmptyNote(), 0);
+    }
+
 
     private static IField emptyImageField() {
         return new ImageField();

--- a/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/fields/ImageFieldTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/fields/ImageFieldTest.java
@@ -32,4 +32,40 @@ public class ImageFieldTest {
         String expected = "<img src=\"paste-abc.jpg\">";
         assertThat(actual, equalTo(expected));
     }
+
+    @Test
+    public void validImageParses() {
+        String goodImage = "<img src='img_202003291657428441724378214970132.png'/>";
+        String imageSrc = ImageField.parseImageSrcFromHtml(goodImage);
+        assertThat(imageSrc, equalTo("img_202003291657428441724378214970132.png"));
+    }
+
+    @Test
+    public void testImageSubstringParsing() {
+        //5874 - previously failed
+        String previouslyBadImage = "<img src='img_202003291657428441724378214970132.png'/>aaaa'/>";
+        String imageSrc = ImageField.parseImageSrcFromHtml(previouslyBadImage);
+        assertThat(imageSrc, equalTo("img_202003291657428441724378214970132.png"));
+    }
+
+    @Test
+    public void firstImageIsSelected() {
+        String goodImage = "<img src='1.png'/>aa<img src='2.png'/>";
+        String imageSrc = ImageField.parseImageSrcFromHtml(goodImage);
+        assertThat(imageSrc, equalTo("1.png"));
+    }
+
+    @Test
+    public void testNoImage() {
+        String knownBadImage = "<br />";
+        String imageSrc = ImageField.parseImageSrcFromHtml(knownBadImage);
+        assertThat(imageSrc, equalTo(""));
+    }
+
+    @Test
+    public void testEmptyImage() {
+        String knownBadImage = "<img />";
+        String imageSrc = ImageField.parseImageSrcFromHtml(knownBadImage);
+        assertThat(imageSrc, equalTo(""));
+    }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/fields/ImageFieldTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/fields/ImageFieldTest.java
@@ -1,15 +1,21 @@
 package com.ichi2.anki.multimediacard.fields;
 
+import com.ichi2.libanki.Collection;
+import com.ichi2.libanki.Media;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 
 import java.io.File;
 
+import androidx.annotation.CheckResult;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @RunWith(AndroidJUnit4.class)
 public class ImageFieldTest {
@@ -67,5 +73,35 @@ public class ImageFieldTest {
         String knownBadImage = "<img />";
         String imageSrc = ImageField.parseImageSrcFromHtml(knownBadImage);
         assertThat(imageSrc, equalTo(""));
+    }
+
+    @Test
+    public void testNoImagePathIsNothing() {
+        String knownBadImage = "<br />";
+        Collection col = collectionWithMediaFolder("media");
+
+        String imageSrc = ImageField.getImageFullPath(col, knownBadImage);
+
+        assertThat("no media should return no paths", imageSrc, equalTo(""));
+    }
+
+    @Test
+    public void testNoImagePathConcat() {
+        String goodImage = "<img src='1.png'/>";
+        Collection col = collectionWithMediaFolder("media");
+
+        String imageSrc = ImageField.getImageFullPath(col, goodImage);
+
+        assertThat("Valid media should have path", imageSrc, equalTo("media/1.png"));
+    }
+
+    @CheckResult
+    protected Collection collectionWithMediaFolder(String dir) {
+        Media media = mock(Media.class);
+        when(media.dir()).thenReturn(dir);
+
+        Collection collectionMock = mock(Collection.class);
+        when(collectionMock.getMedia()).thenReturn(media);
+        return collectionMock;
     }
 }


### PR DESCRIPTION
## Purpose / Description

* The image `src` was not being extracted correctly
* Passing in an invalid image to ImageFieldController started a preview, throwing a FileNotFound Exception, which was logged by ACRA
* Passing a null image to BitmapUtil threw an exception, now returns null

## Fixes
Fixes #5874

## Approach

* We use JSoup instead of Regex
* We avoid logging to ACRA on a regular `FileNotFound`

## How Has This Been Tested?

Unit tests, now displays images on the test data

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code