### PR TITLE
Strip Image text from expected typed answer

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -88,6 +88,7 @@ import com.ichi2.anki.receiver.SdCardReceiver;
 import com.ichi2.anki.reviewer.CardMarker;
 import com.ichi2.anki.reviewer.ReviewerCustomFonts;
 import com.ichi2.anki.reviewer.ReviewerUi;
+import com.ichi2.anki.cardviewer.TypedAnswer;
 import com.ichi2.async.CollectionTask;
 import com.ichi2.compat.CompatHelper;
 import com.ichi2.libanki.Decks;
@@ -156,10 +157,6 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
 
     /** Time to wait in milliseconds before resuming fullscreen mode **/
     protected static final int INITIAL_HIDE_DELAY = 200;
-
-    /** Regex pattern used in removing tags from text before diff */
-    private static final Pattern sSpanPattern = Pattern.compile("</?span[^>]*>");
-    private static final Pattern sBrPattern = Pattern.compile("<br\\s?/?>");
 
     // Type answer patterns
     private static final Pattern sTypeAnsPat = Pattern.compile("\\[\\[type:(.+?)\\]\\]");
@@ -1893,16 +1890,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
      * @return The correct answer text, with actual HTML and media references removed, and HTML entities unescaped.
      */
     protected String cleanCorrectAnswer(String answer) {
-        if (answer == null || "".equals(answer)) {
-            return "";
-        }
-        Matcher matcher = sSpanPattern.matcher(Utils.stripHTMLMedia(answer.trim()));
-        String answerText = matcher.replaceAll("");
-        matcher = sBrPattern.matcher(answerText);
-        answerText = matcher.replaceAll("\n");
-        matcher = Sound.sSoundPattern.matcher(answerText);
-        answerText = matcher.replaceAll("");
-        return Utils.nfcNormalized(answerText);
+        return TypedAnswer.cleanCorrectAnswer(answer);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/TypedAnswer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/TypedAnswer.java
@@ -38,7 +38,7 @@ public class TypedAnswer {
         if (answer == null || "".equals(answer)) {
             return "";
         }
-        Matcher matcher = sSpanPattern.matcher(Utils.stripHTMLMedia(answer.trim()));
+        Matcher matcher = sSpanPattern.matcher(Utils.stripHTML(answer.trim()));
         String answerText = matcher.replaceAll("");
         matcher = sBrPattern.matcher(answerText);
         answerText = matcher.replaceAll("\n");

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/TypedAnswer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/TypedAnswer.java
@@ -1,0 +1,49 @@
+/*
+ Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.cardviewer;
+
+import com.ichi2.libanki.Sound;
+import com.ichi2.libanki.Utils;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class TypedAnswer {
+
+    /** Regex pattern used in removing tags from text before diff */
+    private static final Pattern sSpanPattern = Pattern.compile("</?span[^>]*>");
+    private static final Pattern sBrPattern = Pattern.compile("<br\\s?/?>");
+
+    /**
+     * Clean up the correct answer text, so it can be used for the comparison with the typed text
+     *
+     * @param answer The content of the field the text typed by the user is compared to.
+     * @return The correct answer text, with actual HTML and media references removed, and HTML entities unescaped.
+     */
+    public static String cleanCorrectAnswer(String answer) {
+        if (answer == null || "".equals(answer)) {
+            return "";
+        }
+        Matcher matcher = sSpanPattern.matcher(Utils.stripHTMLMedia(answer.trim()));
+        String answerText = matcher.replaceAll("");
+        matcher = sBrPattern.matcher(answerText);
+        answerText = matcher.replaceAll("\n");
+        matcher = Sound.sSoundPattern.matcher(answerText);
+        answerText = matcher.replaceAll("");
+        return Utils.nfcNormalized(answerText);
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/TypedAnswerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/TypedAnswerTest.java
@@ -1,0 +1,37 @@
+/*
+ Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.cardviewer;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class TypedAnswerTest {
+
+    @Test
+    public void testMediaIsNotExpected() {
+        //#0096 - Anki Desktop did not expect media.
+        String input = "ya[sound:36_ya.mp3]<div><img src=\"paste-efbfdfbff329f818e3b5568e578234d0d0054067.png\" /><br /></div>";
+
+        String expected = "ya";
+
+        String actual = TypedAnswer.cleanCorrectAnswer(input);
+
+        assertThat(actual, is(expected));
+    }
+}


### PR DESCRIPTION
## Anki Desktop code

https://github.com/ankitects/anki/blob/351d8a309f7d3c0cae7f818313b1a0e7aac4408a/qt/aqt/reviewer.py#L403-L435

## Purpose / Description
User reported that the image src was expected to be typed when making a "type:" card. This is different from Anki Desktop

## Fixes
Fixes #6096

## Approach
Use the same function as Anki Desktop

## How Has This Been Tested?

Unit tested, and tested on my device, no longer expects the image.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code