### PR TITLE
Add Border to 'Mark' icon in topbar

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/CardMarker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/CardMarker.java
@@ -31,7 +31,7 @@ public class CardMarker {
     public void displayMark(boolean markStatus) {
         if (markStatus) {
             markView.setVisibility(View.VISIBLE);
-            markView.setImageResource(R.drawable.ic_star_white_24dp);
+            markView.setImageResource(R.drawable.ic_star_white_bordered_24dp);
         } else {
             markView.setVisibility(View.INVISIBLE);
         }

--- a/AnkiDroid/src/main/res/drawable/ic_star_white_bordered_24dp.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_star_white_bordered_24dp.xml
@@ -1,0 +1,8 @@
+<vector android:height="24dp"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FFFFFF"
+        android:strokeColor="#000000"
+        android:strokeWidth="0.2"
+        android:pathData="M12,17.27L18.18,21l-1.64,-7.03L22,9.24l-7.19,-0.61L12,2 9.19,8.63 2,9.24l5.46,4.73L5.82,21z"/>
+</vector>


### PR DESCRIPTION
## Purpose / Description

Reported in https://github.com/ankidroid/Anki-Android/issues/5806#issuecomment-616482609

>  is it possible to change the color of the star when the button is hidden (i.e. only in the menu)? For me, it is rendering white on a gray background, which makes it difficult to see.

This is visible in the 'Plain Theme'

Before: 
![image](https://user-images.githubusercontent.com/62114487/79750599-22cc9a80-8309-11ea-8a32-7451f1559a5e.png)


## Approach
Add a border to the icon used in the topbar

After:
![image](https://user-images.githubusercontent.com/62114487/79750627-2d872f80-8309-11ea-9e06-1b8167190bb1.png)

![image](https://user-images.githubusercontent.com/62114487/79750645-337d1080-8309-11ea-83ff-d63b643f9af0.png)


## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code