### PR TITLE
Get first card quicker during reviews

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.java
@@ -26,6 +26,8 @@ import android.content.ContentValues;
 import android.database.Cursor;
 import android.net.Uri;
 import androidx.test.rule.GrantPermissionRule;
+import timber.log.Timber;
+
 import android.util.Log;
 
 import com.ichi2.anki.AbstractFlashcardViewer;
@@ -33,6 +35,7 @@ import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.CollectionHelper;
 import com.ichi2.anki.FlashCardsContract;
 import com.ichi2.anki.exception.ConfirmModSchemaException;
+import com.ichi2.async.CollectionTask;
 import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Consts;
@@ -791,6 +794,8 @@ public class ContentProviderTest extends InstrumentedTest {
             col.reset();
             nextCard = sched.getCard();
             if(nextCard.note().getId() == noteID && nextCard.getOrd() == cardOrd)break;
+            CollectionTask.waitToFinish();
+
         }
         assertNotNull("Check that there actually is a next scheduled card", nextCard);
         assertEquals("Check that received card and actual card have same note id", nextCard.note().getId(), noteID);
@@ -802,7 +807,7 @@ public class ContentProviderTest extends InstrumentedTest {
      * Test that query for the next card in the schedule returns a valid result WITH a deck selector
      */
     @Test
-    public void testQueryCardFromCertainDeck(){
+    public synchronized void testQueryCardFromCertainDeck(){
         long deckToTest = mTestDeckIds.get(0);
         String deckSelector = "deckID=?";
         String[] deckArguments = {Long.toString(deckToTest)};
@@ -827,6 +832,7 @@ public class ContentProviderTest extends InstrumentedTest {
                 col.reset();
                 nextCard = sched.getCard();
                 if(nextCard.note().getId() == noteID && nextCard.getOrd() == cardOrd)break;
+                try { Thread.sleep(500); } catch (Exception e) { Timber.e(e); } // Reset counts is executed in background.
             }
             assertNotNull("Check that there actually is a next scheduled card", nextCard);
             assertEquals("Check that received card and actual card have same note id", nextCard.note().getId(), noteID);

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.java
@@ -793,6 +793,7 @@ public class ContentProviderTest extends InstrumentedTest {
         for(int i = 0; i < 10; i++) {//minimizing fails, when sched.reset() randomly chooses between multiple cards
             col.reset();
             nextCard = sched.getCard();
+            CollectionTask.waitToFinish();
             if(nextCard.note().getId() == noteID && nextCard.getOrd() == cardOrd)break;
             CollectionTask.waitToFinish();
 

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -130,7 +130,8 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
         FIND_EMPTY_CARDS,
         CHECK_CARD_SELECTION,
         LOAD_COLLECTION_COMPLETE,
-        PRELOAD_NEXT_CARD
+        PRELOAD_NEXT_CARD,
+        RESET,
     }
 
     /**
@@ -486,6 +487,10 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
 
             case PRELOAD_NEXT_CARD:
                 doInBackgroundPreloadNextCard();
+                break;
+
+            case RESET:
+                doInBackgroundReset();
                 break;
 
             default:
@@ -1926,6 +1931,10 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
         if (col != null) {
             CollectionHelper.loadCollectionComplete(col);
         }
+    }
+
+    public void doInBackgroundReset() {
+        getCol().getSched().reset();
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
@@ -50,9 +50,12 @@ public abstract class AbstractSched {
      */
     public abstract @Nullable Card getCard();
 
-    /** Let the scheduler knows that the selected deck potentially changed and all pre-computed data (queue and counts)
-     * should be discarded. Should be called after getCard if the card is not answered. */
-    protected abstract void reset();
+    /**
+     * The collection saves some numbers such as counts, queues of cards to review, queues of decks potentially having some cards.
+     * Reset all of this and compute from scratch. This occurs because anything else than the sequence of getCard/answerCard did occur.
+     */
+    // Should ideally be protected. It's public only because CollectionTask should call it when the scheduler planned this task
+    public abstract void reset();
 
     /** Check whether we are a new day, and update if so. */
     public abstract void _updateCutoff();

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
@@ -442,11 +442,6 @@ public abstract class AbstractSched {
     public abstract void setContext(@Nullable WeakReference<Activity> contextReference);
 
     /**
-     * @return The counts, after having reseted them
-     */
-    public abstract @NonNull int[] recalculateCounts();
-
-    /**
      * Change the maximal number shown in counts.
      * @param reportLimit A maximal number of cards added in the queue at once.
      */

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -258,7 +258,7 @@ public class Sched extends SchedV2 {
     @Override
     protected @Nullable Card _getCard() {
         // learning card due?
-        @Nullable Card c = _getLrnCard();
+        @Nullable Card c = _getLrnCard(false);
         if (c != null) {
             return c;
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -348,7 +348,7 @@ public class Sched extends SchedV2 {
     // sub-day learning
     @Override
     protected boolean _fillLrn() {
-        if (mLrnCount == 0) {
+        if (mHaveCounts && mLrnCount == 0) {
             return false;
         }
         if (!mLrnQueue.isEmpty()) {
@@ -672,7 +672,7 @@ public class Sched extends SchedV2 {
         if (!mRevQueue.isEmpty()) {
             return true;
         }
-        if (mRevCount == 0) {
+        if (mHaveCounts && mRevCount == 0) {
             return false;
         }
         while (!mRevDids.isEmpty()) {
@@ -722,11 +722,14 @@ public class Sched extends SchedV2 {
             // nothing left in the deck; move to next
             mRevDids.remove();
         }
-        // Since we didn't get a card and the count is non-zero, we
-        // need to check again for any cards that were removed from
-        // the queue but not buried
-        _resetRev();
-        return _fillRev(true);
+        if (mHaveCounts && mRevCount != 0) {
+            // if we didn't get a card but the count is non-zero,
+            // we need to check again for any cards that were
+            // removed from the queue but not buried
+            _resetRev();
+            return _fillRev(true);
+        }
+        return false;
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -783,7 +783,7 @@ public class SchedV2 extends AbstractSched {
         if (!mNewQueue.isEmpty()) {
             return true;
         }
-        if (mNewCount == 0) {
+        if (mHaveCounts && mNewCount == 0) {
             return false;
         }
         while (!mNewDids.isEmpty()) {
@@ -818,11 +818,14 @@ public class SchedV2 extends AbstractSched {
             // nothing left in the deck; move to next
             mNewDids.remove();
         }
-        // if we didn't get a card, since the count is non-zero, we
-        // need to check again for any cards that were removed
-        // from the queue but not buried
-        _resetNew();
-        return _fillNew(true);
+        if (mHaveCounts && mNewCount != 0) {
+            // if we didn't get a card but the count is non-zero,
+            // we need to check again for any cards that were
+            // removed from the queue but not buried
+            _resetNew();
+            return _fillNew(true);
+        }
+        return false;
     }
 
 
@@ -854,7 +857,7 @@ public class SchedV2 extends AbstractSched {
      * @return True if it's time to display a new card when distributing.
      */
     protected boolean _timeForNewCard() {
-        if (mNewCount == 0) {
+        if (mHaveCounts && mNewCount == 0) {
             return false;
         }
         @Consts.NEW_CARD_ORDER int spread = mCol.getConf().getInt("newSpread");
@@ -863,6 +866,8 @@ public class SchedV2 extends AbstractSched {
         } else if (spread == Consts.NEW_CARDS_FIRST) {
             return true;
         } else if (mNewCardModulus != 0) {
+            // if the counter has not yet been resetted, this value is
+            // random. This will occur only for the first card of review.
             return (mReps != 0 && (mReps % mNewCardModulus == 0));
         } else {
             return false;
@@ -1001,7 +1006,7 @@ public class SchedV2 extends AbstractSched {
     // sub-day learning
     // Overridden: a single kind of queue in V1
     protected boolean _fillLrn() {
-        if (mLrnCount == 0) {
+        if (mHaveCounts && mLrnCount == 0) {
             return false;
         }
         if (!mLrnQueue.isEmpty()) {
@@ -1064,7 +1069,7 @@ public class SchedV2 extends AbstractSched {
 
     // daily learning
     protected boolean _fillLrnDay() {
-        if (mLrnCount == 0) {
+        if (mHaveCounts && mLrnCount == 0) {
             return false;
         }
         if (!mLrnDayQueue.isEmpty()) {
@@ -1523,7 +1528,7 @@ public class SchedV2 extends AbstractSched {
         if (!mRevQueue.isEmpty()) {
             return true;
         }
-        if (mRevCount == 0) {
+        if (mHaveCounts && mRevCount == 0) {
             return false;
         }
         int lim = Math.min(mQueueLimit, _currentRevLimit(true));
@@ -1557,11 +1562,14 @@ public class SchedV2 extends AbstractSched {
                 return true;
             }
         }
-        // since we didn't get a card and the count is non-zero, we
-        // need to check again for any cards that were removed from
-        // the queue but not buried
-        _resetRev();
-        return _fillRev(true);
+        if (mHaveCounts && mRevCount != 0) {
+            // if we didn't get a card but the count is non-zero,
+            // we need to check again for any cards that were
+            // removed from the queue but not buried
+            _resetRev();
+            return _fillRev(true);
+        }
+        return false;
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -616,7 +616,7 @@ public class SchedV2 extends AbstractSched {
      */
     protected @Nullable Card _getCard() {
         // learning card due?
-        @Nullable Card c = _getLrnCard();
+        @Nullable Card c = _getLrnCard(false);
         if (c != null) {
             return c;
         }
@@ -1028,11 +1028,6 @@ public class SchedV2 extends AbstractSched {
             mLrnQueue.sort();
             return !mLrnQueue.isEmpty();
         }
-    }
-
-
-    protected @Nullable Card _getLrnCard() {
-        return _getLrnCard(false);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -33,6 +33,7 @@ import android.util.Pair;
 
 import com.ichi2.anki.R;
 import com.ichi2.async.CancelListener;
+import com.ichi2.async.CollectionTask;
 import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Consts;
@@ -2993,14 +2994,6 @@ public class SchedV2 extends AbstractSched {
     }
 
     /** not in libAnki. Added due to #5666: inconsistent selected deck card counts on sync */
-    @Override
-    public @NonNull int[] recalculateCounts() {
-        _resetLrnCount();
-        _resetNewCount();
-        _resetRevCount();
-        return new int[] { mNewCount, mLrnCount, mRevCount };
-    }
-
     @Override
     public void setReportLimit(int reportLimit) {
         this.mReportLimit = reportLimit;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -69,6 +69,7 @@ import static com.ichi2.libanki.sched.AbstractSched.UnburyType.*;
 import static com.ichi2.libanki.sched.Counts.Queue.*;
 import static com.ichi2.libanki.sched.Counts.Queue;
 import static com.ichi2.libanki.stats.Stats.SECONDS_PER_DAY;
+import static com.ichi2.async.CollectionTask.TASK_TYPE.*;
 
 @SuppressWarnings({"PMD.ExcessiveClassLength", "PMD.AvoidThrowingRawExceptionTypes","PMD.AvoidReassigningParameters",
                     "PMD.NPathComplexity","PMD.MethodNamingConventions","PMD.AvoidBranchingStatementAsLastInLoop",
@@ -159,14 +160,17 @@ public class SchedV2 extends AbstractSched {
      */
     public @Nullable Card getCard() {
         _checkDay();
-        // check day deal with cutoff if required. No need to do it in resets
-        if (!mHaveCounts) {
-            resetCounts(false);
-        }
         if (!mHaveQueues) {
             resetQueues(false);
         }
         @Nullable Card card = _getCard();
+        if (card == null && !mHaveCounts) {
+            // maybe we didn't refill queues because counts were not
+            // set. This could only occur if the only card is a buried
+            // sibling. So let's try to set counts and check again.
+            reset();
+            card = _getCard();
+        }
         if (card != null) {
             mCol.log(card);
             incrReps();
@@ -181,6 +185,10 @@ public class SchedV2 extends AbstractSched {
             card.startTimer();
         } else {
             discardCurrentCard();
+        }
+        if (!mHaveCounts) {
+            // Need to reset queues once counts are reset
+            CollectionTask.launchCollectionTask(RESET);
         }
         return card;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -198,7 +198,7 @@ public class SchedV2 extends AbstractSched {
         discardCurrentCard();
     }
 
-    protected void reset() {
+    public void reset() {
         _updateCutoff();
         resetCounts(false);
         resetQueues(false);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.java
@@ -36,6 +36,7 @@ import com.ichi2.libanki.Utils;
 
 import com.ichi2.libanki.Deck;
 import com.ichi2.libanki.DeckConfig;
+import com.ichi2.libanki.sched.Counts;
 import com.ichi2.utils.JSONArray;
 import com.ichi2.utils.JSONException;
 import com.ichi2.utils.JSONObject;
@@ -414,9 +415,11 @@ public class Syncer {
             //#5666 - not in libAnki
             //We modified mReportLimit inside the scheduler, and this causes issues syncing dynamic decks.
             AbstractSched syncScheduler = mCol.createScheduler(SYNC_SCHEDULER_REPORT_LIMIT);
-            for (int c : syncScheduler.recalculateCounts()) {
-                counts.put(c);
-            }
+            syncScheduler.resetCounts();
+            Counts counts_ = syncScheduler.counts();
+            counts.put(counts_.getNew());
+            counts.put(counts_.getLrn());
+            counts.put(counts_.getRev());
             check.put(counts);
             check.put(mCol.getDb().queryScalar("SELECT count() FROM cards"));
             check.put(mCol.getDb().queryScalar("SELECT count() FROM notes"));

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
@@ -441,4 +441,10 @@ public class RobolectricTest {
         return activity;
     }
 
+    protected Card getCard() {
+        Card card = getCol().getSched().getCard();
+        advanceRobolectricLooperWithSleep();
+        return card;
+    }
+
 }

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/FinderTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/FinderTest.java
@@ -300,11 +300,11 @@ public class FinderTest extends RobolectricTest {
         if (!isNearCutoff(col)) {
             assertEquals(0, col.findCards("rated:1:1").size());
             assertEquals(0, col.findCards("rated:1:2").size());
-            c = col.getSched().getCard();
+            c = getCard();
             col.getSched().answerCard(c, 2);
             assertEquals(0, col.findCards("rated:1:1").size());
             assertEquals(1, col.findCards("rated:1:2").size());
-            c = col.getSched().getCard();
+            c = getCard();
             col.getSched().answerCard(c, 1);
             assertEquals(1, col.findCards("rated:1:1").size());
             assertEquals(1, col.findCards("rated:1:2").size());

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/AbstractSchedTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/AbstractSchedTest.java
@@ -44,7 +44,9 @@ import static com.ichi2.async.CollectionTask.TASK_TYPE.UNDO;
 import static com.ichi2.async.CollectionTask.nonTaskUndo;
 import static com.ichi2.testutils.AnkiAssert.assertDoesNotThrow;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -172,7 +174,13 @@ public class AbstractSchedTest extends RobolectricTest {
 
         for (int i = 0; i < nbNote; i++) {
             Card card = sched.getCard();
-            assertEquals(new Counts(nbNote * 2 - i, 0, 0), sched.counts(card));
+            Counts counts = sched.counts(card);
+            sched.setCurrentCard(card); // imitate what the reviewer does
+            assertThat(counts.getNew(), is(greaterThan(nbNote - i))); // Actual number of new card.
+            assertThat(counts.getNew(), is(lessThanOrEqualTo(nbNote * 2 - i))); // Maximal number potentially shown,
+            // because decrementing does not consider burying sibling
+            assertEquals(0, counts.getLrn());
+            assertEquals(0, counts.getRev());
             assertEquals(notes[i].firstCard().getId(), card.getId());
             assertEquals(Consts.QUEUE_TYPE_NEW, card.getQueue());
             sched.answerCard(card, sched.answerButtons(card));

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedTest.java
@@ -226,7 +226,7 @@ public class SchedTest extends RobolectricTest {
         col.reset();
         assertEquals(1, col.getSched().counts().getNew());
         // fetch it
-        Card c = col.getSched().getCard();
+        Card c = getCard();
         assertNotNull(c);
         assertEquals(QUEUE_TYPE_NEW, c.getQueue());
         assertEquals(CARD_TYPE_NEW, c.getType());
@@ -255,7 +255,7 @@ public class SchedTest extends RobolectricTest {
         // col.reset()
         // qs = ("2", "3", "2", "3")
         // for (int n = 0; n < 4; n++) {
-        //     c = col.getSched().getCard()
+        //     c = getCard()
         //     assertTrue(qs[n] in c.q())
         //     col.getSched().answerCard(c, 2)
         // }
@@ -283,7 +283,7 @@ public class SchedTest extends RobolectricTest {
         // both confs have defaulted to a limit of 20
         assertEquals("both confs have defaulted to a limit of 20", 20, col.getSched().counts().getNew());
         // first card we get comes from parent
-        Card c = col.getSched().getCard();
+        Card c = getCard();
         assertEquals(1, c.getDid());
         // limit the parent to 10 cards, meaning we get 10 in total
         DeckConfig conf1 = col.getDecks().confForDid(1);
@@ -307,7 +307,7 @@ public class SchedTest extends RobolectricTest {
         note.setItem("Front", "one");
         col.addNote(note);
         col.reset();
-        Card c = col.getSched().getCard();
+        Card c = getCard();
         DeckConfig conf = col.getSched()._cardConf(c);
         conf.getJSONObject("new").put("delays", new JSONArray(new double[] {1, 2, 3, 4, 5}));
         col.getDecks().save(conf);
@@ -331,7 +331,7 @@ public class SchedTest extends RobolectricTest {
         col.getDb().execute("update cards set queue=0, type=0");
         col.reset();
         // sched.getCard should return it, since it's due in the past
-        Card c = col.getSched().getCard();
+        Card c = getCard();
         assertNotNull(c);
         DeckConfig conf = col.getSched()._cardConf(c);
         conf.getJSONObject("new").put("delays", new JSONArray(new double[] {0.5, 3, 10}));
@@ -415,17 +415,17 @@ public class SchedTest extends RobolectricTest {
         col.getDb().execute("update cards set queue=0, type=0");
         col.reset();
         // should get '1' first
-        Card c = col.getSched().getCard();
+        Card c = getCard();
         assertTrue(c.q().endsWith("1"));
         // pass it so it's due in 10 minutes
         col.getSched().answerCard(c, 2);
         // get the other card
-        c = col.getSched().getCard();
+        c = getCard();
         assertTrue(c.q().endsWith("2"));
         // fail it so it's due in 1 minute
         col.getSched().answerCard(c, 1);
         // we shouldn't get the same card again
-        c = col.getSched().getCard();
+        c = getCard();
         assertFalse(c.q().endsWith("2"));
     }
 
@@ -438,7 +438,7 @@ public class SchedTest extends RobolectricTest {
         note.setItem("Front", "one");
         col.addNote(note);
         col.reset();
-        Card c = col.getSched().getCard();
+        Card c = getCard();
         DeckConfig conf = col.getSched()._cardConf(c);
         conf.getJSONObject("new").put("delays", new JSONArray(new double[] {1, 10, 1440, 2880}));
         col.getDecks().save(conf);
@@ -448,20 +448,20 @@ public class SchedTest extends RobolectricTest {
         assertEquals(3, c.getLeft() % 1000);
         assertEquals(1, c.getLeft() / 1000);
         assertEquals(new Counts(0, 1, 0), col.getSched().counts());
-        c = col.getSched().getCard();
+        c = getCard();
 
         assertEquals(SECONDS_PER_DAY, col.getSched().nextIvl(c, 2));
         // answering it will place it in queue 3
         col.getSched().answerCard(c, 2);
         assertEquals(col.getSched().getToday() + 1, c.getDue());
         assertEquals(QUEUE_TYPE_DAY_LEARN_RELEARN, c.getQueue());
-        assertNull(col.getSched().getCard());
+        assertNull(getCard());
         // for testing, move it back a day
         c.setDue(c.getDue() - 1);
         c.flush();
         col.reset();
         assertEquals(new Counts(0, 1, 0), col.getSched().counts());
-        c = col.getSched().getCard();
+        c = getCard();
         // nextIvl should work
         assertEquals(SECONDS_PER_DAY * 2, col.getSched().nextIvl(c, 2));
         // if we fail it, it should be back in the correct queue
@@ -469,7 +469,7 @@ public class SchedTest extends RobolectricTest {
         assertEquals(QUEUE_TYPE_LRN, c.getQueue());
         col.undo();
         col.reset();
-        c = col.getSched().getCard();
+        c = getCard();
         col.getSched().answerCard(c, 2);
         // simulate the passing of another two days
         c.setDue(c.getDue() - 2);
@@ -489,7 +489,7 @@ public class SchedTest extends RobolectricTest {
         conf = col.getSched()._cardConf(c);
         conf.getJSONObject("lapse").put("delays", new JSONArray(new double[] {1440}));
         col.getDecks().save(conf);
-        c = col.getSched().getCard();
+        c = getCard();
         col.getSched().answerCard(c, 1);
         assertEquals(CARD_TYPE_RELEARNING, c.getQueue());
         assertEquals(new Counts(0, 0, 0), col.getSched().counts());
@@ -628,7 +628,7 @@ public class SchedTest extends RobolectricTest {
           col.save();
           col.getSched().reset();
           assertEquals(new Counts(0, 2, 0), col.getSched().counts());
-          c = col.getSched().getCard();
+          c = getCard();
           col.getSched().answerCard(c, 3);
           // it should be due tomorrow
           assertEquals(col.getSched().getToday()+ 1, c.getDue());
@@ -678,7 +678,7 @@ public class SchedTest extends RobolectricTest {
         conf.getJSONObject("new").put("delays", new JSONArray(new double[] {0.5, 3, 10}));
         conf.getJSONObject("lapse").put("delays", new JSONArray(new double[] {1, 5, 9}));
         col.getDecks().save(conf);
-        Card c = col.getSched().getCard();
+        Card c = getCard();
         // new cards
         ////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -739,10 +739,10 @@ public class SchedTest extends RobolectricTest {
         // burying
         col.getSched().buryNote(c.getNid());
         col.reset();
-        assertNull(col.getSched().getCard());
+        assertNull(getCard());
         col.getSched().unburyCards();
         col.reset();
-        assertNotNull(col.getSched().getCard());
+        assertNotNull(getCard());
     }
 
 
@@ -755,14 +755,14 @@ public class SchedTest extends RobolectricTest {
         Card c = note.cards().get(0);
         // suspending
         col.reset();
-        assertNotNull(col.getSched().getCard());
+        assertNotNull(getCard());
         col.getSched().suspendCards(new long[] {c.getId()});
         col.reset();
-        assertNull(col.getSched().getCard());
+        assertNull(getCard());
         // unsuspending
         col.getSched().unsuspendCards(new long[] {c.getId()});
         col.reset();
-        assertNotNull(col.getSched().getCard());
+        assertNotNull(getCard());
         // should cope with rev cards being relearnt
         c.setDue(0);
         c.setIvl(100);
@@ -770,7 +770,7 @@ public class SchedTest extends RobolectricTest {
         c.setQueue(QUEUE_TYPE_REV);
         c.flush();
         col.reset();
-        c = col.getSched().getCard();
+        c = getCard();
         col.getSched().answerCard(c, 1);
         assertThat(c.getDue(), is(greaterThanOrEqualTo(col.getTime().intTime())));
         assertEquals(QUEUE_TYPE_LRN, c.getQueue());
@@ -824,7 +824,7 @@ public class SchedTest extends RobolectricTest {
         // and should appear in the counts
         assertEquals(new Counts(1, 0, 0), col.getSched().counts());
         // grab it and check estimates
-        c = col.getSched().getCard();
+        c = getCard();
         assertEquals(2, col.getSched().answerButtons(c));
         assertEquals(600, col.getSched().nextIvl(c, 1));
         assertEquals(138 * 60 * 60 * 24, col.getSched().nextIvl(c, 2));
@@ -849,7 +849,7 @@ public class SchedTest extends RobolectricTest {
         assertEquals(138 * 60 * 60 * 24, col.getSched().nextIvl(c, 2));
         assertEquals(138 * 60 * 60 * 24, col.getSched().nextIvl(c, 3));
         // when it graduates, due is updated
-        c = col.getSched().getCard();
+        c = getCard();
         col.getSched().answerCard(c, 2);
         assertEquals(138, c.getIvl());
         assertEquals(138, c.getDue());
@@ -859,7 +859,7 @@ public class SchedTest extends RobolectricTest {
         // cram the deck again
         col.getSched().rebuildDyn(did);
         col.reset();
-        c = col.getSched().getCard();
+        c = getCard();
         // check ivls again - passing should be idempotent
         assertEquals(60, col.getSched().nextIvl(c, 1));
         assertEquals(600, col.getSched().nextIvl(c, 2));
@@ -900,7 +900,7 @@ public class SchedTest extends RobolectricTest {
         c2.setDue(325);
         c2.flush();
         // should be able to answer it
-        c = col.getSched().getCard();
+        c = getCard();
         col.getSched().answerCard(c, 4);
         // it should have been moved back to the original deck
         assertEquals(1, c.getDid());
@@ -917,7 +917,7 @@ public class SchedTest extends RobolectricTest {
         long did = col.getDecks().newDyn("Cram");
         col.getSched().rebuildDyn(did);
         col.reset();
-        Card c = col.getSched().getCard();
+        Card c = getCard();
         col.getSched().answerCard(c, 2);
         // answering the card will put it in the learning queue
         assertEquals(QUEUE_TYPE_LRN, c.getQueue());
@@ -947,7 +947,7 @@ public class SchedTest extends RobolectricTest {
         col.getSched().rebuildDyn(did);
         col.reset();
         // graduate should return it to new
-        Card c = col.getSched().getCard();
+        Card c = getCard();
 
         assertEquals(60, col.getSched().nextIvl(c, 1));
         assertEquals(600, col.getSched().nextIvl(c, 2));
@@ -966,7 +966,7 @@ public class SchedTest extends RobolectricTest {
         Card cardcopy = c.clone();
         col.getSched().rebuildDyn(did);
         col.reset();
-        c = col.getSched().getCard();
+        c = getCard();
         assertEquals(600, col.getSched().nextIvl(c, 1));
         assertEquals(0, col.getSched().nextIvl(c, 2));
         assertEquals(0, col.getSched().nextIvl(c, 3));
@@ -978,7 +978,7 @@ public class SchedTest extends RobolectricTest {
         c.flush();
         col.getSched().rebuildDyn(did);
         col.reset();
-        c = col.getSched().getCard();
+        c = getCard();
         col.getSched().answerCard(c, 1);
         col.getSched().emptyDyn(did);
         c.load();
@@ -989,7 +989,7 @@ public class SchedTest extends RobolectricTest {
         c.flush();
         col.getSched().rebuildDyn(did);
         col.reset();
-        c = col.getSched().getCard();
+        c = getCard();
         col.getSched().answerCard(c, 1);
         col.getSched().answerCard(c, 3);
         col.getSched().emptyDyn(did);
@@ -1002,7 +1002,7 @@ public class SchedTest extends RobolectricTest {
         c.flush();
         col.getSched().rebuildDyn(did);
         col.reset();
-        c = col.getSched().getCard();
+        c = getCard();
         col.getSched().answerCard(c, 3);
         col.getSched().emptyDyn(did);
         c.load();
@@ -1014,7 +1014,7 @@ public class SchedTest extends RobolectricTest {
         c.flush();
         col.getSched().rebuildDyn(did);
         col.reset();
-        c = col.getSched().getCard();
+        c = getCard();
         col.getSched().answerCard(c, 1);
         col.getSched().emptyDyn(did);
         c.load();
@@ -1026,7 +1026,7 @@ public class SchedTest extends RobolectricTest {
         c.flush();
         col.getSched().rebuildDyn(did);
         col.reset();
-        c = col.getSched().getCard();
+        c = getCard();
         col.getSched().answerCard(c, 1);
         col.getSched().answerCard(c, 3);
         c.load();
@@ -1037,7 +1037,7 @@ public class SchedTest extends RobolectricTest {
         // col.getSched().answerCard(c, 1)
         // col.getSched().rebuildDyn(did)
         // col.reset()
-        // c = col.getSched().getCard()
+        // c = getCard()
         // col.getSched().answerCard(c, 2)
         // print c.__dict__
     }
@@ -1088,7 +1088,7 @@ public class SchedTest extends RobolectricTest {
         col.addNote(note);
         col.reset();
         assertEquals(new Counts(1, 0, 0), col.getSched().counts());
-        Card c = col.getSched().getCard();
+        Card c = getCard();
         // counter's been decremented but idx indicates 1
         assertEquals(new Counts(0, 0, 0), col.getSched().counts());
         assertEquals(NEW, col.getSched().countIdx(c));
@@ -1096,7 +1096,7 @@ public class SchedTest extends RobolectricTest {
         col.getSched().answerCard(c, 1);
         assertEquals(new Counts(0, 2, 0), col.getSched().counts());
         // fetching again will decrement the count
-        c = col.getSched().getCard();
+        c = getCard();
         assertEquals(new Counts(0, 0, 0), col.getSched().counts());
         assertEquals(LRN, col.getSched().countIdx(c));
         // answering should add it back again
@@ -1114,35 +1114,35 @@ public class SchedTest extends RobolectricTest {
         col.reset();
         // lrnReps should be accurate on pass/fail
         assertEquals(new Counts(1, 0, 0), col.getSched().counts());
-        col.getSched().answerCard(col.getSched().getCard(), 1);
+        col.getSched().answerCard(getCard(), 1);
         assertEquals(new Counts(0, 2, 0), col.getSched().counts());
-        col.getSched().answerCard(col.getSched().getCard(), 1);
+        col.getSched().answerCard(getCard(), 1);
         assertEquals(new Counts(0, 2, 0), col.getSched().counts());
-        col.getSched().answerCard(col.getSched().getCard(), 2);
+        col.getSched().answerCard(getCard(), 2);
         assertEquals(new Counts(0, 1, 0), col.getSched().counts());
-        col.getSched().answerCard(col.getSched().getCard(), 1);
+        col.getSched().answerCard(getCard(), 1);
         assertEquals(new Counts(0, 2, 0), col.getSched().counts());
-        col.getSched().answerCard(col.getSched().getCard(), 2);
+        col.getSched().answerCard(getCard(), 2);
         assertEquals(new Counts(0, 1, 0), col.getSched().counts());
-        col.getSched().answerCard(col.getSched().getCard(), 2);
+        col.getSched().answerCard(getCard(), 2);
         assertEquals(new Counts(0, 0, 0), col.getSched().counts());
         note = col.newNote();
         note.setItem("Front", "two");
         col.addNote(note);
         col.reset();
         // initial pass should be correct too
-        col.getSched().answerCard(col.getSched().getCard(), 2);
+        col.getSched().answerCard(getCard(), 2);
         assertEquals(new Counts(0, 1, 0), col.getSched().counts());
-        col.getSched().answerCard(col.getSched().getCard(), 1);
+        col.getSched().answerCard(getCard(), 1);
         assertEquals(new Counts(0, 2, 0), col.getSched().counts());
-        col.getSched().answerCard(col.getSched().getCard(), 3);
+        col.getSched().answerCard(getCard(), 3);
         assertEquals(new Counts(0, 0, 0), col.getSched().counts());
         // immediate graduate should work
         note = col.newNote();
         note.setItem("Front", "three");
         col.addNote(note);
         col.reset();
-        col.getSched().answerCard(col.getSched().getCard(), 3);
+        col.getSched().answerCard(getCard(), 3);
         assertEquals(new Counts(0, 0, 0), col.getSched().counts());
         // and failing a review should too
         note = col.newNote();
@@ -1155,7 +1155,7 @@ public class SchedTest extends RobolectricTest {
         c.flush();
         col.reset();
         assertEquals(new Counts(0, 0, 1), col.getSched().counts());
-        col.getSched().answerCard(col.getSched().getCard(), 1);
+        col.getSched().answerCard(getCard(), 1);
         assertEquals(new Counts(0, 1, 0), col.getSched().counts());
     }
 
@@ -1176,14 +1176,14 @@ public class SchedTest extends RobolectricTest {
         }
         // fail the first one
         col.reset();
-        Card c = col.getSched().getCard();
+        Card c = getCard();
         // set a a fail delay of 4 seconds
         DeckConfig conf = col.getSched()._cardConf(c);
         conf.getJSONObject("lapse").getJSONArray("delays").put(0, 1 / 15.0);
         col.getDecks().save(conf);
         col.getSched().answerCard(c, 1);
         // the next card should be another review
-        c = col.getSched().getCard();
+        c = getCard();
         assertEquals(QUEUE_TYPE_REV, c.getQueue());
         /* TODO time
         // but if we wait for a few seconds, the failed card should come back
@@ -1193,7 +1193,7 @@ public class SchedTest extends RobolectricTest {
         return orig_time() + 5;
 
         time.time = adjusted_time;
-        c = col.getSched().getCard();
+        c = getCard();
         assertEquals(QUEUE_TYPE_LRN, c.getQueue());
         time.time = orig_time;
 
@@ -1210,11 +1210,11 @@ public class SchedTest extends RobolectricTest {
         col.addNote(note);
         col.reset();
         // test collapsing
-        Card c = col.getSched().getCard();
+        Card c = getCard();
         col.getSched().answerCard(c, 1);
-        c = col.getSched().getCard();
+        c = getCard();
         col.getSched().answerCard(c, 3);
-        assertNull(col.getSched().getCard());
+        assertNull(getCard());
     }
 
 
@@ -1288,7 +1288,7 @@ public class SchedTest extends RobolectricTest {
         col.reset();
         assertEquals(new Counts(3, 0, 0), col.getSched().counts());
         for (String i : new String[] {"one", "three", "two"}) {
-            Card c = col.getSched().getCard();
+            Card c = getCard();
             assertEquals(c.note().getItem("Front"), i);
             col.getSched().answerCard(c, 2);
         }
@@ -1423,7 +1423,7 @@ public class SchedTest extends RobolectricTest {
         DeckConfig conf = col.getSched()._cardConf(c);
         conf.getJSONObject("lapse").put("mult", 0.5);
         col.getDecks().save(conf);
-        c = col.getSched().getCard();
+        c = getCard();
         col.getSched().answerCard(c, 1);
         assertEquals(50, c.getIvl());
         col.getSched().answerCard(c, 1);

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.java
@@ -229,7 +229,7 @@ public class SchedV2Test extends RobolectricTest {
     public void test_basics() throws Exception {
         Collection col = getColV2();
         col.reset();
-        assertNull(col.getSched().getCard());
+        assertNull(getCard());
     }
 
 
@@ -246,7 +246,7 @@ public class SchedV2Test extends RobolectricTest {
         col.reset();
         assertEquals(1, col.getSched().newCount());
         // fetch it
-        Card c = col.getSched().getCard();
+        Card c = getCard();
         assertNotNull(c);
         assertEquals(QUEUE_TYPE_NEW, c.getQueue());
         assertEquals(CARD_TYPE_NEW, c.getType());
@@ -276,7 +276,7 @@ public class SchedV2Test extends RobolectricTest {
         // col.reset()
         // qs = ("2", "3", "2", "3")
         // for (int n = 0; n < 4; n++) {
-        //     c = col.getSched().getCard()
+        //     c = getCard()
         //     assertTrue(qs[n] in c.q())
         //     col.getSched().answerCard(c, 2)
         // }
@@ -303,7 +303,7 @@ public class SchedV2Test extends RobolectricTest {
         // both confs have defaulted to a limit of 20
         assertEquals(20, col.getSched().newCount());
         // first card we get comes from parent
-        Card c = col.getSched().getCard();
+        Card c = getCard();
         assertEquals(1, c.getDid());
         // limit the parent to 10 cards, meaning we get 10 in total
         DeckConfig conf1 = col.getDecks().confForDid(1);
@@ -327,7 +327,7 @@ public class SchedV2Test extends RobolectricTest {
         note.setItem("Front", "one");
         col.addNote(note);
         col.reset();
-        Card c = col.getSched().getCard();
+        Card c = getCard();
         DeckConfig conf = col.getSched()._cardConf(c);
         conf.getJSONObject("new").put("delays", new JSONArray(new double[] {1, 2, 3, 4, 5}));
         col.getDecks().save(conf);
@@ -351,7 +351,7 @@ public class SchedV2Test extends RobolectricTest {
         col.getDb().execute("update cards set queue=0, type=0");
         col.reset();
         // sched.getCard should return it, since it's due in the past
-        Card c = col.getSched().getCard();
+        Card c = getCard();
         assertNotNull(c);
         DeckConfig conf = col.getSched()._cardConf(c);
         conf.getJSONObject("new").put("delays", new JSONArray(new double[] {0.5, 3, 10}));
@@ -423,7 +423,7 @@ public class SchedV2Test extends RobolectricTest {
 
         // fail the card
         col.reset();
-        c = col.getSched().getCard();
+        c = getCard();
         col.getSched().answerCard(c, 1);
         assertEquals(QUEUE_TYPE_LRN, c.getQueue());
         assertEquals(CARD_TYPE_RELEARNING, c.getType());
@@ -457,7 +457,7 @@ public class SchedV2Test extends RobolectricTest {
 
         // fail the card
         col.reset();
-        c = col.getSched().getCard();
+        c = getCard();
         col.getSched().answerCard(c, 1);
         assertEquals(CARD_TYPE_REV, c.getType());
         assertEquals(QUEUE_TYPE_REV, c.getQueue());
@@ -478,17 +478,17 @@ public class SchedV2Test extends RobolectricTest {
         col.getDb().execute("update cards set queue=0, type=0");
         col.reset();
         // should get '1' first
-        Card c = col.getSched().getCard();
+        Card c = getCard();
         assertTrue(c.q().endsWith("1"));
         // pass it so it's due in 10 minutes
         col.getSched().answerCard(c, 3);
         // get the other card
-        c = col.getSched().getCard();
+        c = getCard();
         assertTrue(c.q().endsWith("2"));
         // fail it so it's due in 1 minute
         col.getSched().answerCard(c, 1);
         // we shouldn't get the same card again
-        c = col.getSched().getCard();
+        c = getCard();
         assertFalse(c.q().endsWith("2"));
     }
 
@@ -501,7 +501,7 @@ public class SchedV2Test extends RobolectricTest {
         note.setItem("Front", "one");
         col.addNote(note);
         col.reset();
-        Card c = col.getSched().getCard();
+        Card c = getCard();
         DeckConfig conf = col.getSched()._cardConf(c);
         conf.getJSONObject("new").put("delays", new JSONArray(new double[] {1, 10, 1440, 2880}));
         col.getDecks().save(conf);
@@ -511,20 +511,20 @@ public class SchedV2Test extends RobolectricTest {
         assertEquals(3, c.getLeft() % 1000);
         assertEquals(1, c.getLeft() / 1000);
         assertEquals(new Counts(0, 1, 0), col.getSched().counts());
-        c = col.getSched().getCard();
+        c = getCard();
 
         assertEquals(SECONDS_PER_DAY, col.getSched().nextIvl(c, 3));
         // answering it will place it in queue 3
         col.getSched().answerCard(c, 3);
         assertEquals(col.getSched().getToday() + 1, c.getDue());
         assertEquals(QUEUE_TYPE_DAY_LEARN_RELEARN, c.getQueue());
-        assertNull(col.getSched().getCard());
+        assertNull(getCard());
         // for testing, move it back a day
         c.setDue(c.getDue() - 1);
         c.flush();
         col.reset();
         assertEquals(new Counts(0, 1, 0), col.getSched().counts());
-        c = col.getSched().getCard();
+        c = getCard();
         // nextIvl should work
         assertEquals(SECONDS_PER_DAY * 2, col.getSched().nextIvl(c, 3));
         // if we fail it, it should be back in the correct queue
@@ -532,7 +532,7 @@ public class SchedV2Test extends RobolectricTest {
         assertEquals(QUEUE_TYPE_LRN, c.getQueue());
         col.undo();
         col.reset();
-        c = col.getSched().getCard();
+        c = getCard();
         col.getSched().answerCard(c, 3);
         // simulate the passing of another two days
         c.setDue(c.getDue() - 2);
@@ -552,7 +552,7 @@ public class SchedV2Test extends RobolectricTest {
         conf = col.getSched()._cardConf(c);
         conf.getJSONObject("lapse").put("delays", new JSONArray(new double[] {1440}));
         col.getDecks().save(conf);
-        c = col.getSched().getCard();
+        c = getCard();
         col.getSched().answerCard(c, 1);
         assertEquals(QUEUE_TYPE_DAY_LEARN_RELEARN, c.getQueue());
         assertEquals(new Counts(0, 0, 0), col.getSched().counts());
@@ -689,7 +689,7 @@ public class SchedV2Test extends RobolectricTest {
         assertEquals(new Counts(0, 0, 5), col.getSched().counts());
 
         // answering a card in the child should decrement parent count
-        Card c = col.getSched().getCard();
+        Card c = getCard();
         col.getSched().answerCard(c, 3);
         assertEquals(new Counts(0, 0, 4), col.getSched().counts());
 
@@ -752,7 +752,7 @@ public class SchedV2Test extends RobolectricTest {
            col.save();
            col.getSched().reset();
            assertEquals(new Counts(0, 2, 0), col.getSched().counts());
-           c = col.getSched().getCard();
+           c = getCard();
            col.getSched().answerCard(c, 3);
            // it should be due tomorrow
            assertEquals(col.getSched().getToday()+ 1, c.getDue());
@@ -803,7 +803,7 @@ public class SchedV2Test extends RobolectricTest {
         conf.getJSONObject("new").put("delays", new JSONArray(new double[] {0.5, 3, 10}));
         conf.getJSONObject("lapse").put("delays", new JSONArray(new double[] {1, 5, 9}));
         col.getDecks().save(conf);
-        Card c = col.getSched().getCard();
+        Card c = getCard();
         // new cards
         ////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -877,7 +877,7 @@ public class SchedV2Test extends RobolectricTest {
         assertEquals(QUEUE_TYPE_SIBLING_BURIED, c2.getQueue());
 
         col.reset();
-        assertNull(col.getSched().getCard());
+        assertNull(getCard());
 
         col.getSched().unburyCardsForDeck(AbstractSched.UnburyType.MANUAL);
         c.load();
@@ -907,14 +907,14 @@ public class SchedV2Test extends RobolectricTest {
         Card c = note.cards().get(0);
         // suspending
         col.reset();
-        assertNotNull(col.getSched().getCard());
+        assertNotNull(getCard());
         col.getSched().suspendCards(new long[] {c.getId()});
         col.reset();
-        assertNull(col.getSched().getCard());
+        assertNull(getCard());
         // unsuspending
         col.getSched().unsuspendCards(new long[] {c.getId()});
         col.reset();
-        assertNotNull(col.getSched().getCard());
+        assertNotNull(getCard());
         // should cope with rev cards being relearnt
         c.setDue(0);
         c.setIvl(100);
@@ -922,7 +922,7 @@ public class SchedV2Test extends RobolectricTest {
         c.setQueue(QUEUE_TYPE_REV);
         c.flush();
         col.reset();
-        c = col.getSched().getCard();
+        c = getCard();
         col.getSched().answerCard(c, 1);
         assertThat(c.getDue(), is(greaterThanOrEqualTo(col.getTime().intTime())));
         long due = c.getDue();
@@ -979,7 +979,7 @@ public class SchedV2Test extends RobolectricTest {
         // and should appear in the counts
         assertEquals(new Counts(0, 0, 1), col.getSched().counts());
         // grab it and check estimates
-        c = col.getSched().getCard();
+        c = getCard();
         assertEquals(4, col.getSched().answerButtons(c));
         assertEquals(600, col.getSched().nextIvl(c, 1));
         assertEquals(Math.round(75 * 1.2) * SECONDS_PER_DAY, col.getSched().nextIvl(c, 2));
@@ -1002,7 +1002,7 @@ public class SchedV2Test extends RobolectricTest {
         c.flush();
         col.getSched().rebuildDyn(did);
         col.reset();
-        c = col.getSched().getCard();
+        c = getCard();
 
         assertEquals(60 * SECONDS_PER_DAY, col.getSched().nextIvl(c, 2));
         assertEquals(100 * SECONDS_PER_DAY, col.getSched().nextIvl(c, 3));
@@ -1019,7 +1019,7 @@ public class SchedV2Test extends RobolectricTest {
         col.addNote(note);
 
         // fail the card outside filtered deck
-        Card c = col.getSched().getCard();
+        Card c = getCard();
         DeckConfig conf = col.getSched()._cardConf(c);
         conf.getJSONObject("new").put("delays", new JSONArray(new double[] {1, 10, 61}));
         col.getDecks().save(conf);
@@ -1080,7 +1080,7 @@ public class SchedV2Test extends RobolectricTest {
         col.getSched().rebuildDyn(did);
         col.reset();
         // grab the first card
-        c = col.getSched().getCard();
+        c = getCard();
         assertEquals(2, col.getSched().answerButtons(c));
         assertEquals(600, col.getSched().nextIvl(c, 1));
         assertEquals(0, col.getSched().nextIvl(c, 2));
@@ -1090,7 +1090,7 @@ public class SchedV2Test extends RobolectricTest {
         assertNotEquals(c.getDue(), due);
 
         // the other card should come next
-        Card c2 = col.getSched().getCard();
+        Card c2 = getCard();
         assertNotEquals(c2.getId(), c.getId());
 
         // passing it will remove it
@@ -1100,7 +1100,7 @@ public class SchedV2Test extends RobolectricTest {
         assertEquals(CARD_TYPE_NEW, c2.getType());
 
         // the other card should appear again
-        c = col.getSched().getCard();
+        c = getCard();
         assertEquals(orig.getId(), c.getId());
 
         // emptying the filtered deck should restore card
@@ -1157,7 +1157,7 @@ public class SchedV2Test extends RobolectricTest {
         col.addNote(note);
         col.reset();
         assertEquals(new Counts(1, 0, 0), col.getSched().counts());
-        Card c = col.getSched().getCard();
+        Card c = getCard();
         // counter's been decremented but idx indicates 1
         assertEquals(new Counts(0, 0, 0), col.getSched().counts());
         assertEquals(NEW, col.getSched().countIdx(c));
@@ -1165,7 +1165,7 @@ public class SchedV2Test extends RobolectricTest {
         col.getSched().answerCard(c, 1);
         assertEquals(new Counts(0, 1, 0), col.getSched().counts());
         // fetching again will decrement the count
-        c = col.getSched().getCard();
+        c = getCard();
         assertEquals(new Counts(0, 0, 0), col.getSched().counts());
         assertEquals(LRN, col.getSched().countIdx(c));
         // answering should add it back again
@@ -1183,35 +1183,35 @@ public class SchedV2Test extends RobolectricTest {
         col.reset();
         // lrnReps should be accurate on pass/fail
         assertEquals(new Counts(1, 0, 0), col.getSched().counts());
-        col.getSched().answerCard(col.getSched().getCard(), 1);
+        col.getSched().answerCard(getCard(), 1);
         assertEquals(new Counts(0, 1, 0), col.getSched().counts());
-        col.getSched().answerCard(col.getSched().getCard(), 1);
+        col.getSched().answerCard(getCard(), 1);
         assertEquals(new Counts(0, 1, 0), col.getSched().counts());
-        col.getSched().answerCard(col.getSched().getCard(), 3);
+        col.getSched().answerCard(getCard(), 3);
         assertEquals(new Counts(0, 1, 0), col.getSched().counts());
-        col.getSched().answerCard(col.getSched().getCard(), 1);
+        col.getSched().answerCard(getCard(), 1);
         assertEquals(new Counts(0, 1, 0), col.getSched().counts());
-        col.getSched().answerCard(col.getSched().getCard(), 3);
+        col.getSched().answerCard(getCard(), 3);
         assertEquals(new Counts(0, 1, 0), col.getSched().counts());
-        col.getSched().answerCard(col.getSched().getCard(), 3);
+        col.getSched().answerCard(getCard(), 3);
         assertEquals(new Counts(0, 0, 0), col.getSched().counts());
         note = col.newNote();
         note.setItem("Front", "two");
         col.addNote(note);
         col.reset();
         // initial pass should be correct too
-        col.getSched().answerCard(col.getSched().getCard(), 3);
+        col.getSched().answerCard(getCard(), 3);
         assertEquals(new Counts(0, 1, 0), col.getSched().counts());
-        col.getSched().answerCard(col.getSched().getCard(), 1);
+        col.getSched().answerCard(getCard(), 1);
         assertEquals(new Counts(0, 1, 0), col.getSched().counts());
-        col.getSched().answerCard(col.getSched().getCard(), 4);
+        col.getSched().answerCard(getCard(), 4);
         assertEquals(new Counts(0, 0, 0), col.getSched().counts());
         // immediate graduate should work
         note = col.newNote();
         note.setItem("Front", "three");
         col.addNote(note);
         col.reset();
-        col.getSched().answerCard(col.getSched().getCard(), 4);
+        col.getSched().answerCard(getCard(), 4);
         assertEquals(new Counts(0, 0, 0), col.getSched().counts());
         // and failing a review should too
         note = col.newNote();
@@ -1224,7 +1224,7 @@ public class SchedV2Test extends RobolectricTest {
         c.flush();
         col.reset();
         assertEquals(new Counts(0, 0, 1), col.getSched().counts());
-        col.getSched().answerCard(col.getSched().getCard(), 1);
+        col.getSched().answerCard(getCard(), 1);
         assertEquals(new Counts(0, 1, 0), col.getSched().counts());
     }
 
@@ -1245,16 +1245,16 @@ public class SchedV2Test extends RobolectricTest {
         }
         // fail the first one
         col.reset();
-        Card c = col.getSched().getCard();
+        Card c = getCard();
         col.getSched().answerCard(c, 1);
         // the next card should be another review
-        Card c2 = col.getSched().getCard();
+        Card c2 = getCard();
         assertEquals(QUEUE_TYPE_REV, c2.getQueue());
         // if the failed card becomes due, it should show first
         c.setDue(col.getTime().intTime() - 1);
         c.flush();
         col.reset();
-        c = col.getSched().getCard();
+        c = getCard();
         assertEquals(QUEUE_TYPE_LRN, c.getQueue());
     }
 
@@ -1268,11 +1268,11 @@ public class SchedV2Test extends RobolectricTest {
         col.addNote(note);
         col.reset();
         // test collapsing
-        Card c = col.getSched().getCard();
+        Card c = getCard();
         col.getSched().answerCard(c, 1);
-        c = col.getSched().getCard();
+        c = getCard();
         col.getSched().answerCard(c, 4);
-        assertNull(col.getSched().getCard());
+        assertNull(getCard());
     }
 
 
@@ -1363,7 +1363,7 @@ public class SchedV2Test extends RobolectricTest {
         col.reset();
         assertEquals(new Counts(3, 0, 0), col.getSched().counts());
         for (String i : new String[] {"one", "three", "two"}) {
-            Card c = col.getSched().getCard();
+            Card c = getCard();
             assertEquals(i, c.note().getItem("Front"));
             col.getSched().answerCard(c, 3);
         }
@@ -1498,9 +1498,11 @@ public class SchedV2Test extends RobolectricTest {
         DeckConfig conf = col.getSched()._cardConf(c);
         conf.getJSONObject("lapse").put("mult", 0.5);
         col.getDecks().save(conf);
-        c = col.getSched().getCard();
+        c = getCard();
+        advanceRobolectricLooper();
         col.getSched().answerCard(c, 1);
         assertEquals(50, c.getIvl());
+        advanceRobolectricLooperWithSleep();
         col.getSched().answerCard(c, 1);
         assertEquals(25, c.getIvl());
     }
@@ -1517,7 +1519,7 @@ public class SchedV2Test extends RobolectricTest {
 
         // make it a learning card
         col.reset();
-        Card c = col.getSched().getCard();
+        Card c = getCard();
         col.getSched().answerCard(c, 1);
 
         // the move to v2 should reset it to new
@@ -1528,7 +1530,7 @@ public class SchedV2Test extends RobolectricTest {
 
         // fail it again, and manually bury it
         col.reset();
-        c = col.getSched().getCard();
+        c = getCard();
         col.getSched().answerCard(c, 1);
         col.getSched().buryCards(new long[] {c.getId()});
         c.load();
@@ -1558,7 +1560,7 @@ public class SchedV2Test extends RobolectricTest {
         conf.getJSONObject("lapse").put("mult", 0.5);
         col.getDecks().save(conf);
         col.reset();
-        c = col.getSched().getCard();
+        c = getCard();
         col.getSched().answerCard(c, 1);
         c.load();
         assertEquals(50, c.getIvl());
@@ -1613,7 +1615,7 @@ public class SchedV2Test extends RobolectricTest {
         col.addNote(note);
 
         col.reset();
-        Card c = col.getSched().getCard();
+        Card c = getCard();
         col.getSched().answerCard(c, 2);
         // should be due in ~ 5.5 mins
         long expected = col.getTime().intTime() + (int)(5.5 * 60);


### PR DESCRIPTION
Getting the first card when you select a deck is a long process (at least when you have a big deck collection). This is because before actually getting the first card, AnkiDroid computes the number of new card/review card you need to see. Once it's done, it finally loops over all deck and look for a card to learn.

This PR simply reverse the process. It split reset in two parts, which both can be used or ignored. A part which computes the number of cards to see and a part which reset all queues and list of decks to consider. When reset should be done in `getCard`, it first runs the important part of `reset` (i.e. resetting queues), then look for a card, then finally, in background, computes the numbers of cards.

Ideally, I would just separate `reset` in a pair of functions. I prefer to stay close to upsteam, and so I don't do this and just add variables to control which part of the resetting process I want to deactivate.



This is again a part of https://github.com/ankidroid/Anki-Android/pull/6010

It has a commit in common with https://github.com/ankidroid/Anki-Android/pull/6026 and it contains https://github.com/ankidroid/Anki-Android/pull/6034. Without both of those commits, this PR could not work. Which also means that this PR will get smaller once both other PR are accepted.

