### PR TITLE
Revert "Remove possibility of TagsDialog NullPointerException"

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1211,9 +1211,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
     private void showTagsDialog() {
         TagsDialog dialog = TagsDialog.newInstance(
-                TagsDialog.TYPE_FILTER_BY_TAG,
-                new ArrayList<String>(), new ArrayList<>(getCol().getTags().all()),
-                this::filterByTag);
+                TagsDialog.TYPE_FILTER_BY_TAG, new ArrayList<String>(), new ArrayList<>(getCol().getTags().all()));
+        dialog.setTagsDialogListener(this::filterByTag);
         showDialogFragment(dialog);
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1212,7 +1212,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
     private void showTagsDialog() {
         TagsDialog dialog = TagsDialog.newInstance(
                 TagsDialog.TYPE_FILTER_BY_TAG,
-                new ArrayList<>(), new ArrayList<>(getCol().getTags().all()),
+                new ArrayList<String>(), new ArrayList<>(getCol().getTags().all()),
                 this::filterByTag);
         showDialogFragment(dialog);
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1025,7 +1025,8 @@ public class NoteEditor extends AnkiActivity {
             mSelectedTags = selectedTags;
             updateTags();
         };
-        TagsDialog dialog = TagsDialog.newInstance(TagsDialog.TYPE_ADD_TAG, selTags, tags, tagsDialogListener);
+        TagsDialog dialog = TagsDialog.newInstance(TagsDialog.TYPE_ADD_TAG, selTags, tags);
+        dialog.setTagsDialogListener(tagsDialogListener);
         showDialogFragment(dialog);
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
@@ -151,7 +151,7 @@ public class CustomStudyDialog extends AnalyticsDialogFragment {
                                 long currentDeck = getArguments().getLong("did");
                                 TagsDialog dialogFragment = TagsDialog.newInstance(
                                         TagsDialog.TYPE_CUSTOM_STUDY_TAGS,
-                                        new ArrayList<>(),
+                                        new ArrayList<String>(),
                                         new ArrayList<>(activity.getCol().getTags().byDeck(currentDeck, true)),
                                         CustomStudyDialog.this::customStudyFromTags);
                                 activity.showDialogFragment(dialogFragment);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
@@ -150,10 +150,9 @@ public class CustomStudyDialog extends AnalyticsDialogFragment {
                                  */
                                 long currentDeck = getArguments().getLong("did");
                                 TagsDialog dialogFragment = TagsDialog.newInstance(
-                                        TagsDialog.TYPE_CUSTOM_STUDY_TAGS,
-                                        new ArrayList<String>(),
-                                        new ArrayList<>(activity.getCol().getTags().byDeck(currentDeck, true)),
-                                        CustomStudyDialog.this::customStudyFromTags);
+                                        TagsDialog.TYPE_CUSTOM_STUDY_TAGS, new ArrayList<String>(),
+                                        new ArrayList<>(activity.getCol().getTags().byDeck(currentDeck, true)));
+                                dialogFragment.setTagsDialogListener(CustomStudyDialog.this::customStudyFromTags);
                                 activity.showDialogFragment(dialogFragment);
                                 break;
                             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TagsDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TagsDialog.java
@@ -53,8 +53,7 @@ public class TagsDialog extends AnalyticsDialogFragment {
 
     private String mPositiveText;
     private String mDialogTitle;
-    @NonNull
-    private TagsDialogListener mTagsDialogListener;
+    private TagsDialogListener mTagsDialogListener = null;
     private TagsArrayAdapter mTagsArrayAdapter;
     private int mSelectedOption = -1;
 
@@ -66,13 +65,9 @@ public class TagsDialog extends AnalyticsDialogFragment {
 
     private MaterialDialog mDialog;
 
-    public TagsDialog(@NonNull TagsDialogListener onPositive) {
-        this.mTagsDialogListener = onPositive;
-    }
-
     public static TagsDialog newInstance(int type, ArrayList<String> checked_tags,
-                                            ArrayList<String> all_tags, @NonNull TagsDialogListener onPositive) {
-        TagsDialog t = new TagsDialog(onPositive);
+                                            ArrayList<String> all_tags) {
+        TagsDialog t = new TagsDialog();
 
         Bundle args = new Bundle();
         args.putInt(DIALOG_TYPE_KEY, type);
@@ -272,6 +267,10 @@ public class TagsDialog extends AnalyticsDialogFragment {
             UIUtils.showSnackbar(getActivity(), feedbackText, false, -1, null,
                     mDialog.getView().findViewById(R.id.tags_dialog_snackbar), null);
         }
+    }
+
+    public void setTagsDialogListener(TagsDialogListener selectedTagsListener) {
+        mTagsDialogListener = selectedTagsListener;
     }
 
     public class TagsArrayAdapter extends  RecyclerView.Adapter<TagsArrayAdapter.ViewHolder> implements Filterable{


### PR DESCRIPTION
**Please wait for Travis before review**

Reverts #6175 (manually)

The above commit is a bugfix for an issue which appeared to be from automated testing.

In doing so, this adds a parameter to the fragment constructor, which I didn't realise shouldn't be done.

----

> All `Fragment` classes you create **must** have a public, no-arg constructor.

Saw a crash on ACRA due to "Could not find Fragment constructor"


https://couchdb.ankidroid.org/acralyzer/_design/acralyzer/index.html#/report-details/990db3a6-6ea8-44da-96dd-0e6e41db7769

```
java.lang.RuntimeException: Unable to start activity ComponentInfo{com.ichi2.anki/com.ichi2.anki.NoteEditor}: androidx.fragment.app.Fragment$InstantiationException: Unable to instantiate fragment com.ichi2.anki.dialogs.TagsDialog: could not find Fragment constructor
at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3430)
at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3614)
at android.app.ActivityThread.handleRelaunchActivityInner(ActivityThread.java:5527)
at android.app.ActivityThread.handleRelaunchActivity(ActivityThread.java:5418)
at android.app.servertransaction.ActivityRelaunchItem.execute(ActivityRelaunchItem.java:69)
at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:108)
at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:68)
at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2199)
at android.os.Handler.dispatchMessage(Handler.java:112)
at android.os.Looper.loop(Looper.java:216)
at android.app.ActivityThread.main(ActivityThread.java:7625)
at java.lang.reflect.Method.invoke(Native Method)
at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:524)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:987)
Caused by: androidx.fragment.app.Fragment$InstantiationException: Unable to instantiate fragment com.ichi2.anki.dialogs.TagsDialog: could not find Fragment constructor
at androidx.fragment.app.Fragment.instantiate(Fragment.java:8)
at androidx.fragment.app.FragmentContainer.instantiate(FragmentContainer.java:1)
at androidx.fragment.app.FragmentManagerImpl$6.instantiate(FragmentManagerImpl.java:1)
at androidx.fragment.app.FragmentState.instantiate(FragmentState.java:4)
at androidx.fragment.app.FragmentManagerImpl.restoreSaveState(FragmentManagerImpl.java:27)
at androidx.fragment.app.FragmentController.restoreSaveState(FragmentController.java:2)
at androidx.fragment.app.FragmentActivity.onCreate(FragmentActivity.java:3)
at androidx.appcompat.app.AppCompatActivity.onCreate(AppCompatActivity.java:4)
at com.ichi2.anki.AnkiActivity.onCreate(AnkiActivity.java:4)
at com.ichi2.anki.NoteEditor.onCreate(NoteEditor.java:2)
at android.app.Activity.performCreate(Activity.java:7458)
at android.app.Activity.performCreate(Activity.java:7448)
at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1286)
at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3409)
... 13 more
Caused by: java.lang.NoSuchMethodException: <init> []
at java.lang.Class.getConstructor0(Class.java:2327)
at java.lang.Class.getConstructor(Class.java:1725)
at androidx.fragment.app.Fragment.instantiate(Fragment.java:4)
... 26 more
```