### PR TITLE
string consisting only of whitespace does not generate card (Previously NF: clean _renderQA)

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.java
@@ -344,7 +344,7 @@ public class Card implements Cloneable {
 
 
     public boolean isEmpty() {
-        ArrayList<Integer> ords = mCol.getModels().availOrds(model(), Utils.joinFields(note().getFields()));
+        ArrayList<Integer> ords = mCol.getModels().availOrds(model(), note().getFields());
         return !ords.contains(mOrd);
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.java
@@ -282,9 +282,9 @@ public class Card implements Cloneable {
             if (browser) {
                 String bqfmt = t.getString("bqfmt");
                 String bafmt = t.getString("bafmt");
-                mQA = mCol._renderQA(mId, m, did, mOrd, f.stringTags(), f.joinedFields(), mFlags, browser, bqfmt, bafmt);
+                mQA = mCol._renderQA(mId, m, did, mOrd, f.stringTags(), f.getFields(), mFlags, browser, bqfmt, bafmt);
             } else {
-                mQA = mCol._renderQA(mId, m, did, mOrd, f.stringTags(), f.joinedFields(), mFlags);
+                mQA = mCol._renderQA(mId, m, did, mOrd, f.stringTags(), f.getFields(), mFlags);
             }
         }
         return mQA;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.java
@@ -278,8 +278,7 @@ public class Card implements Cloneable {
             Note f = note(reload);
             JSONObject m = model();
             JSONObject t = template();
-            Object[] data;
-            data = new Object[] { mId, f.getId(), m, mODid != 0L ? mODid : mDid, mOrd, f.stringTags(), f.joinedFields(), mFlags};
+            Object[] data = new Object[] { mId, f.getId(), m, mODid != 0L ? mODid : mDid, mOrd, f.stringTags(), f.joinedFields(), mFlags};
 
             if (browser) {
                 String bqfmt = t.getString("bqfmt");

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.java
@@ -282,9 +282,9 @@ public class Card implements Cloneable {
             if (browser) {
                 String bqfmt = t.getString("bqfmt");
                 String bafmt = t.getString("bafmt");
-                mQA = mCol._renderQA(mId, f.getId(), m, did, mOrd, f.stringTags(), f.joinedFields(), mFlags, browser, bqfmt, bafmt);
+                mQA = mCol._renderQA(mId, m, did, mOrd, f.stringTags(), f.joinedFields(), mFlags, browser, bqfmt, bafmt);
             } else {
-                mQA = mCol._renderQA(mId, f.getId(), m, did, mOrd, f.stringTags(), f.joinedFields(), mFlags);
+                mQA = mCol._renderQA(mId, m, did, mOrd, f.stringTags(), f.joinedFields(), mFlags);
             }
         }
         return mQA;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.java
@@ -278,7 +278,8 @@ public class Card implements Cloneable {
             Note f = note(reload);
             JSONObject m = model();
             JSONObject t = template();
-            Object[] data = new Object[] { mId, f.getId(), m, mODid != 0L ? mODid : mDid, mOrd, f.stringTags(), f.joinedFields(), mFlags};
+            long did = mODid != 0L ? mODid : mDid;
+            Object[] data = new Object[] { mId, f.getId(), m, did, mOrd, f.stringTags(), f.joinedFields(), mFlags};
 
             if (browser) {
                 String bqfmt = t.getString("bqfmt");

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.java
@@ -279,14 +279,12 @@ public class Card implements Cloneable {
             JSONObject m = model();
             JSONObject t = template();
             long did = mODid != 0L ? mODid : mDid;
-            Object[] data = new Object[] { mId, f.getId(), m, did, mOrd, f.stringTags(), f.joinedFields(), mFlags};
-
             if (browser) {
                 String bqfmt = t.getString("bqfmt");
                 String bafmt = t.getString("bafmt");
-                mQA = mCol._renderQA(data, browser, bqfmt, bafmt);
+                mQA = mCol._renderQA(mId, f.getId(), m, did, mOrd, f.stringTags(), f.joinedFields(), mFlags, browser, bqfmt, bafmt);
             } else {
-                mQA = mCol._renderQA(data);
+                mQA = mCol._renderQA(mId, f.getId(), m, did, mOrd, f.stringTags(), f.joinedFields(), mFlags);
             }
         }
         return mQA;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -618,7 +618,7 @@ public class Collection {
      */
     public ArrayList<JSONObject> findTemplates(Note note) {
         JSONObject model = note.model();
-        ArrayList<Integer> avail = mModels.availOrds(model, Utils.joinFields(note.getFields()));
+        ArrayList<Integer> avail = mModels.availOrds(model, note.getFields());
         return _tmplsFromOrds(model, avail);
     }
 
@@ -717,7 +717,7 @@ public class Collection {
                 long mid = cur.getLong(1);
                 String flds = cur.getString(2);
                 JSONObject model = mModels.get(mid);
-                ArrayList<Integer> avail = mModels.availOrds(model, flds);
+                ArrayList<Integer> avail = mModels.availOrds(model, Utils.splitFields(flds));
                 long did = dids.get(nid);
                 // use sibling due if there is one, else use a new id
                 long due;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1016,15 +1016,14 @@ public class Collection {
     /**
      * Returns hash of id, question, answer.
      */
-    public HashMap<String, String> _renderQA(long cid, JSONObject model, long did, int ord, String tags, String packedFields, int flags) {
-        return _renderQA(cid, model, did, ord, tags, packedFields, flags, false, null, null);
+    public HashMap<String, String> _renderQA(long cid, JSONObject model, long did, int ord, String tags, String[] flist, int flags) {
+        return _renderQA(cid, model, did, ord, tags, flist, flags, false, null, null);
     }
 
 
-    public HashMap<String, String> _renderQA(long cid, JSONObject model, long did, int ord, String tags, String packedFields, int flags, boolean browser, String qfmt, String afmt) {
+    public HashMap<String, String> _renderQA(long cid, JSONObject model, long did, int ord, String tags, String[] flist, int flags, boolean browser, String qfmt, String afmt) {
         // data is [cid, nid, mid, did, ord, tags, flds, cardFlags]
         // unpack fields and create dict
-        String[] flist = Utils.splitFields(packedFields);
         Map<String, String> fields = new HashMap<>();
         Map<String, Pair<Integer, JSONObject>> fmap = mModels.fieldMap(model);
         for (String name : fmap.keySet()) {
@@ -1071,7 +1070,7 @@ public class Collection {
             d.put(type, html);
             // empty cloze?
             if ("q".equals(type) && model.getInt("type") == Consts.MODEL_CLOZE) {
-                if (getModels()._availClozeOrds(model, Utils.splitFields(packedFields), false).size() == 0) {
+                if (getModels()._availClozeOrds(model, flist, false).size() == 0) {
                     String link = String.format("<a href=%s#cloze>%s</a>", Consts.HELP_SITE, "help");
                     d.put("q", mContext.getString(R.string.empty_cloze_warning, link));
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1016,12 +1016,12 @@ public class Collection {
     /**
      * Returns hash of id, question, answer.
      */
-    public HashMap<String, String> _renderQA(long cid, long nid, JSONObject model, long did, int ord, String tags, String packedFields, int flags) {
-        return _renderQA(cid, nid, model, did, ord, tags, packedFields, flags, false, null, null);
+    public HashMap<String, String> _renderQA(long cid, JSONObject model, long did, int ord, String tags, String packedFields, int flags) {
+        return _renderQA(cid, model, did, ord, tags, packedFields, flags, false, null, null);
     }
 
 
-    public HashMap<String, String> _renderQA(long cid, long nid, JSONObject model, long did, int ord, String tags, String packedFields, int flags, boolean browser, String qfmt, String afmt) {
+    public HashMap<String, String> _renderQA(long cid, JSONObject model, long did, int ord, String tags, String packedFields, int flags, boolean browser, String qfmt, String afmt) {
         // data is [cid, nid, mid, did, ord, tags, flds, cardFlags]
         // unpack fields and create dict
         String[] flist = Utils.splitFields(packedFields);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1071,7 +1071,7 @@ public class Collection {
             d.put(type, html);
             // empty cloze?
             if ("q".equals(type) && model.getInt("type") == Consts.MODEL_CLOZE) {
-                if (getModels()._availClozeOrds(model, packedFields, false).size() == 0) {
+                if (getModels()._availClozeOrds(model, Utils.splitFields(packedFields), false).size() == 0) {
                     String link = String.format("<a href=%s#cloze>%s</a>", Consts.HELP_SITE, "help");
                     d.put("q", mContext.getString(R.string.empty_cloze_warning, link));
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1016,21 +1016,14 @@ public class Collection {
     /**
      * Returns hash of id, question, answer.
      */
-    public HashMap<String, String> _renderQA(Object[] data) {
-        return _renderQA(data, false, null, null);
+    public HashMap<String, String> _renderQA(long cid, long nid, JSONObject model, long did, int ord, String tags, String packedFields, int flags) {
+        return _renderQA(cid, nid, model, did, ord, tags, packedFields, flags, false, null, null);
     }
 
-    public HashMap<String, String> _renderQA(Object[] data, boolean browser, String qfmt, String afmt) {
+
+    public HashMap<String, String> _renderQA(long cid, long nid, JSONObject model, long did, int ord, String tags, String packedFields, int flags, boolean browser, String qfmt, String afmt) {
         // data is [cid, nid, mid, did, ord, tags, flds, cardFlags]
         // unpack fields and create dict
-        long cid = (Long) data[0];
-        long nid = (Long) data[1];
-        JSONObject model = (JSONObject)data[2];
-        long did = (Long) data[3];
-        int ord = (Integer) data[4];
-        String tags = (String) data[5];
-        String packedFields = (String) data[6];
-        int flags = (Integer) data[7];
         String[] flist = Utils.splitFields(packedFields);
         Map<String, String> fields = new HashMap<>();
         Map<String, Pair<Integer, JSONObject>> fmap = mModels.fieldMap(model);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -1066,14 +1066,14 @@ public class Models {
 
 
     /** Given a joined field string, return available template ordinals */
-    public ArrayList<Integer> availOrds(JSONObject m, String flds) {
-        String[] fields = Utils.splitFields(flds);
+    public ArrayList<Integer> availOrds(JSONObject m, String[] sfld) {
         if (m.getInt("type") == Consts.MODEL_CLOZE) {
-            return _availClozeOrds(m, fields);
+            return _availClozeOrds(m, sfld);
         }
-        int nbField = fields.length;
-        for (int i = 0; i < nbField ; i++) {
-            fields[i] = fields[i].trim();
+        int nbField = sfld.length;
+        String[] fields = new String[nbField];
+        for (int i = 0; i < nbField; i++) {
+            fields[i] = sfld[i].trim();
         }
         ArrayList<Integer> avail = new ArrayList<>();
         JSONArray reqArray = m.getJSONArray("req");

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -1030,8 +1030,8 @@ public class Models {
             b.add("");
         }
         int ord = t.getInt("ord");
-        String full = mCol._renderQA(1L, 1L, m, 1L, ord, "", Utils.joinFields(a.toArray(new String[a.size()])), 0).get("q");
-        String empty = mCol._renderQA(1L, 1L, m, 1L, ord, "", Utils.joinFields(b.toArray(new String[b.size()])), 0).get("q");
+        String full = mCol._renderQA(1L, m, 1L, ord, "", Utils.joinFields(a.toArray(new String[a.size()])), 0).get("q");
+        String empty = mCol._renderQA(1L, m, 1L, ord, "", Utils.joinFields(b.toArray(new String[b.size()])), 0).get("q");
         // if full and empty are the same, the template is invalid and there is no way to satisfy it
         if (full.equals(empty)) {
             return new Object[] { "none", new JSONArray(), new JSONArray() };
@@ -1045,7 +1045,7 @@ public class Models {
             tmp.set(i, "");
             packedFields = Utils.joinFields(tmp.toArray(new String[tmp.size()]));
             // if no field content appeared, field is required
-            if (!mCol._renderQA(1L, 1L, m, 1L, ord, "", packedFields, 0).get("q").contains("ankiflag")) {
+            if (!mCol._renderQA(1L, m, 1L, ord, "", packedFields, 0).get("q").contains("ankiflag")) {
                 req.put(i);
             }
         }
@@ -1061,7 +1061,7 @@ public class Models {
             tmp.set(i, "1");
             packedFields = Utils.joinFields(tmp.toArray(new String[tmp.size()]));
             // if not the same as empty, this field can make the card non-blank
-            if (!mCol._renderQA(1L, 1L, m, 1L, ord, "", packedFields, 0).get("q").equals(empty)) {
+            if (!mCol._renderQA(1L, m, 1L, ord, "", packedFields, 0).get("q").equals(empty)) {
                 req.put(i);
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -1067,10 +1067,10 @@ public class Models {
 
     /** Given a joined field string, return available template ordinals */
     public ArrayList<Integer> availOrds(JSONObject m, String flds) {
-        if (m.getInt("type") == Consts.MODEL_CLOZE) {
-            return _availClozeOrds(m, flds);
-        }
         String[] fields = Utils.splitFields(flds);
+        if (m.getInt("type") == Consts.MODEL_CLOZE) {
+            return _availClozeOrds(m, fields);
+        }
         int nbField = fields.length;
         for (int i = 0; i < nbField ; i++) {
             fields[i] = fields[i].trim();
@@ -1122,8 +1122,8 @@ public class Models {
     }
 
 
-    public ArrayList<Integer> _availClozeOrds(JSONObject m, String flds) {
-        return _availClozeOrds(m, Utils.splitFields(flds), true);
+    public ArrayList<Integer> _availClozeOrds(JSONObject m, String[] sflds) {
+        return _availClozeOrds(m, sflds, true);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -1122,12 +1122,11 @@ public class Models {
 
 
     public ArrayList<Integer> _availClozeOrds(JSONObject m, String flds) {
-        return _availClozeOrds(m, flds, true);
+        return _availClozeOrds(m, Utils.splitFields(flds), true);
     }
 
 
-    public ArrayList<Integer> _availClozeOrds(JSONObject m, String flds, boolean allowEmpty) {
-        String[] sflds = Utils.splitFields(flds);
+    public ArrayList<Integer> _availClozeOrds(JSONObject m, String[] sflds, boolean allowEmpty) {
         Map<String, Pair<Integer, JSONObject>> map = fieldMap(m);
         Set<Integer> ords = new HashSet<>();
         List<String> matches = new ArrayList<>();

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -1071,8 +1071,9 @@ public class Models {
             return _availClozeOrds(m, flds);
         }
         String[] fields = Utils.splitFields(flds);
-        for (String f : fields) {
-            f = f.trim();
+        int nbField = fields.length;
+        for (int i = 0; i < nbField ; i++) {
+            fields[i] = fields[i].trim();
         }
         ArrayList<Integer> avail = new ArrayList<>();
         JSONArray reqArray = m.getJSONArray("req");

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -1029,8 +1029,8 @@ public class Models {
         Arrays.fill(a, "ankiflag");
         Arrays.fill(b, "");
         int ord = t.getInt("ord");
-        String full = mCol._renderQA(1L, m, 1L, ord, "", Utils.joinFields(a), 0).get("q");
-        String empty = mCol._renderQA(1L, m, 1L, ord, "", Utils.joinFields(b), 0).get("q");
+        String full = mCol._renderQA(1L, m, 1L, ord, "", a, 0).get("q");
+        String empty = mCol._renderQA(1L, m, 1L, ord, "", b, 0).get("q");
         // if full and empty are the same, the template is invalid and there is no way to satisfy it
         if (full.equals(empty)) {
             return new Object[] { "none", new JSONArray(), new JSONArray() };
@@ -1039,9 +1039,8 @@ public class Models {
         JSONArray req = new JSONArray();
         for (int i = 0; i < flds.size(); i++) {
             a[i] = "";
-            packedFields = Utils.joinFields(a);
             // if no field content appeared, field is required
-            if (!mCol._renderQA(1L, m, 1L, ord, "", packedFields, 0).get("q").contains("ankiflag")) {
+            if (!mCol._renderQA(1L, m, 1L, ord, "", a, 0).get("q").contains("ankiflag")) {
                 req.put(i);
             }
             a[i] = "ankiflag";
@@ -1054,9 +1053,8 @@ public class Models {
         req = new JSONArray();
         for (int i = 0; i < flds.size(); i++) {
             b[i] = "1";
-            packedFields = Utils.joinFields(b);
             // if not the same as empty, this field can make the card non-blank
-            if (!mCol._renderQA(1L, m, 1L, ord, "", packedFields, 0).get("q").equals(empty)) {
+            if (!mCol._renderQA(1L, m, 1L, ord, "", b, 0).get("q").equals(empty)) {
                 req.put(i);
             }
             b[i] = "";

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -1030,11 +1030,10 @@ public class Models {
             b.add("");
         }
         Object[] data;
-        data = new Object[] {1L, 1L, m, 1L, t.getInt("ord"), "",
-                             Utils.joinFields(a.toArray(new String[a.size()])), 0};
+        int ord = t.getInt("ord");
+        data = new Object[] {1L, 1L, m, 1L, ord, "", Utils.joinFields(a.toArray(new String[a.size()]))packedFields, 0};
         String full = mCol._renderQA(data).get("q");
-        data = new Object[] {1L, 1L, m, 1L, t.getInt("ord"), "",
-                             Utils.joinFields(b.toArray(new String[b.size()])), 0};
+        data = new Object[] {1L, 1L, m, 1L, ord, "", Utils.joinFields(b.toArray(new String[b.size()])), 0};
         String empty = mCol._renderQA(data).get("q");
         // if full and empty are the same, the template is invalid and there is no way to satisfy it
         if (full.equals(empty)) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -1023,15 +1023,14 @@ public class Models {
 
     @SuppressWarnings("PMD.UnusedLocalVariable") // 'String f' is unused upstream as well
     private Object[] _reqForTemplate(JSONObject m, ArrayList<String> flds, JSONObject t) {
-        ArrayList<String> a = new ArrayList<>();
-        ArrayList<String> b = new ArrayList<>();
-        for (String f : flds) {
-            a.add("ankiflag");
-            b.add("");
-        }
+        int nbFields = flds.size();
+        String[] a = new String[nbFields];
+        String[] b = new String[nbFields];
+        Arrays.fill(a, "ankiflag");
+        Arrays.fill(b, "");
         int ord = t.getInt("ord");
-        String full = mCol._renderQA(1L, m, 1L, ord, "", Utils.joinFields(a.toArray(new String[a.size()])), 0).get("q");
-        String empty = mCol._renderQA(1L, m, 1L, ord, "", Utils.joinFields(b.toArray(new String[b.size()])), 0).get("q");
+        String full = mCol._renderQA(1L, m, 1L, ord, "", Utils.joinFields(a), 0).get("q");
+        String empty = mCol._renderQA(1L, m, 1L, ord, "", Utils.joinFields(b), 0).get("q");
         // if full and empty are the same, the template is invalid and there is no way to satisfy it
         if (full.equals(empty)) {
             return new Object[] { "none", new JSONArray(), new JSONArray() };
@@ -1039,13 +1038,13 @@ public class Models {
         String type = "all";
         JSONArray req = new JSONArray();
         for (int i = 0; i < flds.size(); i++) {
-            a.set(i, "");
-            packedFields = Utils.joinFields(a.toArray(new String[a.size()]));
+            a[i] = "";
+            packedFields = Utils.joinFields(a);
             // if no field content appeared, field is required
             if (!mCol._renderQA(1L, m, 1L, ord, "", packedFields, 0).get("q").contains("ankiflag")) {
                 req.put(i);
             }
-            a.set(i, "ankiflag");
+            a[i] = "ankiflag";
         }
         if (req.length() > 0) {
             return new Object[] { type, req };
@@ -1054,13 +1053,13 @@ public class Models {
         type = "any";
         req = new JSONArray();
         for (int i = 0; i < flds.size(); i++) {
-            b.set(i, "1");
-            packedFields = Utils.joinFields(b.toArray(new String[b.size()]));
+            b[i] = "1";
+            packedFields = Utils.joinFields(b);
             // if not the same as empty, this field can make the card non-blank
             if (!mCol._renderQA(1L, m, 1L, ord, "", packedFields, 0).get("q").equals(empty)) {
                 req.put(i);
             }
-            b.set(i, "");
+            b[i] = "";
         }
         return new Object[] { type, req };
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -1039,15 +1039,15 @@ public class Models {
         String type = "all";
         JSONArray req = new JSONArray();
         ArrayList<String> tmp = new ArrayList<>();
+        tmp.addAll(a);
         for (int i = 0; i < flds.size(); i++) {
-            tmp.clear();
-            tmp.addAll(a);
             tmp.set(i, "");
             packedFields = Utils.joinFields(tmp.toArray(new String[tmp.size()]));
             // if no field content appeared, field is required
             if (!mCol._renderQA(1L, m, 1L, ord, "", packedFields, 0).get("q").contains("ankiflag")) {
                 req.put(i);
             }
+            tmp.set(i, "ankiflag");
         }
         if (req.length() > 0) {
             return new Object[] { type, req };
@@ -1055,15 +1055,16 @@ public class Models {
         // if there are no required fields, switch to any mode
         type = "any";
         req = new JSONArray();
+        tmp.clear();
+        tmp.addAll(b);
         for (int i = 0; i < flds.size(); i++) {
-            tmp.clear();
-            tmp.addAll(b);
             tmp.set(i, "1");
             packedFields = Utils.joinFields(tmp.toArray(new String[tmp.size()]));
             // if not the same as empty, this field can make the card non-blank
             if (!mCol._renderQA(1L, m, 1L, ord, "", packedFields, 0).get("q").equals(empty)) {
                 req.put(i);
             }
+            tmp.set(i, "");
         }
         return new Object[] { type, req };
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -1029,12 +1029,9 @@ public class Models {
             a.add("ankiflag");
             b.add("");
         }
-        Object[] data;
         int ord = t.getInt("ord");
-        data = new Object[] {1L, 1L, m, 1L, ord, "", Utils.joinFields(a.toArray(new String[a.size()]))packedFields, 0};
-        String full = mCol._renderQA(data).get("q");
-        data = new Object[] {1L, 1L, m, 1L, ord, "", Utils.joinFields(b.toArray(new String[b.size()])), 0};
-        String empty = mCol._renderQA(data).get("q");
+        String full = mCol._renderQA(1L, 1L, m, 1L, ord, "", Utils.joinFields(a.toArray(new String[a.size()])), 0).get("q");
+        String empty = mCol._renderQA(1L, 1L, m, 1L, ord, "", Utils.joinFields(b.toArray(new String[b.size()])), 0).get("q");
         // if full and empty are the same, the template is invalid and there is no way to satisfy it
         if (full.equals(empty)) {
             return new Object[] { "none", new JSONArray(), new JSONArray() };
@@ -1046,9 +1043,9 @@ public class Models {
             tmp.clear();
             tmp.addAll(a);
             tmp.set(i, "");
-            data[6] = Utils.joinFields(tmp.toArray(new String[tmp.size()]));
+            packedFields = Utils.joinFields(tmp.toArray(new String[tmp.size()]));
             // if no field content appeared, field is required
-            if (!mCol._renderQA(data).get("q").contains("ankiflag")) {
+            if (!mCol._renderQA(1L, 1L, m, 1L, ord, "", packedFields, 0).get("q").contains("ankiflag")) {
                 req.put(i);
             }
         }
@@ -1062,9 +1059,9 @@ public class Models {
             tmp.clear();
             tmp.addAll(b);
             tmp.set(i, "1");
-            data[6] = Utils.joinFields(tmp.toArray(new String[tmp.size()]));
+            packedFields = Utils.joinFields(tmp.toArray(new String[tmp.size()]));
             // if not the same as empty, this field can make the card non-blank
-            if (!mCol._renderQA(data).get("q").equals(empty)) {
+            if (!mCol._renderQA(1L, 1L, m, 1L, ord, "", packedFields, 0).get("q").equals(empty)) {
                 req.put(i);
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -1038,16 +1038,14 @@ public class Models {
         }
         String type = "all";
         JSONArray req = new JSONArray();
-        ArrayList<String> tmp = new ArrayList<>();
-        tmp.addAll(a);
         for (int i = 0; i < flds.size(); i++) {
-            tmp.set(i, "");
-            packedFields = Utils.joinFields(tmp.toArray(new String[tmp.size()]));
+            a.set(i, "");
+            packedFields = Utils.joinFields(a.toArray(new String[a.size()]));
             // if no field content appeared, field is required
             if (!mCol._renderQA(1L, m, 1L, ord, "", packedFields, 0).get("q").contains("ankiflag")) {
                 req.put(i);
             }
-            tmp.set(i, "ankiflag");
+            a.set(i, "ankiflag");
         }
         if (req.length() > 0) {
             return new Object[] { type, req };
@@ -1055,16 +1053,14 @@ public class Models {
         // if there are no required fields, switch to any mode
         type = "any";
         req = new JSONArray();
-        tmp.clear();
-        tmp.addAll(b);
         for (int i = 0; i < flds.size(); i++) {
-            tmp.set(i, "1");
-            packedFields = Utils.joinFields(tmp.toArray(new String[tmp.size()]));
+            b.set(i, "1");
+            packedFields = Utils.joinFields(b.toArray(new String[b.size()]));
             // if not the same as empty, this field can make the card non-blank
             if (!mCol._renderQA(1L, m, 1L, ord, "", packedFields, 0).get("q").equals(empty)) {
                 req.put(i);
             }
-            tmp.set(i, "");
+            b.set(i, "");
         }
         return new Object[] { type, req };
     }


### PR DESCRIPTION
In order to deal with LaTeX in browser, having a cleaner _renderQA seems nice.
This should be NF, with simple to follow commits