### PR TITLE
Scheduler's list are empty instead of null at start

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -76,7 +76,7 @@ public class Sched extends SchedV2 {
     private double[] mEtaCache = new double[] { -1, -1, -1, -1, -1, -1 };
 
     // Queues
-    private LinkedList<Long> mRevDids;
+    private LinkedList<Long> mRevDids = new LinkedList<>();
 
     /**
      * queue types: 0=new/cram, 1=lrn, 2=rev, 3=day lrn, -1=suspended, -2=buried

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -97,8 +97,8 @@ public class SchedV2 extends AbstractSched {
     protected final LinkedList<Long> mLrnDayQueue = new LinkedList<>();
     protected final LinkedList<Long> mRevQueue = new LinkedList<>();
 
-    private LinkedList<Long> mNewDids;
-    protected LinkedList<Long> mLrnDids;
+    private LinkedList<Long> mNewDids = new LinkedList<>();
+    protected LinkedList<Long> mLrnDids = new LinkedList<>();
 
     // Not in libanki
     protected WeakReference<Activity> mContextReference;


### PR DESCRIPTION
There were NullPointerExceptions in https://github.com/ankidroid/Anki-Android/pull/6026 which were due to the fact that the list was found to be null instead of empty. Empty list can be dealt with easily; but .isEmpty on a null pointer is a bad idea.

So this PR will ensure that this does not occur again in future improvement. (Or I could also test whether those value are null everywhere, but i don't think it would be really interesting to do)