### PR TITLE
Tex instead of error

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/LaTeX.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/LaTeX.java
@@ -60,15 +60,16 @@ public class LaTeX {
     public static String mungeQA(String html, Collection col, JSONObject model) {
         StringBuffer sb = new StringBuffer();
         Matcher matcher = sStandardPattern.matcher(html);
+        Media m = col.getMedia();
         while (matcher.find()) {
-            matcher.appendReplacement(sb, _imgLink(matcher.group(1), model));
+            matcher.appendReplacement(sb, _imgLink(matcher.group(1), model, m));
         }
         matcher.appendTail(sb);
 
         matcher = sExpressionPattern.matcher(sb.toString());
         sb = new StringBuffer();
         while (matcher.find()) {
-            matcher.appendReplacement(sb, _imgLink("$" + matcher.group(1) + "$", model));
+            matcher.appendReplacement(sb, _imgLink("$" + matcher.group(1) + "$", model, m));
         }
         matcher.appendTail(sb);
 
@@ -76,7 +77,7 @@ public class LaTeX {
         sb = new StringBuffer();
         while (matcher.find()) {
             matcher.appendReplacement(sb,
-                    _imgLink("\\begin{displaymath}" + matcher.group(1) + "\\end{displaymath}", model));
+                    _imgLink("\\begin{displaymath}" + matcher.group(1) + "\\end{displaymath}", model, m));
         }
         matcher.appendTail(sb);
 
@@ -87,7 +88,7 @@ public class LaTeX {
     /**
      * Return an img link for LATEX.
      */
-    private static String _imgLink(String latex, JSONObject model) {
+    private static String _imgLink(String latex, JSONObject model, Media m) {
         String txt = _latexFromHtml(latex);
 
         String ext = "png";
@@ -96,7 +97,11 @@ public class LaTeX {
         }
 
         String fname = "latex-" + Utils.checksum(txt) + "." + ext;
-        return "<img class=latex src=\"" + fname + "\">";
+        if (m.have(fname)) {
+            return "<img class=latex src=\"" + fname + "\">";
+        } else {
+            return Matcher.quoteReplacement(latex);
+        }
     }
 
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
If you add some LaTeX code to ankidroid and the image is not yet compiled, you just see an error because image is not loaded.
Instead of a broken image, showing the original LaTeX seems to be a good solution.
![2020-05-22-113604_480x854_scrot](https://user-images.githubusercontent.com/357361/82654377-eb5f4f80-9c20-11ea-878d-6d7cd9dc9bd8.png)

## Fixes
FIxes #4597

## Approach
By keeping the LaTeX

## How Has This Been Tested?

Opening ankidroid, creating a card with some LaTeX code `[$]3[/3]` (on a collection which does not already have it, and ensuring that I see "$3$" (which is indeed correct LaTeX) instead of a broken image.

## Learning (optional, can help others)
This idea seems straightforward. It would have helped me a lot. But for some reason, I never thought of it before seeing @dreamflasher's idea while I was looking for another bug report.


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
