### PR TITLE
CardBrowser: Fix crash on deleted card

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1440,16 +1440,27 @@ public class CardBrowser extends NavigationDrawerActivity implements
      * Removes cards from view. Doesn't delete them in model (database).
      */
     private void removeNotesView(Card[] cards) {
+        List<Long> cardIds = new ArrayList<>(cards.length);
+        for (Card c : cards) {
+            cardIds.add(c.getId());
+        }
+        removeNotesView(cardIds);
+    }
+
+    /**
+     * Removes cards from view. Doesn't delete them in model (database).
+     */
+    private void removeNotesView(java.util.Collection<Long> cardsIds) {
         long reviewerCardId = getReviewerCardId();
         List<Map<String, String>> oldMCards = getCards();
         Map<Long, Integer> idToPos = getPositionMap(oldMCards);
         Set<Long> idToRemove = new HashSet<Long>();
-        for (Card card : cards) {
-            if (card.getId() == reviewerCardId) {
+        for (Long cardId : cardsIds) {
+            if (cardId == reviewerCardId) {
                 mReloadRequired = true;
             }
-            if (idToPos.containsKey(card.getId())) {
-                idToRemove.add(card.getId());
+            if (idToPos.containsKey(cardId)) {
+                idToRemove.add(cardId);
             }
         }
 
@@ -1462,7 +1473,6 @@ public class CardBrowser extends NavigationDrawerActivity implements
         mCards = newMCards;
         updateList();
     }
-
 
     private DeckTask.TaskListener mSuspendCardHandler = new ListenerWithProgressBarCloseOnFalse() {
         @Override

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1796,7 +1796,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
          */
         private int getColor(Map<String, String> card) {
             boolean suspended = "True".equals(card.get("suspended"));
-            int flag = new Integer(card.get("flags"));
+            int flag = getFlagOrDefault(card, 0);
             boolean marked = card.get("marked") != null ;
             switch (flag) {
                 case 1:
@@ -1850,6 +1850,22 @@ public class CardBrowser extends NavigationDrawerActivity implements
         }
 
     }
+
+
+    private int getFlagOrDefault(Map<String, String> card, int defaultValue) {
+        String flagValue = card.get("flag");
+        if (flagValue == null) {
+            Timber.w("Unable to obtain flag for card: '%s'. Returning %d", card.get("id"), defaultValue);
+            return defaultValue;
+        }
+        try {
+            return Integer.parseInt(flagValue);
+        } catch (Exception e) {
+            Timber.e(e, "couldn't parse flag value: %s", flagValue);
+            return defaultValue;
+        }
+    }
+
 
     private void onCheck(int position, View cell) {
         CheckBox checkBox = (CheckBox) cell.findViewById(R.id.card_checkbox);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1439,18 +1439,19 @@ public class CardBrowser extends NavigationDrawerActivity implements
     /**
      * Removes cards from view. Doesn't delete them in model (database).
      */
-    private void removeNotesView(Card[] cards) {
+    private void removeNotesView(Card[] cards, boolean reorderCards) {
         List<Long> cardIds = new ArrayList<>(cards.length);
         for (Card c : cards) {
             cardIds.add(c.getId());
         }
-        removeNotesView(cardIds);
+        removeNotesView(cardIds, reorderCards);
     }
 
     /**
      * Removes cards from view. Doesn't delete them in model (database).
+     * @param reorderCards Whether to rearrange the positions of checked items (DEFECT: Currently deselects all)
      */
-    private void removeNotesView(java.util.Collection<Long> cardsIds) {
+    private void removeNotesView(java.util.Collection<Long> cardsIds, boolean reorderCards) {
         long reviewerCardId = getReviewerCardId();
         List<Map<String, String>> oldMCards = getCards();
         Map<Long, Integer> idToPos = getPositionMap(oldMCards);
@@ -1471,6 +1472,15 @@ public class CardBrowser extends NavigationDrawerActivity implements
             }
         }
         mCards = newMCards;
+
+        if (reorderCards) {
+            //Suboptimal from a UX perspective, we should reorder
+            //but this is only hit on a rare sad path and we'd need to rejig the data structures to allow an efficient
+            //search
+            Timber.w("Removing current selection due to unexpected removal of cards");
+            onSelectNone();
+        }
+
         updateList();
     }
 
@@ -1499,7 +1509,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
         @Override
         public void onProgressUpdate(DeckTask.TaskData... values) {
             Card[] cards = (Card[]) values[0].getObjArray();
-            removeNotesView(cards);
+            //we don't need to reorder cards here as we've already deselected all notes,
+            removeNotesView(cards, false);
         }
 
 
@@ -1574,6 +1585,18 @@ public class CardBrowser extends NavigationDrawerActivity implements
         @Override
         public void onPostExecute(TaskData result) {
             if (result != null) {
+                if (result.getObjArray() != null && result.getObjArray().length > 1) {
+                    try {
+                        @SuppressWarnings("unchecked")
+                        List<Long> cardsIdsToHide = (List<Long>) result.getObjArray()[1];
+                        if (cardsIdsToHide.size() > 0) {
+                            Timber.i("Removing %d invalid cards from view", cardsIdsToHide.size());
+                            removeNotesView(cardsIdsToHide, true);
+                        }
+                    } catch (Exception e) {
+                        Timber.e(e, "failed to hide cards");
+                    }
+                }
                 hideProgressBar();
                 mCardsAdapter.notifyDataSetChanged();
                 Timber.d("Completed doInBackgroundRenderBrowserQA Successfuly");
@@ -1972,25 +1995,68 @@ public class CardBrowser extends NavigationDrawerActivity implements
         mActionBarTitle.setVisibility(View.GONE);
     }
 
-    @VisibleForTesting
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     boolean isInMultiSelectMode() {
         return mInMultiSelectMode;
     }
 
-    @VisibleForTesting
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     long cardCount() {
         return mCards.size();
     }
 
-    @VisibleForTesting
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
      boolean isShowingSelectAll() {
         return mActionBarMenu != null && mActionBarMenu.findItem(R.id.action_select_all).isVisible();
     }
 
-    @VisibleForTesting
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     boolean isShowingSelectNone() {
         return mActionBarMenu != null &&
                 mActionBarMenu.findItem(R.id.action_select_none) != null && //
                 mActionBarMenu.findItem(R.id.action_select_none).isVisible();
     }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    void clearCardData(int position) {
+        String id = mCards.get(position).get("id");
+        mCards.get(position).clear();
+        mCards.get(position).put("id", id);
+    }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    void rerenderAllCards() {
+        DeckTask.launchDeckTask(DeckTask.TASK_TYPE_RENDER_BROWSER_QA, mRenderQAHandler,
+                new DeckTask.TaskData(new Object[]{getCards(), 0, mCards.size()-1}));
+    }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    long[] getCardIds() {
+        @SuppressWarnings("unchecked")
+        Map<String, String>[] cardsCopy = mCards.toArray(new Map[0]);
+        long[] ret = new long[cardsCopy.length];
+        for (int i = 0; i < cardsCopy.length; i++) {
+            ret[i] = Long.parseLong(cardsCopy[i].get("id"));
+        }
+        return ret;
+    }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    void checkedCardsAtPositions(int[] positions) {
+        for (int i = 0; i < positions.length; i++) {
+            mCheckedCardPositions.add(positions[i]);
+        }
+        onSelectionChanged();
+    }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    boolean hasCheckedCardAtPosition(int i) {
+        return mCheckedCardPositions.contains(i);
+    }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    public int checkedCardCount() {
+        return mCheckedCardPositions.size();
+    }
+
 }

--- a/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/DeckTask.java
@@ -915,12 +915,14 @@ public class DeckTask extends BaseAsyncTask<DeckTask.TaskData, DeckTask.TaskData
             }
             // Extract card item
             Card c;
+            String cardId = card.get("id");
             try {
-                c = col.getCard(Long.parseLong(card.get("id")));
+                c = col.getCard(Long.parseLong(cardId));
             } catch (Exception e) {
                 //#5891 - card can be inconsistent between the deck browser screen and the collection.
                 //Realistically, we can skip any exception as it's a rendering task which should not kill the
                 //process
+                Timber.e(e, "Could not process card '%s' - skipping", cardId);
                 continue;
             }
             // Update item


### PR DESCRIPTION
## Purpose / Description
We get a crash if trying to render a card with no flag in the properties

## Fixes
Fixes #5900

## Approach
We apply two fixes for this: 

1. Don't crash if we don't have a flag set and assume no flag.
2. If cards cannot be rendered due to them being deleted, remove them from the browser search results and deselect all cards.

## How Has This Been Tested?

Unit tested, browser still works on my phone

##Defects

* It would be ideal to reorder the selections when a note is deleted. This is not implemented as it may add significant latency  (I can easily select 30k cards) and the data strucutres currently in use don't seem appropriate for writing an efficient algorithm.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code