### PR TITLE
NF: Factorize bury sibling

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -1418,56 +1418,6 @@ public class Sched extends SchedV2 {
                 new Object[]{Utils.now(), mCol.usn()});
     }
 
-
-    /**
-     * Sibling spacing
-     * ********************
-     */
-
-    @Override
-    protected void _burySiblings(Card card) {
-        LinkedList<Long> toBury = new LinkedList<>();
-        JSONObject nconf = _newConf(card);
-        boolean buryNew = nconf.optBoolean("bury", true);
-        JSONObject rconf = _revConf(card);
-        boolean buryRev = rconf.optBoolean("bury", true);
-        // loop through and remove from queues
-        Cursor cur = null;
-        try {
-            cur = mCol.getDb().getDatabase().query(
-                    "select id, queue from cards where nid=? and id!=? "+
-                    "and (queue=" + Consts.QUEUE_TYPE_NEW + " or (queue=" + Consts.QUEUE_TYPE_REV + " and due<=?))",
-                    new Object[] {card.getNid(), card.getId(), mToday});
-            while (cur.moveToNext()) {
-                long cid = cur.getLong(0);
-                int queue = cur.getInt(1);
-                if (queue == Consts.QUEUE_TYPE_REV) {
-                    if (buryRev) {
-                        toBury.add(cid);
-                    }
-                    // if bury disabled, we still discard to give same-day spacing
-                    mRevQueue.remove(cid);
-                } else {
-                    // if bury is disabled, we still discard to give same-day spacing
-                    if (buryNew) {
-                        toBury.add(cid);
-                    }
-                    mNewQueue.remove(cid);
-                }
-            }
-        } finally {
-            if (cur != null && !cur.isClosed()) {
-                cur.close();
-            }
-        }
-        // then bury
-        if (!toBury.isEmpty()) {
-            mCol.getDb().execute("update cards set queue=" + Consts.QUEUE_TYPE_SIBLING_BURIED + ",mod=?,usn=? where id in " + Utils.ids2str(toBury),
-                    new Object[] { Utils.now(), mCol.usn() });
-            mCol.log(toBury);
-        }
-    }
-
     /**
      * Repositioning new cards **************************************************
      * *********************************************

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -1411,6 +1411,12 @@ public class Sched extends SchedV2 {
 
     @Override
     public void buryCards(long[] cids) {
+        buryCards(cids, false);
+    }
+
+    @Override
+    public void buryCards(long[] cids, boolean manual) {
+        // The boolean is useless here. However, it ensures that we are override the method with same parameter in SchedV2.
         mCol.log(cids);
         remFromDyn(cids);
         removeLrn(cids);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -2203,19 +2203,21 @@ public class SchedV2 extends AbstractSched {
             while (cur.moveToNext()) {
                 long cid = cur.getLong(0);
                 int queue = cur.getInt(1);
+                List<Long> queue_object;
                 if (queue == Consts.QUEUE_TYPE_REV) {
+                    queue_object = mRevQueue;
                     if (buryRev) {
                         toBury.add(cid);
                     }
-                    // if bury disabled, we still discard to give same-day spacing
-                    mRevQueue.remove(cid);
                 } else {
-                    // if bury is disabled, we still discard to give same-day spacing
+                    queue_object = mNewQueue;
                     if (buryNew) {
                         toBury.add(cid);
                     }
-                    mNewQueue.remove(cid);
                 }
+                // even if burying disabled, we still discard to give
+                // same-day spacing
+                queue_object.remove(cid);
             }
         } finally {
             if (cur != null && !cur.isClosed()) {


### PR DESCRIPTION
This was discussed here https://github.com/ankidroid/Anki-Android/pull/6026#discussion_r432868155
The method _burySibling leads to code duplication. Four copies of the same code occurs. This is especially a problem because other PR I created deal with this part of _burySibling. So factorizing this code is going to be even more useful if my other PR are accepted.

@david-allison-1 didn't like my first factorization, because the code I wrote introduced a method, which took a collection (the queue of card id) and removed elements from it.
I decided that, what was the most natural thing to do is to create an inner class for queue of card ids, and add a method _burySibling in it which simply deal with burying the sibling. This way, it is clear that the code is changing the collection content. Furthermore, I can reuse this method in other PRs and avoid code duplication.
My new method still takes a collection, the collection of card to bury. But since it is not a member of the object but just an object local to the function, I believe that it is a far smaller problem than the one @david-allison-1 mentionned before.

I believe that this essentially improve the code quality. If you disagree, feel free to close the PR.