### PR TITLE
Search for cloze references in all fields

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1687,13 +1687,20 @@ public class NoteEditor extends AnkiActivity {
                 String selectedText = text.substring(selectionStart, selectionEnd);
                 String afterText = text.substring(selectionEnd);
 
-                // Find the largest existing cloze deletion id
-                Matcher matcher = mClozeRegexPattern.matcher(text);
+                // Search in all fields of the current note for the cloze reference with the highest value
+                // Per the manual, cloze references are the name of the delimiters for cloze deletions e.g. {{c1::text}}
                 int highestClozeId = 0;
-                while (matcher.find()) {
-                    int detectedClozeId = Integer.parseInt(matcher.group(1));
-                    if (detectedClozeId > highestClozeId) {
-                        highestClozeId = detectedClozeId;
+                // Begin looping through the fields
+                for (FieldEditText currentField : mEditFields) {
+                    // Get the actual data contained in the current field
+                    String fieldLiteral = currentField.getText().toString();
+                    // Begin searching in the current field for cloze references
+                    Matcher matcher = mClozeRegexPattern.matcher(fieldLiteral);
+                    while (matcher.find()) {
+                        int detectedClozeId = Integer.parseInt(matcher.group(1));
+                        if (detectedClozeId > highestClozeId) {
+                            highestClozeId = detectedClozeId;
+                        }
                     }
                 }
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
_Describe the problem or feature and motivation_
When adding cloze references ({{c1::, {{c2::, {{c3::, ... ) in Anki desktop, the reference increments automatically based on the largest reference it finds after searching in every field. AnkiDroid currently only searches in the currently selected field. As explained in #5652, this is annoying when adding cloze references to notes with more than one {{cloze::}} field (which is recommended in the [cloze deletion section of the Anki Manual](https://docs.ankiweb.net/#/editing?id=cloze-deletion) to handle nested cloze references)

## Fixes
Fixes #5652 

## Approach
_How does this change address the problem?_
The code is largely the same, but instead of performing the search on just the currently selected field, it now iterates through the fields of the current note and performs the search
## How Has This Been Tested?
Android 10.0 virtual device in android studio
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration (SDK version(s), emulator or physical, etc)

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [ x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [ x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ x] You have commented your code, particularly in hard-to-understand areas
- [ x] You have performed a self-review of your own code
