### PR TITLE
Uses classes to sort deck names and deck objects

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
@@ -55,6 +55,7 @@ import com.ichi2.ui.AppCompatPreferenceActivity;
 import com.ichi2.utils.JSONArray;
 import com.ichi2.utils.JSONException;
 import com.ichi2.utils.JSONObject;
+import com.ichi2.utils.NamedJSONComparator;
 
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -778,7 +779,7 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
     protected void buildLists() {
         ListPreference deckConfPref = (ListPreference) findPreference("deckConf");
         ArrayList<JSONObject> confs = mCol.getDecks().allConf();
-        Collections.sort(confs, new JSONNameComparator());
+        Collections.sort(confs, NamedJSONComparator.instance);
         String[] confValues = new String[confs.size()];
         String[] confLabels = new String[confs.size()];
         for (int i = 0; i < confs.size(); i++) {
@@ -844,18 +845,6 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
             count++;
         }
         return count;
-    }
-
-
-    public class JSONNameComparator implements Comparator<JSONObject> {
-        @Override
-        public int compare(JSONObject lhs, JSONObject rhs) {
-            String o1;
-            String o2;
-            o1 = lhs.getString("name");
-            o2 = rhs.getString("name");
-            return o1.compareToIgnoreCase(o2);
-        }
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -78,6 +78,8 @@ import com.ichi2.themes.StyledProgressDialog;
 import com.ichi2.themes.Themes;
 import com.ichi2.anki.widgets.PopupMenuWithIcons;
 import com.ichi2.utils.AdaptionUtil;
+import com.ichi2.utils.DeckComparator;
+import com.ichi2.utils.NamedJSONComparator;
 import com.ichi2.widget.WidgetStatus;
 
 import com.ichi2.utils.JSONArray;
@@ -424,7 +426,7 @@ public class NoteEditor extends AnkiActivity {
         mAllModelIds = new ArrayList<>();
         final ArrayList<String> modelNames = new ArrayList<>();
         ArrayList<JSONObject> models = getCol().getModels().all();
-        Collections.sort(models, new JSONNameComparator());
+        Collections.sort(models, NamedJSONComparator.instance);
         for (JSONObject m : models) {
             modelNames.add(m.getString("name"));
             mAllModelIds.add(m.getLong("id"));
@@ -446,7 +448,7 @@ public class NoteEditor extends AnkiActivity {
         final ArrayList<String> deckNames = new ArrayList<>();
 
         ArrayList<JSONObject> decks = getCol().getDecks().all();
-        Collections.sort(decks, new JSONNameComparator());
+        Collections.sort(decks, DeckComparator.instance);
         for (JSONObject d : decks) {
             // add current deck and all other non-filtered decks to deck list
             long thisDid = d.getLong("id");
@@ -1522,28 +1524,6 @@ public class NoteEditor extends AnkiActivity {
     // INNER CLASSES
     // ----------------------------------------------------------------------------
 
-    public class JSONNameComparator implements Comparator<JSONObject> {
-        @Override
-        public int compare(JSONObject lhs, JSONObject rhs) {
-            String[] o1;
-            String[] o2;
-            o1 = lhs.getString("name").split("::");
-            o2 = rhs.getString("name").split("::");
-            for (int i = 0; i < Math.min(o1.length, o2.length); i++) {
-                int result = o1[i].compareToIgnoreCase(o2[i]);
-                if (result != 0) {
-                    return result;
-                }
-            }
-            if (o1.length < o2.length) {
-                return -1;
-            } else if (o1.length > o2.length) {
-                return 1;
-            } else {
-                return 0;
-            }
-        }
-    }
 
 
     private class SetNoteTypeListener implements OnItemSelectedListener {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -28,6 +28,7 @@ import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.anki.exception.DeckRenameException;
 import com.ichi2.libanki.exception.NoSuchDeckException;
 
+import com.ichi2.utils.DeckComparator;
 import com.ichi2.utils.JSONArray;
 import com.ichi2.utils.JSONObject;
 
@@ -374,12 +375,7 @@ public class Decks {
      */
     public ArrayList<JSONObject> allSorted() {
         ArrayList<JSONObject> decks = all();
-        Collections.sort(decks, new Comparator<JSONObject>() {
-            @Override
-            public int compare(JSONObject lhs, JSONObject rhs) {
-                return lhs.getString("name").compareTo(rhs.getString("name"));
-            }
-        });
+        Collections.sort(decks, DeckComparator.instance);
         return decks;
     }
 
@@ -900,9 +896,7 @@ public class Decks {
         // Go through all decks, sorted by name
         ArrayList<JSONObject> decks = all();
 
-        Collections.sort(decks, (o1, o2) -> {
-                return o1.getString("name").compareTo(o2.getString("name"));
-        });
+        Collections.sort(decks, DeckComparator.instance);
 
         for (JSONObject deck : decks) {
             HashMap node = new HashMap();

--- a/AnkiDroid/src/main/java/com/ichi2/utils/DeckComparator.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/DeckComparator.java
@@ -1,0 +1,15 @@
+package com.ichi2.utils;
+
+import com.ichi2.utils.DeckNameComparator;
+import com.ichi2.utils.JSONObject;
+
+import java.util.Comparator;
+
+public class DeckComparator implements Comparator<JSONObject> {
+    public static final DeckComparator instance = new DeckComparator();
+
+    @Override
+    public int compare(JSONObject lhs, JSONObject rhs) {
+        return DeckNameComparator.instance.compare(lhs.getString("name"), rhs.getString("name"));
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/utils/DeckNameComparator.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/DeckNameComparator.java
@@ -1,0 +1,28 @@
+package com.ichi2.utils;
+
+import java.util.Comparator;
+
+public class DeckNameComparator implements Comparator<String> {
+    public static final DeckNameComparator instance = new DeckNameComparator();
+
+    @Override
+    public int compare(String lhs, String rhs) {
+        String[] o1;
+        String[] o2;
+        o1 = lhs.split("::");
+        o2 = rhs.split("::");
+        for (int i = 0; i < Math.min(o1.length, o2.length); i++) {
+            int result = o1[i].compareToIgnoreCase(o2[i]);
+            if (result != 0) {
+                return result;
+            }
+        }
+        if (o1.length < o2.length) {
+            return -1;
+        } else if (o1.length > o2.length) {
+            return 1;
+        } else {
+            return 0;
+        }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/utils/NamedJSONComparator.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/NamedJSONComparator.java
@@ -1,0 +1,18 @@
+package com.ichi2.utils;
+
+import com.ichi2.utils.JSONObject;
+
+import java.util.Comparator;
+
+public class NamedJSONComparator implements Comparator<JSONObject> {
+    public static final NamedJSONComparator instance = new NamedJSONComparator();
+
+    @Override
+    public int compare(JSONObject lhs, JSONObject rhs) {
+        String o1;
+        String o2;
+        o1 = lhs.getString("name");
+        o2 = rhs.getString("name");
+        return o1.compareToIgnoreCase(o2);
+    }
+}


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
There were a lot of duplicate and almost duplicate code in
AnkiDroid. Often the comparator class was put in some random place,
where it could not easily be found to be used again when needed. So I
tried to make this slightly more consistent by creating three
comparators. One for name of deck. One for json objects representing
decks. One for json objects with a name.

I am also correcting a small bug relating to sorting of decks. The
sorting in allSorted was wrong because A::A should appear before A9,
while it sorted it after. (This is because it considered ":" as a
character, and not a separator).

Luckily, this did not cause real trouble since this method is not even
used to sort decks in the deck picker interface.

## Approach
By putting all comparators together, in utils, so that they can be easily found. I searched for all "sort(" in the anki and libanki, to check whether they could be used elsewhere too.

## How Has This Been Tested?

Adding it to my "merge" branch, and installing it on my phone


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
