### PR TITLE
getJSONArray/Objects get quicker

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/utils/Assert.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/Assert.java
@@ -18,9 +18,10 @@
 package com.ichi2.utils;
 
 public class Assert {
-    public static void that(boolean condition, String message) {
+    public static void that(boolean condition, String message, Object... args) {
         if (!condition) {
-            throw new AssertionError(message);
+            String msg = String.format(message, args);
+            throw new AssertionError(msg);
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/JSONArray.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/JSONArray.java
@@ -29,7 +29,7 @@ public class JSONArray extends org.json.JSONArray {
      * @return the same element as input. But considered as a JSONArray.
      */
     public static JSONArray arrayToArray(org.json.JSONArray ar){
-        Assert.that(ar == null || ar instanceof JSONArray, "Object "+ar+" should have been an instance of our JSONArray.");
+        Assert.that(ar == null || ar instanceof JSONArray, "Object %s should have been an instance of our JSONArray.", ar);
         return (JSONArray) ar;
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/utils/JSONObject.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/JSONObject.java
@@ -120,7 +120,7 @@ public class JSONObject extends org.json.JSONObject implements Iterable<String> 
      * @return Exactly the same object, with a different type.
      */
     public static JSONObject objectToObject(org.json.JSONObject obj){
-        Assert.that(obj == null || (obj instanceof JSONObject), "Object "+ obj+" should have been an instance of our JSONObject.");
+        Assert.that(obj == null || (obj instanceof JSONObject), "Object %s should have been an instance of our JSONObject.", obj);
         return (JSONObject) obj;
     }
 


### PR DESCRIPTION
## Pull Request template
## Fixes
Looking at the profiler, I found out that model loading (something I care a lot about currently) spends more than two seconds in the string builder method. Which makes no sens at all since we're reading a string and don't want to see any. 2 seconds is not a lot, but still that's strange.

I then realized I made an horrible mistake. In my error message, I use the object/array. It's a good idea I believe generally, it'll help debugging. But it means that the object string representation is shown even when it is actually useless. 

## Approach
I send a string that can be formatted, and an argument instead of sending the string pre computed.

## How Has This Been Tested?

Putting it in my merge branch. This method did disappear from the profiler.
I didn't test raising the exception; since this is never supposed to occur in the first place, it would be far too much to do.

## Learning (optional, can help others)
Never send string literal for debugging (actually, I was supposed to know this, an add-on of mine had a similar problem)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
