### PR TITLE
Bury suspend direct query

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -463,14 +463,14 @@ public class Reviewer extends AbstractFlashcardViewer {
         // Setup bury / suspend providers
         MenuItemCompat.setActionProvider(menu.findItem(R.id.action_suspend), new SuspendProvider(this));
         MenuItemCompat.setActionProvider(menu.findItem(R.id.action_bury), new BuryProvider(this));
-        if (dismissNoteAvailable(DismissType.SUSPEND_NOTE)) {
+        if (suspendNoteAvailable()) {
             menu.findItem(R.id.action_suspend).setIcon(R.drawable.ic_action_suspend_dropdown);
             menu.findItem(R.id.action_suspend).setTitle(R.string.menu_suspend);
         } else {
             menu.findItem(R.id.action_suspend).setIcon(R.drawable.ic_action_suspend);
             menu.findItem(R.id.action_suspend).setTitle(R.string.menu_suspend_card);
         }
-        if (dismissNoteAvailable(DismissType.BURY_NOTE)) {
+        if (buryNoteAvailable()) {
             menu.findItem(R.id.action_bury).setIcon(R.drawable.ic_flip_to_back_white_24px_dropdown);
             menu.findItem(R.id.action_bury).setTitle(R.string.menu_bury);
         } else {
@@ -769,18 +769,30 @@ public class Reviewer extends AbstractFlashcardViewer {
      * @param type Currently only SUSPEND_NOTE and BURY_NOTE supported
      * @return true if there is another card of same note that could be dismissed
      */
-    private boolean dismissNoteAvailable(DismissType type) {
-        if (mCurrentCard == null || mCurrentCard.note() == null || mCurrentCard.note().cards().size() < 2 || getControlBlocked()) {
+    private boolean suspendNoteAvailable() {
+        if (mCurrentCard == null || mCurrentCard.note() == null || mCurrentCard.note().cards().size() < 2 || getControlBlocked) {
             return false;
         }
         List<Card> cards = mCurrentCard.note().cards();
         for(Card card : cards) {
             if (card.getId() == mCurrentCard.getId()) continue;
             int queue = card.getQueue();
-            if(type == DismissType.SUSPEND_NOTE && queue != Consts.QUEUE_TYPE_SUSPENDED) {
+            if(queue != Consts.QUEUE_TYPE_SUSPENDED) {
                 return true;
-            } else if (type == DismissType.BURY_NOTE &&
-                    queue != Consts.QUEUE_TYPE_SUSPENDED && queue != Consts.QUEUE_TYPE_SIBLING_BURIED && queue != Consts.QUEUE_TYPE_MANUALLY_BURIED) {
+            }
+        }
+        return false;
+    }
+
+    private boolean buryNoteAvailable() {
+        if (mCurrentCard == null || mCurrentCard.note() == null || mCurrentCard.note().cards().size() < 2) {
+            return false;
+        }
+        List<Card> cards = mCurrentCard.note().cards();
+        for(Card card : cards) {
+            if (card.getId() == mCurrentCard.getId()) continue;
+            int queue = card.getQueue();
+            if (queue != Consts.QUEUE_TYPE_SUSPENDED && queue != Consts.QUEUE_TYPE_SIBLING_BURIED && queue != Consts.QUEUE_TYPE_MANUALLY_BURIED) {
                 return true;
             }
         }
@@ -802,7 +814,7 @@ public class Reviewer extends AbstractFlashcardViewer {
 
         @Override
         public boolean hasSubMenu() {
-            return dismissNoteAvailable(DismissType.SUSPEND_NOTE);
+            return suspendNoteAvailable();
         }
 
         @Override
@@ -844,7 +856,7 @@ public class Reviewer extends AbstractFlashcardViewer {
 
         @Override
         public boolean hasSubMenu() {
-            return dismissNoteAvailable(DismissType.BURY_NOTE);
+            return buryNoteAvailable();
         }
 
         @Override


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
I'm still trying to reduce card loading time. During loading, there was a function which took .7 seconds (probably because I've got a note type with 400 card types). This function was simply used to check whether the bury/suspend note button should be displayed.

Note that another reasonable approach would be simply to remove this function from the main UI thread, since there is no way it is actually needed on loading time. But decreasing it's computation time (and probably making the code simpler) seems nice too.

## Approach
I reduced it to something that I can't even see in the profiler by replacing the explicit loop by a really simple sql query. 

The first commit will probably need to be removed. It's useful only because I'm waiting for another PR to be merged, and needed one type change in the DB class.
## How Has This Been Tested?

Putting it on my merge branch, and reviewing cards.


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
