### PR TITLE
20200403 Dependency updates

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -124,7 +124,7 @@ dependencies {
 
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     //noinspection GradleDependency
-    implementation 'androidx.appcompat:appcompat:1.1.0-rc01'
+    implementation 'androidx.appcompat:appcompat:1.2.0-beta01'
     // Note: the design support library can be quite buggy, so test everything thoroughly before updating it
     implementation 'com.google.android.material:material:1.1.0'
     implementation 'androidx.browser:browser:1.0.0'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -128,7 +128,7 @@ dependencies {
     // Note: the design support library can be quite buggy, so test everything thoroughly before updating it
     implementation 'com.google.android.material:material:1.1.0'
     implementation 'androidx.browser:browser:1.0.0'
-    implementation 'androidx.exifinterface:exifinterface:1.1.0'
+    implementation 'androidx.exifinterface:exifinterface:1.2.0'
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
     implementation 'io.requery:sqlite-android:3.31.0'
     implementation 'android.arch.persistence:db-framework:1.1.1'

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.1'
+        classpath 'com.android.tools.build:gradle:3.6.2'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }


### PR DESCRIPTION
@david-allison-1 not sure if this is related to #5513 (I think that was one where a ContentResolver cursor failed on a png file?) but it includes a bump to exifinterface 1.2 where they made some noise about similar things https://developer.android.com/jetpack/androidx/releases/exifinterface#1.2.0

This also includes a major change for us - a bump to appcompat library which had problems before (#5526) but should fix #5507 while hopefully not triggering #5512 