### PR TITLE
Don't crash on Deck Options corruption

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
@@ -152,6 +152,10 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
                     mValues.put("reminderTime", TimePreference.DEFAULT_VALUE);
                 }
             } catch (JSONException e) {
+                Timber.e(e, "DeckOptions - cacheValues");
+                AnkiDroidApp.sendExceptionReport(e, "DeckOptions: cacheValues");
+                Resources r = DeckOptions.this.getResources();
+                UIUtils.showThemedToast(DeckOptions.this, r.getString(R.string.deck_options_corrupt, e.getLocalizedMessage()), false);
                 finish();
             }
         }
@@ -643,6 +647,10 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
             finish();
         } else {
             mPref = new DeckPreferenceHack();
+            //#6068 - constructor can call finish()
+            if (this.isFinishing()) {
+                return;
+            }
             mPref.registerOnSharedPreferenceChangeListener(this);
 
             this.addPreferencesFromResource(R.xml.deck_options);

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -169,4 +169,7 @@
     <string name="card_browser_deck_change_error">Could not change deck</string>
     <!-- AbstractFlashCardViewer -->
     <string name="card_viewer_url_decode_error">Error decoding data from card</string>
+
+    <!-- Deck Options -->
+    <string name="deck_options_corrupt">Failed to process deck options: %s</string>
 </resources>


### PR DESCRIPTION
## Purpose / Description
Previously, `onCreate` would continue executing and would crash. Instead, show a Toast and continue running.

## Fixes
Fixes #6068

## Approach
Add Exception report and log to failure path, and don't crash.

## How Has This Been Tested?

Tested with corrupt collection, now no longer crashes.


## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code