### PR TITLE
Correct bury/suspend note

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -774,16 +774,16 @@ public class Reviewer extends AbstractFlashcardViewer {
             return false;
         }
         // whether there exists a sibling not buried.
-        return getCol().getDb().queryScalar("select count() from cards where nid = ? and id != ? and queue != " + Consts.QUEUE_TYPE_SUSPENDED + " limit 1",
+        return getCol().getDb().queryScalar("select 1 from cards where nid = ? and id != ? and queue != " + Consts.QUEUE_TYPE_SUSPENDED + " limit 1",
                 new Object[] {mCurrentCard.getNid(), mCurrentCard.getId()}) == 1;
     }
 
     private boolean buryNoteAvailable() {
-        if (mCurrentCard == null) {
+        if (mCurrentCard == null || getControlBlocked()) {
             return false;
         }
         // Whether there exists a sibling which is neither susbended nor buried
-        boolean bury = getCol().getDb().queryScalar("select count(id) from cards where nid = ? and id != ? and queue >=  " + Consts.QUEUE_TYPE_NEW + " limit 1",
+        boolean bury = getCol().getDb().queryScalar("select 1 from cards where nid = ? and id != ? and queue >=  " + Consts.QUEUE_TYPE_NEW + " limit 1",
                 new Object[] {mCurrentCard.getNid(), mCurrentCard.getId()}) == 1;
         return bury;
     }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Correction two of my mistakes.

## Fixes
Burying note worked in a basic collection, but not when I actually use ankidroid. The difference is that it did work correctly on note type with two cards.

## Approach
It seems I did two mistakes.

getControlBlocked did disappear from one condition. Probably due to a
rebasing during a conflict of PR.

"count() ... limit 1"  does not limit counting to one element, but the
number of count result to 1. Which is not what I intended. This
version ensure that I indeed get 0 or 1. (The query actually worked on
note type with two card type, as it is the case with basic and reverse
card type, with which tests are done.)


## How Has This Been Tested?

Testing it on note type with more than two cards and with a single card


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
