### PR TITLE
Remove possibility of TagsDialog NullPointerException

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1130,42 +1130,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
     private void showTagsDialog() {
         TagsDialog dialog = TagsDialog.newInstance(
                 TagsDialog.TYPE_FILTER_BY_TAG, new ArrayList<String>(), new ArrayList<>(getCol().getTags().all()));
-        dialog.setTagsDialogListener(new TagsDialogListener() {
-            @Override
-            public void onPositive(List<String> selectedTags, int option) {
-                mSearchView.setQuery("", false);
-                String tags = selectedTags.toString();
-                mSearchView.setQueryHint(getResources().getString(R.string.card_browser_tags_shown,
-                        tags.substring(1, tags.length() - 1)));
-                StringBuilder sb = new StringBuilder();
-                switch (option) {
-                    case 1:
-                        sb.append("is:new ");
-                        break;
-                    case 2:
-                        sb.append("is:due ");
-                        break;
-                    default:
-                        // Logging here might be appropriate : )
-                        break;
-                }
-                int i = 0;
-                for (String tag : selectedTags) {
-                    if (i != 0) {
-                        sb.append("or ");
-                    } else {
-                        sb.append("("); // Only if we really have selected tags
-                    }
-                    sb.append("tag:").append(tag).append(" ");
-                    i++;
-                }
-                if (i > 0) {
-                    sb.append(")"); // Only if we added anything to the tag list
-                }
-                mSearchTerms = sb.toString();
-                searchCards();
-            }
-        });
+        dialog.setTagsDialogListener(this::filterByTag);
         showDialogFragment(dialog);
     }
 
@@ -1296,6 +1261,42 @@ public class CardBrowser extends NavigationDrawerActivity implements
         }
         return nonDynamicDecks;
     }
