### PR TITLE
NF: Added Logging around collection close

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -259,6 +259,8 @@ public class AnkiDroidApp extends Application {
                 }
             }
         }
+
+        Timber.i("AnkiDroidApp: Starting Services");
         new BootService().onReceive(this, new Intent(this, BootService.class));
 
         // Register BroadcastReceiver NotificationService

--- a/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.java
@@ -221,6 +221,7 @@ public class BackupManager {
     public static boolean repairCollection(Collection col) {
         String deckPath = col.getPath();
         File deckFile = new File(deckPath);
+        Timber.i("BackupManager - RepairCollection - Closing Collection");
         col.close();
 
         // repair file

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
@@ -218,6 +218,7 @@ public abstract class NavigationDrawerActivity extends AnkiActivity implements N
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         final SharedPreferences preferences = getPreferences();
+        Timber.i("Handling Activity Result: %d. Result: %d", requestCode, resultCode);
         // Update language
         AnkiDroidApp.setLanguage(preferences.getString(Preferences.LANGUAGE, ""));
         NotificationChannels.setup(getApplicationContext());

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -1005,6 +1005,7 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
         Timber.d("doInBackgroundRepairDeck");
         Collection col = CollectionHelper.getInstance().getCol(mContext);
         if (col != null) {
+            Timber.i("RepairDeck: Closing collection");
             col.close(false);
         }
         return new TaskData(BackupManager.repairCollection(col));

--- a/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
@@ -463,6 +463,7 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
             }
             return data;
         } finally {
+            Timber.i("Sync Finished - Closing Collection");
             // don't bump mod time unless we explicitly save
             if (col != null) {
                 col.close(false);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.java
@@ -330,6 +330,7 @@ public final class AnkiPackageExporter extends AnkiExporter {
     @Override
     public void exportInto(String path, Context context) throws IOException, JSONException, ImportExportException {
         // sched info+v2 scheduler not compatible w/ older clients
+        Timber.i("Starting export into %s", path);
         _v2sched = mCol.schedVer() != 1 && mIncludeSched;
 
         // open a zip file

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -394,6 +394,7 @@ public class Collection {
 
 
     public void reopen() {
+        Timber.i("Reopening Database");
         if (mDb == null) {
             mDb = new DB(mPath);
             mMedia.connect();
@@ -460,6 +461,7 @@ public class Collection {
         mDecks.beforeUpload();
         modSchemaNoCheck();
         mLs = mScm;
+        Timber.i("Compacting database before full upload");
         // ensure db is compacted before upload
         mDb.execute("vacuum");
         mDb.execute("analyze");

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/FullSyncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/FullSyncer.java
@@ -79,6 +79,7 @@ public class FullSyncer extends HttpSyncer {
         }
         String path;
         if (mCol != null) {
+            Timber.i("Closing collection for full sync");
             // Usual case where collection is non-null
             path = mCol.getPath();
             mCol.close();


### PR DESCRIPTION
in 2.10beta2, we still have issues with the collection being closed, which crashes tasks started by the reviewer, this is probably fixable now, but there's not enough logging to determine why this occurred and I'd rather properly diagnose it, rather than patch around the underling issue.

Ref: 
https://couchdb.ankidroid.org/acralyzer/_design/acralyzer/index.html#/report-details/de3c036d-852f-4f19-a3df-15e4ed8851b8 , but this crashes at various points due to the null database.

This additional logging isn't definitive, but should hopefully be sufficient to be able to understand the UI flow from logs.

## How Has This Been Tested?

🤠 

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code