### PR TITLE
Reuse Connection when Syncing

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HttpSyncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HttpSyncer.java
@@ -112,27 +112,27 @@ public class HttpSyncer {
         }
     }
 
-
+    /** Note: Return value must be closed */
     public Response req(String method) throws UnknownHttpResponseException {
         return req(method, null);
     }
 
-
+    /** Note: Return value must be closed */
     public Response req(String method, InputStream fobj) throws UnknownHttpResponseException {
         return req(method, fobj, 6);
     }
 
-
+    /** Note: Return value must be closed */
     public Response req(String method, int comp, InputStream fobj) throws UnknownHttpResponseException {
         return req(method, fobj, comp);
     }
 
-
+    /** Note: Return value must be closed */
     public Response req(String method, InputStream fobj, int comp) throws UnknownHttpResponseException {
         return req(method, fobj, comp, null);
     }
 
-
+    /** Note: Return value must be closed */
     private Response req(String method, InputStream fobj, int comp, JSONObject registerData) throws UnknownHttpResponseException {
         File tmpFileBuffer = null;
         try {


### PR DESCRIPTION
## Purpose / Description

Flagged by Damien a long while back. We currently make a new TCP/IP connection per HTTP(s) request to AnkiWeb. 

Should get a decent perf gain from this, especially for media syncing and chunking.

## Fixes
Fixes #4568 

## Approach
We reuse the same OkHttpClient

## How Has This Been Tested?
Syncing still works. Took about 2-4 minutes off my sync time (15/17m -> 13m).
Tested using methods described in the PR. Only 3 connections were used.

## Learning

* `OkHttpClient` isn't closeable, only the response object is.
* https://github.com/ankidroid/Anki-Android/issues/4568#issuecomment-613723018 - how to test.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code