### PR TITLE
Use localised field name in Instrumentation Tests

### DIFF
--- a/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/libanki/ImportTest.java
+++ b/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/libanki/ImportTest.java
@@ -87,7 +87,7 @@ public class ImportTest {
 
         // add a note that references a sound
         Note n = testCol.newNote();
-        n.setItem("Front", "[sound:foo.mp3]");
+        n.setField(0, "[sound:foo.mp3]");
         long mid = n.model().getLong("id");
         testCol.addNote(n);
         // add that sound to the media folder

--- a/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/libanki/MediaTest.java
+++ b/AnkiDroid/src/androidTest/java/com.ichi2.anki.tests/libanki/MediaTest.java
@@ -155,13 +155,13 @@ public class MediaTest {
         testCol.getMedia().addFile(file);
         // add a note which references it
         Note f = testCol.newNote();
-        f.setItem("Front", "one");
-        f.setItem("Back", "<img src='fake.png'>");
+        f.setField(0, "one");
+        f.setField(1, "<img src='fake.png'>");
         testCol.addNote(f);
         // and one which references a non-existent file
         f = testCol.newNote();
-        f.setItem("Front", "one");
-        f.setItem("Back", "<img src='fake2.png'>");
+        f.setField(0, "one");
+        f.setField(1, "<img src='fake2.png'>");
         testCol.addNote(f);
         // and add another file which isn't used
         FileOutputStream os;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Note.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Note.java
@@ -197,7 +197,11 @@ public class Note implements Cloneable {
 
 
     private int _fieldOrd(String key) {
-        return mFMap.get(key).first;
+        Pair<Integer, JSONObject> fieldPair = mFMap.get(key);
+        if (fieldPair == null) {
+            throw new IllegalArgumentException(String.format("No field named '%s' found", key));
+        }
+        return fieldPair.first;
     }
 
 


### PR DESCRIPTION
## Purpose / Description
Since #5566, unit tests would fail if run in a non-English locale due to the field names changing

## Approach
Fix the tests (using field index instead), and improve the error message

## How Has This Been Tested?

Unit tests still pass

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code