### PR TITLE
Uses requery's window size

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/ModelTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/ModelTest.java
@@ -1,0 +1,52 @@
+package com.ichi2.anki.tests.libanki;
+
+import com.ichi2.anki.tests.Shared;
+import com.ichi2.libanki.Collection;
+import com.ichi2.libanki.Model;
+import com.ichi2.libanki.Models;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+
+@SuppressWarnings("deprecation")
+@RunWith(androidx.test.runner.AndroidJUnit4.class)
+public class ModelTest {
+
+    private Collection testCol;
+
+    @Before
+    public void setUp() throws IOException {
+        testCol = Shared.getEmptyCol(InstrumentationRegistry.getInstrumentation().getTargetContext());
+    }
+
+    @After
+    public void tearDown() {
+        testCol.close();
+    }
+
+    @Test
+    public void bigQuery() throws IOException {
+        Models models = testCol.getModels();
+        Model model = models.all().get(0);
+        StringBuffer buf = new StringBuffer();
+        for (long i = 0L; i < 400_000L; ++i ) {
+            buf.append("abcdefghijkl");
+        }
+        model.put("test", buf.toString());
+        // Buf should be more than 4MB, so at least two chunks from database.
+        models.flush();
+        // Reload models
+        testCol.load();
+        Model newModel = models.all().get(0);
+        assertEquals(newModel, model);
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/utils/DatabaseChangeDecorator.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/DatabaseChangeDecorator.java
@@ -276,5 +276,9 @@ public class DatabaseChangeDecorator implements SupportSQLiteDatabase {
     public void close() throws IOException {
         wrapped.close();
     }
+
+    public SupportSQLiteDatabase getWrapped() {
+        return wrapped;
+    }
 }
 


### PR DESCRIPTION
I want to look into requery's code to find the actual size of their
window.

I sent them a PR https://github.com/requery/sqlite-android/pull/129 in order to add a getter which returns this window
size to us. Ideally, it would allow to remove those constants from
AnkiDroid code which are here only to copy their constants.

Note that, as I expected, we can't use a chunk whose size is the
window (I tested); that's because the window contains extra
informations. So I decreased the window size slightly in order to have
something reasonable.

P.S.
Since Tim does not like github link in the code, I didn't put it in the code or commit message and just put it in the PR.
Even if, honestly, in this case, I believe that a github link in our comment would be good, as it would allow to link directly to requery's constant in the code, instead of having to deal with the package name 