### PR TITLE
NoteEditor: Improve error on invalid template

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -288,7 +288,7 @@ public class NoteEditor extends AnkiActivity {
 
     private void displayErrorSavingNote() {
         int errorMessageId = getAddNoteErrorResource();
-        UIUtils.showThemedToast(this, getResources().getString(errorMessageId), true);
+        UIUtils.showThemedToast(this, getResources().getString(errorMessageId), false);
     }
 
 
@@ -302,8 +302,22 @@ public class NoteEditor extends AnkiActivity {
             return R.string.note_editor_no_first_field;
         }
 
+        if (allFieldsHaveContent()) {
+            return R.string.note_editor_no_cards_created_all_fields;
+        }
+
         //Otherwise, display "no cards created".
         return R.string.note_editor_no_cards_created;
+    }
+
+
+    private boolean allFieldsHaveContent() {
+        for (String s : this.getCurrentFieldStrings()) {
+            if (TextUtils.isEmpty(s)) {
+                return false;
+            }
+        }
+        return true;
     }
 
 

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -98,6 +98,7 @@
     <string name="note_editor_no_cards_created">No cards created. Please fill in more fields</string>
     <string name="note_editor_no_first_field">The first field is empty</string>
     <string name="note_editor_no_cloze_delations">This note type must contain cloze deletions</string>
+    <string name="note_editor_no_cards_created_all_fields">The current note type did not produce any cards.\nPlease choose another note type, or click ‘Cards’ and add a field substitution</string>
     <string name="saving_facts">Saving note</string>
     <string name="saving_model">Saving note type</string>
     <string name="add">Add</string>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.java
@@ -52,6 +52,30 @@ public class NoteEditorTest extends RobolectricTest {
         assertThat(actualResourceId, is(R.string.note_editor_no_first_field));
     }
 
+    @Test
+    public void errorSavingInvalidNoteWithAllFieldsDisplaysInvalidTemplate() {
+        NoteEditor noteEditor = getNoteEditorAdding(NoteType.THREE_FIELD_INVALID_TEMPLATE)
+                .withFirstField("A")
+                .withSecondField("B")
+                .withThirdField("C")
+                .build();
+
+        int actualResourceId = noteEditor.getAddNoteErrorResource();
+
+        assertThat(actualResourceId, is(R.string.note_editor_no_cards_created_all_fields));
+    }
+
+    @Test
+    public void errorSavingInvalidNoteWitSomeFieldsDisplaysEnterMore() {
+        NoteEditor noteEditor = getNoteEditorAdding(NoteType.THREE_FIELD_INVALID_TEMPLATE)
+                .withFirstField("A")
+                .withThirdField("C")
+                .build();
+
+        int actualResourceId = noteEditor.getAddNoteErrorResource();
+
+        assertThat(actualResourceId, is(R.string.note_editor_no_cards_created));
+    }
 
     @Test
     public void errorSavingClozeNoteWithNoFirstFieldDisplaysClozeError() {
@@ -151,9 +175,14 @@ public class NoteEditorTest extends RobolectricTest {
         switch (noteType) {
             case BASIC: return getCol().getModels().byName("Basic");
             case CLOZE: return getCol().getModels().byName("Cloze");
-            case BACKTOFRONT:
+            case BACKTOFRONT: {
                 String name = super.addNonClozeModel("Reversed", new String[] {"Front", "Back"}, "{{Back}}", "{{Front}}");
                 return getCol().getModels().byName(name);
+            }
+            case THREE_FIELD_INVALID_TEMPLATE: {
+                String name = super.addNonClozeModel("Invalid", new String[] {"Front", "Back", "Side"}, "", "");
+                return getCol().getModels().byName(name);
+            }
             default: throw new IllegalStateException(String.format("unexpected value: %s", noteType));
         }
     }
@@ -207,6 +236,7 @@ public class NoteEditorTest extends RobolectricTest {
         CLOZE,
         /**Basic, but Back is on the front */
         BACKTOFRONT,
+        THREE_FIELD_INVALID_TEMPLATE
     }
 
     @SuppressWarnings("WeakerAccess")
@@ -215,6 +245,7 @@ public class NoteEditorTest extends RobolectricTest {
         private final JSONObject mModel;
         private String mFirstField;
         private String mSecondField;
+        private String mThirdField;
 
 
         public NoteEditorTestBuilder(JSONObject model) {
@@ -235,6 +266,9 @@ public class NoteEditorTest extends RobolectricTest {
             if (mSecondField != null) {
                 noteEditor.setFieldValueFromUi(1, mSecondField);
             }
+            if (mThirdField != null) {
+                noteEditor.setFieldValueFromUi(2, mThirdField);
+            }
             return noteEditor;
         }
 
@@ -251,6 +285,12 @@ public class NoteEditorTest extends RobolectricTest {
 
         public NoteEditorTestBuilder withSecondField(String text) {
             this.mSecondField = text;
+            return this;
+        }
+
+
+        public NoteEditorTestBuilder withThirdField(String text) {
+            this.mThirdField = text;
             return this;
         }
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.java
@@ -21,6 +21,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.robolectric.Shadows.shadowOf;
 
+@SuppressWarnings("SameParameterValue")
 @RunWith(AndroidJUnit4.class)
 public class NoteEditorTest extends RobolectricTest {
 
@@ -208,6 +209,7 @@ public class NoteEditorTest extends RobolectricTest {
         BACKTOFRONT,
     }
 
+    @SuppressWarnings("WeakerAccess")
     public class NoteEditorTestBuilder {
 
         private final JSONObject mModel;


### PR DESCRIPTION
## Purpose / Description
From a user report: They're requested to fill in more fields even if they've filled in them all: https://groups.google.com/forum/#!topic/anki-android/MmJz1XzIyIk

Now, we explain that the card template is likely busted, and how to fix it.

## How Has This Been Tested?

Unit Tested. Quick check on my phone for good luck

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code