### PR TITLE
Remove useless recursion in DeckManager.rem

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -297,7 +297,7 @@ public class Decks {
             mCol.getSched().emptyDyn(did);
             if (childrenToo) {
                 for (long id : children(did).values()) {
-                    rem(id, cardsToo);
+                    rem(id, cardsToo, false);
                 }
             }
         } else {
@@ -305,7 +305,7 @@ public class Decks {
             if (childrenToo) {
                 // we don't want to delete children when syncing
                 for (long id : children(did).values()) {
-                    rem(id, cardsToo);
+                    rem(id, cardsToo, false);
                 }
             }
             // delete cards too?


### PR DESCRIPTION
#  Pull Request template

## Purpose / Description
Following anki and having quicker code

As in dae/anki@7365b93c1a0e809b1f921804cfa30edc78b594e6

## Approach

For any deck the children of it's children are its children. So
applying rem to children of children is useless and actually slightly
costly for deep subdecks

## How Has This Been Tested?

Installing on my phone with all of the other change I'm pushing for those days

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
