### PR TITLE
Logging: Full Sync and Deck Picker Refresh

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -1704,9 +1704,11 @@ public class DeckPicker extends NavigationDrawerActivity implements
                     }
                 }
             } else {
-                // Sync was successful!
+                Timber.i("Sync was successful");
                 if (data.data[2] != null && !"".equals(data.data[2])) {
+                    Timber.i("Syncing had additional information");
                     // There was a media error, so show it
+                    // Note: Do not log this data. May contain user email.
                     String message = res.getString(R.string.sync_database_acknowledge) + "\n\n" + data.data[2];
                     showSimpleMessageDialog(message);
                 } else if (data.data.length > 0 && data.data[0] instanceof String
@@ -1715,17 +1717,20 @@ public class DeckPicker extends NavigationDrawerActivity implements
                     String dataString = (String) data.data[0];
                     switch (dataString) {
                         case "upload":
+                            Timber.i("Full Upload Completed");
                             showSyncLogMessage(R.string.sync_log_uploading_message, syncMessage);
                             break;
                         case "download":
+                            Timber.i("Full Download Completed");
                             showSyncLogMessage(R.string.sync_log_downloading_message, syncMessage);
                             break;
                         default:
+                            Timber.i("Full Sync Completed (Unknown Direction)");
                             showSyncLogMessage(R.string.sync_database_acknowledge, syncMessage);
                             break;
                     }
                 } else {
-                    // Regular sync completed successfully
+                    Timber.i("Regular sync completed successfully");
                     showSyncLogMessage(R.string.sync_database_acknowledge, syncMessage);
                 }
                 updateDeckList();
@@ -2094,6 +2099,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
             @Override
             public void onPostExecute(TaskData result) {
+                Timber.i("Updating deck list UI");
                 hideProgressBar();
                 // Make sure the fragment is visible
                 if (mFragmented) {

--- a/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
@@ -350,6 +350,7 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
                         publishProgress(R.string.sync_downloading_message);
                         Object[] ret = server.download();
                         if (ret == null) {
+                            Timber.w("Sync - fullsync - unknown error");
                             data.success = false;
                             data.result = new Object[] { "genericError" };
                             return data;
@@ -359,6 +360,7 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
                             col.reopen();
                         }
                         if (!"success".equals(ret[0])) {
+                            Timber.w("Sync - fullsync - download failed");
                             data.success = false;
                             data.result = ret;
                             if (!colCorruptFullSync) {
@@ -399,6 +401,7 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
                 MediaSyncer mediaClient = new MediaSyncer(col, (RemoteMediaServer) server, this);
                 String ret;
                 try {
+                    Timber.i("Sync - Performing media sync");
                     ret = mediaClient.sync();
                     if (ret == null) {
                         mediaError = AnkiDroidApp.getAppResources().getString(R.string.sync_media_error);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/FullSyncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/FullSyncer.java
@@ -92,8 +92,10 @@ public class FullSyncer extends HttpSyncer {
         String tpath = path + ".tmp";
         try {
             super.writeToFile(cont, tpath);
+            Timber.d("Full Sync - Downloaded temp file");
             FileInputStream fis = new FileInputStream(tpath);
             if ("upgradeRequired".equals(super.stream2String(fis, 15))) {
+                Timber.w("Full Sync - 'Upgrade Required' message received");
                 return new Object[]{"upgradeRequired"};
             }
         } catch (FileNotFoundException e) {
@@ -123,11 +125,14 @@ public class FullSyncer extends HttpSyncer {
                 tempDb.close();
             }
         }
+        Timber.d("Full Sync: Downloaded file was not corrupt");
         // overwrite existing collection
         File newFile = new File(tpath);
         if (newFile.renameTo(new File(path))) {
+            Timber.i("Full Sync Success: Overwritten collection with downloaded file");
             return new Object[] { "success" };
         } else {
+            Timber.w("Full Sync: Error overwriting collection with downloaded file");
             return new Object[] { "overwriteError" };
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/FullSyncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/FullSyncer.java
@@ -16,9 +16,7 @@
 
 package com.ichi2.libanki.sync;
 
-import android.content.SharedPreferences;
 import android.database.sqlite.SQLiteDatabaseCorruptException;
-import android.net.Uri;
 
 import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.CollectionHelper;
@@ -26,7 +24,6 @@ import com.ichi2.anki.R;
 import com.ichi2.anki.exception.UnknownHttpResponseException;
 import com.ichi2.async.Connection;
 import com.ichi2.libanki.Collection;
-import com.ichi2.libanki.Consts;
 import com.ichi2.libanki.DB;
 import com.ichi2.libanki.Utils;
 import com.ichi2.utils.VersionUtils;


### PR DESCRIPTION
## Purpose / Description
Logging for #6208 - my theory is that the decklist didn't get refreshed, but it's also useful to know if the full sync succeeded.

## How Has This Been Tested?
Had a small test, then added some more logs 🤠.

Debug logging doesn't work too well here, as the sync progress logging spams the logs

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code