### PR TITLE
Reviewer: Don't blink action bar icons

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtonStatus.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtonStatus.java
@@ -67,7 +67,7 @@ public class ActionButtonStatus {
     }
 
 
-    public void setCustomButtons(Menu menu) {
+    public void refreshButtonStatuses(Menu menu) {
         for(int itemId : mCustomButtons.keySet()) {
             if (mCustomButtons.get(itemId) != MENU_DISABLED) {
                 MenuItem item = menu.findItem(itemId);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtonStatus.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtonStatus.java
@@ -72,17 +72,10 @@ public class ActionButtonStatus {
             if (mCustomButtons.get(itemId) != MENU_DISABLED) {
                 MenuItem item = menu.findItem(itemId);
                 item.setShowAsAction(mCustomButtons.get(itemId));
-                Drawable icon = item.getIcon();
                 if (mReviewerUi.getControlBlocked()) {
                     item.setEnabled(false);
-                    if (icon != null) {
-                        icon.setAlpha(Themes.ALPHA_ICON_DISABLED_LIGHT);
-                    }
                 } else {
                     item.setEnabled(true);
-                    if (icon != null) {
-                        icon.setAlpha(Themes.ALPHA_ICON_ENABLED_LIGHT);
-                    }
                 }
             } else {
                 menu.findItem(itemId).setVisible(false);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtons.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtons.java
@@ -32,7 +32,7 @@ public class ActionButtons
 
     /** Sets the order of the Action Buttons in the action bar */
     public void setCustomButtonsStatus(Menu menu) {
-        this.mActionButtonStatus.setCustomButtons(menu);
+        this.mActionButtonStatus.refreshButtonStatuses(menu);
         this.mMenu = menu;
     }
 


### PR DESCRIPTION
## Purpose / Description
User Report: It's distracting for the action item buttons to blink when answering cards.

This was added in 58ec2523777845955f3f7bfbb375c44c4339e818 (#5897)

## Approach
Partial revert of the above commit

## How Has This Been Tested?
On my phone, icons no longer blink

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code