### PR TITLE
Allow optional disable of jacocoDebug

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -48,7 +48,17 @@ android {
             debuggable true
             // Check Crash Reports page on developer wiki for info on ACRA testing
             buildConfigField "String", "ACRA_URL", '"https://918f7f55-f238-436c-b34f-c8b5f1331fe5-bluemix.cloudant.com/acra-ankidroid/_design/acra-storage/_update/report"'
-            testCoverageEnabled true
+
+            // #6009 Allow optional disabling of JaCoCo for general build (assembleDebug).
+            // jacocoDebug task was slow, hung, and wasn't required unless I wanted coverage
+            if (project.rootProject.file('local.properties').exists()) {
+                Properties localProperties = new Properties()
+                localProperties.load(project.rootProject.file('local.properties').newDataInputStream())
+                testCoverageEnabled localProperties['enable_coverage'] != "false"
+            } else {
+                testCoverageEnabled true
+            }
+
         }
         release {
             minifyEnabled true


### PR DESCRIPTION
## Purpose / Description

Task often hung on machine inside Android Studio. I couldn't replicate by commandline. It was previously only sometimes annoying, but it must have added an hour to yesterday's testing overhead.

BUT: There was no need for it if I was just deploying to my Android, and I don't run tests for coverage yet.

## Fixes
Fixes #6009

## Approach
I can set a variable in `local.properties`, this felt cleaner architecturally than an environment variable, but the code's not too nice.

## How Has This Been Tested?

Tested with and without variable set via `println`

false - false
true - true
truu - ture
[unset] - true

## Learning (optional, can help others)

https://stackoverflow.com/questions/21999829/how-do-i-read-properties-defined-in-local-properties-in-build-gradle

[The hidden cost of code coverage](https://jeroenmols.com/blog/2016/09/01/coveragecost/)

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code