### PR TITLE
Only restricted devices require system browser

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -87,7 +87,6 @@ import com.ichi2.utils.NamedJSONComparator;
 import com.ichi2.widget.WidgetStatus;
 
 import com.ichi2.utils.JSONArray;
-import com.ichi2.utils.JSONException;
 import com.ichi2.utils.JSONObject;
 
 import java.util.ArrayList;
@@ -1225,7 +1224,7 @@ public class NoteEditor extends AnkiActivity {
                             return false;
                     }
                 });
-                if (AdaptionUtil.hasReducedPreferences()) {
+                if (AdaptionUtil.isRestrictedLearningDevice()) {
                     popup.getMenu().findItem(R.id.menu_multimedia_photo).setVisible(false);
                     popup.getMenu().findItem(R.id.menu_multimedia_text).setVisible(false);
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -133,7 +133,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
         Iterator iterator = target.iterator();
         while (iterator.hasNext()) {
             Header header = (Header)iterator.next();
-            if ((header.titleRes == R.string.pref_cat_advanced) && AdaptionUtil.hasReducedPreferences()){
+            if ((header.titleRes == R.string.pref_cat_advanced) && AdaptionUtil.isRestrictedLearningDevice()){
                 iterator.remove();
             }
         }
@@ -202,7 +202,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
             case "com.ichi2.anki.prefs.general":
                 listener.addPreferencesFromResource(R.xml.preferences_general);
                 screen = listener.getPreferenceScreen();
-                if (AdaptionUtil.hasReducedPreferences()) {
+                if (AdaptionUtil.isRestrictedLearningDevice()) {
                     CheckBoxPreference mCheckBoxPref_Vibrate = (CheckBoxPreference) screen.findPreference("widgetVibrate");
                     CheckBoxPreference mCheckBoxPref_Blink = (CheckBoxPreference) screen.findPreference("widgetBlink");
                     PreferenceCategory mCategory = (PreferenceCategory) screen.findPreference("category_general_notification_pref");

--- a/AnkiDroid/src/main/java/com/ichi2/utils/AdaptionUtil.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/AdaptionUtil.java
@@ -1,3 +1,19 @@
+/****************************************************************************************
+ * Copyright (c) 2020 gaoyingjun@xiaomi.com                                             *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+
 package com.ichi2.utils;
 
 import android.content.Context;
@@ -12,6 +28,8 @@ import android.os.Build;
 import java.util.List;
 
 public class AdaptionUtil {
+    private static boolean sHasRunRestrictedLearningDeviceCheck = false;
+    private static boolean sIsRestrictedLearningDevice = false;
     private static boolean sHasRunWebBrowserCheck = false;
     private static boolean sHasWebBrowser = true;
 
@@ -23,23 +41,24 @@ public class AdaptionUtil {
         Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse("http://www.google.com"));
         PackageManager pm = context.getPackageManager();
         List<ResolveInfo> list = pm.queryIntentActivities(intent, PackageManager.MATCH_DEFAULT_ONLY);
-        if (list.size() == 0) {
-            sHasWebBrowser = false;
-        } else {
-            sHasWebBrowser = false;
-            for (ResolveInfo ri:list) {
-                String pacagename = ri.activityInfo.packageName;
-                if (isSystemApp(pacagename, pm)) {
-                    sHasWebBrowser = true;
-                    break;
-                }
+        sHasWebBrowser = false;
+        for (ResolveInfo ri : list) {
+            // If we aren't a restricted device, any browser will do
+            if (!isRestrictedLearningDevice()) {
+                sHasWebBrowser = true;
+                break;
+            }
+            // If we are a restricted device, only a system browser will do
+            if (isSystemApp(ri.activityInfo.packageName, pm)) {
+                sHasWebBrowser = true;
+                break;
             }
         }
         sHasRunWebBrowserCheck = true;
         return sHasWebBrowser;
     }
 
-    private static boolean isSystemApp(String packageName, PackageManager pm){
+    private static boolean isSystemApp(String packageName, PackageManager pm) {
         if (packageName != null) {
             try {
                 PackageInfo info = pm.getPackageInfo(packageName, 0);
@@ -53,7 +72,13 @@ public class AdaptionUtil {
         }
     }
 
-    public static boolean hasReducedPreferences(){
-        return "Xiaomi".equalsIgnoreCase(Build.MANUFACTURER) && ("Archytas".equalsIgnoreCase(Build.PRODUCT) || "Archimedes".equalsIgnoreCase(Build.PRODUCT));
+    public static boolean isRestrictedLearningDevice() {
+        if (!sHasRunRestrictedLearningDeviceCheck) {
+            sIsRestrictedLearningDevice =
+                    "Xiaomi".equalsIgnoreCase(Build.MANUFACTURER) &&
+                            ("Archytas".equalsIgnoreCase(Build.PRODUCT) || "Archimedes".equalsIgnoreCase(Build.PRODUCT));
+            sHasRunRestrictedLearningDeviceCheck = true;
+        }
+        return sIsRestrictedLearningDevice;
     }
 }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
#5913 implements a system-app-only requirement for the web browser on restricted learning devices, but implements it in a way that imposes that restriction even for non-restricted browsers


## Fixes
#6109 - non-restricted device could not load web content

## Approach
This makes the "is the browser a system app?" check only apply on restricted devices

I also added copyright header, fixed whitespace, and changed the variable + method names to contain the feature's intent in the name

## How Has This Been Tested?

- Local `./gradlew jacocoTestReport` on this one after visual inspection a few times
- API28 emulator get shared decks with Chrome installed: worked (correct)
- API28 emulator w/Chrome disabled: got a toast saying no browser (correct)
- API28 emulator w/Chrome disabled, Firefox installed as user: worked (correct)

## Learning (optional, can help others)
Nothing special, just that code review is both valuable and still very faulty. Missed this when it went through the first time


## Checklist

- [ ] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
