### PR TITLE
Automatic easing

### DIFF
--- a/AnkiDroid/src/main/res/values/strings.xml
+++ b/AnkiDroid/src/main/res/values/strings.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="ga_trackingId" translatable="false">UA-125800786-1</string>
+    <string name="pref_cat_auto_easing">Automatic easing</string>
+    <string name="ease_timer_summ">Automatically choose easing type based on review time.</string>
+    <string name="ease_timer_text">Automatic easing</string>
+    <string name="ease_timer_easy">Maximum easy time</string>
+    <string name="ease_timer_good">Maximum good time</string>
+    <string name="ease_timer_good_summ">Maximum time in seconds for the question to be considered good.</string>
+    <string name="ease_timer_easy_summ">Maximum time in seconds for the question to be considered easy.</string>
     <!-- If you go over limits, further hits are dropped, setting a sampling percentage can help -->
     <!-- Current limits: 10MM/month globally, 200K/user && 500/session, 1 ever 2s + 60 in a session -->
     <!-- https://developers.google.com/analytics/devguides/collection/android/v4/limits-quotas -->

--- a/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
@@ -155,4 +155,26 @@
             android:summary="@string/timeout_question_seconds_summ"
             android:title="@string/timeout_question_seconds" />
     </PreferenceCategory>
+    <PreferenceCategory android:title="@string/pref_cat_auto_easing">
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:disableDependentsState="false"
+            android:key="easeTimer"
+            android:summary="@string/ease_timer_summ"
+            android:title="@string/ease_timer_text" />
+        <com.ichi2.ui.SeekBarPreference
+            android:defaultValue="3"
+            android:dependency="easeTimer"
+            android:key="ease4AnswerSeconds"
+            android:max="20"
+            android:summary="@string/ease_timer_easy_summ"
+            android:title="@string/ease_timer_easy" />
+        <com.ichi2.ui.SeekBarPreference
+            android:defaultValue="6"
+            android:dependency="easeTimer"
+            android:key="ease3AnswerSeconds"
+            android:max="60"
+            android:summary="@string/ease_timer_good_summ"
+            android:title="@string/ease_timer_good" />
+    </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
## Purpose / Description
One thing that I like about Anki is the option to choose how difficult the question was. However, thinking on how difficult a question was requires extra effort and thus I usually just choose "Good" if I answer the question correctly, and "Again" if i failed.

I would propose that we show the appropriate easing button based on how long it took to answer a question. By default, if it took less than 3 seconds, it's "Easy"; 3-6 seconds - "Good"; More than 6 seconds - "Hard".

At the moment, the options are general to Anki - not deck-specific. Though making them deck specific might be useful to some. I have not tried to implement that, but that would require the back-end to support the options, right?

## Approach
The approach is very simple: a timer on how long the card is shown is already available, so I simply hide certain answer buttons based on the time it took to review the card.

## How Has This Been Tested?
Tested on a physical device (Samsung Galaxy Note 10+) running Android 10.
Ran with default settings (auto-easing disabled) - does not matter how long I waited before pressing "Show Answer", it always displayed all 3 easing options.
When I enabled auto-easing in Settings, and then waited appropriate amounts of time only one of the easing buttons were shown.
"Again" button was never disabled.
