### PR TITLE
Checking which cards are marked is moved to CardBrowser

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -127,6 +127,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
     public static final String LAPSES = "lapses";
     public static final String NOTE = "note";
     public static final String REVIEWS = "reviews";
+    private static Pattern sMarkedPattern = Pattern.compile(".*[Mm]arked.*");
 
     private List<Map<String, String>> mCards;
     private ArrayList<JSONObject> mDropDownDecks;
@@ -1531,7 +1532,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
         item.put(NOTE, c.model().optString("name"));
         item.put(QUESTION, formatQA(q, context));
         item.put(REVIEWS, Integer.toString(c.getReps()));
-        item.put(MARKED, (item.get(TAGS).matches(".*[Mm]arked.*"))?"marked": null);
+        item.put(MARKED, (sMarkedPattern.matcher(item.get(TAGS)).matches())?"marked": null);
     }
 
     @CheckResult

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1531,6 +1531,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
         item.put(NOTE, c.model().optString("name"));
         item.put(QUESTION, formatQA(q, context));
         item.put(REVIEWS, Integer.toString(c.getReps()));
+        item.put(MARKED, (item.get(TAGS).matches(".*[Mm]arked.*"))?"marked": null);
     }
 
     @CheckResult

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
@@ -1050,7 +1050,6 @@ public class Finder {
                 card.put(CardBrowser.ANSWER, null);
                 card.put(CardBrowser.FLAGS, (new Integer(Card.intToFlag(cur.getInt(5)))).toString());
                 card.put(CardBrowser.SUSPENDED, queue == Consts.QUEUE_TYPE_SUSPENDED ? "True": "False");
-                card.put(CardBrowser.MARKED, (tags.matches(".*[Mm]arked.*"))?"marked": null);
             }
         } catch (SQLException e) {
             // invalid grouping


### PR DESCRIPTION
Currently, asking the browser to show the whole collection takes
multiple minutes. On a smaller deck, it takes 40 seconds, out of which
15 are spent executing the regexp and looking for marked cards.

Moving it to updateSearchItemQA ensure it is executed only for card we
intend to display and save most of this time