### PR TITLE
Add Preference: Disable "Card Browser" context menu

### DIFF
--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -197,9 +197,22 @@
                 android:value="com.ichi2.anki.DeckPicker"
                 />
         </activity>
+
+        <!-- Context menu item name is the label, context is the system language -->
+        <!-- Note: This appears to require that the target label is variable -->
+        <activity-alias
+            android:name="com.ichi2.anki.CardBrowserContextMenuAction"
+            android:label="@string/card_browser_context_menu"
+            android:targetActivity="com.ichi2.anki.CardBrowser">
+            <intent-filter>
+                <action android:name="android.intent.action.PROCESS_TEXT" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/plain" />
+            </intent-filter>
+        </activity-alias>
         <activity
             android:name="com.ichi2.anki.CardBrowser"
-            android:label="Card Browser"
+            android:label="@string/card_browser_label"
             android:exported="true"
             android:configChanges="keyboardHidden|orientation|locale|screenSize"
             android:parentActivityName=".DeckPicker"
@@ -209,11 +222,6 @@
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value="com.ichi2.anki.DeckPicker"
                 />
-            <intent-filter>
-                <action android:name="android.intent.action.PROCESS_TEXT" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <data android:mimeType="text/plain" />
-            </intent-filter>
         </activity>
         <activity
             android:name=".ModelBrowser"

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -37,6 +37,7 @@ import android.view.ViewConfiguration;
 import android.webkit.CookieManager;
 
 import com.ichi2.anki.analytics.AnkiDroidCrashReportDialog;
+import com.ichi2.anki.contextmenu.CardBrowserContextMenu;
 import com.ichi2.anki.exception.ManuallyReportedException;
 import com.ichi2.anki.exception.StorageAccessException;
 import com.ichi2.anki.services.BootService;
@@ -45,7 +46,6 @@ import com.ichi2.compat.CompatHelper;
 import com.ichi2.utils.LanguageUtil;
 import com.ichi2.anki.analytics.UsageAnalytics;
 import com.ichi2.utils.Permissions;
-import com.ichi2.utils.WebViewDebugging;
 
 import org.acra.ACRA;
 import org.acra.ReportField;
@@ -228,6 +228,7 @@ public class AnkiDroidApp extends Application {
             UsageAnalytics.setDryRun(true);
         }
 
+        CardBrowserContextMenu.ensureConsistentStateWithSharedPreferences(this);
         setLanguage(preferences.getString(Preferences.LANGUAGE, ""));
         NotificationChannels.setup(getApplicationContext());
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -49,6 +49,7 @@ import android.widget.Toast;
 
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.ichi2.anim.ActivityTransitionAnimation;
+import com.ichi2.anki.contextmenu.CardBrowserContextMenu;
 import com.ichi2.anki.debug.DatabaseLock;
 import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.anki.exception.StorageAccessException;
@@ -339,6 +340,13 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                     startActivity(i);
                     return true;
                 });
+                // FIXME: The menu is named in the system language (as it's defined in the manifest which may be
+                //  different than the app language
+                CheckBoxPreference cardBrowserContextMenuPreference = (CheckBoxPreference) screen.findPreference(CardBrowserContextMenu.CARD_BROWSER_CONTEXT_MENU_PREF_KEY);
+                String menuName = getString(R.string.card_browser_context_menu);
+                cardBrowserContextMenuPreference.setTitle(getString(R.string.card_browser_enable_external_context_menu, menuName));
+                cardBrowserContextMenuPreference.setSummary(getString(R.string.card_browser_enable_external_context_menu_summary, menuName));
+
                 // Make it possible to test crash reporting, but only for DEBUG builds
                 if (BuildConfig.DEBUG) {
                     Timber.i("Debug mode, allowing for test crashes");
@@ -732,6 +740,8 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                     builder.show();
                     break;
                 }
+                case CardBrowserContextMenu.CARD_BROWSER_CONTEXT_MENU_PREF_KEY:
+                    CardBrowserContextMenu.ensureConsistentStateWithSharedPreferences(this);
             }
             // Update the summary text to reflect new value
             updateSummary(pref);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/contextmenu/CardBrowserContextMenu.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/contextmenu/CardBrowserContextMenu.java
