### PR TITLE
load next card in background

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -592,6 +592,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
                 // If the card is null means that there are no more cards scheduled for review.
                 mNoMoreCards = true; // other handlers use this, toggle state every time through
             } else {
+                CollectionTask.launchCollectionTask(PRE_LOAD_CARD);
                 mNoMoreCards = false; // other handlers use this, toggle state every time through
                 // Start reviewing next card
                 updateTypeAnswerInfo();

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -121,6 +121,7 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
         FIND_EMPTY_CARDS,
         CHECK_CARD_SELECTION,
         LOAD_COLLECTION_COMPLETE,
+        PRE_LOAD_CARD,
     }
 
     /**
@@ -423,6 +424,10 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
 
             case LOAD_COLLECTION_COMPLETE:
                 doInBackgroundLoadCollectionComplete();
+                break;
+
+            case PRE_LOAD_CARD:
+                doInBackgroundPreLoadCard();
                 break;
 
             default:
@@ -1717,6 +1722,12 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
         if (col != null) {
             CollectionHelper.loadCollectionComplete(col);
         }
+    }
+
+    public void doInBackgroundPreLoadCard() {
+        Collection col = CollectionHelper.getInstance().getCol(mContext);
+        AbstractSched sched = col.getSched();
+        sched.loadNextCard(true);
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
@@ -418,4 +418,15 @@ public abstract class AbstractSched {
      */
     public abstract void setCurrentCard(@NonNull Card card);
     public abstract void discardCurrentCard();
+
+    /**
+       set mNextCard to the next card that should be reviewed. Fill
+       queue if required.
+       @param qa Whether to also pre-compute question and answer
+       @return The next card to be displayed.
+     */
+    public abstract Card loadNextCard(boolean qa);
+
+    @Nullable
+    public abstract Card getCurrentCard();
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -1682,4 +1682,9 @@ public class Sched extends SchedV2 {
     public void setContext(WeakReference<Activity> contextReference) {
         mContextReference = contextReference;
     }
+
+    @Nullable
+    public Card getCurrent() {
+        return mCurrentCard;
+    }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
@@ -211,6 +211,7 @@ public class RobolectricTest {
         if (getCol().addNote(n) == 0) {
             throw new IllegalStateException(String.format("Could not add note: {%s}", String.join(", ", fields)));
         }
+        getCol().reset();
         return n;
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/FinderTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/FinderTest.java
@@ -31,6 +31,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
 
 @RunWith(AndroidJUnit4.class)


### PR DESCRIPTION
Sometime, loading the next question takes more than a second. This PR simply precompute the next question (finding the card from the database, computing question and answer side), so that the next question can be loaded quickly. The next card is discarded as soon as there is a reason to do so (e.g. when reset() is done, when it's buried by a sibling.) 

This is of course done in background.

This was initially a part of the bug PR "reset in background", and then I relazied that it was actually a self-contained commit.

Note that the constant is 52 because I used constant 50 and 51 in other branch/PR. It's easier for me to keep this number, this will ensure that I have less merge problem when multiple PR are accepted. Historically, it seems it did happens quite often in the past weeks, since I concentrate on one part of the code specially.

I want to emphasize that, with this PR, even with complex card type, I see no lag at all between two cards, and that's extremely nice. Alas the time is still long enough for the buttons to flicker. 


I ensured that the difference with upstream anki is as small as possible. I could of course pre load the value in the reviewer directly, so that there is literally no difference in the scheduler, but I believe that this would make the code less clear. In particular because the nice thing with the code as it is right now is that, even if the card is removed from it's queue, the count remains correct. This would not be the case if the scheduler had really sent the card to the reviewer