### PR TITLE
display languages in preferences using their own language

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -367,6 +367,7 @@ public class AnkiDroidApp extends Application {
             }
         } catch (Exception e) {
             Timber.e(e, "failed to update context with new language");
+            //during AnkiDroidApp.attachBaseContext() ACRA is not initialized, so the exception report will not be sent
             sendExceptionReport(e,"AnkiDroidApp.updateContextWithLanguage");
             return remoteContext;
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -811,24 +811,19 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
     private void initializeLanguageDialog(PreferenceScreen screen) {
         ListPreference languageSelection = (ListPreference) screen.findPreference(LANGUAGE);
         if (languageSelection != null) {
-            Map<String, List<String>> items = new TreeMap<>();
+            Map<String, String> items = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
             for (String localeCode : LanguageUtil.APP_LANGUAGES) {
                 Locale loc = LanguageUtil.getLocale(localeCode);
-                //TreeMap always sorted by key.
-                //      Key is a String: all display names converted to lower case for correct display order.
-                //      Value is list of 2 strings:
-                //          1st element is display name with unmodified case
-                //          2nd element is locale code
-                items.put(loc.getDisplayName(loc).toLowerCase(), Arrays.asList(loc.getDisplayName(loc), loc.toString()));
+                items.put(loc.getDisplayName(loc), loc.toString());
             }
             CharSequence[] languageDialogLabels = new CharSequence[items.size() + 1];
             CharSequence[] languageDialogValues = new CharSequence[items.size() + 1];
             languageDialogLabels[0] = getResources().getString(R.string.language_system);
             languageDialogValues[0] = "";
             int i = 1;
-            for (Map.Entry<String, List<String>> e : items.entrySet()) {
-                languageDialogLabels[i] = e.getValue().get(0); //display name
-                languageDialogValues[i] = e.getValue().get(1); //locale code
+            for (Map.Entry<String, String> e : items.entrySet()) {
+                languageDialogLabels[i] = e.getKey();
+                languageDialogValues[i] = e.getValue();
                 i++;
             }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -810,22 +810,25 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
 
     private void initializeLanguageDialog(PreferenceScreen screen) {
         ListPreference languageSelection = (ListPreference) screen.findPreference(LANGUAGE);
-        Locale currentAppLocale = LanguageUtil.getLocale(AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance())
-                .getString(Preferences.LANGUAGE, ""));
         if (languageSelection != null) {
-            Map<String, String> items = new TreeMap<>();
+            Map<String, List<String>> items = new TreeMap<>();
             for (String localeCode : LanguageUtil.APP_LANGUAGES) {
                 Locale loc = LanguageUtil.getLocale(localeCode);
-                items.put(loc.getDisplayName(currentAppLocale), loc.toString());
+                //TreeMap always sorted by key.
+                //      Key is a String: all display names converted to lower case for correct display order.
+                //      Value is list of 2 strings:
+                //          1st element is display name with unmodified case
+                //          2nd element is locale code
+                items.put(loc.getDisplayName(loc).toLowerCase(), Arrays.asList(loc.getDisplayName(loc), loc.toString()));
             }
             CharSequence[] languageDialogLabels = new CharSequence[items.size() + 1];
             CharSequence[] languageDialogValues = new CharSequence[items.size() + 1];
             languageDialogLabels[0] = getResources().getString(R.string.language_system);
             languageDialogValues[0] = "";
             int i = 1;
-            for (Map.Entry<String, String> e : items.entrySet()) {
-                languageDialogLabels[i] = e.getKey();
-                languageDialogValues[i] = e.getValue();
+            for (Map.Entry<String, List<String>> e : items.entrySet()) {
+                languageDialogLabels[i] = e.getValue().get(0); //display name
+                languageDialogValues[i] = e.getValue().get(1); //locale code
                 i++;
             }
 


### PR DESCRIPTION
sort languages alphabetically, ignoring upper/lower case

add comment on exception handler

## Purpose / Description
Make each language show up in the preference's list in their own language, sorted alphabetically. Also adds a comment for PR #6138 that was merged a little bit quick. :)

## Fixes
Fixes #6251 
Also supersedes/closes #6252 

## Approach
Gets the display name of each locale, localized with itself.
Changes TreeMap <String, String> to TreeMap <String, List<String>> and change the way the data is stored, so it automatically gets sorted correctly.

## How Has This Been Tested?

Compiled and tested in emulators, APIs 28 and 16. Works

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
