### PR TITLE
Handle corrupt CustomTabs implementations 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/compat/customtabs/CustomTabActivityHelper.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/customtabs/CustomTabActivityHelper.java
@@ -111,12 +111,19 @@ public class CustomTabActivityHelper implements ServiceConnectionCallback {
             CustomTabsClient.bindCustomTabsService(activity, packageName, mConnection);
         } catch (SecurityException e) {
             Timber.w(e, "CustomTabsService bind attempt failed, using fallback");
-            sCustomTabsFailed = true;
-            mClient = null;
-            mCustomTabsSession = null;
-            mConnection = null;
+            disableCustomTabHandler();
         }
     }
+
+
+    private void disableCustomTabHandler() {
+        Timber.i("Disabling custom tab handler and using fallback");
+        sCustomTabsFailed = true;
+        mClient = null;
+        mCustomTabsSession = null;
+        mConnection = null;
+    }
+
 
     /**
      * @see {@link CustomTabsSession#mayLaunchUrl(Uri, Bundle, List)}.

--- a/AnkiDroid/src/main/java/com/ichi2/compat/customtabs/CustomTabActivityHelper.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/customtabs/CustomTabActivityHelper.java
@@ -17,6 +17,9 @@ package com.ichi2.compat.customtabs;
 import android.app.Activity;
 import android.net.Uri;
 import android.os.Bundle;
+
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 import androidx.browser.customtabs.CustomTabsClient;
 import androidx.browser.customtabs.CustomTabsIntent;
 import androidx.browser.customtabs.CustomTabsServiceConnection;
@@ -32,8 +35,11 @@ import timber.log.Timber;
  */
 public class CustomTabActivityHelper implements ServiceConnectionCallback {
     private static boolean sCustomTabsFailed = false;
+    @Nullable
     private CustomTabsSession mCustomTabsSession;
+    @Nullable
     private CustomTabsClient mClient;
+    @Nullable
     private CustomTabsServiceConnection mConnection;
 
     /**
@@ -158,4 +164,8 @@ public class CustomTabActivityHelper implements ServiceConnectionCallback {
         void openUri(Activity activity, Uri uri);
     }
 
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    public static void resetFailed() {
+        sCustomTabsFailed = false;
+    }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
@@ -22,6 +22,7 @@ import android.content.Intent;
 import com.afollestad.materialdialogs.DialogAction;
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.ichi2.anki.exception.ConfirmModSchemaException;
+import com.ichi2.compat.customtabs.CustomTabActivityHelper;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.DB;
 import com.ichi2.libanki.Models;
@@ -49,6 +50,9 @@ public class RobolectricTest {
 
         // Robolectric can't handle our default sqlite implementation of requery, it needs the framework
         DB.setSqliteOpenHelperFactory(new FrameworkSQLiteOpenHelperFactory());
+
+        //Reset static variable for custom tabs failure.
+        CustomTabActivityHelper.resetFailed();
     }
 
     @After

--- a/AnkiDroid/src/test/java/com/ichi2/compat/customtabs/CustomTabActivityHelperTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/compat/customtabs/CustomTabActivityHelperTest.java
@@ -1,0 +1,83 @@
+/*
+ Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.compat.customtabs;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import androidx.annotation.CheckResult;
+import androidx.annotation.NonNull;
+import androidx.browser.customtabs.CustomTabsClient;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class CustomTabActivityHelperTest {
+
+    @Before
+    public void before() {
+        CustomTabActivityHelper.resetFailed();
+    }
+
+    @Test
+    public void ensureInvalidClientWithSecurityExceptionDoesNotCrash() {
+        CustomTabsClient badClient  = getClientThrowingSecurityException();
+        CustomTabActivityHelper customTabActivityHelper = getValidTabHandler();
+
+        customTabActivityHelper.onServiceConnected(badClient);
+
+        assertThat("Should be failed after call", customTabActivityHelper.isFailed());
+    }
+
+
+    @Test
+    public void invalidClientMeansFallbackIsCalled() {
+        CustomTabsClient badClient  = getClientThrowingSecurityException();
+        CustomTabActivityHelper customTabActivityHelper = getValidTabHandler();
+
+        customTabActivityHelper.onServiceConnected(badClient);
+
+        CustomTabActivityHelper.CustomTabFallback fallback = mock(CustomTabActivityHelper.CustomTabFallback.class);
+        CustomTabActivityHelper.openCustomTab(null, null, null, fallback);
+
+        verify(fallback, times(1)).openUri(any(), any());
+    }
+
+    @NonNull @CheckResult
+    private CustomTabActivityHelper getValidTabHandler() {
+        CustomTabActivityHelper customTabActivityHelper = new CustomTabActivityHelper();
+        assertThat("Should not be failed before call", !customTabActivityHelper.isFailed());
+        return customTabActivityHelper;
+    }
+
+    @NonNull @CheckResult
+    private CustomTabsClient getClientThrowingSecurityException() {
+        SecurityException exceptionToThrow = new SecurityException("Binder invocation to an incorrect interface");
+
+        CustomTabsClient invalidClient = mock(CustomTabsClient.class);
+        doThrow(exceptionToThrow).when(invalidClient).warmup(anyLong());
+        doThrow(exceptionToThrow).when(invalidClient).extraCommand(anyString(), any());
+        doThrow(exceptionToThrow).when(invalidClient).newSession(any());
+        return invalidClient;
+    }
+}


### PR DESCRIPTION
## Purpose / Description
Some CustomTabs implementation will throw: SecurityException: "Binder invocation to an incorrect interface". If we encounter this problem, then we should use the fallback implementation.

## Fixes
Fixes #6142

## Approach
Try..catch..fail gracefully

## How Has This Been Tested?

Unit Tested 🤠

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code