### PR TITLE
Assertion to try to debug https://github.com/ankidroid/Anki-Android/issues/6383

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -39,6 +39,7 @@ import com.ichi2.libanki.Utils;
 import com.ichi2.libanki.Deck;
 import com.ichi2.libanki.DeckConfig;
 
+import com.ichi2.utils.Assert;
 import com.ichi2.utils.JSONArray;
 import com.ichi2.utils.JSONException;
 import com.ichi2.utils.JSONObject;
@@ -230,6 +231,8 @@ public class Sched extends SchedV2 {
             int rlim = _deckRevLimitSingle(deck);
             if (!TextUtils.isEmpty(p)) {
                 Integer[] parentLims = lims.get(p);
+                // 'temporary for diagnosis of bug #6383'
+                Assert.that(parentLims != null, "Deck %s is supposed to have parent %s. It has not be found.", deckName, p);
                 nlim = Math.min(nlim, parentLims[0]);
                 // review
                 rlim = Math.min(rlim, parentLims[1]);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -229,9 +229,10 @@ public class Sched extends SchedV2 {
             int nlim = _deckNewLimitSingle(deck);
             int rlim = _deckRevLimitSingle(deck);
             if (!TextUtils.isEmpty(p)) {
-                nlim = Math.min(nlim, lims.get(p)[0]);
+                Integer[] parentLims = lims.get(p);
+                nlim = Math.min(nlim, parentLims[0]);
                 // review
-                rlim = Math.min(rlim, lims.get(p)[1]);
+                rlim = Math.min(rlim, parentLims[1]);
             }
             int _new = _newForDeck(deck.getLong("id"), nlim);
             // learning

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -223,7 +223,8 @@ public class Sched extends SchedV2 {
             if (collectionTask != null && collectionTask.isCancelled()) {
                 return null;
             }
-            String p = Decks.parent(deck.getString("name"));
+            String deckName = deck.getString("name");
+            String p = Decks.parent(deckName);
             // new
             int nlim = _deckNewLimitSingle(deck);
             if (!TextUtils.isEmpty(p)) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -227,17 +227,16 @@ public class Sched extends SchedV2 {
             String p = Decks.parent(deckName);
             // new
             int nlim = _deckNewLimitSingle(deck);
+            int rlim = _deckRevLimitSingle(deck);
             if (!TextUtils.isEmpty(p)) {
                 nlim = Math.min(nlim, lims.get(p)[0]);
+                // review
+                rlim = Math.min(rlim, lims.get(p)[1]);
             }
             int _new = _newForDeck(deck.getLong("id"), nlim);
             // learning
             int lrn = _lrnForDeck(deck.getLong("id"));
             // reviews
-            int rlim = _deckRevLimitSingle(deck);
-            if (!TextUtils.isEmpty(p)) {
-                rlim = Math.min(rlim, lims.get(p)[1]);
-            }
             int rev = _revForDeck(deck.getLong("id"), rlim);
             // save to list
             data.add(new DeckDueTreeNode(deck.getString("name"), deck.getLong("id"), rev, lrn, _new));

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -455,7 +455,8 @@ public class SchedV2 extends AbstractSched {
             if (collectionTask != null && collectionTask.isCancelled()) {
                 return null;
             }
-            String p = Decks.parent(deck.getString("name"));
+            String deckName = deck.getString("name");
+            String p = Decks.parent(deckName);
             // new
             int nlim = _deckNewLimitSingle(deck);
             if (!TextUtils.isEmpty(p)) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -461,9 +461,10 @@ public class SchedV2 extends AbstractSched {
             int nlim = _deckNewLimitSingle(deck);
             Integer plim = null;
             if (!TextUtils.isEmpty(p)) {
-                nlim = Math.min(nlim, lims.get(p)[0]);
+                Integer[] parentLims = lims.get(p);
+                nlim = Math.min(nlim, parentLims[0]);
                 // reviews
-                plim = lims.get(p)[1];
+                plim = parentLims[1];
             }
             int _new = _newForDeck(deck.getLong("id"), nlim);
             // learning

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -44,6 +44,7 @@ import com.ichi2.libanki.DeckConfig;
 
 import com.ichi2.libanki.utils.SystemTime;
 import com.ichi2.libanki.utils.Time;
+import com.ichi2.utils.Assert;
 import com.ichi2.utils.JSONArray;
 import com.ichi2.utils.JSONException;
 import com.ichi2.utils.JSONObject;
@@ -462,6 +463,8 @@ public class SchedV2 extends AbstractSched {
             Integer plim = null;
             if (!TextUtils.isEmpty(p)) {
                 Integer[] parentLims = lims.get(p);
+                // 'temporary for diagnosis of bug #6383'
+                Assert.that(parentLims != null, "Deck %s is supposed to have parent %s. It has not be found.", deckName, p);
                 nlim = Math.min(nlim, parentLims[0]);
                 // reviews
                 plim = parentLims[1];

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -459,19 +459,16 @@ public class SchedV2 extends AbstractSched {
             String p = Decks.parent(deckName);
             // new
             int nlim = _deckNewLimitSingle(deck);
+            Integer plim = null;
             if (!TextUtils.isEmpty(p)) {
                 nlim = Math.min(nlim, lims.get(p)[0]);
+                // reviews
+                plim = lims.get(p)[1];
             }
             int _new = _newForDeck(deck.getLong("id"), nlim);
             // learning
             int lrn = _lrnForDeck(deck.getLong("id"));
             // reviews
-            Integer plim;
-            if (!TextUtils.isEmpty(p)) {
-                plim = lims.get(p)[1];
-            } else {
-                plim = null;
-            }
             int rlim = _deckRevLimitSingle(deck, plim);
             int rev = _revForDeck(deck.getLong("id"), rlim, childMap);
             // save to list


### PR DESCRIPTION
This is related to https://github.com/ankidroid/Anki-Android/issues/6383
I add an assertion, so that if the bug occurs again, we get more interesting informations: e.g. the name of the deck whose parent is not seen. 

Normally, checkIntegrity has added the parent of all decks. The sorting function should ensure that parents are seen before the children. So either it's a problem related to normalization or something similar, in which case it may help understand it (assuming at least that Acra does not break unnormalized unicode)
If, as I suspect, it's a problem related to the fact that the set of deck was changed while the method is executed, i.e. because of sync or renaming... then this will occur so rarely that I don't expect to see many bug reports, and I don't really see how to get interesting information to reproduce it.
