### PR TITLE
Remove {{=

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/template/Template.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/template/Template.java
@@ -50,17 +50,17 @@ public class Template {
     private static final Pattern fHookFieldMod = Pattern.compile("^(.*?)(?:\\((.*)\\))?$");
     private static final String TAG = Template.class.getName();
 
-    // The regular expression used to find a #section
-    private Pattern sSection_re = null;
-
-    // The regular expression used to find a tag.
-    private Pattern sTag_re = null;
-
     // Opening tag delimiter
     private static final String sOtag = Pattern.quote("{{");
 
     // Closing tag delimiter
     private static final String sCtag = Pattern.quote("}}");
+
+    // The regular expression used to find a #section
+    private Pattern sSection_re = null;
+
+    // The regular expression used to find a tag.
+    private Pattern sTag_re = null;
 
     // MathJax opening delimiters
     private static String sMathJaxOpenings[] = {"\\(", "\\["};

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/template/Template.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/template/Template.java
@@ -167,8 +167,6 @@ public class Template {
                 replacement = render_tag(tag_name, context);
             } else if ("!".equals(tag_type)) {
                 replacement = render_comment();
-            } else if ("=".equals(tag_type)) {
-                replacement = render_delimiter(tag_name);
             } else {
                 return "{{invalid template}}";
             }
@@ -405,22 +403,5 @@ public class Template {
             m.appendReplacement(repl, Matcher.quoteReplacement(m.group(0)));
         }
         return m.appendTail(repl).toString();
-    }
-
-
-    /**
-     * Changes the Mustache delimiter.
-     */
-    private String render_delimiter(String tag_name) {
-        try {
-            String[] split = tag_name.split(" ");
-            sOtag = split[0];
-            sCtag = split[1];
-        } catch (IndexOutOfBoundsException e) {
-            // invalid
-            return null;
-        }
-        compile_regexps();
-        return "";
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/template/Template.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/template/Template.java
@@ -57,10 +57,10 @@ public class Template {
     private Pattern sTag_re = null;
 
     // Opening tag delimiter
-    private String sOtag = Pattern.quote("{{");
+    private static final String sOtag = Pattern.quote("{{");
 
     // Closing tag delimiter
-    private String sCtag = Pattern.quote("}}");
+    private static final String sCtag = Pattern.quote("}}");
 
     // MathJax opening delimiters
     private static String sMathJaxOpenings[] = {"\\(", "\\["};

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/template/Template.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/template/Template.java
@@ -57,10 +57,10 @@ public class Template {
     private Pattern sTag_re = null;
 
     // Opening tag delimiter
-    private String sOtag = "{{";
+    private String sOtag = Pattern.quote("{{");
 
     // Closing tag delimiter
-    private String sCtag = "}}";
+    private String sCtag = Pattern.quote("}}");
 
     // MathJax opening delimiters
     private static String sMathJaxOpenings[] = {"\\(", "\\["};
@@ -105,13 +105,10 @@ public class Template {
      * Compiles our section and tag regular expressions.
      */
     private void compile_regexps() {
-        String otag = Pattern.quote(sOtag);
-        String ctag = Pattern.quote(sCtag);
-
-        String section = otag + "[\\#|^]([^\\}]*)" + ctag + "(.+?)" + otag + "/\\1" + ctag;
+        String section = sOtag + "[\\#|^]([^\\}]*)" + sCtag + "(.+?)" + sOtag + "/\\1" + sCtag;
         sSection_re = Pattern.compile(section, Pattern.MULTILINE | Pattern.DOTALL);
 
-        String tag = otag + "(#|=|&|!|>|\\{)?(.+?)\\1?" + ctag + "+";
+        String tag = sOtag + "(#|=|&|!|>|\\{)?(.+?)\\1?" + sCtag + "+";
         sTag_re = Pattern.compile(tag);
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/template/Template.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/template/Template.java
@@ -89,7 +89,6 @@ public class Template {
     public Template(String template, Map<String, String> context) {
         mTemplate = template;
         mContext = context == null ? new HashMap<String, String>() : context;
-        compile_regexps();
     }
 
 
@@ -99,12 +98,6 @@ public class Template {
     public String render() {
         String template = render_sections(mTemplate, mContext);
         return render_tags(template, mContext);
-    }
-
-    /**
-     * Compiles our section and tag regular expressions.
-     */
-    private void compile_regexps() {
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/template/Template.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/template/Template.java
@@ -57,10 +57,10 @@ public class Template {
     private static final String sCtag = Pattern.quote("}}");
 
     // The regular expression used to find a #section
-    private Pattern sSection_re = null;
+    private static final Pattern sSection_re = Pattern.compile(sOtag + "[\\#|^]([^\\}]*)" + sCtag + "(.+?)" + sOtag + "/\\1" + sCtag, Pattern.MULTILINE | Pattern.DOTALL);
 
     // The regular expression used to find a tag.
-    private Pattern sTag_re = null;
+    private static final Pattern sTag_re = Pattern.compile(sOtag + "(#|=|&|!|>|\\{)?(.+?)\\1?" + sCtag + "+");
 
     // MathJax opening delimiters
     private static String sMathJaxOpenings[] = {"\\(", "\\["};
@@ -105,9 +105,6 @@ public class Template {
      * Compiles our section and tag regular expressions.
      */
     private void compile_regexps() {
-        sSection_re = Pattern.compile(sOtag + "[\\#|^]([^\\}]*)" + sCtag + "(.+?)" + sOtag + "/\\1" + sCtag, Pattern.MULTILINE | Pattern.DOTALL);
-
-        sTag_re = Pattern.compile(sOtag + "(#|=|&|!|>|\\{)?(.+?)\\1?" + sCtag + "+");
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/template/Template.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/template/Template.java
@@ -105,11 +105,9 @@ public class Template {
      * Compiles our section and tag regular expressions.
      */
     private void compile_regexps() {
-        String section = sOtag + "[\\#|^]([^\\}]*)" + sCtag + "(.+?)" + sOtag + "/\\1" + sCtag;
-        sSection_re = Pattern.compile(section, Pattern.MULTILINE | Pattern.DOTALL);
+        sSection_re = Pattern.compile(sOtag + "[\\#|^]([^\\}]*)" + sCtag + "(.+?)" + sOtag + "/\\1" + sCtag, Pattern.MULTILINE | Pattern.DOTALL);
 
-        String tag = sOtag + "(#|=|&|!|>|\\{)?(.+?)\\1?" + sCtag + "+";
-        sTag_re = Pattern.compile(tag);
+        sTag_re = Pattern.compile(sOtag + "(#|=|&|!|>|\\{)?(.+?)\\1?" + sCtag + "+");
     }
 
     /**


### PR DESCRIPTION
This is a follow-up to https://github.com/ankidroid/Anki-Android/pull/6108#event-3302478237 , following the advice of https://github.com/ankidroid/Anki-Android/issues/6103#issuecomment-623731205
I should note that, since some variable can never be assigned after initialization anymore, there is no need to keep so many function to deal with the change of values. Actually, a lot of variables can become static and final. 

I don't expect to change the computation time in any way. This won't solve any bug. I just want to simplify the codebase by removing things which became useless.