### PR TITLE
Remove Ability to "Change Deck" to Dynamic Deck

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -895,7 +895,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 builderSingle.setTitle(getString(R.string.move_all_to_deck));
 
                 final ArrayAdapter<String> arrayAdapter = new ArrayAdapter<String>(this, R.layout.dropdown_deck_item);
-                for (JSONObject deck : mDropDownDecks) {
+                for (JSONObject deck : getValidDecksForChangeDeck()) {
                     try {
                         arrayAdapter.add(deck.getString("name"));
                     } catch (JSONException e) {
@@ -1230,6 +1230,11 @@ public class CardBrowser extends NavigationDrawerActivity implements
         } else {
             updateCardsInList(cards, null);
         }
+    }
+
+    /** Returns the decks which are valid targets for "Change Deck" */
+    private ArrayList<JSONObject> getValidDecksForChangeDeck() {
+        return mDropDownDecks;
     }
 
     private abstract class ListenerWithProgressBar extends DeckTask.TaskListener {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -363,7 +363,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
     void changeDeck(int deckPosition) {
         long[] ids = getSelectedCardIds();
 
-        JSONObject selectedDeck = mDropDownDecks.get(deckPosition);
+        JSONObject selectedDeck = getValidDecksForChangeDeck().get(deckPosition);
 
         try {
             //#5932 - can't be dynamic
@@ -922,6 +922,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 AlertDialog.Builder builderSingle = new AlertDialog.Builder(this);
                 builderSingle.setTitle(getString(R.string.move_all_to_deck));
 
+                //WARNING: changeDeck depends on this index, so any changes should be reflected there.
                 final ArrayAdapter<String> arrayAdapter = new ArrayAdapter<String>(this, R.layout.dropdown_deck_item);
                 for (JSONObject deck : getValidDecksForChangeDeck()) {
                     try {
@@ -2091,9 +2092,10 @@ public class CardBrowser extends NavigationDrawerActivity implements
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    public int getDeckPositionFromId(long deckId) {
-        for (int i = 0; i < mDropDownDecks.size(); i++) {
-            JSONObject deck = mDropDownDecks.get(i);
+    public int getChangeDeckPositionFromId(long deckId) {
+        List<JSONObject> decks = getValidDecksForChangeDeck();
+        for (int i = 0; i < decks.size(); i++) {
+            JSONObject deck = decks.get(i);
             if (deck.getLong("id") == deckId) {
                 return i;
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -73,6 +73,7 @@ import com.ichi2.compat.CompatHelper;
 import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Consts;
+import com.ichi2.libanki.Decks;
 import com.ichi2.libanki.Note;
 import com.ichi2.libanki.Utils;
 import com.ichi2.themes.Themes;
@@ -1233,8 +1234,16 @@ public class CardBrowser extends NavigationDrawerActivity implements
     }
 
     /** Returns the decks which are valid targets for "Change Deck" */
-    private ArrayList<JSONObject> getValidDecksForChangeDeck() {
-        return mDropDownDecks;
+    @VisibleForTesting
+    List<JSONObject> getValidDecksForChangeDeck() {
+        List<JSONObject> nonDynamicDecks = new ArrayList<>();
+        for (JSONObject d : mDropDownDecks) {
+            if (Decks.isDynamic(d)) {
+                continue;
+            }
+            nonDynamicDecks.add(d);
+        }
+        return nonDynamicDecks;
     }
 
     private abstract class ListenerWithProgressBar extends DeckTask.TaskListener {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -1053,4 +1053,8 @@ public class Decks {
     public void removeDeckOptions(long deckId) throws NoSuchDeckException {
         getDeckOrFail(deckId).remove("conf");
     }
+
+    public static boolean isDynamic(JSONObject deck) {
+        return deck.getInt("dyn") != 0;
+    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -46,7 +46,9 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.regex.Pattern;
 
+import androidx.annotation.CheckResult;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import timber.log.Timber;
 
 // fixmes:
@@ -410,11 +412,12 @@ public class Decks {
     }
 
     /** Obtains the deck from the DeckID, or default if the deck was not found */
+    @CheckResult
     public @NonNull JSONObject get(long did) {
         return get(did, true);
     }
 
-
+    @CheckResult
     public JSONObject get(long did, boolean _default) {
         if (mDecks.containsKey(did)) {
             return mDecks.get(did);
@@ -429,7 +432,8 @@ public class Decks {
     /**
      * Get deck with NAME, ignoring case.
      */
-    public JSONObject byName(String name) {
+    @CheckResult
+    public @Nullable JSONObject byName(String name) {
         for (JSONObject m : mDecks.values()) {
             if (equalName(m.getString("name"),name)) {
                 return m;

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -160,4 +160,7 @@
     <string name="integrity_check_insufficient_space">Check Database uses a large amount of temporary storage.\n\nIt is strongly recommended that you have at least %s free space on your device before continuing.</string>>
     <string name="integrity_check_insufficient_space_extra_content">\n\nYou currently have %s free.</string>
     <string name="video_creation_error">Could not play video</string>
+
+    <!-- Card Browser -->
+    <string name="card_browser_deck_change_error">Could not change deck</string>
 </resources>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
@@ -189,26 +189,11 @@ public class CardBrowserTest extends RobolectricTest {
     }
 
     @Test
-    public void failureToMoveToDynamicDeckIsHandled() {
-        long deckIdToChangeTo = addDynamicDeck("World");
-        selectDefaultDeck();
-        CardBrowser b = getBrowserWithNotes(5);
-        b.checkedCardsAtPositions(new int[] {0, 2});
-
-        List<Long> cardIds = b.getCheckedCardIds();
-
-        final int deckPosition = b.getDeckPositionFromId(deckIdToChangeTo);
-
-        AnkiAssert.assertDoesNotThrow(() -> b.changeDeck(deckPosition));
-
-        for (Long cardId: cardIds) {
-            assertThat("Deck should not be changed", getCol().getCard(cardId).getDid(), not(deckIdToChangeTo));
-        }
-    }
-
-    @Test
     public void moveToNonDynamicDeckWorks() {
+        addDeck("Foo");
+        addDynamicDeck("Bar");
         long deckIdToChangeTo = addDeck("Hello");
+        addDeck("ZZ");
         selectDefaultDeck();
         CardBrowser b = getBrowserWithNotes(5);
         b.checkedCardsAtPositions(new int[] {0, 2});
@@ -219,7 +204,7 @@ public class CardBrowserTest extends RobolectricTest {
             assertThat("Deck should have been changed yet", getCol().getCard(cardId).getDid(), not(deckIdToChangeTo));
         }
 
-        final int deckPosition = b.getDeckPositionFromId(deckIdToChangeTo);
+        final int deckPosition = b.getChangeDeckPositionFromId(deckIdToChangeTo);
 
         //act
         AnkiAssert.assertDoesNotThrow(() -> b.changeDeck(deckPosition));


### PR DESCRIPTION
## Request

Could you ask me to rebase this if this isn't going to be squashed. The final commit is a regression fix introduced in the first commit, it's a bit of effort to fix due to an incorrect unit test based of the assumption in the middle, which isn't worth fixing it if we'll squash-merge this.

## Purpose / Description

You can't move cards to a filtered deck via "Change Deck" in Anki Desktop, we do the same in AnkiDroid

## Fixes
Partially: #5932. Needs a PR for a check database to close this off.

## Approach
Removes filtered decks from the "change deck" screen, and blocks any internal attempts to change them

## How Has This Been Tested?

Unit tests, I can still move decks on my phone, but the filtered decks no longer exist.

Tested on my Android, missed a regression and fixed a test to handle it, now works as normal.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code