### PR TITLE
handleDeckSelection uses a function for cards in learning instead of reset

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -2051,9 +2051,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
             }
             return;
         }
-        getCol().getSched().reset();
-        int[] studyOptionsCounts = getCol().getSched().counts();
-        if (studyOptionsCounts[0] + studyOptionsCounts[1] + studyOptionsCounts[2] > 0) {
+        if (getCol().getSched().hasCardsTodayAfterStudyAheadLimit()) {
             // If there are cards due that can't be studied yet (due to the learn ahead limit) then go to study options
             openStudyOptions(false);
         } else if (getCol().getSched().newDue() || getCol().getSched().revDue()) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
@@ -73,6 +73,9 @@ public abstract class AbstractSched {
     public abstract boolean revDue();
     /** true if there are any new cards due. */
     public abstract boolean newDue();
+    /** true if there are cards in learning, with review due the same
+     * day, in the selected decks. */
+    public abstract boolean hasCardsTodayAfterStudyAheadLimit();
     public abstract boolean haveBuried();
     /**
      * Return the next interval for a card and ease as a string.

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -1952,6 +1952,20 @@ public class SchedV2 extends AbstractSched {
     }
 
 
+    /** true if there are cards in learning, with review due the same
+     * day, in the selected decks. */
+    /* not in upstream anki. As revDue and newDue, it's used to check
+     * what to do when a deck is selected in deck picker. When this
+     * method is called, we already know that no cards is due
+     * immedietly. It answers whether cards will be due later in the
+     * same deck. */
+    public boolean hasCardsTodayAfterStudyAheadLimit() {
+        return mCol.getDb().queryScalar(
+                "SELECT 1 FROM cards WHERE did IN " + _deckLimit()
+                + " AND queue = " + Consts.QUEUE_TYPE_LRN + " LIMIT 1") != 0;
+    }
+
+
     /** true if there are any new cards due. */
     public boolean newDue() {
         return mCol.getDb().queryScalar("SELECT 1 FROM cards WHERE did IN " + _deckLimit() + " AND queue = " + Consts.QUEUE_TYPE_NEW + " LIMIT 1") != 0;


### PR DESCRIPTION
When there are no card to review immediately in a deck, a full reset was done (uselessly) just to check whether there are cards in learning due later today. I introduce a method which simply check whether there are cards in learning due the same day. This means that it gets quicker to decide what to do in this case.

Note that this method is not in upstream. Mostly because upstream always open the reviewer, and just close it if there is nothing to review. Since we do thing very differently anyway, at least, let's do them quickly.