### PR TITLE
Improve opening deck package from Firefox

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -43,6 +43,7 @@ import com.ichi2.anim.ActivityTransitionAnimation;
 import com.ichi2.anki.dialogs.ConfirmationDialog;
 import com.ichi2.anki.dialogs.RescheduleDialog;
 import com.ichi2.anki.reviewer.PeripheralKeymap;
+import com.ichi2.anki.workarounds.FirefoxSnackbarWorkaround;
 import com.ichi2.async.CollectionTask;
 import com.ichi2.anki.reviewer.ActionButtons;
 import com.ichi2.compat.CompatHelper;
@@ -112,6 +113,12 @@ public class Reviewer extends AbstractFlashcardViewer {
     protected void onCreate(Bundle savedInstanceState) {
         Timber.d("onCreate()");
         super.onCreate(savedInstanceState);
+
+        if (FirefoxSnackbarWorkaround.handledLaunchFromWebBrowser(getIntent(), this)) {
+            this.setResult(RESULT_CANCELED);
+            finishWithAnimation(ActivityTransitionAnimation.RIGHT);
+            return;
+        }
 
         if (getIntent().hasExtra("com.ichi2.anki.SchedResetDone")) {
             mSchedResetDone = true;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/workarounds/FirefoxSnackbarWorkaround.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/workarounds/FirefoxSnackbarWorkaround.java
@@ -1,0 +1,58 @@
+/*
+ Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.workarounds;
+
+import android.content.Context;
+import android.content.Intent;
+import android.provider.Browser;
+
+import com.ichi2.anki.R;
+import com.ichi2.anki.UIUtils;
+
+import androidx.annotation.NonNull;
+import timber.log.Timber;
+
+/** #5374
+ *
+ * If a user attempts to open an apkg from the Firefox Snackbar, we just get a ACTION_VIEW on Reviewer...
+ * It works if they click the download notification, but if they click "Open", then that disappears.
+ *
+ * So... tell them to go to about:downloads, or select the file from their file manager.
+ * It sucks, but not much we can do.
+ *
+ * Reported as fixed in Firefox Preview
+ */
+public class FirefoxSnackbarWorkaround {
+
+    public static boolean handledLaunchFromWebBrowser(@NonNull Intent intent, @NonNull Context context) {
+        //noinspection ConstantConditions
+        if (intent == null) {
+            Timber.w("FirefoxSnackbarWorkaround: No intent provided");
+            return false;
+        }
+        if (wasLaunchFromWebBrowser(intent)) {
+            UIUtils.showThemedToast(context, context.getString(R.string.firefox_workaround_launched_reviewer_opening_deck), false);
+            return true;
+        }
+        return false;
+    }
+
+
+    private static boolean wasLaunchFromWebBrowser(@NonNull Intent intent) {
+        return intent.getStringExtra(Browser.EXTRA_APPLICATION_ID) != null;
+    }
+}

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -71,6 +71,7 @@
         <item quantity="one">%d card rescheduled</item>
         <item quantity="other">%d cards rescheduled</item>
     </plurals>
+    <string name="firefox_workaround_launched_reviewer_opening_deck">Select the deck in your file manager or visit the about:downloads page to import it</string>
     <string name="answering_error_title">Database error</string>
     <string name="answering_error_message">Writing to the collection failed. The databese could be corrupt or there may not to be enough empty space on disk.\n\nIf this happens more often, try checking the database, repairing the collection or restoring it from a backup. Touch “options” for that.\n\Or it could be an AnkiDroid bug as well; please report the error so that we can check this.</string>
     <string name="answering_error_report">Report error</string>


### PR DESCRIPTION
## Review Goals

* Should we limit this to certain browsers?
* Is there a chance that a browser will actually want to call `ACTION_VIEW` on the Reviewer intent?
* Probably needs some "nicer UI" fixes on the display string.

## Purpose / Description

Clicking "Open" with the download snackbar in firefox just opens the reviewer. Notify the user that they should do something else to open the file.

Seems like a bug in Firefox.

## Fixes
Fixes #5374

## Approach
Show a toast and close the app

## How Has This Been Tested?

Reviewer still works, toast is displayed.

## Learning
It's a nightmare to submit bugs to Firefox without knowing the process.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code