### PR TITLE
Fix Filtered Deck Options Infinite loop on Don't Keep Activities

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
@@ -171,7 +171,8 @@ public class StudyOptionsFragment extends Fragment implements Toolbar.OnMenuItem
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        if (getArguments() != null) {
+        //If we're being restored, don't launch deck options again.
+        if (savedInstanceState == null && getArguments() != null) {
             mLoadWithDeckOptions = getArguments().getBoolean("withDeckOptions");
         }
     }


### PR DESCRIPTION
## Purpose / Description
If Don't Keep Activities was on, the fragment `onCreate` would be called and this would infinitely open the Filtered Deck Options

## Fixes
Fixes #6113

## Approach
We only set the variable to open the deck options if the activity was created for the first time

## How Has This Been Tested?

On my phone ⚠️ Not with split screen.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code