### PR TITLE
Block Tap/Touch Gesture when hint/linked clicked

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -42,6 +42,7 @@ import android.os.SystemClock;
 
 import androidx.annotation.CheckResult;
 import androidx.annotation.IdRes;
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import androidx.core.content.ContextCompat;
@@ -2612,6 +2613,11 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
                 delayedHide(INITIAL_HIDE_DELAY);
                 return true;
             }
+            return executeTouchCommand(e);
+        }
+
+
+        private boolean executeTouchCommand(@NonNull MotionEvent e) {
             if (mGesturesEnabled && !mIsSelecting) {
                 int height = mTouchLayer.getHeight();
                 int width = mTouchLayer.getWidth();

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -73,6 +73,8 @@
     </string-array>
     <string name="gestures">Enable gestures</string>
     <string name="gestures_summ">Assign gestures to actions such as answering and editing cards.</string>
+    <string name="gestures_allow_links">Ignore touch gestures on links</string>
+    <string name="gestures_allow_links_summary">Touch gestures will not be processed if a link/hint is pressed.</string>
     <string name="gestures_swipe_up">Swipe up</string>
     <string name="gestures_swipe_down">Swipe down</string>
     <string name="gestures_swipe_left">Swipe left</string>

--- a/AnkiDroid/src/main/res/xml/preferences_gestures.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_gestures.xml
@@ -31,6 +31,12 @@
         android:key="gestures"
         android:summary="@string/gestures_summ"
         android:title="@string/gestures" />
+    <CheckBoxPreference
+        android:defaultValue="false"
+        android:disableDependentsState="false"
+        android:key="linkOverridesTouchGesture"
+        android:summary="@string/gestures_allow_links_summary"
+        android:title="@string/gestures_allow_links" />
     <com.ichi2.ui.SeekBarPreference
         android:defaultValue="100"
         android:dependency="gestures"


### PR DESCRIPTION
## Disclosure

I am accepting a financial contribution for this feature request

## Purpose / Description
A user has requested that link clicks do not trigger the "touch" gestures.

## Fixes
Fixes #6141 

## Approach

Complex : we can get a `HitTest()` from the browser, but only inside a touch handler.

So, add the touch handler, filter to only the events that we want, and stop gesture processing on events where the `hitTest` was a link or an image with src.


## How Has This Been Tested?

Tested on my phone. Also tested with option off to remove regressions

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code