### PR TITLE
hasSelectedSingleNoteId: Handle concurrency issue

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -387,11 +387,13 @@ public class CardBrowser extends NavigationDrawerActivity implements
         }
         //copy to array to ensure threadsafe iteration
         Integer[] checkedPositions = mCheckedCardPositions.toArray(new Integer[0]);
+        List<Map<String, String>> cards = mCards;
+
         HashSet<String> notes = new HashSet<>();
         for (Integer position : checkedPositions) {
             String noteId;
             try {
-                noteId = mCards.get(position).get(NOTE);
+                noteId = cards.get(position).get(NOTE);
             } catch (IndexOutOfBoundsException e) {
                 //#6384
                 Timber.w(e, "concurrent modification of mCards array - assume more than one note selected");
@@ -401,7 +403,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 return false;
             }
         }
-        return notes.size() == 1;
+        return mCards == cards && notes.size() == 1;
     }
 
     @VisibleForTesting

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -389,7 +389,14 @@ public class CardBrowser extends NavigationDrawerActivity implements
         Integer[] checkedPositions = mCheckedCardPositions.toArray(new Integer[0]);
         HashSet<String> notes = new HashSet<>();
         for (Integer position : checkedPositions) {
-            String noteId = mCards.get(position).get(NOTE);
+            String noteId;
+            try {
+                noteId = mCards.get(position).get(NOTE);
+            } catch (IndexOutOfBoundsException e) {
+                //#6384
+                Timber.w(e, "concurrent modification of mCards array - assume more than one note selected");
+                return false;
+            }
             if (notes.add(noteId) && notes.size() > 1) {
                 return false;
             }


### PR DESCRIPTION
## Purpose / Description

`hasSelectedSingleNoteId` assumed that `mCards` and `checkedPositions` were in sync. This turned out to be an incorrect assumption.

## Fixes
Fixes #6384

## Approach
Try..catch..ignore. and perform a local copy to reduce the chance of this happening.

## How Has This Been Tested?

None

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code