### PR TITLE
Various Renderer Crash Improvements

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -949,7 +949,11 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
 
     @Override
     public boolean onKeyDown(int keyCode, KeyEvent event) {
-        // Hardware buttons for scrolling
+        return handleHardwareScrollButtons(keyCode) || super.onKeyDown(keyCode, event);
+    }
+
+
+    private boolean handleHardwareScrollButtons(int keyCode) {
         if (keyCode == KeyEvent.KEYCODE_PAGE_UP) {
             mCard.pageUp(false);
             if (mDoubleScrolling) {
@@ -978,7 +982,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
             }
             return true;
         }
-        return super.onKeyDown(keyCode, event);
+        return false;
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1677,6 +1677,8 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
                         .title(res.getString(R.string.webview_crash_loop_dialog_title))
                         .content(res.getString(R.string.webview_crash_loop_dialog_content, cardInformation, errorDetails))
                         .positiveText(R.string.dialog_ok)
+                        .cancelable(false)
+                        .canceledOnTouchOutside(false)
                         .onPositive((materialDialog, dialogAction) -> finishWithoutAnimation())
                         .show();
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -2483,15 +2483,20 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
     public void fillFlashcard() {
         Timber.d("fillFlashcard()");
         Timber.d("base url = %s", mBaseUrl);
-        if (mCard != null) {
-            CompatHelper.getCompat().setHTML5MediaAutoPlay(mCard.getSettings(), getConfigForCurrentCard().optBoolean("autoplay"));
-            mCard.loadDataWithBaseURL(mBaseUrl + "__viewer__.html", mCardContent.toString(), "text/html", "utf-8", null);
-        }
+        loadContentIntoCard(mCard, mCardContent.toString());
         if (mShowTimer && mCardTimer.getVisibility() == View.INVISIBLE) {
             switchTopBarVisibility(View.VISIBLE);
         }
         if (!sDisplayAnswer) {
             updateForNewCard();
+        }
+    }
+
+
+    private void loadContentIntoCard(WebView card, String content) {
+        if (card != null) {
+            CompatHelper.getCompat().setHTML5MediaAutoPlay(card.getSettings(), getConfigForCurrentCard().optBoolean("autoplay"));
+            card.loadDataWithBaseURL(mBaseUrl + "__viewer__.html", content, "text/html", "utf-8", null);
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1656,7 +1656,8 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
                 String nonFatalError = getResources().getString(R.string.webview_crash_nonfatal, errorCauseString);
                 UIUtils.showThemedToast(AbstractFlashcardViewer.this, nonFatalError, false);
 
-                mCardFrameParent.addView(mCardFrame);
+                //we need to add at index 0 so gestures still go through.
+                mCardFrameParent.addView(mCardFrame, 0);
 
                 recreateWebView();
                 displayCardQuestion();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -344,6 +344,9 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
     @Nullable
     private Long lastCrashingCardId = null;
 
+    /** Reference to the parent of the cardFrame to allow regeneration of the cardFrame in case of crash */
+    private ViewGroup mCardFrameParent;
+
     // private int zEase;
 
     // ----------------------------------------------------------------------------
@@ -1298,6 +1301,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
 
         mTopBarLayout = (RelativeLayout) findViewById(R.id.top_bar);
         mCardFrame = (FrameLayout) findViewById(R.id.flashcard);
+        mCardFrameParent = (ViewGroup) mCardFrame.getParent();
         mTouchLayer = (FrameLayout) findViewById(R.id.touch_layer);
         mTouchLayer.setOnTouchListener(mGestureListener);
         if (!mDisableClipboard) {
@@ -1610,8 +1614,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
                 //Otherwise, we get the following error:
                 //"crash wasn't handled by all associated webviews, triggering application crash"
                 destroyWebView(mCard);
-                ViewGroup parent = (ViewGroup) mCardFrame.getParent();
-                parent.removeView(mCardFrame);
+                mCardFrameParent.removeView(mCardFrame);
                 mCard = null;
                 //inflate a new instance of mCardFrame
                 mCardFrame = inflateNewView(R.id.flashcard);
@@ -1647,7 +1650,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
                 String nonFatalError = getResources().getString(R.string.webview_crash_nonfatal, errorCauseString);
                 UIUtils.showThemedToast(AbstractFlashcardViewer.this, nonFatalError, false);
 
-                parent.addView(mCardFrame);
+                mCardFrameParent.addView(mCardFrame);
 
                 recreateWebView();
                 displayCardQuestion();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1617,9 +1617,10 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
                 //Destroy the current WebView (to ensure WebView is GCed).
                 //Otherwise, we get the following error:
                 //"crash wasn't handled by all associated webviews, triggering application crash"
-                destroyWebView(mCard);
                 mCardFrame.removeAllViews();
                 mCardFrameParent.removeView(mCardFrame);
+                //destroy after removal from the view - produces logcat warnings otherwise
+                destroyWebView(mCard);
                 mCard = null;
                 //inflate a new instance of mCardFrame
                 mCardFrame = inflateNewView(R.id.flashcard);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -40,6 +40,7 @@ import android.os.Handler;
 import android.os.Message;
 import android.os.SystemClock;
 
+import androidx.annotation.CheckResult;
 import androidx.annotation.IdRes;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
@@ -96,6 +97,8 @@ import com.ichi2.libanki.template.Template;
 import com.ichi2.themes.HtmlColors;
 import com.ichi2.themes.Themes;
 import com.ichi2.utils.DiffEngine;
+import com.ichi2.utils.FunctionalInterfaces.Consumer;
+import com.ichi2.utils.FunctionalInterfaces.Function;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -111,6 +114,9 @@ import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -347,6 +353,9 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
     /** Reference to the parent of the cardFrame to allow regeneration of the cardFrame in case of crash */
     private ViewGroup mCardFrameParent;
 
+    /** Lock to allow thread-safe regeneration of mCard */
+    private ReadWriteLock mCardLock = new ReentrantReadWriteLock();
+
     // private int zEase;
 
     // ----------------------------------------------------------------------------
@@ -457,16 +466,33 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
                         break;
                 }
             }
-            try {
-                if (event != null) {
-                    mCard.dispatchTouchEvent(event);
-                }
-            } catch (NullPointerException e) {
-                Timber.e(e, "Error on dispatching touch event");
-            }
+            //Gesture listener is added before mCard is set
+            processCardAction(card -> {
+                if (card == null) return;
+                card.dispatchTouchEvent(event);
+            });
             return false;
         }
     };
