### PR TITLE
Fixed error with counting card in learn state

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -2672,7 +2672,7 @@ public class SchedV2 extends AbstractSched {
     /** not in libAnki. Added due to #5666: inconsistent selected deck card counts on sync */
     @Override
     public int[] recalculateCounts() {
-    	_updateLrnCutoff(true);
+        _updateLrnCutoff(true);
         _resetLrnCount();
         _resetNewCount();
         _resetRevCount();

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -2672,6 +2672,7 @@ public class SchedV2 extends AbstractSched {
     /** not in libAnki. Added due to #5666: inconsistent selected deck card counts on sync */
     @Override
     public int[] recalculateCounts() {
+    	_updateLrnCutoff(true);
         _resetLrnCount();
         _resetNewCount();
         _resetRevCount();


### PR DESCRIPTION
## Purpose / Description
I had a problem with syncing to anki-sync-server. It looked like learning cards, whose date was in the past, weren't counted properly.

## Fixes
Not applicable.

## Approach
Current fix resets cutoff date and all cards in the past are calculated as learning ones.

## How Has This Been Tested?
I've tested it manually - based on current change and SDK 28. After patch, syncing works as expected.
