### PR TITLE
Upgrade API to Java 1.8 to allow JDK 14 compilation

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -18,7 +18,7 @@ android {
     defaultConfig {
         applicationId "com.ichi2.anki"
         minSdkVersion 16
-        //noinspection OldTargetApi
+        //noinspection OldTargetApi - also performed in api/build.fradle
         targetSdkVersion 28
         multiDexEnabled true
         testApplicationId "com.ichi2.anki.tests"

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -28,6 +28,10 @@ android {
             includeAndroidResources = true
         }
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
     testOptions.unitTests.all {
         testLogging {
             events "failed", "skipped"

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -13,6 +13,7 @@ android {
 
     defaultConfig {
         minSdkVersion 8
+        //noinspection OldTargetApi
         targetSdkVersion 28
         versionCode 11016   // 4th digit: 1=alpha, 2=beta, 3=official
         versionName version


### PR DESCRIPTION
## Fixes
Fixes #5955 

## How Has This Been Tested?

⚠️ It compiles, and I believe it's unit tested. I ran the connected tests and they all pass on API 16 - we do the same in `AnkiDroid`, but `api` still supports `minSdkVersion 8`

## Learning 

![](https://imgs.xkcd.com/comics/computer_problems.png)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code