### PR TITLE
Don't re-initialise AnkiDroidApp if resources is null

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -195,6 +195,14 @@ public class AnkiDroidApp extends Application {
     @Override
     public void onCreate() {
         super.onCreate();
+        if (sInstance != null) {
+            Timber.i("onCreate() called multiple times");
+            //5887 - fix crash.
+            if (sInstance.getResources() == null) {
+                Timber.w("Skipping re-initialisation - no resources. Maybe uninstalling app?");
+                return;
+            }
+        }
         sInstance = this;
         // Get preferences
         SharedPreferences preferences = getSharedPrefs(this);


### PR DESCRIPTION
## Purpose / Description

From a crash report: it seems that OnCreate can be called twice, with no resources on the second call. This causes a crash in ACRA init.

Instead, as the logic assumes that onCreate() is only called once. We can just log and return and let Android do its thing.

I presume this is from an uninstall, as from reading, this happens when the resources directory doesn't exist.

## Fixes
Fixes #5887

## Approach
Check for null resources and return 

## How Has This Been Tested?

None 🤠 

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code