### PR TITLE
Improve "Error Saving Note" and block adding empty Cloze Deletions.

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1647,15 +1647,8 @@ public class NoteEditor extends AnkiActivity {
         @Override
         public boolean onPrepareActionMode(ActionMode mode, Menu menu) {
             // Adding the cloze deletion floating context menu item, but only once.
-            int noteModelType;
-            try {
-                noteModelType = getCurrentlySelectedModel().getInt("type");
-            } catch (JSONException e) {
-                throw new RuntimeException(e);
-            }
-            boolean isClozeType = noteModelType == Consts.MODEL_CLOZE;
             boolean itemExists = menu.findItem(mMenuId) != null;
-            if (isClozeType && !itemExists) {
+            if (isClozeType() && !itemExists) {
                 menu.add(Menu.NONE, mMenuId, 0, R.string.multimedia_editor_popup_cloze);
                 return true;
             } else {
@@ -1709,6 +1702,18 @@ public class NoteEditor extends AnkiActivity {
             // Left empty on purpose
         }
     }
+
+
+    private boolean isClozeType() {
+        int noteModelType;
+        try {
+            noteModelType = getCurrentlySelectedModel().getInt("type");
+        } catch (JSONException e) {
+            throw new RuntimeException(e);
+        }
+        return noteModelType == Consts.MODEL_CLOZE;
+    }
+
 
     @VisibleForTesting
     void startAdvancedTextEditor(int index) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -29,6 +29,7 @@ import android.graphics.Typeface;
 import android.os.Build;
 import android.os.Bundle;
 
+import androidx.annotation.StringRes;
 import androidx.annotation.VisibleForTesting;
 import androidx.appcompat.widget.PopupMenu;
 import androidx.appcompat.widget.Toolbar;
@@ -233,7 +234,7 @@ public class NoteEditor extends AnkiActivity {
                 UIUtils.showThemedToast(NoteEditor.this,
                         getResources().getQuantityString(R.plurals.factadder_cards_added, count, count), true);
             } else {
-                UIUtils.showThemedToast(NoteEditor.this, getResources().getString(R.string.factadder_saving_error), true);
+                displayErrorSavingNote();
             }
             if (!mAddNote || mCaller == CALLER_CARDEDITOR || mAedictIntent) {
                 mChanged = true;
@@ -286,6 +287,26 @@ public class NoteEditor extends AnkiActivity {
             }
         }
     };
+
+    private void displayErrorSavingNote() {
+        int errorMessageId = getAddNoteErrorResource();
+        UIUtils.showThemedToast(this, getResources().getString(errorMessageId), true);
+    }
+
+
+    protected @StringRes int getAddNoteErrorResource() {
+        //COULD_BE_BETTER: We currently don't perform edits inside this class (wat), so we only handle adds.
+        if (this.isClozeType()) {
+            return R.string.note_editor_no_cloze_delations;
+        }
+
+        if (TextUtils.isEmpty(getCurrentFieldText(0))) {
+            return R.string.note_editor_no_first_field;
+        }
+
+        //Otherwise, display "no cards created".
+        return R.string.note_editor_no_cards_created;
+    }
 
 
     // ----------------------------------------------------------------------------
@@ -692,8 +713,8 @@ public class NoteEditor extends AnkiActivity {
         return mTagsEdited;
     }
 
-
-    private void saveNote() {
+    @VisibleForTesting
+    void saveNote() {
         final Resources res = getResources();
         if (mSelectedTags == null) {
             mSelectedTags = new ArrayList<>();
@@ -1709,7 +1730,7 @@ public class NoteEditor extends AnkiActivity {
         }
         return ClozeUtils.getNextClozeIndex(fieldValues);
     }
-    
+
     private boolean isClozeType() {
         return getCurrentlySelectedModel().getInt("type") == Consts.MODEL_CLOZE;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1079,7 +1079,7 @@ public class NoteEditor extends AnkiActivity {
         }
         String[] ret = new String[mEditFields.size()];
         for (int i = 0; i < mEditFields.size(); i++) {
-            ret[i] = mEditFields.get(i).getText().toString();
+            ret[i] = getCurrentFieldText(i);
         }
         return ret;
     }
@@ -1347,9 +1347,15 @@ public class NoteEditor extends AnkiActivity {
     private String getFieldsText() {
         String[] fields = new String[mEditFields.size()];
         for (int i = 0; i < mEditFields.size(); i++) {
-            fields[i] = mEditFields.get(i).getText().toString();
+            int i1 = i;
+            fields[i] = getCurrentFieldText(i1);
         }
         return Utils.joinFields(fields);
+    }
+
+    /** Returns the value of the field at the given index */
+    private String getCurrentFieldText(int index) {
+        return mEditFields.get(index).getText().toString();
     }
 
 
@@ -1559,7 +1565,7 @@ public class NoteEditor extends AnkiActivity {
                 int size = mEditFields.size();
                 String[] oldValues = new String[size];
                 for (int i = 0; i < size; i++) {
-                    oldValues[i] = mEditFields.get(i).getText().toString();
+                    oldValues[i] = getCurrentFieldText(i);
                 }
                 setNote();
                 resetEditFields(oldValues);
@@ -1712,7 +1718,7 @@ public class NoteEditor extends AnkiActivity {
     @VisibleForTesting
     void startAdvancedTextEditor(int index) {
         TextField field = new TextField();
-        field.setText(mEditFields.get(index).getText().toString());
+        field.setText(getCurrentFieldText(index));
         startMultimediaFieldEditorForField(index, field);
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -721,6 +721,12 @@ public class NoteEditor extends AnkiActivity {
         }
         // treat add new note and edit existing note independently
         if (mAddNote) {
+            //Different from libAnki, block if there are no cloze deletions.
+            if (isClozeType() && !hasClozeDeletions()) {
+                displayErrorSavingNote();
+                return;
+            }
+
             // load all of the fields into the note
             for (FieldEditText f : mEditFields) {
                 updateField(f);
@@ -1719,7 +1725,9 @@ public class NoteEditor extends AnkiActivity {
         }
     }
 
-
+    private boolean hasClozeDeletions() {
+        return getNextClozeIndex() > 1;
+    }
 
     private int getNextClozeIndex() {
         List<String> fieldValues = new ArrayList<>(mEditFields.size());

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1705,13 +1705,7 @@ public class NoteEditor extends AnkiActivity {
 
 
     private boolean isClozeType() {
-        int noteModelType;
-        try {
-            noteModelType = getCurrentlySelectedModel().getInt("type");
-        } catch (JSONException e) {
-            throw new RuntimeException(e);
-        }
-        return noteModelType == Consts.MODEL_CLOZE;
+        return getCurrentlySelectedModel().getInt("type") == Consts.MODEL_CLOZE;
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1692,17 +1692,6 @@ public class NoteEditor extends AnkiActivity {
         }
 
 
-        private int getNextClozeIndex() {
-            List<String> fieldValues = new ArrayList<>(mEditFields.size());
-            for (FieldEditText e : mEditFields) {
-                Editable editable = e.getText();
-                String fieldValue = editable == null ? "" : editable.toString();
-                fieldValues.add(fieldValue);
-            }
-            return ClozeUtils.getNextClozeIndex(fieldValues);
-        }
-
-
         @Override
         public void onDestroyActionMode(ActionMode mode) {
             // Left empty on purpose
@@ -1710,6 +1699,17 @@ public class NoteEditor extends AnkiActivity {
     }
 
 
+
+    private int getNextClozeIndex() {
+        List<String> fieldValues = new ArrayList<>(mEditFields.size());
+        for (FieldEditText e : mEditFields) {
+            Editable editable = e.getText();
+            String fieldValue = editable == null ? "" : editable.toString();
+            fieldValues.add(fieldValue);
+        }
+        return ClozeUtils.getNextClozeIndex(fieldValues);
+    }
+    
     private boolean isClozeType() {
         return getCurrentlySelectedModel().getInt("type") == Consts.MODEL_CLOZE;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -722,6 +722,7 @@ public class NoteEditor extends AnkiActivity {
         // treat add new note and edit existing note independently
         if (mAddNote) {
             //Different from libAnki, block if there are no cloze deletions.
+            //DEFECT: This does not block addition if cloze transpositions are in non-cloze fields.
             if (isClozeType() && !hasClozeDeletions()) {
                 displayErrorSavingNote();
                 return;
@@ -1730,6 +1731,7 @@ public class NoteEditor extends AnkiActivity {
     }
 
     private int getNextClozeIndex() {
+        /** BUG: This assumes all fields are inserted as: {{cloze:Text}} */
         List<String> fieldValues = new ArrayList<>(mEditFields.size());
         for (FieldEditText e : mEditFields) {
             Editable editable = e.getText();

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -95,7 +95,9 @@
     <string name="cardeditor_title_add_note">Add note</string>
     <string name="cardeditor_title_edit_card">Edit note</string>
     <string name="discard_unsaved_changes">Close and lose current input?</string>
-    <string name="factadder_saving_error">Error saving note</string>
+    <string name="note_editor_no_cards_created">No cards created. Please fill in more fields</string>
+    <string name="note_editor_no_first_field">The first field is empty</string>
+    <string name="note_editor_no_cloze_delations">This note type must contain cloze deletions</string>
     <string name="saving_facts">Saving note</string>
     <string name="saving_model">Saving note type</string>
     <string name="add">Add</string>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.java
@@ -81,6 +81,34 @@ public class NoteEditorTest extends RobolectricTest {
         assertThat(actualResourceId, is(R.string.note_editor_no_cards_created));
     }
 
+    @Test
+    public void clozeNoteWithNoClozeDeletionsDoesNotSave() {
+        int initialCards = getCardCount();
+        NoteEditor editor = getNoteEditorAdding(NoteType.CLOZE)
+                .withFirstField("no cloze deletions")
+                .build();
+
+        editor.saveNote();
+
+        assertThat(getCardCount(), is(initialCards));
+    }
+
+    @Test
+    public void clozeNoteWithClozeDeletionsDoesSave() {
+        int initialCards = getCardCount();
+        NoteEditor editor = getNoteEditorAdding(NoteType.CLOZE)
+                .withFirstField("{{c1::AnkiDroid}} is fantastic")
+                .build();
+
+        editor.saveNote();
+
+        assertThat(getCardCount(), is(initialCards + 1));
+    }
+
+    private int getCardCount() {
+        return getCol().cardCount();
+    }
+
     private NoteEditorTestBuilder getNoteEditorAdding(NoteType noteType) {
         JSONObject n = makeNoteForType(noteType);
         return new NoteEditorTestBuilder(n);

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.java
@@ -7,6 +7,7 @@ import com.ichi2.anki.multimediacard.fields.IField;
 import com.ichi2.libanki.Note;
 import com.ichi2.utils.JSONObject;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.shadows.ShadowActivity;
@@ -105,6 +106,20 @@ public class NoteEditorTest extends RobolectricTest {
         assertThat(getCardCount(), is(initialCards + 1));
     }
 
+    @Test
+    @Ignore("Not yet implemented")
+    public void clozeNoteWithClozeInWrongFieldDoesNotSave() {
+        //Anki Desktop blocks with "Continue?", we sould just block to match the above test
+        int initialCards = getCardCount();
+        NoteEditor editor = getNoteEditorAdding(NoteType.CLOZE)
+                .withSecondField("{{c1::AnkiDroid}} is fantastic")
+                .build();
+
+        editor.saveNote();
+
+        assertThat(getCardCount(), is(initialCards));
+    }
+
     private int getCardCount() {
         return getCol().cardCount();
     }
@@ -181,6 +196,7 @@ public class NoteEditorTest extends RobolectricTest {
 
         private final JSONObject mModel;
         private String mFirstField;
+        private String mSecondField;
 
 
         public NoteEditorTestBuilder(JSONObject model) {
@@ -198,6 +214,9 @@ public class NoteEditorTest extends RobolectricTest {
             getCol().getModels().setCurrent(mModel);
             T noteEditor = getNoteEditorAddingNote(FromScreen.REVIEWER, clazz);
             noteEditor.setFieldValueFromUi(0, mFirstField);
+            if (mSecondField != null) {
+                noteEditor.setFieldValueFromUi(1, mSecondField);
+            }
             return noteEditor;
         }
 
@@ -208,6 +227,12 @@ public class NoteEditorTest extends RobolectricTest {
 
         public NoteEditorTestBuilder withFirstField(String text) {
             this.mFirstField = text;
+            return this;
+        }
+
+
+        public NoteEditorTestBuilder withSecondField(String text) {
+            this.mSecondField = text;
             return this;
         }
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
@@ -21,6 +21,7 @@ import android.content.Intent;
 
 import com.afollestad.materialdialogs.DialogAction;
 import com.afollestad.materialdialogs.MaterialDialog;
+import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.DB;
 import com.ichi2.libanki.Models;
@@ -103,15 +104,44 @@ public class RobolectricTest {
     }
 
     protected Note addNoteUsingBasicModel(String front, String back) {
-        JSONObject basicModel = getCol().getModels().byName("Basic");
+        return addNoteUsingModelName("Basic", front, back);
+    }
+
+    protected Note addNoteUsingModelName(String name, String... fields) {
+        JSONObject model = getCol().getModels().byName(name);
         //PERF: if we modify newNote(), we can return the card and return a Pair<Note, Card> here.
         //Saves a database trip afterwards.
-        Note n = getCol().newNote(basicModel);
-        n.setField(0, front);
-        n.setField(1, back);
+        Note n = getCol().newNote(model);
+        for(int i = 0; i < fields.length; i++) {
+            n.setField(i, fields[i]);
+        }
         if (getCol().addNote(n) != 1) {
-            throw new IllegalStateException(String.format("Could not add note: {'%s', '%s'}", front, back));
+            throw new IllegalStateException(String.format("Could not add note: {%s}", String.join(", ", fields)));
         }
         return n;
+    }
+
+
+    protected String addNonClozeModel(String name, String[] fields, String qfmt, String afmt) {
+        JSONObject model = getCol().getModels().newModel(name);
+        for (int i = 0; i < fields.length; i++) {
+            addField(model, fields[i]);
+        }
+        model.put(FlashCardsContract.CardTemplate.QUESTION_FORMAT, qfmt);
+        model.put(FlashCardsContract.CardTemplate.ANSWER_FORMAT, afmt);
+        getCol().getModels().add(model);
+        getCol().getModels().flush();
+        return name;
+    }
+
+
+    private void addField(JSONObject model, String name) {
+        Models models = getCol().getModels();
+
+        try {
+            models.addField(model, models.newField(name));
+        } catch (ConfirmModSchemaException e) {
+            throw new RuntimeException(e);
+        }
     }
 }


### PR DESCRIPTION
## Purpose / Description

**Error Text**

For reference, Anki shows:

```
The input you have provided would make an empty question on all cards.
The first field is empty.
You have a cloze deletion note type but have not made any cloze deletions. Proceed?
```

**Cloze**

Anki displays a dialog asking if the user wants to proceed, from a UX perspective, I'd much rater block the action, even though it is currently permitted by libAnki as it doesn't seem like a logical user action

## Fixes
Fixes #5893

## Approach

Make the error dialog variable, and block adding cloze deletions

## How Has This Been Tested?

Some very pretty unit tests, if I do say so myself

Also tested on my phone, can no longer add empty cloze notes, and the errors are better.

## ⚠️ Defect  
Adding {{c1::XX}} to the "Extras" field will allow addition of a note. Introduced in #5652, have left an ignored test to ensure this doesn't get too big.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code