### PR TITLE
Cache nameMap (performance)

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -1015,11 +1015,6 @@ public class Decks {
      */
     public List<JSONObject> parents(long did) {
         // get parent and grandparent names
-        return parents(did, null);
-    }
-
-    public List<JSONObject> parents(long did, HashMap<String, JSONObject> nameMap) {
-        // get parent and grandparent names
         List<String> parents = new ArrayList<>();
         List<String> parts = Arrays.asList(path(get(did).getString("name")));
         for (int i = 0; i < parts.size() - 1; i++) {
@@ -1034,26 +1029,15 @@ public class Decks {
         List<JSONObject> oParents = new ArrayList<>();
         for (int i = 0; i < parents.size(); i++) {
             String parentName = parents.get(i);
-            JSONObject deck;
-            if (nameMap == null) {
-                deck = get(id(parentName));
-            } else {
-                deck = nameMap.get(parentName);
-            }
+            JSONObject deck = mNameMap.get(parentName);
             oParents.add(i, deck);
         }
         return oParents;
     }
 
 
-    public HashMap<String, JSONObject> nameMap() {
-        HashMap<String, JSONObject> map = new HashMap<>();
-
-        for (JSONObject object : mDecks.values()) {
-            map.put(object.getString("name"), object);
-        }
-
-        return map;
+    protected HashMap<String, JSONObject> nameMap() {
+        return _nameMap;
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -986,7 +986,6 @@ public class Decks {
 
 
     public HashMap<Long, HashMap> childMap() {
-        HashMap<String, JSONObject> nameMap = nameMap();
 
         HashMap<Long, HashMap> childMap = new HashMap<>();
 
@@ -1002,7 +1001,7 @@ public class Decks {
             List<String> parts = Arrays.asList(path(deck.getString("name")));
             if (parts.size() > 1) {
                 String immediateParent = TextUtils.join("::", parts.subList(0, parts.size() - 1));
-                long pid = nameMap.get(immediateParent).getLong("id");
+                long pid = mNameMap.get(immediateParent).getLong("id");
                 childMap.get(pid).put(deck.getLong("id"), node);
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -435,13 +435,9 @@ public class Decks {
      * Get deck with NAME, ignoring case.
      */
     @CheckResult
-    public @Nullable JSONObject byName(String name) {
-        for (JSONObject m : mDecks.values()) {
-            if (equalName(m.getString("name"),name)) {
-                return m;
-            }
-        }
-        return null;
+    public JSONObject byName(String name) {
+        String normalized = normalizeName(name);
+        return mNameMap.get(normalized);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -24,6 +24,7 @@ package com.ichi2.libanki;
 import android.content.ContentValues;
 import android.text.TextUtils;
 
+import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.anki.exception.DeckRenameException;
 import com.ichi2.libanki.exception.NoSuchDeckException;
@@ -437,7 +438,15 @@ public class Decks {
     @CheckResult
     public JSONObject byName(String name) {
         String normalized = normalizeName(name);
-        return mNameMap.get(normalized);
+        JSONObject deck = mNameMap.get(normalized);
+        if (deck == null) {
+            return null;
+        }
+        String foundName = deck.getString("name");
+        if (!equalName(name, foundName)) {
+            AnkiDroidApp.sendExceptionReport("We looked for deck \"" + name + "\" and instead got deck \"" + foundName + "\".", "Decks - byName");
+        }
+        return deck;
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -1036,11 +1036,6 @@ public class Decks {
     }
 
 
-    protected HashMap<String, JSONObject> nameMap() {
-        return _nameMap;
-    }
-
-
     /**
      * Sync handling
      * ***********************************************************

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -331,7 +331,6 @@ public class SchedV2 extends AbstractSched {
         int tot = 0;
         HashMap<Long, Integer> pcounts = new HashMap<>();
         // for each of the active decks
-        HashMap<String, JSONObject> nameMap = mCol.getDecks().nameMap();
         for (long did : mCol.getDecks().active()) {
             // get the individual deck's limit
             int lim = limFn.operation(mCol.getDecks().get(did));
@@ -339,7 +338,7 @@ public class SchedV2 extends AbstractSched {
                 continue;
             }
             // check the parents
-            List<JSONObject> parents = mCol.getDecks().parents(did, nameMap);
+            List<JSONObject> parents = mCol.getDecks().parents(did);
             for (JSONObject p : parents) {
                 // add if missing
                 long id = p.getLong("id");


### PR DESCRIPTION
# Pull Request template

## Purpose / Description
Improving ankidroid speed by doing small efficient changes.

## Approach
_How does this change address the problem?_

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration (SDK version(s), emulator or physical, etc)

## Learning (optional, can help others)
As discussed in https://github.com/ankidroid/Anki-Android/pull/5928 (and it would make
this other PR useless)

Accessing a deck by is name is done quite often. Being able to do it
in constant time consists in part of seconds win in a lot of actions,
allowing ankidroid to be faster.

In this particular case, a little difference from upstream anki makes
sens. Anki need to deals with a lot of add-ons, and add-ons may do
whathever they want to add-on. As we don't have this problem, we can
cache some computation.

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
