### PR TITLE
Allow conditional field inside itself

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/template/Template.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/template/Template.java
@@ -150,7 +150,7 @@ public class Template {
             // conditional is a ^; or if the field is non-empty and
             // the conditional is not ^.
             boolean show_inner = field_is_empty == conditional_is_negative;
-            String replacer = (show_inner) ? render_sections(inner, context) : "";
+            String replacer = (show_inner) ? inner : "";
             match.appendReplacement(sb, Matcher.quoteReplacement(replacer));
         }
         if (!found) {

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/template/TemplateTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/template/TemplateTest.java
@@ -1,0 +1,59 @@
+/*
+ Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.libanki.template;
+
+import com.ichi2.anki.RobolectricTest;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.HashMap;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+@RunWith(AndroidJUnit4.class)
+public class TemplateTest extends RobolectricTest {
+
+    @Test
+    public void nestedTemplatesRenderWell() {
+        //#6123
+        String problematicTemplate = "{{#One}}\n" +
+                "    {{#One}}\n" +
+                "        {{One}}<br>\n" +
+                "    {{/One}}\n" +
+                "    {{#Two}}\n" +
+                "        {{Two}}\n" +
+                "    {{/Two}}\n" +
+                "{{/One}}";
+
+        HashMap<String, String> context = new HashMap<>();
+        context.put("One", "Card1 - One");
+        context.put("Two", "Card1 - Two");
+        Template template = new Template(problematicTemplate, context);
+
+        String result = template.render();
+
+        //most important - that it does render
+        assertThat(result, not("{{invalid template}}"));
+        //Actual value (may be subject to change).
+        assertThat(result, is("\n    \n        Card1 - One<br>\n    \n    \n        Card1 - Two\n    \n"));
+    }
+}


### PR DESCRIPTION
This corrects #6123. See the bug report discussion for more context.

Anki up to 2.1.17 does not deal correctly with a conditional field
containing the same conditional field. AnkiDroid didn't
either. However, it still worked as long as all conditions evaluates
to true, and broke only when a condition evaluates to False. If a
condition evaluated to False, an error message would be raised.

I am copying back this rules. All evaluations to True still products
the same result as before. A conditional evaluated to False produce an
error message.

I personally am not convinced at all that this is relevant. Saying
"you can used a conditional nested in the same conditional only when
all conditionals evaluate to true" is more confusing than saying that
this feature is not supported. However, as I'm not the maintainer and I
broke this feature, I correct it.

## How Has This Been Tested?

Not yet. Because the test of https://github.com/ankidroid/Anki-Android/issues/6123#issuecomment-625734765 does not seem to be in code base yet, and it's not clear to me how to add a test.

## Learning (optional, can help others)

It was bad of me to assume that, because nested conditional does not work when a conditional fail, we don't allow them at all.


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
