### PR TITLE
Fix changing the GUI language from the system default

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
@@ -69,6 +69,11 @@ public class AnkiActivity extends AppCompatActivity implements SimpleMessageDial
     }
 
     @Override
+    protected void attachBaseContext(Context base) {
+        super.attachBaseContext(AnkiDroidApp.updateContextWithLanguage(base));
+    }
+
+    @Override
     protected void onStart() {
         Timber.i("AnkiActivity::onStart");
         super.onStart();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -26,7 +26,9 @@ import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.content.res.Resources;
+import android.os.Build;
 import android.os.Environment;
+import android.os.LocaleList;
 import android.preference.PreferenceManager;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -190,6 +192,13 @@ public class AnkiDroidApp extends Application {
         ACRA.init(this, acraCoreConfigBuilder);
     }
 
+    @Override
+    protected void attachBaseContext(Context base) {
+        //update base context with preferred app language before attach
+        //possible since API 17, only supported way since API 25
+        //for API < 17 we update the configuration directly
+        super.attachBaseContext(updateContextWithLanguage(base));
+    }
 
     /**
      * On application creation.
@@ -229,7 +238,6 @@ public class AnkiDroidApp extends Application {
         }
 
         CardBrowserContextMenu.ensureConsistentStateWithSharedPreferences(this);
-        setLanguage(preferences.getString(Preferences.LANGUAGE, ""));
         NotificationChannels.setup(getApplicationContext());
 
         // Configure WebView to allow file scheme pages to access cookies.
@@ -269,15 +277,6 @@ public class AnkiDroidApp extends Application {
         LocalBroadcastManager lbm = LocalBroadcastManager.getInstance(this);
         lbm.registerReceiver(ns, new IntentFilter(NotificationService.INTENT_ACTION));
     }
-
-
-    @Override
-    public void onConfigurationChanged(Configuration newConfig) {
-        super.onConfigurationChanged(newConfig);
-        // Preserve the language from the settings, e.g. when the device is rotated
-        setLanguage(getSharedPrefs(this).getString(Preferences.LANGUAGE, ""));
-    }
-
 
 
     /**
@@ -337,23 +336,82 @@ public class AnkiDroidApp extends Application {
         context.getFileStreamPath("ACRA-limiter.json").delete();
     }
 
+    /**
+     *  Returns a Context with the correct, saved language, to be attached using attachBase().
+     *  For old APIs directly sets language using deprecated functions
+     *
+     * @param remoteContext The base context offered by attachBase() to be passed to super.attachBase().
+     *                      Can be modified here to set correct GUI language.
+     */
+    @SuppressWarnings("deprecation")
+    @NonNull
+    public static Context updateContextWithLanguage(@NonNull Context remoteContext) {
+        try {
+            SharedPreferences preferences;
+            //sInstance (returned by getInstance() ) set during application OnCreate()
+            //if getInstance() is null, the method is called during applications attachBaseContext()
+            // and preferences need mBase directly (is provided by remoteContext during attachBaseContext())
+            if (getInstance() != null) {
+                preferences = getSharedPrefs(getInstance().getBaseContext());
+            } else {
+                preferences = getSharedPrefs(remoteContext);
+            }
+            Configuration langConfig = getLanguageConfig(remoteContext.getResources().getConfiguration(), preferences);
+            //API level >= 25: supported since API 17
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+                return remoteContext.createConfigurationContext(langConfig);
+            } else {
+                //API level < 25:
+                remoteContext.getResources().updateConfiguration(langConfig, remoteContext.getResources().getDisplayMetrics());
+                return remoteContext;
+            }
+        } catch (Exception e) {
+            Timber.e(e, "failed to update context with new language");
+            sendExceptionReport(e,"AnkiDroidApp.updateContextWithLanguage");
+            return remoteContext;
+        }
+    }
 
     /**
-     * Sets the user language.
+     *  Creates and returns a new configuration with the chosen GUI language that is saved in the preferences
      *
-     * @param localeCode The locale code of the language to set, system language if empty
+     * @param remoteConfig The configuration of the remote context to set the language for
+     * @param prefs
      */
