### PR TITLE
simplifying counts

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -42,6 +42,7 @@ import com.ichi2.utils.JSONArray;
 import com.ichi2.utils.JSONException;
 import com.ichi2.utils.JSONObject;
 
+
 import java.lang.ref.WeakReference;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
@@ -55,6 +56,7 @@ import java.util.ListIterator;
 import java.util.Locale;
 import java.util.Random;
 
+import androidx.annotation.NonNull;
 import timber.log.Timber;
 
 @SuppressWarnings({"PMD.ExcessiveClassLength", "PMD.AvoidThrowingRawExceptionTypes","PMD.AvoidReassigningParameters",
@@ -136,21 +138,13 @@ public class Sched extends SchedV2 {
 
 
     @Override
-    public int[] counts() {
-        return counts(null);
-    }
-
-
-    @Override
-    public int[] counts(Card card) {
-        int[] counts = {mNewCount, mLrnCount, mRevCount};
-        if (card != null) {
-            int idx = countIdx(card);
-            if (idx == 1) {
-                counts[1] += card.getLeft() / 1000;
-            } else {
-                counts[idx] += 1;
-            }
+    public int[] counts(@NonNull Card card) {
+        int[] counts = counts();
+        int idx = countIdx(card);
+        if (idx == 1) {
+            counts[1] += card.getLeft() / 1000;
+        } else {
+            counts[idx] += 1;
         }
         return counts;
     }
@@ -159,7 +153,7 @@ public class Sched extends SchedV2 {
     @Override
     public int countIdx(Card card) {
         if (card.getQueue() == Consts.QUEUE_TYPE_DAY_LEARN_RELEARN) {
-            return 1;
+            return Consts.QUEUE_TYPE_LRN;
         }
         return card.getQueue();
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -20,6 +20,7 @@
 package com.ichi2.libanki.sched;
 
 import android.app.Activity;
+
 import android.content.Context;
 import android.database.Cursor;
 import android.database.SQLException;
@@ -58,6 +59,7 @@ import java.util.ListIterator;
 import java.util.Locale;
 import java.util.Random;
 
+import androidx.annotation.NonNull;
 import timber.log.Timber;
 
 @SuppressWarnings({"PMD.ExcessiveClassLength", "PMD.AvoidThrowingRawExceptionTypes","PMD.AvoidReassigningParameters",
@@ -222,16 +224,14 @@ public class SchedV2 extends AbstractSched {
 
 
     public int[] counts() {
-        return counts(null);
+        return new int[] {mNewCount, mLrnCount, mRevCount};
     }
 
 
-    public int[] counts(Card card) {
-        int[] counts = {mNewCount, mLrnCount, mRevCount};
-        if (card != null) {
-            int idx = countIdx(card);
-            counts[idx] += 1;
-        }
+    public int[] counts(@NonNull Card card) {
+        int[] counts = counts();
+        int idx = countIdx(card);
+        counts[idx] += 1;
         return counts;
     }
 


### PR DESCRIPTION
I did check that `counts(Card)` is called in a single place, and after cheching that card is not null.

This allows to simplify the code slightly. I believe that it is still a correct way to port upstream, when we take into consideration how java and python differs.

This is still done in order to simplify the "reset" PR, and moving it into simpler PR