### PR TITLE
Card Browser: "Search All Decks" button if no results

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -657,13 +657,19 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
         // If a valid value for last deck exists then use it, otherwise use libanki selected deck
         if (getLastDeckId() != null && getLastDeckId() == ALL_DECKS_ID) {
-            selectDropDownItem(0);
+            selectAllDecks();
         } else  if (getLastDeckId() != null && getCol().getDecks().get(getLastDeckId(), false) != null) {
             selectDeckById(getLastDeckId());
         } else {
             selectDeckById(getCol().getDecks().selected());
         }
     }
+
+
+    private void selectAllDecks() {
+        selectDropDownItem(0);
+    }
+
 
     /** Opens the note editor for a card.
      * We use the Card ID to specify the preview target */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1676,14 +1676,19 @@ public class CardBrowser extends NavigationDrawerActivity implements
         @Override
         public void onPostExecute(TaskData result) {
             if (result != null && mCards != null) {
-                Timber.i("CardBrowser:: Completed doInBackgroundSearchCards Successfully");
-                updateList();
-                if ((mSearchView != null) && !mSearchView.isIconified()) {
-                    UIUtils.showSimpleSnackbar(CardBrowser.this, getSubtitleText(), true);
-                }
+                handleSearchResult();
             }
             updatePreviewMenuItem();
             hideProgressBar();
+        }
+
+
+        private void handleSearchResult() {
+            Timber.i("CardBrowser:: Completed doInBackgroundSearchCards Successfully");
+            updateList();
+            if ((mSearchView != null) && !mSearchView.isIconified()) {
+                UIUtils.showSimpleSnackbar(CardBrowser.this, getSubtitleText(), true);
+            }
         }
     };
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1217,7 +1217,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
         showDialogFragment(dialog);
     }
 
-
+    /** Selects the given position in the deck list */
     public void selectDropDownItem(int position) {
         mActionBarSpinner.setSelection(position);
         deckDropDownItemChanged(position);
@@ -1699,10 +1699,53 @@ public class CardBrowser extends NavigationDrawerActivity implements
             Timber.i("CardBrowser:: Completed doInBackgroundSearchCards Successfully");
             updateList();
             if ((mSearchView != null) && !mSearchView.isIconified()) {
-                UIUtils.showSimpleSnackbar(CardBrowser.this, getSubtitleText(), true);
+                if (getCardCount() == 0 && !hasSelectedAllDecks()) {
+                    View root = CardBrowser.this.findViewById(R.id.root_layout);
+                    UIUtils.showSnackbar(CardBrowser.this,
+                            getString(R.string.card_browser_no_cards_in_deck, getSelectedDeckNameForUi()),
+                            SNACKBAR_DURATION,
+                            R.string.card_browser_search_all_decks,
+                            (v) -> searchAllDecks(),
+                            root,
+                            null);
+                } else {
+                    UIUtils.showSimpleSnackbar(CardBrowser.this, getSubtitleText(), true);
+                }
             }
         }
     };
+
+    public boolean hasSelectedAllDecks() {
+        Long lastDeckId = getLastDeckId();
+        return lastDeckId != null && lastDeckId == ALL_DECKS_ID;
+    }
+
+
+    public void searchAllDecks() {
+        //all we need to do is select all decks
+        selectAllDecks();
+    }
+
+    /**
+     * Returns the current deck name, "All Decks" if all decks are selected, or "Unknown"
+     * Do not use this for any business logic, as this will return inconsistent data
+     * with the collection.
+     */
+    public String getSelectedDeckNameForUi() {
+        try {
+            Long lastDeckId = getLastDeckId();
+            if (lastDeckId == null) {
+                return getString(R.string.card_browser_unknown_deck_name);
+            }
+            if (lastDeckId == ALL_DECKS_ID) {
+                return getString(R.string.card_browser_all_decks);
+            }
+            return getCol().getDecks().name(lastDeckId);
+        } catch (Exception e) {
+            Timber.w(e, "Unable to get selected deck name");
+            return getString(R.string.card_browser_unknown_deck_name);
+        }
+    }
 
     private CollectionTask.TaskListener mRenderQAHandler = new CollectionTask.TaskListener() {
         @Override

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -857,8 +857,14 @@ public class CardBrowser extends NavigationDrawerActivity implements
         if (mPreviewItem == null) {
             return;
         }
-        mPreviewItem.setVisible(getCards().size() > 0);
+        mPreviewItem.setVisible(getCardCount() > 0);
     }
+
+    /** Returns the number of cards that are visible on the screen */
+    public int getCardCount() {
+        return getCards().size();
+    }
+
 
     private void updateMultiselectMenu() {
         Timber.d("updateMultiselectMenu()");
@@ -884,7 +890,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
     }
 
     private boolean hasSelectedAllCards() {
-        return mCheckedCardPositions.size() >= getCards().size(); //must handle 0.
+        return mCheckedCardPositions.size() >= getCardCount(); //must handle 0.
     }
 
 
@@ -1283,7 +1289,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
      * @return text to be used in the subtitle of the drop-down deck selector
      */
     public String getSubtitleText() {
-        int count = getCards().size();
+        int count = getCardCount();
         return getResources().getQuantityString(R.plurals.card_browser_subtitle, count, count);
     }
 
@@ -1411,7 +1417,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
             Note note = c.note();
             // get position in the mCards search results HashMap
             int pos = idToPos.containsKey(c.getId()) ? idToPos.get(c.getId()) : -1;
-            if (pos < 0 || pos >= getCards().size()) {
+            if (pos < 0 || pos >= getCardCount()) {
                 continue;
             }
             Map<String, String> card = getCards().get(pos);
@@ -1784,7 +1790,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
         public void onScroll(AbsListView view, int firstVisibleItem, int visibleItemCount, int totalItemCount) {
             // Show the progress bar if scrolling to given position requires rendering of the question / answer
             int lastVisibleItem = firstVisibleItem + visibleItemCount;
-            int size = getCards().size();
+            int size = getCardCount();
             if ((size > 0) && (firstVisibleItem < size) && ((lastVisibleItem - 1) < size)) {
                 String firstAns = getCards().get(firstVisibleItem).get("answer");
                 // Note: max value of lastVisibleItem is totalItemCount, so need to subtract 1
@@ -1959,7 +1965,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
         @Override
         public int getCount() {
-            return getCards().size();
+            return getCardCount();
         }
 
 

--- a/AnkiDroid/src/main/res/values/07-cardbrowser.xml
+++ b/AnkiDroid/src/main/res/values/07-cardbrowser.xml
@@ -81,4 +81,7 @@
     <string name="card_browser_due_filtered_card">(filtered)</string>
     <string name="card_browser_interval_learning_card">(learning)</string>
     <string name="card_browser_note_editor_error">Error opening Note Editor</string>
+    <string name="card_browser_no_cards_in_deck">No cards found in deck ‘%s’</string>
+    <string name="card_browser_search_all_decks">Search all decks</string>
+    <string name="card_browser_unknown_deck_name">Unknown</string>
 </resources>


### PR DESCRIPTION
## Purpose / Description
Allow a user to search all decks if there was no results for a search

This is makes the 'Card Browser' context menu item much more effective.

## Fixes
Fixes #5159 (I feel it's in a better manner, but your call).

## Approach
We use a snackbar: 
![image](https://user-images.githubusercontent.com/62114487/82676287-0db39600-9c3e-11ea-9665-b615f5289d83.png)


## How Has This Been Tested?

Tested on my device

⛔ Please reject this and ask me to add a few unit tests (in a direction of your choosing).

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code