### PR TITLE
Use deepclone instead of toString/model creation

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
@@ -237,7 +237,7 @@ public class CardTemplateEditor extends AnkiActivity {
         }
         // Make backup of the model for cancellation purposes
         if (mModelBackup == null) {
-            mModelBackup = new JSONObject(col.getModels().get(mModelId).toString());
+            mModelBackup = col.getModels().get(mModelId).deepClone();
         }
         // Close collection opening dialog if needed
         Timber.i("CardTemplateEditor:: Card template editor successfully started for model id %d", mModelId);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.java
@@ -374,7 +374,7 @@ public class ModelBrowser extends AnkiActivity {
             } else {
                 //New model
                 //Model that is being cloned
-                JSONObject oldModel = new JSONObject(mModels.get(position - nbStdModels).toString());
+                JSONObject oldModel = mModels.get(position - nbStdModels).deepClone();
                 JSONObject newModel = StdModels.basicModel.add(col);
                 oldModel.put("id", newModel.get("id"));
                 model = oldModel;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -412,7 +412,7 @@ public class Models {
     /** Copy, save and return. */
     public JSONObject copy(JSONObject m) {
         JSONObject m2 = null;
-        m2 = new JSONObject(Utils.jsonToString(m));
+        m2 = m.deepClone();
         m2.put("name", m2.getString("name") + " copy");
         add(m2);
         return m2;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
@@ -336,7 +336,7 @@ public class Anki2Importer extends Importer {
             // missing from target col?
             if (!mDst.getModels().have(mid)) {
                 // copy it over
-                JSONObject model = new JSONObject(Utils.jsonToString(srcModel));
+                JSONObject model = srcModel.deepClone();
                 model.put("id", mid);
                 model.put("mod", Utils.intTime());
                 model.put("usn", mCol.usn());
@@ -348,7 +348,7 @@ public class Anki2Importer extends Importer {
             String dstScm = mDst.getModels().scmhash(dstModel);
             if (srcScm.equals(dstScm)) {
                 // they do; we can reuse this mid
-                JSONObject model = new JSONObject(Utils.jsonToString(srcModel));
+                JSONObject model = srcModel.deepClone();
                 model.put("id", mid);
                 model.put("mod", Utils.intTime());
                 model.put("usn", mCol.usn());


### PR DESCRIPTION
I added a method to clone deep an object in our JSON library. It seems I forgot to use it in some place. This is repaired