### PR TITLE
Empty ACTION_VIEW opens app

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.java
@@ -60,11 +60,17 @@ public class IntentHandler extends Activity {
         }
     }
 
+    private static boolean isValidViewIntent(@NonNull Intent intent) {
+        // Negating a negative because we want to call specific attention to the fact that it's invalid
+        // #6312 - Smart Launcher provided an empty ACTION_VIEW, no point in importing here.
+        return !ImportUtils.isInvalidViewIntent(intent);
+    }
+
     @VisibleForTesting
     @CheckResult
     static LaunchType getLaunchType(@NonNull Intent intent) {
         String action = intent.getAction();
-        if (Intent.ACTION_VIEW.equals(action)) {
+        if (Intent.ACTION_VIEW.equals(action) && isValidViewIntent(intent)) {
             return LaunchType.FILE_IMPORT;
         } else if ("com.ichi2.anki.DO_SYNC".equals(action)) {
             return LaunchType.SYNC;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/ReminderService.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/ReminderService.java
@@ -20,6 +20,8 @@ import android.app.PendingIntent;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+
+import androidx.annotation.NonNull;
 import androidx.core.app.NotificationCompat;
 import androidx.core.app.NotificationManagerCompat;
 import androidx.core.content.ContextCompat;
@@ -84,7 +86,7 @@ public class ReminderService extends BroadcastReceiver {
                     .setContentIntent(PendingIntent.getActivity(
                             context,
                             (int) deckId,
-                            new Intent(context, IntentHandler.class).putExtra(EXTRA_DECK_ID, deckId),
+                            getReviewDeckIntent(context, deckId),
                             PendingIntent.FLAG_UPDATE_CURRENT
                     ))
                     .setAutoCancel(true)
@@ -92,6 +94,13 @@ public class ReminderService extends BroadcastReceiver {
             notificationManager.notify((int) deckId, notification);
         }
     }
+
+
+    @NonNull
+    public static Intent getReviewDeckIntent(@NonNull Context context, long deckId) {
+        return new Intent(context, IntentHandler.class).putExtra(EXTRA_DECK_ID, deckId);
+    }
+
 
     // getDeckDue information, will recur one time to workaround collection close if recur is true
     private Sched.DeckDueTreeNode getDeckDue(Context context, long deckId, boolean recur) {

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
@@ -66,6 +66,15 @@ public class ImportUtils {
         return FileImporter.isDeckPackage(filename) || isCollectionPackage(filename);
     }
 
+    /**
+     * Whether importUtils can handle the given intent
+     * Caused by #6312 - A launcher was sending ACTION_VIEW instead of ACTION_MAIN
+     */
+    public static boolean isInvalidViewIntent(@NonNull Intent intent) {
+        return intent.getData() == null && intent.getClipData() == null;
+    }
+
+
     @SuppressWarnings("WeakerAccess")
     protected static class FileImporter {
         /**

--- a/AnkiDroid/src/test/java/com/ichi2/anki/IntentHandlerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/IntentHandlerTest.java
@@ -72,4 +72,15 @@ public class IntentHandlerTest {
 
         assertThat(expected, is(LaunchType.DEFAULT_START_APP_IF_NEW));
     }
+
+    @Test
+    public void viewWithNoDataPerformsDefaultAction() {
+        // #6312 - Smart Launcher double-tap launches us with this. No data at all in the intent
+        // so we can only perform the default action
+        Intent intent = new Intent(Intent.ACTION_VIEW);
+
+        LaunchType expected = IntentHandler.getLaunchType(intent);
+
+        assertThat(expected, is(LaunchType.DEFAULT_START_APP_IF_NEW));
+    }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/IntentHandlerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/IntentHandlerTest.java
@@ -1,0 +1,75 @@
+/*
+ Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki;
+
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+
+import com.ichi2.anki.IntentHandler.LaunchType;
+import com.ichi2.anki.services.ReminderService;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+
+@RunWith(AndroidJUnit4.class)
+public class IntentHandlerTest {
+    // COULD_BE_BETTER: We're testing class internals here, would like to see these tests be replaced with
+    // higher-level tests at a later date when we better extract dependencies
+
+    @Test
+    public void viewIntentReturnsView() {
+        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse("content://invalid"));
+
+        LaunchType expected = IntentHandler.getLaunchType(intent);
+
+        assertThat(expected, is(LaunchType.FILE_IMPORT));
+    }
+
+    @Test
+    public void syncIntentReturnsSync() {
+        Intent intent = new Intent("com.ichi2.anki.DO_SYNC");
+
+        LaunchType expected = IntentHandler.getLaunchType(intent);
+
+        assertThat(expected, is(LaunchType.SYNC));
+    }
+
+    @Test
+    public void reviewIntentReturnsReview() {
+        Intent intent = ReminderService.getReviewDeckIntent(mock(Context.class), 1);
+
+        LaunchType expected = IntentHandler.getLaunchType(intent);
+
+        assertThat(expected, is(LaunchType.REVIEW));
+    }
+
+    @Test
+    public void mainIntentStartsApp() {
+        Intent intent = new Intent(Intent.ACTION_MAIN);
+
+        LaunchType expected = IntentHandler.getLaunchType(intent);
+
+        assertThat(expected, is(LaunchType.DEFAULT_START_APP_IF_NEW));
+    }
+}


### PR DESCRIPTION
## Purpose / Description
Smart Launcher performs an empty `ACTION_VIEW` on a double tap, this seems unusual, but the development documents say "make your best judgement" for an `ACTION_VIEW`. In this case, I feel the best action is to launch the app if it isn't launched.

## Fixes
Fixes #6312

## Approach
Don't try to import the file 

## How Has This Been Tested?

Double tap now opens the app

## Learning (optional, can help others)
https://developer.android.com/reference/android/content/Intent#ACTION_VIEW

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code