### PR TITLE
Add Cloze Icon

### DIFF
--- a/AnkiDroid/src/main/res/drawable/ic_cloze_black_24dp.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_cloze_black_24dp.xml
@@ -1,0 +1,23 @@
+<vector android:height="24dp" android:viewportHeight="24"
+    android:viewportWidth="24" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillAlpha="1" android:fillColor="#000000"
+        android:pathData="M7.2282,20.2911L1.9364,20.2911v-16.5821h5.2918v2.2995l-2.995,-0.004v11.9873l3.0013,-0.0003z"
+        android:strokeAlpha="1" android:strokeColor="#00000000"
+        android:strokeLineCap="butt" android:strokeLineJoin="miter" android:strokeWidth="0.71791428"/>
+    <path android:fillAlpha="1" android:fillColor="#000000"
+        android:pathData="m7.8244,13.4336q-0.5977,0 -1.0156,-0.418 -0.418,-0.418 -0.418,-1.0157 0,-0.5976 0.418,-1.0156 0.418,-0.418 1.0156,-0.418 0.5977,0 1.0156,0.418 0.4219,0.418 0.4219,1.0156 0,0.5977 -0.4219,1.0157 -0.418,0.418 -1.0156,0.418z"
+        android:strokeAlpha="1" android:strokeColor="#00000000"
+        android:strokeLineCap="butt" android:strokeLineJoin="miter" android:strokeWidth="0.5454601"/>
+    <path android:fillAlpha="1" android:fillColor="#000000"
+        android:pathData="m12.0745,13.4336q-0.5977,0 -1.0156,-0.418 -0.418,-0.418 -0.418,-1.0157 0,-0.5976 0.418,-1.0156 0.418,-0.418 1.0156,-0.418 0.5977,0 1.0156,0.418 0.4219,0.418 0.4219,1.0156 0,0.5977 -0.4219,1.0157 -0.418,0.418 -1.0156,0.418z"
+        android:strokeAlpha="1" android:strokeColor="#00000000"
+        android:strokeLineCap="butt" android:strokeLineJoin="miter" android:strokeWidth="0.5454601"/>
+    <path android:fillAlpha="1" android:fillColor="#000000"
+        android:pathData="m16.3245,13.4336q-0.5977,0 -1.0156,-0.418 -0.418,-0.418 -0.418,-1.0157 0,-0.5976 0.418,-1.0156 0.418,-0.418 1.0156,-0.418 0.5977,0 1.0156,0.418 0.4219,0.418 0.4219,1.0156 0,0.5977 -0.4219,1.0157 -0.418,0.418 -1.0156,0.418z"
+        android:strokeAlpha="1" android:strokeColor="#00000000"
+        android:strokeLineCap="butt" android:strokeLineJoin="miter" android:strokeWidth="0.5454601"/>
+    <path android:fillAlpha="1" android:fillColor="#000000"
+        android:pathData="m22.0636,20.2911h-5.2918v-2.3045h2.995L19.7668,6.0063h-2.995v-2.2974h5.2918z"
+        android:strokeAlpha="1" android:strokeColor="#00000000"
+        android:strokeLineCap="butt" android:strokeLineJoin="miter" android:strokeWidth="0.71791428"/>
+</vector>

--- a/AnkiDroid/src/main/vector_source/cloze_icon.svg
+++ b/AnkiDroid/src/main/vector_source/cloze_icon.svg
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+  This program is free software; you can redistribute it and/or modify it under
+  the terms of the GNU General Public License as published by the Free Software
+  Foundation; either version 3 of the License, or (at your option) any later
+  version.
+
+  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along with
+  this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="90.708664"
+   height="90.708664"
+   viewBox="0 0 24 24"
+   version="1.1"
+   id="svg8"
+   sodipodi:docname="cloze_icon.svg"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="5.6568542"
+     inkscape:cx="19.576374"
+     inkscape:cy="31.244144"
+     inkscape:document-units="mm"
+     inkscape:current-layer="text4572"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1280"
+     inkscape:window-height="657"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-273)">
+    <g
+       aria-label="[•••]"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:3.17499995px;line-height:125%;font-family:'Meiryo UI';-inkscape-font-specification:'Meiryo UI';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       id="text4572"
+       transform="translate(-0.35433477,-0.03319467)">
+      <path
+         d="M 7.5825349,293.32427 H 2.2907212 v -16.58215 h 5.2918137 v 2.29946 l -2.9950488,-0.004 v 11.98728 l 3.0012941,-2.9e-4 z"
+         style="font-weight:bold;font-size:6.35000038px;stroke-width:0.71791428px"
+         id="path4600"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccc" />
+      <path
+         d="m 8.1787545,286.46681 q -0.5976625,0 -1.0156353,-0.41798 -0.417973,-0.418 -0.417973,-1.01566 0,-0.59762 0.417973,-1.01563 0.4179728,-0.41797 1.0156353,-0.41797 0.5976625,0 1.0156356,0.41797 0.4218792,0.41801 0.4218792,1.01563 0,0.59766 -0.4218792,1.01566 -0.4179731,0.41798 -1.0156356,0.41798 z"
+         style="font-size:3.88055563px;stroke-width:0.5454601px"
+         id="path4602"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 12.428799,286.46681 q -0.597665,0 -1.015637,-0.41798 -0.417973,-0.418 -0.417973,-1.01566 0,-0.59762 0.417973,-1.01563 0.417972,-0.41797 1.015637,-0.41797 0.597662,0 1.015636,0.41797 0.421876,0.41801 0.421876,1.01563 0,0.59766 -0.421876,1.01566 -0.417974,0.41798 -1.015636,0.41798 z"
+         style="font-size:3.88055563px;stroke-width:0.5454601px"
+         id="path4604"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 16.67884,286.46681 q -0.597662,0 -1.015636,-0.41798 -0.417971,-0.418 -0.417971,-1.01566 0,-0.59762 0.417971,-1.01563 0.417974,-0.41797 1.015636,-0.41797 0.597664,0 1.015638,0.41797 0.421876,0.41801 0.421876,1.01563 0,0.59766 -0.421876,1.01566 -0.417974,0.41798 -1.015638,0.41798 z"
+         style="font-size:3.88055563px;stroke-width:0.5454601px"
+         id="path4606"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 22.417949,293.32427 h -5.291812 v -2.30445 h 2.995047 V 279.0395 h -2.995047 v -2.29738 h 5.291812 z"
+         style="font-weight:bold;font-size:6.3499999px;stroke-width:0.71791428px"
+         id="path4608"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccc" />
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
My own work. Created with Inkscape. Intended for the visual editor. 

GPL-3 for this project, but placing this under the public domain.

----

Inkscape: text tool - convert to path - use the measure tool and fix lines to same length via guides. Delete Guides. Center & Align. 

@mikehardy You were right, this was unexpectedly fun to do once I got over the initial hurdle. 

https://github.com/ankidroid/Anki-Android/blob/53c12a3045d8ff460b22dc8500d621f5e3608b41/AnkiDroid/src/main/vector_source/cloze_icon.svg

![image](https://user-images.githubusercontent.com/62114487/79596252-20cfc500-80d8-11ea-9b86-43460a4dd897.png)