+
+
+    private void filterByTag(List<String> selectedTags, int option) {
+        mSearchView.setQuery("", false);
+        String tags = selectedTags.toString();
+        mSearchView.setQueryHint(getResources().getString(R.string.card_browser_tags_shown,
+                tags.substring(1, tags.length() - 1)));
+        StringBuilder sb = new StringBuilder();
+        switch (option) {
+            case 1:
+                sb.append("is:new ");
+                break;
+            case 2:
+                sb.append("is:due ");
+                break;
+            default:
+                // Logging here might be appropriate : )
+                break;
+        }
+        int i = 0;
+        for (String tag : selectedTags) {
+            if (i != 0) {
+                sb.append("or ");
+            } else {
+                sb.append("("); // Only if we really have selected tags
+            }
+            sb.append("tag:").append(tag).append(" ");
+            i++;
+        }
+        if (i > 0) {
+            sb.append(")"); // Only if we added anything to the tag list
+        }
+        mSearchTerms = sb.toString();
+        searchCards();
+    }
+
 
     private abstract class ListenerWithProgressBar extends CollectionTask.TaskListener {
         @Override

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1129,8 +1129,9 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
     private void showTagsDialog() {
         TagsDialog dialog = TagsDialog.newInstance(
-                TagsDialog.TYPE_FILTER_BY_TAG, new ArrayList<String>(), new ArrayList<>(getCol().getTags().all()));
-        dialog.setTagsDialogListener(this::filterByTag);
+                TagsDialog.TYPE_FILTER_BY_TAG,
+                new ArrayList<String>(), new ArrayList<>(getCol().getTags().all()),
+                this::filterByTag);
         showDialogFragment(dialog);
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1264,6 +1264,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
 
     private void filterByTag(List<String> selectedTags, int option) {
+        //TODO: Duplication between here and CustomStudyDialog:customStudyFromTags
         mSearchView.setQuery("", false);
         String tags = selectedTags.toString();
         mSearchView.setQueryHint(getResources().getString(R.string.card_browser_tags_shown,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1130,7 +1130,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
     private void showTagsDialog() {
         TagsDialog dialog = TagsDialog.newInstance(
                 TagsDialog.TYPE_FILTER_BY_TAG,
-                new ArrayList<String>(), new ArrayList<>(getCol().getTags().all()),
+                new ArrayList<>(), new ArrayList<>(getCol().getTags().all()),
                 this::filterByTag);
         showDialogFragment(dialog);
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -998,15 +998,15 @@ public class NoteEditor extends AnkiActivity {
         }
         ArrayList<String> tags = new ArrayList<>(getCol().getTags().all());
         ArrayList<String> selTags = new ArrayList<>(mSelectedTags);
-        TagsDialog dialog = TagsDialog.newInstance(TagsDialog.TYPE_ADD_TAG, selTags,
-                tags);
-        dialog.setTagsDialogListener((selectedTags, option) -> {
+        TagsDialog.TagsDialogListener tagsDialogListener = (selectedTags, option) -> {
             if (!mSelectedTags.equals(selectedTags)) {
                 mTagsEdited = true;
             }
             mSelectedTags = selectedTags;
             updateTags();
-        });
+        };
+        TagsDialog dialog = TagsDialog.newInstance(TagsDialog.TYPE_ADD_TAG, selTags, tags);
+        dialog.setTagsDialogListener(tagsDialogListener);
         showDialogFragment(dialog);
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1005,8 +1005,7 @@ public class NoteEditor extends AnkiActivity {
             mSelectedTags = selectedTags;
             updateTags();
         };
-        TagsDialog dialog = TagsDialog.newInstance(TagsDialog.TYPE_ADD_TAG, selTags, tags);
-        dialog.setTagsDialogListener(tagsDialogListener);
+        TagsDialog dialog = TagsDialog.newInstance(TagsDialog.TYPE_ADD_TAG, selTags, tags, tagsDialogListener);
         showDialogFragment(dialog);
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
@@ -147,9 +147,10 @@ public class CustomStudyDialog extends AnalyticsDialogFragment {
                                  */
                                 long currentDeck = getArguments().getLong("did");
                                 TagsDialog dialogFragment = TagsDialog.newInstance(
-                                        TagsDialog.TYPE_CUSTOM_STUDY_TAGS, new ArrayList<String>(),
-                                        new ArrayList<>(activity.getCol().getTags().byDeck(currentDeck, true)));
-                                dialogFragment.setTagsDialogListener(CustomStudyDialog.this::customStudyFromTags);
+                                        TagsDialog.TYPE_CUSTOM_STUDY_TAGS,
+                                        new ArrayList<String>(),
+                                        new ArrayList<>(activity.getCol().getTags().byDeck(currentDeck, true)),
+                                        CustomStudyDialog.this::customStudyFromTags);
                                 activity.showDialogFragment(dialogFragment);
                                 break;
                             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
@@ -149,36 +149,7 @@ public class CustomStudyDialog extends AnalyticsDialogFragment {
                                 TagsDialog dialogFragment = TagsDialog.newInstance(
                                         TagsDialog.TYPE_CUSTOM_STUDY_TAGS, new ArrayList<String>(),
                                         new ArrayList<>(activity.getCol().getTags().byDeck(currentDeck, true)));
-                                dialogFragment.setTagsDialogListener(new TagsDialog.TagsDialogListener() {
-                                    @Override
-                                    public void onPositive(List<String> selectedTags, int option) {
-                                        /*
-                                         * Here's the method that gathers the final selection of tags, type of cards and
-                                         * generates the search screen for the custom study deck.
-                                         */
-                                        StringBuilder sb = new StringBuilder();
-                                        switch (option) {
-                                            case 1:
-                                                sb.append("is:new ");
-                                                break;
-                                            case 2:
-                                                sb.append("is:due ");
-                                                break;
-                                            default:
-                                                // Logging here might be appropriate : )
-                                                break;
-                                        }
-                                        List<String> arr = new ArrayList<>();
-                                        if (selectedTags.size() > 0) {
-                                            for (String tag : selectedTags) {
-                                                arr.add(String.format("tag:'%s'", tag));
-                                            }
-                                            sb.append("(").append(TextUtils.join(" or ", arr)).append(")");
-                                        }
-                                        createCustomStudySession(new JSONArray(), new Object[]{sb.toString(),
-                                                Consts.DYN_MAX_SIZE, Consts.DYN_RANDOM}, true);
-                                    }
-                                });
+                                dialogFragment.setTagsDialogListener(CustomStudyDialog.this::customStudyFromTags);
                                 activity.showDialogFragment(dialogFragment);
                                 break;
                             }
@@ -326,6 +297,29 @@ public class CustomStudyDialog extends AnalyticsDialogFragment {
         return keyValueMap;
     }
 
+    private void customStudyFromTags(List<String> selectedTags, int option) {
+        StringBuilder sb = new StringBuilder();
+        switch (option) {
+            case 1:
+                sb.append("is:new ");
+                break;
+            case 2:
+                sb.append("is:due ");
+                break;
+            default:
+                // Logging here might be appropriate : )
+                break;
+        }
+        List<String> arr = new ArrayList<>();
+        if (selectedTags.size() > 0) {
+            for (String tag : selectedTags) {
+                arr.add(String.format("tag:'%s'", tag));
+            }
+            sb.append("(").append(TextUtils.join(" or ", arr)).append(")");
+        }
+        createCustomStudySession(new JSONArray(), new Object[] {sb.toString(),
+                Consts.DYN_MAX_SIZE, Consts.DYN_RANDOM}, true);
+    }
 
     /**
      * Retrieve the list of ids to put in the context menu list

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
@@ -148,7 +148,7 @@ public class CustomStudyDialog extends AnalyticsDialogFragment {
                                 long currentDeck = getArguments().getLong("did");
                                 TagsDialog dialogFragment = TagsDialog.newInstance(
                                         TagsDialog.TYPE_CUSTOM_STUDY_TAGS,
-                                        new ArrayList<String>(),
+                                        new ArrayList<>(),
                                         new ArrayList<>(activity.getCol().getTags().byDeck(currentDeck, true)),
                                         CustomStudyDialog.this::customStudyFromTags);
                                 activity.showDialogFragment(dialogFragment);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TagsDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TagsDialog.java
@@ -53,7 +53,8 @@ public class TagsDialog extends AnalyticsDialogFragment {
 
     private String mPositiveText;
     private String mDialogTitle;
-    private TagsDialogListener mTagsDialogListener = null;
+    @NonNull
+    private TagsDialogListener mTagsDialogListener;
     private TagsArrayAdapter mTagsArrayAdapter;
     private int mSelectedOption = -1;
 
@@ -65,9 +66,13 @@ public class TagsDialog extends AnalyticsDialogFragment {
 
     private MaterialDialog mDialog;
 
+    public TagsDialog(@NonNull TagsDialogListener onPositive) {
+        this.mTagsDialogListener = onPositive;
+    }
+
     public static TagsDialog newInstance(int type, ArrayList<String> checked_tags,
-                                            ArrayList<String> all_tags) {
-        TagsDialog t = new TagsDialog();
+                                            ArrayList<String> all_tags, @NonNull TagsDialogListener onPositive) {
+        TagsDialog t = new TagsDialog(onPositive);
 
         Bundle args = new Bundle();
         args.putInt(DIALOG_TYPE_KEY, type);
@@ -267,10 +272,6 @@ public class TagsDialog extends AnalyticsDialogFragment {
             UIUtils.showSnackbar(getActivity(), feedbackText, false, -1, null,
                     mDialog.getView().findViewById(R.id.tags_dialog_snackbar), null);
         }
-    }
-
-    public void setTagsDialogListener(TagsDialogListener selectedTagsListener) {
-        mTagsDialogListener = selectedTagsListener;
     }
 
     public class TagsArrayAdapter extends  RecyclerView.Adapter<TagsArrayAdapter.ViewHolder> implements Filterable{


### PR DESCRIPTION
## Purpose / Description

An ACRA crash occurred as the listener was null.

Visually, this should never have occurred as the listener is set on the next line. It might not be possible to trigger by a human, but it's fixable

## Fixes
Fixes #6174

## Approach
Move the listener from a setter to a constructor parameter

## How Has This Been Tested?

Tested functionality on my phone, no visible change.

Effectively nonfunctional but I'd like to confirm this in an alpha release

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code