### PR TITLE
Improve anki2 import experience

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
@@ -146,8 +146,14 @@ public class ImportUtils {
             }
 
             if (!isValidPackageName(filename)) {
-                // Don't import if file doesn't have an Anki package extension
-                return context.getResources().getString(R.string.import_error_not_apkg_extension, filename);
+                if (isAnkiDatabase(filename)) {
+                    //.anki2 files aren't supported by Anki Desktop, we should eventually support them, because we can
+                    //but for now, show a "nice" error.
+                    return context.getResources().getString(R.string.import_error_load_imported_database);
+                } else {
+                    // Don't import if file doesn't have an Anki package extension
+                    return context.getResources().getString(R.string.import_error_not_apkg_extension, filename);
+                }
             } else {
                 // Copy to temporary file
                 filename = ensureValidLength(filename);
@@ -161,6 +167,11 @@ public class ImportUtils {
                 }
             }
             return errorMessage;
+        }
+
+
+        private boolean isAnkiDatabase(String filename) {
+            return filename != null && hasExtension(filename, "anki2");
         }
 
 

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -159,6 +159,7 @@
     <string name="import_error_unhandled_request">Unable to process import request</string>
     <string name="import_error_exception">Failed to import package\n\n%s</string>
     <string name="import_error_not_apkg_extension">Filename “%s” doesn’t have .apkg or .colpkg extension</string>
+    <string name="import_error_load_imported_database">Anki Database (.anki2) replacements are not yet supported. Please see the manual for replacement instructions.</string>
     <string name="import_error_content_provider">The selected file couldn’t be imported automatically by AnkiDroid. Please see the user manual for how to manually import anki files: \n%s</string>
     <string name="import_replacing">Replacing collection…</string>
     <string name="import_interrupted">Import interrupted</string>


### PR DESCRIPTION
## Purpose / Description

I feel it's likely users are trying to import anki2 files. They likely shouldn't, as anki2 files don't contain media and require a full replacement of the database.

I've added an entry in the manual, so this will hopefully reduce some of our support work.

## Approach
Additional error message, and linked PR for the manual

## How Has This Been Tested?

Deemed this to be a risk-free change as it's only textual

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code