### PR TITLE
Upgrade to robolectric 4.3.1 with new Looper mode

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -160,7 +160,7 @@ dependencies {
     testImplementation 'org.powermock:powermock-api-mockito2:2.0.7'
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
     testImplementation 'net.lachlanmckee:timber-junit-rule:1.0.1'
-    testImplementation "org.robolectric:robolectric:4.2.1"
+    testImplementation "org.robolectric:robolectric:4.3.1"
     testImplementation 'androidx.test:core:1.2.0'
     testImplementation 'androidx.test.ext:junit:1.1.1'
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.java
@@ -3,11 +3,11 @@ package com.ichi2.anki;
 import android.content.Context;
 
 import androidx.test.core.app.ActivityScenario;
-import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -16,13 +16,14 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 @RunWith(AndroidJUnit4.class)
+@LooperMode(LooperMode.Mode.PAUSED)
 public class DeckPickerTest extends RobolectricTest {
 
     @Test
     public void verifyCodeMessages() {
 
         Map<Integer, String> mCodeResponsePairs = new HashMap<>();
-        final Context context = ApplicationProvider.getApplicationContext();
+        final Context context = getTargetContext();
         mCodeResponsePairs.put(407, context.getString(R.string.sync_error_407_proxy_required));
         mCodeResponsePairs.put(409, context.getString(R.string.sync_error_409));
         mCodeResponsePairs.put(413, context.getString(R.string.sync_error_413_collection_size));

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.java
@@ -1,10 +1,8 @@
 package com.ichi2.anki;
 
-import com.ichi2.libanki.Collection;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.Robolectric;
+import org.robolectric.annotation.LooperMode;
 
 import androidx.test.core.app.ActivityScenario;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
@@ -13,6 +11,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 @RunWith(AndroidJUnit4.class)
+@LooperMode(LooperMode.Mode.PAUSED)
 public class ReviewerTest extends RobolectricTest {
 
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
@@ -36,7 +36,7 @@ import org.robolectric.shadows.ShadowDialog;
 import org.robolectric.shadows.ShadowLog;
 
 import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory;
-import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.core.app.ApplicationProvider;
 import timber.log.Timber;
 
 public class RobolectricTest {
@@ -77,7 +77,7 @@ public class RobolectricTest {
 
 
     protected Context getTargetContext() {
-        return InstrumentationRegistry.getInstrumentation().getTargetContext();
+        return ApplicationProvider.getApplicationContext();
     }
 
 
@@ -87,7 +87,7 @@ public class RobolectricTest {
 
 
     protected Collection getCol() {
-        return CollectionHelper.getInstance().getCol(InstrumentationRegistry.getInstrumentation().getTargetContext());
+        return CollectionHelper.getInstance().getCol(getTargetContext());
     }
 
 
@@ -97,10 +97,9 @@ public class RobolectricTest {
     }
 
     protected <T extends AnkiActivity> T startActivityNormallyOpenCollectionWithIntent(Class<T> clazz, Intent i) {
-        ActivityController controller = Robolectric.buildActivity(clazz, i)
+        ActivityController<T> controller = Robolectric.buildActivity(clazz, i)
                 .create().start().resume().visible();
-        //noinspection unchecked
-        return (T) controller.get();
+        return controller.get();
     }
 
     protected Note addNoteUsingBasicModel(String front, String back) {

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -44,7 +44,7 @@ android {
 dependencies {
     api fileTree(dir: 'libs', include: ['*.jar'])
     testImplementation 'org.junit.vintage:junit-vintage-engine:5.6.1'
-    testImplementation "org.robolectric:robolectric:4.2.1"
+    testImplementation 'org.robolectric:robolectric:4.3.1'
 }
 
 // Borrowed from here:

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,8 +18,6 @@ android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
 android.enableJetifier=true
 
-android.enableUnitTestBinaryResources=true
-
 # With de-coupled gradle sub-modules, they may run in parallel
 org.gradle.parallel=true
 


### PR DESCRIPTION
This involved handling some timer differences, and accessing Context differently

The only troubling part was in AbstractFlashcardViewerTest - there's a thorny timing
issue there which I solved by coarsely hacking in a sleep

@david-allison-1 I'd like to remove that sleep if possible but I couldn't think of a quick way to sort out exactly how, and I didn't want to spend too much time on test-specific work vs app enhancement. This is not a high priority for me to fix, but something for the unconscious to chew on and if you come up with something elegant, awesome. Otherwise even if it's flaky I'm just going to bump up the sleep hack until it's reliable