### PR TITLE
Save deck in collection

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DB.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DB.java
@@ -54,7 +54,7 @@ public class DB {
     private static SupportSQLiteOpenHelper.Factory sqliteOpenHelperFactory = null;
 
     /**
-     * The deck, which is actually an SQLite database.
+     * The collection, which is actually an SQLite database.
      */
     private SupportSQLiteDatabase mDatabase;
     private boolean mMod = false;
@@ -227,7 +227,7 @@ public class DB {
 
     /**
      * Convenience method for querying the database for an entire column. The column will be returned as an ArrayList of
-     * the specified class. See Deck.initUndo() for a usage example.
+     * the specified class.
      *
      * @param type The class of the column's data type. Example: int.class, String.class.
      * @param query The SQL query statement.

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -859,7 +859,7 @@ public class Decks {
             ja.put(n);
         }
         mCol.getConf().put("activeDecks", ja);
-        mChanged = true;
+        mCol.setMod();
     }
 
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
When a deck is picked, the set of decks were saved, while this present no interest. 

I also replace one occurrence of "deck" by collection, and remove another occurrence of Deck in a place where it made no more sens.

## Approach
I realized that is because upstream was incorrectly ported. `select()` should indicates that the configuration is changed, but there is nothing in the deck collection itself which is changed.

In upstream, saving the deck collection is done thanks to `self.changed` and not `setMod`

## How Has This Been Tested?

Merging in the branch I use to run ankidroid.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
