### PR TITLE
Fix "Too many alarms (500) registered"

### DIFF
--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -193,4 +193,8 @@
 
     <!-- Browser Appearance -->
     <string name="card_template_editor_card_browser_appearance_failed">Could not load Card Browser Appearance</string>
+
+    <!-- Boot Service -->
+    <string name="boot_service_failed_to_schedule_notifications">Failed to schedule reminders</string>
+    <string name="boot_service_too_many_notifications">Too many reminders scheduled. Some will not appear</string>
 </resources>


### PR DESCRIPTION
## Purpose / Description

This is typically caused by having alarms on over 500 decks.

Mostly occurs on Samsung phones.

I'm setting this to high priority as it's more likely to affect med students, and means they can't review, so I'd like to see this out more than my normal fixes.

## Fixes
Fixes #6332

## Approach
Try...catch...Toast

## How Has This Been Tested?

On my phone - brief graphical ghosting of the Toast as it's performed with the Application Context and activities are switched.

## Learning

https://stackoverflow.com/questions/29344971/java-lang-securityexception-too-many-alarms-500-registered-from-pid-10790-u

This occurred on Android 9, so it's more prevalent than just Lolipop.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code