### PR TITLE
No tex in browser

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.java
@@ -285,7 +285,7 @@ public class Card implements Cloneable {
             if (browser) {
                 String bqfmt = t.getString("bqfmt");
                 String bafmt = t.getString("bafmt");
-                mQA = mCol._renderQA(data, bqfmt, bafmt);
+                mQA = mCol._renderQA(data, browser, bqfmt, bafmt);
             } else {
                 mQA = mCol._renderQA(data);
             }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1010,11 +1010,10 @@ public class Collection {
      * Returns hash of id, question, answer.
      */
     public HashMap<String, String> _renderQA(Object[] data) {
-        return _renderQA(data, null, null);
+        return _renderQA(data, false, null, null);
     }
 
-
-    public HashMap<String, String> _renderQA(Object[] data, String qfmt, String afmt) {
+    public HashMap<String, String> _renderQA(Object[] data, boolean browser, String qfmt, String afmt) {
         // data is [cid, nid, mid, did, ord, tags, flds, cardFlags]
         // unpack fields and create dict
         String[] flist = Utils.splitFields((String) data[6]);
@@ -1058,7 +1057,10 @@ public class Collection {
             }
             String html = new Template(format, fields).render();
             html = ChessFilter.fenToChessboard(html, getContext());
-            html = LaTeX.mungeQA(html, this, model);
+            if (!browser) {
+                // browser don't show image. So compiling LaTeX actually remove information.
+                html = LaTeX.mungeQA(html, this, model);
+            }
             d.put(type, html);
             // empty cloze?
             if ("q".equals(type) && model.getInt("type") == Consts.MODEL_CLOZE) {


### PR DESCRIPTION
![2020-05-24-182400_480x854_scrot](https://user-images.githubusercontent.com/357361/82759185-f2868900-9deb-11ea-896c-657c65de40c2.png)

LaTeX is usually compiled to image, and images are stripped in Card Browser. This mean that LaTeX does not appear in Card Browser. This PR wants to avoid it.
It's based on https://github.com/ankidroid/Anki-Android/pull/6269 , so it should not be accepted until the question of hook is resolved. The goal here is only to show what was my points with hook first.

Of course, now that hooks related to language are removed, this is less interesting than when I started considering hooks, since we can also decide not to apply any hook in the browser. This seems more acceptable for Chess than for language with non-latin character