### PR TITLE
Fix widget crash if external storage not mounted

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/widget/AnkiDroidWidgetSmall.java
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/AnkiDroidWidgetSmall.java
@@ -155,7 +155,7 @@ public class AnkiDroidWidgetSmall extends AppWidgetProvider {
                         @Override
                         public void onReceive(Context context, Intent intent) {
                             String action = intent.getAction();
-                            if (action.equals(Intent.ACTION_MEDIA_MOUNTED)) {
+                            if (action != null && action.equals(Intent.ACTION_MEDIA_MOUNTED)) {
                                 Timber.d("mMountReceiver - Action = Media Mounted");
                                 if (remounted) {
                                     WidgetStatus.update(getBaseContext());

--- a/AnkiDroid/src/main/java/com/ichi2/widget/AnkiDroidWidgetSmall.java
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/AnkiDroidWidgetSmall.java
@@ -161,7 +161,7 @@ public class AnkiDroidWidgetSmall extends AppWidgetProvider {
                                     WidgetStatus.update(getBaseContext());
                                     remounted = false;
                                     if (mMountReceiver != null) {
-                                        unregisterReceiver(mMountReceiver);
+                                        AnkiDroidApp.getInstance().unregisterReceiver(mMountReceiver);
                                     }
                                 } else {
                                     remounted = true;
@@ -172,7 +172,7 @@ public class AnkiDroidWidgetSmall extends AppWidgetProvider {
                     IntentFilter iFilter = new IntentFilter();
                     iFilter.addAction(Intent.ACTION_MEDIA_MOUNTED);
                     iFilter.addDataScheme("file");
-                    registerReceiver(mMountReceiver, iFilter);
+                    AnkiDroidApp.getInstance().registerReceiver(mMountReceiver, iFilter);
                 }
             } else {
                 // If we do not have a cached version, always update.


### PR DESCRIPTION
## Purpose / Description
A service has no `baseContext`, so `registerReceiver` threw. See linked issue.

## Fixes
Fixes #6214 

## Approach
Use the application context instead.

## How Has This Been Tested?

Tested on my phone and modified code, can now take the branch without a crash

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code