### PR TITLE
Regression tests for CustomStudyDialog JSON output

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -20,9 +20,11 @@ android {
         minSdkVersion 16
         //noinspection OldTargetApi
         targetSdkVersion 28
+        multiDexEnabled true
         testApplicationId "com.ichi2.anki.tests"
         vectorDrawables.useSupportLibrary = true
-        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
+        // This is a custom class, in androidx to override package-level functions
+        testInstrumentationRunner 'androidx.test.runner.MultiDexJUnitRunner'
 
         // This enables long timeouts required on slow ARM emulators, e.g. Travis
         adbOptions {
@@ -141,6 +143,7 @@ dependencies {
     implementation 'com.afollestad.material-dialogs:core:0.9.6.0'
     implementation 'com.getbase:floatingactionbutton:1.10.1'
     implementation 'org.bitbucket.cowwoc:diff-match-patch:1.2'
+    implementation "androidx.multidex:multidex:2.0.1"
 
     // May need a resolution strategy for support libs to our versions
     implementation'ch.acra:acra-http:5.5.1'
@@ -175,4 +178,5 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.2.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test:rules:1.2.0'
+    androidTestImplementation 'org.smali:dexlib2:2.0.3'
 }

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -171,6 +171,8 @@ dependencies {
     testImplementation "org.robolectric:robolectric:4.3.1"
     testImplementation 'androidx.test:core:1.2.0'
     testImplementation 'androidx.test.ext:junit:1.1.1'
+    // debugImplementation required vs testImplementation: https://issuetracker.google.com/issues/128612536
+    debugImplementation 'androidx.fragment:fragment-testing:1.2.4'
 
     // May need a resolution strategy for support libs to our versions
     androidTestImplementation 'com.azimolabs.conditionwatcher:conditionwatcher:0.2'

--- a/AnkiDroid/src/androidTest/java/androidx/test/internal/runner/MultiDexClassPathScanner.java
+++ b/AnkiDroid/src/androidTest/java/androidx/test/internal/runner/MultiDexClassPathScanner.java
@@ -1,0 +1,156 @@
+/*
+ Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package androidx.test.internal.runner;
+
+import android.content.Context;
+import android.os.Build;
+
+import com.ichi2.libanki.Utils;
+
+import org.jf.dexlib2.DexFileFactory;
+import org.jf.dexlib2.dexbacked.DexBackedDexFile;
+import org.jf.dexlib2.iface.ClassDef;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Locale;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
+import timber.log.Timber;
+
+/**
+ * This class exists as I could get MultiDex working, but ClassPathScanner uses new DexFile(),
+ * which only loads the classes from classes.dex in Android < 21. MultiDex.install() fixes the class loader,
+ * but since we don't return all the class names from the dex, we don't see these as potential test classes to filter.
+ **/
+class MultiDexClassPathScanner extends ClassPathScanner {
+    private final List<String> classPathEntries;
+    private final Context targetContext;
+
+    public MultiDexClassPathScanner(List<String> classPath, Context targetContext) {
+        super(classPath);
+        //There's no accessor in the base class.
+        this.classPathEntries = classPath;
+        //We need context to get a temporary folder to store our extracted dex files.
+        this.targetContext = targetContext;
+    }
+
+    @Override
+    @VisibleForTesting
+    //dalvik.system.DexFile
+    @SuppressWarnings( {"deprecation", "RedundantSuppression"})
+    Enumeration<String> getDexEntries(dalvik.system.DexFile dexFile) {
+        List<String> ret = new ArrayList<>();
+        String absolutePath = targetContext.getCacheDir().getAbsolutePath();
+
+        for (String classPath : classPathEntries) {
+            for (String dexPath: extractDexFilesFromApk(classPath, absolutePath)) {
+                List<String> classes = extractClassesFromDexPath(dexPath);
+                ret.addAll(classes);
+            }
+        }
+
+        return Collections.enumeration(ret);
+    }
+
+
+    private List<String> extractClassesFromDexPath(String dexPath) {
+        List<String> ret = new ArrayList<>();
+        try {
+            DexBackedDexFile dex = DexFileFactory.loadDexFile(dexPath, Build.VERSION.SDK_INT);
+            for (ClassDef classDef: dex.getClasses()) {
+                String typeName = extractTypeNameFromDef(classDef);
+                ret.add(typeName);
+            }
+
+        } catch (IOException e) {
+            throw new RuntimeException(e.getLocalizedMessage(), e);
+        }
+        return ret;
+    }
+
+
+    /**
+     * @param classDef The class definition to extract the name from
+     * @return A classname in the form: java.util.scanner
+     */
+    @NonNull
+    private String extractTypeNameFromDef(ClassDef classDef) {
+        String type = classDef.getType();
+        //classes are inconsistently named: https://stackoverflow.com/a/11350724
+        //Assumed structure: Ljava/lang/String;
+        if (!type.startsWith("L") || !type.endsWith(";")) {
+            throw new IllegalArgumentException("Unhandled class type: " + type);
+        }
+        type = type.substring(1, type.length() - 1); //trim suffix and prefix
+        type = type.replace('/', '.');
+        return type;
+    }
+
+
+    private List<String> extractDexFilesFromApk(String path, String targetDirectory) {
+        //Modified from Utils.unzipFiles
+        ZipFile zip;
+        try {
+            zip = new ZipFile(new File(path), ZipFile.OPEN_READ);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        List<String> fileNames = new ArrayList<>();
+
+        try {
+            File tempDir = new File(targetDirectory);
+            if (!tempDir.exists() && !tempDir.mkdirs()) {
+                throw new IOException("Failed to create target directory: " + targetDirectory);
+            }
+
+            for (ZipEntry ze : Collections.list(zip.entries())) {
+                String name = ze.getName();
+                if (!name.endsWith(".dex") || ze.isDirectory()) {
+                    continue;
+                }
+
+                File destFile = new File(tempDir, name);
+                if (!Utils.isInside(destFile, tempDir)) {
+                    Timber.e("Refusing to decompress invalid path: %s", destFile.getCanonicalPath());
+                    String message = String.format(Locale.US, "File is outside extraction target directory. %s %s", tempDir, destFile);
+                    throw new IOException(message);
+                }
+
+                try (InputStream zis = zip.getInputStream(ze)) {
+                    Utils.writeToFile(zis, destFile.getAbsolutePath());
+                }
+
+                fileNames.add(destFile.getAbsolutePath());
+
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e.getLocalizedMessage(), e);
+        }
+
+        return fileNames;
+    }
+}

--- a/AnkiDroid/src/androidTest/java/androidx/test/internal/runner/MultiDexTestRequestBuilder.java
+++ b/AnkiDroid/src/androidTest/java/androidx/test/internal/runner/MultiDexTestRequestBuilder.java
@@ -1,0 +1,50 @@
+/*
+ Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package androidx.test.internal.runner;
+
+import android.app.Instrumentation;
+import android.content.Context;
+import android.os.Build;
+import android.os.Bundle;
+
+import java.util.List;
+
+import androidx.annotation.VisibleForTesting;
+
+/**
+ * A class which allows building test requests in a multidex environment on Android < 21
+ *
+ * This is in androidx to override package-level functions
+ * */
+public class MultiDexTestRequestBuilder extends TestRequestBuilder {
+    private Context mContext;
+
+    public MultiDexTestRequestBuilder(Instrumentation instr, Bundle arguments) {
+        super(instr, arguments);
+        this.mContext = instr.getTargetContext();
+    }
+
+
+    @VisibleForTesting
+    @Override
+    ClassPathScanner createClassPathScanner(List<String> classPath) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            return new MultiDexClassPathScanner(classPath, mContext);
+        }
+        return super.createClassPathScanner(classPath);
+    }
+}

--- a/AnkiDroid/src/androidTest/java/androidx/test/runner/MultiDexJUnitRunner.java
+++ b/AnkiDroid/src/androidTest/java/androidx/test/runner/MultiDexJUnitRunner.java
@@ -1,0 +1,49 @@
+/*
+ Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package androidx.test.runner;
+
+import android.app.Instrumentation;
+import android.os.Bundle;
+
+import androidx.annotation.VisibleForTesting;
+import androidx.multidex.MultiDex;
+import androidx.test.internal.runner.MultiDexTestRequestBuilder;
+import androidx.test.internal.runner.TestRequestBuilder;
+
+/**
+ * A class which allows loading MultiDex tests on Android < 21
+ *
+ * This is in androidx to override package-level functions
+ */
+@SuppressWarnings("unused") //referenced by build.gradle
+public class MultiDexJUnitRunner extends AndroidJUnitRunner {
+    // TODO: See if we can check the number of executed tests on a full run, and ensure this exceeds a threshold.
+    // as instrumentation runs on my local machine occasionally fail to load com.ichi2.anki
+
+    @Override
+    public void onCreate(Bundle arguments) {
+        MultiDex.installInstrumentation(getContext(), getTargetContext());
+        super.onCreate(arguments);
+    }
+
+
+    @VisibleForTesting
+    @Override
+    TestRequestBuilder createTestRequestBuilder(Instrumentation instr, Bundle arguments) {
+        return new MultiDexTestRequestBuilder(instr, arguments);
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -65,6 +65,7 @@ import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import androidx.multidex.MultiDexApplication;
 import timber.log.Timber;
 import static timber.log.Timber.DebugTree;
 
@@ -137,7 +138,7 @@ import static timber.log.Timber.DebugTree;
         exceptionClassLimit = 1000,
         stacktraceLimit = 1
 )
-public class AnkiDroidApp extends Application {
+public class AnkiDroidApp extends MultiDexApplication {
 
     public static final String XML_CUSTOM_NAMESPACE = "http://arbitrary.app.namespace/com.ichi2.anki";
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
@@ -21,6 +21,7 @@ import android.content.SharedPreferences;
 import android.content.res.Resources;
 import android.os.Bundle;
 import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
 import timber.log.Timber;
 
 import android.text.Editable;
@@ -63,7 +64,8 @@ public class CustomStudyDialog extends AnalyticsDialogFragment {
     private static final int CUSTOM_STUDY_NEW = 100;
     private static final int CUSTOM_STUDY_REV = 101;
     private static final int CUSTOM_STUDY_FORGOT = 102;
-    private static final int CUSTOM_STUDY_AHEAD = 103;
+    @VisibleForTesting
+    static final int CUSTOM_STUDY_AHEAD = 103;
     private static final int CUSTOM_STUDY_RANDOM = 104;
     private static final int CUSTOM_STUDY_PREVIEW = 105;
     private static final int CUSTOM_STUDY_TAGS = 106;
@@ -501,7 +503,7 @@ public class CustomStudyDialog extends AnalyticsDialogFragment {
         activity.dismissAllDialogFragments();
     }
 
-    private AnkiActivity getAnkiActivity() {
+    protected AnkiActivity getAnkiActivity() {
         return (AnkiActivity) getActivity();
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
@@ -124,7 +124,7 @@ public class CustomStudyDialog extends AnalyticsDialogFragment {
                     @Override
                     public void onSelection(MaterialDialog materialDialog, View view, int which,
                                             CharSequence charSequence) {
-                        AnkiActivity activity = (AnkiActivity) getActivity();
+                        AnkiActivity activity = getAnkiActivity();
                         switch (view.getId()) {
                             case DECK_OPTIONS: {
                                 // User asked to permanently change the deck options
@@ -159,7 +159,7 @@ public class CustomStudyDialog extends AnalyticsDialogFragment {
                                 // User asked for a standard custom study option
                                 CustomStudyDialog d = CustomStudyDialog.newInstance(view.getId(),
                                         getArguments().getLong("did"), jumpToReviewer);
-                                ((AnkiActivity) getActivity()).showDialogFragment(d);
+                                getAnkiActivity().showDialogFragment(d);
                             }
                         }
                     }
@@ -259,7 +259,7 @@ public class CustomStudyDialog extends AnalyticsDialogFragment {
                             break;
                     }
                 })
-                .onNegative((dialog, which) -> ((AnkiActivity) getActivity()).dismissAllDialogFragments());
+                .onNegative((dialog, which) -> getAnkiActivity().dismissAllDialogFragments());
         final MaterialDialog dialog = builder.build();
         mEditText.addTextChangedListener(new TextWatcher() {
             @Override
@@ -334,7 +334,7 @@ public class CustomStudyDialog extends AnalyticsDialogFragment {
      * @return the ids of which values to show
      */
     private int[] getListIds(int dialogId) {
-        Collection col = ((AnkiActivity) getActivity()).getCol();
+        Collection col = getAnkiActivity().getCol();
         switch (dialogId) {
             case CONTEXT_MENU_STANDARD:
                 // Standard context menu
@@ -423,7 +423,7 @@ public class CustomStudyDialog extends AnalyticsDialogFragment {
      */
     private void createCustomStudySession(JSONArray delays, Object[] terms, Boolean resched) {
         JSONObject dyn;
-        final AnkiActivity activity = (AnkiActivity) getActivity();
+        final AnkiActivity activity = getAnkiActivity();
         Collection col = CollectionHelper.getInstance().getCol(activity);
         long did = getArguments().getLong("did");
         String deckToStudyName = col.getDecks().get(did).getString("name");
@@ -491,7 +491,7 @@ public class CustomStudyDialog extends AnalyticsDialogFragment {
     }
 
     private void onLimitsExtended(boolean jumpToReviewer) {
-        AnkiActivity activity = (AnkiActivity) getActivity();
+        AnkiActivity activity = getAnkiActivity();
         if (jumpToReviewer) {
             activity.startActivityForResultWithoutAnimation(new Intent(activity, Reviewer.class), AnkiActivity.REQUEST_REVIEW);
             CollectionHelper.getInstance().getCol(activity).startTimebox();
@@ -499,5 +499,9 @@ public class CustomStudyDialog extends AnalyticsDialogFragment {
             ((CustomStudyListener) activity).onExtendStudyLimits();
         }
         activity.dismissAllDialogFragments();
+    }
+
+    private AnkiActivity getAnkiActivity() {
+        return (AnkiActivity) getActivity();
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.java
@@ -1,0 +1,112 @@
+/*
+ Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.dialogs;
+
+import android.content.Intent;
+
+import com.afollestad.materialdialogs.DialogAction;
+import com.afollestad.materialdialogs.MaterialDialog;
+import com.ichi2.anki.AnkiActivity;
+import com.ichi2.anki.CardTemplateBrowserAppearanceEditor;
+import com.ichi2.anki.RobolectricTest;
+import com.ichi2.anki.dialogs.CustomStudyDialog.CustomStudyListener;
+import com.ichi2.utils.JSONObject;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import androidx.annotation.NonNull;
+import androidx.fragment.app.testing.FragmentScenario;
+import androidx.lifecycle.Lifecycle;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.core.IsNull.notNullValue;
+
+@RunWith(AndroidJUnit4.class)
+public class CustomStudyDialogTest extends RobolectricTest {
+
+    @Test
+    public void learnAheadCardsRegressionTest() {
+        // #6289 - Regression Test
+        CustomStudyDialog args = CustomStudyDialog.newInstance(CustomStudyDialog.CUSTOM_STUDY_AHEAD, 1);
+
+        FragmentScenario<CustomStudyDialogForTesting> scenario = getDialogScenario(args);
+
+        scenario.moveToState(Lifecycle.State.STARTED);
+
+        scenario.onFragment(f -> {
+            MaterialDialog dialog = (MaterialDialog) f.getDialog();
+            assertThat(dialog, notNullValue());
+            dialog.getActionButton(DialogAction.POSITIVE).callOnClick();
+        });
+
+
+        JSONObject customStudy = getCol().getDecks().current();
+        assertThat("Custom Study should be dynamic", customStudy.getInt("dyn") == 1);
+        assertThat("could not find deck: Custom study session", customStudy, notNullValue());
+        customStudy.remove("id");
+        customStudy.remove("mod");
+        customStudy.remove("name");
+
+        String expected = "{\"newToday\":[0,0],\"revToday\":[0,0],\"lrnToday\":[0,0],\"timeToday\":[0,0],\"collapsed\":false,\"dyn\":1,\"desc\":\"\",\"usn\":-1,\"delays\":null,\"separate\":true,\"terms\":[[\"deck:\\\"Default\\\" prop:due<=1\",99999,6]],\"resched\":true,\"return\":true}";
+        assertThat(customStudy.toString(), is(expected));
+    }
+
+
+    @NonNull
+    private FragmentScenario<CustomStudyDialogForTesting> getDialogScenario(CustomStudyDialog args) {
+        FragmentScenario<CustomStudyDialogForTesting> scenario = FragmentScenario.launch(CustomStudyDialogForTesting.class, args.getArguments());
+
+        // Pick an arbitrary easy activity
+        CustomStudyActivity d = super.startActivityNormallyOpenCollectionWithIntent(CustomStudyActivity.class, new Intent());
+
+        scenario.onFragment(f -> f.setActivity(d));
+        return scenario;
+    }
+
+    private static class CustomStudyActivity extends CardTemplateBrowserAppearanceEditor implements CustomStudyListener {
+
+        @Override
+        public void onCreateCustomStudySession() {
+            // Intentionally blank
+        }
+
+
+        @Override
+        public void onExtendStudyLimits() {
+            // Intentionally blank
+        }
+    }
+
+
+    public static class CustomStudyDialogForTesting extends CustomStudyDialog {
+        private AnkiActivity mAnkiActivity;
+
+        @SuppressWarnings("WeakerAccess")
+        public <T extends AnkiActivity & CustomStudyListener> void setActivity(T ankiActivity) {
+            mAnkiActivity = ankiActivity;
+        }
+
+
+        @Override
+        protected AnkiActivity getAnkiActivity() {
+            return mAnkiActivity;
+        }
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/utils/JSONObjectTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/JSONObjectTest.java
@@ -1,0 +1,34 @@
+/*
+ Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.utils;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsNull.notNullValue;
+
+@RunWith(AndroidJUnit4.class)
+public class JSONObjectTest {
+    @Test
+    public void objectNullIsNotNull() {
+        //#6289
+        assertThat(JSONObject.NULL, notNullValue());
+    }
+}


### PR DESCRIPTION
Adds more regression cover.

Fragment testing is much more complex than I'd expected, especially as we use the containing activity to access the collection.

At some point in the future:tm: we should move to a more self-contained and testable model.

Fixes #6289