### PR TITLE
Add Diagnostic Logging to Collection.close

### DIFF
--- a/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/ContentProviderTest.java
+++ b/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/ContentProviderTest.java
@@ -976,7 +976,7 @@ public class ContentProviderTest {
     }
 
     private Collection reopenCol() {
-        CollectionHelper.getInstance().closeCollection(false);
+        CollectionHelper.getInstance().closeCollection(false, "ContentProviderTest: reopenCol");
         return CollectionHelper.getInstance().getCol(InstrumentationRegistry.getInstrumentation().getTargetContext());
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
@@ -135,8 +135,8 @@ public class CollectionHelper {
      * Close the {@link Collection}, optionally saving
      * @param save whether or not save before closing
      */
-    public synchronized void closeCollection(boolean save) {
-        Timber.i("closeCollection");
+    public synchronized void closeCollection(boolean save, String reason) {
+        Timber.i("closeCollection: %s", reason);
         if (mCollection != null) {
             mCollection.close(save);
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -1375,7 +1375,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
 
     public void exit() {
-        CollectionHelper.getInstance().closeCollection(false);
+        CollectionHelper.getInstance().closeCollection(false, "DeckPicker:exit()");
         finishWithoutAnimation();
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
@@ -237,7 +237,7 @@ public abstract class NavigationDrawerActivity extends AnkiActivity implements N
                 }
             } else {
                 // collection path has changed so kick the user back to the DeckPicker
-                CollectionHelper.getInstance().closeCollection(true);
+                CollectionHelper.getInstance().closeCollection(true, "Preference Modification: collection path changed");
                 restartActivityInvalidateBackstack(this);
             }
         } else {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.java
@@ -229,7 +229,7 @@ public class DatabaseErrorDialog extends AsyncDialogFragment {
                         .positiveText(res.getString(R.string.dialog_positive_create))
                         .negativeText(res.getString(R.string.dialog_cancel))
                         .onPositive((inner_dialog, which) -> {
-                            CollectionHelper.getInstance().closeCollection(false);
+                            CollectionHelper.getInstance().closeCollection(false, "DatabaseErrorDialog: Before Create New Collection");
                             String path1 = CollectionHelper.getCollectionPath(getActivity());
                             if (BackupManager.moveDatabaseToBrokenFolder(path1, false)) {
                                 ((DeckPicker) getActivity()).restartActivity();

--- a/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
@@ -922,7 +922,7 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
             return new TaskData(false);
         } else {
             // Close the collection and we restart the app to reload
-            CollectionHelper.getInstance().closeCollection(true);
+            CollectionHelper.getInstance().closeCollection(true, "Check Database Completed");
             return new TaskData(0, result, true);
         }
     }
@@ -1063,7 +1063,7 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
         publishProgress(new TaskData(res.getString(R.string.importing_collection)));
         if (col != null) {
             // unload collection and trigger a backup
-            CollectionHelper.getInstance().closeCollection(true);
+            CollectionHelper.getInstance().closeCollection(true, "Importing new collection");
             CollectionHelper.getInstance().lockCollection();
             BackupManager.performBackupInBackground(colPath, true);
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DB.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DB.java
@@ -120,7 +120,7 @@ public class DB {
         public void onCorruption(SupportSQLiteDatabase db) {
             Timber.e("The database has been corrupted: %s", db.getPath());
             AnkiDroidApp.sendExceptionReport(new RuntimeException("Database corrupted"), "DB.MyDbErrorHandler.onCorruption", "Db has been corrupted: " + db.getPath());
-            CollectionHelper.getInstance().closeCollection(false);
+            CollectionHelper.getInstance().closeCollection(false, "Database corrupted");
             DatabaseErrorDialog.databaseCorruptFlag = true;
         }
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
@@ -48,7 +48,7 @@ public class RobolectricTest {
     @After
     public void tearDown() {
         // If you don't tear down the database you'll get unexpected IllegalStateExceptions related to connections
-        CollectionHelper.getInstance().closeCollection(false);
+        CollectionHelper.getInstance().closeCollection(false, "RoboelectricTest: End");
 
         // After every test, make sure the sqlite implementation is set back to default
         DB.setSqliteOpenHelperFactory(null);


### PR DESCRIPTION
## Purpose / Description

We have many async crashes relating to the collection being null, it'll be useful to understand the underlying reason that the collection is null in these cases.

I'm adding this because I can replicate one crash by changing the AnkiDroid directory whilst calculating stats, but I doubt this is the path which was taken to cause the crash.

## Fixes
N/A

## Approach
Adding additional string param to method

## How Has This Been Tested?

Anki still works, tests still pass

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code