### PR TITLE
Allow to enter spaces in steps

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/preferences/StepsPreference.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/StepsPreference.java
@@ -20,7 +20,6 @@ import android.content.Context;
 import android.preference.EditTextPreference;
 import android.text.InputType;
 import android.text.TextUtils;
-import android.text.method.DigitsKeyListener;
 import android.util.AttributeSet;
 import android.widget.EditText;
 
@@ -39,34 +38,18 @@ public class StepsPreference extends EditTextPreference {
     public StepsPreference(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
         mAllowEmpty = getAllowEmptyFromAttributes(attrs);
-        updateSettings();
     }
 
 
     public StepsPreference(Context context, AttributeSet attrs) {
         super(context, attrs);
         mAllowEmpty = getAllowEmptyFromAttributes(attrs);
-        updateSettings();
     }
 
 
     public StepsPreference(Context context) {
         super(context);
         mAllowEmpty = getAllowEmptyFromAttributes(null);
-        updateSettings();
-    }
-
-
-    /**
-     * Update settings to show a numeric keyboard instead of the default keyboard.
-     * <p>
-     * This method should only be called once from the constructor.
-     */
-    private void updateSettings() {
-        // Use the number pad but still allow normal text for spaces and decimals.
-        EditText editText = getEditText();
-        editText.setInputType(InputType.TYPE_CLASS_NUMBER | InputType.TYPE_CLASS_TEXT);
-        editText.setKeyListener(DigitsKeyListener.getInstance("0123456789 "));
     }
 
 


### PR DESCRIPTION
There is a problem that, at least on my phone, I can't enter the space
character in the step option. So I can't add multiple steps unless I
copy paste a space character.

Only removing TYPE_CLASS_NUMBER does not change anything.

Only removing DigitsKeyListener allow me to access a set of symbols
such as #, (, and space. I believe it is quite confusing that spaces
is hard to get and that it offers a limited set of symbols, but most
of them are rejected. At this point, I believe the UI is simpler if either:
* we create a list and allow user to add more elmenets in this list
* we leave the full standard keyboard and then reject entries which
  are not valid with a valid error message

This was tested by installing it on my phone and seeing that I can, at least, enter multiple steps for my lapses