### PR TITLE
Render the official changelog for public releases

### DIFF
--- a/tools/release.sh
+++ b/tools/release.sh
@@ -7,30 +7,60 @@
 # tools/release.sh # For an alpha or beta release
 # tools/release.sh public # For a public (non alpha/beta) release
 
+
+# Basic expectations
+# - tools needed: sed, gawk, github-release, git
+# - authority needed: ability to commit/tag/push directly to master in AnkiDroid, ability to create releases
+# - ankidroiddocs checked out in a sibling directory (that is, '../ankidroiddocs' should exist with 'upstream' remote set correctly)
+
 # Suffix configuration
 SUFFIX=""
-#SUFFIX="-EXPERIMENTAL"
-
 PUBLIC=$1
 
-# Define the location of the manifest file
-SRC_DIR="./AnkiDroid/src/main/"
-MANIFEST="AndroidManifest.xml"
-
-if [ "$PUBLIC" = "public" ]; then
-  echo "About to perform a public release. Please first:"
-  echo "- Edit the version in AndroidManifest.xml manually but do not commit it."
-  echo "Press Enter to continue."
-  read -r
-else
-  echo "Performing testing release."
+# Check basic expectations
+for UTILITY in sed gawk github-release asciidoctor; do
+  if ! command -v "$UTILITY" >/dev/null 2>&1; then echo "$UTILITY" missing; exit 1; fi
+done
+if ! [ -f ../ankidroiddocs/changelog.asc ]; then
+  echo "Could not find ../ankidroiddocs/changelog.asc?"
+  exit 1
 fi
 
-if ! VERSION=$(grep android:versionName $SRC_DIR$MANIFEST | sed -e 's/.*="//' | sed -e 's/".*//')
+# Define the location of the manifest file
+SRC_DIR="./AnkiDroid/src/main"
+MANIFEST="$SRC_DIR/AndroidManifest.xml"
+CHANGELOG="$SRC_DIR/assets/changelog.html"
+
+if ! VERSION=$(grep android:versionName $MANIFEST | sed -e 's/.*="//' | sed -e 's/".*//')
 then
   echo "Unable to get current version. Is sed installed?"
   exit 1
 fi
+
+if [ "$PUBLIC" = "public" ]; then
+  echo "About to perform a public release. Please first:"
+  echo "- Edit the version in AndroidManifest.xml manually but do not commit it."
+  echo "- Author and merge a PR to ankidroiddocs/changelog.asc with details for the current version"
+  echo "Press Enter to continue."
+  read -r
+
+  # Render the new changelog
+  if ! asciidoctor ../ankidroiddocs/changelog.asc -o "$CHANGELOG"
+  then
+    echo "Failed to render changelog?"
+    exit 1
+  fi
+  if ! grep "Version $VERSION " "$CHANGELOG"
+  then
+    echo "Could not find entry for version $VERSION in rendered $CHANGELOG ?"
+    exit 1
+  fi
+
+else
+  echo "Performing testing release."
+fi
+
+exit 1
 
 if [ "$PUBLIC" != "public" ]; then
   # Increment version name
@@ -49,13 +79,13 @@ if [ "$PUBLIC" != "public" ]; then
   # Increment version code
   # It is an integer in AndroidManifest that nobody actually sees.
   # Ex: 72 to 73
-  PREVIOUS_CODE=$(grep android:versionCode $SRC_DIR$MANIFEST | sed -e 's/.*="//' | sed -e 's/".*//')
+  PREVIOUS_CODE=$(grep android:versionCode $MANIFEST | sed -e 's/.*="//' | sed -e 's/".*//')
   GUESSED_CODE=$((PREVIOUS_CODE + 1))
 
   # Edit AndroidManifest.xml to bump version string
   echo "Bumping version from $PREVIOUS_VERSION$SUFFIX to $VERSION (and code from $PREVIOUS_CODE to $GUESSED_CODE)"
-  sed -i -e s/"$PREVIOUS_VERSION"$SUFFIX/"$VERSION"/g $SRC_DIR$MANIFEST
-  sed -i -e s/versionCode=\""$PREVIOUS_CODE"/versionCode=\""$GUESSED_CODE"/g $SRC_DIR$MANIFEST
+  sed -i -e s/"$PREVIOUS_VERSION"$SUFFIX/"$VERSION"/g $MANIFEST
+  sed -i -e s/versionCode=\""$PREVIOUS_CODE"/versionCode=\""$GUESSED_CODE"/g $MANIFEST
 fi
 
 # Read the key passwords
@@ -68,15 +98,15 @@ export KEYPWD
 if ! ./gradlew publishReleaseApk
 then
   # APK contains problems, abort release
-  git checkout -- $SRC_DIR$MANIFEST # Revert version change
+  git checkout -- $MANIFEST # Revert version change
   exit
 fi
 
 # Copy exported file to cwd
 cp AnkiDroid/build/outputs/apk/release/AnkiDroid-release.apk AnkiDroid-"$VERSION".apk
 
-# Commit modified AndroidManifest.xml
-git add $SRC_DIR$MANIFEST
+# Commit modified AndroidManifest.xml (and changelog.html if it changed)
+git add $MANIFEST $CHANGELOG
 git commit -m "Bumped version to $VERSION
 @branch-specific"
 


### PR DESCRIPTION

## Pull Request template

## Purpose / Description
The ankidroid changelog is sourced from the ankiddroiddocs repo (with any merged PRs there auto-published to the official ankidroid.org site) but there is a copy in this repo that is shipped with the app

This copy was diverging from the authoritative ankidroiddocs source

## Fixes
Fixes #6197

## Approach
First I altered the release script to be more robust with regard to verifying that all the required tools were available (github-release requirement might be a surprise for instance, and now asciidoctor would otherwise surprise people)

Then for public releases (the ones that get changelog entries) I verify that the authoritative ankidroiddocs repo is checked out in parallel with Anki-Android as a sibling directory, and that when we render it we get a valid entry for the version you are publishing


## How Has This Been Tested?
Lots of testing on the local machine while developing it. But I'm the only publisher right now so if it doesn't work for you despite my best efforts, it doesn't matter? :cowboy_hat_face: 

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