+
+    @SuppressLint("CheckResult")
+    private void processCardAction(Consumer<WebView> cardConsumer) {
+        processCardFunction(card -> {
+            cardConsumer.consume(card);
+            return true;
+        });
+    }
+
+    @CheckResult
+    private <T> T processCardFunction(Function<WebView, T> cardFunction) {
+        Lock readLock = mCardLock.readLock();
+        try {
+            readLock.lock();
+            return cardFunction.apply(mCard);
+        } finally {
+            readLock.unlock();
+        }
+    }
 
 
     protected DeckTask.TaskListener mDismissCardHandler = new NextCardHandler() { /* superclass is sufficient */ };
@@ -933,7 +959,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
         if (mCardFrame != null) {
             mCardFrame.removeAllViews();
         }
-        destroyWebView(mCard);
+        destroyWebView(mCard); //OK to do without a lock
     }
 
 
@@ -949,7 +975,10 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
 
     @Override
     public boolean onKeyDown(int keyCode, KeyEvent event) {
-        return processHardwareButtonScroll(keyCode, mCard) || super.onKeyDown(keyCode, event);
+        if (processCardFunction(card -> processHardwareButtonScroll(keyCode, card))) {
+            return true;
+        }
+        return super.onKeyDown(keyCode, event);
     }
 
 
