### PR TITLE
Fix lint warning on format string

### DIFF
--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -58,7 +58,7 @@
     <string name="webview_crash_nonfatal">WebView renderer crashed. Cause: %s</string>
     <string name="webview_crash_fatal">Fatal Error: WebView renderer crashed. Cause: %s</string>
     <string name="webview_crash_loop_dialog_title">System WebView Rendering Failure</string>
-    <string name="webview_crash_loop_dialog_content">System WebView failed to render card \'%s\'.\n %s</string>
+    <string name="webview_crash_loop_dialog_content">System WebView failed to render card \'%1$s\'.\n %2$s</string>
 
     <!-- Browser -->
     <string-array name="browser_column1_headings">


### PR DESCRIPTION
## Purpose / Description
A lint warning was caused by having two `%s` formatters in the same string

## Fixes
Fixes #5876 

## Approach
Fixes the format string by adding positional arguments.

## How Has This Been Tested?

Tested on my device, string still formats correctly.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code