### PR TITLE
Fix RenderBrowserQA Race Condition: Crash on no card

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
@@ -864,7 +864,7 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
         List<Map<String,String>> searchResult = col.findCardsForCardBrowser(query, order, deckNames);
         // Render the first few items
         for (int i = 0; i < Math.min(numCardsToRender, searchResult.size()); i++) {
-            Card c = col.getCard(Long.parseLong(searchResult.get(i).get("id"), 10));
+            Card c = col.getCard(Long.parseLong(searchResult.get(i).get("id")));
             CardBrowser.updateSearchItemQA(mContext, searchResult.get(i), c);
         }
         // Finish off the task
@@ -898,7 +898,7 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
             Map<String, String> card = cards.get(i);
             if (card.get("answer") == null) {
                 // Extract card item
-                Card c = col.getCard(Long.parseLong(card.get("id"), 10));
+                Card c = col.getCard(Long.parseLong(card.get("id")));
                 // Update item
                 CardBrowser.updateSearchItemQA(mContext, card, c);
                 float progress = (float) i / n * 100;

--- a/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
@@ -897,7 +897,16 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
             if (i < 0 || i >= cards.size()) {
                 continue;
             }
-            Map<String, String> card = cards.get(i);
+            Map<String, String> card;
+            try {
+                card = cards.get(i);
+            }
+            catch (IndexOutOfBoundsException e) {
+                //even though we test against card.size() above, there's still a race condition
+                //We might be able to optimise this to return here. Logically if we're past the end of the collection,
+                //we won't reach any more cards.
+                continue;
+            }
             if (card.get("answer") == null) {
                 // Extract card item
                 Card c;

--- a/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
@@ -898,7 +898,15 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
             Map<String, String> card = cards.get(i);
             if (card.get("answer") == null) {
                 // Extract card item
-                Card c = col.getCard(Long.parseLong(card.get("id")));
+                Card c;
+                try {
+                    c = col.getCard(Long.parseLong(card.get("id")));
+                } catch (Exception e) {
+                    //#5891 - card can be inconsistent between the deck browser screen and the collection.
+                    //Realistically, we can skip any exception as it's a rendering task which should not kill the
+                    //process
+                    continue;
+                }
                 // Update item
                 CardBrowser.updateSearchItemQA(mContext, card, c);
                 float progress = (float) i / n * 100;

--- a/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
@@ -907,22 +907,24 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
                 //we won't reach any more cards.
                 continue;
             }
-            if (card.get("answer") == null) {
-                // Extract card item
-                Card c;
-                try {
-                    c = col.getCard(Long.parseLong(card.get("id")));
-                } catch (Exception e) {
-                    //#5891 - card can be inconsistent between the deck browser screen and the collection.
-                    //Realistically, we can skip any exception as it's a rendering task which should not kill the
-                    //process
-                    continue;
-                }
-                // Update item
-                CardBrowser.updateSearchItemQA(mContext, card, c);
-                float progress = (float) i / n * 100;
-                publishProgress(new TaskData((int) progress));
+            if (card.get("answer") != null) {
+                //We've already rendered the answer, we don't need to do it again.
+                continue;
             }
+            // Extract card item
+            Card c;
+            try {
+                c = col.getCard(Long.parseLong(card.get("id")));
+            } catch (Exception e) {
+                //#5891 - card can be inconsistent between the deck browser screen and the collection.
+                //Realistically, we can skip any exception as it's a rendering task which should not kill the
+                //process
+                continue;
+            }
+            // Update item
+            CardBrowser.updateSearchItemQA(mContext, card, c);
+            float progress = (float) i / n * 100;
+            publishProgress(new TaskData((int) progress));
         }
         return new TaskData(cards);
     }

--- a/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
@@ -892,16 +892,17 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
                 Timber.d("doInBackgroundRenderBrowserQA was aborted");
                 return null;
             }
-            if (i >= 0 && i < cards.size()) {
-                Map<String, String> card = cards.get(i);
-                if (card.get("answer") == null) {
-                    // Extract card item
-                    Card c = col.getCard(Long.parseLong(card.get("id"), 10));
-                    // Update item
-                    CardBrowser.updateSearchItemQA(mContext, card, c);
-                    float progress = (float) i / n * 100;
-                    publishProgress(new TaskData((int) progress));
-                }
+            if (i < 0 || i >= cards.size()) {
+                continue;
+            }
+            Map<String, String> card = cards.get(i);
+            if (card.get("answer") == null) {
+                // Extract card item
+                Card c = col.getCard(Long.parseLong(card.get("id"), 10));
+                // Update item
+                CardBrowser.updateSearchItemQA(mContext, card, c);
+                float progress = (float) i / n * 100;
+                publishProgress(new TaskData((int) progress));
             }
         }
         return new TaskData(cards);

--- a/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
@@ -879,6 +879,8 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
 
 
     private TaskData doInBackgroundRenderBrowserQA(TaskData... params) {
+        //TODO: Convert this to accept the following to make thread-safe:
+        //(Range<Position>, Function<Position, BrowserCard>)
         Timber.d("doInBackgroundRenderBrowserQA");
         Collection col = CollectionHelper.getInstance().getCol(mContext);
         List<Map<String, String>> cards = (List<Map<String, String>>) params[0].getObjArray()[0];


### PR DESCRIPTION
## Purpose / Description

We fix a few race conditions and clean up the code of RenderBrowserQA

## Fixes
Fixes #5891 

## Approach
Try-catch-continue

## How Has This Been Tested?

Card Browser still works on my phone. Since we're adding catch statements, there should be 

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code