### PR TITLE
Fix FileImport NullPointerExceptions and implement ClipData

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
@@ -8,6 +8,7 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.os.Message;
 import android.provider.OpenableColumns;
+import android.text.TextUtils;
 
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.ichi2.anki.AnkiActivity;
@@ -40,6 +41,9 @@ public class ImportUtils {
         // This intent is used for opening apkg package files
         // We want to go immediately to DeckPicker, clearing any history in the process
         Timber.i("IntentHandler/ User requested to view a file");
+        String extras = intent.getExtras() == null ? "none" : TextUtils.join(", ", intent.getExtras().keySet());
+        Timber.i("Intent: %s. Data: %s", intent, extras);
+
         String errorMessage = null;
         // If the file is being sent from a content provider we need to read the content before we can open the file
         if ("content".equals(intent.getData().getScheme())) {

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
@@ -45,6 +45,15 @@ public class ImportUtils {
         String extras = intent.getExtras() == null ? "none" : TextUtils.join(", ", intent.getExtras().keySet());
         Timber.i("Intent: %s. Data: %s", intent, extras);
 
+        try {
+            return handleFileImportInternal(context, intent);
+        } catch (Exception e) {
+            return context.getString(R.string.import_error_exception, e.getLocalizedMessage());
+        }
+    }
+
+    //Added to remove exception handlers
+    private static String handleFileImportInternal(Context context, Intent intent) {
         String errorMessage = null;
 
         if (intent.getData() == null) {
@@ -52,22 +61,14 @@ public class ImportUtils {
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN || intent.getClipData() == null) {
                 return context.getString(R.string.import_error_unhandled_request);
             }
-            try {
-                Uri clipUri = intent.getClipData().getItemAt(0).getUri();
-                return handleContentProviderFile(context, intent, clipUri);
-            } catch (Exception e) {
-                return context.getString(R.string.import_error_exception, e.getLocalizedMessage());
-            }
+            Uri clipUri = intent.getClipData().getItemAt(0).getUri();
+            return handleContentProviderFile(context, intent, clipUri);
         }
 
         // If the file is being sent from a content provider we need to read the content before we can open the file
         if ("content".equals(intent.getData().getScheme())) {
             Timber.i("Attempting to read content from intent.");
-            try {
-                return handleContentProviderFile(context, intent, intent.getData());
-            } catch (Exception e) {
-                return context.getString(R.string.import_error_exception, e.getLocalizedMessage());
-            }
+            return handleContentProviderFile(context, intent, intent.getData());
         } else if ("file".equals(intent.getData().getScheme())) {
             Timber.i("Attempting to read file from intent.");
             // When the VIEW intent is sent as a file, we can open it directly without copying from content provider

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
@@ -49,6 +49,7 @@ public class ImportUtils {
             return handleFileImportInternal(context, intent);
         } catch (Exception e) {
             AnkiDroidApp.sendExceptionReport(e, "handleFileImport");
+            Timber.e(e, "failed to handle import intent");
             return context.getString(R.string.import_error_exception, e.getLocalizedMessage());
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
@@ -45,6 +45,11 @@ public class ImportUtils {
         Timber.i("Intent: %s. Data: %s", intent, extras);
 
         String errorMessage = null;
+
+        if (intent.getData() == null) {
+            return context.getString(R.string.import_error_unhandled_request);
+        }
+
         // If the file is being sent from a content provider we need to read the content before we can open the file
         if ("content".equals(intent.getData().getScheme())) {
             return handleContentProviderFile(context, intent, intent.getData());

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
@@ -47,7 +47,7 @@ public class ImportUtils {
         String errorMessage = null;
         // If the file is being sent from a content provider we need to read the content before we can open the file
         if ("content".equals(intent.getData().getScheme())) {
-            return handleContentProviderFile(context, intent);
+            return handleContentProviderFile(context, intent, intent.getData());
         } else if ("file".equals(intent.getData().getScheme())) {
             // When the VIEW intent is sent as a file, we can open it directly without copying from content provider
             String filename = intent.getData().getPath();
@@ -63,13 +63,13 @@ public class ImportUtils {
     }
 
 
-    private static String handleContentProviderFile(Context context, Intent intent) {
+    private static String handleContentProviderFile(Context context, Intent intent, Uri data) {
         // Get the original filename from the content provider URI
         String errorMessage = null;
         String filename = null;
         Cursor cursor = null;
         try {
-            cursor = context.getContentResolver().query(intent.getData(), new String[]{OpenableColumns.DISPLAY_NAME}, null, null, null);
+            cursor = context.getContentResolver().query(data, new String[]{OpenableColumns.DISPLAY_NAME}, null, null, null);
             if (cursor != null && cursor.moveToFirst()) {
                 filename = cursor.getString(0);
                 Timber.d("handleFileImport() Importing from content provider: %s", filename);

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
@@ -59,7 +59,9 @@ public class ImportUtils {
 
         if (intent.getData() == null) {
             Timber.i("No intent data. Attempting to read clip data.");
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN || intent.getClipData() == null) {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN
+                    || intent.getClipData() == null
+                    || intent.getClipData().getItemCount() == 0) {
                 return context.getString(R.string.import_error_unhandled_request);
             }
             Uri clipUri = intent.getClipData().getItemAt(0).getUri();

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
@@ -48,6 +48,7 @@ public class ImportUtils {
         try {
             return handleFileImportInternal(context, intent);
         } catch (Exception e) {
+            AnkiDroidApp.sendExceptionReport(e, "handleFileImport");
             return context.getString(R.string.import_error_exception, e.getLocalizedMessage());
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
@@ -48,6 +48,7 @@ public class ImportUtils {
         String errorMessage = null;
 
         if (intent.getData() == null) {
+            Timber.i("No intent data. Attempting to read clip data.");
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN || intent.getClipData() == null) {
                 return context.getString(R.string.import_error_unhandled_request);
             }
@@ -61,12 +62,14 @@ public class ImportUtils {
 
         // If the file is being sent from a content provider we need to read the content before we can open the file
         if ("content".equals(intent.getData().getScheme())) {
+            Timber.i("Attempting to read content from intent.");
             try {
                 return handleContentProviderFile(context, intent, intent.getData());
             } catch (Exception e) {
                 return context.getString(R.string.import_error_exception, e.getLocalizedMessage());
             }
         } else if ("file".equals(intent.getData().getScheme())) {
+            Timber.i("Attempting to read file from intent.");
             // When the VIEW intent is sent as a file, we can open it directly without copying from content provider
             String filename = intent.getData().getPath();
             Timber.d("Importing regular file: %s", filename);

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -152,6 +152,7 @@
     <string name="import_message_replace_confirm">This will delete your existing collection and replace it with the data of file %s</string>
     <string name="import_message_add_confirm">Add “%s” to collection? This may take a long time</string>
     <string name="import_log_no_apkg">This isn’t a valid Anki package file</string>
+    <string name="import_error_unhandled_request">Unable to process import request</string>
     <string name="import_error_not_apkg_extension">Filename “%s” doesn’t have .apkg or .colpkg extension</string>
     <string name="import_error_content_provider">The selected file couldn’t be imported automatically by AnkiDroid. Please see the user manual for how to manually import anki files: \n%s</string>
     <string name="import_replacing">Replacing collection…</string>

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -153,6 +153,7 @@
     <string name="import_message_add_confirm">Add “%s” to collection? This may take a long time</string>
     <string name="import_log_no_apkg">This isn’t a valid Anki package file</string>
     <string name="import_error_unhandled_request">Unable to process import request</string>
+    <string name="import_error_exception">Failed to import package\n\n%s</string>
     <string name="import_error_not_apkg_extension">Filename “%s” doesn’t have .apkg or .colpkg extension</string>
     <string name="import_error_content_provider">The selected file couldn’t be imported automatically by AnkiDroid. Please see the user manual for how to manually import anki files: \n%s</string>
     <string name="import_replacing">Replacing collection…</string>


### PR DESCRIPTION
## Purpose / Description
A NPE was caused by the file import.

A few stack traces imply that ClipData wasn't being handled correctly, we try to pass this into the content provider API and hope this works.

## Fixes
Fixes #5870

## Approach

* We explicitly handle null.
* We attempt to extract the URI from the clip data.
* We use [Pokémon Exception Handling](https://wiki.c2.com/?PokemonExceptionHandling) to avoid failure.


## How Has This Been Tested?

Untested. My Android still imports correctly.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code

## Review goals

* Line 84: We implicitly return null if the intent is unhandled, this seems unintentional
* The crash report logging may log far too many problems, not sure about your opinion on this.
* (optional) Ask me to unit test this