### PR TITLE
Card Browser: Always show 'Search All'

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1699,18 +1699,27 @@ public class CardBrowser extends NavigationDrawerActivity implements
             Timber.i("CardBrowser:: Completed doInBackgroundSearchCards Successfully");
             updateList();
             if ((mSearchView != null) && !mSearchView.isIconified()) {
-                if (getCardCount() == 0 && !hasSelectedAllDecks()) {
-                    View root = CardBrowser.this.findViewById(R.id.root_layout);
-                    UIUtils.showSnackbar(CardBrowser.this,
-                            getString(R.string.card_browser_no_cards_in_deck, getSelectedDeckNameForUi()),
-                            SNACKBAR_DURATION,
-                            R.string.card_browser_search_all_decks,
-                            (v) -> searchAllDecks(),
-                            root,
-                            null);
-                } else {
+                if (hasSelectedAllDecks()) {
                     UIUtils.showSimpleSnackbar(CardBrowser.this, getSubtitleText(), true);
+                    return;
                 }
+
+                //If we haven't selected all decks, allow the user the option to search all decks.
+                String displayText;
+                if (getCardCount() == 0) {
+                    displayText = getString(R.string.card_browser_no_cards_in_deck, getSelectedDeckNameForUi());
+                } else {
+                    displayText = getSubtitleText();
+                }
+                View root = CardBrowser.this.findViewById(R.id.root_layout);
+                UIUtils.showSnackbar(CardBrowser.this,
+                        displayText,
+                        SNACKBAR_DURATION,
+                        R.string.card_browser_search_all_decks,
+                        (v) -> searchAllDecks(),
+                        root,
+                        null);
+
             }
         }
     };

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1698,29 +1698,32 @@ public class CardBrowser extends NavigationDrawerActivity implements
         private void handleSearchResult() {
             Timber.i("CardBrowser:: Completed doInBackgroundSearchCards Successfully");
             updateList();
-            if ((mSearchView != null) && !mSearchView.isIconified()) {
-                if (hasSelectedAllDecks()) {
-                    UIUtils.showSimpleSnackbar(CardBrowser.this, getSubtitleText(), true);
-                    return;
-                }
-
-                //If we haven't selected all decks, allow the user the option to search all decks.
-                String displayText;
-                if (getCardCount() == 0) {
-                    displayText = getString(R.string.card_browser_no_cards_in_deck, getSelectedDeckNameForUi());
-                } else {
-                    displayText = getSubtitleText();
-                }
-                View root = CardBrowser.this.findViewById(R.id.root_layout);
-                UIUtils.showSnackbar(CardBrowser.this,
-                        displayText,
-                        SNACKBAR_DURATION,
-                        R.string.card_browser_search_all_decks,
-                        (v) -> searchAllDecks(),
-                        root,
-                        null);
-
+            
+            if ((mSearchView == null) || mSearchView.isIconified()) {
+                return;
             }
+
+            if (hasSelectedAllDecks()) {
+                UIUtils.showSimpleSnackbar(CardBrowser.this, getSubtitleText(), true);
+                return;
+            }
+
+            //If we haven't selected all decks, allow the user the option to search all decks.
+            String displayText;
+            if (getCardCount() == 0) {
+                displayText = getString(R.string.card_browser_no_cards_in_deck, getSelectedDeckNameForUi());
+            } else {
+                displayText = getSubtitleText();
+            }
+            View root = CardBrowser.this.findViewById(R.id.root_layout);
+            UIUtils.showSnackbar(CardBrowser.this,
+                    displayText,
+                    SNACKBAR_DURATION,
+                    R.string.card_browser_search_all_decks,
+                    (v) -> searchAllDecks(),
+                    root,
+                    null);
+
         }
     };
 


### PR DESCRIPTION
## Draft

Realised that "Search All" makes little sense without explaining that a deck was searched.

##  Purpose / Description
Already requested by 2 users since it went into the alpha - seems like a great improvement got even better

## Fixes
Fixes #6344

## Approach
Just refactor the logic and remove the need for `cards == 0`

## How Has This Been Tested?

On my device

## Learning 
Lovely to get feedback from Alpha testers

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code