### PR TITLE
Loading models after GUI is shown

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -2122,6 +2122,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
                 // Update the mini statistics bar as well
                 AnkiStatsTaskHandler.createReviewSummaryStatistics(getCol(), mReviewSummaryTextView);
+                getCol().loadModels(); // No more DB access is needed now, so we can do the DB intesive action of loading the models asynchronously.
             }
         });
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -57,6 +57,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.FutureTask;
 import java.util.regex.Pattern;
 
 import androidx.annotation.Nullable;
@@ -82,9 +84,8 @@ public class Collection {
     //private double mLastSave;
     private Media mMedia;
     private Decks mDecks;
-    private Models mModels;
     private Tags mTags;
-
+    private ModelsLoader mModels;
     private AbstractSched mSched;
 
     private double mStartTime;
@@ -168,7 +169,7 @@ public class Collection {
         //mLastSave = Utils.now(); // assigned but never accessed - only leaving in for upstream comparison
         clearUndo();
         mMedia = new Media(this, server);
-        mModels = new Models(this);
+        mModels = new ModelsLoader(this);
         mDecks = new Decks(this);
         mTags = new Tags(this);
         load();
@@ -266,7 +267,8 @@ public class Collection {
                 cursor.close();
             }
         }
-        mModels.load(loadColumn("models"));
+        // mModels.load(loadColumn("models"));
+        // We deviate from upstream by lazy loading the models to improve app start time
         mDecks.load(loadColumn("decks"), deckConf);
     }
 
