### PR TITLE
restrict to use system web browser

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/utils/AdaptionUtil.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/AdaptionUtil.java
@@ -2,6 +2,8 @@ package com.ichi2.utils;
 
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.net.Uri;
@@ -17,15 +19,38 @@ public class AdaptionUtil {
         if (sHasRunWebBrowserCheck) {
             return sHasWebBrowser;
         }
-        
+
         Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse("http://www.google.com"));
         PackageManager pm = context.getPackageManager();
         List<ResolveInfo> list = pm.queryIntentActivities(intent, PackageManager.MATCH_DEFAULT_ONLY);
         if (list.size() == 0) {
             sHasWebBrowser = false;
+        } else {
+            sHasWebBrowser = false;
+            for (ResolveInfo ri:list) {
+                String pacagename = ri.activityInfo.packageName;
+                if (isSystemApp(pacagename, pm)) {
+                    sHasWebBrowser = true;
+                    break;
+                }
+            }
         }
         sHasRunWebBrowserCheck = true;
         return sHasWebBrowser;
+    }
+
+    private static boolean isSystemApp(String packageName, PackageManager pm){
+        if (packageName != null) {
+            try {
+                PackageInfo info = pm.getPackageInfo(packageName, 0);
+                return (info != null) && (info.applicationInfo != null) &&
+                        ((info.applicationInfo.flags & ApplicationInfo.FLAG_SYSTEM) != 0);
+            } catch (PackageManager.NameNotFoundException e) {
+                return false;
+            }
+        } else {
+            return false;
+        }
     }
 
     public static boolean hasReducedPreferences(){


### PR DESCRIPTION
Signed-off-by: landinggao <gaoyingjun@xiaomi.com>

## Pull Request template

## Purpose / Description
On device without system web browser, we don't want user use web browser. But if there some other third part apk for some reason has web browser capability, the restriction on using web browser will be invalide. 

## Fixes
When to check web browser, only when there is system app has web browser capability, we think the device support web browser.

## Approach
Even there is third party apk has browser capability, can't open external link.

## How Has This Been Tested?

Test on mobile and Xiaomi AI teacher.



## Checklist
_Please, go through these checks before submitting the PR._

- [ ] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
