### PR TITLE
Fix windows path issues in UtilsTest

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/libanki/UtilsTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/UtilsTest.java
@@ -37,8 +37,8 @@ public class UtilsTest {
 
         ClassLoader classLoader = getClass().getClassLoader();
         URL resource = classLoader.getResource("path-traversal.zip");
-        File file = new File(resource.getPath());
         try {
+            File file = new File(resource.toURI());
             ZipFile zipFile = new ZipFile(file);
             Enumeration zipEntries = zipFile.entries();
             while (zipEntries.hasMoreElements()) {
@@ -47,8 +47,8 @@ public class UtilsTest {
             }
             Assert.fail("Expected an IOException");
         }
-        catch (IOException e) {
-            Assert.assertEquals(e.getMessage(), "File is outside extraction target directory.");
+        catch (Exception e) {
+            Assert.assertEquals("File is outside extraction target directory.", e.getMessage());
         }
     }
 
@@ -81,7 +81,7 @@ public class UtilsTest {
         URL resource = Objects.requireNonNull(getClass().getClassLoader()).getResource("path-traversal.zip");
         File copy = File.createTempFile("testCopyFileToStream", ".zip");
         copy.deleteOnExit();
-        Utils.copyFile(new File(resource.getFile()), copy);
+        Utils.copyFile(new File(resource.toURI()), copy);
         Assert.assertEquals(TestUtils.getMD5(resourcePath), TestUtils.getMD5(copy.getCanonicalPath()));
     }
 }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
@Alyxvance was attempting to follow my guidance to patch up PR #5868 but was blocked by a unit test failure on windows in a test I wrote - we exercise windows now so I'm not sure why the CI job didn't catch it but I was able to replicate the problem

## Approach
Use the built-in path generator from URI to handle all the escaping and quoting necessary on windows, hopefully it works on Linux, CI will tell us

## How Has This Been Tested?

On a local windows 10 environment I had laying around

## Learning (optional, can help others)
Always stack overflow, let's admit it
