### PR TITLE
Add English back to Language list

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/utils/LanguageUtil.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/LanguageUtil.java
@@ -28,9 +28,10 @@ import java.util.Locale;
  */
 public class LanguageUtil {
 
-    /** A list of all languages supported by AnkiDroid */
+    /** A list of all languages supported by AnkiDroid
+     * Please modify LanguageUtilsLanguageRegressionTest if changing */
     public static final String[] APP_LANGUAGES = {"af", "am", "ar", "az", "be", "bg", "bn", "ca", "ckb", "cs", "da",
-            "de", "el", "eo", "es-AR", "es-ES", "et", "eu", "fa", "fi", "fil", "fr", "fy-NL", "ga-IE", "gl", "got",
+            "de", "el", "en", "eo", "es-AR", "es-ES", "et", "eu", "fa", "fi", "fil", "fr", "fy-NL", "ga-IE", "gl", "got",
             "gu-IN", "he", "hi", "hr", "hu", "hy-AM", "id", "is", "it", "ja", "jv", "ka", "kk", "km", "ko", "ku",
             "ky", "lt", "lv", "mk", "mn", "mr", "ms", "my", "nl", "nn-NO", "no", "pa-IN", "pl", "pt-BR", "pt-PT",
             "ro", "ru", "sk", "sl", "sq", "sr", "ss", "sv-SE", "sw", "ta", "te", "tg", "th", "ti", "tl", "tn", "tr",

--- a/AnkiDroid/src/main/java/com/ichi2/utils/LanguageUtil.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/LanguageUtil.java
@@ -23,6 +23,9 @@ import java.text.DateFormat;
 import java.util.Date;
 import java.util.Locale;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 /**
  * Utility call for proving language related functionality.
  */
@@ -43,6 +46,7 @@ public class LanguageUtil {
      *
      * @return The {@link Locale} for the given code
      */
+    @NonNull
     public static Locale getLocale() {
         return getLocale("");
     }
@@ -53,7 +57,8 @@ public class LanguageUtil {
      * @param localeCode The locale code of the language
      * @return The {@link Locale} for the given code
      */
-    public static Locale getLocale(String localeCode) {
+    @NonNull
+    public static Locale getLocale(@Nullable String localeCode) {
         Locale locale;
         if (localeCode == null || TextUtils.isEmpty(localeCode)) {
 
@@ -76,10 +81,14 @@ public class LanguageUtil {
         return locale;
     }
 
+
+    @NonNull
     public static String getShortDateFormatFromMs(long ms) {
         return DateFormat.getDateInstance(DateFormat.SHORT, getLocale()).format(new Date(ms));
     }
 
+
+    @NonNull
     public static String getShortDateFormatFromS(long s) {
         return DateFormat.getDateInstance(DateFormat.SHORT, getLocale()).format(new Date(s * 1000L));
     }

--- a/AnkiDroid/src/test/java/com/ichi2/utils/LanguageUtilsLanguageRegressionTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/LanguageUtilsLanguageRegressionTest.java
@@ -1,0 +1,74 @@
+/*
+ Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.utils;
+
+import com.google.common.collect.Sets;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasItem;
+
+public class LanguageUtilsLanguageRegressionTest {
+
+    private static final String[] PREVIOUS_LANGUAGES = { "ar", "bg", "ca", "cs", "de", "el", "en", "eo", "es-AR", "es-ES", "et", "fa",
+            "fi", "fr", "got", "gl", "hi", "hu", "id", "it", "ja", "ko", "lt", "nl", "nn-NO", "no", "pl", "pt_PT", "pt_BR", "ro", "ru",
+            "sk", "sl", "sr", "sv", "th", "tr", "tt-RU", "uk", "vi", "zh_CN", "zh_TW" };
+
+    private static final String[] CURRENT_LANGUAGES = {"af", "am", "ar", "az", "be", "bg", "bn", "ca", "ckb", "cs", "da",
+            "de", "el", "en", "eo", "es-AR", "es-ES", "et", "eu", "fa", "fi", "fil", "fr", "fy-NL", "ga-IE", "gl", "got",
+            "gu-IN", "he", "hi", "hr", "hu", "hy-AM", "id", "is", "it", "ja", "jv", "ka", "kk", "km", "ko", "ku",
+            "ky", "lt", "lv", "mk", "mn", "mr", "ms", "my", "nl", "nn-NO", "no", "pa-IN", "pl", "pt-BR", "pt-PT",
+            "ro", "ru", "sk", "sl", "sq", "sr", "ss", "sv-SE", "sw", "ta", "te", "tg", "th", "ti", "tl", "tn", "tr",
+            "ts", "tt-RU", "uk", "ur-PK", "uz", "ve", "vi", "wo", "xh", "yu", "zh-CN", "zh-TW", "zu" };
+
+    /** Languages which were removed for good reason */
+    private static final HashSet<String> previousLanguageExclusions = Sets.newHashSet(
+            "pt_PT", //pt-PT
+            "pt_BR", //pt-BR
+            "sv",    //sv-SE
+            "zh_CN", //zh-CN
+            "zh_TW"  //zh-TW
+    );
+
+    @Test
+    public void testNoLanguageIsRemoved() {
+        HashSet<String> languages = new HashSet<>();
+        Collections.addAll(languages, LanguageUtil.APP_LANGUAGES);
+
+        List<String> previousLanguages = new ArrayList<>(asList(PREVIOUS_LANGUAGES));
+        previousLanguages.removeAll(previousLanguageExclusions);
+
+        for (String language: previousLanguages) {
+            assertThat(languages, hasItem(language));
+        }
+    }
+
+    @Test
+    public void testCurrentLanguagesHaveNotChanged() {
+        List<String> actual = asList(LanguageUtil.APP_LANGUAGES);
+        assertThat("Languages have been updated, please modify test variables: " +
+                "PREVIOUS_LANGUAGES and CURRENT_LANGUAGES", actual, contains(CURRENT_LANGUAGES));
+    }
+}


### PR DESCRIPTION
## Goals

Please check the tests to see if you're happy with breakages if the language is changed

## Purpose / Description
I noticed that English was no longer a selectable language

## Approach
Adds English back in

## How Has This Been Tested?
On my device, and with regression tests.

## Learning (optional, can help others)

English is a language

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code