### PR TITLE
Regex

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/template/Template.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/template/Template.java
@@ -107,11 +107,10 @@ public class Template {
         String otag = Pattern.quote(sOtag);
         String ctag = Pattern.quote(sCtag);
 
-        String section = String.format(Locale.US,
-                "%s[\\#|^]([^\\}]*)%s(.+?)%s/\\1%s", otag, ctag, otag, ctag);
+        String section = otag + "[\\#|^]([^\\}]*)" + ctag + "(.+?)" + otag + "/\\1" + ctag;
         sSection_re = Pattern.compile(section, Pattern.MULTILINE | Pattern.DOTALL);
 
-        String tag = String.format(Locale.US, "%s(#|=|&|!|>|\\{)?(.+?)\\1?%s+", otag, ctag);
+        String tag = otag + "(#|=|&|!|>|\\{)?(.+?)\\1?" + ctag + "+";
         sTag_re = Pattern.compile(tag);
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/template/Template.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/template/Template.java
@@ -166,13 +166,9 @@ public class Template {
      * Renders all the tags in a template for a context.
      */
     private String render_tags(String template, Map<String, String> context) {
-        while (true) {
-            Matcher match = sTag_re.matcher(template);
-            if (!match.find()) {
-                break;
-            }
-
-            String tag = match.group(0);
+        StringBuffer sb = new StringBuffer();
+        Matcher match = sTag_re.matcher(template);
+        while (match.find()) {
             String tag_type = match.group(1);
             String tag_name = match.group(2).trim();
             String replacement;
@@ -187,9 +183,10 @@ public class Template {
             } else {
                 return "{{invalid template}}";
             }
-            template = template.replace(tag, replacement);
+            match.appendReplacement(sb, Matcher.quoteReplacement(replacement));
         }
-        return template;
+        match.appendTail(sb);
+        return sb.toString();
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/template/Template.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/template/Template.java
@@ -118,31 +118,32 @@ public class Template {
      * Expands sections.
      */
     private String render_sections(String template, Map<String, String> context) {
-        while (true) {
-            Matcher match = sSection_re.matcher(template);
-            if (!match.find()) {
-                break;
-            }
-
+        StringBuffer sb = new StringBuffer();
+        Matcher match = sSection_re.matcher(template);
+        while (match.find()) {
             String section = match.group(0);
             String section_name = match.group(1);
             String inner = match.group(2);
             section_name = section_name.trim();
             String it = get_or_attr(context, section_name, null);
             String replacer = "";
-            if (!TextUtils.isEmpty(it)) {
+            boolean field_is_empty = TextUtils.isEmpty(it);
+
+            if (!field_is_empty) {
                 it = Utils.stripHTMLMedia(it).trim();
             }
-            if (!TextUtils.isEmpty(it)) {
+            field_is_empty = TextUtils.isEmpty(it);
+            if (!field_is_empty) {
                 if (section.charAt(2) != '^') {
-                    replacer = inner;
+                    replacer = render_sections(inner, context);
                 }
-            } else if (TextUtils.isEmpty(it) && section.charAt(2) == '^') {
-                replacer = inner;
+            } else if (field_is_empty && section.charAt(2) == '^') {
+                replacer = render_sections(inner, context);
             }
-            template = template.replace(section, replacer);
+            match.appendReplacement(sb, Matcher.quoteReplacement(replacer));
         }
-        return template;
+        match.appendTail(sb);
+        return sb.toString();
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/template/Template.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/template/Template.java
@@ -128,22 +128,7 @@ public class Template {
             String section_name = match.group(1);
             String inner = match.group(2);
             section_name = section_name.trim();
-            String it;
-
-            // check for cloze
-            Matcher m = fClozeSection.matcher(section_name);
-            if (m.find()) {
-                // get full field text
-                String txt = get_or_attr(context, m.group(2), null);
-                Matcher mm = Pattern.compile(String.format(clozeReg, m.group(1))).matcher(txt);
-                if (mm.find()) {
-                    it = mm.group(1);
-                } else {
-                    it = null;
-                }
-            } else {
-                it = get_or_attr(context, section_name, null);
-            }
+            String it = get_or_attr(context, section_name, null);
             String replacer = "";
             if (!TextUtils.isEmpty(it)) {
                 it = Utils.stripHTMLMedia(it).trim();


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Making question/answer creation faster and kind of following anki.

## Fixes
When you have 200 field in a note type, creating the question is slow. (Yeah, I've got note type with 200 fields)
Furthermore, anki evolved in template generation recently, and we are not even close to anki anymore.

## Approach
Instead of doing a lot of replace and iteration, we do a single iteration for {{# and {{^, and then a single iteration for cloze; using what java's documentation recommand to do multiple search/replace simultaneously.

I should note that upstream code, in rust, parse the template to generate a tree, and then use the tree to compute answer/question. This is extremely useful to quickly determine exactly which cards should be generated/deleted for each note. If I recall correctly DAE told he intended to eventually remove `req` and really check whether a field is present or not in the question.



## How Has This Been Tested?

AnkiDroid test already tests cloze. And I added it in my "merge" branch, which I run on my phone