### PR TITLE
Fix androidTest on real device

### DIFF
--- a/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/ACRATest.java
+++ b/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/ACRATest.java
@@ -4,6 +4,7 @@ import android.Manifest;
 import android.app.Instrumentation;
 import android.content.SharedPreferences;
 
+import androidx.test.annotation.UiThreadTest;
 import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.rule.GrantPermissionRule;
 
@@ -46,6 +47,7 @@ public class ACRATest {
 
 
     @Before
+    @UiThreadTest
     public void setUp() {
         Instrumentation instrumentation = InstrumentationRegistry.getInstrumentation();
         app = (AnkiDroidApp) instrumentation.getTargetContext().getApplicationContext();

--- a/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/NotificationChannelTest.java
+++ b/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/NotificationChannelTest.java
@@ -20,6 +20,8 @@ import android.Manifest;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.content.Context;
+
+import androidx.test.annotation.UiThreadTest;
 import androidx.test.platform.app.InstrumentationRegistry;
 import androidx.test.rule.GrantPermissionRule;
 
@@ -51,6 +53,7 @@ public class NotificationChannelTest {
     private NotificationManager mManager = null;
 
     @Before
+    @UiThreadTest
     public void setUp() {
         Context targetContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
         ((AnkiDroidApp)targetContext.getApplicationContext()).onCreate();

--- a/AnkiDroid/src/main/java/com/ichi2/utils/WebViewDebugging.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/WebViewDebugging.java
@@ -4,8 +4,11 @@ import android.content.SharedPreferences;
 import android.os.Build;
 import android.webkit.WebView;
 
+import androidx.annotation.UiThread;
+
 public class WebViewDebugging {
 
+    @UiThread
     public static void initializeDebugging(SharedPreferences sharedPrefs) {
         // DEFECT: We might be able to cache this value: check what happens on WebView Renderer crash
         // On your desktop use chrome://inspect to connect to emulator WebViews


### PR DESCRIPTION
## Purpose / Description
#5970 requires that `AnkiDroidApp.onCreate` is run on the UI thread. This broke tests.

## Fixes
N/A

## Approach
Application.onCreate is guaranteed to be run on the UI thread, so this
fixes tests to do this.
## How Has This Been Tested?

Ran tests, they now pass

https://stackoverflow.com/a/30390340

## Learning (optional, can help others)

https://stackoverflow.com/a/30390340

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code