### PR TITLE
Switch to JSON for Google Play credentials

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -101,8 +101,7 @@ android {
 }
 
 play {
-    serviceAccountEmail = '294046724212-r3bef6kl46pb9gk0h1pl5rcjmpfrdpjl@developer.gserviceaccount.com'
-    serviceAccountCredentials = file("${homePath}/src/583631bdd16d.p12")
+    serviceAccountCredentials = file("${homePath}/src/AnkiDroid-GCP-Publish-Credentials.json")
     track = 'alpha'
 }
 


### PR DESCRIPTION
This fixes a deprecation noted in the play publishing plugin we use

This will unblock the dependency update of gradle-6.3 as there is an incompatibility between play publisher plugin in PKCS12 credential mode and gradle 6.3