### PR TITLE
SchedV2: Fix incorrect intervals on Lapsed Filtered cards [Take 2]

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -47,7 +47,6 @@ import com.ichi2.utils.JSONException;
 import com.ichi2.utils.JSONObject;
 
 import java.lang.ref.WeakReference;
-import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
@@ -1777,7 +1776,7 @@ public class SchedV2 extends AbstractSched {
         dict.put("leechFails", oconf.getJSONObject("lapse").getInt("leechFails"));
         dict.put("leechAction", oconf.getJSONObject("lapse").getInt("leechAction"));
         dict.put("mult", oconf.getJSONObject("lapse").getDouble("mult"));
-        dict.put("delays", oconf.getJSONObject("new").getJSONArray("delays"));
+        dict.put("delays", oconf.getJSONObject("lapse").getJSONArray("delays"));
         // overrides
         dict.put("resched", conf.getBoolean("resched"));
         return dict;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -1049,7 +1049,7 @@ public class SchedV2 extends AbstractSched {
     protected void _rescheduleAsRev(Card card, JSONObject conf, boolean early) {
         boolean lapse = (card.getType() == Consts.CARD_TYPE_REV || card.getType() == Consts.CARD_TYPE_RELEARNING);
         if (lapse) {
-            _rescheduleGraduatingLapse(card);
+            _rescheduleGraduatingLapse(card, early);
         } else {
             _rescheduleNew(card, conf, early);
         }
@@ -1059,7 +1059,10 @@ public class SchedV2 extends AbstractSched {
         }
     }
 
-    private void _rescheduleGraduatingLapse(Card card) {
+    private void _rescheduleGraduatingLapse(Card card, boolean early) {
+        if (early) {
+            card.setIvl(card.getIvl() + 1);
+        }
         card.setDue(mToday + card.getIvl());
         card.setQueue(Consts.QUEUE_TYPE_REV);
         card.setType(Consts.CARD_TYPE_REV);
@@ -1109,7 +1112,8 @@ public class SchedV2 extends AbstractSched {
 
     private int _graduatingIvl(Card card, JSONObject conf, boolean early, boolean fuzz) {
         if (card.getType() == Consts.CARD_TYPE_REV || card.getType() == Consts.CARD_TYPE_RELEARNING) {
-            return card.getIvl();
+            int bonus = early ? 1 : 0;
+            return card.getIvl() + bonus;
         }
         int ideal;
         JSONArray ja;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -40,6 +40,8 @@ import com.ichi2.libanki.Note;
 import com.ichi2.libanki.Utils;
 import com.ichi2.libanki.hooks.Hooks;
 
+import com.ichi2.libanki.utils.SystemTime;
+import com.ichi2.libanki.utils.Time;
 import com.ichi2.utils.JSONArray;
 import com.ichi2.utils.JSONException;
 import com.ichi2.utils.JSONObject;
@@ -60,6 +62,7 @@ import java.util.Locale;
 import java.util.Random;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
 import timber.log.Timber;
 
 @SuppressWarnings({"PMD.ExcessiveClassLength", "PMD.AvoidThrowingRawExceptionTypes","PMD.AvoidReassigningParameters",
@@ -105,6 +108,8 @@ public class SchedV2 extends AbstractSched {
     // Not in libanki
     protected WeakReference<Activity> mContextReference;
 
+    // Not in libAnki.
+    private final Time mTime;
 
     /**
      * card types: 0=new, 1=lrn, 2=rev, 3=relrn
@@ -117,7 +122,15 @@ public class SchedV2 extends AbstractSched {
      */
 
     public SchedV2(Collection col) {
+        this(col, new SystemTime());
+    }
+
+    /** we need a constructor as the constructor performs work
+     * involving the dependency, so we can't use setter injection */
+    @VisibleForTesting
+    SchedV2(Collection col, Time time) {
         super();
+        this.mTime = time;
         mCol = col;
         mQueueLimit = 50;
         mReportLimit = 99999;
@@ -1833,13 +1846,13 @@ public class SchedV2 extends AbstractSched {
             rolloverTime = 24 + rolloverTime;
         }
         Calendar date = Calendar.getInstance();
-        date.setTime(new Date());
+        date.setTime(mTime.getCurrentDate());
         date.set(Calendar.HOUR_OF_DAY, rolloverTime);
         date.set(Calendar.MINUTE, 0);
         date.set(Calendar.SECOND, 0);
         date.set(Calendar.MILLISECOND, 0);
         Calendar today = Calendar.getInstance();
-        today.setTime(new Date());
+        today.setTime(mTime.getCurrentDate());
         if (date.before(today)) {
             date.add(Calendar.DAY_OF_MONTH, 1);
         }
@@ -1857,7 +1870,7 @@ public class SchedV2 extends AbstractSched {
         c.set(Calendar.SECOND, 0);
         c.set(Calendar.MILLISECOND, 0);
 
-        return (int) ((new Date().getTime() - c.getTimeInMillis()) / 1000) / 86400;
+        return (int) ((mTime.time() - c.getTimeInMillis()) / 1000) / 86400;
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/utils/SystemTime.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/utils/SystemTime.java
@@ -16,6 +16,8 @@
 
 package com.ichi2.libanki.utils;
 
+import com.ichi2.libanki.Utils;
+
 import java.util.Date;
 
 public class SystemTime implements Time {
@@ -28,5 +30,15 @@ public class SystemTime implements Time {
     @Override
     public Date getCurrentDate() {
         return new Date();
+    }
+
+    @Override
+    public long intTime() {
+        return Utils.intTime();
+    }
+
+    @Override
+    public double now() {
+        return Utils.now();
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/utils/SystemTime.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/utils/SystemTime.java
@@ -1,0 +1,32 @@
+/*
+ Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.libanki.utils;
+
+import java.util.Date;
+
+public class SystemTime implements Time {
+    @Override
+    public long time() {
+        return new Date().getTime();
+    }
+
+
+    @Override
+    public Date getCurrentDate() {
+        return new Date();
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/utils/Time.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/utils/Time.java
@@ -1,0 +1,25 @@
+/*
+ Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.libanki.utils;
+
+import java.util.Date;
+
+/** Allows injection of time dependencies */
+public interface Time {
+    long time();
+    Date getCurrentDate();
+}

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/utils/Time.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/utils/Time.java
@@ -22,4 +22,8 @@ import java.util.Date;
 public interface Time {
     long time();
     Date getCurrentDate();
+    /**The time in integer seconds. */
+    long intTime();
+    /**The time in integer seconds. */
+    double now();
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
@@ -260,16 +260,6 @@ public class CardBrowserTest extends RobolectricTest {
         getCol().getDecks().select(1);
     }
 
-
-    private long addDynamicDeck(String name) {
-        return getCol().getDecks().newDyn(name);
-    }
-
-
-    private long addDeck(String deckName) {
-        return getCol().getDecks().id(deckName, true);
-    }
-
     private void deleteCardAtPosition(CardBrowser browser, int positionToCorrupt) {
         removeCardFromCollection(browser.getCardIds()[positionToCorrupt]);
         browser.clearCardData(positionToCorrupt);

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
@@ -152,4 +152,12 @@ public class RobolectricTest {
             throw new RuntimeException(e);
         }
     }
+
+    protected long addDeck(String deckName) {
+        return getCol().getDecks().id(deckName, true);
+    }
+
+    protected long addDynamicDeck(String name) {
+        return getCol().getDecks().newDyn(name);
+    }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.java
@@ -1,0 +1,126 @@
+/*
+ Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.libanki.sched;
+
+import com.ichi2.anki.RobolectricTest;
+import com.ichi2.libanki.Card;
+import com.ichi2.libanki.Consts;
+import com.ichi2.libanki.Note;
+import com.ichi2.testutils.MockTime;
+import com.ichi2.utils.JSONArray;
+import com.ichi2.utils.JSONObject;
+
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.platform.commons.util.CollectionUtils.getOnlyElement;
+
+@RunWith(AndroidJUnit4.class)
+public class SchedV2Test extends RobolectricTest {
+
+    /** Reported by /u/CarelessSecretary9 on reddit: */
+    @Test
+    public void filteredDeckSchedulingOptionsRegressionTest() {
+        getCol().setCrt(1587852900L);
+        //30 minutes learn ahead. required as we have 20m delay
+        getCol().getConf().put("collapseTime", 1800);
+
+        long homeDeckId = addDeck("Poorretention");
+
+        JSONObject homeDeckConf = getCol().getDecks().confForDid(homeDeckId);
+        JSONObject lapse = homeDeckConf.getJSONObject("lapse");
+
+        lapse.put("minInt", 2);
+        lapse.put("mult", 0.7d);
+        lapse.put("delays", new JSONArray("[20]"));
+
+        ensureLapseMatchesSppliedAnkiDesktopConfig(lapse);
+
+        getCol().flush();
+
+        long dynId = addDynamicDeck("Dyn");
+
+        /*
+        >>> pp(self.reviewer.card)
+        {'data': '', 'did': 1587939535230, 'due': 0, 'factor': 1300, 'flags': 0, 'id': 1510928829863, 'ivl': 25,
+        'lapses': 5, 'left': 1004, 'mod': 1587921512, 'nid': 1510928805161, 'odid': 1587920944107,
+        'odue': 0, 'ord': 0, 'queue': 2, 'reps': 22, 'type': 2, 'usn': -1}
+
+         */
+        Note n = addNoteUsingBasicModel("Hello", "World");
+        Card c = getOnlyElement(n.cards());
+        c.setType(Consts.CARD_TYPE_REV);
+        c.setQueue(Consts.QUEUE_TYPE_REV);
+        c.setIvl(25);
+        c.setDue(0);
+        c.setLapses(5);
+        c.setFactor(1300);
+        c.setLeft(1004);
+        c.setODid(homeDeckId);
+        c.setDid(dynId);
+        c.flush();
+
+        SchedV2 v2 = new SchedV2(getCol(), new MockTime(1587928085001L));
+
+        Card schedCard = v2.getCard();
+        assertThat(schedCard, Matchers.notNullValue());
+        v2.answerCard(schedCard, Consts.BUTTON_ONE);
+
+        Card after = v2.getCard();
+
+        /* Data from Anki - pp(self.reviewer.card)
+        {'data': '', 'did': 1587939535230, 'due': 1587941137, 'factor': 1300,
+        'flags': 0, 'id': 1510928829863, 'ivl': 17, 'lapses': 6, 'left': 1001,
+        'mod': 1587939720, 'nid': 1510928805161, 'odid': 1587920944107, 'odue': 0,
+        'ord': 0, 'queue': 1, 'reps': 23, 'type': 3, 'usn': -1}
+         */
+        assertThat(after.getType(), is(Consts.CARD_TYPE_RELEARNING));
+        assertThat(after.getQueue(), is(Consts.QUEUE_TYPE_LRN));
+        assertThat(after.getLeft(), is(1001));
+        assertThat("ivl is reduced by 70%", after.getIvl(), is(17));
+        assertThat("One lapse is added", after.getLapses(), is(6));
+
+        assertThat(v2.answerButtons(after), is(4));
+
+        long one = v2.nextIvl(after, Consts.BUTTON_ONE);
+        long two = v2.nextIvl(after, Consts.BUTTON_TWO);
+        long three = v2.nextIvl(after, Consts.BUTTON_THREE);
+        long four = v2.nextIvl(after, Consts.BUTTON_FOUR);
+
+        assertThat("Again should pick the current step", one, is(1200L));      // 20 mins
+        assertThat("Repeating single step - 20 minutes * 1.5", two, is(1800L));      // 30 mins
+        assertThat("Good should take the reduced interval (25 * 0.7)", three, is(1468800L)); // 17 days
+        //TODO: the below is not complete
+        //assertThat("Easy should have a bonus day over good", four, is(1555200L));  // 18 days
+    }
+
+
+    private void ensureLapseMatchesSppliedAnkiDesktopConfig(JSONObject lapse) {
+        assertThat(lapse.getInt("minInt"), is(2));
+        assertThat(lapse.getDouble("mult"), is(0.7d));
+        assertThat(lapse.getJSONArray("delays").length(), is(1));
+        assertThat(lapse.getJSONArray("delays").get(0), is(20));
+
+    }
+
+
+}

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.java
@@ -84,8 +84,9 @@ public class SchedV2Test extends RobolectricTest {
         Card schedCard = v2.getCard();
         assertThat(schedCard, Matchers.notNullValue());
         v2.answerCard(schedCard, Consts.BUTTON_ONE);
-
+        assertThat("The lapsed card should now be counted as lrn", v2.mLrnCount, is(1));
         Card after = v2.getCard();
+        assertThat("A card should be returned ", after, Matchers.notNullValue());
 
         /* Data from Anki - pp(self.reviewer.card)
         {'data': '', 'did': 1587939535230, 'due': 1587941137, 'factor': 1300,

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.java
@@ -109,8 +109,7 @@ public class SchedV2Test extends RobolectricTest {
         assertThat("Again should pick the current step", one, is(1200L));      // 20 mins
         assertThat("Repeating single step - 20 minutes * 1.5", two, is(1800L));      // 30 mins
         assertThat("Good should take the reduced interval (25 * 0.7)", three, is(1468800L)); // 17 days
-        //TODO: the below is not complete
-        //assertThat("Easy should have a bonus day over good", four, is(1555200L));  // 18 days
+        assertThat("Easy should have a bonus day over good", four, is(1555200L));  // 18 days
     }
 
 

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/MockTime.java
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/MockTime.java
@@ -38,4 +38,17 @@ public class MockTime implements Time {
     public Date getCurrentDate() {
         return new Date(mTime);
     }
+
+    /**These need confirmation */
+
+    @Override
+    public long intTime() {
+        return (long) now();
+    }
+
+
+    @Override
+    public double now() {
+        return (double)mTime / 1000.0d;
+    }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/MockTime.java
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/MockTime.java
@@ -1,0 +1,41 @@
+/*
+ Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.testutils;
+
+import com.ichi2.libanki.utils.Time;
+
+import java.util.Date;
+
+public class MockTime implements Time {
+
+    private final long mTime;
+
+    public MockTime(long time) {
+        mTime = time;
+    }
+
+    @Override
+    public long time() {
+        return mTime;
+    }
+
+
+    @Override
+    public Date getCurrentDate() {
+        return new Date(mTime);
+    }
+}


### PR DESCRIPTION
See: #6083 (previous PR)
Related: #6082

A time dependency in Utils wasn't mocked, causing a unit test to fail. Therefore the previous PR got reverted.

This adds:
https://github.com/ankidroid/Anki-Android/commit/7f4a41b07191a6f4e2fd6cc3d6cd9e784fb57a3d