@@ -1,0 +1,97 @@
+/*
+ Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.contextmenu;
+
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.pm.PackageManager;
+
+import com.ichi2.anki.AnkiDroidApp;
+
+import androidx.annotation.CheckResult;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import timber.log.Timber;
+
+import static android.content.pm.PackageManager.*;
+
+public class CardBrowserContextMenu {
+
+    @NonNull
+    private final Context mContext;
+    private static final boolean DEFAULT_ENABLED_STATUS = true;
+    public static final String CARD_BROWSER_CONTEXT_MENU_PREF_KEY = "card_browser_enable_external_context_menu";
+    /** We define an activity alias so we can disable the context menu without disabling the activity */
+    private static final String ACTIVITY_ALIAS_NAME = "com.ichi2.anki.CardBrowserContextMenuAction";
+
+    @SuppressWarnings("WeakerAccess")
+    public CardBrowserContextMenu(@NonNull Context context) {
+        this.mContext = context;
+    }
+
+    public static void ensureConsistentStateWithSharedPreferences(@NonNull Context context) {
+        new CardBrowserContextMenu(context).ensureConsistentStateWithSharedPreferences();
+    }
+
+    @CheckResult
+    @Nullable
+    private Boolean getSystemMenuStatus() {
+        try {
+            return getPackageManager().getComponentEnabledSetting(getComponentName()) == COMPONENT_ENABLED_STATE_ENABLED;
+        } catch (Exception e) {
+            Timber.w("Failed to read context menu status setting");
+            return null;
+        }
+    }
+
+    @SuppressWarnings("WeakerAccess")
+    public void setSystemMenuEnabled(boolean enabled) {
+        try {
+            int enabledState = enabled ? COMPONENT_ENABLED_STATE_ENABLED : COMPONENT_ENABLED_STATE_DISABLED;
+            getPackageManager().setComponentEnabledSetting(getComponentName(), enabledState, DONT_KILL_APP);
+        } catch (Exception e) {
+            Timber.w(e, "Failed to set Context Menu state");
+        }
+    }
+
+
+    private PackageManager getPackageManager() {
+        return mContext.getPackageManager();
+    }
+
+
+    //this can throw if context.getPackageName() throws
+    @CheckResult
+    private ComponentName getComponentName() {
+        return new ComponentName(mContext, ACTIVITY_ALIAS_NAME);
+    }
+
+
+    private boolean getPreferenceStatus() {
+        return AnkiDroidApp.getSharedPrefs(mContext).getBoolean(CARD_BROWSER_CONTEXT_MENU_PREF_KEY, DEFAULT_ENABLED_STATUS);
+    }
+
+    @SuppressWarnings("WeakerAccess")
+    public void ensureConsistentStateWithSharedPreferences() {
+        boolean preferenceStatus = getPreferenceStatus();
+        Boolean actualStatus = getSystemMenuStatus();
+        if (actualStatus == null || actualStatus != preferenceStatus) {
+            Timber.d("Modifying Context Menu Status: Preference was %b", preferenceStatus);
+            setSystemMenuEnabled(preferenceStatus);
+        }
+    }
+}

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -171,4 +171,6 @@
     <!-- Permissions -->
     <string name="read_write_permission_label">Read and write to the AnkiDroid database</string>
     <string name="read_write_permission_description">access existing notes, cards, note types, and decks, as well as create new ones</string>
+    <string name="card_browser_label">Card Browser</string>
+    <string name="card_browser_context_menu">Card Browser</string>
 </resources>

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -88,6 +88,8 @@
     <string name="gestures_tap_right">Touch right</string>
     <string name="more_scrolling_buttons">eReader</string>
     <string name="more_scrolling_buttons_summ">Also use kanji/katakana, emoji/kao-moji buttons for scrolling</string>
+    <string name="card_browser_enable_external_context_menu">‘%s’ Menu</string>
+    <string name="card_browser_enable_external_context_menu_summary">Enables the ‘%s’ context menu globally</string>
     <string name="double_scrolling_gap">Double scrolling</string>
     <string name="double_scrolling_gap_summ">Double the scroll gap with eReader</string>
     <string name="swipe_sensitivity">Swipe sensitivity</string>

--- a/AnkiDroid/src/main/res/xml/preferences_advanced.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_advanced.xml
@@ -131,6 +131,12 @@
                 android:key="html_javascript_debugging"
                 android:summary="@string/html_javascript_debugging_summ"
                 android:title="@string/html_javascript_debugging"/>
+            <!-- Title and summary are variable, handled in string:
+            card_browser_enable_external_context_menu -->
+            <CheckBoxPreference
+                android:id="@+id/card_browser_external_context_menu"
+                android:defaultValue="true"
+                android:key="card_browser_enable_external_context_menu"/>
         </PreferenceCategory>
 
 


### PR DESCRIPTION
##  Purpose / Description

This allows the user to disable the card browser context menu.

This commit also changes the menu to make it localizable. This is based on the system language.

## Fixes
Fixes #6226

## Approach

We can disable the menu via defining an activity alias, then disabling it in the system.

According to StackOverflow, this is persisted until uninstall/reinstall but it's unknown whether this affects updates.

It doesn't matter, as we perform the check on startup.

## How Has This Been Tested?

On my device. Localisation on the context menu item now works

## Learning

https://stackoverflow.com/questions/14142101/how-to-create-disable-intent-filter-programmatically/14142215#14142215

https://developer.android.com/guide/topics/manifest/activity-alias-element.html

https://stackoverflow.com/questions/22949754/is-packagemanager-getcomponentenabledsettings-persistent-between-cold-starts

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code