### PR TITLE
File Export: Add timestamps to ensure uniqueness

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -106,6 +106,9 @@ import com.ichi2.libanki.Models;
 import com.ichi2.libanki.sched.Sched;
 import com.ichi2.libanki.Utils;
 import com.ichi2.libanki.importer.AnkiPackageImporter;
+import com.ichi2.libanki.utils.SystemTime;
+import com.ichi2.libanki.utils.Time;
+import com.ichi2.libanki.utils.TimeUtils;
 import com.ichi2.themes.StyledProgressDialog;
 import com.ichi2.utils.ImportUtils;
 import com.ichi2.utils.Permissions;
@@ -205,6 +208,8 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
     /** If we have accepted the "We will show you permissions" dialog, don't show it again on activity rebirth */
     private boolean mClosedWelcomeMessage;
+
+    private Time mTime = new SystemTime();
 
     // ----------------------------------------------------------------------------
     // LISTENERS
@@ -1838,19 +1843,21 @@ public class DeckPicker extends NavigationDrawerActivity implements
         File exportDir = new File(getExternalCacheDir(), "export");
         exportDir.mkdirs();
         File exportPath;
+        String timeStampSuffix = "-" + TimeUtils.getTimestamp(mTime);
         if (filename != null) {
             // filename has been explicitly specified
             exportPath = new File(exportDir, filename);
         } else if (did != null) {
             // filename not explicitly specified, but a deck has been specified so use deck name
-            exportPath = new File(exportDir, getCol().getDecks().get(did).getString("name").replaceAll("\\W+", "_") + ".apkg");
+            exportPath = new File(exportDir, getCol().getDecks().get(did).getString("name").replaceAll("\\W+", "_") + timeStampSuffix + ".apkg");
         } else if (!includeSched) {
             // full export without scheduling is assumed to be shared with someone else -- use "All Decks.apkg"
-            exportPath = new File(exportDir, "All Decks.apkg");
+            exportPath = new File(exportDir, "All Decks" + timeStampSuffix + ".apkg");
         } else {
             // full collection export -- use "collection.colpkg"
             File colPath = new File(getCol().getPath());
-            exportPath = new File(exportDir, colPath.getName().replace(".anki2", ".colpkg"));
+            String newFileName = colPath.getName().replace(".anki2", timeStampSuffix + ".colpkg");
+            exportPath = new File(exportDir, newFileName);
         }
         // add input arguments to new generic structure
         Object[] inputArgs = new Object[5];

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
@@ -53,6 +53,8 @@ import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.R;
 import com.ichi2.anki.UIUtils;
 import com.ichi2.compat.CompatHelper;
+import com.ichi2.libanki.utils.SystemTime;
+import com.ichi2.libanki.utils.TimeUtils;
 import com.ichi2.utils.BitmapUtil;
 import com.ichi2.utils.ExifUtil;
 import com.ichi2.utils.Permissions;
@@ -61,9 +63,6 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.Locale;
 
 import timber.log.Timber;
 
@@ -80,6 +79,7 @@ public class BasicImageFieldController extends FieldControllerBase implements IF
 
     private String mTempCameraImagePath;
     private DisplayMetrics mMetrics = null;
+    private SystemTime mTime = new SystemTime();
 
 
     private int getMaxImageSize() {
@@ -115,7 +115,7 @@ public class BasicImageFieldController extends FieldControllerBase implements IF
             Intent cameraIntent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
             File image;
             File storageDir;
-            String timeStamp = new SimpleDateFormat("yyyyMMddHHmmss", Locale.US).format(new Date());
+            String timeStamp = TimeUtils.getTimestamp(mTime);
             try {
                 storageDir = mActivity.getCacheDir();
                 image = File.createTempFile("img_" + timeStamp, ".jpg", storageDir);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/utils/TimeUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/utils/TimeUtils.java
@@ -1,0 +1,29 @@
+/*
+ Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.libanki.utils;
+
+import java.text.SimpleDateFormat;
+import java.util.Locale;
+
+import androidx.annotation.NonNull;
+
+public class TimeUtils {
+    @NonNull
+    public static String getTimestamp(@NonNull Time time) {
+        return new SimpleDateFormat("yyyyMMddHHmmss", Locale.US).format(time.getCurrentDate());
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
@@ -57,7 +57,7 @@ public class ImportUtils {
     }
 
     public static boolean isCollectionPackage(String filename) {
-        return filename != null && (FileImporter.hasExtension(filename, "colpkg") || filename.startsWith("collection.apkg"));
+        return filename != null && (filename.toLowerCase().endsWith(".colpkg") || "collection.apkg".equals(filename));
     }
 
     /** @return Whether the file is either a deck, or a collection package */
@@ -259,8 +259,8 @@ public class ImportUtils {
             DialogHandler.storeMessage(handlerMessage);
         }
 
-        public static boolean isDeckPackage(String filename) {
-            return filename != null && hasExtension(filename, "apkg") && !filename.startsWith("collection.apkg");
+        private static boolean isDeckPackage(String filename) {
+            return filename != null && filename.toLowerCase().endsWith(".apkg") && !"collection.apkg".equals(filename);
         }
 
 

--- a/AnkiDroid/src/test/java/com/ichi2/utils/ImportUtilsTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/ImportUtilsTest.java
@@ -120,35 +120,6 @@ public class ImportUtilsTest extends RobolectricTest {
         assertFalse(ImportUtils.isValidPackageName("test.docx"));
     }
 
-    @Test
-    public void duplicateFileIsAccepted() {
-        assertTrue(ImportUtils.isValidPackageName(getInvalidDuplicateFileExtension("collection.apkg")));
-    }
-
-    @Test
-    public void duplicateFileWithDotIsAccepted() {
-        assertTrue(ImportUtils.isValidPackageName(getInvalidDuplicateFileExtension("collection.dot.apkg")));
-    }
-
-    @Test
-    public void duplicateCollectionIsNotDeckPackage() {
-        assertFalse(ImportUtils.FileImporter.isDeckPackage(getInvalidDuplicateFileExtension("collection.apkg")));
-    }
-
-    @Test
-    public void encodedCollectionIsStillCollection() {
-        assertTrue(ImportUtils.isCollectionPackage("col.colpkg%20(1)"));
-    }
-
-    @Test
-    public void encodedDeckCollectionIsStillCollection() {
-        assertTrue(ImportUtils.isCollectionPackage("collection.apkg%20(1)"));
-    }
-
-    private String getInvalidDuplicateFileExtension(String s) {
-        //6259 - SAF Issue will cause this: https://stackoverflow.com/q/32849387
-        return s + " (1)";
-    }
 
     @CheckResult
     private Intent getValidClipDataUri(String fileName) {


### PR DESCRIPTION
## Purpose / Description
We shouldn't be more permissive with file imports, as this leaves an incompatibility between AnkiDroid and Anki imports, where AnkiDroid is more permissive of bad values.

## Fixes
Fixes #6259 (take 2)

## Approach

Revert the previous commit

Add a timestamp to the filename

## How Has This Been Tested?

On my device, tested all 3 imports:

* Full Collection with scheduling
* Full collection without scheduling
* Deck

## Learning (optional, can help others)
Think more about breaking compatibility when self-reviewing.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code