### PR TITLE
Use Anki Desktop compatible LaTeX nightmode

### DIFF
--- a/AnkiDroid/src/main/assets/flashcard.css
+++ b/AnkiDroid/src/main/assets/flashcard.css
@@ -2,7 +2,8 @@ body {
   margin: 0px;
   padding: 0px;
 }
-.night_mode .latex {
+
+.nightMode .latex {
     background-color: white;
 }
 


### PR DESCRIPTION
## Purpose / Description
#6206 introduced `nightMode` in our CSS, this was merged after #6246 which added a background to LaTeX images.

This makes it easier for users to produce Anki Desktop compatible code.

## Approach
Use `nightMode` instead of `night_mode`

## How Has This Been Tested?

On my device, works as expected

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code