### PR TITLE
Model loading ends before reviewer open

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -1971,6 +1971,8 @@ public class DeckPicker extends NavigationDrawerActivity implements
     }
 
     private void handleDeckSelection(long did, boolean dontSkipStudyOptions) {
+        // ensure that models are entirely loaded before doing anything else
+        getCol().getModels();
         // Clear the undo history when selecting a new deck
         if (getCol().getDecks().selected() != did) {
             getCol().clearUndo();


### PR DESCRIPTION



## Fixes
If the reviewer get opened before the model are loaded, database acces
gets locked, and the reviewer never fully loads.

This can only occur when note type takes times to load and deck is selected quickly.

## Approach
I thus ensure notes are loaded before any action related to deck
selection is done.

## How Has This Been Tested?

Adding it to my merge branch.



## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
