### PR TITLE
More path

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.java
@@ -450,11 +450,11 @@ public class Statistics extends NavigationDrawerActivity implements DeckDropDown
             mDeckId = ((Statistics) getActivity()).getDeckId();
             if (mDeckId != Stats.ALL_DECKS_ID) {
                 Collection col = CollectionHelper.getInstance().getCol(getActivity());
-                List<String> parts = Arrays.asList(Decks.path(col.getDecks().current().getString("name")));
+                String baseName = Decks.basename(col.getDecks().current().getString("name"));
                 if (sIsSubtitle) {
-                    ((AppCompatActivity) getActivity()).getSupportActionBar().setSubtitle(parts.get(parts.size() - 1));
+                    ((AppCompatActivity) getActivity()).getSupportActionBar().setSubtitle(baseName);
                 } else {
-                    getActivity().setTitle(parts.get(parts.size() - 1));
+                    getActivity().setTitle(baseName);
                 }
             } else {
                 if (sIsSubtitle) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.java
@@ -450,7 +450,7 @@ public class Statistics extends NavigationDrawerActivity implements DeckDropDown
             mDeckId = ((Statistics) getActivity()).getDeckId();
             if (mDeckId != Stats.ALL_DECKS_ID) {
                 Collection col = CollectionHelper.getInstance().getCol(getActivity());
-                List<String> parts = Arrays.asList(col.getDecks().current().getString("name").split("::", -1));
+                List<String> parts = Arrays.asList(Decks.path(col.getDecks().current().getString("name")));
                 if (sIsSubtitle) {
                     ((AppCompatActivity) getActivity()).getSupportActionBar().setSubtitle(parts.get(parts.size() - 1));
                 } else {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1068,7 +1068,7 @@ public class Collection {
         fields.put("Tags", ((String) data[5]).trim());
         fields.put("Type", (String) model.get("name"));
         fields.put("Deck", mDecks.name((Long) data[3]));
-        String[] parents = fields.get("Deck").split("::", -1);
+        String[] parents = Decks.path(fields.get("Deck"));
         fields.put("Subdeck", parents[parents.length-1]);
         fields.put("CardFlag", _flagNameFromCardFlags((Integer) data[7]));
         JSONObject template;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1068,8 +1068,8 @@ public class Collection {
         fields.put("Tags", ((String) data[5]).trim());
         fields.put("Type", (String) model.get("name"));
         fields.put("Deck", mDecks.name((Long) data[3]));
-        String[] parents = Decks.path(fields.get("Deck"));
-        fields.put("Subdeck", parents[parents.length-1]);
+        String baseName = Decks.basename(fields.get("Deck"));
+        fields.put("Subdeck", baseName);
         fields.put("CardFlag", _flagNameFromCardFlags((Integer) data[7]));
         JSONObject template;
         if (model.getInt("type") == Consts.MODEL_STD) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -551,7 +551,7 @@ public class Decks {
     private static HashMap<String, String[]> pathCache = new HashMap();
     public static String[] path(String name) {
         if (!pathCache.containsKey(name)) {
-            pathCache.put(name, path(name));
+            pathCache.put(name, name.split("::", -1));
         }
         return pathCache.get(name);
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -462,7 +462,7 @@ public class Decks {
         newName = _ensureParents(newName);
         // make sure we're not nesting under a filtered deck
         if (newName.contains("::")) {
-            List<String> parts = Arrays.asList(newName.split("::", -1));
+            List<String> parts = Arrays.asList(path(newName));
             String newParent = TextUtils.join("::", parts.subList(0, parts.size() - 1));
             if (byName(newParent).getInt("dyn") != 0) {
                 throw new DeckRenameException(DeckRenameException.FILTERED_NOSUBDEKCS);
@@ -551,7 +551,7 @@ public class Decks {
     private static HashMap<String, String[]> pathCache = new HashMap();
     public static String[] path(String name) {
         if (!pathCache.containsKey(name)) {
-            pathCache.put(name, name.split("::", -1));
+            pathCache.put(name, path(name));
         }
         return pathCache.get(name);
     }
@@ -912,7 +912,7 @@ public class Decks {
             HashMap node = new HashMap();
             childMap.put(deck.getLong("id"), node);
 
-            List<String> parts = Arrays.asList(deck.getString("name").split("::", -1));
+            List<String> parts = Arrays.asList(path(deck.getString("name")));
             if (parts.size() > 1) {
                 String immediateParent = TextUtils.join("::", parts.subList(0, parts.size() - 1));
                 long pid = nameMap.get(immediateParent).getLong("id");
@@ -935,7 +935,7 @@ public class Decks {
     public List<JSONObject> parents(long did, HashMap<String, JSONObject> nameMap) {
         // get parent and grandparent names
         List<String> parents = new ArrayList<>();
-        List<String> parts = Arrays.asList(get(did).getString("name").split("::", -1));
+        List<String> parts = Arrays.asList(path(get(did).getString("name")));
         for (int i = 0; i < parts.size() - 1; i++) {
             String part = parts.get(i);
             if (parents.size() == 0) {
@@ -1032,7 +1032,7 @@ public class Decks {
 
     public static String parent(String deckName) {
         // method parent, from sched's method deckDueList in python
-        List<String> parts = Arrays.asList(deckName.split("::", -1));
+        List<String> parts = Arrays.asList(path(deckName));
         if (parts.size() < 2) {
             return null;
         } else {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
@@ -25,6 +25,7 @@ import com.ichi2.anki.exception.ImportExportException;
 import com.ichi2.async.CollectionTask;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Consts;
+import com.ichi2.libanki.Decks;
 import com.ichi2.libanki.Media;
 import com.ichi2.libanki.Storage;
 import com.ichi2.libanki.Utils;
@@ -379,7 +380,7 @@ public class Anki2Importer extends Importer {
         String name = g.getString("name");
         // if there's a prefix, replace the top level deck
         if (!TextUtils.isEmpty(mDeckPrefix)) {
-            List<String> parts = Arrays.asList(name.split("::", -1));
+            List<String> parts = Arrays.asList(Decks.path(name));
             String tmpname = TextUtils.join("::", parts.subList(1, parts.size()));
             name = mDeckPrefix;
             if (!TextUtils.isEmpty(tmpname)) {
@@ -388,7 +389,7 @@ public class Anki2Importer extends Importer {
         }
         // Manually create any parents so we can pull in descriptions
         String head = "";
-        List<String> parents = Arrays.asList(name.split("::", -1));
+        List<String> parents = Arrays.asList(Decks.path(name));
         for (String parent : parents.subList(0, parents.size() -1)) {
             if (!TextUtils.isEmpty(head)) {
                 head += "::";

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -419,7 +419,7 @@ public class SchedV2 extends AbstractSched {
     private List<DeckDueTreeNode> _groupChildren(List<DeckDueTreeNode> grps) {
         // first, split the group names into components
         for (DeckDueTreeNode g : grps) {
-            g.names = g.names[0].split("::", -1);
+            g.names = Decks.path(g.names[0]);
         }
         // and sort based on those components
         Collections.sort(grps);


### PR DESCRIPTION
I realized that I was still loosing quite some time splitting things. And then I realize that I only searched all `split("::")` and didn't search  `splitt("::", -1)`. This is now corrected and path() is used, with its caching.

This led to finding more place where the method basename is useful too.

I changed parents() so that it returns array, and thus avoid useless transformation into list when it's not required.

Tested in my "merge" branch, which I use to find all places where can still win seconds