### PR TITLE
Extract and modify: GetNextClozeIndex

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Note.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Note.java
@@ -28,6 +28,8 @@ import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import timber.log.Timber;
 
@@ -388,5 +390,32 @@ public class Note implements Cloneable {
     @Override
     public int hashCode() {
         return (int) (mId ^ (mId >>> 32));
+    }
+
+
+    public static class ClozeUtils {
+        private static final Pattern mClozeRegexPattern = Pattern.compile("\\{\\{c(\\d+)::");
+
+        /*
+        Returns the next index that a cloze should be inserted at, given a list of fields.
+        Per the manual, cloze references are the name of the delimiters for cloze deletions e.g. {{c1::text}}
+        The next index is index after the highest existing cloze deletion, gaps are not considered.
+         */
+        public static int getNextClozeIndex(Iterable<String> fieldValues) {
+
+            int highestClozeId = 0;
+            // Begin looping through the fields
+            for (String fieldLiteral : fieldValues) {
+                // Begin searching in the current field for cloze references
+                Matcher matcher = mClozeRegexPattern.matcher(fieldLiteral);
+                while (matcher.find()) {
+                    int detectedClozeId = Integer.parseInt(matcher.group(1));
+                    if (detectedClozeId > highestClozeId) {
+                        highestClozeId = detectedClozeId;
+                    }
+                }
+            }
+            return highestClozeId + 1;
+        }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Note.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Note.java
@@ -396,10 +396,13 @@ public class Note implements Cloneable {
     public static class ClozeUtils {
         private static final Pattern mClozeRegexPattern = Pattern.compile("\\{\\{c(\\d+)::");
 
-        /*
-        Returns the next index that a cloze should be inserted at, given a list of fields.
-        Per the manual, cloze references are the name of the delimiters for cloze deletions e.g. {{c1::text}}
-        The next index is index after the highest existing cloze deletion, gaps are not considered.
+        /**
+         * Calculate the next number that should be used if inserting a new cloze deletion.
+         * Per the manual the next number should be greater than any existing cloze deletion
+         * even if there are gaps in the sequence, and regardless of existing cloze ordering
+         *
+         * @param fieldValues Iterable of field values that may contain existing cloze deletions
+         * @return the next index that a cloze should be inserted at
          */
         public static int getNextClozeIndex(Iterable<String> fieldValues) {
 

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/NoteTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/NoteTest.java
@@ -1,0 +1,58 @@
+package com.ichi2.libanki;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static com.ichi2.libanki.Note.ClozeUtils.getNextClozeIndex;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@RunWith(AndroidJUnit4.class)
+public class NoteTest {
+    @Test
+    public void noFieldDataReturnsFirstClozeIndex() {
+        int expected = getNextClozeIndex(Collections.emptyList());
+
+        assertThat("No data should return a cloze index of 1 the next.", expected, is(1));
+    }
+
+    @Test
+    public void negativeFieldIsIgnored() {
+        String fieldValue = "{{c-1::foo}}";
+        int actual = getNextClozeIndex(Collections.singletonList(fieldValue));
+
+        assertThat("The next consecutive value should be returned.", actual, is(1));
+    }
+
+    @Test
+    public void singleFieldReturnsNextValue() {
+        String fieldValue = "{{c2::bar}}{{c1::foo}}";
+        int actual = getNextClozeIndex(Collections.singletonList(fieldValue));
+
+        assertThat("The next consecutive value should be returned.", actual, is(3));
+    }
+
+    @Test
+    public void multiFieldIsHandled() {
+        List<String> fields = Arrays.asList("{{c1::foo}}", "{{c2::bar}}");
+        int actual = getNextClozeIndex(fields);
+
+        assertThat("The highest of all fields should be used.", actual, is(3));
+    }
+
+    @Test
+    public void missingFieldIsSkipped() {
+        //this mimics Anki Desktop
+        List<String> fields = Arrays.asList("{{c1::foo}}", "{{c3::bar}}{{c4::baz}}");
+        int actual = getNextClozeIndex(fields);
+
+        assertThat("A missing cloze index should not be selected if there are higher values.", actual, is(5));
+
+    }
+}


### PR DESCRIPTION
## Purpose / Description
I want to access this functionality from the Visual Editor without a reference to FieldEditText.

This also likely improves performance, taking the Regex.Compile from an instance variable into a static.


## Fixes
Paves the way for #1377

## Approach
Part automatic, part manual refactoring

## How Has This Been Tested?

Tested on my Android, no issues.

Added Unit Tests (all the existing code was good, I incremented the result by 1)

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code