### PR TITLE
Trying to remove blink during review

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1162,7 +1162,6 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
 
     protected void undo() {
         if (isUndoAvailable()) {
-            blockControls();
             CollectionTask.launchCollectionTask(CollectionTask.TASK_TYPE_UNDO, mAnswerCardHandler);
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -2368,7 +2368,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
     }
 
     public boolean executeCommand(@ViewerCommandDef int which) {
-        if (getControlBlocked() && which != COMMAND_EXIT) {
+        if (isControlBlocked() && which != COMMAND_EXIT) {
             return false;
         }
         switch (which) {
@@ -3229,7 +3229,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
                 new CollectionTask.TaskData(null, 0));
     }
 
-    public boolean getControlBlocked() {
+    public boolean isControlBlocked() {
         return mControlBlocked;
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -474,10 +474,10 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
     }
 
 
-    protected CollectionTask.TaskListener mDismissCardHandler = new NextCardHandler() { /* superclass is sufficient */ };
+    protected final CollectionTask.TaskListener mDismissCardHandler = new NextCardHandler() { /* superclass is sufficient */ };
 
 
-    private CollectionTask.TaskListener mUpdateCardHandler = new CollectionTask.TaskListener() {
+    private final CollectionTask.TaskListener mUpdateCardHandler = new CollectionTask.TaskListener() {
         private boolean mNoMoreCards;
 
 
@@ -618,9 +618,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
     }
 
 
-    protected CollectionTask.TaskListener mAnswerCardHandler = new NextCardHandler() {
-
-
+    protected final CollectionTask.TaskListener mAnswerCardHandler = new NextCardHandler() {
         @Override
         public void onPreExecute() {
             blockControls();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -786,7 +786,7 @@ public class Reviewer extends AbstractFlashcardViewer {
      * @return true if there is another card of same note that could be dismissed
      */
     private boolean suspendNoteAvailable() {
-        if (mCurrentCard == null || getControlBlocked()) {
+        if (mCurrentCard == null || isControlBlocked()) {
             return false;
         }
         // whether there exists a sibling not buried.
@@ -795,7 +795,7 @@ public class Reviewer extends AbstractFlashcardViewer {
     }
 
     private boolean buryNoteAvailable() {
-        if (mCurrentCard == null || getControlBlocked()) {
+        if (mCurrentCard == null || isControlBlocked()) {
             return false;
         }
         // Whether there exists a sibling which is neither susbended nor buried

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -217,7 +217,7 @@ public class Reviewer extends AbstractFlashcardViewer {
             mSched.reset();     // Reset schedule in case card was previously loaded
             mSchedResetDone = false;
         }
-        CollectionTask.launchCollectionTask(CollectionTask.TASK_TYPE_ANSWER_CARD, mAnswerCardHandler,
+        CollectionTask.launchCollectionTask(CollectionTask.TASK_TYPE_ANSWER_CARD, mAnswerCardHandler(false),
                 new CollectionTask.TaskData(null, 0));
 
         disableDrawerSwipeOnConflicts();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtonStatus.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtonStatus.java
@@ -73,11 +73,7 @@ public class ActionButtonStatus {
                 MenuItem item = menu.findItem(itemId);
                 item.setShowAsAction(mCustomButtons.get(itemId));
                 Drawable icon = item.getIcon();
-                if (mReviewerUi.isControlBlocked()) {
-                    item.setEnabled(false);
-                } else {
-                    item.setEnabled(true);
-                }
+                item.setEnabled(!mReviewerUi.isControlBlocked());
                 if (icon != null) {
                     if (mReviewerUi.isControlBlocked()) {
                         icon.setAlpha(Themes.ALPHA_ICON_DISABLED_LIGHT);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtonStatus.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtonStatus.java
@@ -73,7 +73,7 @@ public class ActionButtonStatus {
                 MenuItem item = menu.findItem(itemId);
                 item.setShowAsAction(mCustomButtons.get(itemId));
                 Drawable icon = item.getIcon();
-                if (mReviewerUi.getControlBlocked()) {
+                if (mReviewerUi.isControlBlocked()) {
                     item.setEnabled(false);
                     if (icon != null) {
                         icon.setAlpha(Themes.ALPHA_ICON_DISABLED_LIGHT);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtonStatus.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtonStatus.java
@@ -75,7 +75,17 @@ public class ActionButtonStatus {
                 Drawable icon = item.getIcon();
                 item.setEnabled(!mReviewerUi.isControlBlocked());
                 if (icon != null) {
-                    if (mReviewerUi.isControlBlocked()) {
+                    /* Ideally, we want to give feedback to users that
+                    buttons are disabled.  However, some actions are
+                    expected to be so quick that the visual feedback
+                    is useless and is only seen as a flickering.
+
+                    We use a heuristic to decide whether the next card
+                    will appear quickly or slowly.  We change the
+                    color only if the buttons are blocked and we
+                    expect the next card to take time to arrive.
+                    */
+                    if (mReviewerUi.getControlBlocked() == ReviewerUi.ControlBlock.SLOW) {
                         icon.setAlpha(Themes.ALPHA_ICON_DISABLED_LIGHT);
                     } else {
                         icon.setAlpha(Themes.ALPHA_ICON_ENABLED_LIGHT);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtonStatus.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtonStatus.java
@@ -75,12 +75,13 @@ public class ActionButtonStatus {
                 Drawable icon = item.getIcon();
                 if (mReviewerUi.isControlBlocked()) {
                     item.setEnabled(false);
-                    if (icon != null) {
-                        icon.setAlpha(Themes.ALPHA_ICON_DISABLED_LIGHT);
-                    }
                 } else {
                     item.setEnabled(true);
-                    if (icon != null) {
+                }
+                if (icon != null) {
+                    if (mReviewerUi.isControlBlocked()) {
+                        icon.setAlpha(Themes.ALPHA_ICON_DISABLED_LIGHT);
+                    } else {
                         icon.setAlpha(Themes.ALPHA_ICON_ENABLED_LIGHT);
                     }
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ReviewerUi.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ReviewerUi.java
@@ -17,5 +17,5 @@
 package com.ichi2.anki.reviewer;
 
 public interface ReviewerUi {
-    boolean getControlBlocked();
+    boolean isControlBlocked();
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ReviewerUi.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ReviewerUi.java
@@ -17,5 +17,19 @@
 package com.ichi2.anki.reviewer;
 
 public interface ReviewerUi {
+    /** How to block UI buttons. */
+    enum ControlBlock {
+        /** Buttons are functional*/
+        UNBLOCKED,
+        /**Don't record click; as it's ambiguous whether it would apply to next or previous card.
+         * We expect the next card load quickly, so no need to give visual feedback to user,
+         * which would be considered as flickering. */
+        QUICK,
+        /**Don't record click; as it's ambiguous whether it would apply to next or previous card.
+         * We expect the next card may take time to load, as scheduler needs to recompute its queues;
+         * so we show the button get deactivated. */
+        SLOW
+    }
+    ControlBlock getControlBlocked();
     boolean isControlBlocked();
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerCommandTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerCommandTest.java
@@ -183,8 +183,13 @@ public class AbstractFlashcardViewerCommandTest {
 
 
         @Override
+        public ControlBlock getControlBlocked() {
+            return ControlBlock.UNBLOCKED;
+        }
+
+        @Override
         public boolean isControlBlocked() {
-            return false;
+            return getControlBlocked() != ControlBlock.UNBLOCKED;
         }
 
         @Override

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerCommandTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerCommandTest.java
@@ -183,7 +183,7 @@ public class AbstractFlashcardViewerCommandTest {
 
 
         @Override
-        public boolean getControlBlocked() {
+        public boolean isControlBlocked() {
             return false;
         }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerKeyboardInputTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerKeyboardInputTest.java
@@ -18,6 +18,7 @@ package com.ichi2.anki;
 
 import android.view.KeyEvent;
 
+import com.ichi2.anki.reviewer.ReviewerUi;
 import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
 
@@ -232,7 +233,7 @@ public class ReviewerKeyboardInputTest {
         //We pick an arbitrary action to ensure that nothing happens if controls are blocked
         KeyboardInputTestReviewer underTest = KeyboardInputTestReviewer.displayingQuestion()
                 .withUndoAvailable(true)
-                .withControlsBlocked(true);
+                .withControlsBlocked(ReviewerUi.ControlBlock.SLOW);
 
         underTest.handleUnicodeKeyPress('z');
 
@@ -267,12 +268,12 @@ public class ReviewerKeyboardInputTest {
         private Collection.DismissType mDismissType;
         private boolean mUndoCalled;
         private boolean mReplayAudioCalled;
-        private boolean mControlsAreBlocked = false;
+        private ControlBlock mControlsAreBlocked = ControlBlock.UNBLOCKED;
         private boolean mUndoAvailable;
 
 
         @Override
-        public boolean isControlBlocked() {
+        public ControlBlock getControlBlocked() {
             return mControlsAreBlocked;
         }
 
@@ -290,7 +291,7 @@ public class ReviewerKeyboardInputTest {
             return keyboardInputTestReviewer;
         }
 
-        public KeyboardInputTestReviewer withControlsBlocked(boolean value) {
+        public KeyboardInputTestReviewer withControlsBlocked(ControlBlock value) {
             mControlsAreBlocked = value;
             return this;
         }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerKeyboardInputTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerKeyboardInputTest.java
@@ -272,7 +272,7 @@ public class ReviewerKeyboardInputTest {
 
 
         @Override
-        public boolean getControlBlocked() {
+        public boolean isControlBlocked() {
             return mControlsAreBlocked;
         }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.java
@@ -43,7 +43,7 @@ public class ReviewerTest extends RobolectricTest {
             scenario.moveToState(Lifecycle.State.CREATED);
             shadowOf(getMainLooper()).idle();
             scenario.onActivity(reviewer -> {
-                reviewer.blockControls();
+                reviewer.blockControls(true);
                 reviewer.executeCommand(ViewerCommand.COMMAND_EXIT);
             });
             assertThat(scenario.getResult().getResultCode(), is(RESULT_DEFAULT));


### PR DESCRIPTION
I follow the idea given in https://github.com/ankidroid/Anki-Android/pull/6224 . Given the feedback I received, I don't expect this PR to be accepted, but it was quick to do and to test, so I thought I'd still give it a try.



There are three ways to block buttons. Not blocking (i.e. buttons are
activated), quick blocking and slow blocking. Buttons are grayed only
if we expect the blocking to be slow. I.e. when we need to recompute
the queue because the user decided to undo/bury/suspend or just loaded
the deck. Otherwise, we expect the next card to load quickly, and so
can block the buttons without graying them. This will ensure that the
buttons does not blink.

Note that loading the next card can sometime be slow, so it's still
not a perfect solution.

## Pull Request template

## Purpose / Description
Users sees buttons blinking/flickering when they review. This is because buttons are deactivated and reactivated immediately.

## Fixes
Only change color if we expect the scheduler to take time to give the new card, because we know that it needs to recompute the queue. Otherwise, assume that the card will come quickly and so changing the color is useless.

## Approach
Avoiding flicker for the most common case. Letting potential flickr for the slower and rarer actions.

## How Has This Been Tested?

Android emulator, with a few card reviewed and cancelled.

## Learning (optional, can help others)
I did the research when I tried to find where ankidroid was slow. I have no made any research for this bug right now. The idea actually arrived when I read "TL;DR: Predicting future events is hard" in https://github.com/ankidroid/Anki-Android/pull/6224#issuecomment-631074449 and realized that I was disagreeing with it, and that I already have a model of which events are quick/slow

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
