### PR TITLE
Card Browser: Browse certain decks containing brackets and stars return correct result

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
@@ -56,7 +56,6 @@ public class Finder {
 
     private Collection mCol;
 
-
     public Finder(Collection col) {
         mCol = col;
     }
@@ -631,26 +630,24 @@ public class Finder {
             ids = dids(mCol.getDecks().id(val, false));
         } else {
             // wildcard
-            try{
-                ids = dids(mCol.getDecks().id(val, false));
-            }catch(Exception e){
+            ids = dids(mCol.getDecks().id(val, false));
+            if (ids == null) {
                 ids = new ArrayList<>();
-            }
-            val = val.replace("*", ".*");
-            val = val.replace("+", "\\+");
+                val = val.replace("*", ".*");
+                val = val.replace("+", "\\+");
 
-            for (JSONObject d : mCol.getDecks().all()) {
-                String deckName = d.getString("name");
-                deckName = Normalizer.normalize(deckName, Normalizer.Form.NFC);
-                if (deckName.matches("(?i)" + val)) {
-                    for (long id : dids(d.getLong("id"))) {
-                        if (!ids.contains(id)) {
-                            ids.add(id);
+                for (JSONObject d : mCol.getDecks().all()) {
+                    String deckName = d.getString("name");
+                    deckName = Normalizer.normalize(deckName, Normalizer.Form.NFC);
+                    if (deckName.matches("(?i)" + val)) {
+                        for (long id : dids(d.getLong("id"))) {
+                            if (!ids.contains(id)) {
+                                ids.add(id);
+                            }
                         }
                     }
                 }
             }
-
         }
         if (ids == null || ids.size() == 0) {
             return null;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
@@ -635,17 +635,17 @@ public class Finder {
                 ids = dids(mCol.getDecks().id(val, false));
             }catch(Exception e){
                 ids = new ArrayList<>();
-                val = val.replace("*", ".*");
-                val = val.replace("+", "\\+");
+            }
+            val = val.replace("*", ".*");
+            val = val.replace("+", "\\+");
 
-                for (JSONObject d : mCol.getDecks().all()) {
-                    String deckName = d.getString("name");
-                    deckName = Normalizer.normalize(deckName, Normalizer.Form.NFC);
-                    if (deckName.matches("(?i)" + val)) {
-                        for (long id : dids(d.getLong("id"))) {
-                            if (!ids.contains(id)) {
-                                ids.add(id);
-                            }
+            for (JSONObject d : mCol.getDecks().all()) {
+                String deckName = d.getString("name");
+                deckName = Normalizer.normalize(deckName, Normalizer.Form.NFC);
+                if (deckName.matches("(?i)" + val)) {
+                    for (long id : dids(d.getLong("id"))) {
+                        if (!ids.contains(id)) {
+                            ids.add(id);
                         }
                     }
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
@@ -614,7 +614,6 @@ public class Finder {
         return res;
     }
 
-
     public String _findDeck(String val) {
         // if searching for all decks, skip
         if ("*".equals(val)) {
@@ -632,20 +631,26 @@ public class Finder {
             ids = dids(mCol.getDecks().id(val, false));
         } else {
             // wildcard
-            ids = new ArrayList<>();
-            val = val.replace("*", ".*");
-            val = val.replace("+", "\\+");
-            for (JSONObject d : mCol.getDecks().all()) {
-                String deckName = d.getString("name");
-                deckName = Normalizer.normalize(deckName, Normalizer.Form.NFC);
-                if (deckName.matches("(?i)" + val)) {
-                    for (long id : dids(d.getLong("id"))) {
-                        if (!ids.contains(id)) {
-                            ids.add(id);
+            try{
+                ids = dids(mCol.getDecks().id(val, false));
+            }catch(Exception e){
+                ids = new ArrayList<>();
+                val = val.replace("*", ".*");
+                val = val.replace("+", "\\+");
+
+                for (JSONObject d : mCol.getDecks().all()) {
+                    String deckName = d.getString("name");
+                    deckName = Normalizer.normalize(deckName, Normalizer.Form.NFC);
+                    if (deckName.matches("(?i)" + val)) {
+                        for (long id : dids(d.getLong("id"))) {
+                            if (!ids.contains(id)) {
+                                ids.add(id);
+                            }
                         }
                     }
                 }
             }
+
         }
         if (ids == null || ids.size() == 0) {
             return null;


### PR DESCRIPTION
## Purpose / Description
Card Browser: Browse certain decks containing brackets and stars return correct result.

## Fixes
Fixes #6288 _Link to the issues._

## Approach
_ Return the deck if we have an exact match, then perform the regex search if a star is contained in the input._

## How Has This Been Tested?

+ Name a deck *Hello (zanki)
+ Add a card
+ Card Browser to choose *Hello (zanki)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
