### PR TITLE
Set reschedule app bar button to show never by default

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtonStatus.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtonStatus.java
@@ -44,6 +44,7 @@ public class ActionButtonStatus {
     }
 
     public void setup(SharedPreferences preferences) {
+        // NOTE: the default values below should be in sync with preferences_custom_buttons.xml and reviewer.xml
         setupButton(preferences, R.id.action_undo, "customButtonUndo", SHOW_AS_ACTION_ALWAYS);
         setupButton(preferences, R.id.action_schedule, "customButtonScheduleCard", SHOW_AS_ACTION_NEVER);
         setupButton(preferences, R.id.action_flag, "customButtonFlag", SHOW_AS_ACTION_ALWAYS);

--- a/AnkiDroid/src/main/res/xml/preferences_custom_buttons.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_custom_buttons.xml
@@ -17,9 +17,9 @@
 
 <!-- Custom buttons Prefrences -->
 <!--
+MenuItem.SHOW_AS_ACTION_NEVER = 0
 MenuItem.SHOW_AS_ACTION_IF_ROOM = 1
 MenuItem.SHOW_AS_ACTION_ALWAYS  = 2
-MenuItem.SHOW_AS_ACTION_NEVER = 0
 MENU_DISABLED = 3
 -->
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
@@ -34,7 +34,7 @@ MENU_DISABLED = 3
             android:key="customButtonUndo"
             android:title="@string/undo" />
         <ListPreference
-            android:defaultValue="2"
+            android:defaultValue="0"
             android:entries="@array/custom_button_labels"
             android:entryValues="@array/custom_button_values"
             android:key="customButtonScheduleCard"


### PR DESCRIPTION

## Pull Request template

## Purpose / Description

The reschedule button has an incorrect default from preferences

## Fixes
Fixes #6054

## Approach
Change the default in prefs xml
Note via code comment where in code things should be in sync
