### PR TITLE
Avoid crash if conditional is not found

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
@@ -295,7 +295,7 @@ public class Utils {
     /**
      * Strip HTML but keep media filenames
      */
-    public static String stripHTMLMedia(String s) {
+    public static String stripHTMLMedia(@NonNull String s) {
         Matcher imgMatcher = imgPattern.matcher(s);
         return stripHTML(imgMatcher.replaceAll(" $1 "));
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/template/Template.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/template/Template.java
@@ -144,7 +144,7 @@ public class Template {
             String section_name = match.group(1).trim();
             String inner = match.group(2);
             String it = get_or_attr(context, section_name, null);
-            boolean field_is_empty = TextUtils.isEmpty(Utils.stripHTMLMedia(it).trim());
+            boolean field_is_empty =  it == null || TextUtils.isEmpty(Utils.stripHTMLMedia(it).trim());
             boolean conditional_is_negative = section.charAt(2) == '^';
             // Showing inner content if either field is empty and the
             // conditional is a ^; or if the field is non-empty and

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/template/TemplateTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/template/TemplateTest.java
@@ -18,6 +18,7 @@ package com.ichi2.libanki.template;
 
 import com.ichi2.anki.RobolectricTest;
 
+import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -31,6 +32,18 @@ import static org.hamcrest.Matchers.not;
 
 @RunWith(AndroidJUnit4.class)
 public class TemplateTest extends RobolectricTest {
+
+    @Test
+    public void testNotFoundWillRender() {
+        String maybeBad = "{{#NotFound}}{{NotFound}}{{/NotFound}}";
+
+        HashMap<String, String> context = new HashMap<>();
+
+        Template template = new Template(maybeBad, context);
+        String result = template.render();
+
+        assertThat(result, Matchers.isEmptyString());
+    }
 
     @Test
     public void nestedTemplatesRenderWell() {


### PR DESCRIPTION
Fixes #6149

## Pull Request template

## Purpose / Description
There's a trivial crash in the template PR we just merged this fixes it

## Fixes
Fixes #6149

## Approach
This fixes the crash and adds a NotNull annotation to the method crashing so hopefully others won't stub their toe on it

## How Has This Been Tested?

@david-allison-1 kindly provided a bisect and unit test ready to go! Incorporating it showed the bug and proved the fix

## Learning (optional, can help others)
Null sucks


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