@@ -349,7 +351,7 @@ public class Collection {
 
     public synchronized void save(String name, long mod) {
         // let the managers conditionally flush
-        mModels.flush();
+        mModels.get().flush();
         mDecks.flush();
         mTags.flush();
         // and flush deck + bump mod if db has been changed
@@ -476,7 +478,7 @@ public class Collection {
         // we can save space by removing the log of deletions
         mDb.execute("delete from graves");
         mUsn += 1;
-        mModels.beforeUpload();
+        mModels.get().beforeUpload();
         mTags.beforeUpload();
         mDecks.beforeUpload();
         modSchemaNoCheck();
@@ -566,7 +568,7 @@ public class Collection {
      * @return The new note
      */
     public Note newNote(boolean forDeck) {
-        return newNote(mModels.current(forDeck));
+        return newNote(mModels.get().current(forDeck));
     }
 
     /**
@@ -637,7 +639,7 @@ public class Collection {
      */
     public ArrayList<JSONObject> findTemplates(Note note) {
         JSONObject model = note.model();
-        ArrayList<Integer> avail = mModels.availOrds(model, Utils.joinFields(note.getFields()));
+        ArrayList<Integer> avail = mModels.get().availOrds(model, Utils.joinFields(note.getFields()));
         return _tmplsFromOrds(model, avail);
     }
 
@@ -735,8 +737,8 @@ public class Collection {
                 long nid = cur.getLong(0);
                 long mid = cur.getLong(1);
                 String flds = cur.getString(2);
-                JSONObject model = mModels.get(mid);
-                ArrayList<Integer> avail = mModels.availOrds(model, flds);
+                JSONObject model = mModels.get().get(mid);
+                ArrayList<Integer> avail = mModels.get().availOrds(model, flds);
                 long did = dids.get(nid);
                 // use sibling due if there is one, else use a new id
                 long due;
@@ -1008,12 +1010,12 @@ public class Collection {
         ArrayList<Object[]> r = new ArrayList<>();
         for (Object[] o : _fieldData(snids)) {
             String[] fields = Utils.splitFields((String) o[2]);
-            JSONObject model = mModels.get((Long) o[1]);
+            JSONObject model = mModels.get().get((Long) o[1]);
             if (model == null) {
                 // note point to invalid model
                 continue;
             }
-            r.add(new Object[] { Utils.stripHTMLMedia(fields[mModels.sortIdx(model)]), Utils.fieldChecksum(fields[0]), o[0] });
+            r.add(new Object[] { Utils.stripHTMLMedia(fields[mModels.get().sortIdx(model)]), Utils.fieldChecksum(fields[0]), o[0] });
         }
         // apply, relying on calling code to bump usn+mod
         mDb.executeMany("UPDATE notes SET sfld=?, csum=? WHERE id=?", r);
@@ -1063,8 +1065,8 @@ public class Collection {
         // unpack fields and create dict
         String[] flist = Utils.splitFields((String) data[6]);
         Map<String, String> fields = new HashMap<>();
-        JSONObject model = mModels.get((Long) data[2]);
-        Map<String, Pair<Integer, JSONObject>> fmap = mModels.fieldMap(model);
+        JSONObject model = mModels.get().get((Long) data[2]);
+        Map<String, Pair<Integer, JSONObject>> fmap = mModels.get().fieldMap(model);
         for (String name : fmap.keySet()) {
             fields.put(name, flist[fmap.get(name).first]);
         }
@@ -1509,13 +1511,13 @@ public class Collection {
         }
         boolean badNotes = mDb.queryScalar(String.format(Locale.US,
                 "select 1 from notes where id not in (select distinct nid from cards) " +
-                "or mid not in %s limit 1", Utils.ids2str(mModels.ids()))) > 0;
+                "or mid not in %s limit 1", Utils.ids2str(mModels.get().ids()))) > 0;
         // notes without cards or models
         if (badNotes) {
             return false;
         }
         // invalid ords
-        for (JSONObject m : mModels.all()) {
+        for (JSONObject m : mModels.get().all()) {
             // ignore clozes
             if (m.getInt("type") != Consts.MODEL_STD) {
                 continue;
@@ -1545,7 +1547,7 @@ public class Collection {
         ArrayList<String> problems = new ArrayList<>();
         long oldSize = file.length();
         final int[] currentTask = {1};
-        int totalTasks = (mModels.all().size() * 4) + 23; // a few fixes are in all-models loops, the rest are one-offs
+        int totalTasks = (mModels.get().all().size() * 4) + 23; // a few fixes are in all-models loops, the rest are one-offs
         Runnable notifyProgress = () -> fixIntegrityProgress(progressCallback, currentTask[0]++, totalTasks);
         FunctionalInterfaces.Consumer<FunctionalInterfaces.FunctionThrowable<Runnable, List<String>, JSONException>> executeIntegrityTask =
                 (FunctionalInterfaces.FunctionThrowable<Runnable, List<String>, JSONException> function) -> {
@@ -1585,7 +1587,7 @@ public class Collection {
 
         executeIntegrityTask.consume(this::deleteNotesWithMissingModel);
         // for each model
-        for (JSONObject m : mModels.all()) {
+        for (JSONObject m : mModels.get().all()) {
             executeIntegrityTask.consume((callback) -> deleteCardsWithInvalidModelOrdinals(callback, m));
             executeIntegrityTask.consume((callback) -> deleteNotesWithWrongFieldCounts(callback, m));
         }
@@ -1626,7 +1628,7 @@ public class Collection {
         Timber.d("ensureModelsAreNotEmpty()");
         ArrayList<String> problems = new ArrayList<>();
         notifyProgress.run();
-        if (mModels.ensureNotEmpty()) {
+        if (mModels.get().ensureNotEmpty()) {
             problems.add("Added missing note type.");
         }
         return problems;
@@ -1712,9 +1714,9 @@ public class Collection {
     private List<String> updateFieldCache(Runnable notifyProgress) {
         Timber.d("updateFieldCache");
         // field cache
-        for (JSONObject m : mModels.all()) {
+        for (JSONObject m : mModels.get().all()) {
             notifyProgress.run();
-            updateFieldCache(Utils.arrayList2array(mModels.nids(m)));
+            updateFieldCache(Utils.arrayList2array(mModels.get().nids(m)));
         }
         return Collections.emptyList();
     }
@@ -1909,7 +1911,7 @@ public class Collection {
         // note types with a missing model
         notifyProgress.run();
         ArrayList<Long> ids = mDb.queryColumn(Long.class,
-                "SELECT id FROM notes WHERE mid NOT IN " + Utils.ids2str(mModels.ids()), 0);
+                "SELECT id FROM notes WHERE mid NOT IN " + Utils.ids2str(mModels.get().ids()), 0);
         notifyProgress.run();
         if (ids.size() != 0) {
             problems.add("Deleted " + ids.size() + " note(s) with missing note type.");
@@ -2034,15 +2036,61 @@ public class Collection {
         return mMedia;
     }
 
+    private class ModelsLoader {
+    /**
+       Loads the note types asynchronously. This decrease start-up
+       time and avoid to lock database access. See
+       https://github.com/ankidroid/Anki-Android/pull/5947 for
+       discussion about this topic.
+
+     */
+        private Collection mCol;
+        private FutureTask<Models> mFutureTask;
+
+        public ModelsLoader (Collection col) {
+            mCol = col;
+        }
+
+        /**
+           Starts a FutureTask on a new thread (if one doesn't already exist) to load the models asynchronously
+         */
+        public synchronized void load() {
+            if (mFutureTask != null) {
+                return;
+            }
+            mFutureTask = new FutureTask<Models> (() -> new Models(mCol).load(loadColumn("models")));
+            new Thread(mFutureTask).start();
+        }
+
+        /** 
+            Waits for the FutureTask to complete and returns the result
+        */
+        public Models get() {
+            load();
+            try {
+                return mFutureTask.get();
+            } catch (ExecutionException | InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    /** 
+        Start loading the models asynchronously
+        This can still indirectly block other operations if they require database access
+    */
+    public void loadModels() {
+        mModels.load();
+    }
 
     public Models getModels() {
-        return mModels;
+        return mModels.get();
     }
 
     /** Check if this collection is valid. */
     public boolean validCollection() {
     	//TODO: more validation code
-    	return mModels.validateModel();
+    	return mModels.get().validateModel();
     }
 
     public JSONObject getConf() {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -145,7 +145,7 @@ public class Models {
     /**
      * Load registry from JSON.
      */
-    public void load(String json) {
+    public Models load(String json) {
         mChanged = false;
         mModels = new HashMap<>();
         JSONObject modelarray = new JSONObject(json);
@@ -157,6 +157,7 @@ public class Models {
                 mModels.put(o.getLong("id"), o);
             }
         }
+        return this;
     }
 
 


### PR DESCRIPTION
This was first push as the Pull Request
https://github.com/ankidroid/Anki-Android/pull/5929 Given the number of change, I am creating a new branch and a new Pull Request, so if it does not please ankidroid mainteneurs, the previous
work is not lost

My AnkiDroid is really slow to start. According to profiling, the
slowest part is reading the database content. In particular, reading
the json configurations. Those are JSON files which may easily takes
more than a MB and does not fit into the cursor.

Note type are not required to show the GUI. So I ensure they are
loaded asynchronously. Furthermore, since loading is database heavy, I
ensure it get done only once the GUI thread has accessed everything it
needs.

In order to ensure that the models are accessed only once they are
loaded, I create a private class, ModelLoader, which will be required
to accessed the models. It ensures that models are returned only once
it's loaded. This diminish the risk that a future edition tries to
access models while they are actually not ready to be used.