### PR TITLE
In night mode, add a white background to latex's svg

### DIFF
--- a/AnkiDroid/src/main/assets/flashcard.css
+++ b/AnkiDroid/src/main/assets/flashcard.css
@@ -2,6 +2,10 @@ body {
   margin: 0px;
   padding: 0px;
 }
+.night_mode .latex {
+    background-color: white;
+}
+
 
 body.night_mode {
   color: white;


### PR DESCRIPTION
I was trying to solve https://github.com/ankidroid/Anki-Android/issues/6245

Ideally, I'd love to port
dae/anki@1450d1ca078ed2578defdc54572296bda7cc9267.

It seems that our browser don't recognize the css command "filter";
it's hard to believe as it's far from new, according to
https://www.w3schools.com/cssref/css3_pr_filter.asp but here it is.

Instead, I decided to imitate what LaTeX already does, put a white
background. That's not beautiful, but at least the content can be read.

![2020-05-22-110750_480x854_scrot](https://user-images.githubusercontent.com/357361/82651575-9e797a00-9c1c-11ea-9a1d-a9230239e385.png)
