### PR TITLE
Display different languages in their own language.

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -846,7 +846,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
             Map<String, String> items = new TreeMap<>();
             for (String localeCode : LanguageUtil.APP_LANGUAGES) {
                 Locale loc = LanguageUtil.getLocale(localeCode);
-                items.put(loc.getDisplayName(), loc.toString());
+                items.put(loc.getDisplayName(loc), loc.toString());
             }
             CharSequence[] languageDialogLabels = new CharSequence[items.size() + 1];
             CharSequence[] languageDialogValues = new CharSequence[items.size() + 1];


### PR DESCRIPTION
## Purpose / Description
In language settings, display different lanuages in their own language.
However, some languages such as Arabic seems display in an wrong location which need further help.

## Fixes
Fixes #6251

## Approach
In function initializeLanguageDialog in Preference.java, Map<String, String> items' key change from loc.getDisplayName() to loc.getDisplayName(loc). 

## How Has This Been Tested?

Starting the app, opening the settings, opening the language settings.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
