### PR TITLE
Remove full reset in syncer

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.java
@@ -378,7 +378,6 @@ public class Syncer {
             if (found) {
                 mCol.getModels().save();
             }
-            mCol.getSched().reset();
             // check for missing parent decks
             mCol.getSched().deckDueList();
             // return summary of deck


### PR DESCRIPTION
The only ponit of this reset was to compute the count. Given that the
count is done again in recalculateCounts, this became useless


I tested it by syncing my collection after putting it in my merge branch