### PR TITLE
Remove 'SyntheticAccessor' from lint check

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,6 @@
 *.java text
 *.txt text
 *.xml text
+
+AnkiDroid/lint-baseline.xml linguist-generated=true
+api/lint-baseline.xml linguist-generated=true

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -149,7 +149,7 @@ dependencies {
     implementation'ch.acra:acra-limiter:5.5.1'
 
     implementation 'net.mikehardy:google-analytics-java7:2.0.13'
-    //noinspection GradleDependency
+    //noinspection GradleDependency NewerVersionAvailable
     implementation 'com.squareup.okhttp3:okhttp:3.12.11'
     implementation 'com.arcao:slf4j-timber:3.1'
 

--- a/lint.gradle
+++ b/lint.gradle
@@ -10,10 +10,18 @@ tasks.whenTaskAdded { task ->
             task.doFirst {
                 // move the baseline by deleting api/baseline.xml and AnkiDroid/baseline.xml then ./gradlew lintDebug
                 android.lintOptions.baseline file('./lint-baseline.xml')
-                // Disable 'SyntheticAccessor' -
+                // # SyntheticAccessor
                 // See discussion on #6205 - we should fix these for performance, but low priority
                 // compared to other more significant warnings.
-                android.lintOptions.disable 'SyntheticAccessor'
+
+                // # ObsoleteLintCustomCheck
+                // Requested in #6211 - not actionable by us - upstream issue
+                // Sample:
+                // > Warning: Lint found an issue registry
+                // > (androidx.appcompat.AppCompatIssueRegistry) which requires a newer API level.
+                // > That means that the custom lint checks are intended for a newer lint version;
+                // > please upgrade
+                android.lintOptions.disable 'SyntheticAccessor', 'ObsoleteLintCustomCheck'
                 android.lintOptions.abortOnError true
                 android.lintOptions.checkAllWarnings true
                 android.lintOptions.warningsAsErrors true

--- a/lint.gradle
+++ b/lint.gradle
@@ -10,6 +10,10 @@ tasks.whenTaskAdded { task ->
             task.doFirst {
                 // move the baseline by deleting api/baseline.xml and AnkiDroid/baseline.xml then ./gradlew lintDebug
                 android.lintOptions.baseline file('./lint-baseline.xml')
+                // Disable 'SyntheticAccessor' -
+                // See discussion on #6205 - we should fix these for performance, but low priority
+                // compared to other more significant warnings.
+                android.lintOptions.disable 'SyntheticAccessor'
                 android.lintOptions.abortOnError true
                 android.lintOptions.checkAllWarnings true
                 android.lintOptions.warningsAsErrors true


### PR DESCRIPTION
## Notes (Before Draft is removed)

@mikehardy You mentioned that there was a comment above the following lines, but I don't see anything. This needs the line: `NewerVersionAvailable` added to `noinspection`
```yaml
    //noinspection GradleDependency 
    implementation 'com.squareup.okhttp3:okhttp:3.12.11'
```


## Purpose / Description
Based on a discussion in #6205, we currently have more important issues picked up by lint than performance penalties.

This removes 875 lint warnings. We should eventually re-enable this once we have lint errors close to, or nearer to zero.

I changed my personal config to mark these as 'Weak Warning'

## How Has This Been Tested?

Ran the lint check `./gradlew lintDebug` before and after. Failed less the second time.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code