### PR TITLE
NF: Avoid mdecks

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -129,7 +129,6 @@ public class CardBrowser extends NavigationDrawerActivity implements
     public static final String REVIEWS = "reviews";
 
     private List<Map<String, String>> mCards;
-    private HashMap<String, String> mDeckNames;
     private ArrayList<JSONObject> mDropDownDecks;
     private ListView mCardsListView;
     private SearchView mSearchView;
@@ -485,10 +484,6 @@ public class CardBrowser extends NavigationDrawerActivity implements
     protected void onCollectionLoaded(Collection col) {
         super.onCollectionLoaded(col);
         Timber.d("onCollectionLoaded()");
-        mDeckNames = new HashMap<>();
-        for (long did : getCol().getDecks().allIds()) {
-            mDeckNames.put(String.valueOf(did), getCol().getDecks().name(did));
-        }
         registerExternalStorageListener();
 
         SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(getBaseContext());

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1278,7 +1278,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
                     TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 20, getResources().getDisplayMetrics())) + 5;
             // Perform database query to get all card ids
             CollectionTask.launchCollectionTask(CollectionTask.TASK_TYPE_SEARCH_CARDS, mSearchCardsHandler, new CollectionTask.TaskData(
-                    new Object[] { mDeckNames, searchText, ((mOrder != CARD_ORDER_NONE)),  numCardsToRender}));
+                    new Object[] {searchText, ((mOrder != CARD_ORDER_NONE)),  numCardsToRender}));
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -896,7 +896,7 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
         String query = (String) params[0].getObjArray()[1];
         Boolean order = (Boolean) params[0].getObjArray()[2];
         int numCardsToRender = (int) params[0].getObjArray()[3];
-        List<Map<String,String>> searchResult = col.findCardsForCardBrowser(query, order, deckNames);
+        List<Map<String,String>> searchResult = col.findCardsForCardBrowser(query, order);
         // Render the first few items
         for (int i = 0; i < Math.min(numCardsToRender, searchResult.size()); i++) {
             Card c = col.getCard(Long.parseLong(searchResult.get(i).get("id")));

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -892,10 +892,9 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
     private TaskData doInBackgroundSearchCards(TaskData... params) {
         Timber.d("doInBackgroundSearchCards");
         Collection col = CollectionHelper.getInstance().getCol(mContext);
-        Map<String, String> deckNames = (HashMap<String, String>) params[0].getObjArray()[0];
-        String query = (String) params[0].getObjArray()[1];
-        Boolean order = (Boolean) params[0].getObjArray()[2];
-        int numCardsToRender = (int) params[0].getObjArray()[3];
+        String query = (String) params[0].getObjArray()[0];
+        Boolean order = (Boolean) params[0].getObjArray()[1];
+        int numCardsToRender = (int) params[0].getObjArray()[2];
         List<Map<String,String>> searchResult = col.findCardsForCardBrowser(query, order);
         // Render the first few items
         for (int i = 0; i < Math.min(numCardsToRender, searchResult.size()); i++) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1123,8 +1123,8 @@ public class Collection {
     }
 
 
-    public List<Map<String, String>> findCardsForCardBrowser(String search, boolean order, Map<String, String> deckNames) {
-        return new Finder(this).findCardsForCardBrowser(search, order, deckNames);
+    public List<Map<String, String>> findCardsForCardBrowser(String search, boolean order) {
+        return new Finder(this).findCardsForCardBrowser(search, order);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
@@ -1039,7 +1039,8 @@ public class Finder {
                 Map<String, String> card = new HashMap<>();
                 card.put(CardBrowser.ID, cur.getString(0));
                 card.put(CardBrowser.SFLD, cur.getString(1));
-                card.put(CardBrowser.DECK, deckNames.get(cur.getString(2)));
+                String did = cur.getString(2);
+                card.put(CardBrowser.DECK, deckNames.get(did));
                 int queue = cur.getInt(3);
                 String tags = cur.getString(4);
                 card.put(CardBrowser.TAGS, tags);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
@@ -1039,8 +1039,8 @@ public class Finder {
                 Map<String, String> card = new HashMap<>();
                 card.put(CardBrowser.ID, cur.getString(0));
                 card.put(CardBrowser.SFLD, cur.getString(1));
-                String did = cur.getString(2);
-                card.put(CardBrowser.DECK, deckNames.get(did));
+                long did = cur.getLong(2);
+                card.put(CardBrowser.DECK, mCol.getDecks().name(did));
                 int queue = cur.getInt(3);
                 String tags = cur.getString(4);
                 card.put(CardBrowser.TAGS, tags);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
@@ -1004,18 +1004,18 @@ public class Finder {
      * ***********************************************************
      */
 
-    public List<Map<String, String>> findCardsForCardBrowser(String query, boolean _order, Map<String, String> deckNames) {
-        return _findCardsForCardBrowser(query, _order, deckNames);
+    public List<Map<String, String>> findCardsForCardBrowser(String query, boolean _order) {
+        return _findCardsForCardBrowser(query, _order);
     }
 
 
-    public List<Map<String, String>> findCardsForCardBrowser(String query, String _order, Map<String, String> deckNames) {
-        return _findCardsForCardBrowser(query, _order, deckNames);
+    public List<Map<String, String>> findCardsForCardBrowser(String query, String _order) {
+        return _findCardsForCardBrowser(query, _order);
     }
 
 
     /** Return a list of card ids for QUERY */
-    private List<Map<String, String>> _findCardsForCardBrowser(String query, Object _order, Map<String, String> deckNames) {
+    private List<Map<String, String>> _findCardsForCardBrowser(String query, Object _order) {
         String[] tokens = _tokenize(query);
         Pair<String, String[]> res1 = _where(tokens);
         String preds = res1.first;


### PR DESCRIPTION
I learned my lesson. Before doing an actual PR with any effect, I'm doing the cleaning first.

The card browser has a member mDecks which seems quite useless, as it has the same content as the deck manager. Removing it and removing the few places where it is used allow to make code slightly smaller. It will also allows eventually to make card browser faster