### PR TITLE
NoteEditor: Allow Exit before collection load

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -692,6 +692,10 @@ public class NoteEditor extends AnkiActivity {
 
 
     private boolean hasUnsavedChanges() {
+        if (!collectionHasLoaded()) {
+            return false;
+        }
+
         // changed note type?
         if (!mAddNote) {
             final JSONObject newModel = getCurrentlySelectedModel();
@@ -711,6 +715,12 @@ public class NoteEditor extends AnkiActivity {
         // changed tags?
         return mTagsEdited;
     }
+
+
+    private boolean collectionHasLoaded() {
+        return mAllModelIds != null;
+    }
+
 
     @VisibleForTesting
     void saveNote() {

--- a/AnkiDroid/src/test/AndroidManifest.xml
+++ b/AnkiDroid/src/test/AndroidManifest.xml
@@ -12,5 +12,8 @@
         <activity
             android:name="com.ichi2.anki.NullCollectionReviewer">
         </activity>
+        <activity
+            android:name="com.ichi2.anki.NullCollectionNoteEditor">
+        </activity>
     </application>
 </manifest>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.java
@@ -1,5 +1,7 @@
 package com.ichi2.anki;
 
+import android.app.Activity;
+import android.app.Instrumentation;
 import android.content.Intent;
 
 import com.ichi2.anki.multimediacard.activity.MultimediaEditFieldActivity;
@@ -12,6 +14,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.shadows.ShadowActivity;
 
+import androidx.test.core.app.ActivityScenario;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -118,6 +121,19 @@ public class NoteEditorTest extends RobolectricTest {
         editor.saveNote();
 
         assertThat(getCardCount(), is(initialCards));
+    }
+
+    @Test
+    public void verifyStartupAndCloseWithNoCollectionDoesNotCrash() {
+        try (ActivityScenario<NullCollectionNoteEditor> scenario = ActivityScenario.launch(NullCollectionNoteEditor.class)) {
+            scenario.onActivity(noteEditor -> {
+                noteEditor.onBackPressed();
+                assertThat("Pressing back should finish the activity", noteEditor.isFinishing());
+            });
+
+            Instrumentation.ActivityResult result = scenario.getResult();
+            assertThat("Activity should be cancelled as no changes were made", result.getResultCode(), is(Activity.RESULT_CANCELED));
+        }
     }
 
     private int getCardCount() {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NullCollectionNoteEditor.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NullCollectionNoteEditor.java
@@ -1,0 +1,34 @@
+/*
+ Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki;
+
+import com.ichi2.libanki.Collection;
+
+public class NullCollectionNoteEditor extends NoteEditor {
+    @Override
+    public Collection getCol() {
+        return null;
+    }
+    @Override
+    public boolean colIsOpen() {
+        return false;
+    }
+    @Override
+    protected void onCollectionLoaded(Collection col) {
+        // it's not fair to expect the classes under test to handle this when we return null for getCol()
+    }
+}


### PR DESCRIPTION
## Purpose / Description
Fix NullPointerException if back is pressed before the collection is loaded

## Fixes
Fixes #6158 

## Approach
Don't crash

## How Has This Been Tested?
TDD: Red, Green, Commit, Push

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code