### PR TITLE
Bump NDK version

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -107,7 +107,7 @@ android {
         check 'NewApi'
         abortOnError true
     }
-    ndkVersion "21.0.6113669"
+    ndkVersion "21.1.6352462"
 }
 
 play {


### PR DESCRIPTION
The NDK is only used when assembling releases.

It is used there to strip symbols in binary libraries (like requery) so we generate
APKs that are as small as possible.

This may cause failures if you attempt assembleRelease and don't have
the right NDK version installed.

Also note that if you have 'ndk.dir' in your project local.properties
you should remove it, that is obsolete per Android documentation and
may also cause failures.