### PR TITLE
SchedV1: Don't filter learn cards

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -1019,7 +1019,7 @@ public class Sched extends SchedV2 {
         if (!TextUtils.isEmpty(search.trim())) {
             search = String.format(Locale.US, "(%s)", search);
         }
-        search = String.format(Locale.US, "%s -is:suspended -is:buried -deck:filtered", search);
+        search = String.format(Locale.US, "%s -is:suspended -is:buried -deck:filtered -is:learn", search);
         ids = mCol.findCards(search, orderlimit);
         if (ids.isEmpty()) {
             return ids;


### PR DESCRIPTION
## Purpose / Description

Handled in Anki Commit: https://github.com/ankitects/anki/commit/13c54e02d8fd2b35f6c2f4b796fc44dec65043b8

> preventing emptying is harder - operations like suspending
  don't expect remFromDyn() to fail

## Fixes
Fixes #6228

## Approach
Follow upstream

## How Has This Been Tested?

Unit Tests

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code