### PR TITLE
don't close collection on sync (performance)

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
@@ -500,6 +500,7 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
             data.resultType = MEDIA_SYNC_SERVER_ERROR;
             data.result = new Object[]{e};
             AnkiDroidApp.sendExceptionReport(e, "doInBackgroundSync");
+            closeCol(col);
             return data;
         } catch (UnknownHttpResponseException e) {
             Timber.e(e, "doInBackgroundSync -- unknown response code error");
@@ -508,6 +509,7 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
             String msg = e.getLocalizedMessage();
             data.resultType = ERROR;
             data.result = new Object[] {code , msg};
+            closeCol(col);
             return data;
         } catch (Exception e) {
             // Global error catcher.
@@ -528,11 +530,11 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
                 data.resultType = ARBITRARY_STRING;
                 data.result = new Object[] {e.getLocalizedMessage(), e};
             }
+            closeCol(col);
             return data;
         } finally {
             Timber.i("Sync Finished - Closing Collection");
             // don't bump mod time unless we explicitly save
-            closeCol(col);
             CollectionHelper.getInstance().unlockCollection();
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
@@ -532,13 +532,16 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
         } finally {
             Timber.i("Sync Finished - Closing Collection");
             // don't bump mod time unless we explicitly save
-            if (col != null) {
-                col.close(false);
-            }
+            closeCol(col);
             CollectionHelper.getInstance().unlockCollection();
         }
     }
 
+    private void closeCol(Collection col) {
+        if (col != null) {
+            col.close(false);
+        }
+    }
 
     public void publishProgress(int id) {
         super.publishProgress(id);


### PR DESCRIPTION
In https://github.com/ankidroid/Anki-Android/pull/5972 we considered the question: why does full sync require a model loading ?

This led me to this PR. It's a small but complex one.

In upstream, the collection is closed on sync only for full download. Of course, since the collection is replaced by an entirely new file. Actually, it's not even closed for exception, which I didn't expect.

On the other hand, currently, our code ALWAYS close the collection. Which is entirely useless. On full upload, it reopens the collection immediatly to check the content, optimize the DB, etc... before uploading. This is a huge loss of time, as we must read a lot of data again from the DB.

It even close the collection on normal sync, when there are no problem. I doubt there is any reason to do it because:
1. I use this code in my "merge" branch, and everything seems to work
2. the Syncer class deals with all change received from the server, so we don't need to re read the database content to find the changes. And anyway, we will only see the changes that were put in it before the data base closed.

Note that I don't even need to close the collection on full download here, since the syncer takes care of it. Instead, I just need to close it on exception, in order to avoid having even more exceptions.

This is clearly a time saver, as loading the collection is a costly process


# How it has been tested

Making change on my computer. Syncing them. Syncing my phone. Seeing the change on my phone. Making chaneg, syncing my phone, syncing the computer, seeing change on the computer.

Doing change on the smartphone, doing a full download, seeing that those change are cancelled and we're back to last version.
Doing change on phone, doing full upload. Doing full download on computer and seeing those changes

Doing a normal sync and removing internet connection. Seeing that the sync in cancelled correctly