### PR TITLE
Cancel due tree when possible

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -1980,12 +1980,10 @@ public class DeckPicker extends NavigationDrawerActivity implements
         // Also forget the last deck used by the Browser
         CardBrowser.clearLastDeckId();
         // Reset the schedule so that we get the counts for the currently selected deck
-        getCol().getSched().reset();
         mFocusedDeck = did;
         // Get some info about the deck to handle special cases
         int pos = mDeckListAdapter.findDeckPosition(did);
         Sched.DeckDueTreeNode deckDueTreeNode = mDeckListAdapter.getDeckList().get(pos);
-        int[] studyOptionsCounts = getCol().getSched().counts();
         // Figure out what action to take
         if (deckDueTreeNode.newCount + deckDueTreeNode.lrnCount + deckDueTreeNode.revCount > 0) {
             // If there are cards to study then either go to Reviewer or StudyOptions
@@ -1996,7 +1994,11 @@ public class DeckPicker extends NavigationDrawerActivity implements
                 // Otherwise jump straight to the reviewer
                 openReviewer();
             }
-        } else if (studyOptionsCounts[0] + studyOptionsCounts[1] + studyOptionsCounts[2] > 0) {
+            return;
+        }
+        getCol().getSched().reset();
+        int[] studyOptionsCounts = getCol().getSched().counts();
+        if (studyOptionsCounts[0] + studyOptionsCounts[1] + studyOptionsCounts[2] > 0) {
             // If there are cards due that can't be studied yet (due to the learn ahead limit) then go to study options
             openStudyOptions(false);
         } else if (getCol().getSched().newDue() || getCol().getSched().revDue()) {
@@ -2350,7 +2352,6 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
     private void openReviewer() {
         Intent reviewer = new Intent(this, Reviewer.class);
-        reviewer.putExtra("com.ichi2.anki.SchedResetDone", true);
         startActivityForResultWithAnimation(reviewer, REQUEST_REVIEW, ActivityTransitionAnimation.LEFT);
         getCol().startTimebox();
     }

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -533,7 +533,7 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
         Collection col = CollectionHelper.getInstance().getCol(mContext);
         try {
             // Get due tree
-            Object[] o = new Object[] {col.getSched().deckDueTree()};
+            Object[] o = new Object[] {col.getSched().deckDueTree(this)};
             return new TaskData(o);
         } catch (RuntimeException e) {
             Timber.e(e, "doInBackgroundLoadDeckCounts - error");

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
@@ -14,26 +14,41 @@ import java.util.List;
 import java.util.Locale;
 
 public abstract class AbstractSched {
+    /**
+     * Pop the next card from the queue. null if finished.
+     */
     public abstract Card getCard();
     public abstract void reset();
     public abstract void answerCard(Card card, int ease);
     public abstract int[] counts();
     public abstract int[] counts(Card card);
+    /**
+     * Return counts over next DAYS. Includes today.
+     */
     public abstract int dueForecast();
     public abstract int dueForecast(int days);
     public abstract int countIdx(Card card);
     public abstract int answerButtons(Card card);
+    /**
+     * Unbury all buried cards in all decks
+     */
     public abstract void unburyCards();
     public abstract void unburyCardsForDeck();
     public abstract void _updateStats(Card card, String type, long cnt);
     public abstract void extendLimits(int newc, int rev);
+    /**
+     * Returns [deckname, did, rev, lrn, new]
+     */
     public abstract List<DeckDueTreeNode> deckDueList();
     public abstract List<DeckDueTreeNode> deckDueTree();
+    /** New count for a single deck. */
     public abstract int _newForDeck(long did, int lim);
+    /** Limit for deck without parent limits. */
     public abstract int _deckNewLimitSingle(JSONObject g);
     public abstract int totalNewForCurrentDeck();
     public abstract int totalRevForCurrentDeck();
     public abstract int[] _fuzzedIvlRange(int ivl);
+    /** Rebuild a dynamic deck. */
     public abstract void rebuildDyn();
     public abstract List<Long> rebuildDyn(long did);
     public abstract void emptyDyn(long did);
@@ -44,23 +59,64 @@ public abstract class AbstractSched {
     public abstract void _checkDay();
     public abstract CharSequence finishedMsg(Context context);
     public abstract String _nextDueMsg(Context context);
+    /** true if there are any rev cards due. */
     public abstract boolean revDue();
+    /** true if there are any new cards due. */
     public abstract boolean newDue();
     public abstract boolean haveBuried();
+    /**
+     * Return the next interval for a card and ease as a string.
+     *
+     * For a given card and ease, this returns a string that shows when the card will be shown again when the
+     * specific ease button (AGAIN, GOOD etc.) is touched. This uses unit symbols like “s” rather than names
+     * (“second”), like Anki desktop.
+     *
+     * @param context The app context, used for localization
+     * @param card The card being reviewed
+     * @param ease The button number (easy, good etc.)
+     * @return A string like “1 min” or “1.7 mo”
+     */
     public abstract String nextIvlStr(Context context, Card card, int ease);
+    /**
+     * Return the next interval for CARD, in seconds.
+     */
     public abstract long nextIvl(Card card, int ease);
+    /**
+     * Suspend cards.
+     */
     public abstract void suspendCards(long[] ids);
+    /**
+     * Unsuspend cards
+     */
     public abstract void unsuspendCards(long[] ids);
     public abstract void buryCards(long[] cids);
+    /**
+     * Bury all cards for note until next session.
+     * @param nid The id of the targeted note.
+     */
     public abstract void buryNote(long nid);
+    /** Put cards at the end of the new queue. */
     public abstract void forgetCards(long[] ids);
+    /**
+     * Put cards in review queue with a new interval in days (min, max).
+     *
+     * @param ids The list of card ids to be affected
+     * @param imin the minimum interval (inclusive)
+     * @param imax The maximum interval (inclusive)
+     */
     public abstract void reschedCards(long[] ids, int imin, int imax);
+    /**
+     * Completely reset cards for export.
+     */
     public abstract void resetCards(Long[] ids);
     public abstract void sortCards(long[] cids, int start);
     public abstract void sortCards(long[] cids, int start, int step, boolean shuffle, boolean shift);
     public abstract void randomizeCards(long did);
     public abstract void orderCards(long did);
     public abstract void resortConf(JSONObject conf);
+    /**
+     * for post-import
+     */
     public abstract void maybeRandomizeDeck();
     public abstract void maybeRandomizeDeck(Long did);
     public abstract boolean haveBuried(long did);
@@ -72,6 +128,23 @@ public abstract class AbstractSched {
     public abstract int getReps();
     public abstract void setReps(int reps);
     public abstract int cardCount();
+    /**
+     * Return an estimate, in minutes, for how long it will take to complete all the reps in {@code counts}.
+     *
+     * The estimator builds rates for each queue type by looking at 10 days of history from the revlog table. For
+     * efficiency, and to maintain the same rates for a review session, the rates are cached and reused until a
+     * reload is forced.
+     *
+     * Notes:
+     * - Because the revlog table does not record deck IDs, the rates cannot be reduced to a single deck and thus cover
+     * the whole collection which may be inaccurate for some decks.
+     * - There is no efficient way to determine how many lrn cards are generated by each new card. This estimator
+     * assumes 1 card is generated as a compromise.
+     * - If there is no revlog data to work with, reasonable defaults are chosen as a compromise to predicting 0 minutes.
+     *
+     * @param counts An array of [new, lrn, rev] counts from the scheduler's counts() method.
+     * @param reload Force rebuild of estimator rates using the revlog.
+     */
     public abstract int eta(int[] counts);
     public abstract int eta(int[] counts, boolean reload);
     public abstract void decrementCounts(Card card);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.content.Context;
 
 
+import com.ichi2.async.CollectionTask;
 import com.ichi2.libanki.Card;
 import com.ichi2.utils.JSONObject;
 
@@ -40,6 +41,8 @@ public abstract class AbstractSched {
      * Returns [deckname, did, rev, lrn, new]
      */
     public abstract List<DeckDueTreeNode> deckDueList();
+    /** load the due tree, but halt if deck task is cancelled*/
+    public abstract List<DeckDueTreeNode> deckDueTree(CollectionTask collectionTask);
     public abstract List<DeckDueTreeNode> deckDueTree();
     /** New count for a single deck. */
     public abstract int _newForDeck(long did, int lim);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -29,6 +29,7 @@ import android.text.TextUtils;
 import android.text.style.StyleSpan;
 
 import com.ichi2.anki.R;
+import com.ichi2.async.CollectionTask;
 import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Consts;
@@ -217,13 +218,16 @@ public class Sched extends SchedV2 {
      * Returns [deckname, did, rev, lrn, new]
      */
     @Override
-    public List<DeckDueTreeNode> deckDueList() {
+    public List<DeckDueTreeNode> deckDueList(CollectionTask collectionTask) {
         _checkDay();
         mCol.getDecks().checkIntegrity();
         ArrayList<JSONObject> decks = mCol.getDecks().allSorted();
         HashMap<String, Integer[]> lims = new HashMap<>();
         ArrayList<DeckDueTreeNode> data = new ArrayList<>();
         for (JSONObject deck : decks) {
+            if (collectionTask != null && collectionTask.isCancelled()) {
+                return null;
+            }
             String p = Decks.parent(deck.getString("name"));
             // new
             int nlim = _deckNewLimitSingle(deck);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -677,7 +677,7 @@ public class Sched extends SchedV2 {
     	removeLrn(null);
     }
 
-    /* Remove cards from the learning queues. */
+    /** Remove cards from the learning queues. */
     private void removeLrn(long[] ids) {
         String extra;
         if (ids != null && ids.length > 0) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -670,7 +670,7 @@ public class SchedV2 extends AbstractSched {
     }
 
 
-    /* New count for a single deck. */
+    /** New count for a single deck. */
     public int _newForDeck(long did, int lim) {
         if (lim == 0) {
             return 0;
@@ -681,7 +681,7 @@ public class SchedV2 extends AbstractSched {
     }
 
 
-    /* Limit for deck without parent limits. */
+    /** Limit for deck without parent limits. */
     public int _deckNewLimitSingle(JSONObject g) {
         if (g.getInt("dyn") != 0) {
             return mDynReportLimit;
@@ -1046,7 +1046,7 @@ public class SchedV2 extends AbstractSched {
     }
 
 
-    /* the number of steps that can be completed by the day cutoff */
+    /** the number of steps that can be completed by the day cutoff */
     protected int _leftToday(JSONArray delays, int left) {
         return _leftToday(delays, left, 0);
     }
@@ -1095,7 +1095,7 @@ public class SchedV2 extends AbstractSched {
     }
 
 
-    /* Reschedule a new card that's graduated for the first time. */
+    /** Reschedule a new card that's graduated for the first time. */
     private void _rescheduleNew(Card card, JSONObject conf, boolean early) {
         card.setIvl(_graduatingIvl(card, conf, early));
         card.setDue(mToday + card.getIvl());
@@ -1438,7 +1438,7 @@ public class SchedV2 extends AbstractSched {
     }
 
 
-    // next interval for card when answered early+correctly
+    /** next interval for card when answered early+correctly */
     private int _earlyReviewIvl(Card card, int ease) {
         if (card.getODid() == 0 || card.getType() != Consts.CARD_TYPE_REV || card.getFactor() == 0) {
             throw new RuntimeException("Unexpected card parameters");
@@ -1484,7 +1484,7 @@ public class SchedV2 extends AbstractSched {
      * *****************************
      */
 
-    /* Rebuild a dynamic deck. */
+    /** Rebuild a dynamic deck. */
     public void rebuildDyn() {
         rebuildDyn(0);
     }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

DeckDueTree is a long method. And it uses a lot of database access, so even in background, it is costly. Worse, sometime, it is useless. I.e. when the method is executed while the deck picker itself is gone.

## Approach

I simply ensured that this method can be cancelled; and that leaving the deck picker cancel it.

I had to do some other small change for efficiency. The commits describe them.

I also copied documentation comment from SchedV2 to AbstractSched, because it's more consistent.

## How Has This Been Tested?

On my phone;
* load a deck
* goes to deck picker
* immediately load a deck

In profiler, check that the deck due tree ends sooner (e.g. does not call _groupChildren)

## Learning (optional, can help others)
I learned there is no way to force a asynctask to be forced to be killed, I've to check myself for cancellation. Which is not such a big commit actually, but still not really nice to have to do oneself

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
