### PR TITLE
Export flags

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.java
@@ -120,8 +120,6 @@ class AnkiExporter extends Exporter {
         Timber.d("Copy cards");
         mSrc.getDb().getDatabase()
                 .execSQL("INSERT INTO DST_DB.cards select * from cards where id in " + Utils.ids2str(cids));
-        mSrc.getDb().getDatabase()
-                .execSQL("UPDATE DST_DB.cards SET flags = 0 where id in " + Utils.ids2str(cids));
         Set<Long> nids = new HashSet<>(mSrc.getDb().queryColumn(Long.class,
                 "select nid from cards where id in " + Utils.ids2str(cids), 0));
         // notes


### PR DESCRIPTION
Anki's code
https://github.com/ankitects/anki/blob/master/pylib/anki/exporting.py#L198
put the flag are put to 0 while exporting. However, this exporter
seems to never be used directly, and children redefine it. I tested,
flags are exported when deck/collection are exported. So I remove the
line removing flags. This corrects #6382
