### PR TITLE
Defer resets (performance)

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1065,7 +1065,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
            The card could have been rescheduled, the deck could have changed, or a change of
            note type could have lead to the card being deleted */
         if (data != null && data.hasExtra("reloadRequired")) {
-            getCol().getSched().reset();
+            getCol().getSched().deferReset();
             CollectionTask.launchCollectionTask(CollectionTask.TASK_TYPE_ANSWER_CARD, mAnswerCardHandler(false),
                     new CollectionTask.TaskData(null, 0));
         }
@@ -1081,7 +1081,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
                 redrawCard();
             }
         } else if (requestCode == DECK_OPTIONS && resultCode == RESULT_OK) {
-            getCol().getSched().reset();
+            getCol().getSched().deferReset();
             CollectionTask.launchCollectionTask(CollectionTask.TASK_TYPE_ANSWER_CARD, mAnswerCardHandler(false),
                     new CollectionTask.TaskData(null, 0));
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -71,9 +71,6 @@ public class Reviewer extends AbstractFlashcardViewer {
     private boolean mPrefFullscreenReview = false;
     private static final int ADD_NOTE = 12;
 
-    // Deck picker reset scheduler before opening the reviewer. So
-    // first reset is useless.
-    private boolean mSchedResetDone = false;
 
     private ActionButtons mActionButtons = new ActionButtons(this);
 
@@ -120,9 +117,6 @@ public class Reviewer extends AbstractFlashcardViewer {
             return;
         }
 
-        if (getIntent().hasExtra("com.ichi2.anki.SchedResetDone")) {
-            mSchedResetDone = true;
-        }
         if (Intent.ACTION_VIEW.equals(getIntent().getAction())) {
             Timber.d("onCreate() :: received Intent with action = %s", getIntent().getAction());
             selectDeckFromExtra();
@@ -226,10 +220,7 @@ public class Reviewer extends AbstractFlashcardViewer {
             setWhiteboardVisibility(whiteboardVisibility);
         }
 
-        if (!mSchedResetDone) {
-            mSched.reset();     // Reset schedule in case card was previously loaded
-            mSchedResetDone = false;
-        }
+        col.getSched().deferReset();     // Reset schedule in case card was previously loaded
         CollectionTask.launchCollectionTask(CollectionTask.TASK_TYPE_ANSWER_CARD, mAnswerCardHandler(false),
                 new CollectionTask.TaskData(null, 0));
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -173,7 +173,7 @@ public class Reviewer extends AbstractFlashcardViewer {
         // Select the deck
         getCol().getDecks().select(did);
         // Reset the schedule so that we get the counts for the currently selected deck
-        getCol().getSched().reset();
+        getCol().getSched().deferReset();
     }
 
     @Override

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
@@ -346,7 +346,7 @@ public class CardContentProvider extends ContentProvider {
                 }
 
                 //retrieve the number of cards provided by the selection parameter "limit"
-                col.getSched().reset();
+                col.getSched().deferReset();
                 for (int k = 0; k< limit; k++){
                     Card currentCard = col.getSched().getCard();
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -504,7 +504,7 @@ public class Collection {
      * Rebuild the queue and reload data after DB modified.
      */
     public void reset() {
-        mSched.reset();
+        mSched.deferReset();
     }
 
 


### PR DESCRIPTION
This is once again a part of the huge commit https://github.com/ankidroid/Anki-Android/pull/6010

It contains a commit in common with https://github.com/ankidroid/Anki-Android/pull/6032/commits/81134cfcf17803f5113035aa1a6aa614e3a8ec92 , a method to defer resetting.

In each commit, I explain why resetting is actually not important immediately, and why we may defer.

I want to emphasize that if you look at anki's code, it almost never reset the scheduler, unless it actually needs to. The only exception to this rule is when a note type is modified.