### PR TITLE
Correct count for undo of learning card V2

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -2645,7 +2645,7 @@ public class SchedV2 extends AbstractSched {
             mNewCount--;
             break;
         case Consts.QUEUE_TYPE_LRN:
-            mLrnCount -= card.getLeft() / 1000;
+            mLrnCount --;
             break;
         case Consts.QUEUE_TYPE_REV:
             mRevCount--;


### PR DESCRIPTION
Here is a bug, fixed by this commit.

In sched v2, create a basic card. Put the deck option so that there is
four steps for new card, "1 1 1 1"
Review the card, press "again" twice. Undo.
You'll see that the nuber of step for cards in learning is "-3". It
should be "1".

The reason is that `decrementCounts` is used only for undoing. More
precisely, when the numbers are reset, the number of the current card
should be decremented; this is done by this method. The trouble being
that the method was directly copied from Sched instead of being
changed to fit with Sched V2 counts of card in learning.

----
_Edit by @david-allison-1_ 

Fixes #6085 