### PR TITLE
Block file import if no storage permissions 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.java
@@ -31,21 +31,7 @@ public class IntentHandler extends Activity {
         reloadIntent.setDataAndType(getIntent().getData(), getIntent().getType());
         String action = intent.getAction();
         if (Intent.ACTION_VIEW.equals(action)) {
-            Timber.i("Handling file import");
-            String errorMessage = ImportUtils.handleFileImport(this, intent);
-            // Start DeckPicker if we correctly processed ACTION_VIEW
-            if (errorMessage == null) {
-                Timber.d("onCreate() import successful");
-                reloadIntent.setAction(action);
-                reloadIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-                startActivity(reloadIntent);
-                AnkiActivity.finishActivityWithFade(this);
-            } else {
-                Timber.i("File import failed");
-                // Don't import the file if it didn't load properly or doesn't have apkg extension
-                //Themes.showThemedToast(this, getResources().getString(R.string.import_log_no_apkg), true);
-                ImportUtils.showImportUnsuccessfulDialog(this, errorMessage, true);
-            }
+            handleFileImport(intent, reloadIntent, action);
         } else if ("com.ichi2.anki.DO_SYNC".equals(action)) {
             Timber.i("Handling Sync Intent");
             sendDoSyncMsg();
@@ -64,6 +50,25 @@ public class IntentHandler extends Activity {
         } else {
             Timber.d("onCreate() performing default action");
             launchDeckPickerIfNoOtherTasks(reloadIntent);
+        }
+    }
+
+
+    private void handleFileImport(Intent intent, Intent reloadIntent, String action) {
+        Timber.i("Handling file import");
+        String errorMessage = ImportUtils.handleFileImport(this, intent);
+        // Start DeckPicker if we correctly processed ACTION_VIEW
+        if (errorMessage == null) {
+            Timber.d("onCreate() import successful");
+            reloadIntent.setAction(action);
+            reloadIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+            startActivity(reloadIntent);
+            AnkiActivity.finishActivityWithFade(this);
+        } else {
+            Timber.i("File import failed");
+            // Don't import the file if it didn't load properly or doesn't have apkg extension
+            //Themes.showThemedToast(this, getResources().getString(R.string.import_log_no_apkg), true);
+            ImportUtils.showImportUnsuccessfulDialog(this, errorMessage, true);
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.java
@@ -33,12 +33,7 @@ public class IntentHandler extends Activity {
         if (Intent.ACTION_VIEW.equals(action)) {
             handleFileImport(intent, reloadIntent, action);
         } else if ("com.ichi2.anki.DO_SYNC".equals(action)) {
-            Timber.i("Handling Sync Intent");
-            sendDoSyncMsg();
-            reloadIntent.setAction(action);
-            reloadIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-            startActivity(reloadIntent);
-            AnkiActivity.finishActivityWithFade(this);
+            handleSyncIntent(reloadIntent, action);
         } else if (intent.hasExtra(ReminderService.EXTRA_DECK_ID)) {
             long deckId = intent.getLongExtra(ReminderService.EXTRA_DECK_ID, 0);
             Timber.i("Handling intent to review deck '%d'", deckId);
@@ -51,6 +46,16 @@ public class IntentHandler extends Activity {
             Timber.d("onCreate() performing default action");
             launchDeckPickerIfNoOtherTasks(reloadIntent);
         }
+    }
+
+
+    private void handleSyncIntent(Intent reloadIntent, String action) {
+        Timber.i("Handling Sync Intent");
+        sendDoSyncMsg();
+        reloadIntent.setAction(action);
+        reloadIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        startActivity(reloadIntent);
+        AnkiActivity.finishActivityWithFade(this);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.java
@@ -7,7 +7,9 @@ import android.os.Message;
 
 import com.ichi2.anki.dialogs.DialogHandler;
 import com.ichi2.anki.services.ReminderService;
+import com.ichi2.utils.FunctionalInterfaces.Consumer;
 import com.ichi2.utils.ImportUtils;
+import com.ichi2.utils.Permissions;
 
 import timber.log.Timber;
 
@@ -22,6 +24,7 @@ import timber.log.Timber;
 public class IntentHandler extends Activity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        //Note: This is our entry point from the launcher with intent: android.intent.action.MAIN
         Timber.d("onCreate()");
         super.onCreate(savedInstanceState);
         setContentView(R.layout.progress_bar);
@@ -30,14 +33,30 @@ public class IntentHandler extends Activity {
         Intent reloadIntent = new Intent(this, DeckPicker.class);
         reloadIntent.setDataAndType(getIntent().getData(), getIntent().getType());
         String action = intent.getAction();
+        // #6157 - We want to block actions that need permissions we don't have, but not the default case
+        // as this requires nothing
+        Consumer<Runnable> runIfStoragePermissions = (runnable) -> performActionIfStoragePermission(runnable, reloadIntent, action);
         if (Intent.ACTION_VIEW.equals(action)) {
-            handleFileImport(intent, reloadIntent, action);
+            runIfStoragePermissions.consume(() -> handleFileImport(intent, reloadIntent, action));
         } else if ("com.ichi2.anki.DO_SYNC".equals(action)) {
-            handleSyncIntent(reloadIntent, action);
+            runIfStoragePermissions.consume(() -> handleSyncIntent(reloadIntent, action));
         } else if (intent.hasExtra(ReminderService.EXTRA_DECK_ID)) {
-            handleReviewIntent(intent);
+            runIfStoragePermissions.consume(() -> handleReviewIntent(intent));
         } else {
             Timber.d("onCreate() performing default action");
+            launchDeckPickerIfNoOtherTasks(reloadIntent);
+        }
+    }
+
+    private void performActionIfStoragePermission(Runnable runnable, Intent reloadIntent, String action) {
+        if (Permissions.hasStorageAccessPermission(this)) {
+            Timber.i("User has storage permissions. Running intent: %s", action);
+            runnable.run();
+        } else {
+            //COULD_BE_BETTER: We could handle this failure in each activity individually, allowing us to pick up after
+            //we get permission
+            Timber.i("No Storage Permission, cancelling intent '%s'", action);
+            UIUtils.showThemedToast(this, getString(R.string.intent_handler_failed_no_storage_permission), false);
             launchDeckPickerIfNoOtherTasks(reloadIntent);
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.java
@@ -35,17 +35,22 @@ public class IntentHandler extends Activity {
         } else if ("com.ichi2.anki.DO_SYNC".equals(action)) {
             handleSyncIntent(reloadIntent, action);
         } else if (intent.hasExtra(ReminderService.EXTRA_DECK_ID)) {
-            long deckId = intent.getLongExtra(ReminderService.EXTRA_DECK_ID, 0);
-            Timber.i("Handling intent to review deck '%d'", deckId);
-            final Intent reviewIntent = new Intent(this, Reviewer.class);
-
-            CollectionHelper.getInstance().getCol(this).getDecks().select(deckId);
-            startActivity(reviewIntent);
-            AnkiActivity.finishActivityWithFade(this);
+            handleReviewIntent(intent);
         } else {
             Timber.d("onCreate() performing default action");
             launchDeckPickerIfNoOtherTasks(reloadIntent);
         }
+    }
+
+
+    private void handleReviewIntent(Intent intent) {
+        long deckId = intent.getLongExtra(ReminderService.EXTRA_DECK_ID, 0);
+        Timber.i("Handling intent to review deck '%d'", deckId);
+        final Intent reviewIntent = new Intent(this, Reviewer.class);
+
+        CollectionHelper.getInstance().getCol(this).getDecks().select(deckId);
+        startActivity(reviewIntent);
+        AnkiActivity.finishActivityWithFade(this);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.java
@@ -62,16 +62,21 @@ public class IntentHandler extends Activity {
             startActivity(reviewIntent);
             AnkiActivity.finishActivityWithFade(this);
         } else {
-            // Launcher intents should start DeckPicker if no other task exists,
-            // otherwise go to previous task
             Timber.d("onCreate() performing default action");
-            Timber.i("Launching DeckPicker");
-            reloadIntent.setAction(Intent.ACTION_MAIN);
-            reloadIntent.addCategory(Intent.CATEGORY_LAUNCHER);
-            reloadIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
-            startActivityIfNeeded(reloadIntent, 0);
-            AnkiActivity.finishActivityWithFade(this);
+            launchDeckPickerIfNoOtherTasks(reloadIntent);
         }
+    }
+
+
+    private void launchDeckPickerIfNoOtherTasks(Intent reloadIntent) {
+        // Launcher intents should start DeckPicker if no other task exists,
+        // otherwise go to previous task
+        Timber.i("Launching DeckPicker");
+        reloadIntent.setAction(Intent.ACTION_MAIN);
+        reloadIntent.addCategory(Intent.CATEGORY_LAUNCHER);
+        reloadIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
+        startActivityIfNeeded(reloadIntent, 0);
+        AnkiActivity.finishActivityWithFade(this);
     }
 
 

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -184,4 +184,7 @@
     <string name="error_selecting_image">Error selecting image. Please see manual. %s</string>
     <string name="error_deleting_image">Error deleting image</string>
     <string name="failed_to_apply_background_image">Failed to apply background image %s</string>
+
+    <!-- Global Intent handler -->
+    <string name="intent_handler_failed_no_storage_permission">Missing required storage permission. Please grant storage permission then retry your action.</string>
 </resources>


### PR DESCRIPTION
## Purpose / Description
A bug occurred where we displayed a import dialog before we requested permissions, which overlapped the dialog. Clicking "Add" crashes, as we had no storage permissions.

## Fixes
Fixes #6157

## Approach

Block the input, show a toast, and load the `DeckPicker`, which shows the storage dialog, followed by the permissions request.

We could do this better in the `DeckPicker` handler and persist the operation, but we're somewhat constrained for time, it's a complex operation, and asking the user to perform the operation again isn't a huge ask

## How Has This Been Tested?

On my device:

* Launching with permissions shows nothing
* Launching from launcher with no permissions shows no toast, followed by permissions dialog
* Launching from file browser with no permissions shows toast, followed by permissions dialog
* Launching from file browser with permissions shows import dialog

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code