### PR TITLE
Add "Try Anyway" button for sync

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -46,6 +46,7 @@ import com.afollestad.materialdialogs.GravityEnum;
 import com.google.android.material.snackbar.Snackbar;
 
 import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
 import androidx.annotation.VisibleForTesting;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.FileProvider;
@@ -1290,7 +1291,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
      *  Show a simple snackbar message or notification if the activity is not in foreground
      * @param messageResource String resource for message
      */
-    private void showSyncLogMessage(int messageResource, String syncMessage) {
+    private void showSyncLogMessage(@StringRes int messageResource, String syncMessage) {
         if (mActivityPaused) {
             Resources res = AnkiDroidApp.getAppResources();
             showSimpleNotification(res.getString(R.string.app_name),
@@ -1298,7 +1299,16 @@ public class DeckPicker extends NavigationDrawerActivity implements
                     NotificationChannels.Channel.SYNC);
         } else {
             if (syncMessage == null || syncMessage.length() == 0) {
-                UIUtils.showSimpleSnackbar(this, messageResource, false);
+                if (messageResource == R.string.youre_offline && !Connection.getAllowSyncOnNoConnection()) {
+                    //#6396 - Add a temporary "Try Anyway" button until we sort out `isOnline`
+                    View root = this.findViewById(R.id.root_layout);
+                    UIUtils.showSnackbar(this, messageResource, false, R.string.sync_even_if_offline, (v) -> {
+                        Connection.setAllowSyncOnNoConnection(true);
+                        sync();
+                    }, null);
+                } else {
+                    UIUtils.showSimpleSnackbar(this, messageResource, false);
+                }
             } else {
                 Resources res = AnkiDroidApp.getAppResources();
                 showSimpleMessageDialog(res.getString(messageResource), syncMessage, false);

--- a/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
@@ -60,6 +60,8 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
     private static boolean sIsCancelled;
     private static boolean sIsCancellable;
 
+    private static boolean sAllowSyncOnNoConnection;
+
     /**
      * Before syncing, we acquire a wake lock and then release it once the sync is complete.
      * This ensures that the device remains awake until the sync is complete. Without it,
@@ -101,6 +103,16 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
 
         sInstance.execute(data);
         return sInstance;
+    }
+
+
+    public static boolean getAllowSyncOnNoConnection() {
+        return sAllowSyncOnNoConnection;
+    }
+
+
+    public static void setAllowSyncOnNoConnection(boolean value) {
+        sAllowSyncOnNoConnection = value;
     }
 
 
@@ -491,6 +503,9 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
     }
 
     public static boolean isOnline() {
+        if (sAllowSyncOnNoConnection) {
+            return true;
+        }
         ConnectivityManager cm = (ConnectivityManager) AnkiDroidApp.getInstance().getApplicationContext()
                 .getSystemService(Context.CONNECTIVITY_SERVICE);
         if (cm != null) {

--- a/AnkiDroid/src/main/res/values/04-network.xml
+++ b/AnkiDroid/src/main/res/values/04-network.xml
@@ -21,6 +21,7 @@
 --><resources>
 
     <string name="youre_offline">You are offline</string>
+    <string name="sync_even_if_offline">Try Anyway</string>
     <string name="sync_error">Sync error</string>
     <string name="vague_error">Error</string>
     <string name="retry">Retry</string>


### PR DESCRIPTION
## Purpose / Description
`isOnline` is currently flaky with multiple network types.
This was suggested as a stopgap


## Fixes
Fixes #6396

## Approach
Add "try anyway" to the snackbar

## How Has This Been Tested?

On my phone. Error after clicking "try anyway" was:

![image](https://user-images.githubusercontent.com/62114487/83964270-cc5cf080-a8a3-11ea-8108-c1080528ac10.png)


## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code