### PR TITLE
Vary lint config debug vs release, CI allows debug lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,11 @@ jobs:
       install: skip
       os: linux
     - stage: unit_test
-      env: LINT=TRUE API=NONE
+      env: LINT=Release API=NONE
+      install: skip
+      os: linux
+    - stage: unit_test
+      env: LINT=Debug API=NONE
       install: skip
       os: linux
     - stage: finalize_coverage
@@ -73,6 +77,7 @@ jobs:
     - env: API=R EMU_FLAVOR=google_apis LOCALE="de_DE" # unreleased Android API30 is failing in local builds, let's expose that on Travis
     - env: API=24 JDK="1.11" # non-default JDKs should not hold up success reporting
     - env: API=24 JDK="1.14" # non-default JDKs should not hold up success reporting
+    - env: LINT=Debug API=NONE # we want to see the full lint report vs baseline but not fail on it
     - env: FINALIZE_COVERAGE=TRUE API=NONE # finalizing coverage should not hold up success reporting
 
 before_install:
@@ -134,7 +139,7 @@ install:
 script:
   - travis_retry ./gradlew :AnkiDroid:compileReleaseJavaWithJavac compileLint # warm gradle w/travis_retry to handle network blips
   - if [ "$UNIT_TEST" = "TRUE" ]; then ./gradlew jacocoUnitTestReport; fi
-  - if [ "$LINT" = "TRUE" ]; then ./gradlew lint; fi
+  - if [ "$LINT" != "FALSE" ]; then ./gradlew lint$LINT; fi
   - if [ "$API" != "NONE" ]; then ./gradlew jacocoAndroidTestReport; fi
 
 after_success:

--- a/AnkiDroid/lint-baseline.xml
+++ b/AnkiDroid/lint-baseline.xml
@@ -5,7 +5,7 @@
         id="ObsoleteLintCustomCheck"
         message="Lint found an issue registry (`androidx.appcompat.AppCompatIssueRegistry`) which requires a newer API level. That means that the custom lint checks are intended for a newer lint version; please upgrade">
         <location
-            file="../../../../.gradle/caches/transforms-2/files-2.1/77f5580fbfc4c470a544230bafa54842/appcompat-1.2.0-beta01/jars/lint.jar"/>
+            file="../../../../.gradle/caches/transforms-2/files-2.1/78f743f337d429e40fb508a05b8cd048/appcompat-1.2.0-rc01/jars/lint.jar"/>
     </issue>
 
     <issue
@@ -653,28 +653,6 @@
     </issue>
 
     <issue
-        id="GradleDependency"
-        message="A newer version of androidx.appcompat:appcompat than 1.2.0-beta01 is available: 1.2.0-rc01"
-        errorLine1="    implementation &apos;androidx.appcompat:appcompat:1.2.0-beta01&apos;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="build.gradle"
-            line="133"
-            column="5"/>
-    </issue>
-
-    <issue
-        id="GradleDependency"
-        message="A newer version of com.afollestad.material-dialogs:core than 0.9.6.0 is available: 3.3.0"
-        errorLine1="    implementation &apos;com.afollestad.material-dialogs:core:0.9.6.0&apos;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="build.gradle"
-            line="141"
-            column="5"/>
-    </issue>
-
-    <issue
         id="NewerVersionAvailable"
         message="A newer version of org.jetbrains:annotations than 16.0.1 is available: 19.0.0"
         errorLine1="    compileOnly &apos;org.jetbrains:annotations:16.0.1&apos;"
@@ -682,28 +660,6 @@
         <location
             file="build.gradle"
             line="125"
