### PR TITLE
Make sched fillLrn comparison quicker

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -764,7 +764,7 @@ public class SchedV2 extends AbstractSched {
             Collections.sort(mLrnQueue, new Comparator<long[]>() {
                 @Override
                 public int compare(long[] lhs, long[] rhs) {
-                    return Long.valueOf(lhs[0]).compareTo(rhs[0]);
+                    return Long.compare(lhs[0], rhs[0]);
                 }
             });
             return !mLrnQueue.isEmpty();


### PR DESCRIPTION
First, I want to emphasize that, on my collection, I am spending two
seconds in the method Long.valueOf(long). Of those two seconds, 1.1
are spent in the compare method in _fillLrn. So it's a not a change
for fun, it's a real time saver I want to do here.

Secondly, Long.valueOf().compareTo uses Long.compare if both values
are long. So we are transforming long into Long to immediately
transform them into Long. That's totally pointless. Using the static
method directly is thus quicker

Thirdly, the sorting could be made in sqlite directly for more efficiency. But I don't do it in this PR as it would diverge from upstream anki. Instead I'm doing a PR in anki and I'll do a PR here once the upstream has an answer.


## Pull Request template

## How Has This Been Tested?

In my merge branch, using ankidroid and ensuring it still works. 