### PR TITLE
Don't crash Check Database when Database is locked

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -1396,9 +1396,8 @@ public class DeckPicker extends NavigationDrawerActivity implements
     }
 
     public void handleDbLocked() {
-        //COULD_BE_BETTER: Do something different
         Timber.i("Displaying Database Locked");
-        showDatabaseErrorDialog(DatabaseErrorDialog.DIALOG_LOAD_FAILED);
+        showDatabaseErrorDialog(DatabaseErrorDialog.DIALOG_DB_LOCKED);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -2397,28 +2397,30 @@ public class DeckPicker extends NavigationDrawerActivity implements
             if (mProgressDialog != null && mProgressDialog.isShowing()) {
                 mProgressDialog.dismiss();
             }
-            if (result != null && result.getBoolean() && result.getObjArray() != null && result.getObjArray().length > 0) {
-                String msg;
-                Collection.CheckDatabaseResult databaseResult = (Collection.CheckDatabaseResult) result.getObjArray()[0];
 
-                int count = databaseResult.getCardsWithFixedHomeDeckCount();
-                if (count != 0) {
-                    String message = getResources().getString(R.string.integrity_check_fixed_no_home_deck, count);
-                    UIUtils.showThemedToast(DeckPicker.this,  message, false);
-                }
-
-                long shrunkInMb = Math.round(databaseResult.getSizeChangeInKb() / 1024.0);
-                if (shrunkInMb > 0.0) {
-                    msg = String.format(Locale.getDefault(),
-                    getResources().getString(R.string.check_db_acknowledge_shrunk), (int) shrunkInMb);
-                } else {
-                    msg = getResources().getString(R.string.check_db_acknowledge);
-                }
-                // Show result of database check and restart the app
-                showSimpleMessageDialog(msg, true);
-            } else {
+            if (result == null || !result.getBoolean() || result.getObjArray() == null || result.getObjArray().length <= 0) {
                 handleDbError();
+                return;
             }
+
+            String msg;
+            Collection.CheckDatabaseResult databaseResult = (Collection.CheckDatabaseResult) result.getObjArray()[0];
+
+            int count = databaseResult.getCardsWithFixedHomeDeckCount();
+            if (count != 0) {
+                String message = getResources().getString(R.string.integrity_check_fixed_no_home_deck, count);
+                UIUtils.showThemedToast(DeckPicker.this,  message, false);
+            }
+
+            long shrunkInMb = Math.round(databaseResult.getSizeChangeInKb() / 1024.0);
+            if (shrunkInMb > 0.0) {
+                msg = String.format(Locale.getDefault(),
+                getResources().getString(R.string.check_db_acknowledge_shrunk), (int) shrunkInMb);
+            } else {
+                msg = getResources().getString(R.string.check_db_acknowledge);
+            }
+            // Show result of database check and restart the app
+            showSimpleMessageDialog(msg, true);
         }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -2383,8 +2383,8 @@ public class DeckPicker extends NavigationDrawerActivity implements
         });
     }
 
