### PR TITLE
only call Sched.reset() once on scheduler opening

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -2351,6 +2351,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
     private void openReviewer() {
         Intent reviewer = new Intent(this, Reviewer.class);
+        reviewer.putExtra("com.ichi2.anki.SchedResetDone", true);
         startActivityForResultWithAnimation(reviewer, REQUEST_REVIEW, ActivityTransitionAnimation.LEFT);
         getCol().startTimebox();
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -61,6 +61,9 @@ public class Reviewer extends AbstractFlashcardViewer {
     private boolean mBlackWhiteboard = true;
     private boolean mPrefFullscreenReview = false;
     private static final int ADD_NOTE = 12;
+    // Deck picker reset scheduler before opening the reviewer. So
+    // first reset is useless.
+    private boolean mSchedResetDone = false;
 
 
     private DeckTask.TaskListener mRescheduleCardHandler = new ScheduleDeckTaskListener() {
@@ -96,6 +99,9 @@ public class Reviewer extends AbstractFlashcardViewer {
         Timber.d("onCreate()");
         super.onCreate(savedInstanceState);
 
+        if (getIntent().hasExtra("com.ichi2.anki.SchedResetDone")) {
+            mSchedResetDone = true;
+        }
         if (Intent.ACTION_VIEW.equals(getIntent().getAction())) {
             Timber.d("onCreate() :: received Intent with action = %s", getIntent().getAction());
             selectDeckFromExtra();
@@ -171,7 +177,10 @@ public class Reviewer extends AbstractFlashcardViewer {
             setWhiteboardVisibility(whiteboardVisibility);
         }
 
-        col.getSched().reset();     // Reset schedule incase card had previous been loaded
+        if (!mSchedResetDone) {
+            col.getSched().reset();     // Reset schedule in case card was previously loaded
+            mSchedResetDone = false;
+        }
         DeckTask.launchDeckTask(DeckTask.TASK_TYPE_ANSWER_CARD, mAnswerCardHandler,
                 new DeckTask.TaskData(null, 0));
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Loading my top level deck is long on my phone. Ten seconds. I want to improve that. On my collection and my phone, scheduler's reset take 4 seconds, so I want to avoid doing it in a case where it's absolutely not necessary.

## Fixes
Reset is done twice when reviewer is opened from deck picker. This is because:
* to check whether the deck can be reviewer, reset is done to see the
  correct number of card
* when reviewer starts, it calls reset to check whether there are
  actually cards to review/create the queue

Both actions are useful, but in this case it's a duplicate. Since
starting to review a deck from the list of deck is actually an action
performed often, it's important that it gets optimized, and thus I add
a notion of "reset done" to the intent, to state that reset does not
have to be done immediately by reviewer. I also ensure that future
resets are actually done.
## Approach
Adding an extra value to intent when reset was done, so that reviewer know it does not have to do it.

I'm surprised, because on https://developer.android.com/reference/android/content/Intent#putExtra(java.lang.String,%20android.os.Bundle) it states that extra name:

> must include a package prefix, for example the app com.android.contacts would use names like "com.android.contacts.ShowAll".

And it seems this has not be done in other putExtra in the code

## How Has This Been Tested?

Adding this to my "merge" branch, running the profiler, and ensuring that "reset" was run only once when I clicked on a deck.

## Learning (optional, can help others)
Profilers are wonderful things.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
