### PR TITLE
NF: Extract DiscardChangesDialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
@@ -38,9 +38,9 @@ import android.view.ViewGroup;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.EditText;
 
-import com.afollestad.materialdialogs.MaterialDialog;
 import com.ichi2.anim.ActivityTransitionAnimation;
 import com.ichi2.anki.dialogs.ConfirmationDialog;
+import com.ichi2.anki.dialogs.DiscardChangesDialog;
 import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.async.CollectionTask;
 import com.ichi2.libanki.Card;
@@ -254,10 +254,7 @@ public class CardTemplateEditor extends AnkiActivity {
     }
 
     private void showDiscardChangesDialog() {
-        new MaterialDialog.Builder(this)
-                .content(R.string.discard_unsaved_changes)
-                .positiveText(R.string.dialog_ok)
-                .negativeText(R.string.dialog_cancel)
+        DiscardChangesDialog.getDefault(this)
                 .onPositive((dialog, which) -> {
                     Timber.i("TemplateEditor:: OK button pressed to confirm discard changes");
                     getCol().getModels().update(CardTemplateEditor.this.mModelBackup);
@@ -265,7 +262,8 @@ public class CardTemplateEditor extends AnkiActivity {
                     getCol().reset();
                     finishWithAnimation(ActivityTransitionAnimation.RIGHT);
                 })
-                .build().show();
+                .build()
+                .show();
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -55,6 +55,7 @@ import android.widget.TextView;
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.ichi2.anim.ActivityTransitionAnimation;
 import com.ichi2.anki.dialogs.ConfirmationDialog;
+import com.ichi2.anki.dialogs.DiscardChangesDialog;
 import com.ichi2.anki.dialogs.TagsDialog;
 import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.anki.multimediacard.IMultimediaEditableNote;
@@ -914,10 +915,7 @@ public class NoteEditor extends AnkiActivity {
 
 
     private void showDiscardChangesDialog() {
-        new MaterialDialog.Builder(this)
-                .content(R.string.discard_unsaved_changes)
-                .positiveText(R.string.dialog_ok)
-                .negativeText(R.string.dialog_cancel)
+        DiscardChangesDialog.getDefault(this)
                 .onPositive((dialog, which) -> {
                     Timber.i("NoteEditor:: OK button pressed to confirm discard changes");
                     closeNoteEditor();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DiscardChangesDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DiscardChangesDialog.java
@@ -1,0 +1,32 @@
+/*
+ Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.dialogs;
+
+import android.content.Context;
+
+import com.afollestad.materialdialogs.MaterialDialog;
+import com.ichi2.anki.R;
+
+public class DiscardChangesDialog {
+
+    public static MaterialDialog.Builder getDefault(Context context) {
+        return new MaterialDialog.Builder(context)
+                .content(R.string.discard_unsaved_changes)
+                .positiveText(R.string.dialog_ok)
+                .negativeText(R.string.dialog_cancel);
+    }
+}


### PR DESCRIPTION
To be used in the visual editor, just cherry picking off a smaller safe change

----

Note: Could the following wording:  

`Close and lose current input?` be changed to read "Close and lose unsaved changes"? Current input on the template editor implies the whole template to me.