### PR TITLE
Add Android R and JDK1.14 to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ env:
    - API=27
    - API=28
    - API=29
-   - API=Q # This will be API30 when it is released, until now it is Q and it is failing unfortunately
+   - API=R EMU_FLAVOR=google_apis # This will be API30 when it is released, until now it is R and it is failing unfortunately
    - API=24 JDK="1.11" # make sure we work in future dev environments
    - API=24 JDK="1.14" # make sure we work in future dev environments
 
@@ -70,7 +70,7 @@ jobs:
       install: skip
       script: echo finalize codacy coverage uploads
   allow_failures:
-    - env: API=Q # unreleased Android API30 is failing in local builds, let's expose that on Travis
+    - env: API=R EMU_FLAVOR=google_apis # unreleased Android API30 is failing in local builds, let's expose that on Travis
     - env: API=24 JDK="1.11" # non-default JDKs should not hold up success reporting
     - env: API=24 JDK="1.14" # non-default JDKs should not hold up success reporting
     - env: FINALIZE_COVERAGE=TRUE API=NONE # finalizing coverage should not hold up success reporting

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ env:
    - API=27
    - API=28
    - API=29
+   - API=Q # This will be API30 when it is released, until now it is Q and it is failing unfortunately
    - API=24 JDK="1.11" # make sure we work in the future
 
 jobs:
@@ -68,6 +69,7 @@ jobs:
       install: skip
       script: echo finalize codacy coverage uploads
   allow_failures:
+    - env: API=Q # unreleased Android API30 is failing in local builds, let's expose that on Travis
     - env: API=24 JDK="1.11" # non-default JDKs should not hold up success reporting
     - env: FINALIZE_COVERAGE=TRUE API=NONE # finalizing coverage should not hold up success reporting
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,8 @@ env:
    - API=28
    - API=29
    - API=Q # This will be API30 when it is released, until now it is Q and it is failing unfortunately
-   - API=24 JDK="1.11" # make sure we work in the future
+   - API=24 JDK="1.11" # make sure we work in future dev environments
+   - API=24 JDK="1.14" # make sure we work in future dev environments
 
 jobs:
   fast_finish: true  # Report success without waiting for jobs that allowed to fail.
@@ -71,6 +72,7 @@ jobs:
   allow_failures:
     - env: API=Q # unreleased Android API30 is failing in local builds, let's expose that on Travis
     - env: API=24 JDK="1.11" # non-default JDKs should not hold up success reporting
+    - env: API=24 JDK="1.14" # non-default JDKs should not hold up success reporting
     - env: FINALIZE_COVERAGE=TRUE API=NONE # finalizing coverage should not hold up success reporting
 
 before_install:


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
There is a new "LTS" release of Java (1.14) which I'd like to canary for forward-porting

There is also a test release of Android API R/30 which I noticed we currently fail completely on with database access issues, which I would like to start a canary on - it could also show if we have problems with the API restrictions changing per comments in #5918 


## Approach
I have added instrumented test runs for JDK1.14 and APIR so we can expose problems, both are set to allow failure so it won't affect PR velocity

## How Has This Been Tested?

I have a personal Travis CI instance hooked to my AnkiDroid fork so I can develop things like this: https://travis-ci.com/github/mikehardy/Anki-Android/branches

This should be passing now so I know I won't blow up the project: https://travis-ci.com/github/mikehardy/Anki-Android/builds/159314705

## Learning (optional, can help others)
I will post a couple separate issues for the failures exposed by these test runs


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
