### PR TITLE
Turn off undo during slow control block

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -43,6 +43,7 @@ import com.ichi2.anim.ActivityTransitionAnimation;
 import com.ichi2.anki.dialogs.ConfirmationDialog;
 import com.ichi2.anki.dialogs.RescheduleDialog;
 import com.ichi2.anki.reviewer.PeripheralKeymap;
+import com.ichi2.anki.reviewer.ReviewerUi;
 import com.ichi2.anki.workarounds.FirefoxSnackbarWorkaround;
 import com.ichi2.async.CollectionTask;
 import com.ichi2.anki.reviewer.ActionButtons;
@@ -457,7 +458,7 @@ public class Reviewer extends AbstractFlashcardViewer {
             undoIcon = R.drawable.ic_undo_white_24dp;
             undoEnabled = (colIsOpen() && getCol().undoAvailable());
         }
-        int alpha = (undoEnabled) ? Themes.ALPHA_ICON_ENABLED_LIGHT : Themes.ALPHA_ICON_DISABLED_LIGHT ;
+        int alpha = (undoEnabled && getControlBlocked() != ReviewerUi.ControlBlock.SLOW) ? Themes.ALPHA_ICON_ENABLED_LIGHT : Themes.ALPHA_ICON_DISABLED_LIGHT ;
         menu.findItem(R.id.action_undo).setIcon(undoIcon);
         menu.findItem(R.id.action_undo).setEnabled(undoEnabled).getIcon().setAlpha(alpha);
 


### PR DESCRIPTION
## Pull Request template
Eh, I do a PR which is not NF. I missed it ! 

## Purpose / Description

When you block all buttons because a slow action is occurring, the undo button light keep turned on. I was actually pretty sure I already fixed it, but can't find any PR, anything in git history, in my merge branch.... 

## Approach
Actually, I believe that there is never a reason to turn the light
on. By default it's usually on, except when buttons are blocked, and
we don't want to turn-it on when buttons are blocked.
So

```
if (!undoEnabled) {
    menu.findItem(R.id.action_undo).setAlpha(Themes.ALPHA_ICON_DISABLED_LIGHT);
}
```
may be slightly simpler and quicker. I'm not confident enough to be
sure that I get nothing wrong here, so I keep the most secure version
of the code.

I just use disabled light if it is disabled by a slow action or if there is nothing to undo.


## How Has This Been Tested?

Open a collection, review a card (so there is something to undo), then suspend a card. Check that the undo light turns off with the other buttons.