### PR TITLE
Remove sublist from Decks.parents

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -932,7 +932,8 @@ public class Decks {
         // get parent and grandparent names
         List<String> parents = new ArrayList<>();
         List<String> parts = Arrays.asList(get(did).getString("name").split("::", -1));
-        for (String part : parts.subList(0, parts.size() - 1)) {
+        for (int i = 0; i < parts.size() - 1; i++) {
+            String part = parts.get(i);
             if (parents.size() == 0) {
                 parents.add(part);
             } else {


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Making ankidroid faster. 

Currently, scheduler's reset spend 1 second and a half in the class sublist iterator. This is entirely useless, as removing it virtually does not increase code complexity and decrease the time of this method.

## Approach
Creating an explicit loop over indexes instead of using a sublist

## How Has This Been Tested?

Doing it in my "merge" branch, using anki, and ensuring everything works



## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code