### PR TITLE
use localised field name during collection export

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.java
@@ -22,7 +22,6 @@ import com.ichi2.anki.CollectionHelper;
 import com.ichi2.anki.R;
 import com.ichi2.anki.exception.ImportExportException;
 import com.ichi2.compat.CompatHelper;
-
 import com.ichi2.utils.JSONArray;
 import com.ichi2.utils.JSONException;
 import com.ichi2.utils.JSONObject;
@@ -444,7 +443,9 @@ public final class AnkiPackageExporter extends AnkiExporter {
         f.delete();
         Collection c = Storage.Collection(context, path);
         Note n = c.newNote();
-        n.setItem("Front", context.getString(R.string.export_v2_dummy_note));
+        //The created dummy collection only contains the StdModels.
+        //The field names for those are localised during creation, so we need to consider that when creating dummy note
+        n.setItem(context.getString(R.string.front_field_name), context.getString(R.string.export_v2_dummy_note));
         c.addNote(n);
         c.save();
         c.close();


### PR DESCRIPTION
## Purpose / Description
Fixes a crash when the collections is exported with time data while using V2 scheduler.
When the dummy collection is created, it uses the StdModels. Those are initialised with their field's names being localised with the application's context language. Currently the _addDummyCollection() method, that is used during export, tries to add a single note while using the "Front" field. That field can't be found e.g. on german devices, when StdModels is using e.g. "Vorne" as field name.

## Fixes
Fixes #6145 

## Approach
Just take the same string that is used during field creation to set the item for the dummy note.

## How Has This Been Tested?
Using the Android Emulator APIs 19 & 25. Imported the collection, that crashed on my phone. Reproduced the crash in the emulators. Applied patch and recompiled. Patched version doesn't crash (neither with language set to english, nor with different languages.)

## Checklist
_Please, go through these checks before submitting the PR._

- [] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
