### PR TITLE
Multimedia Editor: fix Automated Testing Crash

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
@@ -99,6 +99,12 @@ public class MultimediaEditFieldActivity extends AnkiActivity
 
         mFieldIndex = intent.getIntExtra(EXTRA_FIELD_INDEX, 0);
 
+        if (mField == null) {
+            UIUtils.showThemedToast(this, getString(R.string.multimedia_editor_failed), false);
+            finishCancel();
+            return;
+        }
+
         recreateEditingUi(ChangeUIRequest.init(mField));
     }
 
@@ -413,7 +419,7 @@ public class MultimediaEditFieldActivity extends AnkiActivity
             return newField;
         }
 
-        private static ChangeUIRequest init(IField field) {
+        private static ChangeUIRequest init(@NonNull IField field) {
             return new ChangeUIRequest(field, ACTIVITY_LOAD);
         }
 

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -145,6 +145,7 @@
     <!-- Multimedia - Edit Field Activity -->
     <string name="multimedia_editor_audio_permission_refused">Could not obtain microphone permission.</string>
     <string name="multimedia_editor_camera_permission_refused">Could not obtain camera permission. Functionality has been disabled.</string>
+    <string name="multimedia_editor_failed">Failed to open Multimedia Editor</string>
 
     <!-- Multimedia - Audio View -->
     <string name="multimedia_editor_audio_permission_denied">Audio recording permission denied</string>


### PR DESCRIPTION
## Purpose / Description
Someone runs an automated testing tool, and these crashes come up in ACRA. Might as well fix the low-hanging (if impossible) fruit to clean up.

## How Has This Been Tested?

None

## Learning 
Should have done this a while back

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code