### PR TITLE
Browser: Don't compute question/answer unless they are required

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -2124,10 +2124,10 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 case 4:
                     return R.attr.flagBlue;
                 default:
-                    if (get(MARKED) != null) {
+                    if (getCard().note().hasTag("marked")) {
                         return R.attr.markedColor;
                     } else {
-                        if ("True".equals(get(SUSPENDED))) {
+                        if (getCard().getQueue() == Consts.QUEUE_TYPE_SUSPENDED) {
                             return R.attr.suspendedColor;
                         } else {
                             return android.R.attr.colorBackground;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1935,7 +1935,10 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 // set font for column
                 setFont(col);
                 // set text for column
-                String text_for_column = card.get(mFromKeys[i]);
+                String text_for_column = card.getColumnHeaderText(mFromKeys[i]);
+                if (text_for_column == null) {
+                    text_for_column = card.get(mFromKeys[i]);
+                }
                 col.setText(text_for_column);
             }
             // set card's background color
@@ -2134,6 +2137,13 @@ public class CardBrowser extends NavigationDrawerActivity implements
                             return android.R.attr.colorBackground;
                         }
                     }
+            }
+        }
+
+        public String getColumnHeaderText(String key) {
+            switch (key) {
+            default:
+                return null;
             }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -2166,6 +2166,25 @@ public class CardBrowser extends NavigationDrawerActivity implements
             q = formatQA(q, AnkiDroidApp.getInstance());
             mQa = new Pair<>(q, a);
         }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            return getId() == ((CardCache) obj).getId();
+        }
+
+        @Override
+        public int hashCode() {
+            return new Long(getId()).hashCode();
+        }
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1594,9 +1594,9 @@ public class CardBrowser extends NavigationDrawerActivity implements
         }
 
         List<CardCache> newMCards = new ArrayList<>();
-        for (CardCache cardProperties: oldMCards) {
-            if (! idToRemove.contains(cardProperties.getId())) {
-                newMCards.add(cardProperties);
+        for (CardCache card: oldMCards) {
+            if (!idToRemove.contains(card.getId())) {
+                newMCards.add(card);
             }
         }
         mCards = newMCards;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -378,7 +378,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
         long[] ids = new long[checkedPositions.length];
         int count = 0;
         for (int cardPosition : checkedPositions) {
-            ids[count++] = Long.valueOf(mCards.get(cardPosition).get(ID));
+            ids[count++] = mCards.get(cardPosition).getId();
         }
         return ids;
     }
@@ -611,7 +611,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
                     onCheck(position, view);
                 } else {
                     // load up the card selected on the list
-                    long clickedCardId = Long.parseLong(getCards().get(position).get(ID));
+                    long clickedCardId = getCards().get(position).getId();
                     openNoteEditorForCard(clickedCardId);
                 }
             }
@@ -1290,7 +1290,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
     private Map<Long, Integer> getPositionMap(List<CardCache> list) {
         Map<Long, Integer> positions = new HashMap<>();
         for (int i = 0; i < list.size(); i++) {
-            positions.put(Long.valueOf(list.get(i).get(ID)), i);
+            positions.put(list.get(i).getId(), i);
         }
         return positions;
     }
