### PR TITLE
Removing the method lock which was useless

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -352,23 +352,12 @@ public class Collection {
         if (mDb.getMod()) {
             flush(mod);
             mDb.commit();
-            lock();
             mDb.setMod(false);
         }
         // undoing non review operation is handled differently in ankidroid
 //        _markOp(name);
         //mLastSave = Utils.now(); // assigned but never accessed - only leaving in for upstream comparison
     }
-
-
-    /** make sure we don't accidentally bump mod time */
-    public void lock() {
-        // make sure we don't accidentally bump mod time
-        boolean mod = mDb.getMod();
-        mDb.execute("UPDATE col SET mod=mod");
-        mDb.setMod(mod);
-    }
-
 
     /**
      * Disconnect from DB.


### PR DESCRIPTION
Unless I don't understand anything about SQL, the query 
```sql
UPDATE col SET mod=mod
```
is entirely useless.

Intuitively, I would assume that the idea was to do

```sql
UDPATE col set mod=?
``` 
with value `mod`.

Except that here, the java variable is a boolean while the sql column
contains an integer.

The other action is also useless: `mod` is read and then put
back. This would maybe make sens if there was synchronicity issue; but
there should be none here. And anyway, `lock` is called only once,
after which `setMode(false)` is called anyway.

## How Has This Been Tested?

It's in my "merge" branch on my phone. No particular test were done here.