### PR TITLE
Use AnkiWeb Dynamic Sync Url

### DIFF
--- a/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/libanki/HttpTest.java
+++ b/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/libanki/HttpTest.java
@@ -36,7 +36,7 @@ public class HttpTest {
 
         String username = "AnkiDroidInstrumentedTestUser";
         String password = "AnkiDroidInstrumentedTestInvalidPass";
-        Connection.Payload invalidPayload = new Connection.Payload(new Object[]{username, password, new HostNum("")});
+        Connection.Payload invalidPayload = new Connection.Payload(new Object[]{username, password, new HostNum(null)});
         TestTaskListener testListener = new TestTaskListener(invalidPayload);
 
         // We have to carefully run things on the main thread here or the threading protections in BaseAsyncTask throw

--- a/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/libanki/HttpTest.java
+++ b/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/libanki/HttpTest.java
@@ -5,6 +5,7 @@ import android.os.Build;
 
 import com.ichi2.async.Connection;
 import com.ichi2.compat.CompatHelper;
+import com.ichi2.libanki.sync.HostNum;
 
 import org.junit.Assert;
 import org.junit.Rule;
@@ -35,7 +36,7 @@ public class HttpTest {
 
         String username = "AnkiDroidInstrumentedTestUser";
         String password = "AnkiDroidInstrumentedTestInvalidPass";
-        Connection.Payload invalidPayload = new Connection.Payload(new Object[]{username, password, ""});
+        Connection.Payload invalidPayload = new Connection.Payload(new Object[]{username, password, new HostNum("")});
         TestTaskListener testListener = new TestTaskListener(invalidPayload);
 
         // We have to carefully run things on the main thread here or the threading protections in BaseAsyncTask throw

--- a/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/libanki/HttpTest.java
+++ b/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/libanki/HttpTest.java
@@ -35,7 +35,7 @@ public class HttpTest {
 
         String username = "AnkiDroidInstrumentedTestUser";
         String password = "AnkiDroidInstrumentedTestInvalidPass";
-        Connection.Payload invalidPayload = new Connection.Payload(new Object[]{username, password});
+        Connection.Payload invalidPayload = new Connection.Payload(new Object[]{username, password, ""});
         TestTaskListener testListener = new TestTaskListener(invalidPayload);
 
         // We have to carefully run things on the main thread here or the threading protections in BaseAsyncTask throw

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -93,7 +93,7 @@ import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.anki.exception.DeckRenameException;
 import com.ichi2.anki.receiver.SdCardReceiver;
 import com.ichi2.anki.stats.AnkiStatsTaskHandler;
-import com.ichi2.anki.web.PreferenceBackedHostNum;
+import com.ichi2.anki.web.HostNumFactory;
 import com.ichi2.anki.widgets.DeckAdapter;
 import com.ichi2.async.Connection;
 import com.ichi2.async.Connection.Payload;
@@ -1471,7 +1471,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
                     new Connection.Payload(new Object[] { hkey,
                             preferences.getBoolean("syncFetchesMedia", true),
                             syncConflictResolution,
-                            PreferenceBackedHostNum.fromPreferences(preferences) }));
+                            HostNumFactory.getInstance(getBaseContext()) }));
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -100,6 +100,7 @@ import com.ichi2.async.CollectionTask;
 import com.ichi2.async.CollectionTask.TaskData;
 import com.ichi2.compat.CompatHelper;
 import com.ichi2.libanki.Collection;
+import com.ichi2.libanki.Consts;
 import com.ichi2.libanki.Models;
 import com.ichi2.libanki.sched.Sched;
 import com.ichi2.libanki.Utils;
@@ -1467,8 +1468,10 @@ public class DeckPicker extends NavigationDrawerActivity implements
             showSyncErrorDialog(SyncErrorDialog.DIALOG_USER_NOT_LOGGED_IN_SYNC);
         } else {
             Connection.sync(mSyncListener,
-                    new Connection.Payload(new Object[] { hkey, preferences.getBoolean("syncFetchesMedia", true),
-                            syncConflictResolution }));
+                    new Connection.Payload(new Object[] { hkey,
+                            preferences.getBoolean("syncFetchesMedia", true),
+                            syncConflictResolution,
+                            preferences.getString("hostNum", Consts.DEFAULT_HOST_NUM) }));
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -93,6 +93,7 @@ import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.anki.exception.DeckRenameException;
 import com.ichi2.anki.receiver.SdCardReceiver;
 import com.ichi2.anki.stats.AnkiStatsTaskHandler;
+import com.ichi2.anki.web.PreferenceBackedHostNum;
 import com.ichi2.anki.widgets.DeckAdapter;
 import com.ichi2.async.Connection;
 import com.ichi2.async.Connection.Payload;
@@ -100,7 +101,6 @@ import com.ichi2.async.CollectionTask;
 import com.ichi2.async.CollectionTask.TaskData;
 import com.ichi2.compat.CompatHelper;
 import com.ichi2.libanki.Collection;
-import com.ichi2.libanki.Consts;
 import com.ichi2.libanki.Models;
 import com.ichi2.libanki.sched.Sched;
 import com.ichi2.libanki.Utils;
@@ -1471,7 +1471,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
                     new Connection.Payload(new Object[] { hkey,
                             preferences.getBoolean("syncFetchesMedia", true),
                             syncConflictResolution,
-                            preferences.getString("hostNum", Consts.DEFAULT_HOST_NUM) }));
+                            PreferenceBackedHostNum.fromPreferences(preferences) }));
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.java
@@ -30,7 +30,7 @@ import android.widget.TextView;
 
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.ichi2.anim.ActivityTransitionAnimation;
-import com.ichi2.anki.web.PreferenceBackedHostNum;
+import com.ichi2.anki.web.HostNumFactory;
 import com.ichi2.async.Connection;
 import com.ichi2.async.Connection.Payload;
 import com.ichi2.themes.StyledProgressDialog;
@@ -114,9 +114,8 @@ public class MyAccount extends AnkiActivity {
         String password = mPassword.getText().toString();
 
         if (!"".equalsIgnoreCase(username) && !"".equalsIgnoreCase(password)) {
-            SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(this);
             Connection.login(loginListener, new Connection.Payload(new Object[]{username, password,
-                    PreferenceBackedHostNum.fromPreferences(preferences) }));
+                    HostNumFactory.getInstance(this) }));
         } else {
             UIUtils.showSimpleSnackbar(this, R.string.invalid_username_password, true);
         }
