### PR TITLE
Importer - allow import of "collection.apkg (1)"

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
@@ -27,10 +27,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
+import java.util.Locale;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
 import androidx.annotation.CheckResult;
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import timber.log.Timber;
 
@@ -56,7 +58,7 @@ public class ImportUtils {
     }
 
     public static boolean isCollectionPackage(String filename) {
-        return filename != null && (filename.toLowerCase().endsWith(".colpkg") || "collection.apkg".equals(filename));
+        return filename != null && (FileImporter.hasExtension(filename, "colpkg") || filename.startsWith("collection.apkg"));
     }
 
     /** @return Whether the file is either a deck, or a collection package */
@@ -247,9 +249,22 @@ public class ImportUtils {
             DialogHandler.storeMessage(handlerMessage);
         }
 
-        private static boolean isDeckPackage(String filename) {
-            return filename != null && filename.toLowerCase().endsWith(".apkg") && !"collection.apkg".equals(filename);
+        public static boolean isDeckPackage(String filename) {
+            return filename != null && hasExtension(filename, "apkg") && !filename.startsWith("collection.apkg");
         }
+
+
+        private static boolean hasExtension(@NonNull String filename, String extension) {
+            String[] fileParts = filename.split("\\.");
+            if (fileParts.length < 2) {
+                return false;
+            }
+            String extensionSegment = fileParts[fileParts.length - 1];
+            //either "apkg", or "apkg (1)".
+            // COULD_BE_BETTE: accepts .apkgaa"
+            return extensionSegment.toLowerCase(Locale.US).startsWith(extension);
+        }
+
 
         /**
          * Check if the InputStream is to a valid non-empty zip file

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
@@ -67,6 +67,7 @@ public class ImportUtils {
         return FileImporter.isDeckPackage(filename) || isCollectionPackage(filename);
     }
 
+    @SuppressWarnings("WeakerAccess")
     protected static class FileImporter {
         /**
          * This code is used in multiple places to handle package imports
@@ -254,7 +255,7 @@ public class ImportUtils {
         }
 
 
-        private static boolean hasExtension(@NonNull String filename, String extension) {
+        public static boolean hasExtension(@NonNull String filename, String extension) {
             String[] fileParts = filename.split("\\.");
             if (fileParts.length < 2) {
                 return false;

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
@@ -147,7 +147,7 @@ public class ImportUtils {
             if (!isValidPackageName(filename)) {
                 // Don't import if file doesn't have an Anki package extension
                 errorMessage = context.getResources().getString(R.string.import_error_not_apkg_extension, filename);
-            } else if (filename != null) {
+            } else {
                 // Copy to temporary file
                 filename = ensureValidLength(filename);
                 String tempOutDir = Uri.fromFile(new File(context.getCacheDir(), filename)).getEncodedPath();

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
@@ -19,6 +19,8 @@ import com.ichi2.anki.R;
 import com.ichi2.anki.dialogs.DialogHandler;
 import com.ichi2.compat.CompatHelper;
 
+import org.jetbrains.annotations.Contract;
+
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -57,7 +59,9 @@ public class ImportUtils {
         return filename != null && (filename.toLowerCase().endsWith(".colpkg") || "collection.apkg".equals(filename));
     }
 
-    public static boolean isValidPackageName(String filename) {
+    /** @return Whether the file is either a deck, or a collection package */
+    @Contract("null -> false")
+    public static boolean isValidPackageName(@Nullable String filename) {
         return FileImporter.isDeckPackage(filename) || isCollectionPackage(filename);
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
@@ -128,7 +128,7 @@ public class ImportUtils {
             //Note: intent.getData() can be null. Use data instead.
 
             // Get the original filename from the content provider URI
-            String errorMessage = null;
+            String errorMessage;
             String filename = getFileNameFromContentProvider(context, data);
 
             // Hack to fix bug where ContentResolver not returning filename correctly
@@ -140,13 +140,13 @@ public class ImportUtils {
                 } else {
                     Timber.e("Could not retrieve filename from ContentProvider or read content as ZipFile");
                     AnkiDroidApp.sendExceptionReport(new RuntimeException("Could not import apkg from ContentProvider"), "IntentHandler.java", "apkg import failed");
-                    errorMessage = AnkiDroidApp.getAppResources().getString(R.string.import_error_content_provider, AnkiDroidApp.getManualUrl() + "#importing");
+                    return AnkiDroidApp.getAppResources().getString(R.string.import_error_content_provider, AnkiDroidApp.getManualUrl() + "#importing");
                 }
             }
 
             if (!isValidPackageName(filename)) {
                 // Don't import if file doesn't have an Anki package extension
-                errorMessage = context.getResources().getString(R.string.import_error_not_apkg_extension, filename);
+                return context.getResources().getString(R.string.import_error_not_apkg_extension, filename);
             } else {
                 // Copy to temporary file
                 filename = ensureValidLength(filename);

--- a/AnkiDroid/src/test/java/com/ichi2/utils/ImportUtilsTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/ImportUtilsTest.java
@@ -37,6 +37,8 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.spy;
 
 @RunWith(AndroidJUnit4.class)
@@ -88,6 +90,35 @@ public class ImportUtilsTest extends RobolectricTest {
         return cacheFileName;
     }
 
+    @Test
+    public void collectionApkgIsValid() {
+        assertTrue(ImportUtils.isValidPackageName("collection.apkg"));
+    }
+
+    @Test
+    public void collectionColPkgIsValid() {
+        assertTrue(ImportUtils.isValidPackageName("collection.colpkg"));
+    }
+
+    @Test
+    public void deckApkgIsValid() {
+        assertTrue(ImportUtils.isValidPackageName("deckName.apkg"));
+    }
+
+    @Test
+    public void deckColPkgIsValid() {
+        assertTrue(ImportUtils.isValidPackageName("deckName.colpkg"));
+    }
+
+    @Test
+    public void nullIsNotValidPackage() {
+        assertFalse(ImportUtils.isValidPackageName(null));
+    }
+
+    @Test
+    public void docxIsNotValidForImport() {
+        assertFalse(ImportUtils.isValidPackageName("test.docx"));
+    }
 
     @CheckResult
     private Intent getValidClipDataUri(String fileName) {

--- a/AnkiDroid/src/test/java/com/ichi2/utils/ImportUtilsTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/ImportUtilsTest.java
@@ -166,6 +166,7 @@ public class ImportUtilsTest extends RobolectricTest {
     }
 
 
+    @SuppressWarnings("WeakerAccess")
     public static class TestFileImporter extends ImportUtils.FileImporter {
         private String mCacheFileName;
         private final String mFileName;

--- a/AnkiDroid/src/test/java/com/ichi2/utils/ImportUtilsTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/ImportUtilsTest.java
@@ -120,6 +120,36 @@ public class ImportUtilsTest extends RobolectricTest {
         assertFalse(ImportUtils.isValidPackageName("test.docx"));
     }
 
+    @Test
+    public void duplicateFileIsAccepted() {
+        assertTrue(ImportUtils.isValidPackageName(getInvalidDuplicateFileExtension("collection.apkg")));
+    }
+
+    @Test
+    public void duplicateFileWithDotIsAccepted() {
+        assertTrue(ImportUtils.isValidPackageName(getInvalidDuplicateFileExtension("collection.dot.apkg")));
+    }
+
+    @Test
+    public void duplicateCollectionIsNotDeckPackage() {
+        assertFalse(ImportUtils.FileImporter.isDeckPackage(getInvalidDuplicateFileExtension("collection.apkg")));
+    }
+
+    @Test
+    public void encodedCollectionIsStillCollection() {
+        assertTrue(ImportUtils.isCollectionPackage("col.colpkg%20(1)"));
+    }
+
+    @Test
+    public void encodedDeckCollectionIsStillCollection() {
+        assertTrue(ImportUtils.isCollectionPackage("collection.apkg%20(1)"));
+    }
+
+    private String getInvalidDuplicateFileExtension(String s) {
+        //6259 - SAF Issue will cause this: https://stackoverflow.com/q/32849387
+        return s + " (1)";
+    }
+
     @CheckResult
     private Intent getValidClipDataUri(String fileName) {
         Intent i = new Intent();


### PR DESCRIPTION
## Purpose / Description
This is caused by a bug in the storage library, duplicate files have their extension changed.

## Fixes
Fixes #6259

## Approach
Check the extension, and use `.startsWith(extension + " ")`

## How Has This Been Tested?

Unit tested only

## Learning 
https://stackoverflow.com/questions/32849387/how-to-handle-file-extension-correctly-in-saf-storage-access-framework

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code