-            column="5"/>
-    </issue>
-
-    <issue
-        id="NewerVersionAvailable"
-        message="A newer version of com.google.auto.service:auto-service-annotations than 1.0-rc6 is available: 1.0-rc7"
-        errorLine1="    compileOnly &quot;com.google.auto.service:auto-service-annotations:1.0-rc6&quot;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="build.gradle"
-            line="126"
-            column="5"/>
-    </issue>
-
-    <issue
-        id="NewerVersionAvailable"
-        message="A newer version of com.google.auto.service:auto-service than 1.0-rc6 is available: 1.0-rc7"
-        errorLine1="    annotationProcessor &quot;com.google.auto.service:auto-service:1.0-rc6&quot;"
-        errorLine2="    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="build.gradle"
-            line="127"
             column="5"/>
     </issue>
 
@@ -63109,9 +63065,9 @@
         <location
             file="src/main/res/drawable-xhdpi/ic_remove_circle_grey600_24dp.png"/>
         <location
-            file="src/main/res/drawable-mdpi/ic_remove_circle_grey600_24dp.png"/>
-        <location
             file="src/main/res/drawable-xxhdpi/ic_remove_circle_grey600_24dp.png"/>
+        <location
+            file="src/main/res/drawable-mdpi/ic_remove_circle_grey600_24dp.png"/>
         <location
             file="src/main/res/drawable-hdpi/ic_remove_circle_grey600_24dp.png"/>
     </issue>

--- a/lint.gradle
+++ b/lint.gradle
@@ -1,34 +1,23 @@
-android {
-    lintOptions {
-        // move the baseline by deleting api/baseline.xml and AnkiDroid/baseline.xml then ./gradlew lintDebug
-        baseline file('./lint-baseline.xml')
-        // if true, stop the gradle build if errors are found
-        abortOnError true
-        // if true, only report errors
-        //ignoreWarnings true
-        // if true, check all issues, including those that are off by default
-        checkAllWarnings true
-        // if true, treat all warnings as errors
-        warningsAsErrors true
-        // turn off checking the given issue id's
-        //disable 'TypographyFractions','TypographyQuotes'
-        // turn on the given issue id's
-        enable 'RtlHardcoded','RtlCompat', 'RtlEnabled', 'WrongThreadInterprocedural'
-        // check *only* the given issue id's
-        //check 'NewApi', 'InlinedApi'
-        // if true, don't include source code lines in the error output
-        //noLines true
-        // if true, show all locations for an error, do not truncate lists, etc.
-        showAll true
-        // if true, generate a text report of issues (false by default)
-        textReport true
-        // location to write the output; can be a file or 'stdout'
-        textOutput 'stdout'
-        // if true, generate an HTML report (with issue explanations, sourcecode, etc)
-        htmlReport true
-        // Set the severity of the given issues to error
-        error 'NewApi', 'InlinedApi', 'Wakelock', 'TextViewEdits'
-        // Set the severity of the given issues to warning
-        //warning 'ResourceAsColor', 'RtlHardcoded','RtlCompat', 'RtlEnabled'
+tasks.whenTaskAdded { task ->
+    if (task.name.startsWith("lint")) {
+        if (task.name.toLowerCase().endsWith("release")) {
+            task.doFirst {
+                android.lintOptions.abortOnError = true
+                android.lintOptions.warningsAsErrors true
+                android.lintOptions.check 'NewApi', 'InlinedApi'
+            }
+        } else {
+            task.doFirst {
+                // move the baseline by deleting api/baseline.xml and AnkiDroid/baseline.xml then ./gradlew lintDebug
+                android.lintOptions.baseline file('./lint-baseline.xml')
+                android.lintOptions.abortOnError true
+                android.lintOptions.checkAllWarnings true
+                android.lintOptions.warningsAsErrors true
+                android.lintOptions.showAll true
+                android.lintOptions.textReport true
+                android.lintOptions.textOutput 'stdout'
+                android.lintOptions.htmlReport true
+            }
+        }
     }
 }


### PR DESCRIPTION
We want to expose when the lint results change vs current baseline, but
we can't hard fail on them because they are subject to false-positive just because
line numbers changed

For the smaller set of things that we classify as release blockers we do want
CI to check and hard fail for

Also updated the current debug baseline

This should help with the CI failure seen on #6138 which was not related to that PR