### PR TITLE
Reviewer <-> Editor - Handle Don't keep Activities 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1098,7 +1098,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
                         new DeckTask.TaskData(mCurrentCard, true));
             } else if (resultCode == RESULT_CANCELED && !(data!=null && data.hasExtra("reloadRequired"))) {
                 // nothing was changed by the note editor so just redraw the card
-                fillFlashcard();
+                redrawCard();
             }
         } else if (requestCode == DECK_OPTIONS && resultCode == RESULT_OK) {
             getCol().getSched().reset();
@@ -1119,6 +1119,21 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
     protected long getParentDid() {
         long deckID = getCol().getDecks().selected();
         return deckID;
+    }
+
+    private void redrawCard() {
+        //#3654 We can call this from ActivityResult, which could mean that the card content hasn't yet been set
+        //if the activity was destroyed. In this case, just wait until onCollectionLoaded callback succeeds.
+        if (hasLoadedCardContent()) {
+            fillFlashcard();
+        } else {
+            Timber.i("Skipping card redraw - card still initialising.");
+        }
+    }
+
+    /** Whether the callback to onCollectionLoaded has loaded card content */
+    private boolean hasLoadedCardContent() {
+        return mCardContent != null;
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -2549,6 +2549,10 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
     public void fillFlashcard() {
         Timber.d("fillFlashcard()");
         Timber.d("base url = %s", mBaseUrl);
+        if (mCardContent == null) {
+            Timber.w("fillFlashCard() called with no card content");
+            return;
+        }
         final String cardContent = mCardContent.toString();
         processCardAction(card -> loadContentIntoCard(card, cardContent));
         if (mShowTimer && mCardTimer.getVisibility() == View.INVISIBLE) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -92,7 +92,6 @@ import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Consts;
 import com.ichi2.libanki.Note;
-import com.ichi2.libanki.Sched;
 import com.ichi2.libanki.Sound;
 import com.ichi2.libanki.Utils;
 import com.ichi2.libanki.template.Template;


### PR DESCRIPTION
## Purpose / Description

Crash flagged by Xiaomi alpha testing: https://couchdb.ankidroid.org/acralyzer/_design/acralyzer/index.html#/report-details/b53866f8-7298-413c-a79d-9bc98b0c6feb

This was caused by trying to call `fillFlashCard()` before the collection had been reloaded.

## Fixes
Part of #3654 

## Approach

We can avoid the call and let the AsyncTask callback handle the redraw

## How Has This Been Tested?

On my Android

1. Enable Don't Keep Activities
2. Load Card
3. Load Editor
4. Load Card

Previously crashes, now works as expected.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code