### PR TITLE
Dependency updates 20200430

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -155,7 +155,7 @@ dependencies {
 
     implementation 'net.mikehardy:google-analytics-java7:2.0.13'
     //noinspection GradleDependency
-    implementation 'com.squareup.okhttp3:okhttp:3.12.10'
+    implementation 'com.squareup.okhttp3:okhttp:3.12.11'
     implementation 'com.arcao:slf4j-timber:3.1'
 
     implementation 'com.jakewharton.timber:timber:4.7.1'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -163,7 +163,7 @@ dependencies {
     implementation 'org.jsoup:jsoup:1.13.1'
     api project(":api")
 
-    testImplementation 'org.junit.vintage:junit-vintage-engine:5.6.1'
+    testImplementation 'org.junit.vintage:junit-vintage-engine:5.6.2'
     testImplementation 'org.mockito:mockito-core:3.3.3'
     testImplementation 'org.powermock:powermock-core:2.0.7'
     testImplementation 'org.powermock:powermock-module-junit4:2.0.7'

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -43,7 +43,7 @@ android {
 
 dependencies {
     api fileTree(dir: 'libs', include: ['*.jar'])
-    testImplementation 'org.junit.vintage:junit-vintage-engine:5.6.1'
+    testImplementation 'org.junit.vintage:junit-vintage-engine:5.6.2'
     testImplementation 'org.robolectric:robolectric:4.3.1'
 }
 


### PR DESCRIPTION
Weekly dependency updates.

JUnit is obviously test-only

Okhttp is interesting, the current stable Java8 build introduced a fairly deep change and OkHttp had to respond to it in order to avoid crashes under very specific conditions. Android 10 did likewise causing OkHttp some compatibility pain with how it responds to URLs with underscores.