### PR TITLE
Brackets in name become possible to be searched

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
@@ -180,13 +180,25 @@ public class Finder {
                 // nesting
             } else if (c == '(' || c == ')') {
                 if (inQuote != 0) {
-                    token += c;
-                } else {
-                    if (c == ')' && token.length() != 0) {
-                        tokens.add(token);
-                        token = "";
+                    if ('(' == inQuote) {
+                        inQuote = 0;
                     }
-                    tokens.add(String.valueOf(c));
+                    token += c;
+                }else {
+                    if (c == '('){
+                        if(i == 0 | (query.charAt(i-1) != ' ' && query.charAt(i-1) != '-')){ //'(' as a card name
+                            inQuote = c;
+                            token += c;
+                        }else{ //'(' as an alternative function
+                            tokens.add(String.valueOf(c));
+                        }
+                    }else{
+                        if (c == ')' && token.length() != 0) {
+                            tokens.add(token);
+                            token = "";
+                        }
+                        tokens.add(String.valueOf(c));
+                    }
                 }
                 // negation
             } else if (c == '-') {


### PR DESCRIPTION
## Purpose / Description
In Card Brower, AnkiDroid use brackets to implement an alternative search function. However, sometimes card name will contain brackets which will be mistakenly identified as a alternative search function. I try to separate these two kinds of brackets and now bracket in searching such as `hello(world)` can be considered as a part of card name.

## Fixes
Fixes #6298

## Approach
Brackets now will be considered as an alternative search function if previous char is `' '` or `'-'` according to https://docs.ankiweb.net/#/searching?id=simple-searches. Otherwise, it will be considered as a part of name. 

## How Has This Been Tested?

+ Create new card name `hello(world)`, `dog cat` and `dog mouse`
+ In Card Brower, search `hello(wor`, `hello(world)` and `dog (cat or mouse)`
+ Successfully return search results.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
