### PR TITLE
Don't perform app init init if launched from ACRA sender

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -228,6 +228,12 @@ public class AnkiDroidApp extends Application {
             UsageAnalytics.setDryRun(true);
         }
 
+        //Stop after analytics and logging are initialised.
+        if (ACRA.isACRASenderServiceProcess()) {
+            Timber.d("Skipping AnkiDroidApp.onCreate from ACRA sender process");
+            return;
+        }
+
         CardBrowserContextMenu.ensureConsistentStateWithSharedPreferences(this);
         setLanguage(preferences.getString(Preferences.LANGUAGE, ""));
         NotificationChannels.setup(getApplicationContext());


### PR DESCRIPTION
This was mentioned in #6266 and seems like a reasonable action to take

We get a second application launched to perform the sending of ACRA reports, and we don't want this to perform our normal setup code.

## Fixes
Maybe #6266

## Approach
Don't init the app after analytics/ACRA/Timber if we're launched from ACRA

## How Has This Been Tested?
Tested on my device. No crashes

## Learning

https://github.com/ankidroid/Anki-Android/issues/6266#issuecomment-633161123

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code