### PR TITLE
Fix Crash on Unreadable Gallery Image

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
@@ -68,7 +68,8 @@ import timber.log.Timber;
 
 public class BasicImageFieldController extends FieldControllerBase implements IFieldController {
 
-    private static final int ACTIVITY_SELECT_IMAGE = 1;
+    @VisibleForTesting
+    static final int ACTIVITY_SELECT_IMAGE = 1;
     private static final int ACTIVITY_TAKE_PICTURE = 2;
     private static final int IMAGE_SAVE_MAX_WIDTH = 1920;
 
@@ -225,8 +226,17 @@ public class BasicImageFieldController extends FieldControllerBase implements IF
         }
         mImageFileSizeWarning.setVisibility(View.GONE);
         if (requestCode == ACTIVITY_SELECT_IMAGE) {
-            handleSelectImageIntent(data);
+            try {
+                handleSelectImageIntent(data);
+                mImageFileSizeWarning.setVisibility(View.GONE);
+            } catch (Exception e) {
+                AnkiDroidApp.sendExceptionReport(e, "BasicImageFieldController - handleSelectImageIntent");
+                Timber.e(e, "Failed to select image");
+                UIUtils.showThemedToast(mActivity, mActivity.getResources().getString(R.string.multimedia_editor_something_wrong), false);
+                return;
+            }
         } else if (requestCode == ACTIVITY_TAKE_PICTURE) {
+            mImageFileSizeWarning.setVisibility(View.GONE);
             String imagePath = rotateAndCompress(mTempCameraImagePath);
             mField.setImagePath(imagePath);
             mField.setHasTemporaryMedia(true);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
@@ -223,18 +223,7 @@ public class BasicImageFieldController extends FieldControllerBase implements IF
         }
         mImageFileSizeWarning.setVisibility(View.GONE);
         if (requestCode == ACTIVITY_SELECT_IMAGE) {
-            Uri selectedImage = data.getData();
-            // Timber.d(selectedImage.toString());
-            String[] filePathColumn = { MediaColumns.DATA };
-
-            Cursor cursor = mActivity.getContentResolver().query(selectedImage, filePathColumn, null, null, null);
-            cursor.moveToFirst();
-
-            int columnIndex = cursor.getColumnIndex(filePathColumn[0]);
-            String filePath = cursor.getString(columnIndex);
-            cursor.close();
-
-            mField.setImagePath(filePath);
+            handleSelectImageIntent(data);
         } else if (requestCode == ACTIVITY_TAKE_PICTURE) {
             String imagePath = rotateAndCompress(mTempCameraImagePath);
             mField.setImagePath(imagePath);
@@ -242,6 +231,23 @@ public class BasicImageFieldController extends FieldControllerBase implements IF
         }
         setPreviewImage(mField.getImagePath(), getMaxImageSize());
     }
+
+
+    private void handleSelectImageIntent(Intent data) {
+        Uri selectedImage = data.getData();
+        // Timber.d(selectedImage.toString());
+        String[] filePathColumn = { MediaColumns.DATA };
+
+        Cursor cursor = mActivity.getContentResolver().query(selectedImage, filePathColumn, null, null, null);
+        cursor.moveToFirst();
+
+        int columnIndex = cursor.getColumnIndex(filePathColumn[0]);
+        String filePath = cursor.getString(columnIndex);
+        cursor.close();
+
+        mField.setImagePath(filePath);
+    }
+
 
     @Override
     public void onFocusLost() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
@@ -48,7 +48,9 @@ import android.widget.LinearLayout;
 import android.widget.LinearLayout.LayoutParams;
 import android.widget.TextView;
 
+import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.R;
+import com.ichi2.anki.UIUtils;
 import com.ichi2.compat.CompatHelper;
 import com.ichi2.utils.BitmapUtil;
 import com.ichi2.utils.ExifUtil;
@@ -228,6 +230,9 @@ public class BasicImageFieldController extends FieldControllerBase implements IF
             String imagePath = rotateAndCompress(mTempCameraImagePath);
             mField.setImagePath(imagePath);
             mField.setHasTemporaryMedia(true);
+        } else {
+            Timber.w("Unhandled request code: %d", requestCode);
+            return;
         }
         setPreviewImage(mField.getImagePath(), getMaxImageSize());
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivityTestBase.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivityTestBase.java
@@ -10,12 +10,15 @@ import com.ichi2.anki.multimediacard.fields.IField;
 import com.ichi2.anki.multimediacard.fields.IFieldController;
 import com.ichi2.anki.multimediacard.impl.MultimediaEditableNote;
 
+import org.mockito.Mockito;
 import org.robolectric.Robolectric;
 import org.robolectric.Shadows;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.shadows.ShadowApplication;
 
 import androidx.test.core.app.ApplicationProvider;
