### PR TITLE
equalsIgnoreCase constant string before variable

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -2935,7 +2935,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
             WebResourceResponse webResourceResponse = null;
             if (!AdaptionUtil.hasWebBrowser(getBaseContext())) {
                 String scheme = request.getUrl().getScheme().trim();
-                if (scheme.equalsIgnoreCase("http") || scheme.equalsIgnoreCase("https")) {
+                if ("http".equalsIgnoreCase(scheme) || "https".equalsIgnoreCase(scheme)) {
                     String response = getResources().getString(R.string.no_outgoing_link_in_cardbrowser);
                     webResourceResponse = new WebResourceResponse("text/html", "utf-8", new ByteArrayInputStream(response.getBytes()));
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/TtsParser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/TtsParser.java
@@ -34,8 +34,8 @@ public final class TtsParser {
     }
 
     private static void parseTtsElements(Element element, List<LocalisedText> textsToRead) {
-        if (element.tagName().equalsIgnoreCase("tts") &&
-                element.attr("service").equalsIgnoreCase("android")) {
+        if ("tts".equalsIgnoreCase(element.tagName()) &&
+                "android".equalsIgnoreCase(element.attr("service"))) {
             textsToRead.add(new LocalisedText(element.text(), element.attr("voice")));
             return; // ignore any children
         }

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatHelper.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatHelper.java
@@ -96,7 +96,7 @@ public class CompatHelper {
 
     public static boolean isChromebook() {
         return "chromium".equalsIgnoreCase(Build.BRAND) || "chromium".equalsIgnoreCase(Build.MANUFACTURER)
-                || Build.DEVICE.equalsIgnoreCase("novato_cheets");
+                || "novato_cheets".equalsIgnoreCase(Build.DEVICE);
     }
 
     public static boolean isKindle() {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Media.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Media.java
@@ -702,7 +702,7 @@ public class Media {
                 continue;
             }
             String fname = f.getName();
-            if (fname.equalsIgnoreCase("thumbs.db")) {
+            if ("thumbs.db".equalsIgnoreCase(fname)) {
                 continue;
             }
             // and files with invalid chars

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
@@ -806,7 +806,7 @@ public class Utils {
         // Use android.net.Uri class to ensure whole path is properly encoded
         // File.toURL() does not work here, and URLEncoder class is not directly usable
         // with existing slashes
-        if (mediaDir.length() != 0 && !mediaDir.equalsIgnoreCase("null")) {
+        if (mediaDir.length() != 0 && !"null".equalsIgnoreCase(mediaDir)) {
             Uri mediaDirUri = Uri.fromFile(new File(mediaDir));
             return mediaDirUri.toString() +"/";
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/hooks/ChessFilter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/hooks/ChessFilter.java
@@ -75,7 +75,7 @@ public class ChessFilter extends Hook {
         while (mf.find()) {
             if (mf.group(1) != null) {
                 Matcher mo = fFenOrientationPattern.matcher(mf.group(1));
-                if (mo.find() && mo.group(1) != null && mo.group(1).equalsIgnoreCase("black")) {
+                if (mo.find() && mo.group(1) != null && "black".equalsIgnoreCase(mo.group(1))) {
                     showBlack = true;
                 }
             }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/FullSyncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/FullSyncer.java
@@ -124,7 +124,7 @@ public class FullSyncer extends HttpSyncer {
         DB tempDb = null;
         try {
             tempDb = new DB(tpath);
-            if (!tempDb.queryString("PRAGMA integrity_check").equalsIgnoreCase("ok")) {
+            if (!"ok".equalsIgnoreCase(tempDb.queryString("PRAGMA integrity_check"))) {
                 Timber.e("Full sync - downloaded file corrupt");
                 return new Object[] { "remoteDbError" };
             }
@@ -150,7 +150,7 @@ public class FullSyncer extends HttpSyncer {
     public Object[] upload() throws UnknownHttpResponseException {
         // make sure it's ok before we try to upload
         mCon.publishProgress(R.string.sync_check_upload_file);
-        if (!mCol.getDb().queryString("PRAGMA integrity_check").equalsIgnoreCase("ok")) {
+        if (!"ok".equalsIgnoreCase(mCol.getDb().queryString("PRAGMA integrity_check"))) {
             return new Object[] { "dbError" };
         }
         if (!mCol.basicCheck()) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteServer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteServer.java
@@ -120,7 +120,7 @@ public class RemoteServer extends HttpSyncer {
 
     /** Note: these conversion helpers aren't needed in libanki as type deduction occurs automatically there **/
     private JSONObject parseDict(String s) {
-        if (!s.equalsIgnoreCase("null") && s.length() != 0) {
+        if (!"null".equalsIgnoreCase(s) && s.length() != 0) {
             return new JSONObject(s);
         } else {
             return new JSONObject();

--- a/AnkiDroid/src/main/java/com/ichi2/utils/AdaptionUtil.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/AdaptionUtil.java
@@ -54,6 +54,6 @@ public class AdaptionUtil {
     }
 
     public static boolean hasReducedPreferences(){
-        return Build.MANUFACTURER.equalsIgnoreCase("Xiaomi") && (Build.PRODUCT.equalsIgnoreCase("Archytas") || Build.PRODUCT.equalsIgnoreCase("Archimedes"));
+        return "Xiaomi".equalsIgnoreCase(Build.MANUFACTURER) && ("Archytas".equalsIgnoreCase(Build.PRODUCT) || "Archimedes".equalsIgnoreCase(Build.PRODUCT));
     }
 }


### PR DESCRIPTION
The same idea than a previous commit which put constant before equals instead of after.

I'm actually surprised that it's not signaled as a risk automatically.

(I saw this because I was dealing with equalsIgnoreCase recently, with deck name. Not because I found any actual bug here