### PR TITLE
Fix Crash: Remove WebViewDebugging in App.onCreate

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -228,8 +228,6 @@ public class AnkiDroidApp extends Application {
             UsageAnalytics.setDryRun(true);
         }
 
-        WebViewDebugging.initializeDebugging(preferences);
-
         setLanguage(preferences.getString(Preferences.LANGUAGE, ""));
         NotificationChannels.setup(getApplicationContext());
 

--- a/AnkiDroid/src/main/java/com/ichi2/utils/WebViewDebugging.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/WebViewDebugging.java
@@ -12,6 +12,12 @@ public class WebViewDebugging {
     public static void initializeDebugging(SharedPreferences sharedPrefs) {
         // DEFECT: We might be able to cache this value: check what happens on WebView Renderer crash
         // On your desktop use chrome://inspect to connect to emulator WebViews
+        // Beware: Crash in AnkiDroidApp.onCreate() with:
+        /*
+        java.lang.RuntimeException: Using WebView from more than one process at once with the same data directory
+        is not supported. https://crbug.com/558377 : Lock owner com.ichi2.anki:acra at
+        org.chromium.android_webview.AwDataDirLock.a(PG:26)
+         */
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
             boolean enableDebugging = sharedPrefs.getBoolean("html_javascript_debugging", false);
             WebView.setWebContentsDebuggingEnabled(enableDebugging);


### PR DESCRIPTION
## Purpose / Description
The `onCreate()` code caused exception when clashing with ACRA which used WebView in a
separate process.

We already perform this init before the WebView is needed, this was intended as an optimisation.

## Fixes
Fixes #6070

## Approach

* Remove the offending code. Add a "here be dragons"

## How Has This Been Tested?

Untested, but worked previously without the code here. 🤠 

## Learning (optional, can help others)
Alpha testing is great

Premature optimisation is the root of all evil.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code