### PR TITLE
Use chunk of 1mb in cursor

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -272,7 +272,7 @@ public class Collection {
 
     public String loadColumn(String columnName) {
         int pos = 1;
-        int chunk = 256*1024;
+        int chunk = 1024*1024; // 1 mb, a little less than what a cursor line may contain
         StringBuffer buf = new StringBuffer("");
 
         while (true) {


### PR DESCRIPTION
#Pull Request template

## Purpose / Description
AnkiDroid takse more than a minutes to start on my phone. Actually, profiling show it takes more than a minute to load the note type (I've got note type with >400 card types).
It seems that the maximal cursor size is slightly more than a mega bite. 
## Fixes
https://github.com/ankidroid/Anki-Android/issues/5921
 On my phone, it reduces loading from >1 minute to <20 seconds.

## Approach
I ensured that a megabyte is used, so that the number of query decrease and the speed increase.

I'd be curious to see if any alpha tester get problem (in which case it must be reverted) or if one mb is enough for every body.

## How Has This Been Tested?

Installing on my phone and seeing that I don't need to wait a minute regularly.

## Learning (optional, can help others)

I was trying to see how to use sqlite4java in AnkiDroid. It seems more efficient. But I don't fully understand how to replace the sqlite library used and what should be sqliteOpenHelperFactory in libanki/DB.java
So this is a less efficient fix, but quicker to create and to test 

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
