### PR TITLE
Dependency updates 20200331

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -156,7 +156,7 @@ dependencies {
 
     testImplementation 'org.junit.vintage:junit-vintage-engine:5.6.0'
     testImplementation 'org.mockito:mockito-core:3.3.3'
-    testImplementation 'org.powermock:powermock-core:2.0.5'
+    testImplementation 'org.powermock:powermock-core:2.0.6'
     testImplementation 'org.powermock:powermock-module-junit4:2.0.5'
     testImplementation 'org.powermock:powermock-api-mockito2:2.0.5'
     testImplementation 'org.hamcrest:hamcrest-all:1.3'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -158,7 +158,7 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:3.3.3'
     testImplementation 'org.powermock:powermock-core:2.0.6'
     testImplementation 'org.powermock:powermock-module-junit4:2.0.6'
-    testImplementation 'org.powermock:powermock-api-mockito2:2.0.5'
+    testImplementation 'org.powermock:powermock-api-mockito2:2.0.6'
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
     testImplementation 'net.lachlanmckee:timber-junit-rule:1.0.1'
     testImplementation "org.robolectric:robolectric:4.2.1"

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -154,7 +154,7 @@ dependencies {
     implementation 'org.jsoup:jsoup:1.13.1'
     api project(":api")
 
-    testImplementation 'org.junit.vintage:junit-vintage-engine:5.6.0'
+    testImplementation 'org.junit.vintage:junit-vintage-engine:5.6.1'
     testImplementation 'org.mockito:mockito-core:3.3.3'
     testImplementation 'org.powermock:powermock-core:2.0.6'
     testImplementation 'org.powermock:powermock-module-junit4:2.0.6'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -158,7 +158,7 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:3.3.3'
     testImplementation 'org.powermock:powermock-core:2.0.7'
     testImplementation 'org.powermock:powermock-module-junit4:2.0.6'
-    testImplementation 'org.powermock:powermock-api-mockito2:2.0.6'
+    testImplementation 'org.powermock:powermock-api-mockito2:2.0.7'
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
     testImplementation 'net.lachlanmckee:timber-junit-rule:1.0.1'
     testImplementation "org.robolectric:robolectric:4.2.1"

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -157,7 +157,7 @@ dependencies {
     testImplementation 'org.junit.vintage:junit-vintage-engine:5.6.0'
     testImplementation 'org.mockito:mockito-core:3.3.3'
     testImplementation 'org.powermock:powermock-core:2.0.6'
-    testImplementation 'org.powermock:powermock-module-junit4:2.0.5'
+    testImplementation 'org.powermock:powermock-module-junit4:2.0.6'
     testImplementation 'org.powermock:powermock-api-mockito2:2.0.5'
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
     testImplementation 'net.lachlanmckee:timber-junit-rule:1.0.1'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -156,7 +156,7 @@ dependencies {
 
     testImplementation 'org.junit.vintage:junit-vintage-engine:5.6.1'
     testImplementation 'org.mockito:mockito-core:3.3.3'
-    testImplementation 'org.powermock:powermock-core:2.0.6'
+    testImplementation 'org.powermock:powermock-core:2.0.7'
     testImplementation 'org.powermock:powermock-module-junit4:2.0.6'
     testImplementation 'org.powermock:powermock-api-mockito2:2.0.6'
     testImplementation 'org.hamcrest:hamcrest-all:1.3'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -151,7 +151,7 @@ dependencies {
 
     implementation 'com.jakewharton.timber:timber:4.7.1'
     implementation 'com.google.code.gson:gson:2.8.6'
-    implementation 'org.jsoup:jsoup:1.12.2'
+    implementation 'org.jsoup:jsoup:1.13.1'
     api project(":api")
 
     testImplementation 'org.junit.vintage:junit-vintage-engine:5.6.0'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -2,7 +2,7 @@ import com.android.ddmlib.DdmPreferences
 
 plugins {
  // Gradle plugin portal 
- id 'com.github.triplet.play' version '2.7.2'
+ id 'com.github.triplet.play' version '2.7.3'
 }
 
 apply plugin: 'com.android.application'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -146,7 +146,7 @@ dependencies {
 
     implementation 'net.mikehardy:google-analytics-java7:2.0.13'
     //noinspection GradleDependency
-    implementation 'com.squareup.okhttp3:okhttp:3.12.8'
+    implementation 'com.squareup.okhttp3:okhttp:3.12.10'
     implementation 'com.arcao:slf4j-timber:3.1'
 
     implementation 'com.jakewharton.timber:timber:4.7.1'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -155,7 +155,7 @@ dependencies {
     api project(":api")
 
     testImplementation 'org.junit.vintage:junit-vintage-engine:5.6.0'
-    testImplementation 'org.mockito:mockito-core:3.3.1'
+    testImplementation 'org.mockito:mockito-core:3.3.3'
     testImplementation 'org.powermock:powermock-core:2.0.5'
     testImplementation 'org.powermock:powermock-module-junit4:2.0.5'
     testImplementation 'org.powermock:powermock-api-mockito2:2.0.5'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -157,7 +157,7 @@ dependencies {
     testImplementation 'org.junit.vintage:junit-vintage-engine:5.6.1'
     testImplementation 'org.mockito:mockito-core:3.3.3'
     testImplementation 'org.powermock:powermock-core:2.0.7'
-    testImplementation 'org.powermock:powermock-module-junit4:2.0.6'
+    testImplementation 'org.powermock:powermock-module-junit4:2.0.7'
     testImplementation 'org.powermock:powermock-api-mockito2:2.0.7'
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
     testImplementation 'net.lachlanmckee:timber-junit-rule:1.0.1'

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -43,7 +43,7 @@ android {
 
 dependencies {
     api fileTree(dir: 'libs', include: ['*.jar'])
-    testImplementation 'org.junit.vintage:junit-vintage-engine:5.6.0'
+    testImplementation 'org.junit.vintage:junit-vintage-engine:5.6.1'
     testImplementation "org.robolectric:robolectric:4.2.1"
 }
 


### PR DESCRIPTION
Standard dependency updates - trickle-feeding them in to avoid a big batch at once

Current stack of stable versions we can't merge:
- androidx-browser (requires #5665)
- robolectric (requires some changes in #5151)
- appcompat (requires testing because of #5512 among other issues)
- gradle 6.3 (requires a fix for https://github.com/Triple-T/gradle-play-publisher/issues/797 or move from PKCS12 Google Cloud Platform credentials to JSON, I already pinged @nicolas-raoul about that via email)