### PR TITLE
Allow changing the case of a deck name

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -456,8 +456,16 @@ public class Decks {
      */
     public void rename(JSONObject g, String newName) throws DeckRenameException {
         // make sure target node doesn't already exist
-        if (byName(newName) != null) {
-            throw new DeckRenameException(DeckRenameException.ALREADY_EXISTS);
+        JSONObject deckWithThisName = byName(newName);
+        if (deckWithThisName != null) {
+            if (deckWithThisName.getLong("id") != g.getLong("id")) {
+                throw new DeckRenameException(DeckRenameException.ALREADY_EXISTS);
+            }
+            /* else: We are renaming the deck to the "same"
+             * name. I.e. case may varie, normalization may be
+             * different, but anki essentially consider that the name
+             * did not change. We still need to run the remaining of
+             * the code in order do this change. */
         }
         // ensure we have parents
         newName = _ensureParents(newName);


### PR DESCRIPTION
# Pull Request template
## Purpose / Description

## Fixes
Currently, if you try to rename Default to DEFAULT, it will be
rejected because the deck already exists. This code allow this kind of
change to occur.

## Approach
If the deck already exists because it's the same deck than the one renamed, renaming can still go on.

## How Has This Been Tested?

Trying to rename a deck by changing its case.

## Learning (optional, can help others)
Anki recently solved that while moving to rust. Probably in f592672fa952260655881a75a2e3c921b2e23857
I don't understand rust

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
