### PR TITLE
 Hide card template add/delete for cloze model 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
@@ -44,6 +44,7 @@ import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.async.CollectionTask;
 import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
+import com.ichi2.libanki.Consts;
 import com.ichi2.libanki.Models;
 import com.ichi2.libanki.Note;
 import com.ichi2.ui.SlidingTabLayout;
@@ -427,6 +428,13 @@ public class CardTemplateEditor extends AnkiActivity {
         @Override
         public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
             inflater.inflate(R.menu.card_template_editor, menu);
+
+            if (mModel.getInt("type") == Consts.MODEL_CLOZE) {
+                Timber.d("Editing cloze model, disabling add/delete card template functionality");
+                menu.findItem(R.id.action_add).setVisible(false);
+                menu.findItem(R.id.action_delete).setVisible(false);
+            }
+
             super.onCreateOptionsMenu(menu, inflater);
         }
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
The cloze template can't have cards added to it or deleted from it, so we should block that in the CardTemplateEditor

## Fixes
Fixes #6015 

## Approach
During options menu inflate, set those options to invisible for cloze type

## How Has This Been Tested?
API28 emulator with this branch on it, I attempted to edit a cloze template pre-patch and I could (an error) then with the patch I could no longer add/delete (fixed!) but I could add/delete on other template types.


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
