### PR TITLE
Add "Browser Appearance" Screen

### DIFF
--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -429,6 +429,12 @@
             android:windowSoftInputMode="stateAlwaysHidden|adjustPan"
             >
         </activity>
+        <activity
+            android:name=".CardTemplateBrowserAppearanceEditor"
+            android:label="@string/card_template_browser_appearance_title"
+            android:exported="false"
+            android:configChanges="keyboardHidden|orientation|locale|screenSize"
+            />
         <!-- stuff for Samsung Multi-Window -->
         <uses-library
             android:name="com.sec.android.app.multiwindow"

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateBrowserAppearanceEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateBrowserAppearanceEditor.java
@@ -1,0 +1,260 @@
+/*
+ Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki;
+
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.widget.EditText;
+
+import com.afollestad.materialdialogs.MaterialDialog;
+import com.ichi2.anki.dialogs.DiscardChangesDialog;
+import com.ichi2.utils.JSONObject;
+
+import org.jetbrains.annotations.Contract;
+
+import androidx.annotation.CheckResult;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import timber.log.Timber;
+
+/** Allows specification of the Question and Answer format of a card template in the Card Browser
+ * This is known as "Browser Appearance" in Anki
+ * We do not allow the user to change fonts as Android only has a handful
+ * We do not allow the user to change the font size as this can be done in the Appearance settings.
+ */
+public class CardTemplateBrowserAppearanceEditor extends AnkiActivity {
+
+    public static final String INTENT_QUESTION_FORMAT = "bqfmt";
+    public static final String INTENT_ANSWER_FORMAT = "bafmt";
+
+    /** Specified the card browser should use the default template formatter */
+    public static final String VALUE_USE_DEFAULT = "";
+
+    private EditText mQuestionEditText;
+    private EditText mAnswerEditText;
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        Bundle bundle = savedInstanceState;
+        if (bundle == null) {
+            bundle = getIntent().getExtras();
+        }
+        if (bundle == null) {
+            UIUtils.showThemedToast(this, getString(R.string.card_template_editor_card_browser_appearance_failed), true);
+            finishActivityWithFade(this);
+            return;
+        }
+        initializeUiFromBundle(bundle);
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(@NonNull Menu menu) {
+        getMenuInflater().inflate(R.menu.card_template_browser_appearance_editor, menu);
+        return true;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(@NonNull MenuItem item) {
+        if (item.getItemId() == R.id.action_confirm) {
+            Timber.i("Save pressed");
+            saveAndExit();
+            return true;
+        } else if (item.getItemId() == R.id.action_restore_default) {
+            Timber.i("Restore Default pressed");
+            showRestoreDefaultDialog();
+            return true;
+        } else if (item.getItemId() == android.R.id.home) {
+            Timber.i("Back Pressed");
+            closeWithDiscardWarning();
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
+    }
+
+
+    @Override
+    public void onBackPressed() {
+        Timber.i("Back Button Pressed");
+        closeWithDiscardWarning();
+    }
+
+
+    private void closeWithDiscardWarning() {
+        if (hasChanges()) {
+            Timber.i("Changes detected - displaying discard warning dialog");
+            showDiscardChangesDialog();
+        } else {
+            discardChangesAndClose();
+        }
+    }
+
+
+    private void showDiscardChangesDialog() {
+        DiscardChangesDialog
+                .getDefault(this)
+                .onPositive((dialog, which) -> discardChangesAndClose())
+                .show();
+    }
+
+
+    private void showRestoreDefaultDialog() {
+        MaterialDialog.Builder builder = new MaterialDialog.Builder(this)
+                .positiveText(R.string.dialog_ok)
+                .negativeText(R.string.cancel)
+                .content(R.string.card_template_browser_appearance_restore_default_dialog)
+                .onPositive((dialog, which) -> restoreDefaultAndClose());
+        builder.show();
+    }
+
+
+    @Override
+    public void onSaveInstanceState(@NonNull Bundle outState) {
+        outState.putString(INTENT_QUESTION_FORMAT, getQuestionFormat());
+        outState.putString(INTENT_ANSWER_FORMAT, getAnswerFormat());
+        super.onSaveInstanceState(outState);
+    }
+
+    private void initializeUiFromBundle(@NonNull Bundle bundle) {
+        setContentView(R.layout.card_browser_appearance);
+
+        mQuestionEditText = findViewById(R.id.question_format);
+        mQuestionEditText.setText(bundle.getString(INTENT_QUESTION_FORMAT));
+
+        mAnswerEditText = findViewById(R.id.answer_format);
+        mAnswerEditText.setText(bundle.getString(INTENT_ANSWER_FORMAT));
+
+        enableToolbar();
+    }
+
+    private boolean answerHasChanged(Intent intent) {
+        return !intent.getStringExtra(INTENT_ANSWER_FORMAT).equals(getAnswerFormat());
+    }
+
+    private boolean questionHasChanged(Intent intent) {
+        return !intent.getStringExtra(INTENT_QUESTION_FORMAT).equals(getQuestionFormat());
+    }
+
+    private String getQuestionFormat() {
+        return getTextValue(mQuestionEditText);
+    }
+
+    private String getAnswerFormat() {
+        return getTextValue(mAnswerEditText);
+    }
+
+    private String getTextValue(EditText editText) {
+        return editText.getText().toString();
+    }
+
+    private void restoreDefaultAndClose() {
+        Timber.i("Restoring Default and Closing");
+        mQuestionEditText.setText(VALUE_USE_DEFAULT);
+        mAnswerEditText.setText(VALUE_USE_DEFAULT);
+        saveAndExit();
+    }
+
+    private void discardChangesAndClose() {
+        Timber.i("Closing and discarding changes");
+        setResult(RESULT_CANCELED);
+        finishActivityWithFade(this);
+    }
+
+    private void saveAndExit() {
+        Timber.i("Save and Exit");
+        Intent data = new Intent();
+        data.putExtra(INTENT_QUESTION_FORMAT, getQuestionFormat());
+        data.putExtra(INTENT_ANSWER_FORMAT, getAnswerFormat());
+        setResult(RESULT_OK, data);
+        finishActivityWithFade(this);
+    }
+
+    public boolean hasChanges() {
+        try {
+            Intent intent = getIntent();
+            return questionHasChanged(intent) || answerHasChanged(intent);
+        } catch (Exception e) {
+            Timber.w(e, "Failed to detect changes. Assuming true");
+            return true;
+        }
+    }
+
+    @NonNull @CheckResult
+    public static Intent getIntentFromTemplate(@NonNull Context context, @NonNull JSONObject template) {
+        String browserQuestionTemplate = template.getString("bqfmt");
+        String browserAnswerTemplate = template.getString("bafmt");
+        return CardTemplateBrowserAppearanceEditor.getIntent(context, browserQuestionTemplate, browserAnswerTemplate);
+    }
+
+    @NonNull @CheckResult
+    public static Intent getIntent(@NonNull Context context, @NonNull String questionFormat, @NonNull String answerFormat) {
+        Intent intent = new Intent(context, CardTemplateBrowserAppearanceEditor.class);
+        intent.putExtra(INTENT_QUESTION_FORMAT, questionFormat);
+        intent.putExtra(INTENT_ANSWER_FORMAT, answerFormat);
+        return intent;
+    }
+
+    public static class Result {
+        @NonNull
+        private final String mQuestion;
+        @NonNull
+        private final String mAnswer;
+
+        private Result(String question, String answer) {
+            this.mQuestion = question == null ? VALUE_USE_DEFAULT : question;
+            this.mAnswer = answer == null ? VALUE_USE_DEFAULT : answer;
+        }
+
+
+        @Nullable
+        @Contract("null -> null")
+        @SuppressWarnings("WeakerAccess")
+        public static Result fromIntent(@Nullable Intent intent) {
+            if (intent == null) {
+                return null;
+            }
+            try {
+                String question = intent.getStringExtra(INTENT_QUESTION_FORMAT);
+                String answer = intent.getStringExtra(INTENT_ANSWER_FORMAT);
+                return new Result(question, answer);
+            } catch (Exception e) {
+                Timber.w(e, "Could not read result from intent");
+                return null;
+            }
+        }
+
+        @NonNull
+        public String getQuestion() {
+            return mQuestion;
+        }
+
+        @NonNull
+        public String getAnswer() {
+            return mAnswer;
+        }
+
+
+        @SuppressWarnings("WeakerAccess")
+        public void applyTo(@NonNull JSONObject template) {
+            template.put("bqfmt", getQuestion());
+            template.put("bafmt", getAnswer());
+        }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
@@ -21,6 +21,10 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.res.Resources;
 import android.os.Bundle;
+
+import androidx.annotation.CheckResult;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentPagerAdapter;
@@ -73,6 +77,7 @@ public class CardTemplateEditor extends AnkiActivity {
     private long mNoteId;
     private int mOrdId;
     private static final int REQUEST_PREVIEWER = 0;
+    private static final int REQUEST_CARD_BROWSER_APPEARANCE = 1;
     private static final String DUMMY_TAG = "DUMMY_NOTE_TO_DELETE_x0-90-fa";
 
 
@@ -497,10 +502,43 @@ public class CardTemplateEditor extends AnkiActivity {
                     }
 
                     return true;
+                case R.id.action_card_browser_appearance:
+                    Timber.i("CardTemplateEditor::Card Browser Template button pressed");
+                    launchCardBrowserAppearance(getCurrentTemplate());
                 default:
                     return super.onOptionsItemSelected(item);
             }
         }
+
+
+        private void launchCardBrowserAppearance(JSONObject currentTemplate) {
+            Context context = AnkiDroidApp.getInstance().getBaseContext();
+            if (context == null) {
+                //Catch-22, we can't notify failure as there's no context. Shouldn't happen anyway
+                Timber.w("Context was null - couldn't launch Card Browser Appearance window");
+                return;
+            }
+            Intent browserAppearanceIntent = CardTemplateBrowserAppearanceEditor.getIntentFromTemplate(context, currentTemplate);
+            startActivityForResult(browserAppearanceIntent, REQUEST_CARD_BROWSER_APPEARANCE);
+        }
+
+
+        @CheckResult @NonNull
+        private JSONObject getCurrentTemplate() {
+            int currentCardTemplateIndex = getCurrentCardTemplateIndex();
+            return (JSONObject) getModel().getJSONArray("tmpls").get(currentCardTemplateIndex);
+        }
+
+
+        /**
+         * @return The index of the card template which is currently referred to by the fragment
+         */
+        @CheckResult
+        private int getCurrentCardTemplateIndex() {
+            //COULD_BE_BETTER: Lots of duplicate code could call this. Hold off on the refactor until #5151 goes in.
+            return getArguments().getInt("position");
+        }
+
 
         /**
          * Get a dummy card
@@ -536,9 +574,35 @@ public class CardTemplateEditor extends AnkiActivity {
         }
 
         @Override
-        public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        public void onActivityResult(int requestCode, int resultCode, @Nullable Intent data) {
             super.onActivityResult(requestCode, resultCode, data);
-            deleteDummyCards();
+            if (requestCode == REQUEST_CARD_BROWSER_APPEARANCE) {
+                onCardBrowserAppearanceResult(resultCode, data);
+                return;
+            }
+
+            if (requestCode == REQUEST_PREVIEWER) {
+                deleteDummyCards();
+            }
+        }
+
+
+        private void onCardBrowserAppearanceResult(int resultCode, @Nullable Intent data) {
+            if (resultCode != RESULT_OK) {
+                Timber.i("Activity Cancelled: Card Template Browser Appearance");
+                return;
+            }
+
+            CardTemplateBrowserAppearanceEditor.Result result = CardTemplateBrowserAppearanceEditor.Result.fromIntent(data);
+            if (result == null) {
+                Timber.w("Error processing Card Template Browser Appearance result");
+                return;
+            }
+
+            Timber.i("Applying Card Template Browser Appearance result");
+
+            JSONObject currentTemplate = getCurrentTemplate();
+            result.applyTo(currentTemplate);
         }
 
         /* Used for updating the collection when a model has been edited */

--- a/AnkiDroid/src/main/res/drawable/ic_view_list_white_24dp.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_view_list_white_24dp.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M4,14h4v-4L4,10v4zM4,19h4v-4L4,15v4zM4,9h4L8,5L4,5v4zM9,14h12v-4L9,10v4zM9,19h12v-4L9,15v4zM9,5v4h12L21,5L9,5z"/>
+</vector>

--- a/AnkiDroid/src/main/res/layout/card_browser_appearance.xml
+++ b/AnkiDroid/src/main/res/layout/card_browser_appearance.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+  This program is free software; you can redistribute it and/or modify it under
+  the terms of the GNU General Public License as published by the Free Software
+  Foundation; either version 3 of the License, or (at your option) any later
+  version.
+
+  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along with
+  this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical" android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <include layout="@layout/toolbar" />
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical" >
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/card_template_browser_appearance_summary"
+                android:layout_margin="@dimen/content_vertical_padding"
+                android:layout_marginBottom="@dimen/title_frame_margin_bottom"
+                />
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/card_template_browser_appearance_question_format">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/question_format"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="start|top"
+                    android:lines="3"
+                    android:inputType="textNoSuggestions|textMultiLine"
+                    android:layout_margin="@dimen/content_vertical_padding"/>
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/card_template_browser_appearance_answer_format">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/answer_format"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="start|top"
+                    android:lines="3"
+                    android:inputType="textNoSuggestions|textMultiLine"
+                    android:layout_margin="@dimen/content_vertical_padding"/>
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/card_template_browser_appearance_saving_note"
+                android:layout_margin="@dimen/content_vertical_padding"
+                />
+        </LinearLayout>
+    </ScrollView>
+</LinearLayout>

--- a/AnkiDroid/src/main/res/menu/card_template_browser_appearance_editor.xml
+++ b/AnkiDroid/src/main/res/menu/card_template_browser_appearance_editor.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+  This program is free software; you can redistribute it and/or modify it under
+  the terms of the GNU General Public License as published by the Free Software
+  Foundation; either version 3 of the License, or (at your option) any later
+  version.
+
+  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along with
+  this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:ankidroid="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/action_restore_default"
+        android:icon="@drawable/ic_clear_white_24dp"
+        android:title="@string/restore_default"
+        ankidroid:showAsAction="ifRoom"
+        android:visible="true"/>
+    <item
+        android:id="@+id/action_confirm"
+        android:icon="@drawable/ic_done_white_24dp"
+        android:title="@string/save"
+        ankidroid:showAsAction="always"
+        android:visible="true"/>
+</menu>

--- a/AnkiDroid/src/main/res/menu/card_template_editor.xml
+++ b/AnkiDroid/src/main/res/menu/card_template_editor.xml
@@ -22,4 +22,9 @@
         android:icon="@drawable/ic_action_cancel"
         android:title="@string/card_template_editor_menu_delete"
         ankidroid:showAsAction="never"/>
+    <item
+        android:id="@+id/action_card_browser_appearance"
+        android:icon="@drawable/ic_view_list_white_24dp"
+        android:title="@string/card_template_editor_menu_card_browser_appearance"
+        ankidroid:showAsAction="ifRoom"/>
 </menu>

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -160,6 +160,7 @@
     <string name="card_template_editor_back">Back template</string>
     <string name="card_template_editor_styling">Styling</string>
     <string name="card_template_editor_menu_delete">Delete</string>
+    <string name="card_template_editor_menu_card_browser_appearance">Card Browser Appearance</string>
     <string name="card_template_editor_cant_delete">At least one card type is required</string>
     <plurals name="card_template_editor_confirm_delete">
         <item quantity="one">Delete the “%2$s” card type, and its %1$d card?</item>
@@ -168,6 +169,10 @@
     <string name="invalid_template">A card could not be generated</string>
     <string name="card_template_editor_would_delete_note">Removing this card type would cause one or more notes to be deleted. Please create a new card type first.</string>
     <string name="template_for_current_card_deleted">The card type for the current card was deleted.</string>
+
+    <!-- Card Browser Appearance -->
+    <string name="card_template_browser_appearance_title">Browser appearance</string>
+
     <!-- Permissions -->
     <string name="read_write_permission_label">Read and write to the AnkiDroid database</string>
     <string name="read_write_permission_description">access existing notes, cards, note types, and decks, as well as create new ones</string>

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -255,4 +255,6 @@
     <!-- Deckpicker Background -->
     <string name="background_image_title">Background</string>
     <string name="choose_an_image">Choose an Image</string>
+    <!-- Card Template Browser Appearance -->
+    <string name="restore_default">Restore Default</string>
 </resources>

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -188,4 +188,7 @@
     <!-- Global Intent handler -->
     <!-- Also used by Card Browser, not renaming to save translators effort -->
     <string name="intent_handler_failed_no_storage_permission">Missing required storage permission. Please grant storage permission then retry your action.</string>
+
+    <!-- Browser Appearance -->
+    <string name="card_template_editor_card_browser_appearance_failed">Could not load Card Browser Appearance</string>
 </resources>

--- a/AnkiDroid/src/main/res/values/17-model-manager.xml
+++ b/AnkiDroid/src/main/res/values/17-model-manager.xml
@@ -66,4 +66,11 @@
     <string name="model_browser_add_add">Add: %1$s </string> <!--This prefix is used for standard note types-->
     <string name="model_browser_add_clone">Clone: %1$s </string>
 
+    <!--Browser Appearance-->
+    <string name="card_template_browser_appearance_summary">Enter the template that the card browser will use to display your cards. Use this to display a more concise answer.\n\nA front template of\n“The capital of {{Country}} is:”\ncould be compressed in the card browser to\n“Capital: {{Country}}”</string>
+    <string name="card_template_browser_appearance_question_format">Question Format</string>
+    <string name="card_template_browser_appearance_answer_format">Answer Format</string>
+    <string name="card_template_browser_appearance_restore_default_dialog">Restore Default Values?</string>
+    <string name="card_template_browser_appearance_saving_note">These changes are applied when the card template is saved</string>
+
 </resources>


### PR DESCRIPTION
As defined in Anki Desktop: A user can edit the format string which is used in the Card Browser to render a card template.

This allows them to mark the reverse side in a card, for example without it appearing in the UI, or removing JavaScript or media fields to reduce rendering time.

This adds:

* UI with 2 textboxes
* Reset to Default button
* Save/Cancel buttons with logic

Fixes #5158

## How Has This Been Tested?

⛔ Manually, not unit tested, please provide a few tests if you think they'd be useful.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
