### PR TITLE
More efficient resetting.

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1069,7 +1069,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
            The card could have been rescheduled, the deck could have changed, or a change of
            note type could have lead to the card being deleted */
         if (data != null && data.hasExtra("reloadRequired")) {
-            getCol().getSched().reset();
+            getCol().getSched().planifyReset();
             CollectionTask.launchCollectionTask(CollectionTask.TASK_TYPE_ANSWER_CARD, mAnswerCardHandler,
                     new CollectionTask.TaskData(null, 0));
         }
@@ -1085,7 +1085,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
                 redrawCard();
             }
         } else if (requestCode == DECK_OPTIONS && resultCode == RESULT_OK) {
-            getCol().getSched().reset();
+            getCol().getSched().planifyReset();
             CollectionTask.launchCollectionTask(CollectionTask.TASK_TYPE_ANSWER_CARD, mAnswerCardHandler,
                     new CollectionTask.TaskData(null, 0));
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1754,9 +1754,21 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
 
 
     protected void updateScreenCounts() {
-        int[] counts = mSched.counts(mCurrentCard);
-        updateScreenCounts(counts);
-    }
+        CollectionTask.launchCollectionTask(CollectionTask.TASK_TYPE_SCHED_COUNT,
+                                            new CollectionTask.TaskListener(){
+                                                @Override
+                                                public void onPreExecute() {
+
+                                                }
+
+                                                @Override
+                                                public void onPostExecute(CollectionTask.TaskData result) {
+                                                    int [] counts = result.getCounts();
+                                                    updateScreenCounts(counts);
+                                                }
+                                            }
+                                            );
+            }
 
     protected void updateScreenCounts(int[] counts) {
         if (mCurrentCard == null) return;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1754,10 +1754,13 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
 
 
     protected void updateScreenCounts() {
+        int[] counts = mSched.counts(mCurrentCard);
+        updateScreenCounts(counts);
+    }
+
+    protected void updateScreenCounts(int[] counts) {
         if (mCurrentCard == null) return;
         ActionBar actionBar = getSupportActionBar();
-        int[] counts = mSched.counts(mCurrentCard);
-
         if (actionBar != null) {
             String title = Decks.basename(getCol().getDecks().get(mCurrentCard.getDid()).getString("name"));
             actionBar.setTitle(title);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1754,6 +1754,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
 
 
     protected void updateScreenCounts() {
+        if (mCurrentCard == null) return;
         CollectionTask.launchCollectionTask(CollectionTask.TASK_TYPE_SCHED_COUNT,
                                             new CollectionTask.TaskListener(){
                                                 @Override
@@ -1768,7 +1769,8 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
                                                 }
                                             }
                                             );
-            }
+        updateScreenCounts(null);
+    }
 
     protected void updateScreenCounts(int[] counts) {
         if (mCurrentCard == null) return;
@@ -1776,15 +1778,21 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity {
         if (actionBar != null) {
             String title = Decks.basename(getCol().getDecks().get(mCurrentCard.getDid()).getString("name"));
             actionBar.setTitle(title);
-            if (mPrefShowETA) {
+            if (mPrefShowETA && counts != null) {
                 int eta = mSched.eta(counts, false);
                 actionBar.setSubtitle(Utils.remainingTime(AnkiDroidApp.getInstance(), eta * 60));
             }
         }
 
-        SpannableString newCount = new SpannableString(String.valueOf(counts[0]));
-        SpannableString lrnCount = new SpannableString(String.valueOf(counts[1]));
-        SpannableString revCount = new SpannableString(String.valueOf(counts[2]));
+        String[] countsString;
+        if (counts == null) {
+            countsString = new String[] {"", "", ""};
+        } else {
+            countsString = new String[] {String.valueOf(counts[0]), String.valueOf(counts[1]), String.valueOf(counts[2])};
+        }
+        SpannableString newCount = new SpannableString(countsString[0]);
+        SpannableString lrnCount = new SpannableString(countsString[1]);
+        SpannableString revCount = new SpannableString(countsString[2]);
         if (mPrefHideDueCount) {
             revCount = new SpannableString("???");
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -2010,6 +2010,8 @@ public class DeckPicker extends NavigationDrawerActivity implements
             return;
         }
         getCol().getSched().reset();
+        // Actual reset is required because we need count.
+        // More precisely, simply knowing a card exists would be sufficient.
         int[] studyOptionsCounts = getCol().getSched().counts();
         if (studyOptionsCounts[0] + studyOptionsCounts[1] + studyOptionsCounts[2] > 0) {
             // If there are cards due that can't be studied yet (due to the learn ahead limit) then go to study options

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -2009,11 +2009,10 @@ public class DeckPicker extends NavigationDrawerActivity implements
             }
             return;
         }
-        getCol().getSched().reset();
+        getCol().getSched().quickReset();
         // Actual reset is required because we need count.
         // More precisely, simply knowing a card exists would be sufficient.
-        int[] studyOptionsCounts = getCol().getSched().counts();
-        if (studyOptionsCounts[0] + studyOptionsCounts[1] + studyOptionsCounts[2] > 0) {
+        if (getCol().getSched().lrnDueFromToday()) {
             // If there are cards due that can't be studied yet (due to the learn ahead limit) then go to study options
             openStudyOptions(false);
         } else if (getCol().getSched().newDue() || getCol().getSched().revDue()) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -124,7 +124,7 @@ public class Reviewer extends AbstractFlashcardViewer {
         // Select the deck
         getCol().getDecks().select(did);
         // Reset the schedule so that we get the counts for the currently selected deck
-        getCol().getSched().reset();
+        getCol().getSched().planifyReset();
     }
 
     @Override

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -60,9 +60,6 @@ public class Reviewer extends AbstractFlashcardViewer {
     private boolean mBlackWhiteboard = true;
     private boolean mPrefFullscreenReview = false;
     private static final int ADD_NOTE = 12;
-    // Deck picker reset scheduler before opening the reviewer. So
-    // first reset is useless.
-    private boolean mSchedResetDone = false;
 
 
     private CollectionTask.TaskListener mRescheduleCardHandler = new ScheduleCollectionTaskListener() {
@@ -98,9 +95,6 @@ public class Reviewer extends AbstractFlashcardViewer {
         Timber.d("onCreate()");
         super.onCreate(savedInstanceState);
 
-        if (getIntent().hasExtra("com.ichi2.anki.SchedResetDone")) {
-            mSchedResetDone = true;
-        }
         if (Intent.ACTION_VIEW.equals(getIntent().getAction())) {
             Timber.d("onCreate() :: received Intent with action = %s", getIntent().getAction());
             selectDeckFromExtra();
@@ -177,10 +171,7 @@ public class Reviewer extends AbstractFlashcardViewer {
             setWhiteboardVisibility(whiteboardVisibility);
         }
 
-        if (!mSchedResetDone) {
-            col.getSched().reset();     // Reset schedule in case card was previously loaded
-            mSchedResetDone = false;
-        }
+        col.getSched().planifyReset();     // Reset schedule in case card was previously loaded
         CollectionTask.launchCollectionTask(CollectionTask.TASK_TYPE_ANSWER_CARD, mAnswerCardHandler,
                 new CollectionTask.TaskData(null, 0));
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -171,7 +171,7 @@ public class Reviewer extends AbstractFlashcardViewer {
             setWhiteboardVisibility(whiteboardVisibility);
         }
 
-        col.getSched().planifyReset();     // Reset schedule in case card was previously loaded
+        mSched.planifyReset();     // Reset schedule in case card was previously loaded
         CollectionTask.launchCollectionTask(CollectionTask.TASK_TYPE_ANSWER_CARD, mAnswerCardHandler,
                 new CollectionTask.TaskData(null, 0));
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
@@ -346,7 +346,7 @@ public class CardContentProvider extends ContentProvider {
                 }
 
                 //retrieve the number of cards provided by the selection parameter "limit"
-                col.getSched().reset();
+                col.getSched().planifyReset();
                 for (int k = 0; k< limit; k++){
                     Card currentCard = col.getSched().getCard();
 

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -863,7 +863,6 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
                     newCard.startTimer();
                     col.reset();
                     col.getSched().decrementCounts(newCard);
-                    sched.planifyReset();
                 } else if (cid != -1){
                     col.reset();
                     newCard = sched.getCard();

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -110,6 +110,7 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
     public static final int TASK_TYPE_FIND_EMPTY_CARDS = 48;
     public static final int TASK_TYPE_CHECK_CARD_SELECTION = 49;
     public static final int TASK_TYPE_SCHED_RESET = 50;
+    public static final int TASK_TYPE_SCHED_COUNT = 51;
     public static final int TASK_TYPE_LOAD_NEXT_CARD = 52;
 
     /**
@@ -355,6 +356,8 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
                 return doInBackgroundCheckCardSelection(params);
             case TASK_TYPE_SCHED_RESET:
                 return doInBackgroundReset(params);
+            case TASK_TYPE_SCHED_COUNT:
+                return doInBackgroundCount(params);
             case TASK_TYPE_LOAD_NEXT_CARD:
                 return doInBackgroundLoadNextCard(params);
 
@@ -1573,6 +1576,11 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
         return null;
     }
 
+    public TaskData doInBackgroundCount(TaskData... params) {
+        int[] counts = CollectionHelper.getInstance().getCol(mContext).getSched().counts();
+        return new TaskData(counts);
+    }
+
     public TaskData doInBackgroundLoadNextCard(TaskData... params) {
         CollectionHelper.getInstance().getCol(mContext).getSched().loadNextCard();
         return null;
@@ -1714,6 +1722,7 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
         private int mType;
         private Comparator mComparator;
         private Object[] mObjects;
+        private int[] mCounts;
 
 
         public TaskData(Object[] obj) {
@@ -1841,6 +1850,10 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
             mBool = bool;
         }
 
+        public TaskData(int[] counts) {
+            mCounts = counts;
+        }
+
 
         public List<Map<String, String>> getCards() {
             return mCards;
@@ -1899,6 +1912,10 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
 
         public Object[] getObjArray() {
             return mObjects;
+        }
+
+        public int[] getCounts() {
+            return mCounts;
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -446,7 +446,7 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
                         // reload qa-cache
                         newCard.q(true);
                     } else {
-                        newCard = getCard(sched);
+                        newCard = sched.getCard();
                     }
                     publishProgress(new TaskData(newCard));
                 } else {
@@ -512,7 +512,7 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
                     Timber.i("Answering card %d", oldCard.getId());
                     sched.answerCard(oldCard, ease);
                 }
-                newCard = getCard(sched);
+                newCard = sched.getCard();
                 if (newCard != null) {
                     // render cards before locking database
                     newCard._getQA(true);
@@ -528,11 +528,6 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
             return new TaskData(false);
         }
         return new TaskData(true);
-    }
-
-
-    private Card getCard(AbstractSched sched) {
-        return sched.getCard();
     }
 
 
@@ -621,7 +616,7 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
                     }
                 }
                 // With sHadCardQueue set, getCard() resets the scheduler prior to getting the next card
-                publishProgress(new TaskData(getCard(col.getSched()), 0));
+                publishProgress(new TaskData(col.getSched().getCard(), 0));
                 col.getDb().getDatabase().setTransactionSuccessful();
             } finally {
                 col.getDb().getDatabase().endTransaction();
@@ -819,7 +814,7 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
                         }
                         // In all cases schedule a new card so Reviewer doesn't sit on the old one
                         col.reset();
-                        publishProgress(new TaskData(getCard(sched), 0));
+                        publishProgress(new TaskData(sched.getCard(), 0));
                         break;
                     }
                 }
@@ -871,7 +866,7 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
                     sched.planifyReset();
                 } else if (cid != -1){
                     col.reset();
-                    newCard = getCard(sched);
+                    newCard = sched.getCard();
                 }
                 // TODO: handle leech undoing properly
                 publishProgress(new TaskData(newCard, 0));

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -109,6 +109,7 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
     public static final int TASK_TYPE_SAVE_MODEL = 47;
     public static final int TASK_TYPE_FIND_EMPTY_CARDS = 48;
     public static final int TASK_TYPE_CHECK_CARD_SELECTION = 49;
+    public static final int TASK_TYPE_SCHED_RESET = 50;
     public static final int TASK_TYPE_LOAD_NEXT_CARD = 52;
 
     /**
@@ -352,6 +353,8 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
                 return doInBackGroundFindEmptyCards(params);
             case TASK_TYPE_CHECK_CARD_SELECTION:
                 return doInBackgroundCheckCardSelection(params);
+            case TASK_TYPE_SCHED_RESET:
+                return doInBackgroundReset(params);
             case TASK_TYPE_LOAD_NEXT_CARD:
                 return doInBackgroundLoadNextCard(params);
 
@@ -1562,6 +1565,12 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
         }
 
         return new TaskData(new Object[] { hasUnsuspended, hasUnmarked});
+    }
+
+    public TaskData doInBackgroundReset(TaskData... params) {
+        Collection col = CollectionHelper.getInstance().getCol(mContext);
+        col.getSched().reset();
+        return null;
     }
 
     public TaskData doInBackgroundLoadNextCard(TaskData... params) {

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -1012,6 +1012,7 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
             Object[] obj = params[0].getObjArray();
             boolean reset = (Boolean) obj[0];
             if (reset) {
+                // reset actually required because of counts, which is used in getCollectionTaskListener
                 sched.reset();
             }
             int[] counts = sched.counts();

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -109,6 +109,7 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
     public static final int TASK_TYPE_SAVE_MODEL = 47;
     public static final int TASK_TYPE_FIND_EMPTY_CARDS = 48;
     public static final int TASK_TYPE_CHECK_CARD_SELECTION = 49;
+    public static final int TASK_TYPE_LOAD_NEXT_CARD = 52;
 
     /**
      * A reference to the application context to use to fetch the current Collection object.
@@ -353,6 +354,8 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
                 return doInBackGroundFindEmptyCards(params);
             case TASK_TYPE_CHECK_CARD_SELECTION:
                 return doInBackgroundCheckCardSelection(params);
+            case TASK_TYPE_LOAD_NEXT_CARD:
+                return doInBackgroundLoadNextCard(params);
 
             default:
                 Timber.e("unknown task type: %d", mType);
@@ -1570,6 +1573,11 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
         }
 
         return new TaskData(new Object[] { hasUnsuspended, hasUnmarked});
+    }
+
+    public TaskData doInBackgroundLoadNextCard(TaskData... params) {
+        CollectionHelper.getInstance().getCol(mContext).getSched().loadNextCard();
+        return null;
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -501,7 +501,7 @@ public class Collection {
      * Rebuild the queue and reload data after DB modified.
      */
     public void reset() {
-        mSched.reset();
+        mSched.planifyReset();
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
@@ -20,6 +20,8 @@ public abstract class AbstractSched {
      */
     public abstract Card getCard();
     public abstract void reset();
+    /** Ensures that reset is executed before the next card is selected */
+    public abstract void planifyReset();
     public abstract void answerCard(Card card, int ease);
     public abstract int[] counts();
     public abstract int[] counts(Card card);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
@@ -22,6 +22,8 @@ public abstract class AbstractSched {
     public abstract void reset();
     /** Ensures that reset is executed before the next card is selected */
     public abstract void planifyReset();
+    /** Empty list, set list of deck but don't compute numbers*/
+    public abstract void quickReset();
     public abstract void answerCard(Card card, int ease);
     public abstract int[] counts();
     public abstract int[] counts(Card card);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
@@ -70,6 +70,8 @@ public abstract class AbstractSched {
     public abstract boolean revDue();
     /** true if there are any new cards due. */
     public abstract boolean newDue();
+    /** true if there are cards due from today */
+    public abstract boolean lrnDueFromToday();
     public abstract boolean haveBuried();
     /**
      * Return the next interval for a card and ease as a string.

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
@@ -232,4 +232,9 @@ public abstract class AbstractSched {
     public interface CountMethod {
         int operation(long did, int lim);
     }
+
+    // Should be called in background, preload next question/answer.
+    // Not in libanki. In AnkiDroid to improve interactive
+    // responsiveness
+    public abstract void loadNextCard();
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -42,6 +42,8 @@ import com.ichi2.utils.JSONArray;
 import com.ichi2.utils.JSONException;
 import com.ichi2.utils.JSONObject;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.lang.ref.WeakReference;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
@@ -136,21 +138,13 @@ public class Sched extends SchedV2 {
 
 
     @Override
-    public int[] counts() {
-        return counts(null);
-    }
-
-
-    @Override
-    public int[] counts(Card card) {
-        int[] counts = {mNewCount, mLrnCount, mRevCount};
-        if (card != null) {
-            int idx = countIdx(card);
-            if (idx == 1) {
-                counts[1] += card.getLeft() / 1000;
-            } else {
-                counts[idx] += 1;
-            }
+    public int[] counts(@NotNull Card card) {
+        int[] counts = counts();
+        int idx = countIdx(card);
+        if (idx == 1) {
+            counts[1] += card.getLeft() / 1000;
+        } else {
+            counts[idx] += 1;
         }
         return counts;
     }
@@ -159,7 +153,7 @@ public class Sched extends SchedV2 {
     @Override
     public int countIdx(Card card) {
         if (card.getQueue() == Consts.QUEUE_TYPE_DAY_LEARN_RELEARN) {
-            return 1;
+            return Consts.QUEUE_TYPE_LRN;
         }
         return card.getQueue();
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -1442,17 +1442,9 @@ public class Sched extends SchedV2 {
                 long cid = cur.getLong(0);
                 int queue = cur.getInt(1);
                 if (queue == Consts.QUEUE_TYPE_REV) {
-                    if (buryRev) {
-                        toBury.add(cid);
-                    }
-                    // if bury disabled, we still discard to give same-day spacing
-                    mRevQueue.remove(cid);
+                    _actualBurySibling(cid, mRevQueue, buryRev, toBury);
                 } else {
-                    // if bury is disabled, we still discard to give same-day spacing
-                    if (buryNew) {
-                        toBury.add(cid);
-                    }
-                    mNewQueue.remove(cid);
+                    _actualBurySibling(cid, mNewQueue, buryNew, toBury);
                 }
             }
         } finally {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -320,36 +320,36 @@ public class Sched extends SchedV2 {
      * Return the next due card, or null.
      */
     @Override
-    protected Card _getCard() {
+    protected Card _getCard(boolean ignoreNumbers) {
         // learning card due?
-        Card c = _getLrnCard();
+        Card c = _getLrnCard(false, ignoreNumbers);
         if (c != null) {
             return c;
         }
         // new first, or time for one?
-        if (_timeForNewCard()) {
-            c = _getNewCard();
+        if (_timeForNewCard(ignoreNumbers)) {
+            c = _getNewCard(ignoreNumbers);
             if (c != null) {
                 return c;
             }
         }
         // Card due for review?
-        c = _getRevCard();
+        c = _getRevCard(ignoreNumbers);
         if (c != null) {
             return c;
         }
         // day learning card due?
-        c = _getLrnDayCard();
+        c = _getLrnDayCard(ignoreNumbers);
         if (c != null) {
             return c;
         }
         // New cards left?
-        c = _getNewCard();
+        c = _getNewCard(ignoreNumbers);
         if (c != null) {
             return c;
         }
         // collapse or finish
-        return _getLrnCard(true);
+        return _getLrnCard(true, ignoreNumbers);
     }
 
 
@@ -421,8 +421,8 @@ public class Sched extends SchedV2 {
 
     // sub-day learning
     @Override
-    protected boolean _fillLrn() {
-        if (mLrnCount == 0) {
+    protected boolean _fillLrn(boolean ignoreNumbers) {
+        if (!ignoreNumbers && mLrnCount == 0) {
             return false;
         }
         if (!mLrnQueue.isEmpty()) {
@@ -457,14 +457,8 @@ public class Sched extends SchedV2 {
 
 
     @Override
-    protected Card _getLrnCard() {
-        return _getLrnCard(false);
-    }
-
-
-    @Override
-    protected Card _getLrnCard(boolean collapse) {
-        if (_fillLrn()) {
+    protected Card _getLrnCard(boolean collapse, boolean ignoreNumbers) {
+        if (_fillLrn(ignoreNumbers)) {
             double cutoff = Utils.now();
             if (collapse) {
                 cutoff += mCol.getConf().getInt("collapseTime");
@@ -768,11 +762,11 @@ public class Sched extends SchedV2 {
 
 
     @Override
-    protected boolean _fillRev() {
+    protected boolean _fillRev(boolean ignoreNumbers) {
         if (!mRevQueue.isEmpty()) {
             return true;
         }
-        if (mRevCount == 0) {
+        if (!ignoreNumbers && mRevCount == 0) {
             return false;
         }
         while (!mRevDids.isEmpty()) {
@@ -820,12 +814,12 @@ public class Sched extends SchedV2 {
             // nothing left in the deck; move to next
             mRevDids.remove();
         }
-        if (mRevCount != 0) {
+        if (!ignoreNumbers && mRevCount != 0) {
             // if we didn't get a card but the count is non-zero,
             // we need to check again for any cards that were
             // removed from the queue but not buried
             _resetRev();
-            return _fillRev();
+            return _fillRev(ignoreNumbers);
         }
         return false;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -409,8 +409,10 @@ public class Sched extends SchedV2 {
 
 
     @Override
-    protected void _resetLrn() {
-        _resetLrnCount();
+    protected void _resetLrn(boolean computeNumber) {
+        if (computeNumber) {
+            _resetLrnCount();
+        }
         mLrnQueue.clear();
         mLrnDayQueue.clear();
         mLrnDids = mCol.getDecks().active();
@@ -756,8 +758,10 @@ public class Sched extends SchedV2 {
 
 
     @Override
-    protected void _resetRev() {
-        _resetRevCount();
+    protected void _resetRev(boolean computeNumber) {
+        if (computeNumber) {
+            _resetRevCount();
+        }
         mRevQueue.clear();
         mRevDids = mCol.getDecks().active();
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -43,6 +43,8 @@ import com.ichi2.utils.JSONArray;
 import com.ichi2.utils.JSONException;
 import com.ichi2.utils.JSONObject;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.lang.ref.WeakReference;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
@@ -222,16 +224,14 @@ public class SchedV2 extends AbstractSched {
 
 
     public int[] counts() {
-        return counts(null);
+        return new int[] {mNewCount, mLrnCount, mRevCount};
     }
 
 
-    public int[] counts(Card card) {
-        int[] counts = {mNewCount, mLrnCount, mRevCount};
-        if (card != null) {
-            int idx = countIdx(card);
-            counts[idx] += 1;
-        }
+    public int[] counts(@NotNull Card card) {
+        int[] counts = counts();
+        int idx = countIdx(card);
+        counts[idx] += 1;
         return counts;
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -155,6 +155,11 @@ public class SchedV2 extends AbstractSched {
         return card;
     }
 
+    /** Ensures that reset is executed before the next card is selected */
+    public void planifyReset(){
+        mHaveQueues = false;
+    }
+
     public void reset() {
         mNextCard = null;
         _updateCutoff();

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -160,13 +160,19 @@ public class SchedV2 extends AbstractSched {
         mHaveQueues = false;
     }
 
+    public void quickReset() {
+        reset(false);
+    }
+
     public void reset() {
         mNextCard = null;
         _updateCutoff();
-        _resetLrn();
-        _resetRev();
-        _resetNew();
-        mHaveQueues = true;
+        _resetLrn(computeNumber);
+        _resetRev(computeNumber);
+        _resetNew(computeNumber);
+        if (computeNumber) {
+            mHaveQueues = true;
+        }
         backgroundNextCard();
     }
 
@@ -572,12 +578,19 @@ public class SchedV2 extends AbstractSched {
                 new Object[]{did, lim});
     }
 
-
     private void _resetNew() {
-        _resetNewCount();
+        _resetNew(true);
+    }
+
+    private void _resetNew(boolean computeNumber) {
+        if (computeNumber) {
+            _resetNewCount();
+        }
         mNewDids = new LinkedList<>(mCol.getDecks().active());
         mNewQueue.clear();
-        _updateNewCardRatio();
+        if (computeNumber) {
+            _updateNewCardRatio();
+        }
     }
 
 
@@ -765,8 +778,14 @@ public class SchedV2 extends AbstractSched {
 
 
     protected void _resetLrn() {
+        _resetLrn(true);
+    }
+
+    protected void _resetLrn(boolean computeNumber) {
         _updateLrnCutoff(true);
-        _resetLrnCount();
+        if (computeNumber) {
+            _resetLrnCount();
+        }
         mLrnQueue.clear();
         mLrnDayQueue.clear();
         mLrnDids = mCol.getDecks().active();
@@ -1233,7 +1252,13 @@ public class SchedV2 extends AbstractSched {
 
 
     protected void _resetRev() {
-        _resetRevCount();
+        _resetRev(true);
+    }
+
+    protected void _resetRev(boolean computeNumber) {
+        if (computeNumber) {
+            _resetRevCount();
+        }
         mRevQueue.clear();
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -1972,6 +1972,17 @@ public class SchedV2 extends AbstractSched {
     }
 
 
+    /** true if there are cards in learning, from today due today (not necessarily immediately) */
+    /* We ignore cards from previous days and previews, because they
+     * would have been found by _resetLrnCount. Not in upstream anki;
+     * here for speed efficiency. */
+    public boolean lrnDueFromToday() {
+        return mCol.getDb().queryScalar(
+                "SELECT 1 FROM cards WHERE did IN " + _deckLimit()
+                + " AND queue = " + Consts.QUEUE_TYPE_LRN + " LIMIT 1") != 0;
+    }
+
+
     /** true if there are any new cards due. */
     public boolean newDue() {
         return mCol.getDb().queryScalar("SELECT 1 FROM cards WHERE did IN " + _deckLimit() + " AND queue = " + Consts.QUEUE_TYPE_NEW + " LIMIT 1") != 0;


### PR DESCRIPTION
This is the most complex PR I ever did on ankidroid. I expect it to require a lot of discussion and probably change before potentially being accepted in an alpha version. All of those changes are strongly related, I don't see a way to make multiple pull request. I hope that at least, the multiple commits will allow you to see that each change make sens by itself.

# Instead of resetting, planify resetting

There are a few things which are still slow in ankidroid with a big collection. One of those is "resetting" the scheduler. Which is done far too often, even when it is actually useless. So I improved the resetting process a lot while keeping it almost identical to what it is in upstream anki.

Resetting the scheduler has two effects:
* Computing the number of cards due in the currently selected deck (and it's subdecks). Three numbers, new, review and learning cards.
* emptying all cards queues (review, learn, new) so that when the reviewer request a card, we don't use the cached value
* emptying the list of subdecks without new/review cards to see today.

The last point needs a little bit of explanation. In order to get a new card for the reviewer, Anki recalls the set of subdecks which have no more new/review card to see today; so that it keeps looking for cards in decks which potentially have new/review cards. More precisely, it recalls the list of decks which potentially have new/review cards for today, and when this subdeck is found to be empty, the subdeck is removed from the list. Resetting put all subdecks (selected decks) as decks which potentially have new cards.

So, resetting is actually useful only in two situations: if we need to know the number of cards due, or if we need to get a card to review. In all other situation, we don't actually need to reset, we only need to note "the scheduler needs to reset before the next time we need to take a card". And that's great, there is already a boolean variable in the scheduler which contains this information.
So I changed most call from `reset` to `planifyReset`, which simply will indicate that reset should be done.

# Compute only the numbers required
The number of cards due is required only in two cases. To display them to users, and to check whether there are cards in learning which are not due yet but will be due later. The second case does not need a full reset, it only need to consider cards in learning. So I added a method which consider cards in learning, and I used it instead of a full resetting, in order to win time. The change only occurs when a deck has no more cards due, but have some cards in learning for today and not yet due.

# Resetting as a background task.
Since resetting is a task which may take multiple seconds, I created a background task to do it. 

# Getting the first card without computing the number of cards
In order to display the first card in the reviewer, I don't actually need to know the number of cards that will be seen today in the selected deck. So I ensured that, when reset is due, `getCard` do only the minimal amount of work in reset, then returns the card, then do a full reset in background.

The only difference here is that, since numbers are not yet known, if the user selected to mix new cards and review, they may see the wrong type of cards first, with a review shown while a new card should have been shown or reciprocally. The problem will only occur for the first card reviewed after the selection. I believe it's not an actual problem; the review/new card will still be mixed, it's only that the first card of the mix is different.

# Number of cards to review as a background task
Computing the number of cards to review is a long process, since it suppose going through all decks and checking what is the limit for it, taking into account the number of cards seen, the number of cards in the deck, parents and children...

The reviewer delayed showing the first cards by a few seconds because it was taking time to compute this number. By moving this task to background, I ensured that the card is shown sooner. The downside of this is that the numbers are not shown immediately, and appears after one second or so in the reviewer. 

Note that it seems that the reviewer does not load it's content until `updateScreenCounts` has been called. So I call it once when I don't have the correct numbers, and then again with the correct numbers. In the first call, I would expect it to leave the three numbers to be empty string; but instead it seems that it keeps displaying the numbers of cards of the previous deck reviewed (during a second or less) before showing the correct number of cards. I don't understand why, but it may be something I didn't understood about SpannableString.

# Other changes

Finally, I also did a lot of small change, such as creating a noOpTask, which simply does nothing before and after executing the background task. This is essentially what a lot of task does, except that they Timber instead of really doing nothing. I added some comments, cleaned a little bit of code that I was touching.

# Test
This was tested by running the program on my phone, using it, and also by looking at the profiler and seeing that I was finally able to see a card while resetting was still processing.

# TODO:
This could be improved even more in the following way
* if I was allowed to differ slightly more from upstream anki, I could use the data saved while looking for the first card to avoid doing a complete reset. (But this is not actually a problem; since the reset is done while the user is reading/answering the first card. So I have not seen any slow down here)
* if there was mulitple asynchronous task. It should be noted that AsyncTask is deprecated according to java, and should not be used anyway for long task (i.e. multiple seconds), so that's really something that ideally should be changed. This was actually a real problem, because I wanted to start an asynchronous task from another one and wait until a semaphore of the second task tells the first one that some value where computed. That didn't work, since the second task never started, since the executor was waiting for the first task to ends. 