### PR TITLE
Revert making TLS more permissive

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Tls12SocketFactory.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Tls12SocketFactory.java
@@ -51,7 +51,7 @@ import timber.log.Timber;
  * @see SSLSocketFactory
  */
 public class Tls12SocketFactory extends SSLSocketFactory {
-    private static final String[] TLS_V12_ONLY = {"TLSv1", "TLSv1.1", "TLSv1.2"};
+    private static final String[] TLS_V12_ONLY =  {"TLSv1.2"};
 
     private final SSLSocketFactory delegate;
 


### PR DESCRIPTION
Debugging code added in 6de5b98b2a01ecea8e4090c7f08a93553616eb7d

Shouldn't cause problems, as this is similar to how higher Android APIs handle it but it's best to not make unintended changes.

Works on API 16 emulator

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code