### PR TITLE
Allow import of files with long Unicode Names

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DialogHandler.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DialogHandler.java
@@ -20,6 +20,7 @@ import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
 
+import androidx.annotation.VisibleForTesting;
 import timber.log.Timber;
 
 
@@ -65,7 +66,6 @@ public class DialogHandler extends Handler {
         // Use weak reference to main activity to prevent leaking the activity when it's closed
         mActivity = new WeakReference<>(activity);
     }
-
 
     @Override
     public void handleMessage(Message msg) {
@@ -153,6 +153,11 @@ public class DialogHandler extends Handler {
             Timber.i("Dispatching persistent message: %d", sStoredMessage.what);
             sendMessage(sStoredMessage);
         }
+        sStoredMessage = null;
+    }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    public static void discardMessage() {
         sStoredMessage = null;
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
@@ -37,232 +37,248 @@ public class ImportUtils {
      * @param intent contains the file to import
      * @return null if successful, otherwise error message
      */
-    @SuppressWarnings("PMD.NPathComplexity")
     public static String handleFileImport(Context context, Intent intent) {
-        // This intent is used for opening apkg package files
-        // We want to go immediately to DeckPicker, clearing any history in the process
-        Timber.i("IntentHandler/ User requested to view a file");
-        String extras = intent.getExtras() == null ? "none" : TextUtils.join(", ", intent.getExtras().keySet());
-        Timber.i("Intent: %s. Data: %s", intent, extras);
-
-        try {
-            return handleFileImportInternal(context, intent);
-        } catch (Exception e) {
-            AnkiDroidApp.sendExceptionReport(e, "handleFileImport");
-            Timber.e(e, "failed to handle import intent");
-            return context.getString(R.string.import_error_exception, e.getLocalizedMessage());
-        }
+        return new FileImporter().handleFileImport(context, intent);
     }
-
-    //Added to remove exception handlers
-    private static String handleFileImportInternal(Context context, Intent intent) {
-        String errorMessage = null;
-
-        if (intent.getData() == null) {
-            Timber.i("No intent data. Attempting to read clip data.");
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN
-                    || intent.getClipData() == null
-                    || intent.getClipData().getItemCount() == 0) {
-                return context.getString(R.string.import_error_unhandled_request);
-            }
-            Uri clipUri = intent.getClipData().getItemAt(0).getUri();
-            return handleContentProviderFile(context, intent, clipUri);
-        }
-
-        // If the file is being sent from a content provider we need to read the content before we can open the file
-        if ("content".equals(intent.getData().getScheme())) {
-            Timber.i("Attempting to read content from intent.");
-            return handleContentProviderFile(context, intent, intent.getData());
-        } else if ("file".equals(intent.getData().getScheme())) {
-            Timber.i("Attempting to read file from intent.");
-            // When the VIEW intent is sent as a file, we can open it directly without copying from content provider
-            String filename = intent.getData().getPath();
-            Timber.d("Importing regular file: %s", filename);
-            if (isValidPackageName(filename)) {
-                // If file has apkg extension then send message to show Import dialog
-                ImportUtils.sendShowImportFileDialogMsg(filename);
-            } else {
-                errorMessage = context.getResources().getString(R.string.import_error_not_apkg_extension, filename);
-            }
-        }
-        return errorMessage;
-    }
-
-
-    private static String handleContentProviderFile(Context context, Intent intent, Uri data) {
-        //Note: intent.getData() can be null. Use data instead.
-
-        // Get the original filename from the content provider URI
-        String errorMessage = null;
-        String filename = null;
-        try (Cursor cursor = context.getContentResolver().query(data, new String[] {OpenableColumns.DISPLAY_NAME}, null, null, null)) {
-            if (cursor != null && cursor.moveToFirst()) {
-                filename = cursor.getString(0);
-                Timber.d("handleFileImport() Importing from content provider: %s", filename);
-            }
-        }
-
-        // Hack to fix bug where ContentResolver not returning filename correctly
-        if (filename == null) {
-            if (intent.getType() != null && ("application/apkg".equals(intent.getType()) || ImportUtils.hasValidZipFile(context, data))) {
-                // Set a dummy filename if MIME type provided or is a valid zip file
-                filename = "unknown_filename.apkg";
-                Timber.w("Could not retrieve filename from ContentProvider, but was valid zip file so we try to continue");
-            } else {
-                Timber.e("Could not retrieve filename from ContentProvider or read content as ZipFile");
-                AnkiDroidApp.sendExceptionReport(new RuntimeException("Could not import apkg from ContentProvider"), "IntentHandler.java", "apkg import failed");
-                errorMessage = AnkiDroidApp.getAppResources().getString(R.string.import_error_content_provider, AnkiDroidApp.getManualUrl() + "#importing");
-            }
-        }
-
-        if (!isValidPackageName(filename)) {
-            // Don't import if file doesn't have an Anki package extension
-            errorMessage = context.getResources().getString(R.string.import_error_not_apkg_extension, filename);
-        } else if (filename != null) {
-            // Copy to temporary file
-            String tempOutDir = Uri.fromFile(new File(context.getCacheDir(), filename)).getEncodedPath();
-            errorMessage = ImportUtils.copyFileToCache(context, data, tempOutDir) ? null : "copyFileToCache() failed (possibly out of storage space)";
-            // Show import dialog
-            if (errorMessage == null) {
-                ImportUtils.sendShowImportFileDialogMsg(tempOutDir);
-            } else {
-                AnkiDroidApp.sendExceptionReport(new RuntimeException("Error importing apkg file"), "IntentHandler.java", "apkg import failed");
-            }
-        }
-        return errorMessage;
-    }
-
 
     public static void showImportUnsuccessfulDialog(Activity activity, String errorMessage, boolean exitActivity) {
-        Timber.e("showImportUnsuccessfulDialog() message %s", errorMessage);
-        String title = activity.getResources().getString(R.string.import_log_no_apkg);
-        new MaterialDialog.Builder(activity)
-                .title(title)
-                .content(errorMessage)
-                .positiveText(activity.getResources().getString(R.string.dialog_ok))
-                .onPositive((dialog, which) -> {
-                    if (exitActivity) {
-                        AnkiActivity.finishActivityWithFade(activity);
-                    }
-                })
-                .build().show();
-    }
-
-
-    /**
-     * Send a Message to AnkiDroidApp so that the DialogMessageHandler shows the Import apkg dialog.
-     * @param path path to apkg file which will be imported
-     */
-    private static void sendShowImportFileDialogMsg(String path) {
-        // Get the filename from the path
-        File f = new File(path);
-        String filename = f.getName();
-
-        // Create a new message for DialogHandler so that we see the appropriate import dialog in DeckPicker
-        Message handlerMessage = Message.obtain();
-        Bundle msgData = new Bundle();
-        msgData.putString("importPath", path);
-        handlerMessage.setData(msgData);
-        if (isCollectionPackage(filename)) {
-            // Show confirmation dialog asking to confirm import with replace when file called "collection.apkg"
-            handlerMessage.what = DialogHandler.MSG_SHOW_COLLECTION_IMPORT_REPLACE_DIALOG;
-        } else {
-            // Otherwise show confirmation dialog asking to confirm import with add
-            handlerMessage.what = DialogHandler.MSG_SHOW_COLLECTION_IMPORT_ADD_DIALOG;
-        }
-        // Store the message in AnkiDroidApp message holder, which is loaded later in AnkiActivity.onResume
-        DialogHandler.storeMessage(handlerMessage);
+        new FileImporter().showImportUnsuccessfulDialog(activity, errorMessage, exitActivity);
     }
 
     public static boolean isCollectionPackage(String filename) {
         return filename != null && (filename.toLowerCase().endsWith(".colpkg") || "collection.apkg".equals(filename));
     }
 
-    private static boolean isDeckPackage(String filename) {
-        return filename != null && filename.toLowerCase().endsWith(".apkg") && !"collection.apkg".equals(filename);
-    }
-
     public static boolean isValidPackageName(String filename) {
-        return isDeckPackage(filename) || isCollectionPackage(filename);
+        return FileImporter.isDeckPackage(filename) || isCollectionPackage(filename);
     }
 
-    /**
-     * Check if the InputStream is to a valid non-empty zip file
-     * @param data uri from which to get input stream
-     * @return whether or not valid zip file
-     */
-    private static boolean hasValidZipFile(Context context, Uri data) {
-        // Get an input stream to the data in ContentProvider
-        InputStream in = null;
-        try {
-            in = context.getContentResolver().openInputStream(data);
-        } catch (FileNotFoundException e) {
-            Timber.e(e, "Could not open input stream to intent data");
-        }
-        // Make sure it's not null
-        if (in == null) {
-            Timber.e("Could not open input stream to intent data");
-            return false;
-        }
-        // Open zip input stream
-        ZipInputStream zis = new ZipInputStream(in);
-        boolean ok = false;
-        try {
+    protected static class FileImporter {
+        /**
+         * This code is used in multiple places to handle package imports
+         *
+         * @param context for use in resource resolution and path finding
+         * @param intent contains the file to import
+         * @return null if successful, otherwise error message
+         */
+        public String handleFileImport(Context context, Intent intent) {
+            // This intent is used for opening apkg package files
+            // We want to go immediately to DeckPicker, clearing any history in the process
+            Timber.i("IntentHandler/ User requested to view a file");
+            String extras = intent.getExtras() == null ? "none" : TextUtils.join(", ", intent.getExtras().keySet());
+            Timber.i("Intent: %s. Data: %s", intent, extras);
+
             try {
-                ZipEntry ze = zis.getNextEntry();
-                if (ze != null) {
-                    // set ok flag to true if there are any valid entries in the zip file
-                    ok = true;
+                return handleFileImportInternal(context, intent);
+            } catch (Exception e) {
+                AnkiDroidApp.sendExceptionReport(e, "handleFileImport");
+                Timber.e(e, "failed to handle import intent");
+                return context.getString(R.string.import_error_exception, e.getLocalizedMessage());
+            }
+        }
+
+        //Added to remove exception handlers
+        private static String handleFileImportInternal(Context context, Intent intent) {
+            String errorMessage = null;
+
+            if (intent.getData() == null) {
+                Timber.i("No intent data. Attempting to read clip data.");
+                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN
+                        || intent.getClipData() == null
+                        || intent.getClipData().getItemCount() == 0) {
+                    return context.getString(R.string.import_error_unhandled_request);
                 }
-            } catch (Exception e) {
-                // don't set ok flag
-                Timber.d(e, "Error checking if provided file has a zip entry");
+                Uri clipUri = intent.getClipData().getItemAt(0).getUri();
+                return handleContentProviderFile(context, intent, clipUri);
             }
-        } finally {
-            // close the input streams
-            try {
-                zis.close();
-                in.close();
-            } catch (Exception e) {
-                Timber.d(e, "Error closing the InputStream");
+
+            // If the file is being sent from a content provider we need to read the content before we can open the file
+            if ("content".equals(intent.getData().getScheme())) {
+                Timber.i("Attempting to read content from intent.");
+                return handleContentProviderFile(context, intent, intent.getData());
+            } else if ("file".equals(intent.getData().getScheme())) {
+                Timber.i("Attempting to read file from intent.");
+                // When the VIEW intent is sent as a file, we can open it directly without copying from content provider
+                String filename = intent.getData().getPath();
+                Timber.d("Importing regular file: %s", filename);
+                if (isValidPackageName(filename)) {
+                    // If file has apkg extension then send message to show Import dialog
+                    sendShowImportFileDialogMsg(filename);
+                } else {
+                    errorMessage = context.getResources().getString(R.string.import_error_not_apkg_extension, filename);
+                }
             }
-        }
-        return ok;
-    }
-
-
-    /**
-     * Copy the data from the intent to a temporary file
-     * @param data intent from which to get input stream
-     * @param tempPath temporary path to store the cached file
-     * @return whether or not copy was successful
-     */
-    private static boolean copyFileToCache(Context context, Uri data, String tempPath) {
-        // Get an input stream to the data in ContentProvider
-        InputStream in;
-        try {
-            in = context.getContentResolver().openInputStream(data);
-        } catch (FileNotFoundException e) {
-            Timber.e(e, "Could not open input stream to intent data");
-            return false;
-        }
-        // Check non-null
-        if (in == null) {
-            return false;
+            return errorMessage;
         }
 
-        try {
-            CompatHelper.getCompat().copyFile(in, tempPath);
-        } catch (IOException e) {
-            Timber.e(e, "Could not copy file to %s", tempPath);
-            return false;
-        } finally {
+
+        private static String handleContentProviderFile(Context context, Intent intent, Uri data) {
+            //Note: intent.getData() can be null. Use data instead.
+
+            // Get the original filename from the content provider URI
+            String errorMessage = null;
+            String filename = null;
+            try (Cursor cursor = context.getContentResolver().query(data, new String[] {OpenableColumns.DISPLAY_NAME}, null, null, null)) {
+                if (cursor != null && cursor.moveToFirst()) {
+                    filename = cursor.getString(0);
+                    Timber.d("handleFileImport() Importing from content provider: %s", filename);
+                }
+            }
+
+            // Hack to fix bug where ContentResolver not returning filename correctly
+            if (filename == null) {
+                if (intent.getType() != null && ("application/apkg".equals(intent.getType()) || hasValidZipFile(context, data))) {
+                    // Set a dummy filename if MIME type provided or is a valid zip file
+                    filename = "unknown_filename.apkg";
+                    Timber.w("Could not retrieve filename from ContentProvider, but was valid zip file so we try to continue");
+                } else {
+                    Timber.e("Could not retrieve filename from ContentProvider or read content as ZipFile");
+                    AnkiDroidApp.sendExceptionReport(new RuntimeException("Could not import apkg from ContentProvider"), "IntentHandler.java", "apkg import failed");
+                    errorMessage = AnkiDroidApp.getAppResources().getString(R.string.import_error_content_provider, AnkiDroidApp.getManualUrl() + "#importing");
+                }
+            }
+
+            if (!isValidPackageName(filename)) {
+                // Don't import if file doesn't have an Anki package extension
+                errorMessage = context.getResources().getString(R.string.import_error_not_apkg_extension, filename);
+            } else if (filename != null) {
+                // Copy to temporary file
+                String tempOutDir = Uri.fromFile(new File(context.getCacheDir(), filename)).getEncodedPath();
+                errorMessage = copyFileToCache(context, data, tempOutDir) ? null : "copyFileToCache() failed (possibly out of storage space)";
+                // Show import dialog
+                if (errorMessage == null) {
+                    sendShowImportFileDialogMsg(tempOutDir);
+                } else {
+                    AnkiDroidApp.sendExceptionReport(new RuntimeException("Error importing apkg file"), "IntentHandler.java", "apkg import failed");
+                }
+            }
+            return errorMessage;
+        }
+
+
+        public void showImportUnsuccessfulDialog(Activity activity, String errorMessage, boolean exitActivity) {
+            Timber.e("showImportUnsuccessfulDialog() message %s", errorMessage);
+            String title = activity.getResources().getString(R.string.import_log_no_apkg);
+            new MaterialDialog.Builder(activity)
+                    .title(title)
+                    .content(errorMessage)
+                    .positiveText(activity.getResources().getString(R.string.dialog_ok))
+                    .onPositive((dialog, which) -> {
+                        if (exitActivity) {
+                            AnkiActivity.finishActivityWithFade(activity);
+                        }
+                    })
+                    .build().show();
+        }
+
+
+        /**
+         * Send a Message to AnkiDroidApp so that the DialogMessageHandler shows the Import apkg dialog.
+         * @param path path to apkg file which will be imported
+         */
+        private static void sendShowImportFileDialogMsg(String path) {
+            // Get the filename from the path
+            File f = new File(path);
+            String filename = f.getName();
+
+            // Create a new message for DialogHandler so that we see the appropriate import dialog in DeckPicker
+            Message handlerMessage = Message.obtain();
+            Bundle msgData = new Bundle();
+            msgData.putString("importPath", path);
+            handlerMessage.setData(msgData);
+            if (isCollectionPackage(filename)) {
+                // Show confirmation dialog asking to confirm import with replace when file called "collection.apkg"
+                handlerMessage.what = DialogHandler.MSG_SHOW_COLLECTION_IMPORT_REPLACE_DIALOG;
+            } else {
+                // Otherwise show confirmation dialog asking to confirm import with add
+                handlerMessage.what = DialogHandler.MSG_SHOW_COLLECTION_IMPORT_ADD_DIALOG;
+            }
+            // Store the message in AnkiDroidApp message holder, which is loaded later in AnkiActivity.onResume
+            DialogHandler.storeMessage(handlerMessage);
+        }
+
+        private static boolean isDeckPackage(String filename) {
+            return filename != null && filename.toLowerCase().endsWith(".apkg") && !"collection.apkg".equals(filename);
+        }
+
+        /**
+         * Check if the InputStream is to a valid non-empty zip file
+         * @param data uri from which to get input stream
+         * @return whether or not valid zip file
+         */
+        private static boolean hasValidZipFile(Context context, Uri data) {
+            // Get an input stream to the data in ContentProvider
+            InputStream in = null;
             try {
-                in.close();
+                in = context.getContentResolver().openInputStream(data);
+            } catch (FileNotFoundException e) {
+                Timber.e(e, "Could not open input stream to intent data");
+            }
+            // Make sure it's not null
+            if (in == null) {
+                Timber.e("Could not open input stream to intent data");
+                return false;
+            }
+            // Open zip input stream
+            ZipInputStream zis = new ZipInputStream(in);
+            boolean ok = false;
+            try {
+                try {
+                    ZipEntry ze = zis.getNextEntry();
+                    if (ze != null) {
+                        // set ok flag to true if there are any valid entries in the zip file
+                        ok = true;
+                    }
+                } catch (Exception e) {
+                    // don't set ok flag
+                    Timber.d(e, "Error checking if provided file has a zip entry");
+                }
+            } finally {
+                // close the input streams
+                try {
+                    zis.close();
+                    in.close();
+                } catch (Exception e) {
+                    Timber.d(e, "Error closing the InputStream");
+                }
+            }
+            return ok;
+        }
+
+
+        /**
+         * Copy the data from the intent to a temporary file
+         * @param data intent from which to get input stream
+         * @param tempPath temporary path to store the cached file
+         * @return whether or not copy was successful
+         */
+        private static boolean copyFileToCache(Context context, Uri data, String tempPath) {
+            // Get an input stream to the data in ContentProvider
+            InputStream in;
+            try {
+                in = context.getContentResolver().openInputStream(data);
+            } catch (FileNotFoundException e) {
+                Timber.e(e, "Could not open input stream to intent data");
+                return false;
+            }
+            // Check non-null
+            if (in == null) {
+                return false;
+            }
+
+            try {
+                CompatHelper.getCompat().copyFile(in, tempPath);
             } catch (IOException e) {
-                Timber.e(e, "Error closing input stream");
+                Timber.e(e, "Could not copy file to %s", tempPath);
+                return false;
+            } finally {
+                try {
+                    in.close();
+                } catch (IOException e) {
+                    Timber.e(e, "Error closing input stream");
+                }
             }
+            return true;
         }
-        return true;
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
@@ -21,6 +21,7 @@ import android.content.Intent;
 
 import com.afollestad.materialdialogs.DialogAction;
 import com.afollestad.materialdialogs.MaterialDialog;
+import com.ichi2.anki.dialogs.DialogHandler;
 import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.DB;
@@ -49,6 +50,9 @@ public class RobolectricTest {
 
         // Robolectric can't handle our default sqlite implementation of requery, it needs the framework
         DB.setSqliteOpenHelperFactory(new FrameworkSQLiteOpenHelperFactory());
+
+        //See: #6140 - This global ideally shouldn't exist, but it will cause crashes if set.
+        DialogHandler.discardMessage();
     }
 
     @After

--- a/AnkiDroid/src/test/java/com/ichi2/utils/ImportUtilsTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/ImportUtilsTest.java
@@ -1,0 +1,117 @@
+/*
+ Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.utils;
+
+import android.content.ClipData;
+import android.content.ClipDescription;
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+
+import com.ichi2.anki.RobolectricTest;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import androidx.annotation.CheckResult;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.Mockito.spy;
+
+@RunWith(AndroidJUnit4.class)
+public class ImportUtilsTest extends RobolectricTest {
+
+    @Test
+    public void cjkNamesAreConvertedToUnicode() {
+        //NOTE: I don't know whether this still needs to exist, but it was added as this previously crashes
+        //and I would have added a regression without checking the history.
+        //https://github.com/ankidroid/Anki-Android/commit/ed06954c8c678024e2fce25c19bd6cdaf0120260#diff-8eefa7f7b20c936f007c934965238520R58
+
+        String inputFileName = "好.apkg";
+
+        String actualFilePath = importValidFile(inputFileName);
+
+        assertThat("Unicode character should be stripped", actualFilePath, not(containsString("好")));
+        assertThat("Unicode character should be urlencoded", actualFilePath, endsWith("%E5%A5%BD.apkg"));
+    }
+
+    private String importValidFile(String fileName) {
+        TestFileImporter testFileImporter = new TestFileImporter(fileName);
+
+        Intent intent = getValidClipDataUri(fileName);
+        Context mockContext = spy(getTargetContext());
+        testFileImporter.handleFileImport(mockContext, intent);
+        String cacheFileName = testFileImporter.getCacheFileName();
+
+        if (cacheFileName == null) {
+            throw new IllegalStateException("No filename created");
+        }
+
+        //COULD_BE_BETTER: Strip off the file path
+        return cacheFileName;
+    }
+
+
+    @CheckResult
+    private Intent getValidClipDataUri(String fileName) {
+        Intent i = new Intent();
+        i.setClipData(clipDataUriFromFile(fileName));
+        return i;
+    }
+
+
+    @NonNull
+    private ClipData clipDataUriFromFile(String fileName) {
+        ClipData.Item item = new ClipData.Item(Uri.parse("content://" + fileName));
+        ClipDescription description = new ClipDescription("", new String[] {});
+        return new ClipData(description, item);
+    }
+
+
+    public static class TestFileImporter extends ImportUtils.FileImporter {
+        private String mCacheFileName;
+        private final String mFileName;
+
+        public TestFileImporter(String fileName) {
+            this.mFileName = fileName;
+        }
+
+        @Override
+        protected boolean copyFileToCache(Context context, Uri data, String tempPath) {
+            this.mCacheFileName = tempPath;
+            return true;
+        }
+
+
+        @Nullable
+        @Override
+        protected String getFileNameFromContentProvider(Context context, Uri data) {
+            return mFileName;
+        }
+
+
+        public String getCacheFileName() {
+            return mCacheFileName;
+        }
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/utils/ImportUtilsTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/ImportUtilsTest.java
@@ -35,6 +35,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.not;
 import static org.mockito.Mockito.spy;
 
@@ -53,6 +54,22 @@ public class ImportUtilsTest extends RobolectricTest {
 
         assertThat("Unicode character should be stripped", actualFilePath, not(containsString("好")));
         assertThat("Unicode character should be urlencoded", actualFilePath, endsWith("%E5%A5%BD.apkg"));
+    }
+
+    @Test
+    public void fileNamesAreLimitedTo100Chars() {
+        //#6137 - We URLEncode due to the above. Therefore: 好 -> %E5%A5%BD
+        //This caused filenames to be too long.
+        String inputFileName = "好好好好好好好好好好好好好好好好好好好好好好好好好好好好好好好好好好好好好好好好好好好好.apkg";
+
+        String actualFilePath = importValidFile(inputFileName);
+
+        assertThat(actualFilePath, endsWith(".apkg"));
+        assertThat(actualFilePath, containsString("..."));
+        //Obtain the filename from the path
+        assertThat(actualFilePath, containsString("%E5%A5%BD"));
+        String fileName = actualFilePath.substring(actualFilePath.indexOf("%E5%A5%BD"));
+        assertThat(fileName.length(), lessThanOrEqualTo(100));
     }
 
     private String importValidFile(String fileName) {


### PR DESCRIPTION
## Purpose / Description
We URLEncode filenames, and CJK characters are 9x the size when this happens. This allows them to easily blow up when imported with "File path too long"


## Fixes
Fixes #6137 

## Approach
Truncate the filename before import. We do this at the end, not at the middle.

## How Has This Been Tested?

Unit tests, I can now import `好好好好好好好好好好好好好好好好好好好好好好好好好好好好好好好好好好好好好好好好好好好好.apkg`

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code