-    @SuppressWarnings("deprecation") // Tracked as #4729 in github
-    public static void setLanguage(String localeCode) {
-        Configuration config = getInstance().getResources().getConfiguration();
-        Locale newLocale = LanguageUtil.getLocale(localeCode);
-        config.locale = newLocale;
-        getInstance().getResources().updateConfiguration(config, getInstance().getResources().getDisplayMetrics());
+    @SuppressWarnings("deprecation")
+    @NonNull
+    private static Configuration getLanguageConfig(@NonNull Configuration remoteConfig, @NonNull SharedPreferences prefs) {
+        Configuration newConfig = new Configuration(remoteConfig);
+        Locale newLocale = LanguageUtil.getLocale(prefs.getString(Preferences.LANGUAGE, ""), prefs);
+        //API level >=24
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            //Build list of locale strings, separated by commas: newLocale as first element
+            String strLocaleList = newLocale.toLanguageTag();
+            //if Anki locale from settings is no equal to system default, add system default as second item
+            //LocaleList must not contain language tags twice, will crash otherwise!
+            if (!strLocaleList.contains(Locale.getDefault().toLanguageTag())) {
+                strLocaleList = strLocaleList + "," + Locale.getDefault().toLanguageTag();
+            }
+
+            LocaleList newLocaleList = LocaleList.forLanguageTags(strLocaleList);
+            //first element of setLocales() is automatically setLocal()
+            newConfig.setLocales(newLocaleList);
+        } else {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+                //API level >=17 but <24
+                newConfig.setLocale(newLocale);
+            } else {
+                //Legacy, API level <17
+                newConfig.locale = newLocale;
+            }
+        }
+
+        return newConfig;
     }
 
 
     public static boolean initiateGestures(SharedPreferences preferences) {
-        Boolean enabled = preferences.getBoolean("gestures", false);
+        boolean enabled = preferences.getBoolean("gestures", false);
         if (enabled) {
             int sensitivity = preferences.getInt("swipeSensitivity", 100);
             if (sensitivity != 100) {
@@ -428,12 +486,14 @@ public class AnkiDroidApp extends Application {
      * @return
      */
     public static String getFeedbackUrl() {
+        //TODO actually this can be done by translating "link_help" string for each language when the App is
+        // properly translated
         if (isCurrentLanguage("ja")) {
-            return sInstance.getResources().getString(R.string.link_help_ja);
+            return getAppResources().getString(R.string.link_help_ja);
         } else if (isCurrentLanguage("zh")) {
-            return sInstance.getResources().getString(R.string.link_help_zh);
+            return getAppResources().getString(R.string.link_help_zh);
         } else {
-            return sInstance.getResources().getString(R.string.link_help);
+            return getAppResources().getString(R.string.link_help);
         }
     }
 
@@ -442,12 +502,14 @@ public class AnkiDroidApp extends Application {
      * @return
      */
     public static String getManualUrl() {
+        //TODO actually this can be done by translating "link_manual" string for each language when the App is
+        // properly translated
         if (isCurrentLanguage("ja")) {
-            return sInstance.getResources().getString(R.string.link_manual_ja);
+            return getAppResources().getString(R.string.link_manual_ja);
         } else if (isCurrentLanguage("zh")) {
-            return sInstance.getResources().getString(R.string.link_manual_zh);
+            return getAppResources().getString(R.string.link_manual_zh);
         } else {
-            return sInstance.getResources().getString(R.string.link_manual);
+            return getAppResources().getString(R.string.link_manual);
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
@@ -219,8 +219,6 @@ public abstract class NavigationDrawerActivity extends AnkiActivity implements N
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         final SharedPreferences preferences = getPreferences();
         Timber.i("Handling Activity Result: %d. Result: %d", requestCode, resultCode);
-        // Update language
-        AnkiDroidApp.setLanguage(preferences.getString(Preferences.LANGUAGE, ""));
         NotificationChannels.setup(getApplicationContext());
         // Restart the activity on preference change
         if (requestCode == REQUEST_PREFERENCES_UPDATE) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -128,6 +128,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
         // Add a home button to the actionbar
         getSupportActionBar().setHomeButtonEnabled(true);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+        setTitle(getResources().getText(R.string.preferences_title));
     }
 
     private Collection getCol() {
@@ -842,11 +843,13 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
 
     private void initializeLanguageDialog(PreferenceScreen screen) {
         ListPreference languageSelection = (ListPreference) screen.findPreference(LANGUAGE);
+        Locale currentAppLocale = LanguageUtil.getLocale(AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance())
+                .getString(Preferences.LANGUAGE, ""));
         if (languageSelection != null) {
             Map<String, String> items = new TreeMap<>();
             for (String localeCode : LanguageUtil.APP_LANGUAGES) {
                 Locale loc = LanguageUtil.getLocale(localeCode);
-                items.put(loc.getDisplayName(), loc.toString());
+                items.put(loc.getDisplayName(currentAppLocale), loc.toString());
             }
             CharSequence[] languageDialogLabels = new CharSequence[items.size() + 1];
             CharSequence[] languageDialogValues = new CharSequence[items.size() + 1];

--- a/AnkiDroid/src/main/java/com/ichi2/anki/stats/AnkiStatsTaskHandler.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/stats/AnkiStatsTaskHandler.java
@@ -226,7 +226,7 @@ public class AnkiStatsTaskHandler {
                         cur.close();
                     }
                 }
-                Resources res = collection.getContext().getResources();
+                Resources res = mTextView.getResources();
                 final String span = res.getQuantityString(R.plurals.in_minutes, minutes, minutes);
                 return res.getQuantityString(R.plurals.studied_cards_today, cards, cards, span);
             } finally {

--- a/AnkiDroid/src/main/java/com/ichi2/ui/AppCompatPreferenceActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/AppCompatPreferenceActivity.java
@@ -16,6 +16,7 @@
 
 package com.ichi2.ui;
 
+import android.content.Context;
 import android.content.res.Configuration;
 import android.os.Bundle;
 import android.preference.PreferenceActivity;
@@ -27,6 +28,8 @@ import androidx.appcompat.widget.Toolbar;
 import android.view.MenuInflater;
 import android.view.View;
 import android.view.ViewGroup;
+
+import com.ichi2.anki.AnkiDroidApp;
 
 /**
  * A {@link android.preference.PreferenceActivity} which implements and proxies the necessary calls
@@ -44,6 +47,11 @@ public abstract class AppCompatPreferenceActivity extends PreferenceActivity {
         getDelegate().installViewFactory();
         getDelegate().onCreate(savedInstanceState);
         super.onCreate(savedInstanceState);
+    }
+
+    @Override
+    protected void attachBaseContext(Context base) {
+        super.attachBaseContext(AnkiDroidApp.updateContextWithLanguage(base));
     }
 
     @Override

--- a/AnkiDroid/src/main/java/com/ichi2/utils/LanguageUtil.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/LanguageUtil.java
@@ -14,6 +14,7 @@
 
 package com.ichi2.utils;
 
+import android.content.SharedPreferences;
 import android.text.TextUtils;
 
 import com.ichi2.anki.AnkiDroidApp;
@@ -42,7 +43,7 @@ public class LanguageUtil {
 
 
     /**
-     * Returns the {@link Locale} for the given code or the default locale, if no code is given.
+     * Returns the {@link Locale} for the given code or the default locale, if no code or preferences are given.
      *
      * @return The {@link Locale} for the given code
      */
@@ -52,24 +53,35 @@ public class LanguageUtil {
     }
 
     /**
+     * Returns the {@link Locale} for the given code or the default locale, if no preferences are given.
+     *
+     * @return The {@link Locale} for the given code
+     */
+    @NonNull
+    public static Locale getLocale(@Nullable String localeCode) {
+        SharedPreferences prefs = AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance().getBaseContext());
+        return getLocale(localeCode, prefs);
+    }
+
+    /**
      * Returns the {@link Locale} for the given code or the default locale, if no code is given.
      *
      * @param localeCode The locale code of the language
      * @return The {@link Locale} for the given code
      */
     @NonNull
-    public static Locale getLocale(@Nullable String localeCode) {
+    public static Locale getLocale(@Nullable String localeCode, @NonNull SharedPreferences prefs) {
         Locale locale;
         if (localeCode == null || TextUtils.isEmpty(localeCode)) {
 
-            localeCode = AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance().getBaseContext()).getString(
-                    Preferences.LANGUAGE, "");
+            localeCode = prefs.getString(Preferences.LANGUAGE, "");
             // If no code provided use the app language.
         }
         if (TextUtils.isEmpty(localeCode)) {
-            locale = Locale.getDefault();
             // Fall back to (system) default only if that fails.
-        } else if (localeCode.length() > 2) {
+            localeCode = Locale.getDefault().toString();
+        }
+        if (localeCode.length() > 2) {
             try {
                 locale = new Locale(localeCode.substring(0, 2), localeCode.substring(3, 5));
             } catch (StringIndexOutOfBoundsException e) {


### PR DESCRIPTION
## Purpose / Description
If you currently change the language in AnkiDroid, the change won't really take effect in the GUI. Nearly all strings will still be in the Android system's default language.

With this PR I provide my partially working solution, as I seem to not get any further and want to provide the code so I can get some feedback and/or someone else can have a look at it.
This is also intended as an answer to Mike Hardy, who talked to me in the forums: https://groups.google.com/d/msg/anki-android/m3fhLy2RcZg/2Z-XDNx_BwAJ

## Fixes
Partially fixes #4729 
API levels 24 and lower will be fully localized. The language setting is applied to the whole application.
API level 25 and above will be localized on the main screen (DeckPicker, Settings) but the chosen GUI language won't apply to other activities.

## Approach
For APIs <= 24 the application's configuration is updated to the correct language:
   function UpdateContextWithLanguage -> call updateConfiguration()

For APIs > 24 the previous solution is deprecated. Instead the configuration should be changed during attachBase(). But the current solution can't be applied to attachBase() of AnkiDroidApp. The saved configuration seems to not be available when AnkiDroidApp's attachBase() is called, but is required to know, what language the GUI should be using.
By applying the solution of API <=24 to API > 24, the whole GUI has the right language (but this is deprecated!) This might not not be the "right way to do it", but should work.
Overwriting all attachBase() functions for all Anki activities might also work, but I haven't tried that.

## How Has This Been Tested?
As this is only a have working draft, this has only been tested very superficially by using the Android emulators. (APIs: 15, 19, 25, 29)
Starting the app, opening the settings, changing the language, closing & opening the App, opening some menus.
On some devices, a single card was created and learned.

No crashes or abnormal behavior were experienced during testing.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
