### PR TITLE
Reviewer: Action Bar buttons disabled while DeckTask working

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -360,6 +360,9 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
     /** Lock to allow thread-safe regeneration of mCard */
     private ReadWriteLock mCardLock = new ReentrantReadWriteLock();
 
+    /** whether controls are currently blocked */
+    private boolean mControlBlocked = true;
+
     // private int zEase;
 
     // ----------------------------------------------------------------------------
@@ -2373,6 +2376,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
 
 
     private void unblockControls() {
+        mControlBlocked = false;
         mCardFrame.setEnabled(true);
         mFlipCardLayout.setEnabled(true);
 
@@ -2426,6 +2430,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
 
 
     private void blockControls() {
+        mControlBlocked = true;
         mCardFrame.setEnabled(false);
         mFlipCardLayout.setEnabled(false);
         mTouchLayer.setVisibility(View.INVISIBLE);
@@ -3205,5 +3210,9 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
     void loadInitialCard() {
         DeckTask.launchDeckTask(DeckTask.TASK_TYPE_ANSWER_CARD, mAnswerCardHandler,
                 new DeckTask.TaskData(null, 0));
+    }
+
+    public boolean getControlBlocked() {
+        return mControlBlocked;
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -2426,6 +2426,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
         }
         mTouchLayer.setVisibility(View.VISIBLE);
         mInAnswer = false;
+        invalidateOptionsMenu();
     }
 
 
@@ -2480,6 +2481,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
         if (typeAnswer()) {
             mAnswerField.setEnabled(false);
         }
+        invalidateOptionsMenu();
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1187,6 +1187,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
 
     protected void undo() {
         if (getCol().undoAvailable()) {
+            blockControls();
             DeckTask.launchDeckTask(DeckTask.TASK_TYPE_UNDO, mAnswerCardHandler);
         }
     }
@@ -2865,6 +2866,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
     }
 
     protected void dismiss(Collection.DismissType type) {
+        blockControls();
         DeckTask.launchDeckTask(DeckTask.TASK_TYPE_DISMISS, mDismissCardHandler,
                 new DeckTask.TaskData(new Object[]{mCurrentCard, type}));
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -759,7 +759,7 @@ public class Reviewer extends AbstractFlashcardViewer {
      * @return true if there is another card of same note that could be dismissed
      */
     private boolean dismissNoteAvailable(DismissType type) {
-        if (mCurrentCard == null || mCurrentCard.note() == null || mCurrentCard.note().cards().size() < 2) {
+        if (mCurrentCard == null || mCurrentCard.note() == null || mCurrentCard.note().cards().size() < 2 || getControlBlocked()) {
             return false;
         }
         List<Card> cards = mCurrentCard.note().cards();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -367,7 +367,20 @@ public class Reviewer extends AbstractFlashcardViewer {
     private void setCustomButtons(Menu menu) {
         for(int itemId : mCustomButtons.keySet()) {
             if(mCustomButtons.get(itemId) != MENU_DISABLED) {
-                menu.findItem(itemId).setShowAsAction(mCustomButtons.get(itemId));
+                MenuItem item = menu.findItem(itemId);
+                item.setShowAsAction(mCustomButtons.get(itemId));
+                Drawable icon = item.getIcon();
+                if (getControlBlocked()) {
+                    item.setEnabled(false);
+                    if (icon != null) {
+                        icon.setAlpha(Themes.ALPHA_ICON_DISABLED_LIGHT);
+                    }
+                } else {
+                    item.setEnabled(true);
+                    if (icon != null) {
+                        icon.setAlpha(Themes.ALPHA_ICON_ENABLED_LIGHT);
+                    }
+                }
             }
             else {
                 menu.findItem(itemId).setVisible(false);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -423,14 +423,12 @@ public class Reviewer extends AbstractFlashcardViewer {
         if (mShowWhiteboard && mWhiteboard != null && mWhiteboard.undoSize() > 0) {
             // Whiteboard undo queue non-empty. Switch the undo icon to a whiteboard specific one.
             menu.findItem(R.id.action_undo).setIcon(R.drawable.ic_eraser_variant_white_24dp);
-            menu.findItem(R.id.action_undo).setEnabled(true).getIcon().setAlpha(Themes.ALPHA_ICON_ENABLED_LIGHT);
         } else if (mShowWhiteboard && mWhiteboard != null && mWhiteboard.isUndoModeActive()) {
             // Whiteboard undo queue empty, but user has added strokes to it for current card. Disable undo button.
             menu.findItem(R.id.action_undo).setIcon(R.drawable.ic_eraser_variant_white_24dp);
             menu.findItem(R.id.action_undo).setEnabled(false).getIcon().setAlpha(Themes.ALPHA_ICON_DISABLED_LIGHT);
         } else if (colIsOpen() && getCol().undoAvailable()) {
             menu.findItem(R.id.action_undo).setIcon(R.drawable.ic_undo_white_24dp);
-            menu.findItem(R.id.action_undo).setEnabled(true).getIcon().setAlpha(Themes.ALPHA_ICON_ENABLED_LIGHT);
         } else {
             menu.findItem(R.id.action_undo).setIcon(R.drawable.ic_undo_white_24dp);
             menu.findItem(R.id.action_undo).setEnabled(false).getIcon().setAlpha(Themes.ALPHA_ICON_DISABLED_LIGHT);


### PR DESCRIPTION
#  Pull Request template

## Purpose / Description
Some actions can take more than 15 seconds on my phone. This is mostly
due to a huge number of deck (and a bad way of dealing with a lot of
deck in scheduler)

Buttons are still activated. That can be shown because if you click on
"bury" the list will open once the new card is loaded. The problem is
that it's not clear at all to me (even when I look at the code) on
which card the action are taken. If I press twice on bury, will it
also bury the next card ? is the action ignored ? Does the scheduler
tries to bury/review/suspend... multiple time the same card ?

This is even more worrysome when I click on the undo button, where
I've no clue whether the click is registered or not, and whether
multiple undo will be done...

## Fixes

I remove buttons while they can't be used because the card is not fixed, and put them back when the new card is loaded.

## Approach
I ensure that less confusion arrive by setting the card to `null` while waiting for the new card to load, and then removing the buttons until the cards are loaded. I call the link to 

I created a method which should be called when card will be changed. It sets mCurrentCard to null and call the method to draw the bars. This method then state not to put any buttons if mCurrentCard is null.

## How Has This Been Tested?

I put it on my phone. Used my big collection (where each bury/suspend takes 15 seconds), I review (and everything works as before), and I suspend/bury, and now button disappear, and reappear when the new card arrive

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
