### PR TITLE
"Card Browser" action item: Display DeckPicker if no Permissions

### DIFF
--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -186,5 +186,6 @@
     <string name="failed_to_apply_background_image">Failed to apply background image %s</string>
 
     <!-- Global Intent handler -->
+    <!-- Also used by Card Browser, not renaming to save translators effort -->
     <string name="intent_handler_failed_no_storage_permission">Missing required storage permission. Please grant storage permission then retry your action.</string>
 </resources>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
@@ -1,5 +1,9 @@
 package com.ichi2.anki;
 
+import android.Manifest;
+import android.app.Activity;
+import android.app.Application;
+import android.content.ComponentName;
 import android.content.Intent;
 import android.widget.AdapterView;
 import android.widget.ListView;
@@ -16,13 +20,16 @@ import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.android.controller.ActivityController;
 import org.robolectric.shadows.ShadowActivity;
+import org.robolectric.shadows.ShadowApplication;
 
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import javax.annotation.CheckReturnValue;
 
+import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import timber.log.Timber;
 
@@ -31,6 +38,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.core.Is.is;
 import static org.robolectric.Shadows.shadowOf;
 
@@ -246,6 +254,28 @@ public class CardBrowserTest extends RobolectricTest {
         int actualFlag = b.getFlagOrDefault(cardProperties, 0);
 
         assertThat("The card flag value should be reflected in the UI", actualFlag, is(1));
+    }
+
+    @Test
+    public void startupFromCardBrowserActionItemShouldEndActivityIfNoPermissions() {
+        Application application = ApplicationProvider.getApplicationContext();
+        ShadowApplication app = shadowOf(application);
+        app.denyPermissions(Manifest.permission.READ_EXTERNAL_STORAGE);
+        app.denyPermissions(Manifest.permission.WRITE_EXTERNAL_STORAGE);
+        Intent inputIntent = new Intent("android.intent.action.PROCESS_TEXT");
+
+        CardBrowser cardBrowser = Robolectric.buildActivity(CardBrowser.class, inputIntent).create().get();
+
+        ShadowActivity shadowActivity = shadowOf(cardBrowser);
+        Intent outputIntent = shadowActivity.getNextStartedActivity();
+        ComponentName component = outputIntent.getComponent();
+
+        assertThat(component, notNullValue());
+        ComponentName componentName = Objects.requireNonNull(component);
+
+        assertThat("Deck Picker currently handles permissions, so should be called", componentName.getClassName(), is("com.ichi2.anki.DeckPicker"));
+        assertThat("Activity should be finishing", cardBrowser.isFinishing());
+        assertThat("Activity should be cancelled as it did nothing", shadowActivity.getResultCode(), is(Activity.RESULT_CANCELED));
     }
 
 


### PR DESCRIPTION
## Purpose / Description
Starting the CardBrowser via the 'Card Browser' action item with no permissions would previously crash.


## Fixes
Fixes #5930

## Approach
Now we show a permissions dialog from the DeckPicker.

## How Has This Been Tested?

Tested via unit tests, and on my device.

I've left a TODO in, because I feel the reduction in code duplication would slightly help maintenance, but `IntentHandler` isn't well tested, and it's a lot of effort in a critical part of the code for a slight gain.

## Learning (optional, can help others)
Some unit tests take significantly longer to get right than the code itself.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code