### PR TITLE
Allow Streaming (download) of Images from ContentProvider 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
@@ -272,7 +272,8 @@ public class BasicImageFieldController extends FieldControllerBase implements IF
 
         String filePath;
         try {
-            filePath = mContentProviderFileReference.extractFilePath(mActivity.getContentResolver(), selectedImage);
+            String downloadDirectory = this.mActivity.getCacheDir().getAbsolutePath();
+            filePath = mContentProviderFileReference.extractFilePath(mActivity.getContentResolver(), selectedImage, downloadDirectory);
         } catch (Exception e) {
             Timber.w("URI decoding failed");
             showSomethingWentWrong();

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ContentProviderFileReference.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ContentProviderFileReference.java
@@ -68,7 +68,7 @@ public class ContentProviderFileReference {
                 return null;
             }
             CompatHelper.getCompat().copyFile(is, file.getAbsolutePath());
-            return file.getPath();
+            return file.getAbsolutePath();
         } catch (IOException e) {
             Timber.e(e, "Exception copying stream");
             return null;

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ContentProviderFileReference.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ContentProviderFileReference.java
@@ -1,0 +1,52 @@
+package com.ichi2.utils;
+
+import android.content.ContentResolver;
+import android.database.Cursor;
+import android.net.Uri;
+import android.provider.MediaStore;
+
+import androidx.annotation.CheckResult;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import timber.log.Timber;
+
+public class ContentProviderFileReference {
+    @CheckResult
+    public @Nullable String extractFilePath(@NonNull ContentResolver resolver, @NonNull Uri uri) {
+        String[] filePathColumn = { MediaStore.MediaColumns.DATA };
+
+        Cursor cursor = null;
+        try {
+            cursor = resolver.query(uri, filePathColumn, null, null, null);
+
+            if (cursor == null) {
+                Timber.w("cursor was null");
+                return null;
+            }
+
+            if (!cursor.moveToFirst()) {
+                //TODO: #5909, it would be best to instrument this to see if we can fix the failure
+                Timber.w("cursor had no data");
+                return null;
+            }
+
+            int columnIndex = cursor.getColumnIndex(filePathColumn[0]);
+
+            String filePath = cursor.getString(columnIndex);
+
+            if (filePath == null) {
+                Timber.w("Failed to decode filepath");
+                return null;
+            }
+
+            return filePath;
+        } catch (Exception e) {
+          Timber.e(e, "Exception decoding filepath");
+          return null;
+        } finally {
+            if (cursor != null) {
+                cursor.close();
+            }
+        }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ContentProviderFileReference.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ContentProviderFileReference.java
@@ -5,11 +5,11 @@ import android.database.Cursor;
 import android.net.Uri;
 import android.provider.MediaStore;
 
+import com.ichi2.compat.CompatHelper;
+
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 
 import androidx.annotation.CheckResult;
 import androidx.annotation.NonNull;
@@ -67,17 +67,7 @@ public class ContentProviderFileReference {
                 Timber.w("Couldn't create %s", file.toString());
                 return null;
             }
-            try (OutputStream output = new FileOutputStream(file, false)) {
-                byte[] buffer = new byte[4 * 1024]; // or other buffer size
-                int read;
-
-                while ((read = is.read(buffer)) != -1) {
-                    output.write(buffer, 0, read);
-                }
-
-                output.flush();
-
-            }
+            CompatHelper.getCompat().copyFile(is, file.getAbsolutePath());
             return file.getPath();
         } catch (IOException e) {
             Timber.e(e, "Exception copying stream");

--- a/AnkiDroid/src/test/java/com/ichi2/utils/ContentProviderFileReferenceTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/ContentProviderFileReferenceTest.java
@@ -8,11 +8,19 @@ import android.provider.MediaStore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.mockito.ArgumentMatchers.any;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
@@ -26,19 +34,80 @@ public class ContentProviderFileReferenceTest {
         //copied data from a local "google photos" file into a mock.
         Uri uri = Uri.parse("content://com.google.android.apps.photos.contentprovider/0/1/content%3A%2F%2Fmedia%2Fexternal%2Fimages%2Fmedia%2F438342/ORIGINAL/NONE/image%2Fjpeg/1178426345");
 
-        Cursor cursor = mock(Cursor.class);
         ContentResolver resolver = mock(ContentResolver.class);
-        when(resolver.query(eq(uri), any(), isNull(), isNull(), isNull())).thenReturn(cursor);
-        when(cursor.moveToFirst()).thenReturn(true);
-        when(cursor.getColumnIndex(MediaStore.MediaColumns.DATA)).thenReturn(0);
-        when(cursor.getString(0)).thenReturn("/storage/emulated/0/DCIM/Facebook/FB_IMG_1586592500530.jpg");
+        setupLocalPathResolverReturning(uri, resolver, "/storage/emulated/0/DCIM/Facebook/FB_IMG_1586592500530.jpg");
 
         ContentProviderFileReference underTest = new ContentProviderFileReference();
 
 
-        String actual = underTest.extractFilePath(resolver, uri);
+        String actual = underTest.extractFilePath(resolver, uri, null);
 
         String expected = "/storage/emulated/0/DCIM/Facebook/FB_IMG_1586592500530.jpg";
         assertThat("File path should be returned correctly", actual, equalTo(expected));
+    }
+
+    @Test
+    public void googlePhotosDownloadFileRegressionTest() throws IOException {
+        //Note: This creates a temporary file in "java.io.tmpdir", and cleans it up.
+        //copied data from a streaming/download "google photos" file into a mock.
+        Uri uri = Uri.parse("content://com.google.android.apps.photos.contentprovider/0/1/content%3A%2F%2Fmedia%2Fexternal%2Fimages%2Fmedia%2F438342/ORIGINAL/NONE/image%2Fjpeg/1178426345");
+
+        byte[] fileData = new byte[] { 123 };
+        String fileName = "IMG_20200330_135308.jpg";
+        String actualFilePath = null;
+        try {
+            ContentResolver resolver = mock(ContentResolver.class);
+            setupLocalPathResolverReturning(uri, resolver, null);
+            setupDownloadingResolverReturning(uri, resolver, fileName, fileData);
+
+            //Act
+            ContentProviderFileReference underTest = new ContentProviderFileReference();
+            String tempDirectory = System.getProperty("java.io.tmpdir");
+            actualFilePath = underTest.extractFilePath(resolver, uri, tempDirectory);
+
+            //Assert
+            String expected = new File(tempDirectory, fileName).getAbsolutePath();
+            assertThat("File path should be returned correctly", actualFilePath, equalTo(expected));
+
+            byte[] actualData = Files.readAllBytes(Paths.get(actualFilePath));
+
+            //COULD_BE_BETTER: seems to be no primitive matcher for byte.
+            assertThat("Data should be the same", actualData[0], is(fileData[0]));
+        } finally {
+            if (actualFilePath != null) {
+                Files.delete(Paths.get(actualFilePath));
+            }
+        }
+    }
+
+
+    private void setupDownloadingResolverReturning(Uri uri, ContentResolver resolver, String fileName, byte[] fileData) {
+        //Setup filename
+        Cursor downloadCursor = mock(Cursor.class);
+        String[] input = new String[] { MediaStore.MediaColumns.DISPLAY_NAME, MediaStore.MediaColumns.TITLE };
+        when(resolver.query(eq(uri), eq(input), isNull(), isNull(), isNull())).thenReturn(downloadCursor);
+        when(downloadCursor.moveToFirst()).thenReturn(true);
+        when(downloadCursor.getColumnIndex(MediaStore.MediaColumns.DISPLAY_NAME)).thenReturn(0);
+        when(downloadCursor.getColumnIndex(MediaStore.MediaColumns.TITLE)).thenReturn(1);
+
+        when(downloadCursor.getString(0)).thenReturn(fileName);
+        //Different: No data.
+        when(downloadCursor.getString(1)).thenReturn(null);
+
+        try {
+            when(resolver.openInputStream(uri)).thenReturn(new ByteArrayInputStream(fileData));
+        } catch (FileNotFoundException e) {
+            fail();
+        }
+    }
+
+
+    private void setupLocalPathResolverReturning(Uri uri, ContentResolver resolver, String result) {
+        Cursor localDataCursor = mock(Cursor.class);
+        when(resolver.query(eq(uri), eq(new String[] { MediaStore.MediaColumns.DATA }), isNull(), isNull(), isNull())).thenReturn(localDataCursor);
+        when(localDataCursor.moveToFirst()).thenReturn(true);
+        when(localDataCursor.getColumnIndex(MediaStore.MediaColumns.DATA)).thenReturn(0);
+        //Different: No data.
+        when(localDataCursor.getString(0)).thenReturn(result);
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/utils/ContentProviderFileReferenceTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/ContentProviderFileReferenceTest.java
@@ -1,0 +1,44 @@
+package com.ichi2.utils;
+
+import android.content.ContentResolver;
+import android.database.Cursor;
+import android.net.Uri;
+import android.provider.MediaStore;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(AndroidJUnit4.class)
+public class ContentProviderFileReferenceTest {
+
+    @Test
+    public void googlePhotosLocalFileRegressionTest() {
+        //copied data from a local "google photos" file into a mock.
+        Uri uri = Uri.parse("content://com.google.android.apps.photos.contentprovider/0/1/content%3A%2F%2Fmedia%2Fexternal%2Fimages%2Fmedia%2F438342/ORIGINAL/NONE/image%2Fjpeg/1178426345");
+
+        Cursor cursor = mock(Cursor.class);
+        ContentResolver resolver = mock(ContentResolver.class);
+        when(resolver.query(eq(uri), any(), isNull(), isNull(), isNull())).thenReturn(cursor);
+        when(cursor.moveToFirst()).thenReturn(true);
+        when(cursor.getColumnIndex(MediaStore.MediaColumns.DATA)).thenReturn(0);
+        when(cursor.getString(0)).thenReturn("/storage/emulated/0/DCIM/Facebook/FB_IMG_1586592500530.jpg");
+
+        ContentProviderFileReference underTest = new ContentProviderFileReference();
+
+
+        String actual = underTest.extractFilePath(resolver, uri);
+
+        String expected = "/storage/emulated/0/DCIM/Facebook/FB_IMG_1586592500530.jpg";
+        assertThat("File path should be returned correctly", actual, equalTo(expected));
+    }
+}


### PR DESCRIPTION
## Purpose / Description

ContentProviders should typically be used with `.openInputStream.`

We didn't do this, and instead tried to extract a path from the content provider, which fails if the file is only streamable.

## Fixes
Fixes #5973

## Approach

We fallback to a stream if the original method to reference the on-disk file fails.

## How Has This Been Tested?

Unit tested, tested on my device.

I thought I has a problem but was just using a "type" card. All is good.

Tested again after the compat change. All good.

Tested again. I definitely spend more time testing than coding.

## Learning (optional, can help others)
https://stackoverflow.com/a/23270545 - Get Name
https://stackoverflow.com/a/5657557 - use .openInputStream(uri)

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code