### PR TITLE
Correct Device "Back" Button in Restore From Backup

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.java
@@ -223,7 +223,16 @@ public class DatabaseErrorDialog extends AsyncDialogFragment {
                                         return true;
                                     });
                 }
-                return builder.show();
+                MaterialDialog materialDialog = builder.build();
+                materialDialog.setOnKeyListener((dialog, keyCode, event) -> {
+                    if (keyCode == KeyEvent.KEYCODE_BACK) {
+                        Timber.i("catch");
+                        dismissAllDialogFragments();
+                        return true;
+                    }
+                    return false;
+                });
+                return materialDialog;
             }
             case DIALOG_NEW_COLLECTION: {
                 // Allow user to create a new empty collection

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.java
@@ -4,6 +4,7 @@ package com.ichi2.anki.dialogs;
 import android.content.res.Resources;
 import android.os.Bundle;
 import android.os.Message;
+import android.view.KeyEvent;
 
 import com.afollestad.materialdialogs.MaterialDialog;
 
@@ -16,6 +17,8 @@ import com.ichi2.anki.R;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+
+import timber.log.Timber;
 
 public class DatabaseErrorDialog extends AsyncDialogFragment {
     private int[] mRepairValues;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.java
@@ -226,7 +226,7 @@ public class DatabaseErrorDialog extends AsyncDialogFragment {
                 MaterialDialog materialDialog = builder.build();
                 materialDialog.setOnKeyListener((dialog, keyCode, event) -> {
                     if (keyCode == KeyEvent.KEYCODE_BACK) {
-                        Timber.i("catch");
+                        Timber.i("DIALOG_RESTORE_BACKUP caught hardware back button");
                         dismissAllDialogFragments();
                         return true;
                     }


### PR DESCRIPTION
## Purpose / Description

Now, AnkiDroid can return to deck browser successfully when visit "Restore From Backup" Dialog while the previous version will return to the confirmation dialog.

## Fixes
Fixes #5833

## Approach
For MaterialDialog, adding a Listener by setOnKeyListener() can moniter system's back key. Rewrite system back key operation by method dismissAllDialogFragments() which make its function same as button "Cancel".

## How Has This Been Tested?

1. Open Deck Browser
2. Select "Restore From Backup"
3. Accept the confirmation
4. Press the physical "Back" button on the device.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
