### PR TITLE
NF: CardViewer - Only log URLS in debug mode

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -2819,7 +2819,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         @TargetApi(Build.VERSION_CODES.N)
         public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {
             String url = request.getUrl().toString();
-            Timber.i("Obtained URL from card: '%s'", url);
+            Timber.d("Obtained URL from card: '%s'", url);
             return filterUrl(url);
         }
 


### PR DESCRIPTION
Caught in the alpha that we're logging file:// and http:// requests from cards to logcat.

This was intended to catch problematic signals used in IPC between the WebView and AnkiDroid (such as the invalid unicode crash on typing answer), not all resources.