### PR TITLE
Add Option: Display filenames in card browser

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
@@ -296,16 +296,27 @@ public class Utils {
      * Strip HTML but keep media filenames
      */
     public static String stripHTMLMedia(@NonNull String s) {
-        Matcher imgMatcher = imgPattern.matcher(s);
-        return stripHTML(imgMatcher.replaceAll(" $1 "));
+        return stripHTMLMedia(s, " $1 ");
     }
+
+
+    public static String stripHTMLMedia(@NonNull String s, String replacement) {
+        Matcher imgMatcher = imgPattern.matcher(s);
+        return stripHTML(imgMatcher.replaceAll(replacement));
+    }
+
 
     /**
      * Strip sound but keep media filenames
      */
     public static String stripSoundMedia(String s) {
+        return stripSoundMedia(s, " $1 ");
+    }
+
+
+    public static String stripSoundMedia(String s, String replacement) {
         Matcher soundMatcher = soundPattern.matcher(s);
-        return soundMatcher.replaceAll(" $1 ");
+        return soundMatcher.replaceAll(replacement);
     }
 
 

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -60,6 +60,8 @@
     <string name="image_zoom">Image zoom</string>
     <string name="button_size">Answer button size</string>
     <string name="card_browser_font_size">Card browser font scaling</string>
+    <string name="card_browser_hide_media">Display filenames in card browser</string>
+    <string name="card_browser_hide_media_summary">Display media filenames in the card browser question/answer fields</string>
     <string name="col_path">AnkiDroid directory</string>
     <string name="fullscreen_review">Fullscreen mode</string>
     <string name="full_screen_off">Off</string>

--- a/AnkiDroid/src/main/res/xml/preferences_appearance.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_appearance.xml
@@ -74,4 +74,12 @@
                 app:interval="10"
                 app:min="10" />
         </PreferenceCategory>
+    <PreferenceCategory android:title="@string/card_browser">
+        <CheckBoxPreference
+            android:checked="false"
+            android:defaultValue="false"
+            android:key="card_browser_show_media_filenames"
+            android:title="@string/card_browser_hide_media"
+            android:summary="@string/card_browser_hide_media_summary"/>
+    </PreferenceCategory>
 </PreferenceScreen>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserNonAndroidTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserNonAndroidTest.java
@@ -1,0 +1,65 @@
+/*
+ Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki;
+
+import org.junit.Test;
+
+import androidx.annotation.CheckResult;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class CardBrowserNonAndroidTest {
+
+    @Test
+    public void soundIsStrippedCorrectly() {
+        String output = formatWithFilenamesStripped("aou[sound:foo.mp3]aou");
+
+        assertThat(output, is("aou aou"));
+    }
+
+    @Test
+    public void soundIsRetainedWithoutTag() {
+        String output = formatWithFilenamesRetained("aou[sound:foo.mp3]aou");
+
+        assertThat(output, is("aou foo.mp3 aou"));
+    }
+
+    @Test
+    public void imageIsStrippedCorrectly() {
+        String output = formatWithFilenamesStripped("aou<img src=\"test.jpg\">aou");
+
+        assertThat(output, is("aou aou"));
+    }
+
+    @Test
+    public void imageIsRetainedWithNoHtml() {
+        String output = formatWithFilenamesRetained("aou<img src=\"test.jpg\">aou");
+
+        assertThat(output, is("aou test.jpg aou"));
+    }
+
+    @CheckResult
+    private String formatWithFilenamesRetained(String input) {
+        return CardBrowser.formatQAInternal(input, true);
+    }
+
+    @CheckResult
+    private String formatWithFilenamesStripped(String input) {
+        return CardBrowser.formatQAInternal(input, false);
+    }
+}


### PR DESCRIPTION
## Purpose / Description
Many users want the previous behaviour of hiding filenames in the card browser.

Changed in revision: decdc6239ef267d4e8f2c1451c41e301a2479f9d

Fixes #5987

## Approach
I've defaulted this setting to false (don't show filenames), as this was the default before AnkiDroid 2.10.x


## How Has This Been Tested?

Tested on my phone, works as expected. Also added unit tests.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code