### PR TITLE
Add Disable Extended Text UI Preference

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.java
@@ -2,13 +2,18 @@
 package com.ichi2.anki;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.graphics.drawable.Drawable;
 import android.os.Parcelable;
+import android.preference.PreferenceManager;
 import android.util.AttributeSet;
 import android.widget.TextView;
 import androidx.appcompat.widget.AppCompatEditText;
+import timber.log.Timber;
 
 import com.ichi2.themes.Themes;
+
+import static android.view.inputmethod.EditorInfo.IME_FLAG_NO_EXTRACT_UI;
 
 
 public class FieldEditText extends AppCompatEditText {
@@ -40,6 +45,25 @@ public class FieldEditText extends AppCompatEditText {
         // content text has been saved in NoteEditor.java, restore twice caused issue#5660
         super.onSaveInstanceState();
         return null;
+    }
+
+    @Override
+    protected void onAttachedToWindow() {
+        super.onAttachedToWindow();
+        if (shouldDisableExtendedTextUi()) {
+            Timber.i("Disabling Extended Text UI");
+            this.setImeOptions(this.getImeOptions() | IME_FLAG_NO_EXTRACT_UI);
+        }
+    }
+
+    private boolean shouldDisableExtendedTextUi() {
+        try {
+            SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(this.getContext());
+            return sp.getBoolean("disableExtendedTextUi", false);
+        } catch (Exception e) {
+            Timber.e(e, "Failed to get extended UI preference");
+            return false;
+        }
     }
 
 

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -123,6 +123,9 @@
     <string name="select_locale_title">Select language</string>
     <string name="safe_display">Safe display mode</string>
     <string name="safe_display_summ">Disable all animations and use safer method for drawing cards. E-ink devices may require this.</string>
+    <string name="disable_extended_text_ui">Disable Single-Field Edit Mode</string>
+    <!--See: multimedia_editor_popup_cloze. We can't use format strings as this is auto-generated-->
+    <string name="disable_extended_text_ui_summ">Allows \'Cloze Deletion\' context menu when in landscape mode.</string>
     <string name="vertical_centering">Center align</string>
     <string name="vertical_centering_summ">Center the content of cards vertically</string>
     <string name="pref_backup_max">Max number of backups</string>

--- a/AnkiDroid/src/main/res/xml/preferences_advanced.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_advanced.xml
@@ -67,6 +67,12 @@
                 android:key="fixHebrewText"
                 android:summary="@string/fix_hebrew_text_summ"
                 android:title="@string/fix_hebrew_text" />
+            <!-- Workaround for #5533 -->
+            <CheckBoxPreference
+                android:defaultValue="false"
+                android:key="disableExtendedTextUi"
+                android:summary="@string/disable_extended_text_ui_summ"
+                android:title="@string/disable_extended_text_ui" />
         </PreferenceCategory>
         <PreferenceCategory
             android:key="category_plugins"


### PR DESCRIPTION
## Purpose / Description
This allows 'Cloze Deletion' to be shown in Landscape mode.

## Fixes
Fixes #5533

## Approach
We pass a flag to the IME to disable the Extended Text UI

## How Has This Been Tested?

On my Android with GBoard

![image](https://user-images.githubusercontent.com/62114487/78611128-2585b500-785e-11ea-891d-4670f8412690.png)


## Learning (optional, can help others)

https://stackoverflow.com/a/23367951

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code