### PR TITLE
Cache deck split

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -117,7 +117,6 @@ import java.lang.ref.WeakReference;
 import java.net.URLDecoder;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.locks.Lock;
@@ -1779,8 +1778,8 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
         int[] counts = mSched.counts(mCurrentCard);
 
         if (actionBar != null) {
-            List<String> title = Decks.path(getCol().getDecks().get(mCurrentCard.getDid()).getString("name"));
-            actionBar.setTitle(title.get(title.size() - 1));
+            String title = Decks.basename(getCol().getDecks().get(mCurrentCard.getDid()).getString("name"));
+            actionBar.setTitle(title);
             if (mPrefShowETA) {
                 int eta = mSched.eta(counts, false);
                 actionBar.setSubtitle(Utils.remainingTime(AnkiDroidApp.getInstance(), eta * 60));

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -87,6 +87,7 @@ import com.ichi2.anki.receiver.SdCardReceiver;
 import com.ichi2.anki.reviewer.ReviewerExtRegistry;
 import com.ichi2.async.DeckTask;
 import com.ichi2.compat.CompatHelper;
+import com.ichi2.libanki.Decks;
 import com.ichi2.libanki.sched.AbstractSched;
 import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
@@ -116,6 +117,7 @@ import java.lang.ref.WeakReference;
 import java.net.URLDecoder;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.locks.Lock;
@@ -1777,8 +1779,8 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
         int[] counts = mSched.counts(mCurrentCard);
 
         if (actionBar != null) {
-            String[] title = getCol().getDecks().get(mCurrentCard.getDid()).getString("name").split("::");
-            actionBar.setTitle(title[title.length - 1]);
+            List<String> title = Decks.path(getCol().getDecks().get(mCurrentCard.getDid()).getString("name"));
+            actionBar.setTitle(title.get(title.size() - 1));
             if (mPrefShowETA) {
                 int eta = mSched.eta(counts, false);
                 actionBar.setSubtitle(Utils.remainingTime(AnkiDroidApp.getInstance(), eta * 60));

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -52,7 +52,6 @@ import com.ichi2.widget.WidgetStatus;
 
 
 import java.lang.ref.WeakReference;
-import java.util.ArrayList;
 import java.util.List;
 
 import timber.log.Timber;
@@ -138,16 +137,15 @@ public class Reviewer extends AbstractFlashcardViewer {
 
     @Override
     protected void setTitle() {
-        List<String> title;
+        String title;
         if (colIsOpen()) {
-            title = Decks.path(getCol().getDecks().current().getString("name"));
+            title = Decks.basename(getCol().getDecks().current().getString("name"));
         } else {
             Timber.e("Could not set title in reviewer because collection closed");
-            title = new ArrayList<>();
-            title.add("");
+            title = "";
         }
-        getSupportActionBar().setTitle(title.get(title.size() - 1));
-        super.setTitle(title.get(title.size() - 1));
+        getSupportActionBar().setTitle(title);
+        super.setTitle(title);
         getSupportActionBar().setSubtitle("");
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -45,12 +45,14 @@ import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Collection.DismissType;
 import com.ichi2.libanki.Consts;
+import com.ichi2.libanki.Decks;
 import com.ichi2.themes.Themes;
 import com.ichi2.utils.FunctionalInterfaces.Consumer;
 import com.ichi2.widget.WidgetStatus;
 
 
 import java.lang.ref.WeakReference;
+import java.util.ArrayList;
 import java.util.List;
 
 import timber.log.Timber;
@@ -136,14 +138,16 @@ public class Reviewer extends AbstractFlashcardViewer {
 
     @Override
     protected void setTitle() {
-        String[] title = {""};
+        List<String> title;
         if (colIsOpen()) {
-            title = getCol().getDecks().current().getString("name").split("::");
+            title = Decks.path(getCol().getDecks().current().getString("name"));
         } else {
             Timber.e("Could not set title in reviewer because collection closed");
+            title = new ArrayList<>();
+            title.add("");
         }
-        getSupportActionBar().setTitle(title[title.length - 1]);
-        super.setTitle(title[title.length - 1]);
+        getSupportActionBar().setTitle(title.get(title.size() - 1));
+        super.setTitle(title.get(title.size() - 1));
         getSupportActionBar().setSubtitle("");
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.java
@@ -606,11 +606,11 @@ public class Statistics extends NavigationDrawerActivity implements DeckDropDown
             Collection col = CollectionHelper.getInstance().getCol(getActivity());
             mDeckId = ((Statistics) getActivity()).getDeckId();
             if (mDeckId != Stats.ALL_DECKS_ID) {
-                List<String> parts = Decks.path(col.getDecks().current().getString("name"));
+                String basename = Decks.basename(col.getDecks().current().getString("name"));
                 if (sIsSubtitle) {
-                    ((AppCompatActivity) getActivity()).getSupportActionBar().setSubtitle(parts.get(parts.size() - 1));
+                    ((AppCompatActivity) getActivity()).getSupportActionBar().setSubtitle(basename);
                 } else {
-                    getActivity().setTitle(parts.get(parts.size() - 1));
+                    getActivity().setTitle(basename);
                 }
             } else {
                 if (sIsSubtitle) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.java
@@ -42,6 +42,7 @@ import com.ichi2.anki.stats.AnkiStatsTaskHandler;
 import com.ichi2.anki.stats.ChartView;
 import com.ichi2.anki.widgets.DeckDropDownAdapter;
 import com.ichi2.libanki.Collection;
+import com.ichi2.libanki.Decks;
 import com.ichi2.libanki.Stats;
 import com.ichi2.ui.SlidingTabLayout;
 
@@ -605,7 +606,7 @@ public class Statistics extends NavigationDrawerActivity implements DeckDropDown
             Collection col = CollectionHelper.getInstance().getCol(getActivity());
             mDeckId = ((Statistics) getActivity()).getDeckId();
             if (mDeckId != Stats.ALL_DECKS_ID) {
-                List<String> parts = Arrays.asList(col.getDecks().current().getString("name").split("::"));
+                List<String> parts = Decks.path(col.getDecks().current().getString("name"));
                 if (sIsSubtitle) {
                     ((AppCompatActivity) getActivity()).getSupportActionBar().setSubtitle(parts.get(parts.size() - 1));
                 } else {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
@@ -50,8 +50,6 @@ import com.ichi2.utils.HtmlUtils;
 
 import com.ichi2.utils.JSONObject;
 
-import java.util.List;
-
 import timber.log.Timber;
 
 public class StudyOptionsFragment extends Fragment implements Toolbar.OnMenuItemClickListener {
@@ -566,19 +564,19 @@ public class StudyOptionsFragment extends Fragment implements Toolbar.OnMenuItem
                     JSONObject deck = getCol().getDecks().current();
                     // Main deck name
                     fullName = deck.getString("name");
-                    List<String> name = Decks.path(fullName);
+                    String[] name = Decks.path(fullName);
                     StringBuilder nameBuilder = new StringBuilder();
-                    if (name.size() > 0) {
-                        nameBuilder.append(name.get(0));
+                    if (name.length > 0) {
+                        nameBuilder.append(name[0]);
                     }
-                    if (name.size() > 1) {
-                        nameBuilder.append("\n").append(name.get(1));
+                    if (name.length > 1) {
+                        nameBuilder.append("\n").append(name[1]);
                     }
-                    if (name.size() > 3) {
+                    if (name.length > 3) {
                         nameBuilder.append("...");
                     }
-                    if (name.size() > 2) {
-                        nameBuilder.append("\n").append(name.get(name.size() - 1));
+                    if (name.length > 2) {
+                        nameBuilder.append("\n").append(name[name.length - 1]);
                     }
                     mTextDeckName.setText(nameBuilder.toString());
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
@@ -43,11 +43,14 @@ import com.ichi2.async.DeckTask;
 import com.ichi2.compat.CompatHelper;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Consts;
+import com.ichi2.libanki.Decks;
 import com.ichi2.libanki.Utils;
 import com.ichi2.themes.StyledProgressDialog;
 import com.ichi2.utils.HtmlUtils;
 
 import com.ichi2.utils.JSONObject;
+
+import java.util.List;
 
 import timber.log.Timber;
 
@@ -563,19 +566,19 @@ public class StudyOptionsFragment extends Fragment implements Toolbar.OnMenuItem
                     JSONObject deck = getCol().getDecks().current();
                     // Main deck name
                     fullName = deck.getString("name");
-                    String[] name = fullName.split("::");
+                    List<String> name = Decks.path(fullName);
                     StringBuilder nameBuilder = new StringBuilder();
-                    if (name.length > 0) {
-                        nameBuilder.append(name[0]);
+                    if (name.size() > 0) {
+                        nameBuilder.append(name.get(0));
                     }
-                    if (name.length > 1) {
-                        nameBuilder.append("\n").append(name[1]);
+                    if (name.size() > 1) {
+                        nameBuilder.append("\n").append(name.get(1));
                     }
-                    if (name.length > 3) {
+                    if (name.size() > 3) {
                         nameBuilder.append("...");
                     }
-                    if (name.length > 2) {
-                        nameBuilder.append("\n").append(name[name.length - 1]);
+                    if (name.size() > 2) {
+                        nameBuilder.append("\n").append(name.get(name.size() - 1));
                     }
                     mTextDeckName.setText(nameBuilder.toString());
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -498,9 +498,6 @@ public class Decks {
                 rename(draggedDeck, basename(draggedDeckName));
             }
         } else if (_canDragAndDrop(draggedDeckName, ontoDeckName)) {
-            draggedDeck = get(draggedDeckDid);
-            draggedDeckName = draggedDeck.getString("name");
-            ontoDeckName = get(ontoDeckDid).getString("name");
             rename(draggedDeck, ontoDeckName + "::" + basename(draggedDeckName));
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -517,9 +517,14 @@ public class Decks {
 
     private boolean _isParent(String parentDeckName, String childDeckName) {
         List<String> parentDeckPath = path(parentDeckName);
+        List<String> childDeckPath = path(childDeckName);
         parentDeckPath.add(basename(childDeckName));
 
-        Iterator<String> cpIt = path(childDeckName).iterator();
+        if (parentDeckPath.size() != childDeckPath.size()) {
+            return false;
+        }
+
+        Iterator<String> cpIt = childDeckPath.iterator();
         Iterator<String> ppIt = parentDeckPath.iterator();
         while (cpIt.hasNext() && ppIt.hasNext()) {
             if (!cpIt.next().equals(ppIt.next())) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -536,8 +536,13 @@ public class Decks {
 
 
     private boolean _isAncestor(String ancestorDeckName, String descendantDeckName) {
-        Iterator<String> apIt = path(ancestorDeckName).iterator();
-        Iterator<String> dpIt = path(descendantDeckName).iterator();
+        List<String> ancestorDeckPath = path(ancestorDeckName);
+        List<String> descendantDeckPath = path(descendantDeckName);
+        if (ancestorDeckPath.size() > descendantDeckName.size()) {
+            return false;
+        }
+        Iterator<String> apIt = ancestorDeckPath.iterator();
+        Iterator<String> dpIt = descendantDeckPath.iterator();
         while (apIt.hasNext() && dpIt.hasNext()) {
             if (!apIt.next().equals(dpIt.next())) {
                 return false;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -570,7 +570,8 @@ public class Decks {
         if (path.size() < 2) {
             return name;
         }
-        for(String p : path.subList(0, path.size() - 1)) {
+        for(int i = 0; i < path.size() - 1; i++) {
+            String p = path.get(i);
             if (TextUtils.isEmpty(s)) {
                 s += p;
             } else {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -518,9 +518,8 @@ public class Decks {
     private boolean _isParent(String parentDeckName, String childDeckName) {
         List<String> parentDeckPath = path(parentDeckName);
         List<String> childDeckPath = path(childDeckName);
-        parentDeckPath.add(basename(childDeckName));
 
-        if (parentDeckPath.size() != childDeckPath.size()) {
+        if (parentDeckPath.size() + 1 != childDeckName.size()) {
             return false;
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -548,8 +548,12 @@ public class Decks {
     }
 
 
+    private static HashMap<String, String[]> pathCache = new HashMap();
     public static String[] path(String name) {
-        return name.split("::", -1);
+        if (!pathCache.containsKey(name)) {
+            pathCache.put(name, name.split("::", -1));
+        }
+        return pathCache.get(name);
     }
 
     public static String basename(String name) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -495,13 +495,13 @@ public class Decks {
 
         if (ontoDeckDid == null) {
             if (path(draggedDeckName).size() > 1) {
-                rename(draggedDeck, _basename(draggedDeckName));
+                rename(draggedDeck, basename(draggedDeckName));
             }
         } else if (_canDragAndDrop(draggedDeckName, ontoDeckName)) {
             draggedDeck = get(draggedDeckDid);
             draggedDeckName = draggedDeck.getString("name");
             ontoDeckName = get(ontoDeckDid).getString("name");
-            rename(draggedDeck, ontoDeckName + "::" + _basename(draggedDeckName));
+            rename(draggedDeck, ontoDeckName + "::" + basename(draggedDeckName));
         }
     }
 
@@ -519,7 +519,7 @@ public class Decks {
 
     private boolean _isParent(String parentDeckName, String childDeckName) {
         List<String> parentDeckPath = path(parentDeckName);
-        parentDeckPath.add(_basename(childDeckName));
+        parentDeckPath.add(basename(childDeckName));
 
         Iterator<String> cpIt = path(childDeckName).iterator();
         Iterator<String> ppIt = parentDeckPath.iterator();
@@ -547,7 +547,8 @@ public class Decks {
     public static List<String> path(String name) {
         return Arrays.asList(name.split("::", -1));
     }
-    private String _basename(String name) {
+
+    public static String basename(String name) {
         List<String> path = path(name);
         return path.get(path.size() - 1);
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -493,12 +493,13 @@ public class Decks {
         String draggedDeckName = draggedDeck.getString("name");
         String ontoDeckName = get(ontoDeckDid).getString("name");
 
+        String draggedBasename = basename(draggedDeckName);
         if (ontoDeckDid == null) {
-            if (path(draggedDeckName).size() > 1) {
-                rename(draggedDeck, basename(draggedDeckName));
+            if (!draggedBasename.equals(draggedDeckName)) {
+                rename(draggedDeck, draggedBasename);
             }
         } else if (_canDragAndDrop(draggedDeckName, ontoDeckName)) {
-            rename(draggedDeck, ontoDeckName + "::" + basename(draggedDeckName));
+            rename(draggedDeck, ontoDeckName + "::" + draggedBasename);
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -516,17 +516,15 @@ public class Decks {
 
 
     private boolean _isParent(String parentDeckName, String childDeckName) {
-        List<String> parentDeckPath = path(parentDeckName);
-        List<String> childDeckPath = path(childDeckName);
+        String[] parentDeckPath = path(parentDeckName);
+        String[] childDeckPath = path(childDeckName);
 
-        if (parentDeckPath.size() + 1 != childDeckName.size()) {
+        if (parentDeckPath.length + 1 != childDeckPath.length) {
             return false;
         }
 
-        Iterator<String> cpIt = childDeckPath.iterator();
-        Iterator<String> ppIt = parentDeckPath.iterator();
-        while (cpIt.hasNext() && ppIt.hasNext()) {
-            if (!cpIt.next().equals(ppIt.next())) {
+        for (int i = 0; i < parentDeckPath.length; i++) {
+            if (! parentDeckPath[i].equals(childDeckPath[i])) {
                 return false;
             }
         }
@@ -535,15 +533,14 @@ public class Decks {
 
 
     private boolean _isAncestor(String ancestorDeckName, String descendantDeckName) {
-        List<String> ancestorDeckPath = path(ancestorDeckName);
-        List<String> descendantDeckPath = path(descendantDeckName);
-        if (ancestorDeckPath.size() > descendantDeckName.size()) {
+        String[] ancestorDeckPath = path(ancestorDeckName);
+        String[] descendantDeckPath = path(descendantDeckName);
+        if (ancestorDeckPath.length > descendantDeckPath.length) {
             return false;
         }
-        Iterator<String> apIt = ancestorDeckPath.iterator();
-        Iterator<String> dpIt = descendantDeckPath.iterator();
-        while (apIt.hasNext() && dpIt.hasNext()) {
-            if (!apIt.next().equals(dpIt.next())) {
+
+        for (int i = 0; i < ancestorDeckPath.length; i++) {
+            if (ancestorDeckPath[i] != descendantDeckPath[i]) {
                 return false;
             }
         }
@@ -551,13 +548,13 @@ public class Decks {
     }
 
 
-    public static List<String> path(String name) {
-        return Arrays.asList(name.split("::", -1));
+    public static String[] path(String name) {
+        return name.split("::", -1);
     }
 
     public static String basename(String name) {
-        List<String> path = path(name);
-        return path.get(path.size() - 1);
+        String[] path = path(name);
+        return path[path.length - 1];
     }
 
 
@@ -566,12 +563,12 @@ public class Decks {
      */
     public String _ensureParents(String name) {
         String s = "";
-        List<String> path = path(name);
-        if (path.size() < 2) {
+        String[] path = path(name);
+        if (path.length < 2) {
             return name;
         }
-        for(int i = 0; i < path.size() - 1; i++) {
-            String p = path.get(i);
+        for(int i = 0; i < path.length - 1; i++) {
+            String p = path[i];
             if (TextUtils.isEmpty(s)) {
                 s += p;
             } else {
@@ -582,7 +579,7 @@ public class Decks {
             // get original case
             s = name(did);
         }
-        name = s + "::" + path.get(path.size() - 1);
+        name = s + "::" + path[path.length - 1];
         return name;
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -494,7 +494,7 @@ public class Decks {
         String ontoDeckName = get(ontoDeckDid).getString("name");
 
         if (ontoDeckDid == null) {
-            if (_path(draggedDeckName).size() > 1) {
+            if (path(draggedDeckName).size() > 1) {
                 rename(draggedDeck, _basename(draggedDeckName));
             }
         } else if (_canDragAndDrop(draggedDeckName, ontoDeckName)) {
@@ -518,10 +518,10 @@ public class Decks {
 
 
     private boolean _isParent(String parentDeckName, String childDeckName) {
-        List<String> parentDeckPath = _path(parentDeckName);
+        List<String> parentDeckPath = path(parentDeckName);
         parentDeckPath.add(_basename(childDeckName));
 
-        Iterator<String> cpIt = _path(childDeckName).iterator();
+        Iterator<String> cpIt = path(childDeckName).iterator();
         Iterator<String> ppIt = parentDeckPath.iterator();
         while (cpIt.hasNext() && ppIt.hasNext()) {
             if (!cpIt.next().equals(ppIt.next())) {
@@ -533,8 +533,8 @@ public class Decks {
 
 
     private boolean _isAncestor(String ancestorDeckName, String descendantDeckName) {
-        Iterator<String> apIt = _path(ancestorDeckName).iterator();
-        Iterator<String> dpIt = _path(descendantDeckName).iterator();
+        Iterator<String> apIt = path(ancestorDeckName).iterator();
+        Iterator<String> dpIt = path(descendantDeckName).iterator();
         while (apIt.hasNext() && dpIt.hasNext()) {
             if (!apIt.next().equals(dpIt.next())) {
                 return false;
@@ -544,11 +544,11 @@ public class Decks {
     }
 
 
-    private List<String> _path(String name) {
+    public static List<String> path(String name) {
         return Arrays.asList(name.split("::", -1));
     }
     private String _basename(String name) {
-        List<String> path = _path(name);
+        List<String> path = path(name);
         return path.get(path.size() - 1);
     }
 
@@ -558,7 +558,7 @@ public class Decks {
      */
     public String _ensureParents(String name) {
         String s = "";
-        List<String> path = _path(name);
+        List<String> path = path(name);
         if (path.size() < 2) {
             return name;
         }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/DeckNameComparator.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/DeckNameComparator.java
@@ -1,5 +1,7 @@
 package com.ichi2.utils;
 
+import com.ichi2.libanki.Decks;
+
 import java.util.Comparator;
 
 public class DeckNameComparator implements Comparator<String> {
@@ -7,10 +9,8 @@ public class DeckNameComparator implements Comparator<String> {
 
     @Override
     public int compare(String lhs, String rhs) {
-        String[] o1;
-        String[] o2;
-        o1 = lhs.split("::");
-        o2 = rhs.split("::");
+        String[] o1 = Decks.path(lhs);
+        String[] o2 = Decks.path(rhs);
         for (int i = 0; i < Math.min(o1.length, o2.length); i++) {
             int result = o1[i].compareToIgnoreCase(o2[i]);
             if (result != 0) {


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
This PR does multiple very related changes.

* It takes path and basename from upstream, make them public and uses them where possible to make code more readable
* It uses array instead of list for paths. So that we avoid a useless transformation.
* It cache name splitting, which is actually a very time-consuming operation. (7 seconds in loading the list of decks are spent on splitting deck name on my collection. Mostly because in order to sort decks, we must split them first.)
* the methods `_isParent` and `_isAncestor` were wrongly implemented. In particular in cases where the ancestor was longer than descendant, it may return `true`. 

I should note that if and when you merge this PR or https://github.com/ankidroid/Anki-Android/pull/5943 the other will need to be rebased. Because this other commit does a split without using path() method.

## How Has This Been Tested?

In my "merge" branch.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