@@ -1604,62 +1633,70 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
             @Override
             @TargetApi(Build.VERSION_CODES.O)
             public boolean onRenderProcessGone(WebView view, RenderProcessGoneDetail detail) {
+                Timber.i("Obtaining write lock for card");
+                Lock writeLock = mCardLock.writeLock();
+                Timber.i("Obtained write lock for card");
+                try {
+                    writeLock.lock();
+                    if (mCard == null || !mCard.equals(view)) {
+                        //A view crashed that wasn't ours.
+                        //We have nothing to handle. Returning false is a desire to crash, so return true.
+                        Timber.i("Unrelated WebView Renderer terminated. Crashed: %b",  detail.didCrash());
+                        return true;
+                    }
 
-                if (mCard == null || !mCard.equals(view)) {
-                    //A view crashed that wasn't ours.
-                    //We have nothing to handle. Returning false is a desire to crash, so return true.
-                    Timber.i("Unrelated WebView Renderer terminated. Crashed: %b",  detail.didCrash());
-                    return true;
+                    Timber.e("WebView Renderer process terminated. Crashed: %b",  detail.didCrash());
+
+                    //Destroy the current WebView (to ensure WebView is GCed).
+                    //Otherwise, we get the following error:
+                    //"crash wasn't handled by all associated webviews, triggering application crash"
+                    mCardFrame.removeAllViews();
+                    mCardFrameParent.removeView(mCardFrame);
+                    //destroy after removal from the view - produces logcat warnings otherwise
+                    destroyWebView(mCard);
+                    mCard = null;
+                    //inflate a new instance of mCardFrame
+                    mCardFrame = inflateNewView(R.id.flashcard);
+                    //Even with the above, I occasionally saw the above error. Manually trigger the GC.
+                    //I'll keep this line unless I see another crash, which would point to another underlying issue.
+                    System.gc();
+
+                    //We only want to show one message per branch.
+
+                    //It's not necessarily an OOM crash, false implies a general code which is for "system terminated".
+                    int errorCauseId = detail.didCrash() ? R.string.webview_crash_unknown : R.string.webview_crash_oom;
+                    String errorCauseString = getResources().getString(errorCauseId);
+
+                    if (!canRecoverFromWebViewRendererCrash()) {
+                        Timber.e("Unrecoverable WebView Render crash");
+                        String errorMessage = getResources().getString(R.string.webview_crash_fatal, errorCauseString);
+                        UIUtils.showThemedToast(AbstractFlashcardViewer.this, errorMessage, false);
+                        finishWithoutAnimation();
+                        return true;
+                    }
+
+                    if (webViewRendererLastCrashedOnCard(mCurrentCard.getId())) {
+                        Timber.e("Web Renderer crash loop on card: %d", mCurrentCard.getId());
+                        displayRenderLoopDialog(mCurrentCard, detail);
+                        return true;
+                    }
+
+                    // If we get here, the error is non-fatal and we should re-render the WebView
+                    // This logic may need to be better defined. The card could have changed by the time we get here.
+                    lastCrashingCardId = mCurrentCard.getId();
+
+
+                    String nonFatalError = getResources().getString(R.string.webview_crash_nonfatal, errorCauseString);
+                    UIUtils.showThemedToast(AbstractFlashcardViewer.this, nonFatalError, false);
+
+                    //we need to add at index 0 so gestures still go through.
+                    mCardFrameParent.addView(mCardFrame, 0);
+
+                    recreateWebView();
+                } finally {
+                    writeLock.unlock();
+                    Timber.d("Relinquished writeLock");
                 }
-
-                Timber.e("WebView Renderer process terminated. Crashed: %b",  detail.didCrash());
-
-                //Destroy the current WebView (to ensure WebView is GCed).
-                //Otherwise, we get the following error:
-                //"crash wasn't handled by all associated webviews, triggering application crash"
-                mCardFrame.removeAllViews();
-                mCardFrameParent.removeView(mCardFrame);
-                //destroy after removal from the view - produces logcat warnings otherwise
-                destroyWebView(mCard);
-                mCard = null;
-                //inflate a new instance of mCardFrame
-                mCardFrame = inflateNewView(R.id.flashcard);
-                //Even with the above, I occasionally saw the above error. Manually trigger the GC.
-                //I'll keep this line unless I see another crash, which would point to another underlying issue.
-                System.gc();
-
-                //We only want to show one message per branch.
-
-                //It's not necessarily an OOM crash, false implies a general code which is for "system terminated".
-                int errorCauseId = detail.didCrash() ? R.string.webview_crash_unknown : R.string.webview_crash_oom;
-                String errorCauseString = getResources().getString(errorCauseId);
-
-                if (!canRecoverFromWebViewRendererCrash()) {
-                    Timber.e("Unrecoverable WebView Render crash");
-                    String errorMessage = getResources().getString(R.string.webview_crash_fatal, errorCauseString);
-                    UIUtils.showThemedToast(AbstractFlashcardViewer.this, errorMessage, false);
-                    finishWithoutAnimation();
-                    return true;
-                }
-
-                if (webViewRendererLastCrashedOnCard(mCurrentCard.getId())) {
-                    Timber.e("Web Renderer crash loop on card: %d", mCurrentCard.getId());
-                    displayRenderLoopDialog(mCurrentCard, detail);
-                    return true;
-                }
-
-                // If we get here, the error is non-fatal and we should re-render the WebView
-                // This logic may need to be better defined. The card could have changed by the time we get here.
-                lastCrashingCardId = mCurrentCard.getId();
-
-
-                String nonFatalError = getResources().getString(R.string.webview_crash_nonfatal, errorCauseString);
-                UIUtils.showThemedToast(AbstractFlashcardViewer.this, nonFatalError, false);
-
-                //we need to add at index 0 so gestures still go through.
-                mCardFrameParent.addView(mCardFrame, 0);
-
-                recreateWebView();
                 displayCardQuestion();
 
                 //We handled the crash and can continue.
@@ -1725,7 +1762,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
 
     /** Used to set the "javascript:" URIs for IPC */
     private void loadUrlInViewer(final String url) {
-        mCard.loadUrl(url);
+        processCardAction(card -> card.loadUrl(url));
     }
 
     private <T extends View> T inflateNewView(@IdRes int id) {
@@ -2208,9 +2245,11 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
      * @param dy amount to be scrolled
      */
     public void scrollCurrentCardBy(int dy) {
-        if (dy != 0 && mCard.canScrollVertically(dy)) {
-            mCard.scrollBy(0, dy);
-        }
+        processCardAction(card -> {
+            if (dy != 0 && card.canScrollVertically(dy)) {
+                card.scrollBy(0, dy);
+            }
+        });
     }
 
 
@@ -2224,12 +2263,13 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
         MotionEvent eDown = MotionEvent.obtain(SystemClock.uptimeMillis(),
                 SystemClock.uptimeMillis(), MotionEvent.ACTION_DOWN, x, y,
                 1, 1, 0, 1, 1, 0, 0);
-        mCard.dispatchTouchEvent(eDown);
+        processCardAction(card -> card.dispatchTouchEvent(eDown));
 
         MotionEvent eUp = MotionEvent.obtain(eDown.getDownTime(),
                 SystemClock.uptimeMillis(), MotionEvent.ACTION_UP, x, y,
                 1, 1, 0, 1, 1, 0, 0);
-        mCard.dispatchTouchEvent(eUp);
+        processCardAction(card -> card.dispatchTouchEvent(eUp));
+
     }
 
 
@@ -2263,30 +2303,30 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
     }
 
 
-    private void updateCard(String content) {
+    private void updateCard(final String newContent) {
         Timber.d("updateCard()");
 
         mUseTimerDynamicMS = 0;
 
         // Add CSS for font color and font size
         if (mCurrentCard == null) {
-            mCard.getSettings().setDefaultFontSize(calculateDynamicFontSize(content));
+            processCardAction(card -> card.getSettings().setDefaultFontSize(calculateDynamicFontSize(newContent)));
         }
 
         if (sDisplayAnswer) {
-            addAnswerSounds(content);
+            addAnswerSounds(newContent);
         } else {
             // reset sounds each time first side of card is displayed, which may happen repeatedly without ever
             // leaving the card (such as when edited)
             mSoundPlayer.resetSounds();
             mAnswerSoundsAdded = false;
-            mSoundPlayer.addSounds(mBaseUrl, content, Sound.SOUNDS_QUESTION);
+            mSoundPlayer.addSounds(mBaseUrl, newContent, Sound.SOUNDS_QUESTION);
             if (mUseTimer && !mAnswerSoundsAdded && getConfigForCurrentCard().optBoolean("autoplay", false)) {
                 addAnswerSounds(mCurrentCard.a());
             }
         }
 
-        content = Sound.expandSounds(mBaseUrl, content);
+        String content = Sound.expandSounds(mBaseUrl, newContent);
 
         // In order to display the bold style correctly, we have to change
         // font-weight to 700
@@ -2491,7 +2531,8 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
     public void fillFlashcard() {
         Timber.d("fillFlashcard()");
         Timber.d("base url = %s", mBaseUrl);
-        loadContentIntoCard(mCard, mCardContent.toString());
+        final String cardContent = mCardContent.toString();
+        processCardAction(card -> loadContentIntoCard(card, cardContent));
         if (mShowTimer && mCardTimer.getVisibility() == View.INVISIBLE) {
             switchTopBarVisibility(View.VISIBLE);
         }
@@ -2677,7 +2718,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
     private void selectAndCopyText() {
         try {
             KeyEvent shiftPressEvent = new KeyEvent(0, 0, KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_SHIFT_LEFT, 0, 0);
-            shiftPressEvent.dispatch(mCard);
+            processCardAction(shiftPressEvent::dispatch);
             shiftPressEvent.isShiftPressed();
             mIsSelecting = true;
         } catch (Exception e) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1730,11 +1730,15 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
     }
 
     private void destroyWebView(WebView webView) {
-        if (webView != null) {
-            webView.stopLoading();
-            webView.setWebChromeClient(null);
-            webView.setWebViewClient(null);
-            webView.destroy();
+        try {
+            if (webView != null) {
+                webView.stopLoading();
+                webView.setWebChromeClient(null);
+                webView.setWebViewClient(null);
+                webView.destroy();
+            }
+        } catch (NullPointerException npe) {
+            Timber.e(npe, "WebView became null on destruction");
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1613,7 +1613,8 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
                 ViewGroup parent = (ViewGroup) mCardFrame.getParent();
                 parent.removeView(mCardFrame);
                 mCard = null;
-                mCardFrame = null;
+                //inflate a new instance of mCardFrame
+                mCardFrame = inflateNewView(R.id.flashcard);
                 //Even with the above, I occasionally saw the above error. Manually trigger the GC.
                 //I'll keep this line unless I see another crash, which would point to another underlying issue.
                 System.gc();
@@ -1646,8 +1647,6 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
                 String nonFatalError = getResources().getString(R.string.webview_crash_nonfatal, errorCauseString);
                 UIUtils.showThemedToast(AbstractFlashcardViewer.this, nonFatalError, false);
 
-                //inflate a new instance of mCardFrame
-                mCardFrame = inflateNewView(R.id.flashcard);
                 parent.addView(mCardFrame);
 
                 recreateWebView();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1717,7 +1717,13 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
     @VisibleForTesting()
     @SuppressWarnings("unused")
     public void crashWebViewRenderer() {
-        mCard.loadUrl("chrome://crash");
+        loadUrlInViewer("chrome://crash");
+    }
+
+
+    /** Used to set the "javascript:" URIs for IPC */
+    private void loadUrlInViewer(final String url) {
+        mCard.loadUrl(url);
     }
 
     private <T extends View> T inflateNewView(@IdRes int id) {
@@ -3000,7 +3006,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
         if (mCurrentCard == null) {
             return;
         }
-        mCard.loadUrl("javascript:_drawMark("+mCurrentCard.note().hasTag("marked")+");");
+        loadUrlInViewer("javascript:_drawMark("+mCurrentCard.note().hasTag("marked")+");");
     }
 
     protected void onMark(Card card) {
@@ -3022,7 +3028,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
         if (mCurrentCard == null) {
             return;
         }
-        mCard.loadUrl("javascript:_drawFlag("+mCurrentCard.getUserFlag()+");");
+        loadUrlInViewer("javascript:_drawFlag("+mCurrentCard.getUserFlag()+");");
     }
 
     protected void onFlag(Card card, int flag) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1618,6 +1618,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
                 //Otherwise, we get the following error:
                 //"crash wasn't handled by all associated webviews, triggering application crash"
                 destroyWebView(mCard);
+                mCardFrame.removeAllViews();
                 mCardFrameParent.removeView(mCardFrame);
                 mCard = null;
                 //inflate a new instance of mCardFrame

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -949,36 +949,36 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
 
     @Override
     public boolean onKeyDown(int keyCode, KeyEvent event) {
-        return handleHardwareScrollButtons(keyCode) || super.onKeyDown(keyCode, event);
+        return processHardwareButtonScroll(keyCode, mCard) || super.onKeyDown(keyCode, event);
     }
 
 
-    private boolean handleHardwareScrollButtons(int keyCode) {
+    private boolean processHardwareButtonScroll(int keyCode, WebView card) {
         if (keyCode == KeyEvent.KEYCODE_PAGE_UP) {
-            mCard.pageUp(false);
+            card.pageUp(false);
             if (mDoubleScrolling) {
-                mCard.pageUp(false);
+                card.pageUp(false);
             }
             return true;
         }
         if (keyCode == KeyEvent.KEYCODE_PAGE_DOWN) {
-            mCard.pageDown(false);
+            card.pageDown(false);
             if (mDoubleScrolling) {
-                mCard.pageDown(false);
+                card.pageDown(false);
             }
             return true;
         }
         if (mScrollingButtons && keyCode == KeyEvent.KEYCODE_PICTSYMBOLS) {
-            mCard.pageUp(false);
+            card.pageUp(false);
             if (mDoubleScrolling) {
-                mCard.pageUp(false);
+                card.pageUp(false);
             }
             return true;
         }
         if (mScrollingButtons && keyCode == KeyEvent.KEYCODE_SWITCH_CHARSET) {
-            mCard.pageDown(false);
+            card.pageDown(false);
             if (mDoubleScrolling) {
-                mCard.pageDown(false);
+                card.pageDown(false);
             }
             return true;
         }


### PR DESCRIPTION
##  Purpose / Description

* Fixes Gestures being disabled after renderer is regenerated
* Fixes various race conditions when the render ends
* Fixes a dialog box for a renderer error being cancelable, not ending the activity as expected.

## Fixes
Fixes #5879

## Approach

* Gestures: Insert the view at position 0, rather than position 3 (touches appear to be from lowest to highest).
* Fixes race condition accessing `mCardFrame` via atomic variable replacement
* Fixes race condition accessing `mCardFrameParent` inside `onRenderProcessGone` via extracting the constant reference
* Fixes race condition accessing `mCard` via reader-writer lock
* Made error dialog for render process failure non-cancelable

## How Has This Been Tested?

On my device. I can no longer cause a crash due to mashing the answer buttons/gestures due to a race condition.

There is still an unsolved crash on the first instance of generating the renderer. This previously existed in the branch

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code

## Review Notes

* Happy to split this into two PRs (one handling `mCard`, one for the remainder of the fixes)