### PR TITLE
Scheduler reset performance improvement

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -921,6 +921,11 @@ public class Decks {
      */
     public List<JSONObject> parents(long did) {
         // get parent and grandparent names
+        return parents(did, null);
+    }
+
+    public List<JSONObject> parents(long did, HashMap<String, JSONObject> nameMap) {
+        // get parent and grandparent names
         List<String> parents = new ArrayList<>();
         List<String> parts = Arrays.asList(get(did).getString("name").split("::", -1));
         for (String part : parts.subList(0, parts.size() - 1)) {
@@ -933,7 +938,14 @@ public class Decks {
         // convert to objects
         List<JSONObject> oParents = new ArrayList<>();
         for (int i = 0; i < parents.size(); i++) {
-            oParents.add(i, get(id(parents.get(i))));
+            String parentName = parents.get(i);
+            JSONObject deck;
+            if (nameMap == null) {
+                deck = get(id(parentName));
+            } else {
+                deck = nameMap.get(parentName);
+            }
+            oParents.add(i, deck);
         }
         return oParents;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -951,7 +951,7 @@ public class Decks {
     }
 
 
-    private HashMap<String, JSONObject> nameMap() {
+    protected HashMap<String, JSONObject> nameMap() {
         HashMap<String, JSONObject> map = new HashMap<>();
 
         for (JSONObject object : mDecks.values()) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sched.java
@@ -315,6 +315,7 @@ public class Sched extends AbstractSched {
         int tot = 0;
         HashMap<Long, Integer> pcounts = new HashMap<>();
         // for each of the active decks
+        HashMap<String, JSONObject> nameMap = mCol.getDecks().nameMap();
         try {
             for (long did : mCol.getDecks().active()) {
                 // get the individual deck's limit
@@ -323,7 +324,7 @@ public class Sched extends AbstractSched {
                     continue;
                 }
                 // check the parents
-                List<JSONObject> parents = mCol.getDecks().parents(did);
+                List<JSONObject> parents = mCol.getDecks().parents(did, nameMap);
                 for (JSONObject p : parents) {
                     // add if missing
                     long id = p.getLong("id");

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/SchedV2.java
@@ -312,6 +312,7 @@ public class SchedV2 extends AbstractSched {
         int tot = 0;
         HashMap<Long, Integer> pcounts = new HashMap<>();
         // for each of the active decks
+        HashMap<String, JSONObject> nameMap = mCol.getDecks().nameMap();
         try {
             for (long did : mCol.getDecks().active()) {
                 // get the individual deck's limit
@@ -320,7 +321,7 @@ public class SchedV2 extends AbstractSched {
                     continue;
                 }
                 // check the parents
-                List<JSONObject> parents = mCol.getDecks().parents(did);
+                List<JSONObject> parents = mCol.getDecks().parents(did, nameMap);
                 for (JSONObject p : parents) {
                     // add if missing
                     long id = p.getLong("id");


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
My collection contains hundreds of decks and subdecks. Burying the top level deck was a night mare. It literally tooks more than a minute (Checked it while debugging). Burying, undoying, suspending, all recomputed the list of cards, and took over a minute.
This simple change, copied from anki's code, reduce this time to two seconds.

Actually, four seconds, because for some reason, when I click on a deck, the computation of "Sched.reset" is done twice.

## Approach
Exactly as in anki. Precomputing and saving the atble sending names to the deck object.
By the way, this sohuld probably saved in DeckManager directly, and be discarded each time the collection is reset. But I'm not going to introduce changes that are not in anki and would be non essential. 

## How Has This Been Tested?

Putting it on my phone, and using anki normally.

## Learning (optional, can help others)
I can't use the profiler correctly. I don't know why it only told me that com.ichi2.anki was rurning, which is quite useless.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
