### PR TITLE
Card browser: Add "Edit Note" to multiselect

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -65,7 +65,6 @@ import com.ichi2.anki.dialogs.IntegerDialog;
 import com.ichi2.anki.dialogs.RescheduleDialog;
 import com.ichi2.anki.dialogs.SimpleMessageDialog;
 import com.ichi2.anki.dialogs.TagsDialog;
-import com.ichi2.anki.dialogs.TagsDialog.TagsDialogListener;
 import com.ichi2.anki.receiver.SdCardReceiver;
 import com.ichi2.anki.widgets.DeckDropDownAdapter;
 import com.ichi2.async.CollectionTask;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -615,13 +615,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
                     onCheck(position, view);
                 } else {
                     // load up the card selected on the list
-                    mCurrentCardId = Long.parseLong(getCards().get(position).get(ID));
-                    sCardBrowserCard = getCol().getCard(mCurrentCardId);
-                    // start note editor using the card we just loaded
-                    Intent editCard = new Intent(CardBrowser.this, NoteEditor.class);
-                    editCard.putExtra(NoteEditor.EXTRA_CALLER, NoteEditor.CALLER_CARDBROWSER_EDIT);
-                    editCard.putExtra(NoteEditor.EXTRA_CARD_ID, sCardBrowserCard.getId());
-                    startActivityForResultWithAnimation(editCard, EDIT_CARD, ActivityTransitionAnimation.LEFT);
+                    long clickedCardId = Long.parseLong(getCards().get(position).get(ID));
+                    openNoteEditorForCard(clickedCardId);
                 }
             }
         });
@@ -652,6 +647,19 @@ public class CardBrowser extends NavigationDrawerActivity implements
             selectDeckById(getCol().getDecks().selected());
         }
     }
+
+    /** Opens the note editor for a card.
+     * We use the Card ID to specify the preview target */
+    public void openNoteEditorForCard(long cardId) {
+        mCurrentCardId = cardId;
+        sCardBrowserCard = getCol().getCard(mCurrentCardId);
+        // start note editor using the card we just loaded
+        Intent editCard = new Intent(this, NoteEditor.class);
+        editCard.putExtra(NoteEditor.EXTRA_CALLER, NoteEditor.CALLER_CARDBROWSER_EDIT);
+        editCard.putExtra(NoteEditor.EXTRA_CARD_ID, sCardBrowserCard.getId());
+        startActivityForResultWithAnimation(editCard, EDIT_CARD, ActivityTransitionAnimation.LEFT);
+    }
+
 
     @Override
     protected void onStop() {

--- a/AnkiDroid/src/main/res/menu/card_browser_multiselect.xml
+++ b/AnkiDroid/src/main/res/menu/card_browser_multiselect.xml
@@ -2,6 +2,13 @@
     xmlns:ankidroid="http://schemas.android.com/apk/res-auto" >
 
     <item
+        ankidroid:showAsAction="never"
+        android:visible="false"
+        android:id="@+id/action_edit_note"
+        android:title="@string/card_browser_edit_note"
+        android:icon="@drawable/ic_mode_edit_white_24dp"/>
+
+    <item
         android:id="@+id/action_delete_card"
         android:icon="@drawable/ic_delete_white_24dp"
         android:title="@string/card_browser_delete_card" />

--- a/AnkiDroid/src/main/res/values/07-cardbrowser.xml
+++ b/AnkiDroid/src/main/res/values/07-cardbrowser.xml
@@ -75,8 +75,10 @@
     </string-array>
     <string name="card_browser_select_all">Select all</string>
     <string name="card_browser_select_none">Select none</string>
+    <string name="card_browser_edit_note">Edit note</string>
     <string name="card_browser_interval_new_card">(new)</string>
     <string name="card_browser_ease_new_card">(new)</string>
     <string name="card_browser_due_filtered_card">(filtered)</string>
     <string name="card_browser_interval_learning_card">(learning)</string>
+    <string name="card_browser_note_editor_error">Error opening Note Editor</string>
 </resources>


### PR DESCRIPTION
## Purpose / Description
It's unintuitive to have one action only on single-press

Since it's the default operation, it didn't seem sensible to have it in the visible action bar - it's very likely to become invisible during the mutliselect phase.

## How Has This Been Tested?

On my phone, happy to add unit tests if you see value in them

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code