### PR TITLE
[Fixed] Wrong symbol for ascending/descending sorting in card browser #5802

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -534,10 +534,6 @@ public class CardBrowser extends NavigationDrawerActivity implements
         //upgradeJSONIfNecessary during setConf, which means the
         //conf saved may still have this bug.
         mOrderAsc = Upgrade.upgradeJSONIfNecessary(getCol(), getCol().getConf(), "sortBackwards", false);
-        // default to descending for non-text fields
-        if ("noteFld".equals(fSortTypes[mOrder])) {
-            mOrderAsc = !mOrderAsc;
-        }
 
         mCards = new ArrayList<>();
         mCardsListView = (ListView) findViewById(R.id.card_browser_list);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -236,10 +236,6 @@ public class CardBrowser extends NavigationDrawerActivity implements
                             .putBoolean("cardBrowserNoSorting", false)
                             .commit();
                 }
-                // default to descending for non-text fields
-                if ("noteFld".equals(fSortTypes[mOrder])) {
-                    mOrderAsc = true;
-                }
                 getCol().getConf().put("sortBackwards", mOrderAsc);
                 searchCards();
             } else if (which != CARD_ORDER_NONE) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CardBrowserOrderDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CardBrowserOrderDialog.java
@@ -36,9 +36,9 @@ public class CardBrowserOrderDialog extends AnalyticsDialogFragment {
         for (int i = 0; i < items.length; ++i) {
             if (i != CardBrowser.CARD_ORDER_NONE && i == getArguments().getInt("order")) {
                 if (getArguments().getBoolean("isOrderAsc")) {
-                    items[i] = items[i] + " (\u25b2)";
-                } else {
                     items[i] = items[i] + " (\u25bc)";
+                } else {
+                    items[i] = items[i] + " (\u25b2)";
 
                 }
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CardBrowserOrderDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CardBrowserOrderDialog.java
@@ -36,10 +36,9 @@ public class CardBrowserOrderDialog extends AnalyticsDialogFragment {
         for (int i = 0; i < items.length; ++i) {
             if (i != CardBrowser.CARD_ORDER_NONE && i == getArguments().getInt("order")) {
                 if (getArguments().getBoolean("isOrderAsc")) {
-                    items[i] = items[i] + " (\u25bc)";
-                } else {
                     items[i] = items[i] + " (\u25b2)";
-
+                } else {
+                    items[i] = items[i] + " (\u25bc)";
                 }
             }
         }


### PR DESCRIPTION
## Fixes #5802 

![sorting](https://user-images.githubusercontent.com/20339349/83416872-9d68f980-a421-11ea-84bc-5b378a1a6fa0.PNG)
