### PR TITLE
Allow user to set Language Hints for Note Editor fields

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.java
@@ -13,9 +13,10 @@ import android.widget.TextView;
 
 import java.util.Locale;
 
-import androidx.annotation.Nullable;
-
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
+
 import androidx.appcompat.widget.AppCompatEditText;
 import timber.log.Timber;
 
@@ -107,14 +108,21 @@ public class FieldEditText extends AppCompatEditText {
         setText(content);
         setContentDescription(name);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && hintLocale != null) {
-            Timber.d("Setting hint locale of '%s' to '%s'", name, hintLocale);
-            setImeHintLocales(new LocaleList(hintLocale));
+            setHintLocale(hintLocale);
         }
         setMinimumWidth(400);
         mOrigBackground = getBackground();
         // Fixes bug where new instances of this object have wrong colors, probably
         // from some reuse mechanic in Android.
         setDefaultStyle();
+    }
+
+
+
+    @RequiresApi(api = Build.VERSION_CODES.N)
+    public void setHintLocale(@NonNull Locale locale) {
+        Timber.d("Setting hint locale of '%s' to '%s'", mName, locale);
+        setImeHintLocales(new LocaleList(locale));
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.java
@@ -4,10 +4,16 @@ package com.ichi2.anki;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.graphics.drawable.Drawable;
+import android.os.Build;
+import android.os.LocaleList;
 import android.os.Parcelable;
 import android.preference.PreferenceManager;
 import android.util.AttributeSet;
 import android.widget.TextView;
+
+import java.util.Locale;
+
+import androidx.annotation.Nullable;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.widget.AppCompatEditText;
@@ -89,7 +95,7 @@ public class FieldEditText extends AppCompatEditText {
     }
 
 
-    public void init(int ord, String name, String content) {
+    public void init(int ord, String name, String content, @Nullable Locale hintLocale) {
         mOrd = ord;
         mName = name;
 
@@ -100,6 +106,10 @@ public class FieldEditText extends AppCompatEditText {
         }
         setText(content);
         setContentDescription(name);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && hintLocale != null) {
+            Timber.d("Setting hint locale of '%s' to '%s'", name, hintLocale);
+            setImeHintLocales(new LocaleList(hintLocale));
+        }
         setMinimumWidth(400);
         mOrigBackground = getBackground();
         // Fixes bug where new instances of this object have wrong colors, probably

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.java
@@ -16,6 +16,7 @@
  ****************************************************************************************/
 package com.ichi2.anki;
 
+import android.os.Build;
 import android.os.Bundle;
 
 import android.text.InputType;
@@ -28,6 +29,7 @@ import android.widget.ListView;
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.ichi2.anim.ActivityTransitionAnimation;
 import com.ichi2.anki.dialogs.ConfirmationDialog;
+import com.ichi2.anki.dialogs.LocaleSelectionDialog;
 import com.ichi2.anki.dialogs.ModelEditorContextMenu;
 import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.async.CollectionTask;
@@ -44,10 +46,14 @@ import com.ichi2.utils.JSONObject;
 import java.util.ArrayList;
 import static com.ichi2.async.CollectionTask.TASK_TYPE.*;
 import com.ichi2.async.TaskData;
+import java.util.Locale;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
+import androidx.fragment.app.DialogFragment;
+import timber.log.Timber;
 
-public class ModelFieldEditor extends AnkiActivity {
+public class ModelFieldEditor extends AnkiActivity implements LocaleSelectionDialog.LocaleSelectionDialogHandler {
 
     private final static int NORMAL_EXIT = 100001;
 
@@ -551,6 +557,54 @@ public class ModelFieldEditor extends AnkiActivity {
             case ModelEditorContextMenu.FIELD_TOGGLE_STICKY:
                 toggleStickyField();
                 break;
+            default: {
+                //need this as we can't switch on a @RequiresApi
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && selection == ModelEditorContextMenu.FIELD_ADD_LANGUAGE_HINT) {
+                    Timber.i("displaying locale hint dialog");
+                    localeHintDialog();
+                    break;
+                }
+            }
         }
     };
+
+
+    @RequiresApi(api = Build.VERSION_CODES.N)
+    private void localeHintDialog() {
+        //We don't currently show the current value, but we may want to in the future
+        DialogFragment dialogFragment = LocaleSelectionDialog.newInstance(this);
+        showDialogFragment(dialogFragment);
+    }
+
+
+    /*
+     * Sets the Locale Hint of the field to the provided value.
+     * This allows some keyboard (GBoard) to change language
+     */
+    @RequiresApi(api = Build.VERSION_CODES.N)
+    private void addFieldLocaleHint(@NonNull Locale selectedLocale) {
+        String input = selectedLocale.toLanguageTag();
+        JSONObject field = (JSONObject) mNoteFields.get(mCurrentPos);
+        field.put("ad-hint-locale", input);
+        mCol.getModels().save();
+        Timber.i("Set field locale to %s", selectedLocale);
+        String format = getString(R.string.model_field_editor_language_hint_dialog_success_result, selectedLocale.getDisplayName());
+        UIUtils.showSimpleSnackbar(this, format, true);
+    }
+
+
+
+    @Override
+    @RequiresApi(api = Build.VERSION_CODES.N)
+    public void onSelectedLocale(@NonNull Locale selectedLocale) {
+        addFieldLocaleHint(selectedLocale);
+        dismissAllDialogFragments();
+    }
+
+
+    @Override
+    @RequiresApi(api = Build.VERSION_CODES.N)
+    public void onLocaleSelectionCancelled() {
+        dismissAllDialogFragments();
+    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -80,6 +80,7 @@ import com.ichi2.compat.CompatHelper;
 import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Consts;
+import com.ichi2.libanki.Models;
 import com.ichi2.libanki.Model;
 import com.ichi2.libanki.Note;
 import com.ichi2.libanki.Note.ClozeUtils;
@@ -1693,7 +1694,7 @@ public class NoteEditor extends AnkiActivity {
     private void updateFieldsFromMap(JSONObject newModel) {
         // Get the field map for new model and old fields list
         String [][] oldFields = mEditorNote.items();
-        Map<String, Pair<Integer, JSONObject>> fMapNew = getCol().getModels().fieldMap(newModel);
+        Map<String, Pair<Integer, JSONObject>> fMapNew = Models.fieldMap(newModel);
         // Build array of label/values to provide to field EditText views
         String[][] fields = new String[fMapNew.size()][2];
         for (String fname : fMapNew.keySet()) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -569,13 +569,6 @@ public class NoteEditor extends AnkiActivity {
 
         setNote(mEditorNote);
 
-        // Set current note type and deck positions in spinners
-        int position;
-        position = mAllModelIds.indexOf(mEditorNote.model().getLong("id"));
-        // set selection without firing selectionChanged event
-        // nb: setOnItemSelectedListener needs to occur after this
-        mNoteTypeSpinner.setSelection(position, false);
-
         if (mAddNote) {
             mNoteTypeSpinner.setOnItemSelectedListener(new SetNoteTypeListener());
             setTitle(R.string.cardeditor_title_add_note);
@@ -1585,10 +1578,21 @@ public class NoteEditor extends AnkiActivity {
         if (mSelectedTags == null) {
             mSelectedTags = mEditorNote.getTags();
         }
+        // nb: setOnItemSelectedListener needs to occur after this
+        setNoteTypePosition();
         updateDeckPosition();
         updateTags();
         updateCards(mEditorNote.model());
         populateEditFields();
+    }
+
+
+    private void setNoteTypePosition() {
+        // Set current note type and deck positions in spinners
+        int position;
+        position = mAllModelIds.indexOf(mEditorNote.model().getLong("id"));
+        // set selection without firing selectionChanged event
+        mNoteTypeSpinner.setSelection(position, false);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1888,7 +1888,7 @@ public class NoteEditor extends AnkiActivity {
     @TargetApi(23)
     private class ActionModeCallback implements ActionMode.Callback {
         private FieldEditText mTextBox;
-        private int mMenuId = View.generateViewId();
+        private final int mClozeMenuId = View.generateViewId();
 
         private ActionModeCallback(FieldEditText textBox) {
             super();
@@ -1903,19 +1903,24 @@ public class NoteEditor extends AnkiActivity {
         @Override
         public boolean onPrepareActionMode(ActionMode mode, Menu menu) {
             // Adding the cloze deletion floating context menu item, but only once.
-            boolean itemExists = menu.findItem(mMenuId) != null;
-            if (isClozeType() && !itemExists) {
-                menu.add(Menu.NONE, mMenuId, 0, R.string.multimedia_editor_popup_cloze);
-                return true;
-            } else {
+            if (menu.findItem(mClozeMenuId) != null) {
                 return false;
             }
+
+            int initialSize = menu.size();
+
+            if (isClozeType()) {
+                menu.add(Menu.NONE, mClozeMenuId, 0, R.string.multimedia_editor_popup_cloze);
+            }
+
+            return initialSize != menu.size();
         }
 
         @SuppressLint("SetTextI18n")
         @Override
         public boolean onActionItemClicked(ActionMode mode, MenuItem item) {
-            if (item.getItemId() == mMenuId) {
+            int itemId = item.getItemId();
+            if (itemId == mClozeMenuId) {
                 convertSelectedTextToCloze(mTextBox);
                 mode.finish();
                 return true;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/LocaleSelectionDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/LocaleSelectionDialog.java
@@ -51,6 +51,7 @@ import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 import java8.util.Lists;
 
+/** Locale selection dialog. Note: this must be dismissed onDestroy if not called from an activity implementing LocaleSelectionDialogHandler */
 public class LocaleSelectionDialog extends AnalyticsDialogFragment {
 
     private LocaleSelectionDialogHandler dialogHandler;
@@ -69,8 +70,9 @@ public class LocaleSelectionDialog extends AnalyticsDialogFragment {
     @NonNull
     public static LocaleSelectionDialog newInstance(@NonNull LocaleSelectionDialogHandler handler) {
         LocaleSelectionDialog t = new LocaleSelectionDialog();
-
-        t.setArguments(new Bundle());
+        t.dialogHandler = handler;
+        Bundle args = new Bundle();
+        t.setArguments(args);
 
         return t;
     }
@@ -88,10 +90,12 @@ public class LocaleSelectionDialog extends AnalyticsDialogFragment {
         super.onAttach(context);
         if (context instanceof Activity) {
             Activity activity = (Activity) context;
-            if (!(context instanceof LocaleSelectionDialogHandler)) {
-                throw new IllegalArgumentException("Calling activity must implement LocaleSelectionDialogHandler");
+            if (dialogHandler == null) {
+                if (!(context instanceof LocaleSelectionDialogHandler)) {
+                    throw new IllegalArgumentException("Calling activity must implement LocaleSelectionDialogHandler");
+                }
+                this.dialogHandler = (LocaleSelectionDialogHandler) context;
             }
-            this.dialogHandler = (LocaleSelectionDialogHandler) context;
             activity.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE);
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/LocaleSelectionDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/LocaleSelectionDialog.java
@@ -1,0 +1,269 @@
+/*
+ Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.dialogs;
+
+import android.app.Activity;
+import android.app.Dialog;
+import android.content.Context;
+import android.os.Bundle;
+import android.text.TextUtils;
+import android.view.LayoutInflater;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.Window;
+import android.view.WindowManager;
+import android.view.inputmethod.EditorInfo;
+import android.widget.Filter;
+import android.widget.Filterable;
+import android.widget.TextView;
+
+import com.afollestad.materialdialogs.MaterialDialog;
+import com.ichi2.anki.R;
+import com.ichi2.anki.analytics.AnalyticsDialogFragment;
+import com.ichi2.ui.RecyclerSingleTouchAdapter;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.widget.SearchView;
+import androidx.appcompat.widget.Toolbar;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+import java8.util.Lists;
+
+public class LocaleSelectionDialog extends AnalyticsDialogFragment {
+
+    private LocaleSelectionDialogHandler dialogHandler;
+
+    public interface LocaleSelectionDialogHandler {
+        void onSelectedLocale(@NonNull Locale selectedLocale);
+        void onLocaleSelectionCancelled();
+    }
+
+
+
+    /**
+     * @param handler Marker interface to enforce the convention the caller implementing LocaleSelectionDialogHandler
+     */
+    @SuppressWarnings("unused")
+    @NonNull
+    public static LocaleSelectionDialog newInstance(@NonNull LocaleSelectionDialogHandler handler) {
+        LocaleSelectionDialog t = new LocaleSelectionDialog();
+
+        t.setArguments(new Bundle());
+
+        return t;
+    }
+
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setCancelable(true);
+    }
+
+
+    @Override
+    public void onAttach(@NonNull Context context) {
+        super.onAttach(context);
+        if (context instanceof Activity) {
+            Activity activity = (Activity) context;
+            if (!(context instanceof LocaleSelectionDialogHandler)) {
+                throw new IllegalArgumentException("Calling activity must implement LocaleSelectionDialogHandler");
+            }
+            this.dialogHandler = (LocaleSelectionDialogHandler) context;
+            activity.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE);
+        }
+    }
+
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(@Nullable Bundle savedInstanceState) {
+        Activity activity = requireActivity();
+
+        View tagsDialogView = LayoutInflater.from(activity)
+                .inflate(R.layout.locale_selection_dialog, activity.findViewById(R.id.root_layout), false);
+
+
+        LocaleListAdapter mAdapter = new LocaleListAdapter(Locale.getAvailableLocales());
+        setupRecyclerView(activity, tagsDialogView, mAdapter);
+
+        inflateMenu(tagsDialogView, mAdapter);
+        //Only show a negative button, use the RecyclerView for positive actions
+        MaterialDialog.Builder builder = new MaterialDialog.Builder(activity)
+                .negativeText(getString(R.string.dialog_cancel))
+                .customView(tagsDialogView, false)
+                .onNegative((dialog, which) -> dialogHandler.onLocaleSelectionCancelled());
+
+        Dialog mDialog = builder.build();
+
+        Window window = mDialog.getWindow();
+        if (window != null) {
+            window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE);
+        }
+        return mDialog;
+    }
+
+
+    private void setupRecyclerView(@NonNull Activity activity, @NonNull View tagsDialogView, LocaleListAdapter adapter) {
+        RecyclerView recyclerView = tagsDialogView.findViewById(R.id.locale_dialog_selection_list);
+        recyclerView.requestFocus();
+        recyclerView.setHasFixedSize(true);
+        RecyclerView.LayoutManager layoutManager = new LinearLayoutManager(activity);
+        recyclerView.setLayoutManager(layoutManager);
+        recyclerView.setAdapter(adapter);
+
+
+        recyclerView.addOnItemTouchListener(new RecyclerSingleTouchAdapter(activity, (view, position) -> {
+            Locale l = adapter.getLocaleAtPosition(position);
+            LocaleSelectionDialog.this.dialogHandler.onSelectedLocale(l);
+        }));
+    }
+
+
+    private void inflateMenu(@NonNull View tagsDialogView, @NonNull final LocaleListAdapter adapter) {
+        Toolbar mToolbar = tagsDialogView.findViewById(R.id.locale_dialog_selection_toolbar);
+        mToolbar.setTitle(R.string.locale_selection_dialog_title);
+
+        mToolbar.inflateMenu(R.menu.locale_dialog_search_bar);
+
+        MenuItem searchItem = mToolbar.getMenu().findItem(R.id.locale_dialog_action_search);
+        SearchView searchView = (SearchView) searchItem.getActionView();
+        searchView.setImeOptions(EditorInfo.IME_ACTION_DONE);
+
+        searchView.setOnQueryTextListener(new SearchView.OnQueryTextListener() {
+            @Override
+            public boolean onQueryTextSubmit(String query) {
+                return false;
+            }
+            @Override
+            public boolean onQueryTextChange(String newText) {
+                adapter.getFilter().filter(newText);
+                return false;
+            }
+        });
+    }
+
+
+
+
+    public static class LocaleListAdapter extends RecyclerView.Adapter<LocaleListAdapter.TextViewHolder> implements Filterable {
+        private final List<Locale> mCurrentlyVisibleLocales;
+        private final List<Locale> mSelectableLocales;
+
+        public static class TextViewHolder extends RecyclerView.ViewHolder {
+            @NonNull
+            private final TextView mTextView;
+
+            public TextViewHolder(@NonNull TextView textView) {
+                super(textView);
+                mTextView = textView;
+            }
+
+
+            public void setText(@NonNull String text) {
+                mTextView.setText(text);
+            }
+
+
+            public void setLocale(@NonNull Locale locale) {
+                String displayValue = locale.getDisplayName();
+                mTextView.setText(displayValue);
+            }
+        }
+
+        public LocaleListAdapter(@NonNull Locale[] locales) {
+            mSelectableLocales = Lists.of(locales);
+            mCurrentlyVisibleLocales = new ArrayList<>(Arrays.asList(locales));
+        }
+
+        @NonNull
+        @Override
+        public TextViewHolder onCreateViewHolder(@NonNull ViewGroup parent,
+                                                 int viewType) {
+            TextView v = (TextView) LayoutInflater.from(parent.getContext())
+                    .inflate(R.layout.locale_dialog_fragment_textview, parent, false);
+
+            return new TextViewHolder(v);
+        }
+
+
+        @Override
+        public void onBindViewHolder(@NonNull TextViewHolder holder, int position) {
+            holder.setLocale(mCurrentlyVisibleLocales.get(position));
+        }
+
+
+        @Override
+        public int getItemCount() {
+            return mCurrentlyVisibleLocales.size();
+        }
+
+
+        @NonNull
+        public Locale getLocaleAtPosition(int position) {
+            return mCurrentlyVisibleLocales.get(position);
+        }
+
+        @NonNull
+        @Override
+        public Filter getFilter() {
+            final List<Locale> selectableLocales = mSelectableLocales;
+            final List<Locale> visibleLocales = mCurrentlyVisibleLocales;
+
+            return new Filter() {
+                @Override
+                protected FilterResults performFiltering(CharSequence constraint) {
+                    if (TextUtils.isEmpty(constraint)) {
+                        FilterResults filterResults = new FilterResults();
+                        filterResults.values = selectableLocales;
+                        return filterResults;
+                    }
+
+                    String normalisedConstraint = constraint.toString().toLowerCase();
+                    ArrayList<Locale> locales = new ArrayList<>();
+                    for (Locale l : selectableLocales) {
+                        if (l.getDisplayName().toLowerCase().contains(normalisedConstraint)) {
+                            locales.add(l);
+                        }
+                    }
+
+                    FilterResults filterResults = new FilterResults();
+                    filterResults.values = locales;
+                    return filterResults;
+                }
+
+
+                @Override
+                protected void publishResults(CharSequence constraint, FilterResults results) {
+                    visibleLocales.clear();
+                    //noinspection unchecked
+                    Collection<? extends Locale> values = (Collection<? extends Locale>) results.values;
+                    visibleLocales.addAll(values);
+                    notifyDataSetChanged();
+                }
+            };
+        }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ModelEditorContextMenu.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ModelEditorContextMenu.java
@@ -1,11 +1,14 @@
 package com.ichi2.anki.dialogs;
 
 import android.app.Dialog;
+import android.os.Build;
 import android.os.Bundle;
 
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.ichi2.anki.R;
 import com.ichi2.anki.analytics.AnalyticsDialogFragment;
+
+import androidx.annotation.RequiresApi;
 
 public class ModelEditorContextMenu extends AnalyticsDialogFragment {
 
@@ -14,6 +17,8 @@ public class ModelEditorContextMenu extends AnalyticsDialogFragment {
     public final static int FIELD_RENAME = 2;
     public final static int FIELD_DELETE = 3;
     public final static int FIELD_TOGGLE_STICKY = 4;
+    @RequiresApi(api = Build.VERSION_CODES.N)
+    public final static int FIELD_ADD_LANGUAGE_HINT = 5;
 
 
     private static MaterialDialog.ListCallback mContextMenuListener;
@@ -38,6 +43,9 @@ public class ModelEditorContextMenu extends AnalyticsDialogFragment {
         entries[FIELD_RENAME] = getResources().getString(R.string.model_field_editor_rename);
         entries[FIELD_DELETE] = getResources().getString(R.string.model_field_editor_delete);
         entries[FIELD_TOGGLE_STICKY] = getResources().getString(R.string.model_field_editor_toggle_sticky);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            entries[FIELD_ADD_LANGUAGE_HINT] = getResources().getString(R.string.model_field_editor_language_hint);
+        }
 
         return new MaterialDialog.Builder(getActivity())
                 .title(getArguments().getString("label"))
@@ -48,6 +56,10 @@ public class ModelEditorContextMenu extends AnalyticsDialogFragment {
 
 
     private int getEntryCount() {
-        return 5;
+        int entryCount = 5;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            entryCount++;
+        }
+        return entryCount;
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ModelEditorContextMenu.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ModelEditorContextMenu.java
@@ -32,7 +32,7 @@ public class ModelEditorContextMenu extends AnalyticsDialogFragment {
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        String[] entries = new String[5];
+        String[] entries = new String[getEntryCount()];
         entries[FIELD_REPOSITION] = getResources().getString(R.string.model_field_editor_reposition_menu);
         entries[SORT_FIELD] = getResources().getString(R.string.model_field_editor_sort_field);
         entries[FIELD_RENAME] = getResources().getString(R.string.model_field_editor_rename);
@@ -44,5 +44,10 @@ public class ModelEditorContextMenu extends AnalyticsDialogFragment {
                 .items(entries)
                 .itemsCallback(mContextMenuListener)
                 .build();
+    }
+
+
+    private int getEntryCount() {
+        return 5;
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1082,7 +1082,7 @@ public class Collection {
         // data is [cid, nid, mid, did, ord, tags, flds, cardFlags]
         // unpack fields and create dict
         Map<String, String> fields = new HashMap<>();
-        Map<String, Pair<Integer, JSONObject>> fmap = getModels().fieldMap(model);
+        Map<String, Pair<Integer, JSONObject>> fmap = Models.fieldMap(model);
         for (String name : fmap.keySet()) {
             fields.put(name, flist[fmap.get(name).first]);
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -43,6 +43,8 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import androidx.annotation.NonNull;
+
 @SuppressWarnings({"PMD.ExcessiveClassLength", "PMD.AvoidThrowingRawExceptionTypes","PMD.AvoidReassigningParameters",
         "PMD.NPathComplexity","PMD.MethodNamingConventions",
         "PMD.SwitchStmtsShouldHaveDefault","PMD.CollapsibleIfStatements","PMD.EmptyIfStmt"})
@@ -432,7 +434,8 @@ public class Models {
 
 
     /** "Mapping of field name -> (ord, field). */
-    public Map<String, Pair<Integer, JSONObject>> fieldMap(JSONObject m) {
+    @NonNull
+    public static Map<String, Pair<Integer, JSONObject>> fieldMap(@NonNull JSONObject m) {
         JSONArray flds = m.getJSONArray("flds");
         // TreeMap<Integer, String> map = new TreeMap<Integer, String>();
         Map<String, Pair<Integer, JSONObject>> result = new HashMap<>();

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Note.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Note.java
@@ -80,7 +80,7 @@ public class Note implements Cloneable {
             Arrays.fill(mFields, "");
             mFlags = 0;
             mData = "";
-            mFMap = mCol.getModels().fieldMap(mModel);
+            mFMap = Models.fieldMap(mModel);
             mScm = mCol.getScm();
         }
     }
@@ -102,7 +102,7 @@ public class Note implements Cloneable {
             mFlags = cursor.getInt(6);
             mData = cursor.getString(7);
             mModel = mCol.getModels().get(mMid);
-            mFMap = mCol.getModels().fieldMap(mModel);
+            mFMap = Models.fieldMap(mModel);
             mScm = mCol.getScm();
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/ui/RecyclerSingleTouchAdapter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/RecyclerSingleTouchAdapter.java
@@ -1,0 +1,67 @@
+/*
+ Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.ui;
+
+import android.content.Context;
+import android.view.GestureDetector;
+import android.view.MotionEvent;
+import android.view.View;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+/** Adapts a RecyclerView.OnItemTouchListener to provide a click listener */
+public class RecyclerSingleTouchAdapter implements RecyclerView.OnItemTouchListener {
+    private OnItemClickListener mListener;
+    private GestureDetector mGestureDetector;
+
+    public interface OnItemClickListener {
+        void onItemClick(@NonNull View view, int position);
+    }
+
+
+    public RecyclerSingleTouchAdapter(@NonNull Context context, @NonNull OnItemClickListener listener) {
+        mListener = listener;
+        mGestureDetector = new GestureDetector(context, new GestureDetector.SimpleOnGestureListener() {
+            @Override
+                public boolean onSingleTapUp(MotionEvent e) {
+                //onDown was too fast
+                return true;
+            }
+        });
+    }
+
+
+    @Override
+    public boolean onInterceptTouchEvent(@NonNull RecyclerView view, @NonNull MotionEvent e) {
+        View childView = view.findChildViewUnder(e.getX(), e.getY());
+        if (childView != null && mListener != null && mGestureDetector.onTouchEvent(e)) {
+            mListener.onItemClick(childView, view.getChildAdapterPosition(childView));
+            return true;
+        }
+        return false;
+    }
+
+    @Override public void onTouchEvent(@NonNull RecyclerView view, @NonNull MotionEvent motionEvent) {
+        //intentionally empty
+    }
+
+    @Override
+    public void onRequestDisallowInterceptTouchEvent (boolean disallowIntercept) {
+        //intentionally empty
+    }
+}

--- a/AnkiDroid/src/main/res/layout/locale_dialog_fragment_textview.xml
+++ b/AnkiDroid/src/main/res/layout/locale_dialog_fragment_textview.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+  This program is free software; you can redistribute it and/or modify it under
+  the terms of the GNU General Public License as published by the Free Software
+  Foundation; either version 3 of the License, or (at your option) any later
+  version.
+
+  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along with
+  this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+<androidx.appcompat.widget.AppCompatTextView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/locale_dialog_fragment_text_view"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:textSize="@dimen/content_textsize"
+    android:padding="@dimen/content_vertical_padding"
+    />

--- a/AnkiDroid/src/main/res/layout/locale_selection_dialog.xml
+++ b/AnkiDroid/src/main/res/layout/locale_selection_dialog.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+  This program is free software; you can redistribute it and/or modify it under
+  the terms of the GNU General Public License as published by the Free Software
+  Foundation; either version 3 of the License, or (at your option) any later
+  version.
+
+  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along with
+  this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.appcompat.widget.Toolbar xmlns:app="http://schemas.android.com/apk/res-auto"
+        android:id="@+id/locale_dialog_selection_toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:minHeight="?attr/actionBarSize"
+        android:theme="@style/ActionBarStyle"
+        android:background="?attr/colorPrimary"
+        android:layout_alignParentTop="true"
+        app:title="@string/locale_selection_dialog_title"
+        app:popupTheme="@style/ActionBar.Popup"
+        />
+
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/locale_dialog_selection_list"
+        android:scrollbars="vertical"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/locale_dialog_selection_toolbar"
+        android:layout_above="@+id/locale_dialog_summary"
+        android:fadeScrollbars="false"
+        />
+
+    <TextView
+        android:id="@+id/locale_dialog_summary"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_horizontal"
+        android:text="@string/locale_selection_dialog_summary"
+        android:padding="@dimen/content_vertical_padding"
+        android:layout_alignParentBottom="true"
+        />
+
+</RelativeLayout>

--- a/AnkiDroid/src/main/res/menu/locale_dialog_search_bar.xml
+++ b/AnkiDroid/src/main/res/menu/locale_dialog_search_bar.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+  This program is free software; you can redistribute it and/or modify it under
+  the terms of the GNU General Public License as published by the Free Software
+  Foundation; either version 3 of the License, or (at your option) any later
+  version.
+
+  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along with
+  this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/locale_dialog_action_search"
+        android:title="@string/menu_search"
+        android:icon="@drawable/ic_search_white_24dp"
+        app:actionViewClass="androidx.appcompat.widget.SearchView"
+        app:showAsAction="ifRoom|collapseActionView"
+        />
+</menu>

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -100,6 +100,7 @@
     <string name="note_editor_no_cards_created">No cards created. Please fill in more fields</string>
     <string name="note_editor_no_first_field">The first field is empty</string>
     <string name="note_editor_no_cloze_delations">This note type must contain cloze deletions</string>
+    <string name="note_editor_set_field_language">Set field language</string>
     <string name="note_editor_no_cards_created_all_fields">The current note type did not produce any cards.\nPlease choose another note type, or click ‘Cards’ and add a field substitution</string>
     <string name="note_editor_insert_cloze_no_cloze_note_type">Cloze deletions will only work on a Cloze note type</string>
     <string name="saving_facts">Saving note</string>

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -206,6 +206,11 @@
     <string name="boot_service_failed_to_schedule_notifications">Failed to schedule reminders</string>
     <string name="boot_service_too_many_notifications">Too many reminders scheduled. Some will not appear</string>
 
+    <!-- Locale Selection Dialog -->
+    <string name="locale_selection_dialog_title">Keyboard Hint Selection</string>
+    <string name="locale_selection_dialog_summary">Some multilingual keyboards, such as GBoard support changing language when editing text\n\nPlease request the “setImeHintLocales” feature from your keyboard manufacturer if your keyboard does not change language.</string>
+
+
     <!--Sync-->
     <plurals name="sync_automatic_sync_needs_more_time">
         <item quantity="one">An automatic sync may be triggered in %d second</item>

--- a/AnkiDroid/src/main/res/values/17-model-manager.xml
+++ b/AnkiDroid/src/main/res/values/17-model-manager.xml
@@ -42,6 +42,9 @@
     <!--Rename-->
     <string name="rename_model">Rename note type</string>
 
+    <!--Language Hint-->
+    <string name="model_field_editor_language_hint_dialog_title">Keyboard language hint</string>
+    <string name="model_field_editor_language_hint_dialog_success_result">Set language hint to %s</string>
 
     <!--Field Editing-->
     <string name="model_field_editor_title">Edit fields</string>.
@@ -49,6 +52,7 @@
     <string name="model_field_editor_delete">Delete field</string>
     <string name="model_field_editor_options">Field options</string>
     <string name="model_field_editor_rename">Rename field</string>
+    <string name="model_field_editor_language_hint">Set keyboard language hint</string>
     <string name="model_field_editor_reposition_menu">Reposition field</string>
     <string name="model_field_editor_reposition">Reposition field (enter a value %1$d–%2$d)</string>
     <string name="model_field_editor_toggle_sticky">Remember last input when adding</string>


### PR DESCRIPTION
## Draft

I've removed the draft flag - I'd like to get this in and refactor if it gets traction and then refactor (if feasible)

----

This needs investigation as to whether this can be simplified via 

```java
InputMethodSubtype ims = InputMethodManager.getCurrentInputMethodSubtype().getLocale();
```

If this works (50/50 - Android IME options are flaky), then the field editor fragment and locale selection screen can be removed and this feature is much smaller.

## To Review

* This does not handle an "unset" - I don't feel this is necessary, but that's borderline.
* We use `Locale.getAvailableLocales()` for the locale list, we currently use the system language. Do we want to use the AnkiDroid language here?
* Does this need to be split up further to make it reviewable? Where are the pain points currently?

## Purpose / Description
Feature request: allow the keyboard to remember the last input language on a field.

Sadly, this didn't seem possible, but it is possible to select and keep a "language hint"

## Fixes
Fixes #3496 

## Approach
Add a field into the "field" JSON specifying the language. Add a context menu on the note editor, and menu in the fields screen to set

## How Has This Been Tested?

Manually tested - including with Don't Keep Activities.

This works after syncing.

This does not work with SwiftKey, which is disappointing.

Screenshots and video incoming

## Learning

Initial StackOverflow research said this wasn't possible, they were mistaken

https://developer.android.com/reference/android/widget/TextView#setImeHintLocales(android.os.LocaleList)

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
