### PR TITLE
Speed up getCol(context)

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
@@ -99,8 +99,8 @@ public class CollectionHelper {
      */
     public synchronized Collection getCol(Context context) {
         // Open collection
-        String path = getCollectionPath(context);
         if (!colIsOpen()) {
+            String path = getCollectionPath(context);
             // Check that the directory has been created and initialized
             try {
                 initializeAnkiDroidDirectory(getParentDirectory(path));


### PR DESCRIPTION
## Purpose / Description

`getCol()` is used all over the place, and performs unnecessary IO

## Fixes
Maybe #5938 

We hit `getCol`:

https://github.com/ankidroid/Anki-Android/blob/8a79dd14b6d7e1b865a466d4dc561914ba312f59/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java#L1457-L1459

which is called each time `onPrepareActionMode()` is called.

## Approach
Don't hit the filesystem unless we need to.

## How Has This Been Tested?

Ran on my Android, still works.
Ran 104 unit tests, all pass

## Learning (optional, can help others)

Added in https://github.com/ankidroid/Anki-Android/commit/60d6e07ee61305ab5fbd26036bb8f78fd843faa2#diff-423fd800e2b0faa58e3bfa60cc67b718R88

Implementation: https://github.com/ankidroid/Anki-Android/blob/ad85320486accb900c553ea57d6476f6ffb8e6ac/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java#L213-L231

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code