### PR TITLE
Convert Keyboard Input Map Code to Config

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -3262,6 +3262,9 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         return mControlBlocked;
     }
 
+    public boolean isDisplayingAnswer() {
+        return sDisplayAnswer;
+    }
 
     public boolean isControlBlocked() {
         return getControlBlocked() != ControlBlock.UNBLOCKED;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -39,9 +39,9 @@ import android.view.ViewGroup;
 import android.widget.FrameLayout;
 
 import com.ichi2.anim.ActivityTransitionAnimation;
-import com.ichi2.anki.cardviewer.ViewerCommand;
 import com.ichi2.anki.dialogs.ConfirmationDialog;
 import com.ichi2.anki.dialogs.RescheduleDialog;
+import com.ichi2.anki.reviewer.PeripheralKeymap;
 import com.ichi2.async.CollectionTask;
 import com.ichi2.anki.reviewer.ActionButtons;
 import com.ichi2.compat.CompatHelper;
@@ -87,6 +87,8 @@ public class Reviewer extends AbstractFlashcardViewer {
             return R.plurals.reset_cards_dialog_acknowledge;
         }
     };
+
+    private PeripheralKeymap mProcessor = new PeripheralKeymap(this,this);
 
     /** We need to listen for and handle reschedules / resets very similarly */
     abstract class ScheduleCollectionTaskListener extends NextCardHandler {
@@ -503,71 +505,16 @@ public class Reviewer extends AbstractFlashcardViewer {
 
 
     @Override
+    public boolean onKeyDown(int keyCode, KeyEvent event) {
+        return mProcessor.onKeyDown(keyCode, event) || super.onKeyDown(keyCode, event);
+    }
+
+    @Override
     public boolean onKeyUp(int keyCode, KeyEvent event) {
-        char keyPressed = (char) event.getUnicodeChar();
         if (answerFieldIsFocused()) {
             return super.onKeyUp(keyCode, event);
         }
-        if (sDisplayAnswer) {
-            if (keyPressed == '1' || keyCode == KeyEvent.KEYCODE_BUTTON_Y) {
-                executeCommand(ViewerCommand.COMMAND_ANSWER_FIRST_BUTTON);
-                return true;
-            }
-            if (keyPressed == '2' || keyCode == KeyEvent.KEYCODE_BUTTON_X) {
-                executeCommand(ViewerCommand.COMMAND_ANSWER_SECOND_BUTTON);
-                return true;
-            }
-            if (keyPressed == '3' || keyCode == KeyEvent.KEYCODE_BUTTON_B) {
-                executeCommand(ViewerCommand.COMMAND_ANSWER_THIRD_BUTTON);
-                return true;
-            }
-            if (keyPressed == '4' || keyCode == KeyEvent.KEYCODE_BUTTON_A) {
-                executeCommand(ViewerCommand.COMMAND_ANSWER_FOURTH_BUTTON);
-                return true;
-            }
-            if (keyCode == KeyEvent.KEYCODE_SPACE || keyCode == KeyEvent.KEYCODE_ENTER || keyCode == KeyEvent.KEYCODE_NUMPAD_ENTER) {
-                executeCommand(ViewerCommand.COMMAND_ANSWER_RECOMMENDED);
-                return true;
-            }
-        } else {
-            if (keyCode == KeyEvent.KEYCODE_BUTTON_Y || keyCode == KeyEvent.KEYCODE_BUTTON_X
-                || keyCode == KeyEvent.KEYCODE_BUTTON_B || keyCode == KeyEvent.KEYCODE_BUTTON_A) {
-                    executeCommand(ViewerCommand.COMMAND_SHOW_ANSWER);
-                    return true;
-            }
-        }
-        if (keyPressed == 'e') {
-            executeCommand(ViewerCommand.COMMAND_EDIT);
-            return true;
-        }
-        if (keyPressed == '*') {
-            executeCommand(ViewerCommand.COMMAND_MARK);
-            return true;
-        }
-        if (keyPressed == '-') {
-            executeCommand(ViewerCommand.COMMAND_BURY_CARD);
-            return true;
-        }
-        if (keyPressed == '=') {
-            executeCommand(ViewerCommand.COMMAND_BURY_NOTE);
-            return true;
-        }
-        if (keyPressed == '@') {
-            executeCommand(ViewerCommand.COMMAND_SUSPEND_CARD);
-            return true;
-        }
-        if (keyPressed == '!') {
-            executeCommand(ViewerCommand.COMMAND_SUSPEND_NOTE);
-            return true;
-        }
-        if (keyPressed == 'r' || keyCode == KeyEvent.KEYCODE_F5) {
-            executeCommand(ViewerCommand.COMMAND_PLAY_MEDIA);
-            return true;
-        }
-
-        // different from Anki Desktop
-        if (keyPressed == 'z') {
-            executeCommand(ViewerCommand.COMMAND_UNDO);
+        if (mProcessor.onKeyUp(keyCode, event)) {
             return true;
         }
         return super.onKeyUp(keyCode, event);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -27,6 +27,7 @@ import android.os.Build;
 import android.os.Bundle;
 
 import androidx.annotation.DrawableRes;
+import androidx.annotation.VisibleForTesting;
 import androidx.core.content.ContextCompat;
 import androidx.core.view.ActionProvider;
 import androidx.core.view.MenuItemCompat;
@@ -88,7 +89,8 @@ public class Reviewer extends AbstractFlashcardViewer {
         }
     };
 
-    private PeripheralKeymap mProcessor = new PeripheralKeymap(this,this);
+    @VisibleForTesting
+    protected PeripheralKeymap mProcessor = new PeripheralKeymap(this, this);
 
     /** We need to listen for and handle reschedules / resets very similarly */
     abstract class ScheduleCollectionTaskListener extends NextCardHandler {
@@ -609,6 +611,7 @@ public class Reviewer extends AbstractFlashcardViewer {
     @Override
     protected SharedPreferences restorePreferences() {
         super.restorePreferences();
+        this.mProcessor.setup();
         //Is this line necessary? Can we not use the return value from the call to super?
         SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(getBaseContext());
         mBlackWhiteboard = preferences.getBoolean("blackWhiteboard", true);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/PeripheralCommand.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/PeripheralCommand.java
@@ -1,0 +1,122 @@
+/*
+ Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.reviewer;
+
+import android.view.KeyEvent;
+
+import com.ichi2.anki.cardviewer.ViewerCommand.ViewerCommandDef;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import static com.ichi2.anki.cardviewer.ViewerCommand.*;
+
+public class PeripheralCommand {
+    @Nullable
+    private final Integer mKeyCode;
+
+    @Nullable
+    private final Character mUnicodeCharacter;
+
+    @NonNull
+    private final CardSide mCardSide;
+
+    private final @ViewerCommandDef int mCommand;
+
+    private PeripheralCommand(int keyCode, @ViewerCommandDef int command, @NonNull CardSide side) {
+        this.mKeyCode = keyCode;
+        this.mUnicodeCharacter = null;
+        this.mCommand = command;
+        this.mCardSide = side;
+    }
+
+    private PeripheralCommand(@Nullable Character unicodeCharacter, @ViewerCommandDef int command, @NonNull CardSide side) {
+        this.mKeyCode = null;
+        this.mUnicodeCharacter = unicodeCharacter;
+        this.mCommand = command;
+        this.mCardSide = side;
+    }
+
+    public int getCommand() {
+        return mCommand;
+    }
+
+    public Character getUnicodeCharacter() {
+        return mUnicodeCharacter;
+    }
+
+    public Integer getKeycode() {
+        return mKeyCode;
+    }
+
+    public boolean isQuestion() {
+        return mCardSide == CardSide.QUESTION || mCardSide == CardSide.BOTH;
+    }
+
+    public boolean isAnswer() {
+        return mCardSide == CardSide.ANSWER || mCardSide == CardSide.BOTH;
+    }
+
+    public static PeripheralCommand unicode(char unicodeChar, @ViewerCommandDef int command, CardSide side) {
+        return new PeripheralCommand((Character) unicodeChar, command, side);
+    }
+
+
+    public static PeripheralCommand keyCode(int keyCode, @ViewerCommandDef int command, CardSide side) {
+        return new PeripheralCommand(keyCode, command, side);
+    }
+
+    public static List<PeripheralCommand> getDefaultCommands() {
+        List<PeripheralCommand> ret = new ArrayList<>();
+
+        ret.add(PeripheralCommand.unicode('1', COMMAND_ANSWER_FIRST_BUTTON, CardSide.ANSWER));
+        ret.add(PeripheralCommand.unicode('2', COMMAND_ANSWER_SECOND_BUTTON, CardSide.ANSWER));
+        ret.add(PeripheralCommand.unicode('3', COMMAND_ANSWER_THIRD_BUTTON, CardSide.ANSWER));
+        ret.add(PeripheralCommand.unicode('4', COMMAND_ANSWER_FOURTH_BUTTON, CardSide.ANSWER));
+
+        ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_BUTTON_Y, COMMAND_FLIP_OR_ANSWER_EASE1, CardSide.BOTH));
+        ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_BUTTON_X, COMMAND_FLIP_OR_ANSWER_EASE2, CardSide.BOTH));
+        ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_BUTTON_B, COMMAND_FLIP_OR_ANSWER_EASE3, CardSide.BOTH));
+        ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_BUTTON_A, COMMAND_FLIP_OR_ANSWER_EASE4, CardSide.BOTH));
+
+        ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_SPACE, COMMAND_ANSWER_RECOMMENDED, CardSide.ANSWER));
+        ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_ENTER, COMMAND_ANSWER_RECOMMENDED, CardSide.ANSWER));
+        ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_NUMPAD_ENTER, COMMAND_ANSWER_RECOMMENDED, CardSide.ANSWER));
+
+        ret.add(PeripheralCommand.unicode('e', COMMAND_EDIT, CardSide.BOTH));
+        ret.add(PeripheralCommand.unicode('*', COMMAND_MARK, CardSide.BOTH));
+        ret.add(PeripheralCommand.unicode('-', COMMAND_BURY_CARD, CardSide.BOTH));
+        ret.add(PeripheralCommand.unicode('=', COMMAND_BURY_NOTE, CardSide.BOTH));
+        ret.add(PeripheralCommand.unicode('@', COMMAND_SUSPEND_CARD, CardSide.BOTH));
+        ret.add(PeripheralCommand.unicode('!', COMMAND_SUSPEND_NOTE, CardSide.BOTH));
+        ret.add(PeripheralCommand.unicode('r', COMMAND_PLAY_MEDIA, CardSide.BOTH));
+        ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_F5, COMMAND_PLAY_MEDIA, CardSide.BOTH));
+        ret.add(PeripheralCommand.unicode('z', COMMAND_UNDO, CardSide.BOTH));
+
+        return ret;
+    }
+
+    private enum CardSide {
+        NONE,
+        QUESTION,
+        ANSWER,
+        BOTH
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/PeripheralKeymap.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/PeripheralKeymap.java
@@ -1,0 +1,115 @@
+/*
+ Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>                     
+                                                                                     
+ This program is free software; you can redistribute it and/or modify it under       
+ the terms of the GNU General Public License as published by the Free Software       
+ Foundation; either version 3 of the License, or (at your option) any later          
+ version.                                                                            
+                                                                                     
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY     
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A     
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.            
+                                                                                     
+ You should have received a copy of the GNU General Public License along with        
+ this program.  If not, see <http://www.gnu.org/licenses/>.                          
+ */
+
+package com.ichi2.anki.reviewer;
+
+import android.view.KeyEvent;
+
+import com.ichi2.anki.cardviewer.ViewerCommand;
+import com.ichi2.anki.cardviewer.ViewerCommand.CommandProcessor;
+import com.ichi2.anki.cardviewer.ViewerCommand.ViewerCommandDef;
+
+/** Accepts peripheral input, mapping via various keybinding strategies,
+ * and converting them to commands for the Reviewer. */
+public class PeripheralKeymap {
+
+    private final CommandProcessor mCommandProcessor;
+    private final ReviewerUi mReviewerUI;
+
+
+    public PeripheralKeymap(ReviewerUi reviewerUi, CommandProcessor commandProcessor) {
+        this.mReviewerUI = reviewerUi;
+        this.mCommandProcessor = commandProcessor;
+    }
+
+    @SuppressWarnings("unused")
+    public boolean onKeyDown(int keyCode, KeyEvent event) {
+        return false;
+    }
+
+    public boolean onKeyUp(int keyCode, KeyEvent event) {
+        char keyPressed = (char) event.getUnicodeChar();
+
+        if (mReviewerUI.isDisplayingAnswer()) {
+            if (keyPressed == '1' || keyCode == KeyEvent.KEYCODE_BUTTON_Y) {
+                executeCommand(ViewerCommand.COMMAND_ANSWER_FIRST_BUTTON);
+                return true;
+            }
+            if (keyPressed == '2' || keyCode == KeyEvent.KEYCODE_BUTTON_X) {
+                executeCommand(ViewerCommand.COMMAND_ANSWER_SECOND_BUTTON);
+                return true;
+            }
+            if (keyPressed == '3' || keyCode == KeyEvent.KEYCODE_BUTTON_B) {
+                executeCommand(ViewerCommand.COMMAND_ANSWER_THIRD_BUTTON);
+                return true;
+            }
+            if (keyPressed == '4' || keyCode == KeyEvent.KEYCODE_BUTTON_A) {
+                executeCommand(ViewerCommand.COMMAND_ANSWER_FOURTH_BUTTON);
+                return true;
+            }
+            if (keyCode == KeyEvent.KEYCODE_SPACE || keyCode == KeyEvent.KEYCODE_ENTER || keyCode == KeyEvent.KEYCODE_NUMPAD_ENTER) {
+                executeCommand(ViewerCommand.COMMAND_ANSWER_RECOMMENDED);
+                return true;
+            }
+        } else {
+            if (keyCode == KeyEvent.KEYCODE_BUTTON_Y || keyCode == KeyEvent.KEYCODE_BUTTON_X
+                    || keyCode == KeyEvent.KEYCODE_BUTTON_B || keyCode == KeyEvent.KEYCODE_BUTTON_A) {
+                executeCommand(ViewerCommand.COMMAND_SHOW_ANSWER);
+                return true;
+            }
+        }
+        if (keyPressed == 'e') {
+            executeCommand(ViewerCommand.COMMAND_EDIT);
+            return true;
+        }
+        if (keyPressed == '*') {
+            executeCommand(ViewerCommand.COMMAND_MARK);
+            return true;
+        }
+        if (keyPressed == '-') {
+            executeCommand(ViewerCommand.COMMAND_BURY_CARD);
+            return true;
+        }
+        if (keyPressed == '=') {
+            executeCommand(ViewerCommand.COMMAND_BURY_NOTE);
+            return true;
+        }
+        if (keyPressed == '@') {
+            executeCommand(ViewerCommand.COMMAND_SUSPEND_CARD);
+            return true;
+        }
+        if (keyPressed == '!') {
+            executeCommand(ViewerCommand.COMMAND_SUSPEND_NOTE);
+            return true;
+        }
+        if (keyPressed == 'r' || keyCode == KeyEvent.KEYCODE_F5) {
+            executeCommand(ViewerCommand.COMMAND_PLAY_MEDIA);
+            return true;
+        }
+
+        // different from Anki Desktop
+        if (keyPressed == 'z') {
+            executeCommand(ViewerCommand.COMMAND_UNDO);
+            return true;
+        }
+        return false;
+    }
+
+
+    private void executeCommand(@ViewerCommandDef int command) {
+        this.mCommandProcessor.executeCommand(command);
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ReviewerUi.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ReviewerUi.java
@@ -32,4 +32,6 @@ public interface ReviewerUi {
     }
     ControlBlock getControlBlocked();
     boolean isControlBlocked();
+
+    boolean isDisplayingAnswer();
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerKeyboardInputTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerKeyboardInputTest.java
@@ -32,7 +32,7 @@ public class AbstractFlashcardViewerKeyboardInputTest {
 
         underTest.handleKeyPress(KeyEvent.KEYCODE_SPACE);
 
-        assertThat("Space should display answer on any card viewer",  underTest.isDisplayingAnswer());
+        assertThat("Space should display answer on any card viewer",  underTest.didDisplayAnswer());
     }
 
     @Test
@@ -41,7 +41,7 @@ public class AbstractFlashcardViewerKeyboardInputTest {
 
         underTest.handleKeyPress(KeyEvent.KEYCODE_ENTER);
 
-        assertThat("Enter should display answer on any card viewer",  underTest.isDisplayingAnswer());
+        assertThat("Enter should display answer on any card viewer",  underTest.didDisplayAnswer());
     }
 
     @Test
@@ -50,7 +50,7 @@ public class AbstractFlashcardViewerKeyboardInputTest {
 
         underTest.handleKeyPress(KeyEvent.KEYCODE_NUMPAD_ENTER);
 
-        assertThat("NumPad Enter should display answer on any card viewer",  underTest.isDisplayingAnswer());
+        assertThat("NumPad Enter should display answer on any card viewer",  underTest.didDisplayAnswer());
     }
 
     @Test
@@ -61,7 +61,7 @@ public class AbstractFlashcardViewerKeyboardInputTest {
         underTest.handleKeyPress(KeyEvent.KEYCODE_SPACE);
 
         assertThat("When text field is focused, space should not display answer",
-                !underTest.isDisplayingAnswer());
+                !underTest.didDisplayAnswer());
 
     }
 
@@ -87,7 +87,7 @@ public class AbstractFlashcardViewerKeyboardInputTest {
             mDisplayAnswer = true;
         }
 
-        public boolean isDisplayingAnswer() { return mDisplayAnswer; }
+        public boolean didDisplayAnswer() { return mDisplayAnswer; }
 
         public void handleKeyPress(int keycode) {
             //COULD_BE_BETTER: Saves 20 seconds on tests to remove AndroidJUnit4,

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerKeyboardInputTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerKeyboardInputTest.java
@@ -45,7 +45,7 @@ public class ReviewerKeyboardInputTest {
 
         underTest.handleUnicodeKeyPress('1');
 
-        assertThat("Answer should not be displayed", !underTest.isDisplayingAnswer());
+        assertThat("Answer should not be displayed", !underTest.didDisplayAnswer());
         assertThat("Answer should not be performed", !underTest.hasBeenAnswered());
     }
 
@@ -225,7 +225,7 @@ public class ReviewerKeyboardInputTest {
         underTest.handleSpacebar();
 
         assertThat("When text field is focused, space should not display answer",
-                !underTest.isDisplayingAnswer());
+                !underTest.didDisplayAnswer());
     }
 
     @Test
@@ -243,11 +243,11 @@ public class ReviewerKeyboardInputTest {
 
     private void assertGamepadButtonAnswers(int keycodeButton, int ease) {
         KeyboardInputTestReviewer underTest = KeyboardInputTestReviewer.displayingQuestion();
-        assertThat("Assume: Initially should not display answer", !underTest.isDisplayingAnswer());
+        assertThat("Assume: Initially should not display answer", !underTest.didDisplayAnswer());
 
         underTest.handleGamepadPress(keycodeButton);
 
-        assertThat("Initial button should display answer", underTest.isDisplayingAnswer());
+        assertThat("Initial button should display answer", underTest.didDisplayAnswer());
 
         underTest.displayAnswerForTest();
 
@@ -311,7 +311,7 @@ public class ReviewerKeyboardInputTest {
             mDisplayAnswer = true;
         }
 
-        public boolean isDisplayingAnswer() { return mDisplayAnswer; }
+        public boolean didDisplayAnswer() { return mDisplayAnswer; }
 
         public void handleUnicodeKeyPress(char unicodeChar) {
             KeyEvent key = mock(KeyEvent.class);

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerKeyboardInputTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerKeyboardInputTest.java
@@ -281,6 +281,7 @@ public class ReviewerKeyboardInputTest {
         public static KeyboardInputTestReviewer displayingAnswer() {
             KeyboardInputTestReviewer keyboardInputTestReviewer = new KeyboardInputTestReviewer();
             KeyboardInputTestReviewer.sDisplayAnswer = true;
+            keyboardInputTestReviewer.mProcessor.setup();
             return keyboardInputTestReviewer;
         }
 
@@ -288,6 +289,7 @@ public class ReviewerKeyboardInputTest {
         public static KeyboardInputTestReviewer displayingQuestion() {
             KeyboardInputTestReviewer keyboardInputTestReviewer = new KeyboardInputTestReviewer();
             KeyboardInputTestReviewer.sDisplayAnswer = false;
+            keyboardInputTestReviewer.mProcessor.setup();
             return keyboardInputTestReviewer;
         }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.java
@@ -6,17 +6,14 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.LooperMode;
 
-import androidx.lifecycle.Lifecycle;
 import androidx.test.core.app.ActivityScenario;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
-import static android.os.Looper.getMainLooper;
 import static com.ichi2.anki.AbstractFlashcardViewer.RESULT_DEFAULT;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.robolectric.Shadows.shadowOf;
 
 @RunWith(AndroidJUnit4.class)
 @LooperMode(LooperMode.Mode.PAUSED)
@@ -40,8 +37,6 @@ public class ReviewerTest extends RobolectricTest {
     public void exitCommandWorksAfterControlsAreBlocked() {
         ensureCollectionLoadIsSynchronous();
         try (ActivityScenario<Reviewer> scenario = ActivityScenario.launch(Reviewer.class)) {
-            scenario.moveToState(Lifecycle.State.CREATED);
-            shadowOf(getMainLooper()).idle();
             scenario.onActivity(reviewer -> {
                 reviewer.blockControls(true);
                 reviewer.executeCommand(ViewerCommand.COMMAND_EXIT);


### PR DESCRIPTION
## Purpose / Description
Prep for #6052, as soon as we define our key input in config rather than code, we can later move to defining them in preferences via a serialisation mechanism. This will later allow a user to redefine these mappings

## How Has This Been Tested?

Unit tested, slightly tested with my bluetooth keyboard

## Learning

Really nice to get to a stage where you can trust the tests to act as regression cover. 

It'd be useful to get a toast on some actions to confirm to the user what happened (for example: was suspend/bury pressed).

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code