### PR TITLE
Load deck tree first and numbers later

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -823,8 +823,12 @@ public class DeckPicker extends NavigationDrawerActivity implements
             mSyncOnResume = false;
         } else if (colIsOpen()) {
             selectNavigationItem(R.id.nav_decks);
-            updateDeckList(true, false);
-            updateDeckList(false, true);
+            if (mDeckListAdapter.wasSet()) {
+                updateDeckList();
+            } else {
+                updateDeckList(true, false);
+                updateDeckList(false, true);
+            }
             setTitle(getResources().getString(R.string.app_name));
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -58,7 +58,6 @@ import androidx.recyclerview.widget.DividerItemDecoration;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 import android.text.TextUtils;
-import android.util.Pair;
 import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -212,7 +211,6 @@ public class DeckPicker extends NavigationDrawerActivity implements
     /** If we have accepted the "We will show you permissions" dialog, don't show it again on activity rebirth */
     private boolean mClosedWelcomeMessage;
     private boolean mNumberLoaded = false;
-    private Pair<Long, Boolean> mClickBeforeLoading = null;
 
     private Time mTime = new SystemTime();
 
@@ -2034,10 +2032,6 @@ public class DeckPicker extends NavigationDrawerActivity implements
     }
 
     private void handleDeckSelection(long did, boolean dontSkipStudyOptions) {
-        if (!mNumberLoaded) {
-            mClickBeforeLoading = new Pair<Long, Boolean>(did, dontSkipStudyOptions);
-            return;
-        }
         // Clear the undo history when selecting a new deck
         if (getCol().getDecks().selected() != did) {
             getCol().clearUndo();
@@ -2052,7 +2046,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
         int pos = mDeckListAdapter.findDeckPosition(did);
         Sched.DeckDueTreeNode deckDueTreeNode = mDeckListAdapter.getDeckList().get(pos);
         // Figure out what action to take
-        if (deckDueTreeNode.newCount + deckDueTreeNode.lrnCount + deckDueTreeNode.revCount > 0) {
+        if (!mNumberLoaded || deckDueTreeNode.newCount + deckDueTreeNode.lrnCount + deckDueTreeNode.revCount > 0) {
             // If there are cards to study then either go to Reviewer or StudyOptions
             if (mFragmented || dontSkipStudyOptions) {
                 // Go to StudyOptions screen when tablet or deck counts area was clicked
@@ -2175,9 +2169,6 @@ public class DeckPicker extends NavigationDrawerActivity implements
                 // Update the mini statistics bar as well
                 AnkiStatsTaskHandler.createReviewSummaryStatistics(getCol(), mReviewSummaryTextView);
                 mNumberLoaded = setNumberLoaded;
-                if (mClickBeforeLoading != null) {
-                    handleDeckSelection(mClickBeforeLoading.first, mClickBeforeLoading.second);
-                }
             }
         }, new TaskData(quick));
         tasksToCancelOnClose.add(task);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -210,6 +210,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
     /** If we have accepted the "We will show you permissions" dialog, don't show it again on activity rebirth */
     private boolean mClosedWelcomeMessage;
+    private boolean mNumberLoaded = false;
 
     private Time mTime = new SystemTime();
 
@@ -820,8 +821,8 @@ public class DeckPicker extends NavigationDrawerActivity implements
             mSyncOnResume = false;
         } else if (colIsOpen()) {
             selectNavigationItem(R.id.nav_decks);
-            updateDeckList(true);
-            updateDeckList(false);
+            updateDeckList(true, false);
+            updateDeckList(false, true);
             setTitle(getResources().getString(R.string.app_name));
         }
     }
