### PR TITLE
Allow decreasing daily limits in custom study

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
@@ -28,6 +28,7 @@ import android.text.TextUtils;
 import android.text.TextWatcher;
 import android.view.View;
 import android.view.WindowManager;
+import android.view.inputmethod.EditorInfo;
 import android.widget.EditText;
 import android.widget.TextView;
 
@@ -189,6 +190,9 @@ public class CustomStudyDialog extends AnalyticsDialogFragment {
         // Give EditText focus and show keyboard
         mEditText.setSelectAllOnFocus(true);
         mEditText.requestFocus();
+        if (dialogId == CUSTOM_STUDY_NEW || dialogId == CUSTOM_STUDY_REV) {
+            mEditText.setInputType(EditorInfo.TYPE_CLASS_NUMBER | EditorInfo.TYPE_NUMBER_FLAG_SIGNED);
+        }
         // deck id
         final long did = getArguments().getLong("did");
         // Whether or not to jump straight to the reviewer
@@ -205,7 +209,8 @@ public class CustomStudyDialog extends AnalyticsDialogFragment {
                     try {
                         n = Integer.parseInt(mEditText.getText().toString());
                     } catch (Exception ignored) {
-                        n = Integer.MAX_VALUE;
+                        // This should never happen because we disable positive button for non-parsable inputs
+                        return;
                     }
 
                     // Set behavior when clicking OK button
@@ -269,10 +274,11 @@ public class CustomStudyDialog extends AnalyticsDialogFragment {
 
             @Override
             public void afterTextChanged(Editable editable) {
-                if (editable.length() == 0) {
-                    dialog.getActionButton(DialogAction.POSITIVE).setEnabled(false);
-                } else {
+                try {
+                    Integer.parseInt(mEditText.getText().toString());
                     dialog.getActionButton(DialogAction.POSITIVE).setEnabled(true);
+                } catch (Exception ignored) {
+                    dialog.getActionButton(DialogAction.POSITIVE).setEnabled(false);
                 }
             }
         });


### PR DESCRIPTION

## Pull Request template

## Purpose / Description
Ability to decrease daily limits in custom study and consistency with desktop

## Fixes
Fixes #5615, #5388 

## Approach
Allow negative inputs - same as on desktop

This was added to desktop in commit [59b9c361 in anki repo](https://github.com/ankitects/anki/commit/59b9c361ac7e4b7fec269e9372a384e21bd7bed1). This works by
allowing negative numbers in input and effectively the same change is made
in this commit.
A interesting side effect - you can go negative with number of cards to
review. For example if you have 1 new card to review you can decrease
this number by 5. It will display as if you had 0 cards to review, but
to get back to 1 you need to increase number of cards by 5 instead of 1.
Anki desktop behaves same way so I am leaving it as is.

## How Has This Been Tested?
Emulator api 16 and 28
General ideas:

- Increasing works
- Decreasing works - see above about going negative
- Only numbers can be inputted
- Negatives can be inputted only for new cards and reviews

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
