### PR TITLE
Deactivate gesture when controls are blocked

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -2499,6 +2499,9 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
     }
 
     protected void executeCommand(int which) {
+        if (mControlBlocked) {
+            return;
+        }
         switch (which) {
             case GESTURE_NOTHING:
                 break;


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
When buttons are deactivated, gestures are not. I use the new the new `mControlBlocked` to ensure that gestures are not considered.

## Fixes
If I suspend a card and it takes a second to do it. If durin this second I do a gesture to edit a card, I see that the card opened ni the editor is the card that is not yet loaded. So the action is registered and applied with a card that is not yet seen.

## How Has This Been Tested?

My "merge" branch, and trying to do actions as explained above

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