@@ -129,7 +128,7 @@ public class MyAccount extends AnkiActivity {
         editor.putString("username", "");
         editor.putString("hkey", "");
         editor.apply();
-        PreferenceBackedHostNum.fromPreferences(preferences).reset();
+        HostNumFactory.getInstance(this).reset();
         //  force media resync on deauth
         getCol().getMedia().forceResync();
         switchToState(STATE_LOG_IN);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.java
@@ -32,6 +32,7 @@ import com.afollestad.materialdialogs.MaterialDialog;
 import com.ichi2.anim.ActivityTransitionAnimation;
 import com.ichi2.async.Connection;
 import com.ichi2.async.Connection.Payload;
+import com.ichi2.libanki.Consts;
 import com.ichi2.themes.StyledProgressDialog;
 import com.ichi2.utils.AdaptionUtil;
 
@@ -113,7 +114,9 @@ public class MyAccount extends AnkiActivity {
         String password = mPassword.getText().toString();
 
         if (!"".equalsIgnoreCase(username) && !"".equalsIgnoreCase(password)) {
-            Connection.login(loginListener, new Connection.Payload(new Object[]{username, password}));
+            SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(this);
+            Connection.login(loginListener, new Connection.Payload(new Object[]{username, password,
+                    preferences.getString("hostNum", Consts.DEFAULT_HOST_NUM) }));
         } else {
             UIUtils.showSimpleSnackbar(this, R.string.invalid_username_password, true);
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.java
@@ -128,8 +128,8 @@ public class MyAccount extends AnkiActivity {
         Editor editor = preferences.edit();
         editor.putString("username", "");
         editor.putString("hkey", "");
-        PreferenceBackedHostNum.resetHostNum(editor);
         editor.apply();
+        PreferenceBackedHostNum.fromPreferences(preferences).reset();
         //  force media resync on deauth
         getCol().getMedia().forceResync();
         switchToState(STATE_LOG_IN);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.java
@@ -128,6 +128,7 @@ public class MyAccount extends AnkiActivity {
         Editor editor = preferences.edit();
         editor.putString("username", "");
         editor.putString("hkey", "");
+        PreferenceBackedHostNum.resetHostNum(editor);
         editor.apply();
         //  force media resync on deauth
         getCol().getMedia().forceResync();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.java
@@ -30,9 +30,9 @@ import android.widget.TextView;
 
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.ichi2.anim.ActivityTransitionAnimation;
+import com.ichi2.anki.web.PreferenceBackedHostNum;
 import com.ichi2.async.Connection;
 import com.ichi2.async.Connection.Payload;
-import com.ichi2.libanki.Consts;
 import com.ichi2.themes.StyledProgressDialog;
 import com.ichi2.utils.AdaptionUtil;
 
@@ -116,7 +116,7 @@ public class MyAccount extends AnkiActivity {
         if (!"".equalsIgnoreCase(username) && !"".equalsIgnoreCase(password)) {
             SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(this);
             Connection.login(loginListener, new Connection.Payload(new Object[]{username, password,
-                    preferences.getString("hostNum", Consts.DEFAULT_HOST_NUM) }));
+                    PreferenceBackedHostNum.fromPreferences(preferences) }));
         } else {
             UIUtils.showSimpleSnackbar(this, R.string.invalid_username_password, true);
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -51,6 +51,7 @@ import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.anki.exception.StorageAccessException;
 import com.ichi2.anki.services.BootService;
 import com.ichi2.anki.services.NotificationService;
+import com.ichi2.anki.web.CustomSyncServer;
 import com.ichi2.compat.CompatHelper;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Utils;
@@ -675,10 +676,11 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                 pref.setSummary(getResources().getString(R.string.about_version) + " " + VersionUtils.getPkgVersionName());
                 break;
             case "custom_sync_server_link":
-                if (!AnkiDroidApp.getSharedPrefs(this).getBoolean("useCustomSyncServer", false)) {
+                SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(this);
+                if (!CustomSyncServer.isEnabled(preferences)) {
                     pref.setSummary(R.string.disabled);
                 } else {
-                    pref.setSummary(AnkiDroidApp.getSharedPrefs(this).getString("syncBaseUrl", ""));
+                    pref.setSummary(CustomSyncServer.getSyncBaseUrlOrDefault(preferences, ""));
                 }
                 break;
             case "advanced_statistics_link":

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -480,7 +480,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                 case CustomSyncServer.PREFERENCE_CUSTOM_SYNC_BASE:
                 case CustomSyncServer.PREFERENCE_ENABLE_CUSTOM_SYNC_SERVER:
                     //This may be a tad hasty - performed before "back" is pressed.
-                    CustomSyncServer.handleSyncServerPreferenceChange(prefs);
+                    CustomSyncServer.handleSyncServerPreferenceChange(getBaseContext());
                     break;
                 case "timeoutAnswer": {
                     CheckBoxPreference keepScreenOn = (CheckBoxPreference) screen.findPreference("keepScreenOn");

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -476,6 +476,12 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
             }
             // Handle special cases
             switch (key) {
+                case CustomSyncServer.PREFERENCE_CUSTOM_MEDIA_SYNC_URL:
+                case CustomSyncServer.PREFERENCE_CUSTOM_SYNC_BASE:
+                case CustomSyncServer.PREFERENCE_ENABLE_CUSTOM_SYNC_SERVER:
+                    //This may be a tad hasty - performed before "back" is pressed.
+                    CustomSyncServer.handleSyncServerPreferenceChange(prefs);
+                    break;
                 case "timeoutAnswer": {
                     CheckBoxPreference keepScreenOn = (CheckBoxPreference) screen.findPreference("keepScreenOn");
                     keepScreenOn.setChecked(((CheckBoxPreference) pref).isChecked());

--- a/AnkiDroid/src/main/java/com/ichi2/anki/web/CustomSyncServer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/web/CustomSyncServer.java
@@ -4,8 +4,10 @@ import android.content.SharedPreferences;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import timber.log.Timber;
 
 public class CustomSyncServer {
+    //COULD_BE_BETTER: coupled to PreferenceBackedHostNum
     public static final String PREFERENCE_CUSTOM_SYNC_BASE = "syncBaseUrl";
     public static final String PREFERENCE_CUSTOM_MEDIA_SYNC_URL = "syncMediaUrl";
     public static final String PREFERENCE_ENABLE_CUSTOM_SYNC_SERVER = "useCustomSyncServer";
@@ -26,5 +28,14 @@ public class CustomSyncServer {
 
     public static boolean isEnabled(@NonNull SharedPreferences userPreferences) {
         return userPreferences.getBoolean(PREFERENCE_ENABLE_CUSTOM_SYNC_SERVER, false);
+    }
+
+    public static void handleSyncServerPreferenceChange(SharedPreferences prefs) {
+        Timber.i("Sync Server Preferences updated.");
+        // #4921 - if any of the preferences change, we should reset the HostNum.
+        // This is because different servers use different HostNums for data mappings.
+        SharedPreferences.Editor e = prefs.edit();
+        PreferenceBackedHostNum.resetHostNum(e);
+        e.apply();
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/web/CustomSyncServer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/web/CustomSyncServer.java
@@ -1,5 +1,6 @@
 package com.ichi2.anki.web;
 
+import android.content.Context;
 import android.content.SharedPreferences;
 
 import androidx.annotation.NonNull;
@@ -7,7 +8,6 @@ import androidx.annotation.Nullable;
 import timber.log.Timber;
 
 public class CustomSyncServer {
-    //COULD_BE_BETTER: coupled to PreferenceBackedHostNum
     public static final String PREFERENCE_CUSTOM_SYNC_BASE = "syncBaseUrl";
     public static final String PREFERENCE_CUSTOM_MEDIA_SYNC_URL = "syncMediaUrl";
     public static final String PREFERENCE_ENABLE_CUSTOM_SYNC_SERVER = "useCustomSyncServer";
@@ -30,10 +30,10 @@ public class CustomSyncServer {
         return userPreferences.getBoolean(PREFERENCE_ENABLE_CUSTOM_SYNC_SERVER, false);
     }
 
-    public static void handleSyncServerPreferenceChange(SharedPreferences prefs) {
+    public static void handleSyncServerPreferenceChange(Context context) {
         Timber.i("Sync Server Preferences updated.");
         // #4921 - if any of the preferences change, we should reset the HostNum.
         // This is because different servers use different HostNums for data mappings.
-        PreferenceBackedHostNum.fromPreferences(prefs).reset();
+        HostNumFactory.getInstance(context).reset();
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/web/CustomSyncServer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/web/CustomSyncServer.java
@@ -1,3 +1,19 @@
+/*
+ Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package com.ichi2.anki.web;
 
 import android.content.Context;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/web/CustomSyncServer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/web/CustomSyncServer.java
@@ -1,0 +1,30 @@
+package com.ichi2.anki.web;
+
+import android.content.SharedPreferences;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+public class CustomSyncServer {
+    public static final String PREFERENCE_CUSTOM_SYNC_BASE = "syncBaseUrl";
+    public static final String PREFERENCE_CUSTOM_MEDIA_SYNC_URL = "syncMediaUrl";
+    public static final String PREFERENCE_ENABLE_CUSTOM_SYNC_SERVER = "useCustomSyncServer";
+
+    @Nullable
+    public static String getMediaSyncUrl(@NonNull SharedPreferences preferences) {
+        return preferences.getString(PREFERENCE_CUSTOM_MEDIA_SYNC_URL, null);
+    }
+
+    @Nullable
+    public static String getSyncBaseUrl(@NonNull SharedPreferences preferences) {
+        return getSyncBaseUrlOrDefault( preferences, null);
+    }
+
+    public static String getSyncBaseUrlOrDefault(@NonNull SharedPreferences userPreferences, String defaultValue) {
+        return userPreferences.getString(PREFERENCE_CUSTOM_SYNC_BASE, defaultValue);
+    }
+
+    public static boolean isEnabled(@NonNull SharedPreferences userPreferences) {
+        return userPreferences.getBoolean(PREFERENCE_ENABLE_CUSTOM_SYNC_SERVER, false);
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/web/CustomSyncServer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/web/CustomSyncServer.java
@@ -34,8 +34,6 @@ public class CustomSyncServer {
         Timber.i("Sync Server Preferences updated.");
         // #4921 - if any of the preferences change, we should reset the HostNum.
         // This is because different servers use different HostNums for data mappings.
-        SharedPreferences.Editor e = prefs.edit();
-        PreferenceBackedHostNum.resetHostNum(e);
-        e.apply();
+        PreferenceBackedHostNum.fromPreferences(prefs).reset();
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/web/HostNumFactory.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/web/HostNumFactory.java
@@ -1,3 +1,19 @@
+/*
+ Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package com.ichi2.anki.web;
 
 import android.content.Context;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/web/HostNumFactory.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/web/HostNumFactory.java
@@ -1,0 +1,12 @@
+package com.ichi2.anki.web;
+
+import android.content.Context;
+
+import com.ichi2.anki.AnkiDroidApp;
+import com.ichi2.libanki.sync.HostNum;
+
+public class HostNumFactory {
+    public static HostNum getInstance(Context context) {
+        return PreferenceBackedHostNum.fromPreferences(AnkiDroidApp.getSharedPrefs(context));
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/web/PreferenceBackedHostNum.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/web/PreferenceBackedHostNum.java
@@ -1,0 +1,39 @@
+package com.ichi2.anki.web;
+
+import android.content.SharedPreferences;
+
+import com.ichi2.libanki.Consts;
+import com.ichi2.libanki.sync.HostNum;
+
+import timber.log.Timber;
+
+public class PreferenceBackedHostNum extends HostNum {
+
+    private final SharedPreferences mPreferences;
+
+    public PreferenceBackedHostNum(String hostNum, SharedPreferences preferences) {
+        super(hostNum);
+        this.mPreferences = preferences;
+    }
+
+    public static PreferenceBackedHostNum fromPreferences(SharedPreferences preferences) {
+        String hostNum = preferences.getString("hostNum", null);
+        if (hostNum == null) {
+            return new PreferenceBackedHostNum(Consts.DEFAULT_HOST_NUM, preferences);
+        }
+        return new PreferenceBackedHostNum(hostNum, preferences);
+    }
+
+    @Override
+    public String getHostNum() {
+        String hostNum = mPreferences.getString("hostNum", null);
+        return hostNum != null ? hostNum : Consts.DEFAULT_HOST_NUM;
+    }
+
+    @Override
+    public void setHostNum(String newHostNum) {
+        Timber.d("Setting hostnum to %s", newHostNum);
+        mPreferences.edit().putString("hostNum", newHostNum).apply();
+        super.setHostNum(newHostNum);
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/web/PreferenceBackedHostNum.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/web/PreferenceBackedHostNum.java
@@ -1,3 +1,19 @@
+/*
+ Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package com.ichi2.anki.web;
 
 import android.content.SharedPreferences;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/web/PreferenceBackedHostNum.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/web/PreferenceBackedHostNum.java
@@ -2,44 +2,74 @@ package com.ichi2.anki.web;
 
 import android.content.SharedPreferences;
 
-import com.ichi2.libanki.Consts;
 import com.ichi2.libanki.sync.HostNum;
 
+import androidx.annotation.CheckResult;
+import androidx.annotation.Nullable;
 import timber.log.Timber;
 
 public class PreferenceBackedHostNum extends HostNum {
 
     private final SharedPreferences mPreferences;
 
-    public PreferenceBackedHostNum(String hostNum, SharedPreferences preferences) {
+    public PreferenceBackedHostNum(Integer hostNum, SharedPreferences preferences) {
         super(hostNum);
         this.mPreferences = preferences;
     }
 
     public static PreferenceBackedHostNum fromPreferences(SharedPreferences preferences) {
-        String hostNum = preferences.getString("hostNum", null);
-        if (hostNum == null) {
-            return new PreferenceBackedHostNum(Consts.DEFAULT_HOST_NUM, preferences);
-        }
+        Integer hostNum = getHostNum(preferences);
         return new PreferenceBackedHostNum(hostNum, preferences);
     }
 
     /** Clearing hostNum whenever on log out/changes the server URL should avoid any problems with malicious servers*/
-    public static void resetHostNum(SharedPreferences.Editor editor) {
-        editor.putString("hostNum", Consts.DEFAULT_HOST_NUM);
-    }
-
-
     @Override
-    public String getHostNum() {
-        String hostNum = mPreferences.getString("hostNum", null);
-        return hostNum != null ? hostNum : Consts.DEFAULT_HOST_NUM;
+    public void reset() {
+        setHostNum(getDefaultHostNum());
     }
 
     @Override
-    public void setHostNum(String newHostNum) {
+    public Integer getHostNum() {
+        return getHostNum(this.mPreferences);
+    }
+
+    @Override
+    public void setHostNum(@Nullable Integer newHostNum) {
         Timber.d("Setting hostnum to %s", newHostNum);
-        mPreferences.edit().putString("hostNum", newHostNum).apply();
+        String prefValue = convertToPreferenceValue(newHostNum);
+        mPreferences.edit().putString("hostNum", prefValue).apply();
         super.setHostNum(newHostNum);
+    }
+
+    private static Integer getHostNum(SharedPreferences mPreferences) {
+        try {
+            String hostNum = mPreferences.getString("hostNum", null);
+            Timber.v("Obtained hostNum: %s", hostNum);
+            return convertFromPreferenceValue(hostNum);
+        } catch (Exception e) {
+            Timber.e(e, "Failed to get hostNum");
+            return getDefaultHostNum();
+        }
+    }
+
+    private static Integer convertFromPreferenceValue(String hostNum) {
+        if (hostNum == null) {
+            return getDefaultHostNum();
+        }
+        try {
+            return Integer.parseInt(hostNum);
+        } catch (Exception e) {
+            return getDefaultHostNum();
+        }
+    }
+
+
+    @CheckResult
+    private String convertToPreferenceValue(Integer newHostNum) {
+        if (newHostNum == null) {
+            return null;
+        } else {
+            return newHostNum.toString();
+        }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/web/PreferenceBackedHostNum.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/web/PreferenceBackedHostNum.java
@@ -24,6 +24,12 @@ public class PreferenceBackedHostNum extends HostNum {
         return new PreferenceBackedHostNum(hostNum, preferences);
     }
 
+    /** Clearing hostNum whenever on log out/changes the server URL should avoid any problems with malicious servers*/
+    public static void resetHostNum(SharedPreferences.Editor editor) {
+        editor.putString("hostNum", Consts.DEFAULT_HOST_NUM);
+    }
+
+
     @Override
     public String getHostNum() {
         String hostNum = mPreferences.getString("hostNum", null);

--- a/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
@@ -202,7 +202,8 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
     private Payload doInBackgroundLogin(Payload data) {
         String username = (String) data.data[0];
         String password = (String) data.data[1];
-        HttpSyncer server = new RemoteServer(this, null);
+        String hostNum = (String) data.data[2];
+        HttpSyncer server = new RemoteServer(this, null, hostNum);
         Response ret;
         try {
             ret = server.hostKey(username, password);
@@ -275,6 +276,7 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
         String hkey = (String) data.data[0];
         boolean media = (Boolean) data.data[1];
         String conflictResolution = (String) data.data[2];
+        String hostNum = (String) data.data[3];
         // Use safe version that catches exceptions so that full sync is still possible
         Collection col = CollectionHelper.getInstance().getColSafe(AnkiDroidApp.getInstance());
 
@@ -290,7 +292,7 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
         }
         try {
             CollectionHelper.getInstance().lockCollection();
-            HttpSyncer server = new RemoteServer(this, hkey);
+            HttpSyncer server = new RemoteServer(this, hkey, hostNum);
             Syncer client = new Syncer(col, server);
 
             // run sync and check state
@@ -326,7 +328,7 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
                 try {
                     // Disable sync cancellation for full-sync
                     sIsCancellable = false;
-                    server = new FullSyncer(col, hkey, this);
+                    server = new FullSyncer(col, hkey, this, hostNum);
                     if ("upload".equals(conflictResolution)) {
                         Timber.i("Sync - fullsync - upload collection");
                         publishProgress(R.string.sync_preparing_full_sync_message);
@@ -392,7 +394,7 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
             boolean noMediaChanges = false;
             String mediaError = null;
             if (media) {
-                server = new RemoteMediaServer(col, hkey, this);
+                server = new RemoteMediaServer(col, hkey, this, hostNum);
                 MediaSyncer mediaClient = new MediaSyncer(col, (RemoteMediaServer) server, this);
                 String ret;
                 try {

--- a/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
@@ -32,6 +32,7 @@ import com.ichi2.anki.exception.MediaSyncException;
 import com.ichi2.anki.exception.UnknownHttpResponseException;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.sync.FullSyncer;
+import com.ichi2.libanki.sync.HostNum;
 import com.ichi2.libanki.sync.HttpSyncer;
 import com.ichi2.libanki.sync.MediaSyncer;
 import com.ichi2.libanki.sync.RemoteMediaServer;
@@ -202,7 +203,7 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
     private Payload doInBackgroundLogin(Payload data) {
         String username = (String) data.data[0];
         String password = (String) data.data[1];
-        String hostNum = (String) data.data[2];
+        HostNum hostNum = (HostNum) data.data[2];
         HttpSyncer server = new RemoteServer(this, null, hostNum);
         Response ret;
         try {
@@ -276,7 +277,7 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
         String hkey = (String) data.data[0];
         boolean media = (Boolean) data.data[1];
         String conflictResolution = (String) data.data[2];
-        String hostNum = (String) data.data[3];
+        HostNum hostNum = (HostNum) data.data[3];
         // Use safe version that catches exceptions so that full sync is still possible
         Collection col = CollectionHelper.getInstance().getColSafe(AnkiDroidApp.getInstance());
 
@@ -293,7 +294,7 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
         try {
             CollectionHelper.getInstance().lockCollection();
             HttpSyncer server = new RemoteServer(this, hkey, hostNum);
-            Syncer client = new Syncer(col, server);
+            Syncer client = new Syncer(col, server, hostNum);
 
             // run sync and check state
             boolean noChanges = false;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Consts.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Consts.java
@@ -79,7 +79,8 @@ public class Consts {
     public static final int SCHEMA_VERSION = 11;
     public static final int SYNC_ZIP_SIZE = (int)(2.5*1024*1024);
     public static final int SYNC_ZIP_COUNT = 25;
-    public static final String SYNC_BASE = "https://sync.ankiweb.net/";
+    public static final String LEGACY_SYNC_BASE = "https://sync.ankiweb.net/";
+    public static final String SYNC_BASE = "https://sync%s.ankiweb.net/";
     public static final String DEFAULT_HOST_NUM = "";
     public static final int SYNC_VER = 9;
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Consts.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Consts.java
@@ -80,7 +80,6 @@ public class Consts {
     public static final int SYNC_ZIP_SIZE = (int)(2.5*1024*1024);
     public static final int SYNC_ZIP_COUNT = 25;
     public static final String SYNC_BASE = "https://sync.ankiweb.net/";
-    public static final String SYNC_MEDIA_BASE = "https://sync.ankiweb.net/msync/";
     public static final String DEFAULT_HOST_NUM = "";
     public static final int SYNC_VER = 9;
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Consts.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Consts.java
@@ -80,7 +80,7 @@ public class Consts {
     public static final int SYNC_ZIP_SIZE = (int)(2.5*1024*1024);
     public static final int SYNC_ZIP_COUNT = 25;
     public static final String SYNC_BASE = "https://sync%s.ankiweb.net/";
-    public static final String DEFAULT_HOST_NUM = "";
+    public static final Integer DEFAULT_HOST_NUM = null;
     public static final int SYNC_VER = 9;
 
     public static final String HELP_SITE = "http://ankisrs.net/docs/manual.html";

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Consts.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Consts.java
@@ -81,6 +81,7 @@ public class Consts {
     public static final int SYNC_ZIP_COUNT = 25;
     public static final String SYNC_BASE = "https://sync.ankiweb.net/";
     public static final String SYNC_MEDIA_BASE = "https://sync.ankiweb.net/msync/";
+    public static final String DEFAULT_HOST_NUM = "";
     public static final int SYNC_VER = 9;
 
     public static final String HELP_SITE = "http://ankisrs.net/docs/manual.html";

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Consts.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Consts.java
@@ -79,7 +79,6 @@ public class Consts {
     public static final int SCHEMA_VERSION = 11;
     public static final int SYNC_ZIP_SIZE = (int)(2.5*1024*1024);
     public static final int SYNC_ZIP_COUNT = 25;
-    public static final String LEGACY_SYNC_BASE = "https://sync.ankiweb.net/";
     public static final String SYNC_BASE = "https://sync%s.ankiweb.net/";
     public static final String DEFAULT_HOST_NUM = "";
     public static final int SYNC_VER = 9;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/FullSyncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/FullSyncer.java
@@ -60,20 +60,6 @@ public class FullSyncer extends HttpSyncer {
         mCon = con;
     }
 
-
-    @Override
-    public String syncURL() {
-        // Allow user to specify custom sync server
-        SharedPreferences userPreferences = AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance());
-        if (userPreferences!= null && userPreferences.getBoolean("useCustomSyncServer", false)) {
-            Uri syncBase = Uri.parse(userPreferences.getString("syncBaseUrl", Consts.SYNC_BASE));
-            return syncBase.buildUpon().appendPath("sync").toString() + "/";
-        }
-        // Usual case
-        return Consts.SYNC_BASE + "sync/";
-    }
-
-
     @Override
     public Object[] download() throws UnknownHttpResponseException {
         InputStream cont;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/FullSyncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/FullSyncer.java
@@ -50,8 +50,8 @@ public class FullSyncer extends HttpSyncer {
     private Connection mCon;
 
 
-    public FullSyncer(Collection col, String hkey, Connection con) {
-        super(hkey, con);
+    public FullSyncer(Collection col, String hkey, Connection con, String hostNum) {
+        super(hkey, con, hostNum);
         mPostVars = new HashMap<>();
         mPostVars.put("k", hkey);
         mPostVars.put("v",

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/FullSyncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/FullSyncer.java
@@ -50,7 +50,7 @@ public class FullSyncer extends HttpSyncer {
     private Connection mCon;
 
 
-    public FullSyncer(Collection col, String hkey, Connection con, String hostNum) {
+    public FullSyncer(Collection col, String hkey, Connection con, HostNum hostNum) {
         super(hkey, con, hostNum);
         mPostVars = new HashMap<>();
         mPostVars.put("k", hkey);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HostNum.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HostNum.java
@@ -1,3 +1,19 @@
+/*
+ Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package com.ichi2.libanki.sync;
 
 import com.ichi2.libanki.Consts;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HostNum.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HostNum.java
@@ -1,7 +1,23 @@
 package com.ichi2.libanki.sync;
 
-/** Not part of libAnki directly, but abstracts out Preferences to a libAnki context */
-public abstract class HostNum {
-    public abstract String getHostNum();
-    public abstract void setHostNum(String newHostNum);
+/**
+ * The server provides hostNum in the /sync/meta call. All requests after that (including future meta requests)
+ * should use that hostNum to construct the sync URL, until a future /sync/meta call advises otherwise.
+ *
+ * This class is not part of libAnki directly, but abstracts Preference saving to a libAnki context
+ * */
+public class HostNum {
+    private String mHostNum;
+
+    public HostNum(String hostNum) {
+        mHostNum = hostNum;
+    }
+
+    public String getHostNum() {
+        return mHostNum;
+    }
+
+    public void setHostNum(String newHostNum) {
+        mHostNum = newHostNum;
+    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HostNum.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HostNum.java
@@ -1,5 +1,7 @@
 package com.ichi2.libanki.sync;
 
+import com.ichi2.libanki.Consts;
+
 /**
  * The server provides hostNum in the /sync/meta call. All requests after that (including future meta requests)
  * should use that hostNum to construct the sync URL, until a future /sync/meta call advises otherwise.
@@ -7,17 +9,25 @@ package com.ichi2.libanki.sync;
  * This class is not part of libAnki directly, but abstracts Preference saving to a libAnki context
  * */
 public class HostNum {
-    private String mHostNum;
+    private Integer mHostNum;
 
-    public HostNum(String hostNum) {
+    public HostNum(Integer hostNum) {
         mHostNum = hostNum;
     }
 
-    public String getHostNum() {
+    public Integer getHostNum() {
         return mHostNum;
     }
 
-    public void setHostNum(String newHostNum) {
+    public void setHostNum(Integer newHostNum) {
         mHostNum = newHostNum;
+    }
+
+    public void reset() {
+        mHostNum = getDefaultHostNum();
+    }
+
+    protected static Integer getDefaultHostNum() {
+        return Consts.DEFAULT_HOST_NUM;
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HostNum.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HostNum.java
@@ -1,0 +1,7 @@
+package com.ichi2.libanki.sync;
+
+/** Not part of libAnki directly, but abstracts out Preferences to a libAnki context */
+public abstract class HostNum {
+    public abstract String getHostNum();
+    public abstract void setHostNum(String newHostNum);
+}

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HostNum.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HostNum.java
@@ -7,6 +7,16 @@ import com.ichi2.libanki.Consts;
  * should use that hostNum to construct the sync URL, until a future /sync/meta call advises otherwise.
  *
  * This class is not part of libAnki directly, but abstracts Preference saving to a libAnki context
+ *
+ * This is defined as an integer to avoid string formatting attacks on the URL.
+ * Confirmed to always be an integer or null in AnkiWeb
+ * https://github.com/ankidroid/Anki-Android/pull/6004#issuecomment-613731597
+ *
+ * This should be wiped:
+ * * On Logoff
+ * * On Change of Sync Server
+ *
+ * As new user data will likely not be under the same hostNum
  * */
 public class HostNum {
     private Integer mHostNum;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HttpSyncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HttpSyncer.java
@@ -465,7 +465,7 @@ public class HttpSyncer {
         return "sync";
     }
 
-    protected String getHostNum() {
+    protected Integer getHostNum() {
         return mHostNum.getHostNum();
     }
 
@@ -474,7 +474,12 @@ public class HttpSyncer {
     }
 
     protected String getDefaultAnkiWebUrl() {
-        return String.format(Consts.SYNC_BASE, getHostNum()) + getUrlPrefix() + "/";
+        String hostNumAsStringFormat = "";
+        Integer hostNum = getHostNum();
+        if (hostNum != null) {
+            hostNumAsStringFormat = hostNum.toString();
+        }
+        return String.format(Consts.SYNC_BASE, hostNumAsStringFormat) + getUrlPrefix() + "/";
     }
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HttpSyncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HttpSyncer.java
@@ -90,14 +90,15 @@ public class HttpSyncer {
     protected String mSKey;
     protected Connection mCon;
     protected Map<String, Object> mPostVars;
+    private final String mHostNum;
     private volatile OkHttpClient mHttpClient;
 
-
-    public HttpSyncer(String hkey, Connection con) {
+    public HttpSyncer(String hkey, Connection con, String hostNum) {
         mHKey = hkey;
         mSKey = Utils.checksum(Float.toString(new Random().nextFloat())).substring(0, 8);
         mCon = con;
         mPostVars = new HashMap<>();
+        mHostNum = hostNum;
     }
 
     private OkHttpClient.Builder getHttpClientBuilder() {
@@ -460,6 +461,11 @@ public class HttpSyncer {
         }
         // Usual case
         return Consts.SYNC_BASE + "sync/";
+    }
+
+
+    protected String getHostNum() {
+        return mHostNum;
     }
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HttpSyncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HttpSyncer.java
@@ -220,17 +220,7 @@ public class HttpSyncer {
             bos.close();
             // connection headers
 
-            // Likely can be removed:
-            // https://github.com/ankidroid/Anki-Android/issues/4921#issuecomment-613566744
-            String url = Consts.LEGACY_SYNC_BASE;
-            if ("register".equals(method)) {
-                url = url + "account/signup" + "?username=" + registerData.getString("u") + "&password="
-                        + registerData.getString("p");
-            } else if (method.startsWith("upgrade")) {
-                url = url + method;
-            } else {
-                url = syncURL() + method;
-            }
+            String url = syncURL() + method;
 
             Request.Builder requestBuilder = new Request.Builder();
             requestBuilder.url(url);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HttpSyncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HttpSyncer.java
@@ -219,7 +219,10 @@ public class HttpSyncer {
             bos.flush();
             bos.close();
             // connection headers
-            String url = Consts.SYNC_BASE;
+
+            // Likely can be removed:
+            // https://github.com/ankidroid/Anki-Android/issues/4921#issuecomment-613566744
+            String url = Consts.LEGACY_SYNC_BASE;
             if ("register".equals(method)) {
                 url = url + "account/signup" + "?username=" + registerData.getString("u") + "&password="
                         + registerData.getString("p");
@@ -480,7 +483,7 @@ public class HttpSyncer {
     }
 
     protected String getDefaultAnkiWebUrl() {
-        return Consts.SYNC_BASE + getUrlPrefix() + "/";
+        return String.format(Consts.SYNC_BASE, getHostNum()) + getUrlPrefix() + "/";
     }
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HttpSyncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HttpSyncer.java
@@ -56,6 +56,7 @@ import java.util.zip.GZIPOutputStream;
 
 import javax.net.ssl.SSLException;
 
+import androidx.annotation.Nullable;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -455,7 +456,7 @@ public class HttpSyncer {
     public String syncURL() {
         // Allow user to specify custom sync server
         SharedPreferences userPreferences = AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance());
-        if (userPreferences != null && userPreferences.getBoolean("useCustomSyncServer", false)) {
+        if (isUsingCustomSyncServer(userPreferences)) {
             Uri syncBase = Uri.parse(userPreferences.getString("syncBaseUrl", Consts.SYNC_BASE));
             return syncBase.buildUpon().appendPath(getUrlPrefix()).toString() + "/";
         }
@@ -469,6 +470,10 @@ public class HttpSyncer {
 
     protected String getHostNum() {
         return mHostNum;
+    }
+
+    protected boolean isUsingCustomSyncServer(@Nullable SharedPreferences userPreferences) {
+        return userPreferences != null && userPreferences.getBoolean("useCustomSyncServer", false);
     }
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HttpSyncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HttpSyncer.java
@@ -457,12 +457,15 @@ public class HttpSyncer {
         SharedPreferences userPreferences = AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance());
         if (userPreferences != null && userPreferences.getBoolean("useCustomSyncServer", false)) {
             Uri syncBase = Uri.parse(userPreferences.getString("syncBaseUrl", Consts.SYNC_BASE));
-            return syncBase.buildUpon().appendPath("sync").toString() + "/";
+            return syncBase.buildUpon().appendPath(getUrlPrefix()).toString() + "/";
         }
         // Usual case
-        return Consts.SYNC_BASE + "sync/";
+        return Consts.SYNC_BASE + getUrlPrefix() + "/";
     }
 
+    protected String getUrlPrefix() {
+        return "sync";
+    }
 
     protected String getHostNum() {
         return mHostNum;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HttpSyncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HttpSyncer.java
@@ -475,6 +475,10 @@ public class HttpSyncer {
     protected boolean isUsingCustomSyncServer(@Nullable SharedPreferences userPreferences) {
         return userPreferences != null && userPreferences.getBoolean("useCustomSyncServer", false);
     }
+
+    protected String getDefaultAnkiWebUrl() {
+        return Consts.SYNC_BASE + getUrlPrefix() + "/";
+    }
 }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HttpSyncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HttpSyncer.java
@@ -457,11 +457,14 @@ public class HttpSyncer {
         // Allow user to specify custom sync server
         SharedPreferences userPreferences = AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance());
         if (isUsingCustomSyncServer(userPreferences)) {
-            Uri syncBase = Uri.parse(userPreferences.getString("syncBaseUrl", Consts.SYNC_BASE));
-            return syncBase.buildUpon().appendPath(getUrlPrefix()).toString() + "/";
+            String syncBaseString = userPreferences.getString("syncBaseUrl", null);
+            if (syncBaseString == null) {
+                return getDefaultAnkiWebUrl();
+            }
+            return Uri.parse(syncBaseString).buildUpon().appendPath(getUrlPrefix()).toString() + "/";
         }
         // Usual case
-        return Consts.SYNC_BASE + getUrlPrefix() + "/";
+        return getDefaultAnkiWebUrl();
     }
 
     protected String getUrlPrefix() {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HttpSyncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HttpSyncer.java
@@ -91,10 +91,10 @@ public class HttpSyncer {
     protected String mSKey;
     protected Connection mCon;
     protected Map<String, Object> mPostVars;
-    private final String mHostNum;
     private volatile OkHttpClient mHttpClient;
+    private final HostNum mHostNum;
 
-    public HttpSyncer(String hkey, Connection con, String hostNum) {
+    public HttpSyncer(String hkey, Connection con, HostNum hostNum) {
         mHKey = hkey;
         mSKey = Utils.checksum(Float.toString(new Random().nextFloat())).substring(0, 8);
         mCon = con;
@@ -475,7 +475,7 @@ public class HttpSyncer {
     }
 
     protected String getHostNum() {
-        return mHostNum;
+        return mHostNum.getHostNum();
     }
 
     protected boolean isUsingCustomSyncServer(@Nullable SharedPreferences userPreferences) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HttpSyncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HttpSyncer.java
@@ -25,6 +25,7 @@ import android.net.Uri;
 
 import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.exception.UnknownHttpResponseException;
+import com.ichi2.anki.web.CustomSyncServer;
 import com.ichi2.async.Connection;
 import com.ichi2.libanki.Consts;
 import com.ichi2.libanki.Utils;
@@ -450,7 +451,7 @@ public class HttpSyncer {
         // Allow user to specify custom sync server
         SharedPreferences userPreferences = AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance());
         if (isUsingCustomSyncServer(userPreferences)) {
-            String syncBaseString = userPreferences.getString("syncBaseUrl", null);
+            String syncBaseString = CustomSyncServer.getSyncBaseUrl(userPreferences);
             if (syncBaseString == null) {
                 return getDefaultAnkiWebUrl();
             }
@@ -469,7 +470,7 @@ public class HttpSyncer {
     }
 
     protected boolean isUsingCustomSyncServer(@Nullable SharedPreferences userPreferences) {
-        return userPreferences != null && userPreferences.getBoolean("useCustomSyncServer", false);
+        return userPreferences != null && CustomSyncServer.isEnabled(userPreferences);
     }
 
     protected String getDefaultAnkiWebUrl() {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteMediaServer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteMediaServer.java
@@ -50,8 +50,8 @@ public class RemoteMediaServer extends HttpSyncer {
     private Collection mCol;
 
 
-    public RemoteMediaServer(Collection col, String hkey, Connection con) {
-        super(hkey, con);
+    public RemoteMediaServer(Collection col, String hkey, Connection con, String hostNum) {
+        super(hkey, con, hostNum);
         mCol = col;
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteMediaServer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteMediaServer.java
@@ -65,7 +65,7 @@ public class RemoteMediaServer extends HttpSyncer {
             return mediaSyncBase.toString() + "/";
         }
         // Usual case
-        return Consts.SYNC_MEDIA_BASE;
+        return Consts.SYNC_BASE + getUrlPrefix() + "/";
     }
 
 
@@ -183,5 +183,12 @@ public class RemoteMediaServer extends HttpSyncer {
             return (T) resp.getJSONArray("data");
         }
         throw new RuntimeException("Did not specify a valid type for the 'data' element in resopnse");
+    }
+
+    // Difference from libAnki: we allow a custom URL to specify a different prefix, so this is only used with the
+    // default URL
+    @Override
+    protected String getUrlPrefix() {
+        return "msync";
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteMediaServer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteMediaServer.java
@@ -60,7 +60,7 @@ public class RemoteMediaServer extends HttpSyncer {
     public String syncURL() {
         // Allow user to specify custom sync server
         SharedPreferences userPreferences = AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance());
-        if (userPreferences!= null && userPreferences.getBoolean("useCustomSyncServer", false)) {
+        if (isUsingCustomSyncServer(userPreferences)) {
             Uri mediaSyncBase = Uri.parse(userPreferences.getString("syncMediaUrl", Consts.SYNC_MEDIA_BASE));
             return mediaSyncBase.toString() + "/";
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteMediaServer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteMediaServer.java
@@ -26,12 +26,10 @@ import com.ichi2.anki.exception.MediaSyncException;
 import com.ichi2.anki.exception.UnknownHttpResponseException;
 import com.ichi2.async.Connection;
 import com.ichi2.libanki.Collection;
-import com.ichi2.libanki.Consts;
 import com.ichi2.libanki.Utils;
-import com.ichi2.utils.VersionUtils;
-
 import com.ichi2.utils.JSONArray;
 import com.ichi2.utils.JSONObject;
+import com.ichi2.utils.VersionUtils;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -50,7 +48,7 @@ public class RemoteMediaServer extends HttpSyncer {
     private Collection mCol;
 
 
-    public RemoteMediaServer(Collection col, String hkey, Connection con, String hostNum) {
+    public RemoteMediaServer(Collection col, String hkey, Connection con, HostNum hostNum) {
         super(hkey, con, hostNum);
         mCol = col;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteMediaServer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteMediaServer.java
@@ -65,6 +65,8 @@ public class RemoteMediaServer extends HttpSyncer {
             if (mediaSyncBase == null) {
                 return getDefaultAnkiWebUrl();
             }
+            //Note: the preference did not necessarily contain /msync/, so we can't concat with the default as done in
+            // getDefaultAnkiWebUrl
             return Uri.parse(mediaSyncBase).toString() + "/";
         }
         // Usual case

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteMediaServer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteMediaServer.java
@@ -61,8 +61,11 @@ public class RemoteMediaServer extends HttpSyncer {
         // Allow user to specify custom sync server
         SharedPreferences userPreferences = AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance());
         if (isUsingCustomSyncServer(userPreferences)) {
-            Uri mediaSyncBase = Uri.parse(userPreferences.getString("syncMediaUrl", Consts.SYNC_MEDIA_BASE));
-            return mediaSyncBase.toString() + "/";
+            String mediaSyncBase = userPreferences.getString("syncMediaUrl", null);
+            if (mediaSyncBase == null) {
+                return getDefaultAnkiWebUrl();
+            }
+            return Uri.parse(mediaSyncBase).toString() + "/";
         }
         // Usual case
         return getDefaultAnkiWebUrl();

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteMediaServer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteMediaServer.java
@@ -65,7 +65,7 @@ public class RemoteMediaServer extends HttpSyncer {
             return mediaSyncBase.toString() + "/";
         }
         // Usual case
-        return Consts.SYNC_BASE + getUrlPrefix() + "/";
+        return getDefaultAnkiWebUrl();
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteMediaServer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteMediaServer.java
@@ -24,6 +24,7 @@ import android.text.TextUtils;
 import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.exception.MediaSyncException;
 import com.ichi2.anki.exception.UnknownHttpResponseException;
+import com.ichi2.anki.web.CustomSyncServer;
 import com.ichi2.async.Connection;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Utils;
@@ -59,7 +60,7 @@ public class RemoteMediaServer extends HttpSyncer {
         // Allow user to specify custom sync server
         SharedPreferences userPreferences = AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance());
         if (isUsingCustomSyncServer(userPreferences)) {
-            String mediaSyncBase = userPreferences.getString("syncMediaUrl", null);
+            String mediaSyncBase = CustomSyncServer.getMediaSyncUrl(userPreferences);
             if (mediaSyncBase == null) {
                 return getDefaultAnkiWebUrl();
             }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteServer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteServer.java
@@ -35,8 +35,8 @@ import okhttp3.Response;
 @SuppressWarnings({"PMD.AvoidThrowingRawExceptionTypes","PMD.MethodNamingConventions"})
 public class RemoteServer extends HttpSyncer {
 
-    public RemoteServer(Connection con, String hkey) {
-        super(hkey, con);
+    public RemoteServer(Connection con, String hkey, String hostNum) {
+        super(hkey, con, hostNum);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteServer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteServer.java
@@ -35,7 +35,7 @@ import okhttp3.Response;
 @SuppressWarnings({"PMD.AvoidThrowingRawExceptionTypes","PMD.MethodNamingConventions"})
 public class RemoteServer extends HttpSyncer {
 
-    public RemoteServer(Connection con, String hkey, String hostNum) {
+    public RemoteServer(Connection con, String hkey, HostNum hostNum) {
         super(hkey, con, hostNum);
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.java
@@ -66,6 +66,8 @@ public class Syncer {
     private long mRMod;
     //private long mRScm;
     private int mMaxUsn;
+
+    private String mHostNum;
     private long mLMod;
     //private long mLScm;
     private int mMinUsn;
@@ -122,6 +124,7 @@ public class Syncer {
                 mRMod = rMeta.getLong("mod");
                 mMaxUsn = rMeta.getInt("usn");
                 // skip uname, AnkiDroid already stores and shows it
+                mHostNum = rMeta.getString("hostNum");
                 Timber.i("Sync: building local meta data");
                 JSONObject lMeta = meta();
                 mCol.log("lmeta", lMeta);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.java
@@ -255,7 +255,9 @@ public class Syncer {
         //We perform this as old version of the sync server may not provide the hostNum
         //And it's fine to continue without one.
         try {
-            mHostNum.setHostNum(rMeta.getString("hostNum"));
+            if (rMeta.has("hostNum")) {
+                mHostNum.setHostNum(rMeta.getInt("hostNum"));
+            }
         } catch (Exception e) {
             Timber.w(e, "Failed to set hostNum");
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.java
@@ -67,7 +67,7 @@ public class Syncer {
     //private long mRScm;
     private int mMaxUsn;
 
-    private String mHostNum;
+    private HostNum mHostNum;
     private long mLMod;
     //private long mLScm;
     private int mMinUsn;
@@ -79,9 +79,10 @@ public class Syncer {
     private Cursor mCursor;
 
 
-    public Syncer(Collection col, HttpSyncer server) {
+    public Syncer(Collection col, HttpSyncer server, HostNum hostNum) {
         mCol = col;
         mServer = server;
+        mHostNum = hostNum;
     }
 
 
@@ -124,7 +125,7 @@ public class Syncer {
                 mRMod = rMeta.getLong("mod");
                 mMaxUsn = rMeta.getInt("usn");
                 // skip uname, AnkiDroid already stores and shows it
-                mHostNum = rMeta.getString("hostNum");
+                trySetHostNum(rMeta);
                 Timber.i("Sync: building local meta data");
                 JSONObject lMeta = meta();
                 mCol.log("lmeta", lMeta);
@@ -248,6 +249,18 @@ public class Syncer {
         }
         return new Object[] { "success" };
     }
+
+
+    private void trySetHostNum(JSONObject rMeta) {
+        //We perform this as old version of the sync server may not provide the hostNum
+        //And it's fine to continue without one.
+        try {
+            mHostNum.setHostNum(rMeta.getString("hostNum"));
+        } catch (Exception e) {
+            Timber.w(e, "Failed to set hostNum");
+        }
+    }
+
 
     private Object[] _forceFullSync() {
         // roll back and force full sync

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sync/HttpSyncerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sync/HttpSyncerTest.java
@@ -18,6 +18,9 @@ import static org.hamcrest.Matchers.is;
 public class HttpSyncerTest {
     private static String sCustomServerWithNoFormatting = "https://sync.example.com/";
     private static String sCustomServerWithFormatting   = "https://sync%s.example.com/";
+    private static final String sDefaultUrlNoHostNum    = "https://sync.ankiweb.net/sync/";
+    private static final String sDefaultUrlWithHostNum  = "https://sync1.ankiweb.net/sync/";
+
 
     @Test
     public void getDefaultMediaUrlWithNoHostNum() {
@@ -25,7 +28,7 @@ public class HttpSyncerTest {
 
         String syncUrl = underTest.syncURL();
 
-        assertThat(syncUrl, is("https://sync.ankiweb.net/sync/"));
+        assertThat(syncUrl, is(sDefaultUrlNoHostNum));
     }
 
 
@@ -36,7 +39,7 @@ public class HttpSyncerTest {
 
         String syncUrl = underTest.syncURL();
 
-        assertThat(syncUrl, is("https://sync1.ankiweb.net/sync/"));
+        assertThat(syncUrl, is(sDefaultUrlWithHostNum));
     }
 
 
@@ -81,6 +84,32 @@ public class HttpSyncerTest {
         String syncUrl = underTest.syncURL();
 
         assertThat(syncUrl, is("https://sync.example.com/sync/"));
+    }
+
+    @Test
+    public void invalidSettingReturnsCorrectResultWithNoHostNum() {
+        HttpSyncer underTest = getServerWithHostNum("");
+        setCustomServerWithNoUrl();
+
+        String syncUrl = underTest.syncURL();
+
+        assertThat(syncUrl, is(sDefaultUrlNoHostNum));
+    }
+
+    @Test
+    @Ignore("Not yet supported")
+    public void invalidSettingReturnsCorrectResultWithHostNum() {
+        HttpSyncer underTest = getServerWithHostNum("1");
+        setCustomServerWithNoUrl();
+
+        String syncUrl = underTest.syncURL();
+
+        assertThat(syncUrl, is(sDefaultUrlWithHostNum));
+    }
+
+    private void setCustomServerWithNoUrl() {
+        SharedPreferences userPreferences = AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance());
+        userPreferences.edit().putBoolean("useCustomSyncServer", true).commit();
     }
 
     private void setCustomServer(String s) {

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sync/HttpSyncerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sync/HttpSyncerTest.java
@@ -107,7 +107,7 @@ public class HttpSyncerTest {
 
     private void setCustomServerWithNoUrl() {
         SharedPreferences userPreferences = AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance());
-        userPreferences.edit().putBoolean("useCustomSyncServer", true).commit();
+        userPreferences.edit().putBoolean("useCustomSyncServer", true).apply();
     }
 
     private void setCustomServer(String s) {
@@ -116,7 +116,7 @@ public class HttpSyncerTest {
         SharedPreferences.Editor e = userPreferences.edit();
         e.putBoolean("useCustomSyncServer", true);
         e.putString("syncBaseUrl", s);
-        e.commit();
+        e.apply();
     }
 
     @NonNull

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sync/HttpSyncerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sync/HttpSyncerTest.java
@@ -1,3 +1,19 @@
+/*
+ Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package com.ichi2.libanki.sync;
 
 import android.content.SharedPreferences;

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sync/HttpSyncerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sync/HttpSyncerTest.java
@@ -121,6 +121,6 @@ public class HttpSyncerTest {
 
     @NonNull
     private HttpSyncer getServerWithHostNum(String hostNum) {
-        return new HttpSyncer(null, null, hostNum);
+        return new HttpSyncer(null, null, new HostNum(hostNum));
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sync/HttpSyncerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sync/HttpSyncerTest.java
@@ -24,7 +24,7 @@ public class HttpSyncerTest {
 
     @Test
     public void getDefaultMediaUrlWithNoHostNum() {
-        HttpSyncer underTest = getServerWithHostNum("");
+        HttpSyncer underTest = getServerWithHostNum(null);
 
         String syncUrl = underTest.syncURL();
 
@@ -34,7 +34,7 @@ public class HttpSyncerTest {
 
     @Test
     public void getDefaultMediaUrlWithHostNum() {
-        HttpSyncer underTest = getServerWithHostNum("1");
+        HttpSyncer underTest = getServerWithHostNum(1);
 
         String syncUrl = underTest.syncURL();
 
@@ -45,7 +45,7 @@ public class HttpSyncerTest {
     @Test
     @Ignore("Not yet supported")
     public void getCustomMediaUrlWithNoHostNum() {
-        HttpSyncer underTest = getServerWithHostNum("");
+        HttpSyncer underTest = getServerWithHostNum(null);
         setCustomServer(sCustomServerWithFormatting);
 
         String syncUrl = underTest.syncURL();
@@ -57,7 +57,7 @@ public class HttpSyncerTest {
     @Test
     @Ignore("Not yet supported")
     public void getCustomMediaUrlWithHostNum() {
-        HttpSyncer underTest = getServerWithHostNum("1");
+        HttpSyncer underTest = getServerWithHostNum(1);
         setCustomServer(sCustomServerWithFormatting);
 
         String syncUrl = underTest.syncURL();
@@ -67,7 +67,7 @@ public class HttpSyncerTest {
 
     @Test
     public void getUnformattedCustomMediaUrlWithHostNum() {
-        HttpSyncer underTest = getServerWithHostNum("");
+        HttpSyncer underTest = getServerWithHostNum(null);
         setCustomServer(sCustomServerWithNoFormatting);
 
         String syncUrl = underTest.syncURL();
@@ -77,7 +77,7 @@ public class HttpSyncerTest {
 
     @Test
     public void getUnformattedCustomMediaUrlWithNoHostNum() {
-        HttpSyncer underTest = getServerWithHostNum("1");
+        HttpSyncer underTest = getServerWithHostNum(1);
         setCustomServer(sCustomServerWithNoFormatting);
 
         String syncUrl = underTest.syncURL();
@@ -87,7 +87,7 @@ public class HttpSyncerTest {
 
     @Test
     public void invalidSettingReturnsCorrectResultWithNoHostNum() {
-        HttpSyncer underTest = getServerWithHostNum("");
+        HttpSyncer underTest = getServerWithHostNum(null);
         setCustomServerWithNoUrl();
 
         String syncUrl = underTest.syncURL();
@@ -97,7 +97,7 @@ public class HttpSyncerTest {
 
     @Test
     public void invalidSettingReturnsCorrectResultWithHostNum() {
-        HttpSyncer underTest = getServerWithHostNum("1");
+        HttpSyncer underTest = getServerWithHostNum(1);
         setCustomServerWithNoUrl();
 
         String syncUrl = underTest.syncURL();
@@ -120,7 +120,7 @@ public class HttpSyncerTest {
     }
 
     @NonNull
-    private HttpSyncer getServerWithHostNum(String hostNum) {
+    private HttpSyncer getServerWithHostNum(Integer hostNum) {
         return new HttpSyncer(null, null, new HostNum(hostNum));
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sync/HttpSyncerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sync/HttpSyncerTest.java
@@ -33,7 +33,6 @@ public class HttpSyncerTest {
 
 
     @Test
-    @Ignore("Not yet supported")
     public void getDefaultMediaUrlWithHostNum() {
         HttpSyncer underTest = getServerWithHostNum("1");
 
@@ -97,7 +96,6 @@ public class HttpSyncerTest {
     }
 
     @Test
-    @Ignore("Not yet supported")
     public void invalidSettingReturnsCorrectResultWithHostNum() {
         HttpSyncer underTest = getServerWithHostNum("1");
         setCustomServerWithNoUrl();

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sync/HttpSyncerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sync/HttpSyncerTest.java
@@ -1,0 +1,99 @@
+package com.ichi2.libanki.sync;
+
+import android.content.SharedPreferences;
+
+import com.ichi2.anki.AnkiDroidApp;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import androidx.annotation.NonNull;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@RunWith(AndroidJUnit4.class)
+public class HttpSyncerTest {
+    private static String sCustomServerWithNoFormatting = "https://sync.example.com/";
+    private static String sCustomServerWithFormatting   = "https://sync%s.example.com/";
+
+    @Test
+    public void getDefaultMediaUrlWithNoHostNum() {
+        HttpSyncer underTest = getServerWithHostNum("");
+
+        String syncUrl = underTest.syncURL();
+
+        assertThat(syncUrl, is("https://sync.ankiweb.net/sync/"));
+    }
+
+
+    @Test
+    @Ignore("Not yet supported")
+    public void getDefaultMediaUrlWithHostNum() {
+        HttpSyncer underTest = getServerWithHostNum("1");
+
+        String syncUrl = underTest.syncURL();
+
+        assertThat(syncUrl, is("https://sync1.ankiweb.net/sync/"));
+    }
+
+
+    @Test
+    @Ignore("Not yet supported")
+    public void getCustomMediaUrlWithNoHostNum() {
+        HttpSyncer underTest = getServerWithHostNum("");
+        setCustomServer(sCustomServerWithFormatting);
+
+        String syncUrl = underTest.syncURL();
+
+        assertThat(syncUrl, is("https://sync.example.com/sync/"));
+    }
+
+
+    @Test
+    @Ignore("Not yet supported")
+    public void getCustomMediaUrlWithHostNum() {
+        HttpSyncer underTest = getServerWithHostNum("1");
+        setCustomServer(sCustomServerWithFormatting);
+
+        String syncUrl = underTest.syncURL();
+
+        assertThat(syncUrl, is("https://sync1.example.com/sync/"));
+    }
+
+    @Test
+    public void getUnformattedCustomMediaUrlWithHostNum() {
+        HttpSyncer underTest = getServerWithHostNum("");
+        setCustomServer(sCustomServerWithNoFormatting);
+
+        String syncUrl = underTest.syncURL();
+
+        assertThat(syncUrl, is("https://sync.example.com/sync/"));
+    }
+
+    @Test
+    public void getUnformattedCustomMediaUrlWithNoHostNum() {
+        HttpSyncer underTest = getServerWithHostNum("1");
+        setCustomServer(sCustomServerWithNoFormatting);
+
+        String syncUrl = underTest.syncURL();
+
+        assertThat(syncUrl, is("https://sync.example.com/sync/"));
+    }
+
+    private void setCustomServer(String s) {
+
+        SharedPreferences userPreferences = AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance());
+        SharedPreferences.Editor e = userPreferences.edit();
+        e.putBoolean("useCustomSyncServer", true);
+        e.putString("syncBaseUrl", s);
+        e.commit();
+    }
+
+    @NonNull
+    private HttpSyncer getServerWithHostNum(String hostNum) {
+        return new HttpSyncer(null, null, hostNum);
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sync/RemoteMediaServerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sync/RemoteMediaServerTest.java
@@ -108,7 +108,7 @@ public class RemoteMediaServerTest {
 
     private void setCustomServerWithNoUrl() {
         SharedPreferences userPreferences = AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance());
-        userPreferences.edit().putBoolean("useCustomSyncServer", true).commit();
+        userPreferences.edit().putBoolean("useCustomSyncServer", true).apply();
     }
 
     private void setCustomMediaServer(String s) {
@@ -117,7 +117,7 @@ public class RemoteMediaServerTest {
         Editor e = userPreferences.edit();
         e.putBoolean("useCustomSyncServer", true);
         e.putString("syncMediaUrl", s);
-        e.commit();
+        e.apply();
     }
 
     @NonNull

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sync/RemoteMediaServerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sync/RemoteMediaServerTest.java
@@ -1,3 +1,19 @@
+/*
+ Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package com.ichi2.libanki.sync;
 
 import android.content.SharedPreferences;

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sync/RemoteMediaServerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sync/RemoteMediaServerTest.java
@@ -122,6 +122,8 @@ public class RemoteMediaServerTest {
 
     @NonNull
     private RemoteMediaServer getServerWithHostNum(String hostNum) {
-        return new RemoteMediaServer(null, null, null, hostNum);
+        return new RemoteMediaServer(null, null, null, new HostNum(hostNum));
     }
+
+
 }

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sync/RemoteMediaServerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sync/RemoteMediaServerTest.java
@@ -20,6 +20,8 @@ public class RemoteMediaServerTest {
     //COULD_BE_BETTER: We currently fail on a trailing flash in these variables.
     private static String sCustomServerWithNoFormatting = "https://sync.example.com/msync";
     private static String sCustomServerWithFormatting   = "https://sync%s.example.com/msync";
+    private static final String sDefaultUrlNoHostNum    = "https://sync.ankiweb.net/msync/";
+    private static final String sDefaultUrlWithHostNum  = "https://sync1.ankiweb.net/msync/";
 
     @Test
     public void getDefaultMediaUrlWithNoHostNum() {
@@ -27,7 +29,7 @@ public class RemoteMediaServerTest {
 
         String syncUrl = underTest.syncURL();
 
-        assertThat(syncUrl, is("https://sync.ankiweb.net/msync/"));
+        assertThat(syncUrl, is(sDefaultUrlNoHostNum));
     }
 
 
@@ -38,7 +40,7 @@ public class RemoteMediaServerTest {
 
         String syncUrl = underTest.syncURL();
 
-        assertThat(syncUrl, is("https://sync1.ankiweb.net/msync/"));
+        assertThat(syncUrl, is(sDefaultUrlWithHostNum));
     }
 
 
@@ -83,6 +85,33 @@ public class RemoteMediaServerTest {
         String syncUrl = underTest.syncURL();
 
         assertThat(syncUrl, is("https://sync.example.com/msync/"));
+    }
+
+    @Test
+    @Ignore("This should have worked, but was broken before I started")
+    public void invalidSettingReturnsCorrectResultWithNoHostNum() {
+        RemoteMediaServer underTest = getServerWithHostNum("");
+        setCustomServerWithNoUrl();
+
+        String syncUrl = underTest.syncURL();
+
+        assertThat(syncUrl, is(sDefaultUrlNoHostNum));
+    }
+
+    @Test
+    @Ignore("Not yet supported")
+    public void invalidSettingReturnsCorrectResultWithHostNum() {
+        RemoteMediaServer underTest = getServerWithHostNum("1");
+        setCustomServerWithNoUrl();
+
+        String syncUrl = underTest.syncURL();
+
+        assertThat(syncUrl, is(sDefaultUrlWithHostNum));
+    }
+
+    private void setCustomServerWithNoUrl() {
+        SharedPreferences userPreferences = AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance());
+        userPreferences.edit().putBoolean("useCustomSyncServer", true).commit();
     }
 
     private void setCustomMediaServer(String s) {

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sync/RemoteMediaServerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sync/RemoteMediaServerTest.java
@@ -88,7 +88,6 @@ public class RemoteMediaServerTest {
     }
 
     @Test
-    @Ignore("This should have worked, but was broken before I started")
     public void invalidSettingReturnsCorrectResultWithNoHostNum() {
         RemoteMediaServer underTest = getServerWithHostNum("");
         setCustomServerWithNoUrl();

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sync/RemoteMediaServerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sync/RemoteMediaServerTest.java
@@ -34,7 +34,6 @@ public class RemoteMediaServerTest {
 
 
     @Test
-    @Ignore("Not yet supported")
     public void getDefaultMediaUrlWithHostNum() {
         RemoteMediaServer underTest = getServerWithHostNum("1");
 
@@ -98,7 +97,6 @@ public class RemoteMediaServerTest {
     }
 
     @Test
-    @Ignore("Not yet supported")
     public void invalidSettingReturnsCorrectResultWithHostNum() {
         RemoteMediaServer underTest = getServerWithHostNum("1");
         setCustomServerWithNoUrl();

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sync/RemoteMediaServerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sync/RemoteMediaServerTest.java
@@ -1,0 +1,101 @@
+package com.ichi2.libanki.sync;
+
+import android.content.SharedPreferences;
+import android.content.SharedPreferences.Editor;
+
+import com.ichi2.anki.AnkiDroidApp;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import androidx.annotation.NonNull;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@RunWith(AndroidJUnit4.class)
+public class RemoteMediaServerTest {
+    //COULD_BE_BETTER: We currently fail on a trailing flash in these variables.
+    private static String sCustomServerWithNoFormatting = "https://sync.example.com/msync";
+    private static String sCustomServerWithFormatting   = "https://sync%s.example.com/msync";
+
+    @Test
+    public void getDefaultMediaUrlWithNoHostNum() {
+        RemoteMediaServer underTest = getServerWithHostNum("");
+
+        String syncUrl = underTest.syncURL();
+
+        assertThat(syncUrl, is("https://sync.ankiweb.net/msync/"));
+    }
+
+
+    @Test
+    @Ignore("Not yet supported")
+    public void getDefaultMediaUrlWithHostNum() {
+        RemoteMediaServer underTest = getServerWithHostNum("1");
+
+        String syncUrl = underTest.syncURL();
+
+        assertThat(syncUrl, is("https://sync1.ankiweb.net/msync/"));
+    }
+
+
+    @Test
+    @Ignore("Not yet supported")
+    public void getCustomMediaUrlWithNoHostNum() {
+        RemoteMediaServer underTest = getServerWithHostNum("");
+        setCustomMediaServer(sCustomServerWithFormatting);
+
+        String syncUrl = underTest.syncURL();
+
+        assertThat(syncUrl, is("https://sync.example.com/msync/"));
+    }
+
+
+    @Test
+    @Ignore("Not yet supported")
+    public void getCustomMediaUrlWithHostNum() {
+        RemoteMediaServer underTest = getServerWithHostNum("1");
+        setCustomMediaServer(sCustomServerWithFormatting);
+
+        String syncUrl = underTest.syncURL();
+
+        assertThat(syncUrl, is("https://sync1.example.com/msync/"));
+    }
+
+    @Test
+    public void getUnformattedCustomMediaUrlWithHostNum() {
+        RemoteMediaServer underTest = getServerWithHostNum("");
+        setCustomMediaServer(sCustomServerWithNoFormatting);
+
+        String syncUrl = underTest.syncURL();
+
+        assertThat(syncUrl, is("https://sync.example.com/msync/"));
+    }
+
+    @Test
+    public void getUnformattedCustomMediaUrlWithNoHostNum() {
+        RemoteMediaServer underTest = getServerWithHostNum("1");
+        setCustomMediaServer(sCustomServerWithNoFormatting);
+
+        String syncUrl = underTest.syncURL();
+
+        assertThat(syncUrl, is("https://sync.example.com/msync/"));
+    }
+
+    private void setCustomMediaServer(String s) {
+
+        SharedPreferences userPreferences = AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance());
+        Editor e = userPreferences.edit();
+        e.putBoolean("useCustomSyncServer", true);
+        e.putString("syncMediaUrl", s);
+        e.commit();
+    }
+
+    @NonNull
+    private RemoteMediaServer getServerWithHostNum(String hostNum) {
+        return new RemoteMediaServer(null, null, null, hostNum);
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sync/RemoteMediaServerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sync/RemoteMediaServerTest.java
@@ -25,7 +25,7 @@ public class RemoteMediaServerTest {
 
     @Test
     public void getDefaultMediaUrlWithNoHostNum() {
-        RemoteMediaServer underTest = getServerWithHostNum("");
+        RemoteMediaServer underTest = getServerWithHostNum(null);
 
         String syncUrl = underTest.syncURL();
 
@@ -35,7 +35,7 @@ public class RemoteMediaServerTest {
 
     @Test
     public void getDefaultMediaUrlWithHostNum() {
-        RemoteMediaServer underTest = getServerWithHostNum("1");
+        RemoteMediaServer underTest = getServerWithHostNum(1);
 
         String syncUrl = underTest.syncURL();
 
@@ -46,7 +46,7 @@ public class RemoteMediaServerTest {
     @Test
     @Ignore("Not yet supported")
     public void getCustomMediaUrlWithNoHostNum() {
-        RemoteMediaServer underTest = getServerWithHostNum("");
+        RemoteMediaServer underTest = getServerWithHostNum(null);
         setCustomMediaServer(sCustomServerWithFormatting);
 
         String syncUrl = underTest.syncURL();
@@ -58,7 +58,7 @@ public class RemoteMediaServerTest {
     @Test
     @Ignore("Not yet supported")
     public void getCustomMediaUrlWithHostNum() {
-        RemoteMediaServer underTest = getServerWithHostNum("1");
+        RemoteMediaServer underTest = getServerWithHostNum(1);
         setCustomMediaServer(sCustomServerWithFormatting);
 
         String syncUrl = underTest.syncURL();
@@ -68,7 +68,7 @@ public class RemoteMediaServerTest {
 
     @Test
     public void getUnformattedCustomMediaUrlWithHostNum() {
-        RemoteMediaServer underTest = getServerWithHostNum("");
+        RemoteMediaServer underTest = getServerWithHostNum(null);
         setCustomMediaServer(sCustomServerWithNoFormatting);
 
         String syncUrl = underTest.syncURL();
@@ -78,7 +78,7 @@ public class RemoteMediaServerTest {
 
     @Test
     public void getUnformattedCustomMediaUrlWithNoHostNum() {
-        RemoteMediaServer underTest = getServerWithHostNum("1");
+        RemoteMediaServer underTest = getServerWithHostNum(1);
         setCustomMediaServer(sCustomServerWithNoFormatting);
 
         String syncUrl = underTest.syncURL();
@@ -88,7 +88,7 @@ public class RemoteMediaServerTest {
 
     @Test
     public void invalidSettingReturnsCorrectResultWithNoHostNum() {
-        RemoteMediaServer underTest = getServerWithHostNum("");
+        RemoteMediaServer underTest = getServerWithHostNum(null);
         setCustomServerWithNoUrl();
 
         String syncUrl = underTest.syncURL();
@@ -98,7 +98,7 @@ public class RemoteMediaServerTest {
 
     @Test
     public void invalidSettingReturnsCorrectResultWithHostNum() {
-        RemoteMediaServer underTest = getServerWithHostNum("1");
+        RemoteMediaServer underTest = getServerWithHostNum(1);
         setCustomServerWithNoUrl();
 
         String syncUrl = underTest.syncURL();
@@ -121,7 +121,7 @@ public class RemoteMediaServerTest {
     }
 
     @NonNull
-    private RemoteMediaServer getServerWithHostNum(String hostNum) {
+    private RemoteMediaServer getServerWithHostNum(Integer hostNum) {
         return new RemoteMediaServer(null, null, null, new HostNum(hostNum));
     }
 


### PR DESCRIPTION
* https://github.com/ankitects/anki/commit/ae46bfa8d18778a7312828c3fd9b8d6c6e4672d6#diff-be58d55ab11f38bc77a9e44496f1d2a8

## Review Goals

* If the hostNum is corrupt, the user can't sync, and we don't currently provide a means to wipe it. How should we handle this?
* A malicious sync server likely can silently rewrite the sync url as we're performing `String.format` on user-provided data going into the URL.

## Purpose / Description

This is only for AnkiWeb, we still do not support this for custom sync servers. 

This is for a few reasons:

* Debate over whether to keep a separate media sync URL, or do Anki did in the linked commit.
* Changing servers - when to reset the hostNum? Much more likely to get into a situation where we have an invalid hostNum and no way to fix it.

## Fixes
Fixes #4921

## Approach
Careful refactorings and unit tests. Once we remove the uses of `SYNC_BASE` to 1, we add in a format string and convert.

## How Has This Been Tested?

Heavily unit tested.
Sync still works on my device.

## Learning (optional, can help others)
See discussions in linked issue.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code