### PR TITLE
Travis: Set TERM=dumb to reduce log output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ env:
     - UNIT_TEST=FALSE # by default we don't run the unit tests, they are run only in specific builds
     - LINT=FALSE # by default we don't lint, they are run only in specific builds
     - FINALIZE_COVERAGE=FALSE # by default we don't finalize coverage, it is done in one specific build
+    - TERM=dumb
   matrix:
    - API=16 ABI=x86 AUDIO=-no-audio LOCALE="ko_KR"
    - API=17 ABI=x86 LOCALE="it_IT"


### PR DESCRIPTION
This gets rid of Gradle Progress bars, which don't work as Travis' log is write-only. Not sure if you'd prefer we prefixed each gradle instruction with this.

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
