### PR TITLE
Introduce night mode compatibility with desktop Anki

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -2062,7 +2062,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         }
 
         if (isInNightMode()) {
-            if (!mCardAppearance.customNightMode(mCurrentCard)) {
+            if (!mCardAppearance.hasUserDefinedNightMode(mCurrentCard)) {
                 content = HtmlColors.invertColors(content);
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -2062,9 +2062,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         }
 
         if (isInNightMode()) {
-            // If card styling doesn't contain any mention of the night_mode class then do color inversion as fallback
-            // TODO: find more robust solution that won't match unrelated classes like "night_mode_old"
-            if (!mCurrentCard.css().contains(".night_mode")) {
+            if (!mCardAppearance.customNightMode(mCurrentCard)) {
                 content = HtmlColors.invertColors(content);
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardAppearance.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardAppearance.java
@@ -107,7 +107,7 @@ public class CardAppearance {
 
         if (mNightMode) {
             // Enable the night-mode class
-            cardClass.append(" night_mode");
+            cardClass.append(" night_mode nightMode");
 
             // Emit the dark_mode selector to allow dark theme overrides
             if (currentTheme == Themes.THEME_NIGHT_DARK) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardAppearance.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardAppearance.java
@@ -4,6 +4,7 @@ import android.content.SharedPreferences;
 import android.os.Build;
 
 import com.ichi2.anki.reviewer.ReviewerCustomFonts;
+import com.ichi2.libanki.Card;
 import com.ichi2.themes.Themes;
 
 import java.util.regex.Matcher;
@@ -43,6 +44,15 @@ public class CardAppearance {
 
     public boolean isNightMode() {
         return mNightMode;
+    }
+
+
+    /**
+     * customNightMode finds out if the user has included class .night_mode in card's stylesheet
+     */
+    public boolean customNightMode(Card card) {
+        // TODO: find more robust solution that won't match unrelated classes like "night_mode_old"
+        return card.css().contains(".night_mode") || card.css().contains(".nightMode");
     }
 
     public static CardAppearance create(ReviewerCustomFonts customFonts, SharedPreferences preferences) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardAppearance.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardAppearance.java
@@ -48,9 +48,9 @@ public class CardAppearance {
 
 
     /**
-     * customNightMode finds out if the user has included class .night_mode in card's stylesheet
+     * hasUserDefinedNightMode finds out if the user has included class .night_mode in card's stylesheet
      */
-    public boolean customNightMode(Card card) {
+    public boolean hasUserDefinedNightMode(Card card) {
         // TODO: find more robust solution that won't match unrelated classes like "night_mode_old"
         return card.css().contains(".night_mode") || card.css().contains(".nightMode");
     }


### PR DESCRIPTION
## Purpose / Description

Night mode in Anki for Desktop introduces a new CSS class for styling cards incompatible with AnkiDroid. This in turn neccessitates very hacky and verbose CSS for consistent styling of night mode (sometimes impossible), instead of styling for night mode in Anki or for night mode in AnkiDroid.


## Fixes

https://docs.ankiweb.net/#/templates/styling?id=night-mode


## Approach

This change introduces such compatibility (BC/FC) and only potentially breaks things if users have already tried to hack around the incompatibility for both night modes; nonetheless, in virtually all cases, the resulting CSS should be a lot simpler.


## Checklist

- [x] I have not changed whitespace unnecessarily.
- [x] I have a descriptive commit message with a short title (first line, max 50 chars).
- [x] My code follows the style of the project (e.g. never omit braces in `if` statements).
- [x] I have commented my code, particularly in hard-to-understand areas (doesn't apply).
- [x] I have performed a self-review of your own code.
