### PR TITLE
Reset in test

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.java
@@ -650,8 +650,7 @@ public class ContentProviderTest {
      */
     @Test
     public void testQueryAllDecks() throws Exception{
-        Collection col;
-        col = getCol();
+        Collection col = getCol();
         Decks decks = col.getDecks();
 
         Cursor decksCursor = InstrumentationRegistry.getInstrumentation().getTargetContext().getContentResolver()
@@ -678,8 +677,7 @@ public class ContentProviderTest {
      */
     @Test
     public void testQueryCertainDeck() throws Exception {
-        Collection col;
-        col = getCol();
+        Collection col = getCol();
 
         long deckId = mTestDeckIds[0];
         Uri deckUri = Uri.withAppendedPath(FlashCardsContract.Deck.CONTENT_ALL_URI, Long.toString(deckId));
@@ -702,8 +700,7 @@ public class ContentProviderTest {
      */
     @Test
     public void testQueryNextCard(){
-        Collection col;
-        col = getCol();
+        Collection col = getCol();
         AbstractSched sched = col.getSched();
 
         Cursor reviewInfoCursor = InstrumentationRegistry.getInstrumentation().getTargetContext().getContentResolver().query(
@@ -736,8 +733,7 @@ public class ContentProviderTest {
         long deckToTest = mTestDeckIds[0];
         String deckSelector = "deckID=?";
         String deckArguments[] = {Long.toString(deckToTest)};
-        Collection col;
-        col = getCol();
+        Collection col = getCol();
         AbstractSched sched = col.getSched();
         long selectedDeckBeforeTest = col.getDecks().selected();
         col.getDecks().select(1); //select Default deck
@@ -789,8 +785,7 @@ public class ContentProviderTest {
      */
     @Test
     public void testAnswerCard(){
-        Collection col;
-        col = getCol();
+        Collection col = getCol();
         long deckId = mTestDeckIds[0];
         col.getDecks().select(deckId);
         Card card = col.getSched().getCard();
@@ -836,8 +831,7 @@ public class ContentProviderTest {
     public void testBuryCard(){
         // get the first card due
         // ----------------------
-        Collection col;
-        col = getCol();
+        Collection col = getCol();
         long deckId = mTestDeckIds[0];
         col.getDecks().select(deckId);
         Card card = col.getSched().getCard();
@@ -884,8 +878,7 @@ public class ContentProviderTest {
 
         // get the first card due
         // ----------------------
-        Collection col;
-        col = getCol();
+        Collection col = getCol();
         long deckId = mTestDeckIds[0];
         col.getDecks().select(deckId);
         Card card = col.getSched().getCard();
@@ -933,8 +926,7 @@ public class ContentProviderTest {
     public void testUpdateTags() {
         // get the first card due
         // ----------------------
-        Collection col;
-        col = getCol();
+        Collection col = getCol();
         long deckId = mTestDeckIds[0];
         col.getDecks().select(deckId);
         Card card = col.getSched().getCard();

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.java
@@ -780,15 +780,18 @@ public class ContentProviderTest {
         assertEquals("Check that the selected deck has been correctly set", deckId, col.getDecks().selected());
     }
 
+    private Card getFirstCardFromScheduler(Collection col) {
+        long deckId = mTestDeckIds[0];
+        col.getDecks().select(deckId);
+        return col.getSched().getCard();
+    }
     /**
      * Test giving the answer for a reviewed card
      */
     @Test
     public void testAnswerCard(){
         Collection col = getCol();
-        long deckId = mTestDeckIds[0];
-        col.getDecks().select(deckId);
-        Card card = col.getSched().getCard();
+        Card card = getFirstCardFromScheduler(col);
         long cardId = card.getId();
 
         // the card starts out being new
@@ -832,9 +835,7 @@ public class ContentProviderTest {
         // get the first card due
         // ----------------------
         Collection col = getCol();
-        long deckId = mTestDeckIds[0];
-        col.getDecks().select(deckId);
-        Card card = col.getSched().getCard();
+        Card card = getFirstCardFromScheduler(col);
 
         // verify that the card is not already user-buried
         Assert.assertNotEquals("Card is not user-buried before test", Consts.QUEUE_TYPE_SIBLING_BURIED, card.getQueue());
@@ -879,9 +880,7 @@ public class ContentProviderTest {
         // get the first card due
         // ----------------------
         Collection col = getCol();
-        long deckId = mTestDeckIds[0];
-        col.getDecks().select(deckId);
-        Card card = col.getSched().getCard();
+        Card card = getFirstCardFromScheduler(col);
 
         // verify that the card is not already suspended
         Assert.assertNotEquals("Card is not suspended before test", Consts.QUEUE_TYPE_SUSPENDED, card.getQueue());
@@ -927,9 +926,7 @@ public class ContentProviderTest {
         // get the first card due
         // ----------------------
         Collection col = getCol();
-        long deckId = mTestDeckIds[0];
-        col.getDecks().select(deckId);
-        Card card = col.getSched().getCard();
+        Card card = getFirstCardFromScheduler(col);
         Note note = card.note();
         long noteId = note.getId();
 

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.java
@@ -783,6 +783,7 @@ public class ContentProviderTest {
     private Card getFirstCardFromScheduler(Collection col) {
         long deckId = mTestDeckIds[0];
         col.getDecks().select(deckId);
+        col.getSched().reset();
         return col.getSched().getCard();
     }
     /**


### PR DESCRIPTION
This is discussed in https://github.com/ankidroid/Anki-Android/pull/6026/files/63f493482d69b9aee5a0594838d05707d5df6eba#r432866396 and can be considered as a separate PR.

Essentially, tests are wrong, but work by accident. In theory, you should reset each time a deck is selected. It was not done, but didn't create any trouble.
I noticed the problem when testing another PR, where reset became mandatory.

Anyway, this make the test close to ankidroid's code, since in non-test code, reset is called often

As @david-allison-1 asked, I also factorized some code