### PR TITLE
Fix BootService crash if collection is not available

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.java
@@ -35,8 +35,8 @@ public class BootService extends BroadcastReceiver {
             return;
         }
         // There are cases where the app is installed, and we have access, but nothing exist yet
-        if (CollectionHelper.getInstance().getCol(context) == null
-                || CollectionHelper.getInstance().getCol(context).getDecks() == null) {
+        Collection col = getCol(context);
+        if (col == null || col.getDecks() == null) {
             return;
         }
 
@@ -44,6 +44,12 @@ public class BootService extends BroadcastReceiver {
         scheduleNotification(context);
         sWasRun = true;
     }
+
+
+    private Collection getCol(Context context) {
+        return CollectionHelper.getInstance().getCol(context);
+    }
+
 
     private void scheduleDeckReminder(Context context) {
         AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.java
@@ -17,6 +17,8 @@ import com.ichi2.utils.JSONObject;
 
 import java.util.Calendar;
 
+import timber.log.Timber;
+
 public class BootService extends BroadcastReceiver {
 
     /**
@@ -35,7 +37,7 @@ public class BootService extends BroadcastReceiver {
             return;
         }
         // There are cases where the app is installed, and we have access, but nothing exist yet
-        Collection col = getCol(context);
+        Collection col = getColSafe(context);
         if (col == null || col.getDecks() == null) {
             return;
         }
@@ -46,8 +48,15 @@ public class BootService extends BroadcastReceiver {
     }
 
 
-    private Collection getCol(Context context) {
-        return CollectionHelper.getInstance().getCol(context);
+    private Collection getColSafe(Context context) {
+        //#6239 - previously would crash if ejecting, we don't want a report if this happens so don't use
+        //getInstance().getColSafe
+        try {
+            return CollectionHelper.getInstance().getCol(context);
+        } catch (Exception e) {
+            Timber.e(e, "Failed to get collection for boot service - possibly media ejecting");
+            return null;
+        }
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.java
@@ -31,17 +31,21 @@ public class BootService extends BroadcastReceiver {
     @Override
     public void onReceive(Context context, Intent intent) {
         if (sWasRun) {
+            Timber.d("BootService - Already run");
             return;
         }
         if (!Permissions.hasStorageAccessPermission(context)) {
+            Timber.w("Boot Service did not execute - no permissions");
             return;
         }
         // There are cases where the app is installed, and we have access, but nothing exist yet
         Collection col = getColSafe(context);
         if (col == null || col.getDecks() == null) {
+            Timber.w("Boot Service did not execute - error loading collection");
             return;
         }
 
+        Timber.i("Executing Boot Service");
         scheduleDeckReminder(context);
         scheduleNotification(context);
         sWasRun = true;


### PR DESCRIPTION
## Purpose / Description
`BootService` would crash if external storage was `ejecting`. We ignore this error and stop execution

## Fixes
Fixes #6239 

## Approach
Try..Catch

## How Has This Been Tested?

Untested 🐮👦 

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code