### PR TITLE
Allow preview of note edits

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.java
@@ -51,9 +51,11 @@ public class CardTemplatePreviewer extends AbstractFlashcardViewer {
         if (parameters == null) {
             parameters = getIntent().getExtras();
         }
-        mEditedModelFileName = parameters.getString(TemporaryModel.INTENT_MODEL_FILENAME);
-        mCardList = parameters.getLongArray("cardList");
-        mOrdinal = parameters.getInt("ordinal");
+        if (parameters != null) {
+            mEditedModelFileName = parameters.getString(TemporaryModel.INTENT_MODEL_FILENAME);
+            mCardList = parameters.getLongArray("cardList");
+            mOrdinal = parameters.getInt("ordinal");
+        }
 
         if (mEditedModelFileName != null) {
             Timber.d("onCreate() loading edited model from %s", mEditedModelFileName);
@@ -85,14 +87,15 @@ public class CardTemplatePreviewer extends AbstractFlashcardViewer {
         if (mCurrentCard == null || mOrdinal < 0) {
             Timber.e("CardTemplatePreviewer started with empty card list or invalid index");
             finishWithoutAnimation();
-            return;
         }
     }
 
 
     @Override
     protected void setTitle() {
-        getSupportActionBar().setTitle(R.string.preview_title);
+        if (getSupportActionBar() != null) {
+            getSupportActionBar().setTitle(R.string.preview_title);
+        }
     }
 
     @Override
@@ -169,12 +172,12 @@ public class CardTemplatePreviewer extends AbstractFlashcardViewer {
         private Note mNote;
 
 
-        public PreviewerCard(Collection col) {
+        private PreviewerCard(Collection col) {
             super(col);
         }
 
 
-        public PreviewerCard(Collection col, long id) {
+        private PreviewerCard(Collection col, long id) {
             super(col, id);
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.java
@@ -142,8 +142,8 @@ public class CardTemplatePreviewer extends AbstractFlashcardViewer {
         if (mNoteEditorBundle != null) {
             mCurrentCard.setDid(mNoteEditorBundle.getLong("did"));
 
-            // Clear out old tags, add current tags as that can affect render
             Note currentNote = mCurrentCard.note();
+            // Clear out old tags, copy tags to avoid concurrent modification, add current tags for render correctness
             String[] currentTags = currentNote.getTags().toArray(new String[0]);
             for (String tag : currentTags) {
                 currentNote.delTag(tag);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.java
@@ -8,17 +8,22 @@ import android.os.Parcelable;
 import android.preference.PreferenceManager;
 import android.util.AttributeSet;
 import android.widget.TextView;
+
+import androidx.annotation.NonNull;
 import androidx.appcompat.widget.AppCompatEditText;
 import timber.log.Timber;
 
 import com.ichi2.themes.Themes;
+
+import java.util.Objects;
 
 import static android.view.inputmethod.EditorInfo.IME_FLAG_NO_EXTRACT_UI;
 
 
 public class FieldEditText extends AppCompatEditText {
 
-    public static final String NEW_LINE = System.getProperty("line.separator");
+    @NonNull
+    public static final String NEW_LINE = Objects.requireNonNull(System.getProperty("line.separator"));
 
     private String mName;
     private int mOrd;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -176,7 +176,7 @@ public class NoteEditor extends AnkiActivity {
 
     private Note mEditorNote;
     public static Card mCurrentEditedCard;
-    private List<String> mSelectedTags;
+    private ArrayList<String> mSelectedTags;
     private long mCurrentDid;
     private ArrayList<Long> mAllDeckIds;
     private ArrayList<Long> mAllModelIds;
@@ -338,7 +338,7 @@ public class NoteEditor extends AnkiActivity {
             mCaller = savedInstanceState.getInt("caller");
             mAddNote = savedInstanceState.getBoolean("addNote");
             mCurrentDid = savedInstanceState.getLong("did");
-            mSelectedTags = new ArrayList<>(Arrays.asList(savedInstanceState.getStringArray("tags")));
+            mSelectedTags = savedInstanceState.getStringArrayList("tags");
             mSavedFields = savedInstanceState.getBundle("editFields");
             mReloadRequired = savedInstanceState.getBoolean("reloadRequired");
             mChanged = savedInstanceState.getBoolean("changed");
@@ -366,7 +366,7 @@ public class NoteEditor extends AnkiActivity {
         if (mSelectedTags == null) {
             mSelectedTags = new ArrayList<>();
         }
-        savedInstanceState.putStringArray("tags", mSelectedTags.toArray(new String[0]));
+        savedInstanceState.putStringArrayList("tags", mSelectedTags);
         savedInstanceState.putBundle("editFields", getFieldsAsBundle());
         super.onSaveInstanceState(savedInstanceState);
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -919,6 +919,20 @@ public class NoteEditor extends AnkiActivity {
                 closeCardEditorWithCheck();
                 return true;
 
+            case R.id.action_preview:
+                Timber.i("NoteEditor:: Preview button pressed");
+                Intent previewer = new Intent(NoteEditor.this, CardTemplatePreviewer.class);
+
+                previewer.putExtra("ordinal", 0);
+                previewer.putExtra(TemporaryModel.INTENT_MODEL_FILENAME, TemporaryModel.saveTempModel(this, mEditorNote.model()));
+
+                // Send the previewer all our current editing information
+                Bundle noteEditorBundle = new Bundle();
+                onSaveInstanceState(noteEditorBundle);
+                previewer.putExtra("noteEditorBundle", noteEditorBundle);
+                startActivityWithoutAnimation(previewer);
+                return true;
+
             case R.id.action_save:
                 Timber.i("NoteEditor:: Save note button pressed");
                 saveNote();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1136,9 +1136,13 @@ public class NoteEditor extends AnkiActivity {
                     mReloadRequired = true;
                     mEditorNote.reloadModel();
                     if (!mEditorNote.cards().contains(mCurrentEditedCard)) {
-                        Timber.d("onActivityResult() template edit return - current card is gone");
-                        UIUtils.showSimpleSnackbar(this, R.string.template_for_current_card_deleted, false);
-                        closeNoteEditor();
+                        if (!mAddNote) {
+                            Timber.d("onActivityResult() template edit return - current card is gone, close note editor");
+                            UIUtils.showSimpleSnackbar(this, R.string.template_for_current_card_deleted, false);
+                            closeNoteEditor();
+                        } else {
+                            Timber.d("onActivityResult() template edit return, in add mode, just re-display");
+                        }
                     } else {
                         Timber.d("onActivityResult() template edit return - current card exists");
                         // reload current card - the template ordinals are possibly different post-edit

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TagsDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TagsDialog.java
@@ -35,7 +35,7 @@ import java.util.TreeSet;
 
 public class TagsDialog extends AnalyticsDialogFragment {
     public interface TagsDialogListener {
-        void onPositive(List<String> selectedTags, int option);
+        void onPositive(ArrayList<String> selectedTags, int option);
     }
 
     private static final int TYPE_NONE = -1;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Note.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Note.java
@@ -43,7 +43,7 @@ public class Note implements Cloneable {
     private String mGuId;
     private JSONObject mModel;
     private long mMid;
-    private List<String> mTags;
+    private ArrayList<String> mTags;
     private String[] mFields;
     private int mFlags;
     private String mData;
@@ -365,7 +365,7 @@ public class Note implements Cloneable {
     }
 
 
-    public List<String> getTags() {
+    public ArrayList<String> getTags() {
         return mTags;
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Tags.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Tags.java
@@ -274,7 +274,7 @@ public class Tags {
      */
 
     /** Parse a string and return a list of tags. */
-    public List<String> split(String tags) {
+    public ArrayList<String> split(String tags) {
         ArrayList<String> list = new ArrayList<>();
         for (String s : tags.replace('\u3000', ' ').split("\\s")) {
             if (s.length() > 0) {

--- a/AnkiDroid/src/main/res/menu/note_editor.xml
+++ b/AnkiDroid/src/main/res/menu/note_editor.xml
@@ -7,6 +7,12 @@
         android:title="@string/save"
         ankidroid:showAsAction="always"/>
     <item
+        android:id="@+id/action_preview"
+        android:icon="@drawable/ic_remove_red_eye_white_24dp"
+        android:title="@string/card_editor_preview_card"
+        ankidroid:showAsAction="ifRoom"
+        android:visible="true"/>
+    <item
         android:id="@+id/action_add_note_from_note_editor"
         android:title="@string/note_editor_add_note"
         android:visible="false"/>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.java
@@ -19,6 +19,7 @@ package com.ichi2.anki;
 import android.app.Activity;
 import android.app.Instrumentation;
 import android.content.Intent;
+import android.os.Bundle;
 import android.widget.TextView;
 
 import com.ichi2.anki.multimediacard.activity.MultimediaEditFieldActivity;
@@ -32,11 +33,15 @@ import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowActivity;
 
+import java.util.ArrayList;
+
+import androidx.appcompat.view.menu.ActionMenuItemView;
 import androidx.test.core.app.ActivityScenario;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.robolectric.Shadows.shadowOf;
 
 @SuppressWarnings("SameParameterValue")
@@ -48,6 +53,22 @@ public class NoteEditorTest extends RobolectricTest {
     public void verifyCardsList() {
         NoteEditor n = getNoteEditorEditingExistingBasicNote("Test", "Note", FromScreen.DECK_LIST);
         assertThat("Cards list is correct", ((TextView) n.findViewById(R.id.CardEditorCardsText)).getText().toString(), is("Cards: Card 1"));
+    }
+
+    @Test
+    public void verifyPreviewAddingNote() {
+        NoteEditor n = getNoteEditorAdding(NoteType.BASIC).withFirstField("Preview Test").build();
+        ActionMenuItemView previewButton = n.findViewById(R.id.action_preview);
+        previewButton.performClick();
+        ShadowActivity.IntentForResult intent = shadowOf(n).getNextStartedActivityForResult();
+        Bundle noteEditorBundle = intent.intent.getBundleExtra("noteEditorBundle");
+        assertThat("Bundle set to add note style", noteEditorBundle.getBoolean("addNote"), is(true));
+        Bundle fieldsBundle = noteEditorBundle.getBundle("editFields");
+        assertThat("Bundle has fields", fieldsBundle, notNullValue());
+        assertThat("Bundle has fields edited value", fieldsBundle.getString("0"), is("Preview Test"));
+        assertThat("Bundle has empty tag list", noteEditorBundle.getStringArrayList("tags"), is(new ArrayList<>()));
+        assertThat("Bundle has ordinal 0 for ephemeral preview", intent.intent.getIntExtra("ordinal", -1), is(0));
+        assertThat("Bundle has a temporary model saved", intent.intent.hasExtra(TemporaryModel.INTENT_MODEL_FILENAME), is(true));
     }
 
     @Test


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
The Note Editor did not allow preview, a heavily requested feature

## Fixes
Fixes #5644 / Obsoletes #5705 
Fixes #3819

## Approach
I re-use the CardTemplatePreviewer which is good for ephemeral data, with extensions to it's functionality where it can take a bundle from NoteEditor and use that to populate the card it shows with the unsaved note editor contents

## How Has This Been Tested?
API28 emulator, editing a note and hitting the new preview button to see that my edits are now shown in a preview screen. When you cancel the note edit session the edits go away. Seems to work

CardTemplateEditor preview still works as well on same API28 emulator

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