@@ -2027,6 +2028,9 @@ public class DeckPicker extends NavigationDrawerActivity implements
     }
 
     private void handleDeckSelection(long did, boolean dontSkipStudyOptions) {
+        if (!mNumberLoaded) {
+            return;
+        }
         // Clear the undo history when selecting a new deck
         if (getCol().getDecks().selected() != did) {
             getCol().clearUndo();
@@ -2131,10 +2135,10 @@ public class DeckPicker extends NavigationDrawerActivity implements
      * There is a quick version to start ankidroid quickly without database access, and a longuer one with actual numbers.
      */
     private void updateDeckList() {
-        updateDeckList(false);
+        updateDeckList(false, true);
     }
 
-    private void updateDeckList(boolean quick) {
+    private void updateDeckList(boolean quick, boolean setNumberLoaded) {
         CollectionTask task = CollectionTask.launchCollectionTask(CollectionTask.TASK_TYPE_LOAD_DECK_COUNTS, new CollectionTask.TaskListener() {
 
             @Override
@@ -2163,6 +2167,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
                 __renderPage();
                 // Update the mini statistics bar as well
                 AnkiStatsTaskHandler.createReviewSummaryStatistics(getCol(), mReviewSummaryTextView);
+                mNumberLoaded = setNumberLoaded;
             }
         }, new TaskData(quick));
         tasksToCancelOnClose.add(task);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -58,6 +58,7 @@ import androidx.recyclerview.widget.DividerItemDecoration;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 import android.text.TextUtils;
+import android.util.Pair;
 import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -211,6 +212,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
     /** If we have accepted the "We will show you permissions" dialog, don't show it again on activity rebirth */
     private boolean mClosedWelcomeMessage;
     private boolean mNumberLoaded = false;
+    private Pair<Long, Boolean> mClickBeforeLoading = null;
 
     private Time mTime = new SystemTime();
 
@@ -2029,6 +2031,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
     private void handleDeckSelection(long did, boolean dontSkipStudyOptions) {
         if (!mNumberLoaded) {
+            mClickBeforeLoading = new Pair<Long, Boolean>(did, dontSkipStudyOptions);
             return;
         }
         // Clear the undo history when selecting a new deck
@@ -2168,6 +2171,9 @@ public class DeckPicker extends NavigationDrawerActivity implements
                 // Update the mini statistics bar as well
                 AnkiStatsTaskHandler.createReviewSummaryStatistics(getCol(), mReviewSummaryTextView);
                 mNumberLoaded = setNumberLoaded;
+                if (mClickBeforeLoading != null) {
+                    handleDeckSelection(mClickBeforeLoading.first, mClickBeforeLoading.second);
+                }
             }
         }, new TaskData(quick));
         tasksToCancelOnClose.add(task);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -820,7 +820,8 @@ public class DeckPicker extends NavigationDrawerActivity implements
             mSyncOnResume = false;
         } else if (colIsOpen()) {
             selectNavigationItem(R.id.nav_decks);
-            updateDeckList();
+            updateDeckList(true);
+            updateDeckList(false);
             setTitle(getResources().getString(R.string.app_name));
         }
     }
@@ -2126,8 +2127,14 @@ public class DeckPicker extends NavigationDrawerActivity implements
      * in the deck list.
      *
      * This method also triggers an update for the widget to reflect the newly calculated counts.
