### PR TITLE
Publish changes

### DIFF
--- a/AnkiDroid/src/main/res/values/theme_light.xml
+++ b/AnkiDroid/src/main/res/values/theme_light.xml
@@ -17,7 +17,7 @@ APIs. It's visible when there aren't enough decks to fill the screen.
     <color name="theme_light_primary_light">@color/material_light_blue_100</color>
     <color name="theme_light_accent">@color/material_blue_grey_700</color>
     <color name="theme_light_primary_text">@color/black</color>
-    <color name="theme_light_secondary_text">#de000000</color>  <!-- 87% black -->
+    <color name="theme_light_secondary_text">#de000000</color>  <!-- 87 percent black -->
     <color name="theme_light_row_current">#ececec</color>
     <color name="theme_light_drawer_row_current">#E8E8E8</color>
     <color name="theme_light_drawer_item">#DE000000</color>

--- a/tools/lib/increase-version.awk
+++ b/tools/lib/increase-version.awk
@@ -5,8 +5,8 @@
 #
 
 1 {
-    prefix = gensub(/^(.*[^0-9])([0-9]+)$/, "\\1", "")
-    testingversion = gensub(/^(.*[^0-9])([0-9]+)$/, "\\2", "")
+    prefix = gensub(/^(.*[^0-9])([0-9]+)$/, "\\1", "1")
+    testingversion = gensub(/^(.*[^0-9])([0-9]+)$/, "\\2", "1")
 
     next_testingversion = (1*testingversion)+1
     printf "%s%s\n", prefix, next_testingversion

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -2,6 +2,7 @@
 # Perform a release of AnkiDroid
 # Nicolas Raoul 2011/10/24
 # Timothy Rae 2014/11/10
+# Mike Hardy 2020/05/15
 # Usage from AnkiDroid's root directory:
 # tools/release.sh # For an alpha or beta release
 # tools/release.sh public # For a public (non alpha/beta) release
@@ -18,59 +19,61 @@ MANIFEST="AndroidManifest.xml"
 
 if [ "$PUBLIC" = "public" ]; then
   echo "About to perform a public release. Please first:"
-  echo "- Run tools/comment-logs.sh and commit."
-  echo "- Run tools/change-icons-to-blue.sh and commit."
   echo "- Edit the version in AndroidManifest.xml manually but do not commit it."
   echo "Press Enter to continue."
-  read
+  read -r
 else
   echo "Performing testing release."
 fi
 
-set -x
-
-VERSION=`grep android:versionName $SRC_DIR$MANIFEST | sed -e 's/.*="//' | sed -e 's/".*//'`
-echo $VERSION
+if ! VERSION=$(grep android:versionName $SRC_DIR$MANIFEST | sed -e 's/.*="//' | sed -e 's/".*//')
+then
+  echo "Unable to get current version. Is sed installed?"
+  exit 1
+fi
 
 if [ "$PUBLIC" != "public" ]; then
   # Increment version name
   # Ex: 2.1beta7 to 2.1beta8
   PREVIOUS_VERSION=$VERSION
   if [ -n "$SUFFIX" ]; then
-    PREVIOUS_VERSION=`echo $PREVIOUS_VERSION | sed -e "s/$SUFFIX//g"`
+    PREVIOUS_VERSION="${PREVIOUS_VERSION//$SUFFIX/}"
   fi
-  GUESSED_VERSION=`echo $PREVIOUS_VERSION | gawk -f tools/lib/increase-version.awk`
+  if ! GUESSED_VERSION=$(echo "$PREVIOUS_VERSION" | gawk -f tools/lib/increase-version.awk)
+  then
+    echo "Unable to guess next version. Is gawk installed?";
+    exit 1;
+  fi
   VERSION=${1:-$GUESSED_VERSION$SUFFIX}
 
   # Increment version code
   # It is an integer in AndroidManifest that nobody actually sees.
   # Ex: 72 to 73
-  PREVIOUS_CODE=`grep android:versionCode $SRC_DIR$MANIFEST | sed -e 's/.*="//' | sed -e 's/".*//'`
-  GUESSED_CODE=`expr $PREVIOUS_CODE + 1`
+  PREVIOUS_CODE=$(grep android:versionCode $SRC_DIR$MANIFEST | sed -e 's/.*="//' | sed -e 's/".*//')
+  GUESSED_CODE=$((PREVIOUS_CODE + 1))
 
   # Edit AndroidManifest.xml to bump version string
   echo "Bumping version from $PREVIOUS_VERSION$SUFFIX to $VERSION (and code from $PREVIOUS_CODE to $GUESSED_CODE)"
-  sed -i -e s/$PREVIOUS_VERSION$SUFFIX/$VERSION/g $SRC_DIR$MANIFEST
-  sed -i -e s/versionCode=\"$PREVIOUS_CODE/versionCode=\"$GUESSED_CODE/g $SRC_DIR$MANIFEST
+  sed -i -e s/"$PREVIOUS_VERSION"$SUFFIX/"$VERSION"/g $SRC_DIR$MANIFEST
+  sed -i -e s/versionCode=\""$PREVIOUS_CODE"/versionCode=\""$GUESSED_CODE"/g $SRC_DIR$MANIFEST
 fi
 
 # Read the key passwords
-read -sp "Enter keystore password: " KSTOREPWD; echo
-read -sp "Enter key password: " KEYPWD; echo
+read -rsp "Enter keystore password: " KSTOREPWD; echo
+read -rsp "Enter key password: " KEYPWD; echo
 export KSTOREPWD
 export KEYPWD
 # Build signed APK using Gradle and publish to Play 
 # Configuration for pushing to Play specified in build.gradle 'play' task
-CMD="./gradlew publishApkRelease"
-${CMD}
-if [ $? -ne 0 ]; then
+if ! ./gradlew publishReleaseApk
+then
   # APK contains problems, abort release
   git checkout -- $SRC_DIR$MANIFEST # Revert version change
   exit
 fi
 
 # Copy exported file to cwd
-cp AnkiDroid/build/outputs/apk/release/AnkiDroid-release.apk AnkiDroid-$VERSION.apk
+cp AnkiDroid/build/outputs/apk/release/AnkiDroid-release.apk AnkiDroid-"$VERSION".apk
 
 # Commit modified AndroidManifest.xml
 git add $SRC_DIR$MANIFEST
@@ -78,15 +81,15 @@ git commit -m "Bumped version to $VERSION
 @branch-specific"
 
 # Tag the release
-git tag v$VERSION
+git tag v"$VERSION"
 
 # Push both commits and tag
-#git push --follow-tags # Not working... wanted to do both in a single request, to make it faster
 git push
 git push --tags
 
 # Push to Github Releases.
-export GITHUB_TOKEN=`cat ~/src/my-github-personal-access-token`
+GITHUB_TOKEN=$(cat ~/src/my-github-personal-access-token)
+export GITHUB_TOKEN
 export GITHUB_USER="ankidroid"
 export GITHUB_REPO="Anki-Android"
 
@@ -96,5 +99,5 @@ else
   PRE_RELEASE="--pre-release"
 fi
 
-github-release release --tag v$VERSION --name "AnkiDroid $VERSION" $PRE_RELEASE
-github-release upload --tag v$VERSION --name AnkiDroid-$VERSION.apk --file AnkiDroid-$VERSION.apk
+github-release release --tag v"$VERSION" --name "AnkiDroid $VERSION" $PRE_RELEASE
+github-release upload --tag v"$VERSION" --name AnkiDroid-"$VERSION".apk --file AnkiDroid-"$VERSION".apk

--- a/tools/update-localizations.py
+++ b/tools/update-localizations.py
@@ -200,9 +200,9 @@ print "\nRemoving Crowdin file\n"
 zip.close()
 os.remove(zipname)
 
+print "Checking translations for known classes of error."
+subprocess.check_call("./tools/find-broken-strings-variables.sh", shell=True)
+
 print "Committing updates. Please add any fixes as another commit."
 subprocess.call("git add docs/marketing/localized_description AnkiDroid/src/main/res/values*", shell=True)
 subprocess.call("git commit -m 'Updated strings from Crowdin'", shell=True)
-
-print "Checking with Lint."
-subprocess.call("lint . --config lint.xml --nowarn --exitcode", shell=True)


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

The translation and publish release tools (shell and python stuff) were a bit creaky, failing on missing sub-utilities, not handling errors well, and not de-linting known problems with translations

## Fixes
Related to #6160 although it would not have fixed that directly

## Approach
I de-linted the release shell script thoroughly for modern shell conventions and put some nice error handling in when utilities are missing 

De-lint and fix up the translation error finder and hook it in the python translation update script (while fixing upstream translation issues in crowdin)

After this is merged, translations need a resync and we should do a release soon, as Finnish translation has an error that will likely cause a crash for them until we release a fixed translation

## How Has This Been Tested?

Ran release script with the side-effects of publish commented out until it was clean

Ran translation updater on macOS catalina-current (as of this typing) until it worked successfully with the current crowdin translations (by current I mean the ones that I was fixing as I was testing the script)

## Learning (optional, can help others)
- The Android Studio shell helper module is really good for fixing shell scripts!
- You can only build translations on crowdin once every 30 minutes
- You can't install the Python module for IntelliJ fully, when it's the 'Android Studio' mode and you're not using flutter 🤷  (stack overflow thinks you should be able to but me and one other couldn't and it doesn't have an answer yet)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
