### PR TITLE
LINT: Replace try..close with try-with-resources

### DIFF
--- a/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/ContentProviderTest.java
+++ b/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/ContentProviderTest.java
@@ -389,16 +389,13 @@ public class ContentProviderTest {
             cv.put(FlashCardsContract.Note.FLDS, Utils.joinFields(dummyFields2));
             cr.update(uri, cv, null, null);
             // Query the table again
-            Cursor noteCursor = cr.query(uri, FlashCardsContract.Note.DEFAULT_PROJECTION, null, null, null);
-            try {
+            try (Cursor noteCursor = cr.query(uri, FlashCardsContract.Note.DEFAULT_PROJECTION, null, null, null)) {
                 assertNotNull("Check that there is a valid cursor for detail data after update", noteCursor);
                 assertEquals("Check that there is one and only one entry after update", 1, noteCursor.getCount());
                 assertTrue("Move to first item in cursor", noteCursor.moveToFirst());
                 String[] newFlds = Utils.splitFields(
                         noteCursor.getString(noteCursor.getColumnIndex(FlashCardsContract.Note.FLDS)));
                 assertTrue("Check that the flds have been updated correctly", Arrays.equals(newFlds, dummyFields2));
-            } finally {
-                noteCursor.close();
             }
         }
     }
@@ -682,8 +679,7 @@ public class ContentProviderTest {
 
         long deckId = mTestDeckIds[0];
         Uri deckUri = Uri.withAppendedPath(FlashCardsContract.Deck.CONTENT_ALL_URI, Long.toString(deckId));
-        Cursor decksCursor = InstrumentationRegistry.getInstrumentation().getTargetContext().getContentResolver().query(deckUri, null, null, null, null);
-        try {
+        try (Cursor decksCursor = InstrumentationRegistry.getInstrumentation().getTargetContext().getContentResolver().query(deckUri, null, null, null, null)) {
             if (decksCursor == null || !decksCursor.moveToFirst()) {
                 fail("No deck received. Should have delivered deck with id " + deckId);
             } else {
@@ -694,8 +690,6 @@ public class ContentProviderTest {
                 assertEquals("Check that received deck ID equals real deck ID", deckId, returnedDeckID);
                 assertEquals("Check that received deck name equals real deck name", realDeck.getString("name"), returnedDeckName);
             }
-        } finally {
-            decksCursor.close();
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -2149,12 +2149,9 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
 
         if (AnkiDroidApp.getSharedPrefs(this).getBoolean("html_javascript_debugging", false)) {
             try {
-                FileOutputStream f = new FileOutputStream(new File(CollectionHelper.getCurrentAnkiDroidDirectory(this),
-                        "card.html"));
-                try {
+                try (FileOutputStream f = new FileOutputStream(new File(CollectionHelper.getCurrentAnkiDroidDirectory(this),
+                        "card.html"))) {
                     f.write(mCardContent.toString().getBytes());
-                } finally {
-                    f.close();
                 }
             } catch (IOException e) {
                 Timber.d(e, "failed to save card");

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicAudioClipFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicAudioClipFieldController.java
@@ -132,9 +132,7 @@ public class BasicAudioClipFieldController extends FieldControllerBase implement
             }
 
             // Copy file contents into new temp file. Possibly check file size first and warn if large?
-            InputStream inputStream = null;
-            try {
-                inputStream = mActivity.getContentResolver().openInputStream(selectedClip);
+            try (InputStream inputStream = mActivity.getContentResolver().openInputStream(selectedClip)) {
                 CompatHelper.getCompat().copyFile(inputStream, clipCopy.getAbsolutePath());
 
                 // If everything worked, hand off the information
@@ -146,15 +144,6 @@ public class BasicAudioClipFieldController extends FieldControllerBase implement
                 Timber.e(e, "Unable to copy audio file from ContentProvider");
                 UIUtils.showThemedToast(AnkiDroidApp.getInstance().getApplicationContext(),
                         AnkiDroidApp.getInstance().getString(R.string.multimedia_editor_something_wrong), true);
-            }
-            finally {
-                try {
-                    if (inputStream != null) {
-                        inputStream.close();
-                    }
-                } catch (IOException ioe) {
-                    // nothing
-                }
             }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.java
@@ -139,9 +139,7 @@ public class Card implements Cloneable {
 
 
     public void load() {
-        Cursor cursor = null;
-        try {
-            cursor = mCol.getDb().getDatabase().query("SELECT * FROM cards WHERE id = " + mId, null);
+        try (Cursor cursor = mCol.getDb().getDatabase().query("SELECT * FROM cards WHERE id = " + mId, null)) {
             if (!cursor.moveToFirst()) {
                 throw new RuntimeException(" No card with id " + mId);
             }
@@ -163,10 +161,6 @@ public class Card implements Cloneable {
             mODid = cursor.getLong(15);
             mFlags = cursor.getInt(16);
             mData = cursor.getString(17);
-        } finally {
-            if (cursor != null) {
-                cursor.close();
-            }
         }
         mQA = null;
         mNote = null;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -279,11 +279,8 @@ public class Collection {
         StringBuffer buf = new StringBuffer("");
 
         while (true) {
-            Cursor cursor = null;
-            try {
-                cursor = mDb.getDatabase().query(
-                        "SELECT substr(" + columnName + ", ?, ?) FROM col",
-                        new String[]{Integer.toString(pos), Integer.toString(chunk)});
+            try (Cursor cursor = mDb.getDatabase().query("SELECT substr(" + columnName + ", ?, ?) FROM col",
+                    new String[] {Integer.toString(pos), Integer.toString(chunk)})) {
                 if (!cursor.moveToFirst()) {
                     return buf.toString();
                 }
@@ -296,10 +293,6 @@ public class Collection {
                     break;
                 }
                 pos += chunk;
-            } finally {
-                if (cursor != null) {
-                    cursor.close();
-                }
             }
         }
         return buf.toString();

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DB.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DB.java
@@ -199,17 +199,11 @@ public class DB {
     }
 
     public String queryString(String query, Object[] bindArgs) throws SQLException {
-        Cursor cursor = null;
-        try {
-            cursor = mDatabase.query(query, bindArgs);
+        try (Cursor cursor = mDatabase.query(query, bindArgs)) {
             if (!cursor.moveToNext()) {
                 throw new SQLException("No result for query: " + query);
             }
             return cursor.getString(0);
-        } finally {
-            if (cursor != null) {
-                cursor.close();
-            }
         }
     }
 
@@ -219,18 +213,12 @@ public class DB {
     }
 
     public long queryLongScalar(String query, Object[] bindArgs) {
-        Cursor cursor = null;
         long scalar;
-        try {
-            cursor = mDatabase.query(query, bindArgs);
+        try (Cursor cursor = mDatabase.query(query, bindArgs)) {
             if (!cursor.moveToNext()) {
                 return 0;
             }
             scalar = cursor.getLong(0);
-        } finally {
-            if (cursor != null) {
-                cursor.close();
-            }
         }
 
         return scalar;
@@ -254,10 +242,8 @@ public class DB {
         int nullExceptionCount = 0;
         InvocationTargetException nullException = null; // to catch the null exception for reporting
         ArrayList<T> results = new ArrayList<>();
-        Cursor cursor = null;
 
-        try {
-            cursor = mDatabase.query(query, bindArgs);
+        try (Cursor cursor = mDatabase.query(query, bindArgs)) {
             String methodName = getCursorMethodName(type.getSimpleName());
             while (cursor.moveToNext()) {
                 try {
@@ -280,9 +266,6 @@ public class DB {
             // This is really coding error, so it should be revealed if it ever happens
             throw new RuntimeException(e);
         } finally {
-            if (cursor != null) {
-                cursor.close();
-            }
             if (nullExceptionCount > 0) {
                 if (nullException != null) {
                     StringBuilder sb = new StringBuilder();

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Media.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Media.java
@@ -423,9 +423,7 @@ public class Media {
         File mdir = new File(dir());
         // gather all media references in NFC form
         Set<String> allRefs = new HashSet<>();
-        Cursor cur = null;
-        try {
-            cur = mCol.getDb().getDatabase().query("select id, mid, flds from notes", null);
+        try (Cursor cur = mCol.getDb().getDatabase().query("select id, mid, flds from notes", null)) {
             while (cur.moveToNext()) {
                 long nid = cur.getLong(0);
                 long mid = cur.getLong(1);
@@ -441,10 +439,6 @@ public class Media {
                     }
                 }
                 allRefs.addAll(noteRefs);
-            }
-        } finally {
-            if (cur != null) {
-                cur.close();
             }
         }
         // loop through media folder
@@ -689,9 +683,7 @@ public class Media {
 
     private Pair<List<String>, List<String>> _changes() {
         Map<String, Object[]> cache = new HashMap<>();
-        Cursor cur = null;
-        try {
-            cur = mDb.getDatabase().query("select fname, csum, mtime from media where csum is not null", null);
+        try (Cursor cur = mDb.getDatabase().query("select fname, csum, mtime from media where csum is not null", null)) {
             while (cur.moveToNext()) {
                 String name = cur.getString(0);
                 String csum = cur.getString(1);
@@ -700,10 +692,6 @@ public class Media {
             }
         } catch (SQLException e) {
             throw new RuntimeException(e);
-        } finally {
-            if (cur != null) {
-                cur.close();
-            }
         }
         List<String> added = new ArrayList<>();
         List<String> removed = new ArrayList<>();
@@ -784,19 +772,13 @@ public class Media {
 
 
     public Pair<String, Integer> syncInfo(String fname) {
-        Cursor cur = null;
-        try {
-            cur = mDb.getDatabase().query("select csum, dirty from media where fname=?", new String[] { fname });
+        try (Cursor cur = mDb.getDatabase().query("select csum, dirty from media where fname=?", new String[] {fname})) {
             if (cur.moveToNext()) {
                 String csum = cur.getString(0);
                 int dirty = cur.getInt(1);
                 return new Pair<>(csum, dirty);
             } else {
                 return new Pair<>(null, 0);
-            }
-        } finally {
-            if (cur != null) {
-                cur.close();
             }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -663,19 +663,13 @@ public class Models {
             return;
         }
         ArrayList<Object[]> r = new ArrayList<>();
-        Cursor cur = null;
 
-        try {
-            cur = mCol.getDb().getDatabase()
-                    .query("select id, flds from notes where mid = " + m.getLong("id"), null);
+        try (Cursor cur = mCol.getDb().getDatabase()
+                .query("select id, flds from notes where mid = " + m.getLong("id"), null)) {
             while (cur.moveToNext()) {
                 r.add(new Object[] {
                         Utils.joinFields(fn.transform(Utils.splitFields(cur.getString(1)))),
                         Utils.intTime(), mCol.usn(), cur.getLong(0)});
-            }
-        } finally {
-            if (cur != null) {
-                cur.close();
             }
         }
         mCol.getDb().executeMany("update notes set flds=?,mod=?,usn=? where id = ?", r);
@@ -861,10 +855,8 @@ public class Models {
         long mid;
         nfields = newModel.getJSONArray("flds").length();
         mid = newModel.getLong("id");
-        Cursor cur = null;
-        try {
-            cur = mCol.getDb().getDatabase().query(
-                    "select id, flds from notes where id in ".concat(Utils.ids2str(nids)), null);
+        try (Cursor cur = mCol.getDb().getDatabase().query(
+                "select id, flds from notes where id in ".concat(Utils.ids2str(nids)), null)) {
             while (cur.moveToNext()) {
                 long nid = cur.getLong(0);
                 String[] flds = Utils.splitFields(cur.getString(1));
@@ -883,10 +875,6 @@ public class Models {
                 }
                 String joinedFlds = Utils.joinFields(flds2.toArray(new String[flds2.size()]));
                 d.add(new Object[] { joinedFlds, mid, Utils.intTime(), mCol.usn(), nid });
-            }
-        } finally {
-            if (cur != null) {
-                cur.close();
             }
         }
         mCol.getDb().executeMany("update notes set flds=?,mid=?,mod=?,usn=? where id = ?", d);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Note.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Note.java
@@ -86,10 +86,8 @@ public class Note implements Cloneable {
 
     public void load() {
         Timber.d("load()");
-        Cursor cursor = null;
-        try {
-            cursor = mCol.getDb().getDatabase()
-                    .query("SELECT guid, mid, mod, usn, tags, flds, flags, data FROM notes WHERE id = " + mId, null);
+        try (Cursor cursor = mCol.getDb().getDatabase()
+                .query("SELECT guid, mid, mod, usn, tags, flds, flags, data FROM notes WHERE id = " + mId, null)) {
             if (!cursor.moveToFirst()) {
                 throw new RuntimeException("Notes.load(): No result from query for note " + mId);
             }
@@ -104,10 +102,6 @@ public class Note implements Cloneable {
             mModel = mCol.getModels().get(mMid);
             mFMap = mCol.getModels().fieldMap(mModel);
             mScm = mCol.getScm();
-        } finally {
-            if (cursor != null) {
-                cursor.close();
-            }
         }
     }
 
@@ -157,16 +151,10 @@ public class Note implements Cloneable {
 
     public ArrayList<Card> cards() {
         ArrayList<Card> cards = new ArrayList<>();
-        Cursor cur = null;
-        try {
-            cur = mCol.getDb().getDatabase()
-                    .query("SELECT id FROM cards WHERE nid = " + mId + " ORDER BY ord", null);
+        try (Cursor cur = mCol.getDb().getDatabase()
+                .query("SELECT id FROM cards WHERE nid = " + mId + " ORDER BY ord", null)) {
             while (cur.moveToNext()) {
                 cards.add(mCol.getCard(cur.getLong(0)));
-            }
-        } finally {
-            if (cur != null) {
-                cur.close();
             }
         }
         return cards;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Tags.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Tags.java
@@ -142,15 +142,9 @@ public class Tags {
             mChanged = true;
         }
         List<String> tags = new ArrayList<>();
-        Cursor cursor = null;
-        try {
-            cursor = mCol.getDb().getDatabase().query("SELECT DISTINCT tags FROM notes"+lim, null);
+        try (Cursor cursor = mCol.getDb().getDatabase().query("SELECT DISTINCT tags FROM notes" + lim, null)) {
             while (cursor.moveToNext()) {
                 tags.add(cursor.getString(0));
-            }
-        } finally {
-            if (cursor != null) {
-                cursor.close();
             }
         }
         HashSet<String> tagSet = new HashSet<>();
@@ -244,15 +238,13 @@ public class Tags {
             t = t.replace("*", "%");
             lim.append(l).append("like '% ").append(t).append(" %'");
         }
-        Cursor cur = null;
         List<Long> nids = new ArrayList<>();
         ArrayList<Object[]> res = new ArrayList<>();
-        try {
-            cur = mCol
-                    .getDb()
-                    .getDatabase()
-                    .query("select id, tags from notes where id in " + Utils.ids2str(ids) +
-                            " and (" + lim + ")", null);
+        try (Cursor cur = mCol
+                .getDb()
+                .getDatabase()
+                .query("select id, tags from notes where id in " + Utils.ids2str(ids) +
+                        " and (" + lim + ")", null)) {
             if (add) {
                 while (cur.moveToNext()) {
                     nids.add(cur.getLong(0));
@@ -264,10 +256,6 @@ public class Tags {
                     res.add(new Object[] { remFromStr(tags, cur.getString(1)), Utils.intTime(), mCol.usn(),
                             cur.getLong(0) });
                 }
-            }
-        } finally {
-            if (cur != null) {
-                cur.close();
             }
         }
         // update tags

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
@@ -534,19 +534,13 @@ public class Anki2Importer extends Importer {
                 }
                 cards.add(card);
                 // we need to import revlog, rewriting card ids and bumping usn
-                Cursor cur2 = null;
-                try {
-                    cur2 = mSrc.getDb().getDatabase().query("select * from revlog where cid = " + scid, null);
+                try (Cursor cur2 = mSrc.getDb().getDatabase().query("select * from revlog where cid = " + scid, null)) {
                     while (cur2.moveToNext()) {
                         Object[] rev = new Object[] { cur2.getLong(0), cur2.getLong(1), cur2.getInt(2), cur2.getInt(3),
                                 cur2.getLong(4), cur2.getLong(5), cur2.getLong(6), cur2.getLong(7), cur2.getInt(8) };
                         rev[1] = card[0];
                         rev[2] = mDst.usn();
                         revlog.add(rev);
-                    }
-                } finally {
-                    if (cur2 != null) {
-                        cur2.close();
                     }
                 }
                 cnt += 1;

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
@@ -93,16 +93,11 @@ public class ImportUtils {
         // Get the original filename from the content provider URI
         String errorMessage = null;
         String filename = null;
-        Cursor cursor = null;
-        try {
-            cursor = context.getContentResolver().query(data, new String[]{OpenableColumns.DISPLAY_NAME}, null, null, null);
+        try (Cursor cursor = context.getContentResolver().query(data, new String[] {OpenableColumns.DISPLAY_NAME}, null, null, null)) {
             if (cursor != null && cursor.moveToFirst()) {
                 filename = cursor.getString(0);
                 Timber.d("handleFileImport() Importing from content provider: %s", filename);
             }
-        } finally {
-            if (cursor != null)
-                cursor.close();
         }
 
         // Hack to fix bug where ContentResolver not returning filename correctly


### PR DESCRIPTION
## Purpose / Description

Reduce amount of boilerplate code in project

Available on all API levels:

> In addition to the Java 8 language features and APIs above, Android Studio 3.0 and later extends support for try-with-resources to all Android API levels.

https://developer.android.com/studio/write/java8-support


## Fixes
N/A

## Approach

Automated lint fix from Android Studio (except 1, which involved moving a nullvariable, then an auto fix)

Finally, manual undo of the whitespace changes.


## How Has This Been Tested?

Unit, Android, and tested on my machine

## Learning (optional, can help others)
https://developer.android.com/studio/write/java8-support

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code