### PR TITLE
Handle null/non string sync error

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -1730,6 +1730,9 @@ public class DeckPicker extends NavigationDrawerActivity implements
                         }
                         showSyncErrorMessage(joinSyncMessages(dialogMessage, syncMessage));
                     }
+                } else {
+                    dialogMessage = res.getString(R.string.sync_generic_error);
+                    showSyncErrorMessage(joinSyncMessages(dialogMessage, syncMessage));
                 }
             } else {
                 Timber.i("Sync was successful");

--- a/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
@@ -252,6 +252,9 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
 
     private boolean timeoutOccurred(Exception e) {
         String msg = e.getMessage();
+        if (msg == null) {
+            return false;
+        }
         return msg.contains("UnknownHostException") ||
                 msg.contains("HttpHostConnectException") ||
                 msg.contains("SSLException while building HttpClient") ||


### PR DESCRIPTION
## Purpose / Description
Probably not possible - but a non string error was not shown.
Null previously crashed.

Null may have been possible from a badly localised exception

## Fixes
Fixes #6398

## How Has This Been Tested?

On my phone - an exception with an null message now shows a sync error dialog

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code