### PR TITLE
Split collection loading

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
@@ -340,4 +340,14 @@ public class CollectionHelper {
             return insufficientSpace + insufficientSpaceCurrentFree;
         }
     }
+
+    /** Fetches additional collection data not required for
+     * application startup
+     *
+     * Allows mandatory startup procedures to return early, speeding up startup. Less important tasks are offloaded here
+     * No-op if data is already fetched
+     */
+    public static void loadLazyCollection(Collection col) {
+    }
+
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
@@ -348,6 +348,7 @@ public class CollectionHelper {
      * No-op if data is already fetched
      */
     public static void loadLazyCollection(Collection col) {
+        col.getModels();
     }
 
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -841,6 +841,9 @@ public class DeckPicker extends NavigationDrawerActivity implements
             updateDeckList();
             setTitle(getResources().getString(R.string.app_name));
         }
+        /** Complete task and enqueue fetching nonessential data for
+         * startup. */
+        CollectionTask.launchCollectionTask(LOAD_COLLECTION_COMPLETE);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -114,6 +114,7 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
         SAVE_MODEL,
         FIND_EMPTY_CARDS,
         CHECK_CARD_SELECTION,
+        LOAD_COLLECTION_COMPLETE,
     }
 
     /**
@@ -410,6 +411,10 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
 
             case CHECK_CARD_SELECTION:
                 return doInBackgroundCheckCardSelection(params);
+
+            case LOAD_COLLECTION_COMPLETE:
+                doInBackgroundLoadLazyCollection();
+                break;
 
             default:
                 Timber.e("unknown task type: %s", mType);
@@ -1688,6 +1693,13 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
         }
 
         return new TaskData(new Object[] { hasUnsuspended, hasUnmarked});
+    }
+
+    public void doInBackgroundLoadLazyCollection() {
+        Collection col = CollectionHelper.getInstance().getCol(mContext);
+        if (col != null) {
+            CollectionHelper.loadLazyCollection(col);
+        }
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -263,7 +263,11 @@ public class Collection {
                 cursor.close();
             }
         }
-        getModels().load(loadColumn("models"));
+        // getModels().load(loadColumn("models")); This code has been
+        // moved to `CollectionHelper::loadLazyCollection` for
+        // efficiency Models are loaded lazily on demand. The
+        // application layer can asynchronously pre-fetch those parts;
+        // otherwise they get loaded when required.
         mDecks.load(loadColumn("decks"), deckConf);
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -2103,7 +2103,23 @@ public class Collection {
     }
 
 
-    public Models getModels() {
+    /**
+     * On first call, load the model if it was not loaded.
+     *
+     * Synchronized to ensure that loading does not occur twice.
+     * Normally the first call occurs in the background when
+     * collection is loaded.  The only exception being if the user
+     * perform an action (e.g. review) so quickly that
+     * loadModelsInBackground had no time to be called. In this case
+     * it will instantly finish. Note that loading model is a
+     * bottleneck anyway, so background call lose all interest.
+     *
+     * @return The model manager
+     */
+    public synchronized Models getModels() {
+        if (!mModels.isLoaded()) {
+            mModels.load(loadColumn("models"));
+        }
         return mModels;
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -101,6 +101,7 @@ public class Models {
     // BEGIN SQL table entries
     private int mId;
     private String mName = "";
+    private boolean mIsLoaded = false;
     //private long mCrt = Utils.intTime();
     //private long mMod = Utils.intTime();
     //private JSONObject mConf;
@@ -159,6 +160,11 @@ public class Models {
                 mModels.put(o.getLong("id"), o);
             }
         }
+        mIsLoaded = true;
+    }
+
+    public boolean isLoaded() {
+        return mIsLoaded;
     }
 
 


### PR DESCRIPTION
One thing which slow down ankiDroid starts a lot is reading the note type from the database. Mostly because, when they are a lot of card type and note type it takes a lot of place in memory and can't be fetched in a single windows.

Furthermore, the note types are not actually required until a note should be displayed. So this uselessly postpone showing the GUI.


This PR's goal is thus to ensure that the note type is used only when it should be.


## What changed since last time

Of course, you won't accept this PR if I don't explain what went wrong and why I expect that it won't go wrong this time. So here is a slight explanation.

First, I want to states that I tested full sync, I tested starting my reviews immediately, and it worked. 

We do all of our background work using AsyncTask. Which seems to be a mistake, since the documentation states it should be used only for small task. Our background executor runs only a single task at a time and wait for a task to ends for another task to start. This means that if we try to start the task "load the model" in background, it won't actually start until the current background tasks ends. Since this task waits for the models, I created a deadlock.

Now, `getModels` directly load the models if they are not loaded. The async task is only queried from the GUI thread; which ensures that there is no deadlock.
Furthermore, instead of simply `loadModel` I created a function `loadAfterGUI`. It's name indicates clearly it's goal; it does the part of loading which should be done when the GUI is loaded.