### PR TITLE
BUGFIX: Play All Audio on card when viewed

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.java
@@ -49,6 +49,8 @@ import java.util.regex.Pattern;
 import androidx.annotation.Nullable;
 import timber.log.Timber;
 
+
+//NICE_TO_HAVE: Abstract, then add tests fir #6111
 /**
  * Class used to parse, load and play sound files on AnkiDroid.
  */
@@ -381,12 +383,9 @@ public class Sound {
 
         @Override
         public void onCompletion(MediaPlayer mp) {
-            try {
-                //We call onCompletion first, as we release the media player in releaseSound()
-                if (userCallback != null) {
-                    userCallback.onCompletion(mp);
-                }
-            } finally {
+            if (userCallback != null) {
+                userCallback.onCompletion(mp);
+            } else {
                 releaseSound();
             }
         }


### PR DESCRIPTION
## Purpose / Description
Previously, `releaseSound()` was called too early, this stopped the third sound from being heard.

## Fixes
Fixes #6111.

## Approach
We only call `releaseSound()` if the execution is not deferred to a secondary media player

## How Has This Been Tested?

⚠️ This area is extremely hard to test due to using native media players.
So only a note to test has been added rather than unit tests.

Tested on my device manually

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code