### PR TITLE
Factorizing Timber on task listener

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -251,13 +251,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
     };
 
 
-    private CollectionTask.TaskListener mRepositionCardHandler = new CollectionTask.TaskListener() {
-        @Override
-        public void onPreExecute() {
-            Timber.d("CardBrowser::RepositionCardHandler() onPreExecute");
-        }
-
-
+    private CollectionTask.TaskListener mRepositionCardHandler = new CollectionTask.TimberClassListener("CardBrowser::RepositionCardHandler()") {
         @Override
         public void onPostExecute(CollectionTask.TaskData result) {
             Timber.d("CardBrowser::RepositionCardHandler() onPostExecute");
@@ -268,16 +262,10 @@ public class CardBrowser extends NavigationDrawerActivity implements
         }
     };
 
-    private CollectionTask.TaskListener mResetProgressCardHandler = new CollectionTask.TaskListener() {
-        @Override
-        public void onPreExecute() {
-            Timber.d("CardBrowser::ResetProgressCardHandler() onPreExecute");
-        }
-
-
-        @Override
+    private CollectionTask.TaskListener mResetProgressCardHandler = new CollectionTask.TimberClassListener("CardBrowser::ResetProgressCardHandler()") {
+     @Override
         public void onPostExecute(CollectionTask.TaskData result) {
-            Timber.d("CardBrowser::ResetProgressCardHandler() onPostExecute");
+            super.onPostExecute(result);
             mReloadRequired = true;
             int cardCount = result.getObjArray().length;
             UIUtils.showThemedToast(CardBrowser.this,
@@ -285,16 +273,10 @@ public class CardBrowser extends NavigationDrawerActivity implements
         }
     };
 
-    private CollectionTask.TaskListener mRescheduleCardHandler = new CollectionTask.TaskListener() {
-        @Override
-        public void onPreExecute() {
-            Timber.d("CardBrowser::RescheduleCardHandler() onPreExecute");
-        }
-
-
+    private CollectionTask.TaskListener mRescheduleCardHandler = new CollectionTask.TimberClassListener("CardBrowser::RescheduleCardHandler()") {
         @Override
         public void onPostExecute(CollectionTask.TaskData result) {
-            Timber.d("CardBrowser::RescheduleCardHandler() onPostExecute");
+            super.onPostExecute(result);
             mReloadRequired = true;
             int cardCount = result.getObjArray().length;
             UIUtils.showThemedToast(CardBrowser.this,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/UIUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/UIUtils.java
@@ -117,18 +117,7 @@ public class UIUtils {
 
     public static void saveCollectionInBackground(Context context) {
         if (CollectionHelper.getInstance().colIsOpen()) {
-            CollectionTask.launchCollectionTask(CollectionTask.TASK_TYPE_SAVE_COLLECTION, new CollectionTask.TaskListener() {
-                @Override
-                public void onPreExecute() {
-                    Timber.d("saveCollectionInBackground: start");
-                }
-
-
-                @Override
-                public void onPostExecute(TaskData result) {
-                    Timber.d("saveCollectionInBackground: finished");
-                }
-            });
+            CollectionTask.launchCollectionTask(CollectionTask.TASK_TYPE_SAVE_COLLECTION, new CollectionTask.TimberClassListener("saveCollectionInBackground"));
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -1650,6 +1650,21 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
         }
     }
 
+    public static class TimberClassListener extends TaskListener {
+        private String mTaskName;
+
+        public TimberClassListener(String taskName) {
+            mTaskName = taskName;
+        }
+
+        public void onPreExecute(){
+            Timber.d(mTaskName + ": onPreExecute");
+        };
+        public void onPostExecute(TaskData result){
+            Timber.d(mTaskName + ": onPostExecute");
+        }
+    }
+
     /**
      * Helper class for allowing inner function to publish progress of an AsyncTask.
      */


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Factorizing some code. Helping other dev' to make short code for task with timbers.

## Fixes
For some reason unknown to me, some task like to Timber.d before and
after execution. This lead to code duplication which I am
factorizing.

Note that in one case, the timbers started "start/finished" instead of onPre/PostExecute. I believe it's not a change that matters.

## How Has This Been Tested?

In my Merge branch. No particular test was done here. 

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