+
+import static org.mockito.Mockito.when;
 
 public abstract class MultimediaEditFieldActivityTestBase extends RobolectricTest {
 
@@ -49,5 +52,12 @@ public abstract class MultimediaEditFieldActivityTestBase extends RobolectricTes
 
 
         return testCardTemplatePreviewer.getFieldController();
+    }
+
+    protected MultimediaEditFieldActivity setupActivityMock(IFieldController controller, MultimediaEditFieldActivity mActivity) {
+        MultimediaEditFieldActivity activity = Mockito.mock(MultimediaEditFieldActivity.class);
+        when(activity.getResources()).thenReturn(mActivity.getResources());
+        controller.setEditingActivity(activity);
+        return activity;
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldControllerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldControllerTest.java
@@ -1,6 +1,13 @@
 package com.ichi2.anki.multimediacard.fields;
 
+import android.app.Activity;
+import android.content.ContentResolver;
+import android.content.Intent;
+
+import com.ichi2.anki.multimediacard.activity.MultimediaEditFieldActivity;
 import com.ichi2.anki.multimediacard.activity.MultimediaEditFieldActivityTestBase;
+import com.ichi2.testutils.AnkiAssert;
+import com.ichi2.testutils.MockContentResolver;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -63,6 +70,24 @@ public class BasicImageFieldControllerTest extends MultimediaEditFieldActivityTe
         assertThat("A broken existing file should not display a preview",
                 controller.isShowingPreview(),
                 is(false));
+    }
+
+
+    @Test
+    public void invalidImageResultDoesNotCrashController() {
+        BasicImageFieldController controller = getValidControllerNoImage();
+        MultimediaEditFieldActivity activity = setupActivityMock(controller, controller.mActivity);
+
+        ContentResolver mock = MockContentResolver.returningEmptyCursor();
+        when(activity.getContentResolver()).thenReturn(mock);
+
+        //Act & Assert
+        AnkiAssert.assertDoesNotThrow(() -> performImageResult(controller, new Intent()));
+    }
+
+
+    private void performImageResult(BasicImageFieldController controller, Intent intent) {
+        controller.onActivityResult(BasicImageFieldController.ACTIVITY_SELECT_IMAGE, Activity.RESULT_OK, intent);
     }
 
     @CheckResult

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/AnkiAssert.java
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/AnkiAssert.java
@@ -1,6 +1,7 @@
 package com.ichi2.testutils;
 
 import androidx.annotation.NonNull;
+import timber.log.Timber;
 
 import org.junit.Assert;
 
@@ -12,6 +13,7 @@ public class AnkiAssert {
         try {
             runnable.run();
         } catch (Exception e) {
+            Timber.e(e);
             Assert.fail();
         }
     }

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/MockContentResolver.java
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/MockContentResolver.java
@@ -1,0 +1,24 @@
+package com.ichi2.testutils;
+
+import android.content.ContentResolver;
+import android.database.Cursor;
+
+import org.mockito.Mockito;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+public class MockContentResolver {
+
+    public static ContentResolver returningCursor(Cursor cursor) {
+        ContentResolver resolver = Mockito.mock(ContentResolver.class);
+        when(resolver.query(any(), any(), any(), any(), any())).thenReturn(cursor);
+        return resolver;
+    }
+
+    public static ContentResolver returningEmptyCursor() {
+        return returningCursor(MockCursor.getEmpty());
+    }
+
+
+}

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/MockCursor.java
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/MockCursor.java
@@ -1,0 +1,20 @@
+package com.ichi2.testutils;
+
+import android.database.Cursor;
+import android.database.CursorWrapper;
+
+import org.mockito.Mockito;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.when;
+
+public class MockCursor {
+
+    public static Cursor getEmpty() {
+        //Couldn't just mock cursor
+        Cursor mockCursor = Mockito.mock(CursorWrapper.class);
+        when(mockCursor.moveToFirst()).thenReturn(false);
+        when(mockCursor.getString(anyInt())).thenThrow(new IllegalStateException());
+        return mockCursor;
+    }
+}


### PR DESCRIPTION
## Purpose / Description

Crash caused due to being unable to decode the following intent.

```
Failure delivering result ResultInfo{who=null, request=1, result=-1, 
data=Intent { dat=content://com.simplemobiletools.gallery.provider/external_files/data/data/com.simplemobiletools.gallery/files/storage/emulated/0/Pictures/Screenshots/[REDACTED] typ=image/png flg=0x1 }}
 to activity {com.ichi2.anki/com.ichi2.anki.multimediacard.activity.MultimediaEditFieldActivity}: java.lang.IllegalStateException: Couldn't read row 0, col -1 from CursorWindow. Make sure the Cursor is initialized correctly before accessing data from it.
```

## Fixes
Fixes #5909 

## Approach
We catch any exceptions, or show a toast on known failure

## How Has This Been Tested?

Unit Test. Couldn't repro on my device. Image insert still works correctly

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code