### PR TITLE
current.getLong("id") to selected

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1711,8 +1711,9 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
             // Dynamic don't have review options; attempt to get deck-specific auto-advance options
             // but be prepared to go with all default if it's a dynamic deck
             JSONObject revOptions = new JSONObject();
-            if (!getCol().getDecks().isDyn(getCol().getDecks().current().getLong("id"))) {
-                revOptions = getCol().getDecks().confForDid(getCol().getDecks().current().getLong("id")).getJSONObject("rev");
+            long selectedDid = getCol().getDecks().selected();
+            if (!getCol().getDecks().isDyn(selectedDid)) {
+                revOptions = getCol().getDecks().confForDid(selectedDid).getJSONObject("rev");
             }
 
             mOptUseGeneralTimerSettings = revOptions.optBoolean("useGeneralTimeoutSettings", true);


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Improving ankidroid code quality. Shorter code and avoiding useless computation.

## Approach
selected() returns the id. Current is defined as get(selected()). So
doing current.getLong("id") takes the id, get the deck, and then takes
the id.

## How Has This Been Tested?
Put in my "merged" branch, which I run on my phone with all PR I made

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
