### PR TITLE
Ignore API R even after adding LOCALE arg

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ jobs:
       install: skip
       script: echo finalize codacy coverage uploads
   allow_failures:
-    - env: API=R EMU_FLAVOR=google_apis # unreleased Android API30 is failing in local builds, let's expose that on Travis
+    - env: API=R EMU_FLAVOR=google_apis LOCALE="de_DE" # unreleased Android API30 is failing in local builds, let's expose that on Travis
     - env: API=24 JDK="1.11" # non-default JDKs should not hold up success reporting
     - env: API=24 JDK="1.14" # non-default JDKs should not hold up success reporting
     - env: FINALIZE_COVERAGE=TRUE API=NONE # finalizing coverage should not hold up success reporting


### PR DESCRIPTION
forgot to update the fingerprint in the ignore section for API R
but it is still intermittent and it should not fail builds