### PR TITLE
Revert "don't put "undo" to color enabled"

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -432,12 +432,14 @@ public class Reviewer extends AbstractFlashcardViewer {
         if (mShowWhiteboard && mWhiteboard != null && mWhiteboard.undoSize() > 0) {
             // Whiteboard undo queue non-empty. Switch the undo icon to a whiteboard specific one.
             menu.findItem(R.id.action_undo).setIcon(R.drawable.ic_eraser_variant_white_24dp);
+            menu.findItem(R.id.action_undo).setEnabled(true).getIcon().setAlpha(Themes.ALPHA_ICON_ENABLED_LIGHT);
         } else if (mShowWhiteboard && mWhiteboard != null && mWhiteboard.isUndoModeActive()) {
             // Whiteboard undo queue empty, but user has added strokes to it for current card. Disable undo button.
             menu.findItem(R.id.action_undo).setIcon(R.drawable.ic_eraser_variant_white_24dp);
             menu.findItem(R.id.action_undo).setEnabled(false).getIcon().setAlpha(Themes.ALPHA_ICON_DISABLED_LIGHT);
         } else if (colIsOpen() && getCol().undoAvailable()) {
             menu.findItem(R.id.action_undo).setIcon(R.drawable.ic_undo_white_24dp);
+            menu.findItem(R.id.action_undo).setEnabled(true).getIcon().setAlpha(Themes.ALPHA_ICON_ENABLED_LIGHT);
         } else {
             menu.findItem(R.id.action_undo).setIcon(R.drawable.ic_undo_white_24dp);
             menu.findItem(R.id.action_undo).setEnabled(false).getIcon().setAlpha(Themes.ALPHA_ICON_DISABLED_LIGHT);


### PR DESCRIPTION
This reverts commit 029afff7

Fixes #6119 - Eraser was not set to visible after drawing

~~Was asked to revert, but I feel we can get away with just removing line 442, will test.~~

EDIT: From my understanding `.getIcon()` has changed between setting the visibility due to the buttons being disabled, it appears to cache the previous alpha value. Looks good to go. 