+     *
+     * There is a quick version to start ankidroid quickly without database access, and a longuer one with actual numbers.
      */
     private void updateDeckList() {
+        updateDeckList(false);
+    }
+
+    private void updateDeckList(boolean quick) {
         CollectionTask task = CollectionTask.launchCollectionTask(CollectionTask.TASK_TYPE_LOAD_DECK_COUNTS, new CollectionTask.TaskListener() {
 
             @Override
@@ -2157,7 +2164,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
                 // Update the mini statistics bar as well
                 AnkiStatsTaskHandler.createReviewSummaryStatistics(getCol(), mReviewSummaryTextView);
             }
-        });
+        }, new TaskData(quick));
         tasksToCancelOnClose.add(task);
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.java
@@ -71,6 +71,7 @@ public class DeckAdapter extends RecyclerView.Adapter<DeckAdapter.ViewHolder> {
 
     // Flags
     private boolean mHasSubdecks;
+    private boolean mIsSet = false;
 
     // ViewHolder class to save inflated views for recycling
     public class ViewHolder extends RecyclerView.ViewHolder {
@@ -148,6 +149,7 @@ public class DeckAdapter extends RecyclerView.Adapter<DeckAdapter.ViewHolder> {
         mHasSubdecks = false;
         processNodes(nodes);
         notifyDataSetChanged();
+        mIsSet = true;
     }
 
 
@@ -309,5 +311,13 @@ public class DeckAdapter extends RecyclerView.Adapter<DeckAdapter.ViewHolder> {
 
     public List<Sched.DeckDueTreeNode> getDeckList() {
         return mDeckList;
+    }
+
+    /** Whether the adapter has values.
+
+        Those values may be out of date, but that's a good first
+        approximation. */
+    public boolean wasSet() {
+        return mIsSet;
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -243,7 +243,7 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
         // Actually execute the task now that we are at the front of the queue.
         switch (mType) {
             case TASK_TYPE_LOAD_DECK_COUNTS:
-                return doInBackgroundLoadDeckCounts();
+                return doInBackgroundLoadDeckCounts(params);
 
             case TASK_TYPE_SAVE_COLLECTION:
                 doInBackgroundSaveCollection();
@@ -530,12 +530,13 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
     }
 
 
-    private TaskData doInBackgroundLoadDeckCounts() {
+    private TaskData doInBackgroundLoadDeckCounts(TaskData... params) {
         Timber.d("doInBackgroundLoadDeckCounts");
         Collection col = CollectionHelper.getInstance().getCol(mContext);
         try {
+            boolean quick = params[0].getBoolean();
             // Get due tree
-            Object[] o = new Object[] {col.getSched().deckDueTree(this)};
+            Object[] o = new Object[] {col.getSched().deckDueTree(this, quick)};
             return new TaskData(o);
         } catch (RuntimeException e) {
             Timber.e(e, "doInBackgroundLoadDeckCounts - error");

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
@@ -49,7 +49,7 @@ public abstract class AbstractSched {
      */
     public abstract List<DeckDueTreeNode> deckDueList();
     /** load the due tree, but halt if deck task is cancelled*/
-    public abstract List<DeckDueTreeNode> deckDueTree(CollectionTask collectionTask);
+    public abstract List<DeckDueTreeNode> deckDueTree(CollectionTask collectionTask, boolean quick);
     public abstract List<DeckDueTreeNode> deckDueTree();
     /** New count for a single deck. */
     public abstract int _newForDeck(long did, int lim);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -211,9 +211,11 @@ public class Sched extends SchedV2 {
      * Returns [deckname, did, rev, lrn, new]
      */
     @Override
-    public List<DeckDueTreeNode> deckDueList(CollectionTask collectionTask) {
+    public List<DeckDueTreeNode> deckDueList(CollectionTask collectionTask, boolean quick) {
         _checkDay();
-        mCol.getDecks().checkIntegrity();
+        if (!quick) {
+            mCol.getDecks().checkIntegrity();
+        }
         ArrayList<JSONObject> decks = mCol.getDecks().allSorted();
         HashMap<String, Integer[]> lims = new HashMap<>();
         ArrayList<DeckDueTreeNode> data = new ArrayList<>();
@@ -227,11 +229,11 @@ public class Sched extends SchedV2 {
             if (!TextUtils.isEmpty(p)) {
                 nlim = Math.min(nlim, lims.get(p)[0]);
             }
-            int _new = _newForDeck(deck.getLong("id"), nlim);
+            int _new = quick ? 0 : _newForDeck(deck.getLong("id"), nlim);
             // learning
-            int lrn = _lrnForDeck(deck.getLong("id"));
+            int lrn = quick ? 0 : _lrnForDeck(deck.getLong("id"));
             // reviews
-            int rlim = _deckRevLimitSingle(deck);
+            int rlim = quick ? 0 : _deckRevLimitSingle(deck);
             if (!TextUtils.isEmpty(p)) {
                 rlim = Math.min(rlim, lims.get(p)[1]);
             }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -376,12 +376,14 @@ public class SchedV2 extends AbstractSched {
      * Return nulls when deck task is cancelled.
      */
     public List<DeckDueTreeNode> deckDueList() {
-        return deckDueList(null);
+        return deckDueList(null, false);
     }
 
-    public List<DeckDueTreeNode> deckDueList(CollectionTask collectionTask) {
+    public List<DeckDueTreeNode> deckDueList(CollectionTask collectionTask, boolean quick) {
         _checkDay();
-        mCol.getDecks().checkIntegrity();
+        if (!quick) {
+            mCol.getDecks().checkIntegrity();
+        }
         ArrayList<JSONObject> decks = mCol.getDecks().allSorted();
         HashMap<String, Integer[]> lims = new HashMap<>();
         ArrayList<DeckDueTreeNode> data = new ArrayList<>();
@@ -392,13 +394,13 @@ public class SchedV2 extends AbstractSched {
             }
             String p = Decks.parent(deck.getString("name"));
             // new
-            int nlim = _deckNewLimitSingle(deck);
+            int nlim = quick ? 0 : _deckNewLimitSingle(deck);
             if (!TextUtils.isEmpty(p)) {
                 nlim = Math.min(nlim, lims.get(p)[0]);
             }
-            int _new = _newForDeck(deck.getLong("id"), nlim);
+            int _new = quick ? 0 : _newForDeck(deck.getLong("id"), nlim);
             // learning
-            int lrn = _lrnForDeck(deck.getLong("id"));
+            int lrn = quick ? 0 : _lrnForDeck(deck.getLong("id"));
             // reviews
             Integer plim;
             if (!TextUtils.isEmpty(p)) {
@@ -407,7 +409,7 @@ public class SchedV2 extends AbstractSched {
                 plim = null;
             }
             int rlim = _deckRevLimitSingle(deck, plim);
-            int rev = _revForDeck(deck.getLong("id"), rlim, childMap);
+            int rev = quick ? 0 : _revForDeck(deck.getLong("id"), rlim, childMap);
             // save to list
             data.add(new DeckDueTreeNode(deck.getString("name"), deck.getLong("id"), rev, lrn, _new));
             // add deck as a parent
@@ -418,11 +420,11 @@ public class SchedV2 extends AbstractSched {
 
 
     public List<DeckDueTreeNode> deckDueTree() {
-        return deckDueTree(null);
+        return deckDueTree(null, false);
     }
 
-    public List<DeckDueTreeNode> deckDueTree(CollectionTask collectionTask) {
-        List<DeckDueTreeNode> deckDueTree = deckDueList(collectionTask);
+    public List<DeckDueTreeNode> deckDueTree(CollectionTask collectionTask, boolean quick) {
+        List<DeckDueTreeNode> deckDueTree = deckDueList(collectionTask, quick);
         if (deckDueTree == null) {
             return null;
         }


### PR DESCRIPTION
One of the thing which slows anki's start is computing all numbers of the deck tree. It requires multiple database access for each deck. Actually, showing the deck tree can be done extremely quickly, as long as we accept to show it without its numbers. 

This PR split the first loading of decks in the deck picker in two parts: 
# loading the tree 
This way, the user can begin to know where to click to open the deck they want, they can open/close the list of deck, and even open the options

# Loading the numbers
Once the GUI is shown, the number appears; on my collection it takes a few more seconds.

# Change to usage

## Clicking before the numbers are shown

Note that the numbers are used to decides which action should be done. E.g. directly review if they are cards, ask whether they want to review in advance if there is no cards due today... So the deck selection does not immediately open the reviewer; instead it saves the click and waits for the deck tree to be loaded to decide which action to take