### PR TITLE
NoteEditor: Stop replacing newlines with "<br>"

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.java
@@ -18,8 +18,6 @@ import static android.view.inputmethod.EditorInfo.IME_FLAG_NO_EXTRACT_UI;
 
 public class FieldEditText extends AppCompatEditText {
 
-    public static final String NEW_LINE = System.getProperty("line.separator");
-
     private String mName;
     private int mOrd;
     private Drawable mOrigBackground;
@@ -90,8 +88,6 @@ public class FieldEditText extends AppCompatEditText {
 
         if (content == null) {
             content = "";
-        } else {
-            content = content.replaceAll("<br(\\s*\\/*)>", NEW_LINE);
         }
         setText(content);
         setContentDescription(name);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1520,7 +1520,7 @@ public class NoteEditor extends AnkiActivity {
 
 
     private boolean updateField(FieldEditText field) {
-        String newValue = field.getText().toString().replace(FieldEditText.NEW_LINE, "<br>");
+        String newValue = field.getText().toString();
         if (!mEditorNote.values()[field.getOrd()].equals(newValue)) {
             mEditorNote.values()[field.getOrd()] = newValue;
             return true;


### PR DESCRIPTION
## Review Goals

* Determine if there are any cases where we want to perform this operation (checksum, duplicates)?

## Purpose / Description
To my knowledge, Anki Desktop does not do this, and it causes various bugs

## Fixes
Fixes #4189 
Fixes #3304 

## Approach
Remove the offending code

## How Has This Been Tested?

* Ran Unit Tests
* #4189 no longer occurs.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code