### PR TITLE
Fix "Basic (type in the answer)" in English and in other languages

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/StdModels.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/StdModels.java
@@ -81,7 +81,9 @@ public class StdModels {
         ( (Models mm, String name) -> {
         JSONObject m = basicModel._new(mm, name);
         JSONObject t = m.getJSONArray("tmpls").getJSONObject(0);
-        t.put("afmt", "{{"+"Front"+"}}\n\n<hr id=answer>\n\n{{type:"+"Back"+"}}");
+        String frontName = m.getJSONArray("flds").getJSONObject(0).getString("name");
+        String backName = m.getJSONArray("flds").getJSONObject(1).getString("name");
+        t.put("afmt", "{{" + frontName + "}}\n\n<hr id=answer>\n\n{{type:" + backName + "}}");
         return m;
     },
         R.string.basic_typing_model_name);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/StdModels.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/StdModels.java
@@ -83,6 +83,7 @@ public class StdModels {
         JSONObject t = m.getJSONArray("tmpls").getJSONObject(0);
         String frontName = m.getJSONArray("flds").getJSONObject(0).getString("name");
         String backName = m.getJSONArray("flds").getJSONObject(1).getString("name");
+        t.put("qfmt", "{{" + frontName + "}}\n\n{{type:" + backName + "}}");
         t.put("afmt", "{{" + frontName + "}}\n\n<hr id=answer>\n\n{{type:" + backName + "}}");
         return m;
     },

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/StdModels.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/StdModels.java
@@ -2,10 +2,6 @@ package com.ichi2.libanki;
 
 import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.R;
-import com.ichi2.libanki.Collection;
-import com.ichi2.libanki.Consts;
-import com.ichi2.libanki.Models;
-
 import com.ichi2.utils.JSONObject;
 
 import androidx.annotation.StringRes;


### PR DESCRIPTION
## Upstream ref

https://github.com/ankitects/anki/blob/85b28f13d2472813cdb66151dcf0407b39b3d5c3/pylib/anki/stdmodels.py#L47

## Purpose / Description

The "Basic (type in the answer)" model was broken in non-English languages as it depended on a hardcoded field: `{{Front}}`

The "Basic (type in the answer)" model was broken in English as it did not contain `{{type:Back}}` in the question.

## Fixes
Partially: #6167 

## Approach
We fix the internationalisation to use field references and add a `qfmt`.

## How Has This Been Tested?

On my phone, Type now works in Russian and in English

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code