### PR TITLE
Loading models last

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -2120,6 +2120,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
                 // Update the mini statistics bar as well
                 AnkiStatsTaskHandler.createReviewSummaryStatistics(getCol(), mReviewSummaryTextView);
+                getCol().loadModels(); // No more DB access is needed now, so we can do the DB intesive action of loading the models asynchronously.
             }
         });
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -2034,7 +2034,7 @@ public class Collection {
         futureLoadingModel = new FutureTask(
             () -> mModels.load(loadColumn("models"))
         );
-        futureLoadingModel.run();
+        new Thread(futureLoadingModel).start();
     }
 
     public Models getModels() {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -96,6 +96,7 @@ public class Models {
     private boolean mChanged;
     private HashMap<Long, JSONObject> mModels;
 
+
     // BEGIN SQL table entries
     private int mId;
     private String mName = "";
@@ -145,7 +146,7 @@ public class Models {
     /**
      * Load registry from JSON.
      */
-    public void load(String json) {
+    public Models load(String json) {
         mChanged = false;
         mModels = new HashMap<>();
         JSONObject modelarray = new JSONObject(json);
@@ -157,6 +158,7 @@ public class Models {
                 mModels.put(o.getLong("id"), o);
             }
         }
+        return this;
     }
 
 


### PR DESCRIPTION
My AnkiDroid is really slow to start. According to profiling, the
slowest part is reading the database content. In particular, reading
the json configurations. Those are JSON files which may easily takes
more than a MB and does not fit into the cursor.

Deck configuration should be accessed early in order to create the
list of deck. However, the models configuration are not useful until a
card is selected to be reviewed. So I removed the note type query from
initialization.

More precisely, this loading become asynchrone (it's a database access
not mandatory for the GUI, so it should already have been the case). I
also ensure that it is done as soon as possilbe, i.e. when GUI is
loaded, so that reviewing car start soon.

My first idea was to just change the loading of the note type
configuration to make it asynchrone. It didn't work because it did
stop all other thread from accessing the database, and so the number
of cards in each deck could not be computed.

## How Has This Been Tested?
Installing it on my phone and using it. (And merging it with other recent PR in order to have a really quick anki)


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
