### PR TITLE
CardViewer: Correctly Decode typed text in <input>

### DIFF
--- a/AnkiDroid/src/main/assets/scripts/card.js
+++ b/AnkiDroid/src/main/assets/scripts/card.js
@@ -96,7 +96,9 @@ function buttonAnswerEase4() {
 
 /* Tell the app the text in the input box when it loses focus */
 function taBlur(itag) {
-    window.location.href = "typeblurtext:" + itag.value;
+    //#5944 - percent wasn't encoded, but Mandarin was.
+    var encodedVal = encodeURI(itag.value);
+    window.location.href = "typeblurtext:" + encodedVal;
 }
 
 /* Look at the text entered into the input box and send the text on a return */
@@ -111,7 +113,9 @@ function taKey(itag, e) {
     }
 
     if (keycode == 13) {
-        window.location.href = "typeentertext:" + itag.value;
+        //#5944 - percent wasn't encoded, but Mandarin was.
+        var encodedVal = encodeURI(itag.value);
+        window.location.href = "typeentertext:" + encodedVal;
         return false;
     } else {
         return true;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -2916,6 +2916,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
         @TargetApi(Build.VERSION_CODES.N)
         public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {
             String url = request.getUrl().toString();
+            Timber.i("Obtained URL from card: '%s'", url);
             return filterUrl(url);
         }
 

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -163,4 +163,6 @@
 
     <!-- Card Browser -->
     <string name="card_browser_deck_change_error">Could not change deck</string>
+    <!-- AbstractFlashCardViewer -->
+    <string name="card_viewer_url_decode_error">Error decoding data from card</string>
 </resources>


### PR DESCRIPTION
## Purpose / Description
Previously, only some data was URL Encoded when sent from JS to Java. When an invalid sequence (a single `%`) was entered, then the app would crash due to the decode failure.

## Fixes
Fixes #5944

## Approach
We both fix this encoding in the JS, and if invalid data comes in for any reason, we show an error.


## How Has This Been Tested?

Unit Tested with data. No longer crashes my Android.


## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code