### PR TITLE
remove jsonToString

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.java
@@ -343,7 +343,7 @@ public final class AnkiPackageExporter extends AnkiExporter {
             media = exportFiltered(z, path, context);
         }
         // media map
-        z.writeStr("media", Utils.jsonToString(media));
+        z.writeStr("media", media.toString());
         z.close();
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -317,7 +317,7 @@ public class Collection {
         values.put("dty", mDty ? 1 : 0);
         values.put("usn", mUsn);
         values.put("ls", mLs);
-        values.put("conf", Utils.jsonToString(mConf));
+        values.put("conf", mConf.toString());
         mDb.update("col", values);
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -195,12 +195,12 @@ public class Decks {
             for (Map.Entry<Long, JSONObject> d : mDecks.entrySet()) {
                 decksarray.put(Long.toString(d.getKey()), d.getValue());
             }
-            values.put("decks", Utils.jsonToString(decksarray));
+            values.put("decks", decksarray.toString());
             JSONObject confarray = new JSONObject();
             for (Map.Entry<Long, JSONObject> d : mDconf.entrySet()) {
                 confarray.put(Long.toString(d.getKey()), d.getValue());
             }
-            values.put("dconf", Utils.jsonToString(confarray));
+            values.put("dconf", confarray.toString());
             mCol.getDb().update("col", values);
             mChanged = false;
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Media.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Media.java
@@ -894,7 +894,7 @@ public class Media {
             }
 
             z.putNextEntry(new ZipEntry("_meta"));
-            z.write(Utils.jsonToString(meta).getBytes());
+            z.write(meta.toString().getBytes());
             z.closeEntry();
             z.close();
             // Don't leave lingering temp files if the VM terminates.

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -206,7 +206,7 @@ public class Models {
                 array.put(Long.toString(o.getKey()), o.getValue());
             }
             ContentValues val = new ContentValues();
-            val.put("models", Utils.jsonToString(array));
+            val.put("models", array.toString());
             mCol.getDb().update("col", val);
             mChanged = false;
         }
@@ -412,7 +412,7 @@ public class Models {
     /** Copy, save and return. */
     public JSONObject copy(JSONObject m) {
         JSONObject m2 = null;
-        m2 = new JSONObject(Utils.jsonToString(m));
+        m2 = new JSONObject(m.toString());
         m2.put("name", m2.getString("name") + " copy");
         add(m2);
         return m2;
@@ -577,7 +577,7 @@ public class Models {
             }
         }
         // remember old sort field
-        String sortf = Utils.jsonToString(m.getJSONArray("flds").getJSONObject(m.getInt("sortf")));
+        String sortf = m.getJSONArray("flds").getJSONObject(m.getInt("sortf")).toString();
         // move
         l.remove(oldidx);
         l.add(idx, field);
@@ -585,7 +585,7 @@ public class Models {
         // restore sort field
         ja = m.getJSONArray("flds");
         for (int i = 0; i < ja.length(); ++i) {
-            if (Utils.jsonToString(ja.getJSONObject(i)).equals(sortf)) {
+            if (ja.getJSONObject(i).toString().equals(sortf)) {
                 m.put("sortf", i);
                 break;
             }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Storage.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Storage.java
@@ -330,8 +330,8 @@ public class Storage {
         agc.put("1", gc);
         ContentValues values = new ContentValues();
         values.put("conf", Collection.defaultConf);
-        values.put("decks", Utils.jsonToString(ag));
-        values.put("dconf", Utils.jsonToString(agc));
+        values.put("decks", ag.toString());
+        values.put("dconf", agc.toString());
         db.update("col", values);
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Tags.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Tags.java
@@ -85,7 +85,7 @@ public class Tags {
                 tags.put(t.getKey(), t.getValue());
             }
             ContentValues val = new ContentValues();
-            val.put("tags", Utils.jsonToString(tags));
+            val.put("tags", tags.toString());
             // TODO: the database update call here sets mod = true. Verify if this is intended.
             mCol.getDb().update("col", val);
             mChanged = false;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
@@ -931,19 +931,6 @@ public class Utils {
         }
     }
 
-    /**
-     * Like org.json.JSONObject except that it doesn't escape forward slashes
-     * The necessity for this method is due to python's 2.7 json.dumps() function that doesn't escape character '/'.
-     * The org.json.JSONObject parser accepts both escaped and unescaped forward slashes, so we only need to worry for
-     * our output, when we write to the database or syncing.
-     *
-     * @param json a json object to serialize
-     * @return the json serialization of the object
-     * @see org.json.JSONObject#toString()
-     */
-    public static String jsonToString(JSONObject json) {
-        return json.toString().replaceAll("\\\\/", "/");
-    }
 
     /**
      * Like org.json.JSONArray except that it doesn't escape forward slashes

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
@@ -336,7 +336,7 @@ public class Anki2Importer extends Importer {
             // missing from target col?
             if (!mDst.getModels().have(mid)) {
                 // copy it over
-                JSONObject model = new JSONObject(Utils.jsonToString(srcModel));
+                JSONObject model = new JSONObject(srcModel.toString());
                 model.put("id", mid);
                 model.put("mod", Utils.intTime());
                 model.put("usn", mCol.usn());
@@ -348,7 +348,7 @@ public class Anki2Importer extends Importer {
             String dstScm = mDst.getModels().scmhash(dstModel);
             if (srcScm.equals(dstScm)) {
                 // they do; we can reuse this mid
-                JSONObject model = new JSONObject(Utils.jsonToString(srcModel));
+                JSONObject model = new JSONObject(srcModel.toString());
                 model.put("id", mid);
                 model.put("mod", Utils.intTime());
                 model.put("usn", mCol.usn());

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteMediaServer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteMediaServer.java
@@ -80,7 +80,7 @@ public class RemoteMediaServer extends HttpSyncer {
             mPostVars.put("v",
                     String.format(Locale.US, "ankidroid,%s,%s", VersionUtils.getPkgVersionName(), Utils.platDesc()));
 
-            Response resp = super.req("begin", HttpSyncer.getInputStream(Utils.jsonToString(new JSONObject())));
+            Response resp = super.req("begin", HttpSyncer.getInputStream(new JSONObject().toString()));
             JSONObject jresp = new JSONObject(resp.body().string());
             JSONObject ret = _dataOnly(jresp, JSONObject.class);
             mSKey = ret.getString("sk");
@@ -98,7 +98,7 @@ public class RemoteMediaServer extends HttpSyncer {
             mPostVars.put("sk", mSKey);
 
             Response resp = super.req("mediaChanges",
-                    HttpSyncer.getInputStream(Utils.jsonToString(new JSONObject().put("lastUsn", lastUsn))));
+                                      HttpSyncer.getInputStream(new JSONObject().put("lastUsn", lastUsn).toString()));
             JSONObject jresp = new JSONObject(resp.body().string());
             return _dataOnly(jresp, JSONArray.class);
         } catch (IOException e) {
@@ -117,7 +117,7 @@ public class RemoteMediaServer extends HttpSyncer {
         Response resp = null;
         try {
             resp = super.req("downloadFiles",
-                    HttpSyncer.getInputStream(Utils.jsonToString(new JSONObject().put("files", new JSONArray(top)))));
+                             HttpSyncer.getInputStream(new JSONObject().put("files", new JSONArray(top)).toString()));
             String zipPath = mCol.getPath().replaceFirst("collection\\.anki2$", "tmpSyncFromServer.zip");
             // retrieve contents and save to file on disk:
             super.writeToFile(resp.body().byteStream(), zipPath);
@@ -149,7 +149,7 @@ public class RemoteMediaServer extends HttpSyncer {
     public String mediaSanity(int lcnt) throws UnknownHttpResponseException, MediaSyncException {
         try {
             Response resp = super.req("mediaSanity",
-                    HttpSyncer.getInputStream(Utils.jsonToString(new JSONObject().put("local", lcnt))));
+                                      HttpSyncer.getInputStream(new JSONObject().put("local", lcnt).toString()));
             JSONObject jresp = new JSONObject(resp.body().string());
             return _dataOnly(jresp, String.class);
         } catch (IOException | NullPointerException e) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteServer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteServer.java
@@ -48,7 +48,7 @@ public class RemoteServer extends HttpSyncer {
             JSONObject jo = new JSONObject();
             jo.put("u", user);
             jo.put("p", pw);
-            return super.req("hostKey", HttpSyncer.getInputStream(Utils.jsonToString(jo)));
+            return super.req("hostKey", HttpSyncer.getInputStream(jo.toString()));
         } catch (JSONException e) {
             return null;
         }
@@ -64,7 +64,7 @@ public class RemoteServer extends HttpSyncer {
         jo.put("v", Consts.SYNC_VER);
         jo.put("cv",
                 String.format(Locale.US, "ankidroid,%s,%s", VersionUtils.getPkgVersionName(), Utils.platDesc()));
-        return super.req("meta", HttpSyncer.getInputStream(Utils.jsonToString(jo)));
+        return super.req("meta", HttpSyncer.getInputStream(jo.toString()));
     }
 
 
@@ -110,7 +110,7 @@ public class RemoteServer extends HttpSyncer {
 
     /** Python has dynamic type deduction, but we don't, so return String **/
     private String _run(String cmd, JSONObject data) throws UnknownHttpResponseException {
-        Response ret = super.req(cmd, HttpSyncer.getInputStream(Utils.jsonToString(data)));
+        Response ret = super.req(cmd, HttpSyncer.getInputStream(data.toString()));
         try {
             return ret.body().string();
         } catch (IllegalStateException | IOException e) {


### PR DESCRIPTION
This was useful because of python 2.7. Anki 2.0 is officially
deprecated, json library in python 3 (and thus Anki 2.1) have no trouble with escaped and
non-escaped backslash.


Oh and also, it takes a fraction of seconds to do the string replacement during collection saving