### PR TITLE
Handle DeckConfig."timer" as boolean

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
@@ -46,6 +46,7 @@ import com.ichi2.anki.services.ReminderService;
 import com.ichi2.async.CollectionTask;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Consts;
+import com.ichi2.libanki.DeckConfig;
 import com.ichi2.preferences.StepsPreference;
 import com.ichi2.preferences.TimePreference;
 import com.ichi2.themes.StyledProgressDialog;
@@ -106,7 +107,7 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
                 mValues.put("deckConf", mDeck.getString("conf"));
                 // general
                 mValues.put("maxAnswerTime", mOptions.getString("maxTaken"));
-                mValues.put("showAnswerTimer", Boolean.toString(mOptions.getInt("timer") == 1));
+                mValues.put("showAnswerTimer", Boolean.toString(parseTimerValue(mOptions)));
                 mValues.put("autoPlayAudio", Boolean.toString(mOptions.getBoolean("autoplay")));
                 mValues.put("replayQuestion", Boolean.toString(mOptions.optBoolean("replayq", true)));
                 // new
@@ -155,6 +156,12 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
                 finish();
             }
         }
+
+
+        private boolean parseTimerValue(JSONObject options) {
+            return DeckConfig.parseTimerOpt(options, true);
+        }
+
 
         public class Editor implements SharedPreferences.Editor {
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.java
@@ -336,11 +336,6 @@ public class Card implements Cloneable {
     }
 
 
-    public boolean shouldShowTimer() {
-        return mCol.getDecks().confForDid(mODid == 0 ? mDid : mODid).getInt("timer") != 0;
-    }
-
-
     /*
      * Time taken to answer card, in integer MS.
      */
@@ -588,7 +583,8 @@ public class Card implements Cloneable {
 
 
     public boolean showTimer() {
-        return mCol.getDecks().confForDid(mODid == 0 ? mDid : mODid).optInt("timer", 1) != 0;
+        JSONObject options = mCol.getDecks().confForDid(mODid == 0 ? mDid : mODid);
+        return DeckConfig.parseTimerOpt(options, true);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DeckConfig.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DeckConfig.java
@@ -1,0 +1,46 @@
+/*
+ Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.libanki;
+
+import com.ichi2.utils.JSONObject;
+
+import androidx.annotation.Nullable;
+
+public class DeckConfig {
+
+    public static @Nullable Boolean parseTimer(JSONObject config) {
+        //Note: Card.py used != 0, DeckOptions used == 1
+        try {
+            //#6089 - Anki 2.1.24 changed this to a bool, reverted in 2.1.25.
+            return config.getInt("timer") != 0;
+        } catch (Exception e) {
+            try {
+                return config.getBoolean("timer");
+            } catch (Exception ex) {
+                return null;
+            }
+        }
+    }
+
+    public static boolean parseTimerOpt(JSONObject config, boolean defaultValue) {
+        Boolean ret = parseTimer(config);
+        if (ret == null) {
+            ret = defaultValue;
+        }
+        return ret;
+    }
+}


### PR DESCRIPTION
## Notes

Value is written (only other grep for "timer"): https://github.com/ankidroid/Anki-Android/blob/5d0eb69ca943b646a1141ba808e7426e443202e5/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java#L270

I've previously tested the options, and no other crashes were found on other properties.

## Purpose / Description
Anki 2.1.24 converted this to an boolean, reverted in 2.1.25, but we need to coerce it back to avoid a crash.

## Fixes
Fixes #6089

## Approach
Fallback to boolean parsing if integer parsing fails. Remove unused method

## How Has This Been Tested?

On my device, both on 2.1.24 collection and my normal collection

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code