-
-    private class CheckDatabaseListener extends CollectionTask.TaskListener {
+    @VisibleForTesting
+    class CheckDatabaseListener extends CollectionTask.TaskListener {
         @Override
         public void onPreExecute() {
             mProgressDialog = StyledProgressDialog.show(DeckPicker.this, AnkiDroidApp.getAppResources().getString(R.string.app_name),

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -47,6 +47,7 @@ import android.widget.Toast;
 
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.ichi2.anim.ActivityTransitionAnimation;
+import com.ichi2.anki.debug.DatabaseLock;
 import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.anki.exception.StorageAccessException;
 import com.ichi2.anki.services.BootService;
@@ -330,6 +331,18 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                         return true;
                     });
                     screen.addPreference(analyticsDebugMode);
+                }
+                if (BuildConfig.DEBUG) {
+                    Timber.i("Debug mode, allowing database lock preference");
+                    Preference lockDbPreference = new Preference(this);
+                    lockDbPreference.setKey("debug_lock_database");
+                    lockDbPreference.setTitle("Lock Database");
+                    lockDbPreference.setSummary("Touch here to lock the database (all threads block in-process, exception if using second process)");
+                    lockDbPreference.setOnPreferenceClickListener(preference -> {
+                        DatabaseLock.engage(this);
+                        return true;
+                    });
+                    screen.addPreference(lockDbPreference);
                 }
                 // Force full sync option
                 ConfirmationPreference fullSyncPreference = (ConfirmationPreference)screen.findPreference("force_full_sync");

--- a/AnkiDroid/src/main/java/com/ichi2/anki/debug/DatabaseLock.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/debug/DatabaseLock.java
@@ -1,0 +1,34 @@
+/*
+ Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.debug;
+
+import android.content.Context;
+
+import com.ichi2.anki.CollectionHelper;
+import com.ichi2.libanki.Collection;
+
+import timber.log.Timber;
+
+/** Debug only class which will lock the database */
+public class DatabaseLock {
+
+    public static void engage(Context ctx) {
+        Collection c = CollectionHelper.getInstance().getCol(ctx);
+        Timber.w("Toggling database lock");
+        c.getDb().getDatabase().beginTransaction();
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.java
@@ -30,6 +30,8 @@ public class DatabaseErrorDialog extends AsyncDialogFragment {
     public static final int DIALOG_CONFIRM_DATABASE_CHECK = 6;
     public static final int DIALOG_CONFIRM_RESTORE_BACKUP = 7;
     public static final int DIALOG_FULL_SYNC_FROM_SERVER = 8;
+    /** If the database is locked, all we can do is reset the app */
+    public static final int DIALOG_DB_LOCKED = 9;
 
     // public flag which lets us distinguish between inaccessible and corrupt database
     public static boolean databaseCorruptFlag = false;
@@ -76,7 +78,7 @@ public class DatabaseErrorDialog extends AsyncDialogFragment {
                         .negativeText(res.getString(R.string.close))
                         .onPositive((inner_dialog, which) -> ((DeckPicker) getActivity())
                                 .showDatabaseErrorDialog(DIALOG_ERROR_HANDLING))
-                        .onNegative((inner_dialog, which) -> ((DeckPicker) getActivity()).exit())
+                        .onNegative((inner_dialog, which) -> exit())
                         .show();
             }
             case DIALOG_DB_ERROR: {
@@ -95,7 +97,7 @@ public class DatabaseErrorDialog extends AsyncDialogFragment {
                             ((DeckPicker) getActivity()).sendErrorReport();
                             dismissAllDialogFragments();
                         })
-                        .onNeutral((inner_dialog, which) -> ((DeckPicker) getActivity()).exit())
+                        .onNeutral((inner_dialog, which) -> exit())
                         .show();
                 dialog.getCustomView().findViewById(R.id.md_buttonDefaultNegative).setEnabled(
                         ((DeckPicker) getActivity()).hasErrorFiles());
@@ -270,9 +272,22 @@ public class DatabaseErrorDialog extends AsyncDialogFragment {
                         })
                         .show();
             }
+            case DIALOG_DB_LOCKED: {
+                //If the database is locked, all we can do is ask the user to exit.
+                return builder.content(getMessage())
+                        .positiveText(res.getString(R.string.close))
+                        .cancelable(false)
+                        .onPositive((inner_dialog, which) -> exit())
+                        .show();
+            }
             default:
                 return null;
         }
+    }
+
+
+    private void exit() {
+        ((DeckPicker) getActivity()).exit();
     }
 
 
@@ -302,6 +317,8 @@ public class DatabaseErrorDialog extends AsyncDialogFragment {
                 return res().getString(R.string.restore_backup);
             case DIALOG_FULL_SYNC_FROM_SERVER:
                 return res().getString(R.string.backup_full_sync_from_server_question);
+            case DIALOG_DB_LOCKED:
+                return res().getString(R.string.database_locked_summary);
             default:
                 return getArguments().getString("dialogMessage");
         }
@@ -327,6 +344,8 @@ public class DatabaseErrorDialog extends AsyncDialogFragment {
                 return res().getString(R.string.restore_backup_title);
             case DIALOG_FULL_SYNC_FROM_SERVER:
                 return res().getString(R.string.backup_full_sync_from_server);
+            case DIALOG_DB_LOCKED:
+                return res().getString(R.string.database_locked_title);
             default:
                 return res().getString(R.string.answering_error_title);
         }        

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -1894,6 +1894,22 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
         public Object[] getObjArray() {
             return mObjects;
         }
