### PR TITLE
'Clear Data' removes DeckPicker background

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -476,11 +476,19 @@ public class DeckPicker extends NavigationDrawerActivity implements
     }
 
     private void applyDeckPickerBackground(View view) {
+        //Allow the user to clear data and get back to a good state if they provide an invalid background.
+        if (!AnkiDroidApp.getSharedPrefs(this).getBoolean("deckPickerBackground", false)) {
+            Timber.d("No DeckPicker background preference");
+            view.setBackgroundResource(0);
+            return;
+        }
         String currentAnkiDroidDirectory = CollectionHelper.getCurrentAnkiDroidDirectory(this);
         File imgFile = new File(currentAnkiDroidDirectory, "DeckPickerBackground.png" );
         if (!imgFile.exists()) {
+            Timber.d("No DeckPicker background image");
             view.setBackgroundResource(0);
         } else {
+            Timber.i("Applying background");
             Drawable drawable = Drawable.createFromPath(imgFile.getAbsolutePath());
             view.setBackground(drawable);
         }


### PR DESCRIPTION
## Purpose / Description
This allows a user to take action to correct an invalid DeckPicker background image through intuitive actions without knowledge of the filesystem.

We hopefully stopped crashing by enforcing a file size limit, but this allows the user to have even more control. Both via clear data and reinstall

## Fixes
Fixes (partially) #6184

## Approach
We use the DeckPicker preference and don't set the background if it's not set, it defaults to false, and will be reset if the user clears data or uninstall

## How Has This Been Tested?
On my phone:
* Set Image
* Clear Data
* Image no longer shows
* Tick Box & Press Back
* Image is shown

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code