### PR TITLE
Speed up tests by 25s

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
@@ -33,6 +33,7 @@ import org.robolectric.shadows.ShadowLog;
 
 import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory;
 import androidx.test.platform.app.InstrumentationRegistry;
+import timber.log.Timber;
 
 public class RobolectricTest {
 
@@ -52,6 +53,10 @@ public class RobolectricTest {
 
         // After every test, make sure the sqlite implementation is set back to default
         DB.setSqliteOpenHelperFactory(null);
+
+        //called on each AnkiDroidApp.onCreate(), and spams the build
+        //there is no onDestroy(), so call it here.
+        Timber.uprootAll();
     }
 
 


### PR DESCRIPTION
Each test calls AnkiDroidApp.onCreate which plants a Timber config

This causes a lot of log noise, and slows down the tests

Before:
3m19s
3m14s

After:
2m51s
2m52

25 second reduction

## Learning (optional, can help others)

https://stackoverflow.com/a/17278496 - no `Application.onDestroy`

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code