### PR TITLE
In-Memory Multimedia Editor

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -3218,4 +3218,11 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
     public boolean getControlBlocked() {
         return mControlBlocked;
     }
+
+
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    static void setEditorCard(Card card) {
+        //I don't see why we don't do this by intent.
+        sEditorCard = card;
+    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1119,8 +1119,8 @@ public class NoteEditor extends AnkiActivity {
     private void setMMButtonListener(ImageButton mediaButton, final int index) {
         mediaButton.setOnClickListener(v -> {
             Timber.i("NoteEditor:: Multimedia button pressed for field %d", index);
-            final Collection col = CollectionHelper.getInstance().getCol(NoteEditor.this);
             if (mEditorNote.items()[index][1].length() > 0) {
+                final Collection col = CollectionHelper.getInstance().getCol(NoteEditor.this);
                 // If the field already exists then we start the field editor, which figures out the type
                 // automatically
                 IMultimediaEditableNote mNote = NoteService.createEmptyNote(mEditorNote.model());
@@ -1134,37 +1134,28 @@ public class NoteEditor extends AnkiActivity {
                 MenuInflater inflater = popup.getMenuInflater();
                 inflater.inflate(R.menu.popupmenu_multimedia_options, popup.getMenu());
                 popup.setOnMenuItemClickListener(item -> {
-                    IMultimediaEditableNote mNote = NoteService.createEmptyNote(mEditorNote.model());
-                    NoteService.updateMultimediaNoteFromJsonNote(col, mEditorNote, mNote);
-                    IField field;
+
                     switch (item.getItemId()) {
                         case R.id.menu_multimedia_audio: {
                             Timber.i("NoteEditor:: Record audio button pressed");
-                            field = new AudioRecordingField();
-                            mNote.setField(index, field);
-                            startMultimediaFieldEditor(index, mNote, field);
+                            startMultimediaFieldEditorForField(index, new AudioRecordingField());
                             return true;
                         }
                         case R.id.menu_multimedia_audio_clip: {
                             Timber.i("NoteEditor:: Add audio clip button pressed");
-                            field = new AudioClipField();
-                            mNote.setField(index, field);
-                            startMultimediaFieldEditor(index, mNote, field);
+                            startMultimediaFieldEditorForField(index, new AudioClipField());
                             return true;
                         }
                         case R.id.menu_multimedia_photo: {
                             Timber.i("NoteEditor:: Add image button pressed");
-                            field = new ImageField();
-                            mNote.setField(index, field);
-                            startMultimediaFieldEditor(index, mNote, field);
+                            startMultimediaFieldEditorForField(index, new ImageField());
                             return true;
                         }
                         case R.id.menu_multimedia_text: {
                             Timber.i("NoteEditor:: Advanced editor button pressed");
-                            field = new TextField();
+                            TextField field = new TextField();
                             field.setText(mEditFields.get(index).getText().toString());
-                            mNote.setField(index, field);
-                            startMultimediaFieldEditor(index, mNote, field);
+                            startMultimediaFieldEditorForField(index, field);
                             return true;
                         }
                         default:
@@ -1178,6 +1169,15 @@ public class NoteEditor extends AnkiActivity {
                 popup.show();
             }
         });
+    }
+
+
+    private void startMultimediaFieldEditorForField(int index, IField field) {
+        Collection col = CollectionHelper.getInstance().getCol(NoteEditor.this);
+        IMultimediaEditableNote mNote = NoteService.createEmptyNote(mEditorNote.model());
+        NoteService.updateMultimediaNoteFromJsonNote(col, mEditorNote, mNote);
+        mNote.setField(index, field);
+        startMultimediaFieldEditor(index, mNote, field);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -106,6 +106,15 @@ import timber.log.Timber;
  */
 @SuppressWarnings("PMD.AvoidThrowingRawExceptionTypes")
 public class NoteEditor extends AnkiActivity {
+    // DA 2020-04-13 - Refactoring Plans once tested:
+    // * There is a difference in functionality depending on whether we are editing
+    // * Extract mAddNote and mCurrentEditedCard into inner class. Gate mCurrentEditedCard on edit state.
+    // * Possibly subclass
+    // * Make this in memory and immutable for metadata, it's hard to reason about our state if we're modifying col
+    // * Consider persistence strategy for temporary media. Saving after multimedia edit is probably too early, but
+    // we don't want to risk the cache being cleared. Maybe add in functionality to remove from collection if added and
+    // the action is cancelled?
+
 
 //    public static final String SOURCE_LANGUAGE = "SOURCE_LANGUAGE";
 //    public static final String TARGET_LANGUAGE = "TARGET_LANGUAGE";

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -54,7 +54,6 @@ import com.afollestad.materialdialogs.MaterialDialog;
 import com.ichi2.anim.ActivityTransitionAnimation;
 import com.ichi2.anki.dialogs.ConfirmationDialog;
 import com.ichi2.anki.dialogs.TagsDialog;
-import com.ichi2.anki.dialogs.TagsDialog.TagsDialogListener;
 import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.anki.multimediacard.IMultimediaEditableNote;
 import com.ichi2.anki.multimediacard.activity.MultimediaEditFieldActivity;
@@ -296,8 +295,7 @@ public class NoteEditor extends AnkiActivity {
             mCaller = intent.getIntExtra(EXTRA_CALLER, CALLER_NOCALLER);
             if (mCaller == CALLER_NOCALLER) {
                 String action = intent.getAction();
-                if (action != null
-                        && (ACTION_CREATE_FLASHCARD.equals(action) || ACTION_CREATE_FLASHCARD_SEND.equals(action))) {
+                if ((ACTION_CREATE_FLASHCARD.equals(action) || ACTION_CREATE_FLASHCARD_SEND.equals(action))) {
                     mCaller = CALLER_CARDEDITOR_INTENT_ADD;
                 }
             }
@@ -315,7 +313,7 @@ public class NoteEditor extends AnkiActivity {
         if(mSelectedTags == null){
             mSelectedTags = new ArrayList<>();
         }
-        savedInstanceState.putStringArray("tags", mSelectedTags.toArray(new String[mSelectedTags.size()]));
+        savedInstanceState.putStringArray("tags", mSelectedTags.toArray(new String[0]));
         Bundle fields = new Bundle();
         // Save the content of all the note fields. We use the field's ord as the key to
         // easily map the fields correctly later.
@@ -342,21 +340,18 @@ public class NoteEditor extends AnkiActivity {
 
         View mainView = findViewById(android.R.id.content);
 
-        Toolbar toolbar = (Toolbar) mainView.findViewById(R.id.toolbar);
+        Toolbar toolbar = mainView.findViewById(R.id.toolbar);
         if (toolbar != null) {
             setSupportActionBar(toolbar);
         }
 
-        mFieldsLayoutContainer = (LinearLayout) findViewById(R.id.CardEditorEditFieldsLayout);
+        mFieldsLayoutContainer = findViewById(R.id.CardEditorEditFieldsLayout);
 
-        mTagsButton = (TextView) findViewById(R.id.CardEditorTagText);
-        mCardsButton = (TextView) findViewById(R.id.CardEditorCardsText);
-        mCardsButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                Timber.i("NoteEditor:: Cards button pressed. Opening template editor");
-                showCardTemplateEditor();
-            }
+        mTagsButton = findViewById(R.id.CardEditorTagText);
+        mCardsButton = findViewById(R.id.CardEditorCardsText);
+        mCardsButton.setOnClickListener(v -> {
+            Timber.i("NoteEditor:: Cards button pressed. Opening template editor");
+            showCardTemplateEditor();
         });
 
 
@@ -420,7 +415,7 @@ public class NoteEditor extends AnkiActivity {
         }
 
         // Note type Selector
-        mNoteTypeSpinner = (Spinner) findViewById(R.id.note_type_spinner);
+        mNoteTypeSpinner = findViewById(R.id.note_type_spinner);
         mAllModelIds = new ArrayList<>();
         final ArrayList<String> modelNames = new ArrayList<>();
         ArrayList<JSONObject> models = getCol().getModels().all();
@@ -436,12 +431,12 @@ public class NoteEditor extends AnkiActivity {
 
 
         // Deck Selector
-        TextView deckTextView = (TextView) findViewById(R.id.CardEditorDeckText);
+        TextView deckTextView = findViewById(R.id.CardEditorDeckText);
         // If edit mode and more than one card template distinguish between "Deck" and "Card deck"
         if (!mAddNote && mEditorNote.model().getJSONArray("tmpls").length()>1) {
             deckTextView.setText(R.string.CardEditorCardDeck);
         }
-        mNoteDeckSpinner = (Spinner) findViewById(R.id.note_deck_spinner);
+        mNoteDeckSpinner = findViewById(R.id.note_deck_spinner);
         mAllDeckIds = new ArrayList<>();
         final ArrayList<String> deckNames = new ArrayList<>();
 
@@ -510,12 +505,9 @@ public class NoteEditor extends AnkiActivity {
         }
 
 
-        findViewById(R.id.CardEditorTagButton).setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                Timber.i("NoteEditor:: Tags button pressed... opening tags editor");
-                showTagsDialog();
-            }
+        findViewById(R.id.CardEditorTagButton).setOnClickListener(v -> {
+            Timber.i("NoteEditor:: Tags button pressed... opening tags editor");
+            showTagsDialog();
         });
 
         if (!mAddNote && mCurrentEditedCard != null) {
@@ -713,12 +705,9 @@ public class NoteEditor extends AnkiActivity {
                     // If cards will be lost via the new mapping then show a confirmation dialog before proceeding with the change
                     ConfirmationDialog dialog = new ConfirmationDialog ();
                     dialog.setArgs(res.getString(R.string.confirm_map_cards_to_nothing));
-                    Runnable confirm = new Runnable() {
-                        @Override
-                        public void run() {
-                            // Bypass the check once the user confirms
-                            changeNoteTypeWithErrorHandling(oldModel, newModel);
-                        }
+                    Runnable confirm = () -> {
+                        // Bypass the check once the user confirms
+                        changeNoteTypeWithErrorHandling(oldModel, newModel);
                     };
                     dialog.setConfirm(confirm);
                     showDialogFragment(dialog);
@@ -765,8 +754,6 @@ public class NoteEditor extends AnkiActivity {
 
     /**
      * Change the note type from oldModel to newModel, handling the case where a full sync will be required
-     * @param oldModel
-     * @param newModel
      */
     private void changeNoteTypeWithErrorHandling(final JSONObject oldModel, final JSONObject newModel) {
         Resources res = getResources();
@@ -776,17 +763,14 @@ public class NoteEditor extends AnkiActivity {
             // Libanki has determined we should ask the user to confirm first
             ConfirmationDialog dialog = new ConfirmationDialog();
             dialog.setArgs(res.getString(R.string.full_sync_confirmation));
-            Runnable confirm = new Runnable() {
-                @Override
-                public void run() {
-                    // Bypass the check once the user confirms
-                    getCol().modSchemaNoCheck();
-                    try {
-                        changeNoteType(oldModel, newModel);
-                    } catch (ConfirmModSchemaException e2) {
-                        // This should never be reached as we explicitly called modSchemaNoCheck()
-                        throw new RuntimeException(e2);
-                    }
+            Runnable confirm = () -> {
+                // Bypass the check once the user confirms
+                getCol().modSchemaNoCheck();
+                try {
+                    changeNoteType(oldModel, newModel);
+                } catch (ConfirmModSchemaException e2) {
+                    // This should never be reached as we explicitly called modSchemaNoCheck()
+                    throw new RuntimeException(e2);
                 }
             };
             dialog.setConfirm(confirm);
@@ -795,10 +779,8 @@ public class NoteEditor extends AnkiActivity {
     }
 
     /**
-     * Change the note type from oldModel to newModel, throwing ConfirmModSchemaException if a full sync will be required
-     * @param oldModel
-     * @param newModel
-     * @throws ConfirmModSchemaException
+     * Change the note type from oldModel to newModel
+     * @throws ConfirmModSchemaException If a full sync will be required
      */
     private void changeNoteType(JSONObject oldModel, JSONObject newModel) throws ConfirmModSchemaException {
         final long [] nids = {mEditorNote.getId()};
@@ -974,15 +956,12 @@ public class NoteEditor extends AnkiActivity {
         ArrayList<String> selTags = new ArrayList<>(mSelectedTags);
         TagsDialog dialog = TagsDialog.newInstance(TagsDialog.TYPE_ADD_TAG, selTags,
                 tags);
-        dialog.setTagsDialogListener(new TagsDialogListener() {
-            @Override
-            public void onPositive(List<String> selectedTags, int option) {
-                if (!mSelectedTags.equals(selectedTags)) {
-                    mTagsEdited = true;
-                }
-                mSelectedTags = selectedTags;
-                updateTags();
+        dialog.setTagsDialogListener((selectedTags, option) -> {
+            if (!mSelectedTags.equals(selectedTags)) {
+                mTagsEdited = true;
             }
+            mSelectedTags = selectedTags;
+            updateTags();
         });
         showDialogFragment(dialog);
     }
@@ -1025,7 +1004,7 @@ public class NoteEditor extends AnkiActivity {
                     Bundle extras = data.getExtras();
                     int index = extras.getInt(MultimediaEditFieldActivity.EXTRA_RESULT_FIELD_INDEX);
                     IField field = (IField) extras.get(MultimediaEditFieldActivity.EXTRA_RESULT_FIELD);
-                    IMultimediaEditableNote mNote = NoteService.createEmptyNote(mEditorNote.model());
+                    MultimediaEditableNote mNote = NoteService.createEmptyNote(mEditorNote.model());
                     NoteService.updateMultimediaNoteFromJsonNote(col, mEditorNote, mNote);
                     mNote.setField(index, field);
                     FieldEditText fieldEditText = mEditFields.get(index);
@@ -1043,7 +1022,7 @@ public class NoteEditor extends AnkiActivity {
                     else {
                         fieldEditText.getText().append(field.getFormattedValue());
                     }
-                    NoteService.saveMedia(col, (MultimediaEditableNote) mNote);
+                    NoteService.saveMedia(col, mNote);
                     mChanged = true;
                 }
                 break;
@@ -1100,7 +1079,7 @@ public class NoteEditor extends AnkiActivity {
 
         for (int i = 0; i < fields.length; i++) {
             View editline_view = getLayoutInflater().inflate(R.layout.card_multimedia_editline, null);
-            FieldEditText newTextbox = (FieldEditText) editline_view.findViewById(R.id.id_note_editText);
+            FieldEditText newTextbox = editline_view.findViewById(R.id.id_note_editText);
 
             if (Build.VERSION.SDK_INT >= 23) {
                 // Use custom implementation of ActionMode.Callback customize selection and insert menus
@@ -1115,7 +1094,7 @@ public class NoteEditor extends AnkiActivity {
             label.setPadding((int) UIUtils.getDensityAdjustedValue(this, 3.4f), 0, 0, 0);
             mEditFields.add(newTextbox);
 
-            ImageButton mediaButton = (ImageButton) editline_view.findViewById(R.id.id_media_button);
+            ImageButton mediaButton = editline_view.findViewById(R.id.id_media_button);
             // Load icons from attributes
             int[] icons = Themes.getResFromAttr(this, new int[] { R.attr.attachFileImage, R.attr.upDownImage});
             // Make the icon change between media icon and switch field icon depending on whether editing note type
@@ -1138,68 +1117,65 @@ public class NoteEditor extends AnkiActivity {
 
 
     private void setMMButtonListener(ImageButton mediaButton, final int index) {
-        mediaButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                Timber.i("NoteEditor:: Multimedia button pressed for field %d", index);
-                final Collection col = CollectionHelper.getInstance().getCol(NoteEditor.this);
-                if (mEditorNote.items()[index][1].length() > 0) {
-                    // If the field already exists then we start the field editor, which figures out the type
-                    // automatically
+        mediaButton.setOnClickListener(v -> {
+            Timber.i("NoteEditor:: Multimedia button pressed for field %d", index);
+            final Collection col = CollectionHelper.getInstance().getCol(NoteEditor.this);
+            if (mEditorNote.items()[index][1].length() > 0) {
+                // If the field already exists then we start the field editor, which figures out the type
+                // automatically
+                IMultimediaEditableNote mNote = NoteService.createEmptyNote(mEditorNote.model());
+                NoteService.updateMultimediaNoteFromJsonNote(col, mEditorNote, mNote);
+                IField field = mNote.getField(index);
+                startMultimediaFieldEditor(index, mNote, field);
+            } else {
+                // Otherwise we make a popup menu allowing the user to choose between audio/image/text field
+                // TODO: Update the icons for dark material theme, then can set 3rd argument to true
+                PopupMenuWithIcons popup = new PopupMenuWithIcons(NoteEditor.this, v, false);
+                MenuInflater inflater = popup.getMenuInflater();
+                inflater.inflate(R.menu.popupmenu_multimedia_options, popup.getMenu());
+                popup.setOnMenuItemClickListener(item -> {
                     IMultimediaEditableNote mNote = NoteService.createEmptyNote(mEditorNote.model());
                     NoteService.updateMultimediaNoteFromJsonNote(col, mEditorNote, mNote);
-                    IField field = mNote.getField(index);
-                    startMultimediaFieldEditor(index, mNote, field);
-                } else {
-                    // Otherwise we make a popup menu allowing the user to choose between audio/image/text field
-                    // TODO: Update the icons for dark material theme, then can set 3rd argument to true
-                    PopupMenuWithIcons popup = new PopupMenuWithIcons(NoteEditor.this, v, false);
-                    MenuInflater inflater = popup.getMenuInflater();
-                    inflater.inflate(R.menu.popupmenu_multimedia_options, popup.getMenu());
-                    popup.setOnMenuItemClickListener(item -> {
-                        IMultimediaEditableNote mNote = NoteService.createEmptyNote(mEditorNote.model());
-                        NoteService.updateMultimediaNoteFromJsonNote(col, mEditorNote, mNote);
-                        IField field;
-                        switch (item.getItemId()) {
-                            case R.id.menu_multimedia_audio: {
-                                Timber.i("NoteEditor:: Record audio button pressed");
-                                field = new AudioRecordingField();
-                                mNote.setField(index, field);
-                                startMultimediaFieldEditor(index, mNote, field);
-                                return true;
-                            }
-                            case R.id.menu_multimedia_audio_clip: {
-                                Timber.i("NoteEditor:: Add audio clip button pressed");
-                                field = new AudioClipField();
-                                mNote.setField(index, field);
-                                startMultimediaFieldEditor(index, mNote, field);
-                                return true;
-                            }
-                            case R.id.menu_multimedia_photo: {
-                                Timber.i("NoteEditor:: Add image button pressed");
-                                field = new ImageField();
-                                mNote.setField(index, field);
-                                startMultimediaFieldEditor(index, mNote, field);
-                                return true;
-                            }
-                            case R.id.menu_multimedia_text: {
-                                Timber.i("NoteEditor:: Advanced editor button pressed");
-                                field = new TextField();
-                                field.setText(mEditFields.get(index).getText().toString());
-                                mNote.setField(index, field);
-                                startMultimediaFieldEditor(index, mNote, field);
-                                return true;
-                            }
-                            default:
-                                return false;
+                    IField field;
+                    switch (item.getItemId()) {
+                        case R.id.menu_multimedia_audio: {
+                            Timber.i("NoteEditor:: Record audio button pressed");
+                            field = new AudioRecordingField();
+                            mNote.setField(index, field);
+                            startMultimediaFieldEditor(index, mNote, field);
+                            return true;
                         }
-                    });
-                    if (AdaptionUtil.hasReducedPreferences()) {
-                        popup.getMenu().findItem(R.id.menu_multimedia_photo).setVisible(false);
-                        popup.getMenu().findItem(R.id.menu_multimedia_text).setVisible(false);
+                        case R.id.menu_multimedia_audio_clip: {
+                            Timber.i("NoteEditor:: Add audio clip button pressed");
+                            field = new AudioClipField();
+                            mNote.setField(index, field);
+                            startMultimediaFieldEditor(index, mNote, field);
+                            return true;
+                        }
+                        case R.id.menu_multimedia_photo: {
+                            Timber.i("NoteEditor:: Add image button pressed");
+                            field = new ImageField();
+                            mNote.setField(index, field);
+                            startMultimediaFieldEditor(index, mNote, field);
+                            return true;
+                        }
+                        case R.id.menu_multimedia_text: {
+                            Timber.i("NoteEditor:: Advanced editor button pressed");
+                            field = new TextField();
+                            field.setText(mEditFields.get(index).getText().toString());
+                            mNote.setField(index, field);
+                            startMultimediaFieldEditor(index, mNote, field);
+                            return true;
+                        }
+                        default:
+                            return false;
                     }
-                    popup.show();
+                });
+                if (AdaptionUtil.hasReducedPreferences()) {
+                    popup.getMenu().findItem(R.id.menu_multimedia_photo).setVisible(false);
+                    popup.getMenu().findItem(R.id.menu_multimedia_text).setVisible(false);
                 }
+                popup.show();
             }
         });
     }
@@ -1417,7 +1393,7 @@ public class NoteEditor extends AnkiActivity {
     private void updateCards(JSONObject model) {
         Timber.d("updateCards()");
         JSONArray tmpls = model.getJSONArray("tmpls");
-        String cardsList = "";
+        StringBuilder cardsList = new StringBuilder();
         // Build comma separated list of card names
         Timber.d("updateCards() template count is %s", tmpls.length());
         for (int i = 0; i < tmpls.length(); i++) {
@@ -1427,16 +1403,16 @@ public class NoteEditor extends AnkiActivity {
                 mCurrentEditedCard.template().optString("name").equals(name)) {
                 name = "<u>" + name + "</u>";
             }
-            cardsList += name;
+            cardsList.append(name);
             if (i < tmpls.length()-1) {
-                cardsList += ", ";
+                cardsList.append(", ");
             }
         }
         // Make cards list red if the number of cards is being reduced
         if (!mAddNote && tmpls.length() < mEditorNote.model().getJSONArray("tmpls").length()) {
-            cardsList = "<font color='red'>" + cardsList + "</font>";
+            cardsList = new StringBuilder("<font color='red'>" + cardsList + "</font>");
         }
-        mCardsButton.setText(CompatHelper.getCompat().fromHtml(getResources().getString(R.string.CardEditorCards, cardsList)));
+        mCardsButton.setText(CompatHelper.getCompat().fromHtml(getResources().getString(R.string.CardEditorCards, cardsList.toString())));
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -323,18 +323,25 @@ public class NoteEditor extends AnkiActivity {
             mSelectedTags = new ArrayList<>();
         }
         savedInstanceState.putStringArray("tags", mSelectedTags.toArray(new String[0]));
+        savedInstanceState.putBundle("editFields", getFieldsAsBundle());
+        super.onSaveInstanceState(savedInstanceState);
+    }
+
+
+    private Bundle getFieldsAsBundle() {
         Bundle fields = new Bundle();
         // Save the content of all the note fields. We use the field's ord as the key to
         // easily map the fields correctly later.
         if(mEditFields == null){
+            //DA - I don't believe that this is required. Needs testing
             mEditFields = new LinkedList<>();
         }
         for (FieldEditText e : mEditFields) {
             fields.putString(Integer.toString(e.getOrd()), e.getText().toString());
         }
-        savedInstanceState.putBundle("editFields", fields);
-        super.onSaveInstanceState(savedInstanceState);
+        return fields;
     }
+
 
     // Finish initializing the activity after the collection has been correctly loaded
     @Override

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1020,8 +1020,7 @@ public class NoteEditor extends AnkiActivity {
                     Bundle extras = data.getExtras();
                     int index = extras.getInt(MultimediaEditFieldActivity.EXTRA_RESULT_FIELD_INDEX);
                     IField field = (IField) extras.get(MultimediaEditFieldActivity.EXTRA_RESULT_FIELD);
-                    MultimediaEditableNote mNote = NoteService.createEmptyNote(mEditorNote.model());
-                    NoteService.updateMultimediaNoteFromJsonNote(col, mEditorNote, mNote);
+                    MultimediaEditableNote mNote = getCurrentMultimediaEditableNote(col);
                     mNote.setField(index, field);
                     FieldEditText fieldEditText = mEditFields.get(index);
                     // Completely replace text for text fields (because current text was passed in)
@@ -1061,6 +1060,14 @@ public class NoteEditor extends AnkiActivity {
             }
         }
     }
+
+    /** @param col Readonly variable to get cache dir */
+    private MultimediaEditableNote getCurrentMultimediaEditableNote(Collection col) {
+        MultimediaEditableNote mNote = NoteService.createEmptyNote(mEditorNote.model());
+        NoteService.updateMultimediaNoteFromJsonNote(col, mEditorNote, mNote);
+        return mNote;
+    }
+
 
     private void populateEditFields() {
         String[][] fields;
@@ -1139,10 +1146,8 @@ public class NoteEditor extends AnkiActivity {
                 final Collection col = CollectionHelper.getInstance().getCol(NoteEditor.this);
                 // If the field already exists then we start the field editor, which figures out the type
                 // automatically
-                IMultimediaEditableNote mNote = NoteService.createEmptyNote(mEditorNote.model());
-                NoteService.updateMultimediaNoteFromJsonNote(col, mEditorNote, mNote);
-                IField field = mNote.getField(index);
-                startMultimediaFieldEditor(index, mNote, field);
+                IMultimediaEditableNote mNote = getCurrentMultimediaEditableNote(col);
+                startMultimediaFieldEditor(index, mNote);
             } else {
                 // Otherwise we make a popup menu allowing the user to choose between audio/image/text field
                 // TODO: Update the icons for dark material theme, then can set 3rd argument to true
@@ -1190,10 +1195,9 @@ public class NoteEditor extends AnkiActivity {
 
     private void startMultimediaFieldEditorForField(int index, IField field) {
         Collection col = CollectionHelper.getInstance().getCol(NoteEditor.this);
-        IMultimediaEditableNote mNote = NoteService.createEmptyNote(mEditorNote.model());
-        NoteService.updateMultimediaNoteFromJsonNote(col, mEditorNote, mNote);
+        IMultimediaEditableNote mNote = getCurrentMultimediaEditableNote(col);
         mNote.setField(index, field);
-        startMultimediaFieldEditor(index, mNote, field);
+        startMultimediaFieldEditor(index, mNote);
     }
 
 
@@ -1240,7 +1244,8 @@ public class NoteEditor extends AnkiActivity {
     }
 
 
-    private void startMultimediaFieldEditor(final int index, IMultimediaEditableNote mNote, IField field) {
+    private void startMultimediaFieldEditor(final int index, IMultimediaEditableNote mNote) {
+        IField field = mNote.getField(index);
         Intent editCard = new Intent(NoteEditor.this, MultimediaEditFieldActivity.class);
         editCard.putExtra(MultimediaEditFieldActivity.EXTRA_FIELD_INDEX, index);
         editCard.putExtra(MultimediaEditFieldActivity.EXTRA_FIELD, field);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
@@ -96,13 +96,19 @@ public class MultimediaEditFieldActivity extends AnkiActivity
             setSupportActionBar(toolbar);
         }
 
-        mField = (IField) this.getIntent().getExtras().getSerializable(EXTRA_FIELD);
+        Intent intent = this.getIntent();
+        mField = getFieldFromIntent(intent);
 
-        mNote = (IMultimediaEditableNote) this.getIntent().getSerializableExtra(EXTRA_WHOLE_NOTE);
+        mNote = (IMultimediaEditableNote) intent.getSerializableExtra(EXTRA_WHOLE_NOTE);
 
-        mFieldIndex = this.getIntent().getIntExtra(EXTRA_FIELD_INDEX, 0);
+        mFieldIndex = intent.getIntExtra(EXTRA_FIELD_INDEX, 0);
 
         recreateEditingUi(ChangeUIRequest.init(mField));
+    }
+
+    @VisibleForTesting
+    public static IField getFieldFromIntent(Intent intent) {
+        return (IField) intent.getExtras().getSerializable(EXTRA_FIELD);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/IField.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/IField.java
@@ -93,5 +93,9 @@ public interface IField extends Serializable {
     public String getFormattedValue();
 
 
+    /**
+     * @param col Collection - bad abstraction, used to obtain media directory only.
+     * @param value The HTML to send to the field.
+     */
     void setFormattedString(Collection col, String value);
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.java
@@ -71,26 +71,29 @@ public class NoteService {
 
     public static void updateMultimediaNoteFromJsonNote(Collection col, final Note editorNoteSrc, final IMultimediaEditableNote noteDst) {
         if (noteDst instanceof MultimediaEditableNote) {
-            MultimediaEditableNote mmNote = (MultimediaEditableNote) noteDst;
-            String[] values = editorNoteSrc.getFields();
-            for (int i = 0; i < values.length; i++) {
-                String value = values[i];
-                IField field = null;
-                if (value.startsWith("<img")) {
-                    field = new ImageField();
-                } else if (value.startsWith("[sound:") && value.contains("rec")) {
-                    field = new AudioRecordingField();
-                } else if (value.startsWith("[sound:")) {
-                    field = new AudioClipField();
-                } else {
-                    field = new TextField();
-                }
-                field.setFormattedString(col, value);
-                mmNote.setField(i, field);
-            }
-            mmNote.setModelId(editorNoteSrc.getMid());
-            // TODO: set current id of the note as well
+            updateMultimediaNoteFromFields(col, editorNoteSrc.getFields(), editorNoteSrc.getMid(), (MultimediaEditableNote) noteDst);
         }
+    }
+
+
+    public static void updateMultimediaNoteFromFields(Collection col, String[] fields, long modelId, MultimediaEditableNote mmNote) {
+        for (int i = 0; i < fields.length; i++) {
+            String value = fields[i];
+            IField field = null;
+            if (value.startsWith("<img")) {
+                field = new ImageField();
+            } else if (value.startsWith("[sound:") && value.contains("rec")) {
+                field = new AudioRecordingField();
+            } else if (value.startsWith("[sound:")) {
+                field = new AudioClipField();
+            } else {
+                field = new TextField();
+            }
+            field.setFormattedString(col, value);
+            mmNote.setField(i, field);
+        }
+        mmNote.setModelId(modelId);
+        // TODO: set current id of the note as well
     }
 
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.java
@@ -1,0 +1,66 @@
+package com.ichi2.anki;
+
+import android.content.Intent;
+
+import com.ichi2.anki.multimediacard.activity.MultimediaEditFieldActivity;
+import com.ichi2.anki.multimediacard.fields.IField;
+import com.ichi2.libanki.Note;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.shadows.ShadowActivity;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.robolectric.Shadows.shadowOf;
+
+@RunWith(AndroidJUnit4.class)
+public class NoteEditorTest extends RobolectricTest {
+
+    @Test
+    public void whenEditingMultimediaEditUsesCurrentValueOfFields() {
+        //Arrange
+        int fieldIndex = 0;
+        NoteEditor n = getNoteEditorEditingExistingBasicNote("Hello", "World", FromScreen.REVIEWER);
+        enterTextIntoField(n, fieldIndex, "Good Afternoon");
+
+        //Act
+        openAdvancedTextEditor(n, fieldIndex);
+
+        //Assert
+        ShadowActivity.IntentForResult intent = shadowOf(n).getNextStartedActivityForResult();
+        IField actualField = MultimediaEditFieldActivity.getFieldFromIntent(intent.intent);
+        assertThat("Provided value should be the updated value", actualField.getFormattedValue(), is("Good Afternoon"));
+    }
+
+
+    private void openAdvancedTextEditor(NoteEditor n, int fieldIndex) {
+        n.startAdvancedTextEditor(fieldIndex);
+    }
+
+
+    private void enterTextIntoField(NoteEditor n, int i, String newText) {
+        n.setFieldValueFromUi(i, newText);
+    }
+
+
+    private NoteEditor getNoteEditorEditingExistingBasicNote(String front, String back, FromScreen reviewer) {
+        Note n = super.addNoteUsingBasicModel(front, back);
+
+        Intent i = new Intent();
+        if (reviewer == FromScreen.REVIEWER) {
+            i.putExtra(NoteEditor.EXTRA_CALLER, NoteEditor.CALLER_REVIEWER);
+            AbstractFlashcardViewer.setEditorCard(n.cards().get(0));
+        } else {
+            throw new IllegalStateException(reviewer.toString() + " unhandled");
+        }
+
+        return super.startActivityNormallyOpenCollectionWithIntent(NoteEditor.class, i);
+    }
+
+    private enum FromScreen {
+        REVIEWER
+    }
+}


### PR DESCRIPTION
## Purpose / Description

Previously, we were using the field values from the existing model in the database when editing fields.

Now, we use the values shown in the UI.

Automated lint fixes were also executed.

## Fixes
Fixes #5992

## Approach
Pass the field values and the model ID into NoteService, rather than using the model from the card.

## How Has This Been Tested?
Unit Tests
Tested on my device, works as expected.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code