### PR TITLE
Quick deep copy in JSON

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.java
@@ -193,7 +193,7 @@ class AnkiExporter extends Exporter {
                 }
             }
 
-            JSONObject destinationDeck = JSONObjectUtils.slowDeepClone(d);
+            JSONObject destinationDeck = d.deepClone();
             if (!mIncludeSched) {
                 // scheduling not included, so reset deck settings to default
                 destinationDeck.put("conf", 1);
@@ -314,17 +314,6 @@ class AnkiExporter extends Exporter {
 
     public void setDid(Long did) {
         mDid = did;
-    }
-
-    private static class JSONObjectUtils {
-        private JSONObjectUtils() {
-
-        }
-
-        /** Defect: Inefficient deep clone. We should find or write a faster method */
-        private static JSONObject slowDeepClone(JSONObject object) throws JSONException {
-            return new JSONObject(object.toString());
-        }
     }
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/utils/JSONArray.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/JSONArray.java
@@ -241,4 +241,20 @@ public class JSONArray extends org.json.JSONArray {
             throw new JSONException(e);
         }
     }
+
+    public JSONArray deepClone() {
+        JSONArray clone = new JSONArray();
+        for (String key: copyFrom.keys()) {
+            if (get(key) instanceof JSONObject) {
+                JSONObject value = (JSONObject) get(key);
+                clone.put(key, value.deepClone());
+            }
+            else if (get(key) instanceof JSONArray) {
+                JSONArray value = (JSONArray) get(key);
+                clone.put(key, value.deepClone());
+            } else {
+                clone.put(key, get(key));
+            }
+        }
+    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/JSONArray.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/JSONArray.java
@@ -242,19 +242,19 @@ public class JSONArray extends org.json.JSONArray {
         }
     }
 
+
     public JSONArray deepClone() {
         JSONArray clone = new JSONArray();
-        for (String key: copyFrom.keys()) {
-            if (get(key) instanceof JSONObject) {
-                JSONObject value = (JSONObject) get(key);
-                clone.put(key, value.deepClone());
+        for (int i = 0; i < length(); i++) {
+            if (get(i) instanceof JSONObject) {
+                clone.put(getJSONObject(i).deepClone());
             }
-            else if (get(key) instanceof JSONArray) {
-                JSONArray value = (JSONArray) get(key);
-                clone.put(key, value.deepClone());
+            else if (get(i) instanceof JSONArray) {
+                clone.put(getJSONArray(i).deepClone());
             } else {
-                clone.put(key, get(key));
+                clone.put(get(i));
             }
         }
+        return clone;
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/JSONObject.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/JSONObject.java
@@ -288,15 +288,14 @@ public class JSONObject extends org.json.JSONObject implements Iterable<String> 
         JSONObject clone = new JSONObject();
         for (String key: this) {
             if (get(key) instanceof JSONObject) {
-                JSONObject value = (JSONObject) get(key);
-                clone.put(key, value.deepClone());
+                clone.put(key, getJSONObject(key).deepClone());
             }
             else if (get(key) instanceof JSONArray) {
-                JSONArray value = (JSONArray) get(key);
-                clone.put(key, value.deepClone());
+                clone.put(key, getJSONArray(key).deepClone());
             } else {
                 clone.put(key, get(key));
             }
         }
+        return clone;
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/JSONObject.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/JSONObject.java
@@ -283,4 +283,20 @@ public class JSONObject extends org.json.JSONObject implements Iterable<String> 
     public JSONObject optJSONObject(String name) {
         return JSONObject.objectToObject(super.optJSONObject(name));
     }
+
+    public JSONObject deepClone() {
+        JSONObject clone = new JSONObject();
+        for (String key: this) {
+            if (get(key) instanceof JSONObject) {
+                JSONObject value = (JSONObject) get(key);
+                clone.put(key, value.deepClone());
+            }
+            else if (get(key) instanceof JSONArray) {
+                JSONArray value = (JSONArray) get(key);
+                clone.put(key, value.deepClone());
+            } else {
+                clone.put(key, get(key));
+            }
+        }
+    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/JSONObject.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/JSONObject.java
@@ -10,7 +10,7 @@ package com.ichi2.utils;
 import java.util.Iterator;
 import java.util.Map;
 
-public class JSONObject extends org.json.JSONObject {
+public class JSONObject extends org.json.JSONObject implements Iterable<String> {
 
     public static final Object NULL = JSONObject.NULL;
 
@@ -94,13 +94,18 @@ public class JSONObject extends org.json.JSONObject {
 
     public JSONObject(JSONObject copyFrom) {
         this();
-        Iterator<String> it = copyFrom.keys();
-        while (it.hasNext()) {
-            String key = it.next();
+        for (String key: this) {
             put(key, copyFrom.get(key));
         }
     }
 
+    /**
+        Iters on the keys. (Similar to iteration in Python's
+        dictionnary.
+    */
+    public Iterator<String> iterator() {
+        return keys();
+    }
 
     /**
      * Change type from JSONObject to JSONObject.


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
There was a todo in JSONUtils, asking for a deep copy of JSON. I.e. not going through strings and back again. I just implemented it in the class JSON that was put in ankidroid recently

## Approach
Simply iterating on the json objects/arrays, which are the two only components with subvalues in a valid JSON value. This is the way strings are generated and read, but this time there is no string, so it's quicker.


## How Has This Been Tested?

Exporting a package, and trying to import it again


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
