### PR TITLE
Add password visibility toggle on login screen

### DIFF
--- a/AnkiDroid/src/main/res/layout/my_account.xml
+++ b/AnkiDroid/src/main/res/layout/my_account.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.coordinatorlayout.widget.CoordinatorLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/root_layout"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
@@ -40,22 +41,32 @@
                 <!--android:layout_margin="@dimen/content_vertical_padding"/>-->
                 <!--&lt;!&ndash; TODO JS - move into strings.xml &ndash;&gt;-->
 
-                <EditText
-                    android:id="@+id/username"
-                    android:layout_width="fill_parent"
+                <com.google.android.material.textfield.TextInputLayout
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:hint="@string/username"
-                    android:inputType="textNoSuggestions|textEmailAddress"
-                    android:layout_margin="@dimen/content_vertical_padding"/>
+                    android:hint="@string/username">
 
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/username"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:inputType="textNoSuggestions|textEmailAddress"
+                        android:layout_margin="@dimen/content_vertical_padding"/>
+                </com.google.android.material.textfield.TextInputLayout>
 
-                <EditText
-                    android:id="@+id/password"
-                    android:layout_width="fill_parent"
+                <com.google.android.material.textfield.TextInputLayout
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:hint="@string/password"
-                    android:inputType="textPassword"
-                    android:layout_margin="@dimen/content_vertical_padding"/>
+                    app:passwordToggleEnabled="true">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/password"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:inputType="textPassword"
+                        android:layout_margin="@dimen/content_vertical_padding"/>
+                </com.google.android.material.textfield.TextInputLayout>
 
                 <Button
                     android:id="@+id/login_button"


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Toggle to show password

## Fixes
Fixes #5825

## Approach
Suggested feature is not available in stock android, but implemented in
material design library in TextInputLayout and TextInputEditText.

However their behavior details are slightly different from default EditText
(e.g. hint moves to the top of input vs disappearing) so both inputs must
be changed for consistency.

## How Has This Been Tested?
Go to login screen, input password, toggle visibility
Tested on emulator api 16 and 23 (could not download 15) and real device api 29

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
