### PR TITLE
API: Allow null model deck ID

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.java
@@ -964,7 +964,23 @@ public class ContentProviderTest {
 
     }
 
-    private Collection reopenCol() {
+
+
+    /** Test that a null did will not crash the provider (#6378) */
+     @Test
+     public void testProviderProvidesDefaultForEmptyModelDeck() {
+         Collection col = getCol();
+         col.getModels().all().get(0).put("did", JSONObject.NULL);
+         col.save();
+
+         final ContentResolver cr = InstrumentationRegistry.getInstrumentation().getTargetContext().getContentResolver();
+         // Query all available models
+         final Cursor allModels = cr.query(FlashCardsContract.Model.CONTENT_URI, null, null, null, null);
+         assertNotNull(allModels);
+     }
+
+
+ private Collection reopenCol() {
         CollectionHelper.getInstance().closeCollection(false, "ContentProviderTest: reopenCol");
         return getCol();
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
@@ -42,6 +42,7 @@ import com.ichi2.anki.FlashCardsContract;
 import com.ichi2.anki.FlashCardsContract.CardTemplate;
 import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.compat.CompatHelper;
+import com.ichi2.libanki.Consts;
 import com.ichi2.libanki.sched.AbstractSched;
 import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
@@ -1083,7 +1084,8 @@ public class CardContentProvider extends ContentProvider {
                 } else if (column.equals(FlashCardsContract.Model.CSS)) {
                     rb.add(jsonObject.getString("css"));
                 } else if (column.equals(FlashCardsContract.Model.DECK_ID)) {
-                    rb.add(jsonObject.getLong("did"));
+                    //#6378 - Anki Desktop changed schema temporarily to allow null
+                    rb.add(jsonObject.optLong("did", Consts.DEFAULT_DECK_ID));
                 } else if (column.equals(FlashCardsContract.Model.SORT_FIELD_INDEX)) {
                     rb.add(jsonObject.getLong("sortf"));
                 } else if (column.equals(FlashCardsContract.Model.TYPE)) {


### PR DESCRIPTION
## Purpose / Description
Anki Desktop made a change between 2.1.26 and 2.1.28 which corrupted the model deck ID, setting it to null.

This made the API practically unusable as getting all models crashed.

Since it's occurred for a fair time, it's best to fix this in the source.

## Fixes
Fixes #6378

## Approach
Use the default deck if the Id is not found

## How Has This Been Tested?

Unit tests on API 23 emultaor

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code