### PR TITLE
Custom Steps Dialog: Remove Keyboard Suggestions

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/preferences/StepsPreference.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/StepsPreference.java
@@ -20,7 +20,9 @@ import android.content.Context;
 import android.preference.EditTextPreference;
 import android.text.InputType;
 import android.text.TextUtils;
+import android.text.method.DigitsKeyListener;
 import android.util.AttributeSet;
+import android.widget.EditText;
 
 import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.R;
@@ -62,7 +64,9 @@ public class StepsPreference extends EditTextPreference {
      */
     private void updateSettings() {
         // Use the number pad but still allow normal text for spaces and decimals.
-        getEditText().setInputType(InputType.TYPE_CLASS_NUMBER | InputType.TYPE_CLASS_TEXT);
+        EditText editText = getEditText();
+        editText.setInputType(InputType.TYPE_CLASS_NUMBER | InputType.TYPE_CLASS_TEXT);
+        editText.setKeyListener(DigitsKeyListener.getInstance("0123456789 "));
     }
 
 


### PR DESCRIPTION
## Purpose / Description

When I backspace on the Custom Steps Dialog, A phone number is recommended for entry. Not in my phone book, but apparently caught by autocorrect.

`InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS` and
`InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD` failed to work.

But, limiting the digits did. I don't know what's going on here, but it works for me.

## Fixes
Fixes #6291

## How Has This Been Tested?

On my phone, with much confusion

## Learning (optional, can help others)

I found this by accident, not recommended on StackOverflow.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code