+
+
+        public <T> boolean objAtIndexIs(int i, Class<T> clazz) {
+            if (getObjArray() == null) {
+                return false;
+            }
+            if (getObjArray().length <= i) {
+                return false;
+            }
+            Object val = getObjArray()[i];
+            if (val == null) {
+                return false;
+            }
+
+            return clazz.isAssignableFrom(val.getClass());
+        }
     }
 
     public static synchronized CollectionTask getInstance() {

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -991,7 +991,8 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
 
         Collection.CheckDatabaseResult result = col.fixIntegrity(new ProgressCallback(this, AnkiDroidApp.getAppResources()));
         if (result.getFailed()) {
-            return new TaskData(false);
+            //we can fail due to a locked database, which requires knowledge of the failure.
+            return new TaskData(false, new Object[] { result });
         } else {
             // Close the collection and we restart the app to reload
             CollectionHelper.getInstance().closeCollection(true, "Check Database Completed");

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -172,4 +172,8 @@
 
     <!-- Deck Options -->
     <string name="deck_options_corrupt">Failed to process deck options: %s</string>
+
+    <!-- Database Errors-->
+    <string name="database_locked_title">Database Locked</string>
+    <string name="database_locked_summary">The AnkiDroid database is in use by another application. Please close the other application then reopen AnkiDroid.</string>
 </resources>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerCheckDatabaseListenerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerCheckDatabaseListenerTest.java
@@ -1,0 +1,177 @@
+/*
+ Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki;
+
+import android.content.Intent;
+
+import com.ichi2.anki.dialogs.DatabaseErrorDialog;
+import com.ichi2.async.CollectionTask.TaskData;
+import com.ichi2.libanki.Collection.CheckDatabaseResult;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.android.controller.ActivityController;
+
+import androidx.annotation.NonNull;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@RunWith(AndroidJUnit4.class)
+public class DeckPickerCheckDatabaseListenerTest extends RobolectricTest {
+
+    private DeckPickerTestImpl impl;
+
+    @Override
+    public void setUp() {
+        super.setUp();
+        //.visible() crashes: Layout state should be one of 100 but it is 10
+        ActivityController<DeckPickerTestImpl> controller =
+                Robolectric.buildActivity(DeckPickerTestImpl.class, new Intent())
+                .create().start().resume();
+        impl = controller.get();
+        impl.resetVariables();
+    }
+
+    @Test
+    public void failedResultWithNoDataWillDisplayFailedDialog() {
+        TaskData result = failedResultNoData();
+
+        execute(result);
+
+        assertThat("Load Failed dialog should be shown if no data is supplied", impl.didDisplayDialogLoadFailed());
+    }
+
+    @Test
+    public void failedResultWithEmptyDataWillDisplayFailedDialog() {
+        TaskData result = failedResultWithData();
+
+        execute(result);
+
+        assertThat("Load Failed dialog should be shown if empty data is supplied", impl.didDisplayDialogLoadFailed());
+    }
+
+    @Test
+    public void validResultWithEmptyDataWillDisplayFailedDialog() {
+        TaskData result = validResultWithData();
+
+        execute(result);
+
+        assertThat("Load Failed dialog should be shown if empty data is supplied", impl.didDisplayDialogLoadFailed());
+    }
+
+    @Test
+    public void failedResultWithInvalidDataWillDisplayFailedDialog() {
+        TaskData result = failedResultWithData(1);
+
+        execute(result);
+
+        assertThat("Load Failed dialog should be shown if invalid data is supplied", impl.didDisplayDialogLoadFailed());
+    }
+
+    @Test
+    @Ignore("Currently failing")
+    public void validResultWithInvalidDataWillDisplayFailedDialog() {
+        TaskData result = validResultWithData(1);
+
+        execute(result);
+
+        assertThat("Load Failed dialog should be shown if invalid data is supplied", impl.didDisplayDialogLoadFailed());
+    }
+
+    @Test
+    public void validResultWithValidDataWillDisplayMessageBox() {
+        CheckDatabaseResult validData = validData();
+        TaskData result = validResultWithData(validData);
+
+        execute(result);
+
+        assertThat("Load Failed dialog should not be shown if invalid data is supplied", !impl.didDisplayDialogLoadFailed());
+        assertThat("Dialog should be displayed", impl.didDisplayMessage());
+    }
+
+
+    @NonNull
+    private CheckDatabaseResult validData() {
+        return new CheckDatabaseResult(1);
+    }
+
+
+    @NonNull
+    private TaskData failedResultWithData(Object... obj) {
+        return new TaskData(false, obj);
+    }
+
+    @NonNull
+    private TaskData validResultWithData(Object... obj) {
+        return new TaskData(true, obj);
+    }
+
+
+    @NonNull
+    private TaskData failedResultNoData() {
+        return new TaskData(false);
+    }
+
+    private void execute(TaskData result) {
+        DeckPicker.CheckDatabaseListener listener = getInstance(impl);
+
+        listener.onPostExecute(result);
+    }
+
+    @NonNull
+    private DeckPicker.CheckDatabaseListener getInstance(DeckPickerTestImpl test) {
+        return test.new CheckDatabaseListener();
+    }
+
+    /**COULD_BE_BETTER: Listener is too coupled to this */
+    protected static class DeckPickerTestImpl extends DeckPicker {
+
+        private boolean mDidDisplayDialogLoadFailed;
+        private boolean mDidDisplayMessage = false;
+
+
+        public boolean didDisplayDialogLoadFailed() {
+            return mDidDisplayDialogLoadFailed;
+        }
+
+        @Override
+        public void handleDbError() {
+            this.mDidDisplayDialogLoadFailed = true;
+            super.handleDbError();
+            showDatabaseErrorDialog(DatabaseErrorDialog.DIALOG_LOAD_FAILED);
+        }
+
+        public void resetVariables() {
+            mDidDisplayMessage = false;
+            mDidDisplayDialogLoadFailed = false;
+        }
+
+        @Override
+        protected void showSimpleMessageDialog(String message, boolean reload) {
+            mDidDisplayMessage = true;
+            super.showSimpleMessageDialog(message, reload);
+        }
+
+
+        public boolean didDisplayMessage() {
+            return mDidDisplayMessage;
+        }
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/async/AbstractCollectionTaskTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/async/AbstractCollectionTaskTest.java
@@ -1,0 +1,49 @@
+/*
+ Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.async;
+
+import com.ichi2.anki.RobolectricTest;
+
+import org.junit.runner.RunWith;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.notNullValue;
+
+@RunWith(AndroidJUnit4.class)
+public abstract class AbstractCollectionTaskTest extends RobolectricTest {
+
+    protected CollectionTask.TaskData execute(int taskType) {
+        CollectionTask task = CollectionTask.launchCollectionTask(taskType);
+        try {
+            return task.execute().get();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    protected <T> T assertResultArraySingleton(CollectionTask.TaskData result, Class<T> clazz) {
+        assertThat("The result object should be non-null", result.getObjArray(), notNullValue());
+        assertThat("There should only be one result object", result.getObjArray(), arrayWithSize(1));
+        assertThat(String.format("Result should be instance of type '%s'", clazz.getName()), result.getObjArray()[0], instanceOf(clazz));
+        //noinspection unchecked
+        return (T) result.getObjArray()[0];
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/async/CollectionTaskCheckDatabaseTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/async/CollectionTaskCheckDatabaseTest.java
@@ -1,0 +1,48 @@
+/*
+ Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.async;
+
+import com.ichi2.libanki.Collection;
+import com.ichi2.testutils.CollectionUtils;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class CollectionTaskCheckDatabaseTest extends AbstractCollectionTaskTest {
+
+    @Test
+    public void checkDatabaseWithLockedCollectionReturnsLocked() {
+        lockDatabase();
+
+        CollectionTask.TaskData result = super.execute(CollectionTask.TASK_TYPE_CHECK_DATABASE);
+
+        assertThat("The result should specify a failure", result.getBoolean(), is(false));
+        Collection.CheckDatabaseResult checkDbResult = assertObjIsDbResult(result);
+
+        assertThat("The result should specify the database was locked", checkDbResult.getDatabaseLocked());
+    }
+
+    private void lockDatabase() {
+        CollectionUtils.lockDatabase(getCol());
+    }
+
+    protected Collection.CheckDatabaseResult assertObjIsDbResult(CollectionTask.TaskData result) {
+        return assertResultArraySingleton(result, Collection.CheckDatabaseResult.class);
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/CollectionUtils.java
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/CollectionUtils.java
@@ -1,0 +1,46 @@
+/*
+ Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.testutils;
+
+import android.database.sqlite.SQLiteDatabaseLockedException;
+
+import com.ichi2.libanki.Collection;
+import com.ichi2.libanki.DB;
+
+import androidx.sqlite.db.SupportSQLiteDatabase;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+public class CollectionUtils {
+
+    public static void lockDatabase(Collection collection) {
+        DB db = collection.getDb();
+        DB spy = spy(db);
+
+        doThrow(SQLiteDatabaseLockedException.class).when(spy).execute(any());
+        doThrow(SQLiteDatabaseLockedException.class).when(spy).execute(any(), any());
+
+        SupportSQLiteDatabase spiedDb = spy(spy.getDatabase());
+        when(spy.getDatabase()).thenReturn(spiedDb);
+        doThrow(SQLiteDatabaseLockedException.class).when(spiedDb).beginTransaction();
+
+        collection.setDb(spy);
+    }
+}


### PR DESCRIPTION
## Purpose / Description
`beginTransaction` was throwing `SQLiteDatabaseLockedException`

This meant that `endTransaction` threw in Check Integrity.

## Fixes
Fixes #6067 

## Approach
We handle this case in Check Database, and add in a new "Database Error" screen to handle "Database Locked".

## How Has This Been Tested?

Tested on my phone, and unit tests. No longer crashes.

![image](https://user-images.githubusercontent.com/62114487/80917494-1f98cc00-8d57-11ea-9186-797da084c3d9.png)

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code