### PR TITLE
Add default value to Card.timeLimit()

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.java
@@ -25,6 +25,7 @@ import android.text.TextUtils;
 import com.ichi2.utils.Assert;
 import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.R;
+import com.ichi2.utils.JSONUtils;
 import com.ichi2.utils.LanguageUtil;
 import com.ichi2.utils.JSONObject;
 
@@ -337,8 +338,14 @@ public class Card implements Cloneable {
      * Time limit for answering in milliseconds.
      */
     public int timeLimit() {
-        JSONObject conf = mCol.getDecks().confForDid(mODid == 0 ? mDid : mODid);
-        return conf.getInt("maxTaken") * 1000;
+        final int MILLIS_IN_A_SECOND = 1000;
+        final int DEFAULT_MAX_TAKEN = Consts.DECK_CONF_DEFAULT_MAX_TAKEN;
+        try {
+            JSONObject conf = mCol.getDecks().confForDid(mODid == 0 ? mDid : mODid);
+            return JSONUtils.getIntOrSetDefaultWithWarn(conf, "maxTaken", DEFAULT_MAX_TAKEN) * MILLIS_IN_A_SECOND;
+        } catch (Exception e) {
+            return DEFAULT_MAX_TAKEN * MILLIS_IN_A_SECOND;
+        }
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Consts.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Consts.java
@@ -102,4 +102,7 @@ public class Consts {
     public static final int REVLOG_CRAM = 3;
 
     // The labels defined in consts.py are in AnkiDroid's resources files.
+
+    //Deck Configuration
+    public static final int DECK_CONF_DEFAULT_MAX_TAKEN = 60;
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -122,7 +122,7 @@ public class Decks {
                     // may not be set on old decks
                     + "'bury': True"
                 + "},"
-                + "'maxTaken': 60,"
+                + "'maxTaken': " + Consts.DECK_CONF_DEFAULT_MAX_TAKEN + ","
                 + "'timer': 0,"
                 + "'autoplay': True,"
                 + "'replayq': True,"

--- a/AnkiDroid/src/main/java/com/ichi2/utils/JSONUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/JSONUtils.java
@@ -1,0 +1,39 @@
+package com.ichi2.utils;
+
+import androidx.annotation.CheckResult;
+import androidx.annotation.NonNull;
+import timber.log.Timber;
+
+public class JSONUtils {
+
+    @CheckResult
+    public static int getIntOrSetDefaultWithWarn(@NonNull JSONObject jsonObject, String propertyName, int defaultValue) {
+        //noinspection ConstantConditions
+        if (jsonObject == null) {
+            return defaultValue;
+        }
+
+        if (!jsonObject.has(propertyName)) {
+            Timber.w("No value for '%s' set. Setting default to '%d'", propertyName, defaultValue);
+            trySet(jsonObject, propertyName, defaultValue);
+            return defaultValue;
+        }
+
+        try {
+            return jsonObject.getInt(propertyName);
+        } catch (Exception e) {
+            //It feels unsafe to perform a mutation if we have a truly unexpected error
+            //(for example: a string value instead of an int).
+            Timber.w(e, "Exception setting '%s'. Returning default: '%d'", propertyName, defaultValue);
+            return defaultValue;
+        }
+    }
+
+    private static void trySet(@NonNull JSONObject jsonObject, String propertyName, int defaultValue) {
+        try {
+            jsonObject.put(propertyName, defaultValue);
+        } catch (Exception e) {
+            //Don't want to log here due to doubling noise from getIntOrSetDefaultWithWarn
+        }
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
@@ -24,6 +24,7 @@ import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.DB;
 import com.ichi2.libanki.Models;
 
+import com.ichi2.libanki.Note;
 import com.ichi2.utils.JSONException;
 import com.ichi2.utils.JSONObject;
 import org.junit.After;
@@ -85,5 +86,13 @@ public class RobolectricTest {
     protected JSONObject getCurrentDatabaseModelCopy(String modelName) throws JSONException {
         Models collectionModels = getCol().getModels();
         return new JSONObject(collectionModels.byName(modelName).toString().trim());
+    }
+
+
+    public Note addNote(int i) {
+        Note n = getCol().newNote();
+        n.setField(0, Integer.toString(i));
+        getCol().addNote(n);
+        return n;
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/CardsTimeLimitIntegrationTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/CardsTimeLimitIntegrationTest.java
@@ -1,0 +1,94 @@
+package com.ichi2.libanki;
+
+import com.ichi2.anki.RobolectricTest;
+import com.ichi2.libanki.exception.NoSuchDeckException;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@RunWith(AndroidJUnit4.class)
+public class CardsTimeLimitIntegrationTest extends RobolectricTest {
+
+    private final RoboelectricBackend backend = new RoboelectricBackend();
+
+    @Test
+    public void timeLimitIsReadFromJson() {
+        Card c = backend.cardWithDeckOptionsMaxTaken(30);
+
+        int actualValue = c.timeLimit();
+
+        assertThat("The conf 'maxTaken' value should be used if available", actualValue, is(30 * 1000));
+    }
+
+
+    @Test
+    public void noTimeLimitReturnsDefaultValue() {
+        int defaultLimit = backend.getDefaultAnkiTimeLimitInMs();
+
+        Card c = backend.cardWithNoDeckOptionsMaxTaken();
+
+        int actualValue = c.timeLimit();
+
+        assertThat("A default timeLimit() (returned when no value is available) should equal the default conf value",
+                actualValue,
+                is(defaultLimit));
+    }
+
+    @Test
+    public void timeLimitErrorReturnsDefault() {
+        //This one is arguable, in many cases we want an exception if the col is not accessible.
+        //Since this is a UI feature, I'd rather return a sensible default then kill the app.
+        Card c = backend.getCardWithExceptionGettingTimeLimit();
+
+        int actualInMs = c.timeLimit();
+
+        int expected = backend.getDefaultAnkiTimeLimitInMs();
+        assertThat("Problematic timeLimit() should return default", actualInMs, is(expected));
+    }
+
+    @Test
+    public void noTimeLimitDefaultIsCorrect() {
+        int actualDefault = backend.getDefaultAnkiTimeLimitInMs();
+
+        assertThat("Default time limit should be 60 seconds",actualDefault , is(60000));
+    }
+
+
+    private class RoboelectricBackend {
+        public Card cardWithDeckOptionsMaxTaken(int i) {
+            Note n = CardsTimeLimitIntegrationTest.super.addNote(i);
+            Card c = n.cards().get(0);
+            getCol().getDecks().confForDid(c.getDid()).put("maxTaken", i);
+            return c;
+        }
+
+        public int getDefaultAnkiTimeLimitInMs() {
+            return getCol().getDecks().confForDid(1).getInt("maxTaken") * 1000;
+        }
+
+
+        public Card getCardWithExceptionGettingTimeLimit() {
+            Card ret = cardWithDeckOptionsMaxTaken(1);
+            try {
+                getCol().getDecks().removeDeckOptions(1);
+                assertThat(getCol().getDecks().hasDeckOptions(ret.getDid()), is(false));
+            } catch (NoSuchDeckException e) {
+                throw new AssertionError(e);
+            }
+
+            return ret;
+        }
+
+
+        public Card cardWithNoDeckOptionsMaxTaken() {
+            Card ret = cardWithDeckOptionsMaxTaken(1);
+            getCol().getDecks().confForDid(ret.getODid() == 0 ? ret.getDid() : ret.getODid()).put("maxTaken", null);
+            return ret;
+        }
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/utils/JSONUtilsTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/JSONUtilsTest.java
@@ -1,0 +1,78 @@
+package com.ichi2.utils;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@RunWith(AndroidJUnit4.class)
+public class JSONUtilsTest {
+
+    @Test
+    public void validValueIsReturned() {
+        JSONObject object = new JSONObject();
+        object.put("max", 1);
+
+        int result = JSONUtils.getIntOrSetDefaultWithWarn(object, "max", 0);
+
+        assertThat("A valid value should be returned", result, is(1));
+    }
+
+    @Test
+    public void nullJsonObjectWorksCorrectly() {
+        JSONObject object = null;
+
+        @SuppressWarnings("ConstantConditions")
+        int result = JSONUtils.getIntOrSetDefaultWithWarn(object, "max", 1);
+
+        assertThat("A null JsonObject should still return the default", result, is(1));
+    }
+
+    @Test
+    public void nullValueReturnsDefault() {
+        JSONObject object = new JSONObject();
+        object.put("max", null);
+
+        int result = JSONUtils.getIntOrSetDefaultWithWarn(object, "max", 1);
+
+        assertThat("A valid value should be returned", result, is(1));
+    }
+
+    @Test
+    public void nullValueIsSet() {
+        JSONObject object = new JSONObject();
+        object.put("max", null);
+
+        @SuppressWarnings("unused")
+        int unused = JSONUtils.getIntOrSetDefaultWithWarn(object, "max", 1);
+        int actualProperty = object.getInt("max");
+
+        assertThat("A previously null value should be set", actualProperty, is(1));
+    }
+
+    @Test
+    public void invalidValueReturnsDefault() {
+        JSONObject object = new JSONObject();
+        object.put("max", null);
+
+        int actual = JSONUtils.getIntOrSetDefaultWithWarn(object, "max", 1);
+
+
+        assertThat("Default should be returned if value is invalid", actual, is(1));
+    }
+
+    @Test
+    public void invalidValueIsNotFixed() {
+        JSONObject object = new JSONObject();
+        object.put("max", "power");
+
+        @SuppressWarnings("unused")
+        int unused = JSONUtils.getIntOrSetDefaultWithWarn(object, "max", 1);
+        String actualProperty = object.getString("max");
+
+        assertThat("An invalid property will not be mutated", actualProperty, is("power"));
+    }
+}


### PR DESCRIPTION
## Review goals

* Is this overtested? I initially started with a mock-based approach to remove the need for roboelectric, That counts for most of the files in the tests (we could go down to 2 if we remove them), and I'm not sure if there's much future value in mocking given the power of roboelectric, and the lack of abstractions & coupling in libAnki.
  * Mock tests logic is totally duplicated as integration tests except the implementation.
* Is the behaviour "if the value is an invalid data type, don't set it", OK?

## Purpose / Description
For some reason, the Deck Configuration: `maxTaken` variable was null. As we're in (mostly) appearance/UI code, we can set the default value and continue rather than crash.


maxTaken: The number of seconds after which to stop the timer) and caused a crash. 
## Fixes
Fixes #5932

## Approach
We set a default value

## How Has This Been Tested?

Probably too many unit tests

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code