### PR TITLE
Removing `sHadCardQueue`

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -443,7 +443,7 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
                         // reload qa-cache
                         newCard.q(true);
                     } else {
-                        newCard = getCard(sched);
+                        newCard = sched.getCard();
                     }
                     publishProgress(new TaskData(newCard));
                 } else {
@@ -509,7 +509,7 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
                     Timber.i("Answering card %d", oldCard.getId());
                     sched.answerCard(oldCard, ease);
                 }
-                newCard = getCard(sched);
+                newCard = sched.getCard();
                 if (newCard != null) {
                     // render cards before locking database
                     newCard._getQA(true);
@@ -525,11 +525,6 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
             return new TaskData(false);
         }
         return new TaskData(true);
-    }
-
-
-    private Card getCard(AbstractSched sched) {
-        return sched.getCard();
     }
 
 
@@ -618,7 +613,7 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
                     }
                 }
                 // With sHadCardQueue set, getCard() resets the scheduler prior to getting the next card
-                publishProgress(new TaskData(getCard(col.getSched()), 0));
+                publishProgress(new TaskData(col.getSched().getCard(), 0));
                 col.getDb().getDatabase().setTransactionSuccessful();
             } finally {
                 col.getDb().getDatabase().endTransaction();
@@ -816,7 +811,7 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
                         }
                         // In all cases schedule a new card so Reviewer doesn't sit on the old one
                         col.reset();
-                        publishProgress(new TaskData(getCard(sched), 0));
+                        publishProgress(new TaskData(sched.getCard(), 0));
                         break;
                     }
                 }
@@ -868,7 +863,7 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
                     sched.deferReset();
                 } else if (cid != -1){
                     col.reset();
-                    newCard = getCard(sched);
+                    newCard = sched.getCard();
                 }
                 // TODO: handle leech undoing properly
                 publishProgress(new TaskData(newCard, 0));

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
@@ -20,6 +20,8 @@ public abstract class AbstractSched {
      */
     public abstract Card getCard();
     public abstract void reset();
+    /** Ensures that reset is executed before the next card is selected */
+    public abstract void deferReset();
     public abstract void answerCard(Card card, int ease);
     public abstract int[] counts();
     public abstract int[] counts(Card card);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -145,6 +145,10 @@ public class SchedV2 extends AbstractSched {
         return card;
     }
 
+    /** Ensures that reset is executed before the next card is selected */
+    public void deferReset(){
+        mHaveQueues = false;
+    }
 
     public void reset() {
         _updateCutoff();


### PR DESCRIPTION
The variable `sHadCardQueue` was not commented, or documented, and made little sens in the first place since it could be set in a background called and used in another one. That is, the only reason for it to work was that all (but one) call to scheduler's `getCard` went through the CollectionTask. 

So putting instead this variable directly in the scheduler makes far more sens as far as semantic goes. Even better, this variable was already in the scheduler, so we just needed to use it instead of having two redundant variables !


This is, of course, a not subtle way to justify the introduction of `deferReset` in the codebase. (note that I followed your's name advice)