@@ -1595,7 +1595,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
         List<CardCache> newMCards = new ArrayList<>();
         for (CardCache cardProperties: oldMCards) {
-            if (! idToRemove.contains(Long.parseLong(cardProperties.get(ID)))) {
+            if (! idToRemove.contains(cardProperties.getId())) {
                 newMCards.add(cardProperties);
             }
         }
@@ -2049,7 +2049,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
     int getFlagOrDefault(CardCache card, int defaultValue) {
         String flagValue = card.get(FLAGS);
         if (flagValue == null) {
-            Timber.d("Unable to obtain flag for card: '%s'. Returning %d", card.get(ID), defaultValue);
+            Timber.d("Unable to obtain flag for card: '%s'. Returning %d", card.getId(), defaultValue);
             return defaultValue;
         }
         try {
@@ -2123,18 +2123,27 @@ public class CardBrowser extends NavigationDrawerActivity implements
     private long[] getAllCardIds() {
         long[] l = new long[mCards.size()];
         for (int i = 0; i < mCards.size(); i++) {
-            l[i] = Long.parseLong(mCards.get(i).get(ID));
+            l[i] = mCards.get(i).getId();
         }
         return l;
     }
 
     public static class CardCache extends HashMap<String, String> {
+        private long mId;
+        private Collection mCol;
+
+        public CardCache(long id, Collection col) {
+            mId = id;
+            mCol = col;
+        }
+
+        public long getId() {
+            return mId;
+        }
 
         /** clear all values except ID.*/
         public void reload() {
-            String id = get(ID);
             clear();
-            put(ID, id);
         }
     }
 
@@ -2258,7 +2267,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
         CardCache[] cardsCopy = mCards.toArray(new CardCache[0]);
         long[] ret = new long[cardsCopy.length];
         for (int i = 0; i < cardsCopy.length; i++) {
-            ret[i] = Long.parseLong(cardsCopy[i].get(ID));
+            ret[i] = cardsCopy[i].getId();
         }
         return ret;
     }
@@ -2298,8 +2307,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
     public List<Long> getCheckedCardIds() {
         List<Long> cardIds = new ArrayList<>();
         for (Integer pos : mCheckedCardPositions) {
-            String id = mCards.get(pos).get(ID);
-            cardIds.add(Long.valueOf(Objects.requireNonNull(id)));
+            long id = mCards.get(pos).getId();
+            cardIds.add(Objects.requireNonNull(id));
         }
         return cardIds;
     }
@@ -2315,8 +2324,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     public CardCache getPropertiesForCardId(long cardId) {
         for (CardCache props : mCards) {
-            String id = Objects.requireNonNull(props.get(ID));
-            if (Long.parseLong(id) == cardId) {
+            long id = Objects.requireNonNull(props.getId());
+            if (id == cardId) {
                 return props;
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1483,7 +1483,6 @@ public class CardBrowser extends NavigationDrawerActivity implements
         item.put(ANSWER, formatQA(a, context));
 
         Note note = c.note();
-        item.put(CHANGED, LanguageUtil.getShortDateFormatFromS(c.getMod()));
         item.put(CREATED, LanguageUtil.getShortDateFormatFromMs(note.getId()));
         item.put(EDITED, LanguageUtil.getShortDateFormatFromS(note.getMod()));
         // interval
@@ -2135,6 +2134,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 } else {
                     return (getCard().getFactor()/10)+"%";
                 }
+            case CHANGED:
+                return LanguageUtil.getShortDateFormatFromS(getCard().getMod());
             default:
                 return null;
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1481,7 +1481,6 @@ public class CardBrowser extends NavigationDrawerActivity implements
         // database
         item.put(ANSWER, formatQA(a, context));
         item.put(QUESTION, formatQA(q, context));
-        item.put(REVIEWS, Integer.toString(c.getReps()));
     }
 
     @CheckResult
@@ -2134,6 +2133,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 return Integer.toString(getCard().getLapses());
             case NOTE_TYPE:
                 return getCard().model().optString("name");
+            case REVIEWS:
+                return Integer.toString(getCard().getReps());
             default:
                 return null;
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1416,7 +1416,6 @@ public class CardBrowser extends NavigationDrawerActivity implements
             CardCache card = getCards().get(pos);
             card.load(true);
             // update tags
-            card.put(MARKED, (c.note().hasTag("marked")) ? "marked" : null);
             if (updatedCardTags != null) {
                 card.put(TAGS, updatedCardTags.get(c.getNid()));
             }
@@ -1526,7 +1525,6 @@ public class CardBrowser extends NavigationDrawerActivity implements
         item.put(REVIEWS, Integer.toString(c.getReps()));
         String tags = note.stringTags();
         item.put(TAGS, tags);
-        item.put(MARKED, (sMarkedPattern.matcher(item.get(TAGS)).matches())?"marked": null);
         item.put(DECK, col.getDecks().name(c.getDid()));
         item.put(SFLD, note.getSFld());
     }
@@ -2144,6 +2142,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 return (new Integer(getCard().userFlag())).toString();
             case SUSPENDED:
                 return getCard().getQueue() == Consts.QUEUE_TYPE_SUSPENDED ? "True": "False";
+            case MARKED:
+                return getCard().note().hasTag("marked") ? "marked" : null;
             default:
                 return null;
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -75,7 +75,6 @@ import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Consts;
 import com.ichi2.libanki.Decks;
-import com.ichi2.libanki.Note;
 import com.ichi2.libanki.Utils;
 import com.ichi2.libanki.Deck;
 import com.ichi2.themes.Themes;
@@ -1482,8 +1481,6 @@ public class CardBrowser extends NavigationDrawerActivity implements
         // database
         item.put(ANSWER, formatQA(a, context));
 
-        Note note = c.note();
-        item.put(EDITED, LanguageUtil.getShortDateFormatFromS(note.getMod()));
         // interval
         switch (c.getType()) {
             case Consts.CARD_TYPE_NEW:
@@ -2137,6 +2134,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 return LanguageUtil.getShortDateFormatFromS(getCard().getMod());
             case CREATED:
                 return LanguageUtil.getShortDateFormatFromMs(getCard().note().getId());
+            case EDITED:
+                return LanguageUtil.getShortDateFormatFromS(getCard().note().getMod());
             default:
                 return null;
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1411,9 +1411,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
             if (pos < 0 || pos >= getCardCount()) {
                 continue;
             }
-            CardCache card = getCards().get(pos);
             // update Q & A etc
-            card.load(true);
+            getCards().get(pos).load(true);
         }
 
         updateList();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -106,30 +106,32 @@ import timber.log.Timber;
 import static com.ichi2.async.CollectionTask.TASK_TYPE.*;
 import com.ichi2.async.TaskData;
 
+import static com.ichi2.anki.CardBrowser.Column.*;
+
 public class CardBrowser extends NavigationDrawerActivity implements
         DeckDropDownAdapter.SubtitleListener {
 
-    // Properties in mCards. this is a stringly typed map for speed.
-    // Would be even faster as an array given these are all consts.
-    public static final String QUESTION = "question";
-    public static final String ANSWER = "answer";
-    public static final String FLAGS = "flags";
-    public static final String SUSPENDED = "suspended";
-    public static final String MARKED = "marked";
-    public static final String SFLD = "sfld";
-    public static final String DECK = "deck";
-    public static final String TAGS = "tags";
-    public static final String ID = "id";
-    public static final String CARD = "card";
-    public static final String DUE = "due";
-    public static final String EASE = "ease";
-    public static final String CHANGED = "changed";
-    public static final String CREATED = "created";
-    public static final String EDITED = "edited";
-    public static final String INTERVAL = "interval";
-    public static final String LAPSES = "lapses";
-    public static final String NOTE_TYPE = "note";
-    public static final String REVIEWS = "reviews";
+    enum Column {
+        QUESTION,
+        ANSWER,
+        FLAGS,
+        SUSPENDED,
+        MARKED,
+        SFLD,
+        DECK,
+        TAGS,
+        ID,
+        CARD,
+        DUE,
+        EASE,
+        CHANGED,
+        CREATED,
+        EDITED,
+        INTERVAL,
+        LAPSES,
+        NOTE_TYPE,
+        REVIEWS
+    }
 
     private List<CardCache> mCards;
     private ArrayList<Deck> mDropDownDecks;
@@ -175,11 +177,11 @@ public class CardBrowser extends NavigationDrawerActivity implements
         "cardEase",
         "cardReps",
         "cardLapses"};
-    private static final String[] COLUMN1_KEYS = {QUESTION, SFLD};
+    private static final Column[] COLUMN1_KEYS = {QUESTION, SFLD};
 
     // list of available keys in mCards corresponding to the column names in R.array.browser_column2_headings.
     // Note: the last 6 are currently hidden
-    private static final String[] COLUMN2_KEYS = {ANSWER,
+    private static final Column[] COLUMN2_KEYS = {ANSWER,
         CARD,
         DECK,
         NOTE_TYPE,
@@ -534,7 +536,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
                     mColumn1Index = pos;
                     AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance().getBaseContext()).edit()
                             .putInt("cardBrowserColumn1", mColumn1Index).commit();
-                    String[] fromMap = mCardsAdapter.getFromMapping();
+                    Column[] fromMap = mCardsAdapter.getFromMapping();
                     fromMap[0] = COLUMN1_KEYS[mColumn1Index];
                     mCardsAdapter.setFromMapping(fromMap);
                 }
@@ -562,10 +564,10 @@ public class CardBrowser extends NavigationDrawerActivity implements
                     mColumn2Index = pos;
                     AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance().getBaseContext()).edit()
                             .putInt("cardBrowserColumn2", mColumn2Index).commit();
-                    String[] fromMap = mCardsAdapter.getFromMapping();
+                    Column[] fromMap = mCardsAdapter.getFromMapping();
                     fromMap[1] = COLUMN2_KEYS[mColumn2Index];
                     if (fromMap[1] == null) {
-                        fromMap[1] = "";
+                        fromMap[1] = ANSWER;
                     }
                     mCardsAdapter.setFromMapping(fromMap);
                 }
@@ -579,9 +581,9 @@ public class CardBrowser extends NavigationDrawerActivity implements
         // get the font and font size from the preferences
         int sflRelativeFontSize = preferences.getInt("relativeCardBrowserFontSize", DEFAULT_FONT_SIZE_RATIO);
         String sflCustomFont = preferences.getString("browserEditorFont", "");
-        String[] columnsContent = {COLUMN1_KEYS[mColumn1Index], COLUMN2_KEYS[mColumn2Index]};
+        Column[] columnsContent = {COLUMN1_KEYS[mColumn1Index], COLUMN2_KEYS[mColumn2Index]};
         if (columnsContent[1] == null) {
-            columnsContent[1] = "";
+            columnsContent[1] = ANSWER;
         }
         // make a new list adapter mapping the data in mCards to column1 and column2 of R.layout.card_item_browser
         mCardsAdapter = new MultiColumnListAdapter(
@@ -1808,14 +1810,14 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
     private final class MultiColumnListAdapter extends BaseAdapter {
         private final int mResource;
-        private String[] mFromKeys;
+        private Column[] mFromKeys;
         private final int[] mToIds;
         private float mOriginalTextSize = -1.0f;
         private final int mFontSizeScalePcent;
         private Typeface mCustomTypeface = null;
         private LayoutInflater mInflater;
 
-        public MultiColumnListAdapter(Context context, int resource, String[] from, int[] to,
+        public MultiColumnListAdapter(Context context, int resource, Column[] from, int[] to,
                                       int fontSizeScalePcent, String customFont) {
             mResource = resource;
             mFromKeys = from;
@@ -1904,13 +1906,13 @@ public class CardBrowser extends NavigationDrawerActivity implements
             }
         }
 
-        public void setFromMapping(String[] from) {
+        public void setFromMapping(Column[] from) {
             mFromKeys = from;
             notifyDataSetChanged();
         }
 
 
-        public String[] getFromMapping() {
+        public Column[] getFromMapping() {
             return mFromKeys;
         }
 
@@ -2045,7 +2047,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
             }
         }
 
-        public String getColumnHeaderText(String key) {
+        public String getColumnHeaderText(Column key) {
             switch (key) {
             case FLAGS:
                 return (new Integer(getCard().userFlag())).toString();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -2140,17 +2140,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
         @VisibleForTesting
         int getFlagOrDefault(int defaultValue) {
-            String flagValue = get(FLAGS);
-            if (flagValue == null) {
-                Timber.d("Unable to obtain flag for card: '%s'. Returning %d", getId(), defaultValue);
-                return defaultValue;
-            }
-            try {
-                return Integer.parseInt(flagValue);
-            } catch (Exception e) {
-                Timber.e(e, "couldn't parse flag value: %s", flagValue);
-                return defaultValue;
-            }
+            return getCard().userFlag();
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1481,7 +1481,6 @@ public class CardBrowser extends NavigationDrawerActivity implements
         // database
         item.put(ANSWER, formatQA(a, context));
 
-        item.put(LAPSES, Integer.toString(c.getLapses()));
         item.put(NOTE_TYPE, c.model().optString("name"));
         item.put(QUESTION, formatQA(q, context));
         item.put(REVIEWS, Integer.toString(c.getReps()));
@@ -2133,6 +2132,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 default:
                     return Utils.roundedTimeSpanUnformatted(AnkiDroidApp.getInstance(), getCard().getIvl()*86400);
                 }
+            case LAPSES:
+                return Integer.toString(getCard().getLapses());
             default:
                 return null;
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1413,7 +1413,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
             CardCache card = getCards().get(pos);
             card.load(true);
             // update Q & A etc
-            updateSearchItemQA(card, c);
+            updateSearchItemQA(card);
         }
 
         updateList();
@@ -1457,7 +1457,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
         }
     };
 
-    public static void updateSearchItemQA(CardCache item, Card c) {
+    public static void updateSearchItemQA(CardCache item) {
+        Card c = item.getCard();
         Context context = AnkiDroidApp.getInstance();
         // render question and answer
         Map<String, String> qa = c._getQA(true, true);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -407,7 +407,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
             return;
         }
 
-        mNewDid = selectedDeck.getLong(ID);
+        mNewDid = selectedDeck.getLong("id");
 
         Timber.i("Changing selected cards to deck: %d", mNewDid);
 
@@ -2281,7 +2281,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
         List<Deck> decks = getValidDecksForChangeDeck();
         for (int i = 0; i < decks.size(); i++) {
             Deck deck = decks.get(i);
-            if (deck.getLong(ID) == deckId) {
+            if (deck.getLong("id") == deckId) {
                 return i;
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -130,7 +130,6 @@ public class CardBrowser extends NavigationDrawerActivity implements
     public static final String LAPSES = "lapses";
     public static final String NOTE_TYPE = "note";
     public static final String REVIEWS = "reviews";
-    private static Pattern sMarkedPattern = Pattern.compile(".*[Mm]arked.*");
 
     private List<CardCache> mCards;
     private ArrayList<Deck> mDropDownDecks;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1430,7 +1430,6 @@ public class CardBrowser extends NavigationDrawerActivity implements
             deckName = getCol().getDecks().get(c.getDid()).getString("name");
             card.put(DECK, deckName);
             // update flags (marked / suspended / etc) which determine color
-            card.put(SUSPENDED, c.getQueue() == Consts.QUEUE_TYPE_SUSPENDED ? "True": "False");
         }
 
         updateList();
@@ -1528,7 +1527,6 @@ public class CardBrowser extends NavigationDrawerActivity implements
         String tags = note.stringTags();
         item.put(TAGS, tags);
         item.put(MARKED, (sMarkedPattern.matcher(item.get(TAGS)).matches())?"marked": null);
-        item.put(SUSPENDED, c.getQueue() == Consts.QUEUE_TYPE_SUSPENDED ? "True": "False");
         item.put(DECK, col.getDecks().name(c.getDid()));
         item.put(SFLD, note.getSFld());
     }
@@ -2144,6 +2142,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
             switch (key) {
             case FLAGS:
                 return (new Integer(getCard().userFlag())).toString();
+            case SUSPENDED:
+                return getCard().getQueue() == Consts.QUEUE_TYPE_SUSPENDED ? "True": "False";
             default:
                 return null;
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1481,7 +1481,6 @@ public class CardBrowser extends NavigationDrawerActivity implements
         // put all of the fields in except for those that have already been pulled out straight from the
         // database
         item.put(ANSWER, formatQA(a, context));
-        item.put(DUE, c.getDueString());
         if (c.getType() == Consts.CARD_TYPE_NEW) {
             item.put(EASE, context.getString(R.string.card_browser_ease_new_card));
         } else {
@@ -2133,6 +2132,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 return getCard().note().stringTags();
             case CARD:
                 return getCard().template().optString("name");
+            case DUE:
+                return getCard().getDueString();
             default:
                 return null;
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1414,6 +1414,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 continue;
             }
             CardCache card = getCards().get(pos);
+            card.reload();
             // update tags
             card.put(MARKED, (c.note().hasTag("marked")) ? "marked" : null);
             if (updatedCardTags != null) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -565,10 +565,6 @@ public class CardBrowser extends NavigationDrawerActivity implements
                     AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance().getBaseContext()).edit()
                             .putInt("cardBrowserColumn2", mColumn2Index).commit();
                     Column[] fromMap = mCardsAdapter.getFromMapping();
-                    fromMap[1] = COLUMN2_KEYS[mColumn2Index];
-                    if (fromMap[1] == null) {
-                        fromMap[1] = ANSWER;
-                    }
                     mCardsAdapter.setFromMapping(fromMap);
                 }
             }
@@ -582,9 +578,6 @@ public class CardBrowser extends NavigationDrawerActivity implements
         int sflRelativeFontSize = preferences.getInt("relativeCardBrowserFontSize", DEFAULT_FONT_SIZE_RATIO);
         String sflCustomFont = preferences.getString("browserEditorFont", "");
         Column[] columnsContent = {COLUMN1_KEYS[mColumn1Index], COLUMN2_KEYS[mColumn2Index]};
-        if (columnsContent[1] == null) {
-            columnsContent[1] = ANSWER;
-        }
         // make a new list adapter mapping the data in mCards to column1 and column2 of R.layout.card_item_browser
         mCardsAdapter = new MultiColumnListAdapter(
                 this,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1431,7 +1431,6 @@ public class CardBrowser extends NavigationDrawerActivity implements
             card.put(DECK, deckName);
             // update flags (marked / suspended / etc) which determine color
             card.put(SUSPENDED, c.getQueue() == Consts.QUEUE_TYPE_SUSPENDED ? "True": "False");
-            card.put(FLAGS, (new Integer(c.userFlag())).toString());
         }
 
         updateList();
@@ -1529,7 +1528,6 @@ public class CardBrowser extends NavigationDrawerActivity implements
         String tags = note.stringTags();
         item.put(TAGS, tags);
         item.put(MARKED, (sMarkedPattern.matcher(item.get(TAGS)).matches())?"marked": null);
-        item.put(FLAGS, (Integer.toString(c.userFlag())));
         item.put(SUSPENDED, c.getQueue() == Consts.QUEUE_TYPE_SUSPENDED ? "True": "False");
         item.put(DECK, col.getDecks().name(c.getDid()));
         item.put(SFLD, note.getSFld());
@@ -2144,6 +2142,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
         public String getColumnHeaderText(String key) {
             switch (key) {
+            case FLAGS:
+                return (new Integer(getCard().userFlag())).toString();
             default:
                 return null;
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -2131,6 +2131,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
     public static class CardCache extends HashMap<String, String> {
         private long mId;
         private Collection mCol;
+        private Card mCard = null;
 
         public CardCache(long id, Collection col) {
             mId = id;
@@ -2144,6 +2145,14 @@ public class CardBrowser extends NavigationDrawerActivity implements
         /** clear all values except ID.*/
         public void reload() {
             clear();
+            mCard = null;
+        }
+
+        public Card getCard() {
+            if (mCard == null) {
+                mCard = mCol.getCard(mId);
+            }
+            return mCard;
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1290,7 +1290,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
     }
 
 
-    private Map<Long, Integer> getPositionMap(List<CardCache> list) {
+    private static Map<Long, Integer> getPositionMap(List<CardCache> list) {
         Map<Long, Integer> positions = new HashMap<>();
         for (int i = 0; i < list.size(); i++) {
             positions.put(list.get(i).getId(), i);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1483,7 +1483,6 @@ public class CardBrowser extends NavigationDrawerActivity implements
         item.put(ANSWER, formatQA(a, context));
 
         Note note = c.note();
-        item.put(CREATED, LanguageUtil.getShortDateFormatFromMs(note.getId()));
         item.put(EDITED, LanguageUtil.getShortDateFormatFromS(note.getMod()));
         // interval
         switch (c.getType()) {
@@ -2136,6 +2135,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 }
             case CHANGED:
                 return LanguageUtil.getShortDateFormatFromS(getCard().getMod());
+            case CREATED:
+                return LanguageUtil.getShortDateFormatFromMs(getCard().note().getId());
             default:
                 return null;
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -2129,6 +2129,12 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
     public static class CardCache extends HashMap<String, String> {
 
+        /** clear all values except ID.*/
+        public void reload() {
+            String id = get(ID);
+            clear();
+            put(ID, id);
+        }
     }
 
     /**
@@ -2236,9 +2242,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     void clearCardData(int position) {
-        String id = mCards.get(position).get(ID);
-        mCards.get(position).clear();
-        mCards.get(position).put(ID, id);
+        mCards.get(position).reload();
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1938,7 +1938,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 col.setText(card.get(mFromKeys[i]));
             }
             // set card's background color
-            final int backgroundColor = Themes.getColorFromAttr(CardBrowser.this, getColor(card));
+            final int backgroundColor = Themes.getColorFromAttr(CardBrowser.this, card.getColor());
             v.setBackgroundColor(backgroundColor);
             // setup checkbox to change color in multi-select mode
             final CheckBox checkBox = (CheckBox) v.findViewById(R.id.card_checkbox);
@@ -1982,36 +1982,6 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 v.setTypeface(mCustomTypeface);
             }
         }
-
-        /**
-         * Get the background color of items in the card list based on the Card
-         * @param cardProperties -- a card object to color
-         * @return index into TypedArray specifying the background color
-         */
-        private int getColor(CardCache cardProperties) {
-            int flag = cardProperties.getCard().userFlag();
-            switch (flag) {
-                case 1:
-                   return R.attr.flagRed;
-                case 2:
-                   return R.attr.flagOrange;
-                case 3:
-                  return R.attr.flagGreen;
-                case 4:
-                   return R.attr.flagBlue;
-                default:
-                    if (cardProperties.get(MARKED) != null) {
-                        return R.attr.markedColor;
-                    } else {
-                        if ("True".equals(cardProperties.get(SUSPENDED))) {
-                            return R.attr.suspendedColor;
-                        } else {
-                            return android.R.attr.colorBackground;
-                        }
-                    }
-            }
-        }
-
 
         public void setFromMapping(String[] from) {
             mFromKeys = from;
@@ -2136,6 +2106,34 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 mCard = mCol.getCard(mId);
             }
             return mCard;
+        }
+
+        /**
+         * Get the background color of items in the card list based on the Card
+         * @return index into TypedArray specifying the background color
+         */
+        private int getColor() {
+            int flag = getCard().userFlag();
+            switch (flag) {
+                case 1:
+                    return R.attr.flagRed;
+                case 2:
+                    return R.attr.flagOrange;
+                case 3:
+                    return R.attr.flagGreen;
+                case 4:
+                    return R.attr.flagBlue;
+                default:
+                    if (get(MARKED) != null) {
+                        return R.attr.markedColor;
+                    } else {
+                        if ("True".equals(get(SUSPENDED))) {
+                            return R.attr.suspendedColor;
+                        } else {
+                            return android.R.attr.colorBackground;
+                        }
+                    }
+            }
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1857,11 +1857,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 // set font for column
                 setFont(col);
                 // set text for column
-                String text_for_column = card.getColumnHeaderText(mFromKeys[i]);
-                if (text_for_column == null) {
-                    text_for_column = card.get(mFromKeys[i]);
-                }
-                col.setText(text_for_column);
+                col.setText(card.getColumnHeaderText(mFromKeys[i]));
             }
             // set card's background color
             final int backgroundColor = Themes.getColorFromAttr(CardBrowser.this, card.getColor());

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1411,8 +1411,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
         Map<Long, Integer> idToPos = getPositionMap(getCards());
         for (Card c : cards) {
             // get position in the mCards search results HashMap
-            int pos = idToPos.containsKey(c.getId()) ? idToPos.get(c.getId()) : -1;
-            if (pos < 0 || pos >= getCardCount()) {
+            Integer pos = idToPos.get(c.getId());
+            if (pos == null || pos >= getCardCount()) {
                 continue;
             }
             // update Q & A etc

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1989,7 +1989,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
          * @return index into TypedArray specifying the background color
          */
         private int getColor(CardCache cardProperties) {
-            int flag = cardProperties.getFlag();
+            int flag = cardProperties.getCard().userFlag();
             switch (flag) {
                 case 1:
                    return R.attr.flagRed;
@@ -2136,11 +2136,6 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 mCard = mCol.getCard(mId);
             }
             return mCard;
-        }
-
-        @VisibleForTesting
-        int getFlag() {
-            return getCard().userFlag();
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1989,7 +1989,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
          * @return index into TypedArray specifying the background color
          */
         private int getColor(CardCache cardProperties) {
-            int flag = cardProperties.getFlagOrDefault(0);
+            int flag = cardProperties.getFlag();
             switch (flag) {
                 case 1:
                    return R.attr.flagRed;
@@ -2139,7 +2139,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
         }
 
         @VisibleForTesting
-        int getFlagOrDefault(int defaultValue) {
+        int getFlag() {
             return getCard().userFlag();
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -2331,12 +2331,12 @@ public class CardBrowser extends NavigationDrawerActivity implements
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     void checkedCardsAtPositions(int[] positions) {
         for (int position : positions) {
-            mCheckedCardPositions.add(position);
             if (position >= mCards.size()) {
                 throw new IllegalStateException(
                         String.format(Locale.US, "Attempted to check card at index %d. %d cards available",
                                 position, mCards.size()));
             }
+            mCheckedCardPositions.add(position);
         }
         onSelectionChanged();
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1935,7 +1935,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 // set font for column
                 setFont(col);
                 // set text for column
-                col.setText(card.get(mFromKeys[i]));
+                String text_for_column = card.get(mFromKeys[i]);
+                col.setText(text_for_column);
             }
             // set card's background color
             final int backgroundColor = Themes.getColorFromAttr(CardBrowser.this, card.getColor());

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -133,6 +133,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
         REVIEWS
     }
 
+    /** List of cards in the browser.
+    * When the list is changed, the position member of its elements should get changed.*/
     private List<CardCache> mCards;
     private ArrayList<Deck> mDropDownDecks;
     private ListView mCardsListView;
@@ -1525,9 +1527,10 @@ public class CardBrowser extends NavigationDrawerActivity implements
         }
 
         List<CardCache> newMCards = new ArrayList<>();
+        int pos = 0;
         for (CardCache card: oldMCards) {
             if (!idToRemove.contains(card.getId())) {
-                newMCards.add(card);
+                newMCards.add(new CardCache(card, pos++));
             }
         }
         mCards = newMCards;
@@ -2015,9 +2018,22 @@ public class CardBrowser extends NavigationDrawerActivity implements
     public static class CardCache extends Card.Cache {
         private boolean mLoaded = false;
         private Pair<String, String> mQa = null;
+        private int mPosition;
 
-        public CardCache(long id, Collection col) {
+        public CardCache(long id, Collection col, int position) {
             super(col, id);
+            mPosition = position;
+        }
+
+        protected CardCache(CardCache cache, int position) {
+            super(cache);
+            mLoaded = cache.mLoaded;
+            mQa = cache.mQa;
+            mPosition = getPosition();
+        }
+
+        public int getPosition() {
+            return mPosition;
         }
 
         /** clear all values except ID.*/

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1481,18 +1481,6 @@ public class CardBrowser extends NavigationDrawerActivity implements
         // database
         item.put(ANSWER, formatQA(a, context));
 
-        // interval
-        switch (c.getType()) {
-            case Consts.CARD_TYPE_NEW:
-                item.put(INTERVAL, context.getString(R.string.card_browser_interval_new_card));
-                break;
-            case Consts.CARD_TYPE_LRN :
-                item.put(INTERVAL, context.getString(R.string.card_browser_interval_learning_card));
-                break;
-            default:
-                item.put(INTERVAL, Utils.roundedTimeSpanUnformatted(context, c.getIvl()*86400));
-                break;
-        }
         item.put(LAPSES, Integer.toString(c.getLapses()));
         item.put(NOTE_TYPE, c.model().optString("name"));
         item.put(QUESTION, formatQA(q, context));
@@ -2136,6 +2124,15 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 return LanguageUtil.getShortDateFormatFromMs(getCard().note().getId());
             case EDITED:
                 return LanguageUtil.getShortDateFormatFromS(getCard().note().getMod());
+            case INTERVAL:
+                switch (getCard().getType()) {
+                case Consts.CARD_TYPE_NEW:
+                    return AnkiDroidApp.getInstance().getString(R.string.card_browser_interval_new_card);
+                case Consts.CARD_TYPE_LRN :
+                    return AnkiDroidApp.getInstance().getString(R.string.card_browser_interval_learning_card);
+                default:
+                    return Utils.roundedTimeSpanUnformatted(AnkiDroidApp.getInstance(), getCard().getIvl()*86400);
+                }
             default:
                 return null;
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -880,7 +880,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
 
     private boolean hasSelectedCards() {
-        return checkedCardCount() > 0;
+        return !mCheckedCards.isEmpty();
     }
 
     private boolean hasSelectedAllCards() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1408,7 +1408,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
      * @param updatedCardTags Mapping note id -> updated tags
      */
     private void updateCardsInList(List<Card> cards, Map<Long, String> updatedCardTags) {
-        Map<Long, Integer> idToPos = getPositionMap(getCards());
+        List<CardCache> cardList = getCards();
+        Map<Long, Integer> idToPos = getPositionMap(cardList);
         for (Card c : cards) {
             // get position in the mCards search results HashMap
             Integer pos = idToPos.get(c.getId());
@@ -1416,7 +1417,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 continue;
             }
             // update Q & A etc
-            getCards().get(pos).load(true, mColumn1Index, mColumn2Index);
+            cardList.get(pos).load(true, mColumn1Index, mColumn2Index);
         }
 
         updateList();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1990,7 +1990,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
          */
         private int getColor(CardCache cardProperties) {
             boolean suspended = "True".equals(cardProperties.get(SUSPENDED));
-            int flag = getFlagOrDefault(cardProperties, 0);
+            int flag = cardProperties.getFlagOrDefault(0);
             boolean marked = cardProperties.get(MARKED) != null ;
             switch (flag) {
                 case 1:
@@ -2043,21 +2043,6 @@ public class CardBrowser extends NavigationDrawerActivity implements
             return position;
         }
 
-    }
-
-    @VisibleForTesting
-    int getFlagOrDefault(CardCache card, int defaultValue) {
-        String flagValue = card.get(FLAGS);
-        if (flagValue == null) {
-            Timber.d("Unable to obtain flag for card: '%s'. Returning %d", card.getId(), defaultValue);
-            return defaultValue;
-        }
-        try {
-            return Integer.parseInt(flagValue);
-        } catch (Exception e) {
-            Timber.e(e, "couldn't parse flag value: %s", flagValue);
-            return defaultValue;
-        }
     }
 
 
@@ -2153,6 +2138,21 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 mCard = mCol.getCard(mId);
             }
             return mCard;
+        }
+
+        @VisibleForTesting
+        int getFlagOrDefault(int defaultValue) {
+            String flagValue = get(FLAGS);
+            if (flagValue == null) {
+                Timber.d("Unable to obtain flag for card: '%s'. Returning %d", getId(), defaultValue);
+                return defaultValue;
+            }
+            try {
+                return Integer.parseInt(flagValue);
+            } catch (Exception e) {
+                Timber.e(e, "couldn't parse flag value: %s", flagValue);
+                return defaultValue;
+            }
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1481,7 +1481,6 @@ public class CardBrowser extends NavigationDrawerActivity implements
         // put all of the fields in except for those that have already been pulled out straight from the
         // database
         item.put(ANSWER, formatQA(a, context));
-        item.put(CARD, c.template().optString("name"));
         item.put(DUE, c.getDueString());
         if (c.getType() == Consts.CARD_TYPE_NEW) {
             item.put(EASE, context.getString(R.string.card_browser_ease_new_card));
@@ -2132,6 +2131,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 return mCol.getDecks().name(getCard().getDid());
             case TAGS:
                 return getCard().note().stringTags();
+            case CARD:
+                return getCard().template().optString("name");
             default:
                 return null;
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1413,10 +1413,6 @@ public class CardBrowser extends NavigationDrawerActivity implements
             }
             CardCache card = getCards().get(pos);
             card.load(true);
-            // update tags
-            if (updatedCardTags != null) {
-                card.put(TAGS, updatedCardTags.get(c.getNid()));
-            }
             // update Q & A etc
             updateSearchItemQA(getBaseContext(), card, c, getCol());
         }
@@ -1513,8 +1509,6 @@ public class CardBrowser extends NavigationDrawerActivity implements
         item.put(NOTE_TYPE, c.model().optString("name"));
         item.put(QUESTION, formatQA(q, context));
         item.put(REVIEWS, Integer.toString(c.getReps()));
-        String tags = note.stringTags();
-        item.put(TAGS, tags);
     }
 
     @CheckResult
@@ -2136,6 +2130,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 return getCard().note().getSFld();
             case DECK:
                 return mCol.getDecks().name(getCard().getDid());
+            case TAGS:
+                return getCard().note().stringTags();
             default:
                 return null;
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1481,11 +1481,6 @@ public class CardBrowser extends NavigationDrawerActivity implements
         // put all of the fields in except for those that have already been pulled out straight from the
         // database
         item.put(ANSWER, formatQA(a, context));
-        if (c.getType() == Consts.CARD_TYPE_NEW) {
-            item.put(EASE, context.getString(R.string.card_browser_ease_new_card));
-        } else {
-            item.put(EASE, (c.getFactor()/10)+"%");
-        }
 
         Note note = c.note();
         item.put(CHANGED, LanguageUtil.getShortDateFormatFromS(c.getMod()));
@@ -2134,6 +2129,12 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 return getCard().template().optString("name");
             case DUE:
                 return getCard().getDueString();
+            case EASE:
+                if (getCard().getType() == Consts.CARD_TYPE_NEW) {
+                    return AnkiDroidApp.getInstance().getString(R.string.card_browser_ease_new_card);
+                } else {
+                    return (getCard().getFactor()/10)+"%";
+                }
             default:
                 return null;
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1406,7 +1406,6 @@ public class CardBrowser extends NavigationDrawerActivity implements
     private void updateCardsInList(List<Card> cards, Map<Long, String> updatedCardTags) {
         Map<Long, Integer> idToPos = getPositionMap(getCards());
         for (Card c : cards) {
-            Note note = c.note();
             // get position in the mCards search results HashMap
             int pos = idToPos.containsKey(c.getId()) ? idToPos.get(c.getId()) : -1;
             if (pos < 0 || pos >= getCardCount()) {
@@ -1418,9 +1417,6 @@ public class CardBrowser extends NavigationDrawerActivity implements
             if (updatedCardTags != null) {
                 card.put(TAGS, updatedCardTags.get(c.getNid()));
             }
-            // update sfld
-            String sfld = note.getSFld();
-            card.put(SFLD, sfld);
             // update Q & A etc
             updateSearchItemQA(getBaseContext(), card, c, getCol());
             // update deck
@@ -1525,7 +1521,6 @@ public class CardBrowser extends NavigationDrawerActivity implements
         String tags = note.stringTags();
         item.put(TAGS, tags);
         item.put(DECK, col.getDecks().name(c.getDid()));
-        item.put(SFLD, note.getSFld());
     }
 
     @CheckResult
@@ -2143,6 +2138,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 return getCard().getQueue() == Consts.QUEUE_TYPE_SUSPENDED ? "True": "False";
             case MARKED:
                 return getCard().note().hasTag("marked") ? "marked" : null;
+            case SFLD:
+                return getCard().note().getSFld();
             default:
                 return null;
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1413,7 +1413,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
             CardCache card = getCards().get(pos);
             card.load(true);
             // update Q & A etc
-            updateSearchItemQA(getBaseContext(), card, c);
+            updateSearchItemQA(card, c);
         }
 
         updateList();
@@ -1457,7 +1457,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
         }
     };
 
-    public static void updateSearchItemQA(Context context, CardCache item, Card c) {
+    public static void updateSearchItemQA(CardCache item, Card c) {
+        Context context = AnkiDroidApp.getInstance();
         // render question and answer
         Map<String, String> qa = c._getQA(true, true);
         // Render full question / answer if the bafmt (i.e. "browser appearance") setting forced blank result

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1414,7 +1414,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 continue;
             }
             CardCache card = getCards().get(pos);
-            card.reload();
+            card.load(true);
             // update tags
             card.put(MARKED, (c.note().hasTag("marked")) ? "marked" : null);
             if (updatedCardTags != null) {
@@ -1855,10 +1855,10 @@ public class CardBrowser extends NavigationDrawerActivity implements
             int lastVisibleItem = firstVisibleItem + visibleItemCount;
             int size = getCardCount();
             if ((size > 0) && (firstVisibleItem < size) && ((lastVisibleItem - 1) < size)) {
-                String firstAns = getCards().get(firstVisibleItem).get(ANSWER);
+                boolean firstLoaded = getCards().get(firstVisibleItem).isLoaded();
                 // Note: max value of lastVisibleItem is totalItemCount, so need to subtract 1
-                String lastAns = getCards().get(lastVisibleItem - 1).get(ANSWER);
-                if (firstAns == null || lastAns == null) {
+                boolean lastLoaded = getCards().get(lastVisibleItem - 1).isLoaded();
+                if (!firstLoaded || !lastLoaded) {
                     showProgressBar();
                     // Also start rendering the items on the screen every 300ms while scrolling
                     long currentTime = SystemClock.elapsedRealtime ();
@@ -2089,6 +2089,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
         private long mId;
         private Collection mCol;
         private Card mCard = null;
+        private boolean mLoaded = false;
 
         public CardCache(long id, Collection col) {
             mId = id;
@@ -2103,6 +2104,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
         public void reload() {
             clear();
             mCard = null;
+            mLoaded = false;
         }
 
         public Card getCard() {
@@ -2145,6 +2147,20 @@ public class CardBrowser extends NavigationDrawerActivity implements
             default:
                 return null;
             }
+        }
+
+        /** pre compute the note and question/answer.  It can safely
+            be called twice without doing extra work. */
+        public void load(boolean reload) {
+            if (reload) {
+                reload();
+            }
+            getCard().note();
+            mLoaded = true;
+        }
+
+        public boolean isLoaded() {
+            return mLoaded;
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1413,7 +1413,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
             CardCache card = getCards().get(pos);
             card.load(true);
             // update Q & A etc
-            updateSearchItemQA(getBaseContext(), card, c, getCol());
+            updateSearchItemQA(getBaseContext(), card, c);
         }
 
         updateList();
@@ -1457,7 +1457,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
         }
     };
 
-    public static void updateSearchItemQA(Context context, CardCache item, Card c, Collection col) {
+    public static void updateSearchItemQA(Context context, CardCache item, Card c) {
         // render question and answer
         Map<String, String> qa = c._getQA(true, true);
         // Render full question / answer if the bafmt (i.e. "browser appearance") setting forced blank result
@@ -1470,15 +1470,12 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 qa.put("a", qaFull.get("a"));
             }
         }
-        // update the original hash map to include rendered question & answer
         String q = qa.get("q");
         String a = qa.get("a");
         // remove the question from the start of the answer if it exists
         if (a.startsWith(q)) {
             a = a.replaceFirst(Pattern.quote(q), "");
         }
-        // put all of the fields in except for those that have already been pulled out straight from the
-        // database
         item.put(ANSWER, formatQA(a, context));
         item.put(QUESTION, formatQA(q, context));
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1480,8 +1480,6 @@ public class CardBrowser extends NavigationDrawerActivity implements
         // put all of the fields in except for those that have already been pulled out straight from the
         // database
         item.put(ANSWER, formatQA(a, context));
-
-        item.put(NOTE_TYPE, c.model().optString("name"));
         item.put(QUESTION, formatQA(q, context));
         item.put(REVIEWS, Integer.toString(c.getReps()));
     }
@@ -2134,6 +2132,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 }
             case LAPSES:
                 return Integer.toString(getCard().getLapses());
+            case NOTE_TYPE:
+                return getCard().model().optString("name");
             default:
                 return null;
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -132,7 +132,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
     public static final String REVIEWS = "reviews";
     private static Pattern sMarkedPattern = Pattern.compile(".*[Mm]arked.*");
 
-    private List<Map<String, String>> mCards;
+    private List<CardCache> mCards;
     private ArrayList<Deck> mDropDownDecks;
     private ListView mCardsListView;
     private SearchView mSearchView;
@@ -1259,7 +1259,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
         }
         if (colIsOpen() && mCardsAdapter!= null) {
             // clear the existing card list
-            mCards = new ArrayList<Map<String, String>>();
+            mCards = new ArrayList<>();
             mCardsAdapter.notifyDataSetChanged();
             //  estimate maximum number of cards that could be visible (assuming worst-case minimum row height of 20dp)
             int numCardsToRender = (int) Math.ceil(mCardsListView.getHeight()/
@@ -1287,7 +1287,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
     }
 
 
-    private Map<Long, Integer> getPositionMap(List<Map<String, String>> list) {
+    private Map<Long, Integer> getPositionMap(List<CardCache> list) {
         Map<Long, Integer> positions = new HashMap<>();
         for (int i = 0; i < list.size(); i++) {
             positions.put(Long.valueOf(list.get(i).get(ID)), i);
@@ -1413,7 +1413,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
             if (pos < 0 || pos >= getCardCount()) {
                 continue;
             }
-            Map<String, String> card = getCards().get(pos);
+            CardCache card = getCards().get(pos);
             // update tags
             card.put(MARKED, (c.note().hasTag("marked")) ? "marked" : null);
             if (updatedCardTags != null) {
@@ -1474,7 +1474,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
         }
     };
 
-    public static void updateSearchItemQA(Context context, Map<String, String> item, Card c, Collection col) {
+    public static void updateSearchItemQA(Context context, CardCache item, Card c, Collection col) {
         // render question and answer
         Map<String, String> qa = c._getQA(true, true);
         // Render full question / answer if the bafmt (i.e. "browser appearance") setting forced blank result
@@ -1580,7 +1580,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
      */
     private void removeNotesView(java.util.Collection<Long> cardsIds, boolean reorderCards) {
         long reviewerCardId = getReviewerCardId();
-        List<Map<String, String>> oldMCards = getCards();
+        List<CardCache> oldMCards = getCards();
         Map<Long, Integer> idToPos = getPositionMap(oldMCards);
         Set<Long> idToRemove = new HashSet<Long>();
         for (Long cardId : cardsIds) {
@@ -1592,8 +1592,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
             }
         }
 
-        List<Map<String, String>> newMCards = new ArrayList<Map<String, String>>();
-        for (Map<String, String> cardProperties: oldMCards) {
+        List<CardCache> newMCards = new ArrayList<>();
+        for (CardCache cardProperties: oldMCards) {
             if (! idToRemove.contains(Long.parseLong(cardProperties.get(ID)))) {
                 newMCards.add(cardProperties);
             }
@@ -1928,7 +1928,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
         private void bindView(final int position, final View v) {
             // Draw the content in the columns
             View[] columns = (View[]) v.getTag();
-            final Map<String, String> card = getCards().get(position);
+            final CardCache card = getCards().get(position);
             for (int i = 0; i < mToIds.length; i++) {
                 TextView col = (TextView) columns[i];
                 // set font for column
@@ -1987,7 +1987,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
          * @param cardProperties -- a card object to color
          * @return index into TypedArray specifying the background color
          */
-        private int getColor(Map<String, String> cardProperties) {
+        private int getColor(CardCache cardProperties) {
             boolean suspended = "True".equals(cardProperties.get(SUSPENDED));
             int flag = getFlagOrDefault(cardProperties, 0);
             boolean marked = cardProperties.get(MARKED) != null ;
@@ -2045,7 +2045,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
     }
 
     @VisibleForTesting
-    int getFlagOrDefault(Map<String, String> card, int defaultValue) {
+    int getFlagOrDefault(CardCache card, int defaultValue) {
         String flagValue = card.get(FLAGS);
         if (flagValue == null) {
             Timber.d("Unable to obtain flag for card: '%s'. Returning %d", card.get(ID), defaultValue);
@@ -2112,7 +2112,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
         }
     }
 
-    private List<Map<String, String>> getCards() {
+    private List<CardCache> getCards() {
         if (mCards == null) {
             mCards = new ArrayList<>();
         }
@@ -2127,6 +2127,9 @@ public class CardBrowser extends NavigationDrawerActivity implements
         return l;
     }
 
+    public static class CardCache extends HashMap<String, String> {
+
+    }
 
     /**
      * Show/dismiss dialog when sd card is ejected/remounted (collection is saved by SdCardReceiver)
@@ -2247,7 +2250,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     long[] getCardIds() {
         @SuppressWarnings("unchecked")
-        Map<String, String>[] cardsCopy = mCards.toArray(new Map[0]);
+        CardCache[] cardsCopy = mCards.toArray(new CardCache[0]);
         long[] ret = new long[cardsCopy.length];
         for (int i = 0; i < cardsCopy.length; i++) {
             ret[i] = Long.parseLong(cardsCopy[i].get(ID));
@@ -2305,8 +2308,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
 
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    public Map<String, String> getPropertiesForCardId(long cardId) {
-        for (Map<String, String> props : mCards) {
+    public CardCache getPropertiesForCardId(long cardId) {
+        for (CardCache props : mCards) {
             String id = Objects.requireNonNull(props.get(ID));
             if (Long.parseLong(id) == cardId) {
                 return props;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -2002,35 +2002,19 @@ public class CardBrowser extends NavigationDrawerActivity implements
         return l;
     }
 
-    public static class CardCache extends HashMap<String, String> {
-        private long mId;
-        private Collection mCol;
-        private Card mCard = null;
+    public static class CardCache extends Card.Cache {
         private boolean mLoaded = false;
         private Pair<String, String> mQa = null;
 
         public CardCache(long id, Collection col) {
-            mId = id;
-            mCol = col;
-        }
-
-        public long getId() {
-            return mId;
+            super(col, id);
         }
 
         /** clear all values except ID.*/
         public void reload() {
-            clear();
-            mCard = null;
+            super.reload();
             mLoaded = false;
             mQa = null;
-        }
-
-        public Card getCard() {
-            if (mCard == null) {
-                mCard = mCol.getCard(mId);
-            }
-            return mCard;
         }
 
         /**
@@ -2072,7 +2056,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
             case SFLD:
                 return getCard().note().getSFld();
             case DECK:
-                return mCol.getDecks().name(getCard().getDid());
+                return getCol().getDecks().name(getCard().getDid());
             case TAGS:
                 return getCard().note().stringTags();
             case CARD:

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1989,9 +1989,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
          * @return index into TypedArray specifying the background color
          */
         private int getColor(CardCache cardProperties) {
-            boolean suspended = "True".equals(cardProperties.get(SUSPENDED));
             int flag = cardProperties.getFlagOrDefault(0);
-            boolean marked = cardProperties.get(MARKED) != null ;
             switch (flag) {
                 case 1:
                    return R.attr.flagRed;
@@ -2002,10 +2000,10 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 case 4:
                    return R.attr.flagBlue;
                 default:
-                    if (marked) {
+                    if (cardProperties.get(MARKED) != null) {
                         return R.attr.markedColor;
                     } else {
-                        if (suspended) {
+                        if ("True".equals(cardProperties.get(SUSPENDED))) {
                             return R.attr.suspendedColor;
                         } else {
                             return android.R.attr.colorBackground;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1419,11 +1419,6 @@ public class CardBrowser extends NavigationDrawerActivity implements
             }
             // update Q & A etc
             updateSearchItemQA(getBaseContext(), card, c, getCol());
-            // update deck
-            String deckName;
-            deckName = getCol().getDecks().get(c.getDid()).getString("name");
-            card.put(DECK, deckName);
-            // update flags (marked / suspended / etc) which determine color
         }
 
         updateList();
@@ -1520,7 +1515,6 @@ public class CardBrowser extends NavigationDrawerActivity implements
         item.put(REVIEWS, Integer.toString(c.getReps()));
         String tags = note.stringTags();
         item.put(TAGS, tags);
-        item.put(DECK, col.getDecks().name(c.getDid()));
     }
 
     @CheckResult
@@ -2140,6 +2134,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 return getCard().note().hasTag("marked") ? "marked" : null;
             case SFLD:
                 return getCard().note().getSFld();
+            case DECK:
+                return mCol.getDecks().name(getCard().getDid());
             default:
                 return null;
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -880,11 +880,11 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
 
     private boolean hasSelectedCards() {
-        return mCheckedCards.size() > 0;
+        return checkedCardCount() > 0;
     }
 
     private boolean hasSelectedAllCards() {
-        return mCheckedCards.size() >= getCardCount(); //must handle 0.
+        return checkedCardCount() >= getCardCount(); //must handle 0.
     }
 
 
@@ -1054,7 +1054,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
             case R.id.action_preview: {
                 Intent previewer = new Intent(CardBrowser.this, Previewer.class);
-                if (mInMultiSelectMode && mCheckedCards.size() > 1) {
+                if (mInMultiSelectMode && checkedCardCount() > 1) {
                     // Multiple cards have been explicitly selected, so preview only those cards
                     previewer.putExtra("index", 0);
                     previewer.putExtra("cardList", getSelectedCardIds());
@@ -1578,7 +1578,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
         @Override
         protected void actualPostExecute(TaskData result) {
             hideProgressBar();
-            mActionBarTitle.setText(Integer.toString(mCheckedCards.size()));
+            mActionBarTitle.setText(Integer.toString(checkedCardCount()));
             invalidateOptionsMenu();    // maybe the availability of undo changed
             // snackbar to offer undo
             mUndoSnackbar = UIUtils.showSnackbar(CardBrowser.this, getString(R.string.deleted_message), SNACKBAR_DURATION, R.string.undo, new View.OnClickListener() {
@@ -1992,7 +1992,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
             }
 
             updateMultiselectMenu();
-            mActionBarTitle.setText(Integer.toString(mCheckedCards.size()));
+            mActionBarTitle.setText(Integer.toString(checkedCardCount()));
         } finally {
             mCardsAdapter.notifyDataSetChanged();
         }
@@ -2251,7 +2251,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
         mInMultiSelectMode = true;
         // show title and hide spinner
         mActionBarTitle.setVisibility(View.VISIBLE);
-        mActionBarTitle.setText(String.valueOf(mCheckedCards.size()));
+        mActionBarTitle.setText(String.valueOf(checkedCardCount()));
         mActionBarSpinner.setVisibility(View.GONE);
         // reload the actionbar using the multi-select mode actionbar
         supportInvalidateOptionsMenu();

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -1191,7 +1191,7 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
             CardBrowser.CardCache card = searchResult.get(i);
             card.load(false);
             Card c = card.getCard();
-            CardBrowser.updateSearchItemQA(mContext, searchResult.get(i), c, col);
+            CardBrowser.updateSearchItemQA(mContext, searchResult.get(i), c);
         }
         // Finish off the task
         if (isCancelled()) {
@@ -1251,7 +1251,7 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
                 continue;
             }
             // Update item
-            CardBrowser.updateSearchItemQA(mContext, card, c, col);
+            CardBrowser.updateSearchItemQA(mContext, card, c);
             card.load(false);
             float progress = (float) i / n * 100;
             publishProgress(new TaskData((int) progress));

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -1849,7 +1849,6 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
      * @return If there are unselected cards, if there are unmarked cards
      */
     public TaskData doInBackgroundCheckCardSelection(TaskData param) {
-        Collection col = getCol();
         Object[] objects = param.getObjArray();
         Set<CardBrowser.CardCache> checkedCards = (Set<CardBrowser.CardCache>) objects[0];
 

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -1188,7 +1188,7 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
                 Timber.d("doInBackgroundSearchCards was cancelled so return null");
                 return null;
             }
-            CardBrowser.CardCache card = searchResult.get(i).load(false);
+            searchResult.get(i).load(false);
         }
         // Finish off the task
         if (isCancelled()) {

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -1189,7 +1189,7 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
                 Timber.d("doInBackgroundSearchCards was cancelled so return null");
                 return null;
             }
-            Card c = col.getCard(Long.parseLong(searchResult.get(i).get("id")));
+            Card c = col.getCard(Long.parseLong(searchResult.get(i).get(CardBrowser.ID)));
             CardBrowser.updateSearchItemQA(mContext, searchResult.get(i), c, col);
         }
         // Finish off the task
@@ -1238,7 +1238,7 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
             }
             // Extract card item
             Card c;
-            String maybeCardId = card.get("id");
+            String maybeCardId = card.get(CardBrowser.ID);
             if (maybeCardId == null) {
                 Timber.w("CardId was null, skipping");
                 continue;
@@ -1865,7 +1865,7 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
         boolean hasUnsuspended = false;
         boolean hasUnmarked = false;
         for (int cardPosition : checkedCardPositions) {
-            Card card = col.getCard(Long.parseLong(cards.get(cardPosition).get("id")));
+            Card card = col.getCard(Long.parseLong(cards.get(cardPosition).get(CardBrowser.ID)));
             hasUnsuspended = hasUnsuspended || card.getQueue() != Consts.QUEUE_TYPE_SUSPENDED;
             hasUnmarked = hasUnmarked || !card.note().hasTag("marked");
             if (hasUnsuspended && hasUnmarked)

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -1170,11 +1170,13 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
         String query = (String) param.getObjArray()[0];
         Boolean order = (Boolean) param.getObjArray()[1];
         int numCardsToRender = (int) param.getObjArray()[2];
-        List<Long> searchResult_ = col.findCards(query, order, this);
         if (isCancelled()) {
             Timber.d("doInBackgroundSearchCards was cancelled so return null");
             return null;
         }
+        int column1Index = (Integer) param.getObjArray()[3];
+        int column2Index = (Integer) param.getObjArray()[4];
+        List<Long> searchResult_ = col.findCards(query, order, this);
         int resultSize = searchResult_.size();
         List<CardBrowser.CardCache> searchResult = new ArrayList<>(resultSize);
         Timber.d("The search found %d cards", resultSize);
@@ -1188,7 +1190,7 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
                 Timber.d("doInBackgroundSearchCards was cancelled so return null");
                 return null;
             }
-            searchResult.get(i).load(false);
+            searchResult.get(i).load(false, column1Index, column2Index);
         }
         // Finish off the task
         if (isCancelled()) {
@@ -1208,6 +1210,8 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
         List<CardBrowser.CardCache> cards = (List<CardBrowser.CardCache>) param.getObjArray()[0];
         Integer startPos = (Integer) param.getObjArray()[1];
         Integer n = (Integer) param.getObjArray()[2];
+        int column1Index = (Integer) param.getObjArray()[3];
+        int column2Index = (Integer) param.getObjArray()[4];
 
         List<Long> invalidCardIds = new ArrayList<>();
         // for each specified card in the browser list
@@ -1248,7 +1252,7 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
                 continue;
             }
             // Update item
-            card.load(false);
+            card.load(false, column1Index, column2Index);
             float progress = (float) i / n * 100;
             publishProgress(new TaskData((int) progress));
         }

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -1190,8 +1190,7 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
             }
             CardBrowser.CardCache card = searchResult.get(i);
             card.load(false);
-            Card c = card.getCard();
-            CardBrowser.updateSearchItemQA(searchResult.get(i), c);
+            CardBrowser.updateSearchItemQA(searchResult.get(i));
         }
         // Finish off the task
         if (isCancelled()) {
@@ -1238,9 +1237,9 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
                 continue;
             }
             // Extract card item
-            Card c;
             try {
-                c = card.getCard();
+                // Ensure that card still exists.
+                card.getCard();
             } catch (WrongId e) {
                 //#5891 - card can be inconsistent between the deck browser screen and the collection.
                 //Realistically, we can skip any exception as it's a rendering task which should not kill the
@@ -1251,7 +1250,7 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
                 continue;
             }
             // Update item
-            CardBrowser.updateSearchItemQA(card, c);
+            CardBrowser.updateSearchItemQA(card);
             card.load(false);
             float progress = (float) i / n * 100;
             publishProgress(new TaskData((int) progress));

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -1851,13 +1851,13 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
     public TaskData doInBackgroundCheckCardSelection(TaskData param) {
         Collection col = getCol();
         Object[] objects = param.getObjArray();
-        Set<Integer> checkedCardPositions = (Set<Integer>) objects[0];
+        Set<CardBrowser.CardCache> checkedCards = (Set<CardBrowser.CardCache>) objects[0];
         List<CardBrowser.CardCache> cards = (List<CardBrowser.CardCache>) objects[1];
 
         boolean hasUnsuspended = false;
         boolean hasUnmarked = false;
-        for (int cardPosition : checkedCardPositions) {
-            Card card = cards.get(cardPosition).getCard();
+        for (CardBrowser.CardCache c: checkedCards) {
+            Card card = c.getCard();
             hasUnsuspended = hasUnsuspended || card.getQueue() != Consts.QUEUE_TYPE_SUSPENDED;
             hasUnmarked = hasUnmarked || !card.note().hasTag("marked");
             if (hasUnsuspended && hasUnmarked)

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -1179,8 +1179,7 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
         List<CardBrowser.CardCache> searchResult = new ArrayList<>(resultSize);
         Timber.d("The search found %d cards", resultSize);
         for (Long cid: searchResult_) {
-            CardBrowser.CardCache card = new CardBrowser.CardCache();
-            card.put(CardBrowser.ID, cid.toString());
+            CardBrowser.CardCache card = new CardBrowser.CardCache(cid, col);
             searchResult.add(card);
         }
         // Render the first few items
@@ -1189,7 +1188,7 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
                 Timber.d("doInBackgroundSearchCards was cancelled so return null");
                 return null;
             }
-            Card c = col.getCard(Long.parseLong(searchResult.get(i).get(CardBrowser.ID)));
+            Card c = col.getCard(searchResult.get(i).getId());
             CardBrowser.updateSearchItemQA(mContext, searchResult.get(i), c, col);
         }
         // Finish off the task
@@ -1238,25 +1237,14 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
             }
             // Extract card item
             Card c;
-            String maybeCardId = card.get(CardBrowser.ID);
-            if (maybeCardId == null) {
-                Timber.w("CardId was null, skipping");
-                continue;
-            }
-            Long cardId;
-            try {
-                cardId = Long.parseLong(maybeCardId);
-            } catch (Exception e) {
-                Timber.e("Unable to parse CardId: %s. Unable to remove card", maybeCardId);
-                continue;
-            }
+            long cardId = card.getId();
             try {
                 c = col.getCard(cardId);
             } catch (WrongId e) {
                 //#5891 - card can be inconsistent between the deck browser screen and the collection.
                 //Realistically, we can skip any exception as it's a rendering task which should not kill the
                 //process
-                Timber.e(e, "Could not process card '%s' - skipping and removing from sight", maybeCardId);
+                Timber.e(e, "Could not process card '%d' - skipping and removing from sight", cardId);
                 invalidCardIds.add(cardId);
                 continue;
             }

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -1191,7 +1191,7 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
             CardBrowser.CardCache card = searchResult.get(i);
             card.load(false);
             Card c = card.getCard();
-            CardBrowser.updateSearchItemQA(mContext, searchResult.get(i), c);
+            CardBrowser.updateSearchItemQA(searchResult.get(i), c);
         }
         // Finish off the task
         if (isCancelled()) {
@@ -1251,7 +1251,7 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
                 continue;
             }
             // Update item
-            CardBrowser.updateSearchItemQA(mContext, card, c);
+            CardBrowser.updateSearchItemQA(card, c);
             card.load(false);
             float progress = (float) i / n * 100;
             publishProgress(new TaskData((int) progress));

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -1188,9 +1188,7 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
                 Timber.d("doInBackgroundSearchCards was cancelled so return null");
                 return null;
             }
-            CardBrowser.CardCache card = searchResult.get(i);
-            card.load(false);
-            CardBrowser.updateSearchItemQA(searchResult.get(i));
+            CardBrowser.CardCache card = searchResult.get(i).load(false);
         }
         // Finish off the task
         if (isCancelled()) {
@@ -1250,7 +1248,6 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
                 continue;
             }
             // Update item
-            CardBrowser.updateSearchItemQA(card);
             card.load(false);
             float progress = (float) i / n * 100;
             publishProgress(new TaskData((int) progress));

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -1180,8 +1180,9 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
         int resultSize = searchResult_.size();
         List<CardBrowser.CardCache> searchResult = new ArrayList<>(resultSize);
         Timber.d("The search found %d cards", resultSize);
+        int position = 0;
         for (Long cid: searchResult_) {
-            CardBrowser.CardCache card = new CardBrowser.CardCache(cid, col);
+            CardBrowser.CardCache card = new CardBrowser.CardCache(cid, col, position++);
             searchResult.add(card);
         }
         // Render the first few items

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -1188,7 +1188,7 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
                 Timber.d("doInBackgroundSearchCards was cancelled so return null");
                 return null;
             }
-            Card c = col.getCard(searchResult.get(i).getId());
+            Card c = searchResult.get(i).getCard();
             CardBrowser.updateSearchItemQA(mContext, searchResult.get(i), c, col);
         }
         // Finish off the task
@@ -1237,13 +1237,13 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
             }
             // Extract card item
             Card c;
-            long cardId = card.getId();
             try {
-                c = col.getCard(cardId);
+                c = card.getCard();
             } catch (WrongId e) {
                 //#5891 - card can be inconsistent between the deck browser screen and the collection.
                 //Realistically, we can skip any exception as it's a rendering task which should not kill the
                 //process
+                long cardId = card.getId();
                 Timber.e(e, "Could not process card '%d' - skipping and removing from sight", cardId);
                 invalidCardIds.add(cardId);
                 continue;
@@ -1853,7 +1853,7 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
         boolean hasUnsuspended = false;
         boolean hasUnmarked = false;
         for (int cardPosition : checkedCardPositions) {
-            Card card = col.getCard(Long.parseLong(cards.get(cardPosition).get(CardBrowser.ID)));
+            Card card = cards.get(cardPosition).getCard();
             hasUnsuspended = hasUnsuspended || card.getQueue() != Consts.QUEUE_TYPE_SUSPENDED;
             hasUnmarked = hasUnmarked || !card.note().hasTag("marked");
             if (hasUnsuspended && hasUnmarked)

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -1852,7 +1852,6 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
         Collection col = getCol();
         Object[] objects = param.getObjArray();
         Set<CardBrowser.CardCache> checkedCards = (Set<CardBrowser.CardCache>) objects[0];
-        List<CardBrowser.CardCache> cards = (List<CardBrowser.CardCache>) objects[1];
 
         boolean hasUnsuspended = false;
         boolean hasUnmarked = false;

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -1188,7 +1188,9 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
                 Timber.d("doInBackgroundSearchCards was cancelled so return null");
                 return null;
             }
-            Card c = searchResult.get(i).getCard();
+            CardBrowser.CardCache card = searchResult.get(i);
+            card.load(false);
+            Card c = card.getCard();
             CardBrowser.updateSearchItemQA(mContext, searchResult.get(i), c, col);
         }
         // Finish off the task
@@ -1231,7 +1233,7 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
                 //we won't reach any more cards.
                 continue;
             }
-            if (card.get("answer") != null) {
+            if (card.isLoaded()) {
                 //We've already rendered the answer, we don't need to do it again.
                 continue;
             }
@@ -1250,6 +1252,7 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
             }
             // Update item
             CardBrowser.updateSearchItemQA(mContext, card, c, col);
+            card.load(false);
             float progress = (float) i / n * 100;
             publishProgress(new TaskData((int) progress));
         }

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -1176,10 +1176,10 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
             return null;
         }
         int resultSize = searchResult_.size();
-        List<Map<String,String>> searchResult = new ArrayList<>(resultSize);
+        List<CardBrowser.CardCache> searchResult = new ArrayList<>(resultSize);
         Timber.d("The search found %d cards", resultSize);
         for (Long cid: searchResult_) {
-            Map<String, String> card = new HashMap<>();
+            CardBrowser.CardCache card = new CardBrowser.CardCache();
             card.put(CardBrowser.ID, cid.toString());
             searchResult.add(card);
         }
@@ -1207,7 +1207,7 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
         //(Range<Position>, Function<Position, BrowserCard>)
         Timber.d("doInBackgroundRenderBrowserQA");
         Collection col = getCol();
-        List<Map<String, String>> cards = (List<Map<String, String>>) param.getObjArray()[0];
+        List<CardBrowser.CardCache> cards = (List<CardBrowser.CardCache>) param.getObjArray()[0];
         Integer startPos = (Integer) param.getObjArray()[1];
         Integer n = (Integer) param.getObjArray()[2];
 
@@ -1222,7 +1222,7 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
             if (i < 0 || i >= cards.size()) {
                 continue;
             }
-            Map<String, String> card;
+            CardBrowser.CardCache card;
             try {
                 card = cards.get(i);
             }
@@ -1860,7 +1860,7 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
         Collection col = getCol();
         Object[] objects = param.getObjArray();
         Set<Integer> checkedCardPositions = (Set<Integer>) objects[0];
-        List<Map<String, String>> cards = (List<Map<String, String>>) objects[1];
+        List<CardBrowser.CardCache> cards = (List<CardBrowser.CardCache>) objects[1];
 
         boolean hasUnsuspended = false;
         boolean hasUnmarked = false;

--- a/AnkiDroid/src/main/java/com/ichi2/async/TaskData.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/TaskData.java
@@ -3,11 +3,13 @@ package com.ichi2.async;
 
 import android.content.Context;
 
+import com.ichi2.anki.CardBrowser;
 import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Note;
 
 import java.util.List;
 import java.util.Map;
+import static com.ichi2.anki.CardBrowser.CardCache;
 
 public class TaskData {
     private Card mCard;
@@ -15,7 +17,7 @@ public class TaskData {
     private int mInteger;
     private String mMsg;
     private boolean mBool = false;
-    private List<Map<String, String>> mCards;
+    private List<CardCache> mCards;
     private long mLong;
     private Context mContext;
     private int mType;
@@ -76,7 +78,7 @@ public class TaskData {
     }
 
 
-    public TaskData(List<Map<String, String>> cards) {
+    public TaskData(List<CardCache> cards) {
         mCards = cards;
     }
 
@@ -147,12 +149,12 @@ public class TaskData {
     }
 
 
-    public List<Map<String, String>> getCards() {
+    public List<CardCache> getCards() {
         return mCards;
     }
 
 
-    public void setCards(List<Map<String, String>> cards) {
+    public void setCards(List<CardCache> cards) {
         mCards = cards;
     }
 
@@ -215,9 +217,5 @@ public class TaskData {
         }
 
         return clazz.isAssignableFrom(val.getClass());
-    }
-
-    public void setCards(List<Map<String, String>> cards) {
-            mCards = cards;
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/async/TaskData.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/TaskData.java
@@ -216,4 +216,8 @@ public class TaskData {
 
         return clazz.isAssignableFrom(val.getClass());
     }
+
+    public void setCards(List<Map<String, String>> cards) {
+            mCards = cards;
+    }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
@@ -253,7 +253,7 @@ public class CardBrowserTest extends RobolectricTest {
         CardBrowser b = getBrowserWithNoNewCards();
         CardBrowser.CardCache cardProperties = b.getPropertiesForCardId(cardId);
 
-        int actualFlag = b.getFlagOrDefault(cardProperties, 0);
+        int actualFlag = cardProperties.getFlagOrDefault(0);
 
         assertThat("The card flag value should be reflected in the UI", actualFlag, is(1));
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
@@ -253,7 +253,8 @@ public class CardBrowserTest extends RobolectricTest {
         CardBrowser b = getBrowserWithNoNewCards();
         CardBrowser.CardCache cardProperties = b.getPropertiesForCardId(cardId);
 
-        int actualFlag = cardProperties.getFlag();
+
+        int actualFlag = cardProperties.getCard().userFlag();
 
         assertThat("The card flag value should be reflected in the UI", actualFlag, is(1));
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
@@ -253,7 +253,7 @@ public class CardBrowserTest extends RobolectricTest {
         CardBrowser b = getBrowserWithNoNewCards();
         CardBrowser.CardCache cardProperties = b.getPropertiesForCardId(cardId);
 
-        int actualFlag = cardProperties.getFlagOrDefault(0);
+        int actualFlag = cardProperties.getFlag();
 
         assertThat("The card flag value should be reflected in the UI", actualFlag, is(1));
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
@@ -251,7 +251,7 @@ public class CardBrowserTest extends RobolectricTest {
         long cardId = n.cids().get(0);
 
         CardBrowser b = getBrowserWithNoNewCards();
-        Map<String, String> cardProperties = b.getPropertiesForCardId(cardId);
+        CardBrowser.CardCache cardProperties = b.getPropertiesForCardId(cardId);
 
         int actualFlag = b.getFlagOrDefault(cardProperties, 0);
 


### PR DESCRIPTION
The main speed gain here is that we don't compute question/answer unless they are asked by the user.

I find code more elegant, because we don't just deal with a map String->String but uses standard well typed Card object and its methods. 


To test it, I opened the browser, selected cards, marked them, flagged them. Ensured that all was still working, those updates were still correctly shown in the GUI