### PR TITLE
Correcting #6103 by following anki

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/template/Template.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/template/Template.java
@@ -72,6 +72,8 @@ public class Template {
     private String mTemplate;
     private Map<String, String> mContext;
 
+    private static String ALT_HANDLEBAR_DIRECTIVE = "{{=<% %>=}}";
+
     private static String get_or_attr(Map<String, String> obj, String name) {
         return get_or_attr(obj, name, null);
     }
@@ -151,6 +153,9 @@ public class Template {
      * Renders all the tags in a template for a context.
      */
     private String render_tags(String template, Map<String, String> context) {
+        if (template.indexOf(ALT_HANDLEBAR_DIRECTIVE) != -1) {
+            template = template.replace(ALT_HANDLEBAR_DIRECTIVE, "").replace("<%", "{{").replace("%>", "}}");
+        }
         StringBuffer sb = new StringBuffer();
         Matcher match = sTag_re.matcher(template);
         while (match.find()) {


### PR DESCRIPTION
Please accept either this PR or https://github.com/ankidroid/Anki-Android/pull/6107 but not both.

The difference is that the current PR follow anki code (see 
https://github.com/ankitects/anki/commit/9bb0348fdd41b1b50fa07b64405c72c3ff263f98 )
The problem here is that it changes the way ankidroid behaves. Indeed Anki only consider the replacement "{{=<% %>=}}" while AnkiDroid considered any replacement of the form "{{=FOO BAR=}}".

The other PR still accept any replacement, while this PR only accept the very specific replacement accepted by anki. 

I've not yet tested this, mainly because I don't know what is the way we want the feature to be implemented, and so I don't know what is the expected result.
