### PR TITLE
Add Missing Statistics Data to Overview 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/stats/OverviewStatsBuilder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/stats/OverviewStatsBuilder.java
@@ -70,6 +70,9 @@ public class OverviewStatsBuilder {
 
         public long totalCards;
         public long totalNotes;
+        public double lowestEase;
+        public double averageEase;
+        public double highestEase;
 
         public static class AnswerButtonsOverview {
             public int total;
@@ -204,6 +207,13 @@ public class OverviewStatsBuilder {
         stringBuilder.append(res.getString(R.string.stats_overview_card_types_total_cards, oStats.totalCards));
         stringBuilder.append("<br>");
         stringBuilder.append(res.getString(R.string.stats_overview_card_types_total_notes, oStats.totalNotes));
+        stringBuilder.append("<br>");
+        stringBuilder.append(res.getString(R.string.stats_overview_card_types_lowest_ease, oStats.lowestEase));
+        stringBuilder.append("<br>");
+        stringBuilder.append(res.getString(R.string.stats_overview_card_types_average_ease, oStats.averageEase));
+        stringBuilder.append("<br>");
+        stringBuilder.append(res.getString(R.string.stats_overview_card_types_highest_ease, oStats.highestEase));
+
     }
 
     private void appendTodaysStats(StringBuilder stringBuilder) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/stats/OverviewStatsBuilder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/stats/OverviewStatsBuilder.java
@@ -48,7 +48,7 @@ public class OverviewStatsBuilder {
     private final Stats.AxisType mType;
 
 
-    public class OverviewStats {
+    public static class OverviewStats {
         public int forecastTotalReviews;
         public double forecastAverageReviews;
         public int forecastDueTomorrow;
@@ -64,6 +64,21 @@ public class OverviewStatsBuilder {
         public int totalNewCards;
         public double averageInterval;
         public double longestInterval;
+        public AnswerButtonsOverview newCardsOverview;
+        public AnswerButtonsOverview youngCardsOverview;
+        public AnswerButtonsOverview matureCardsOverview;
+
+        public static class AnswerButtonsOverview {
+            public int total;
+            public int correct;
+
+            public double getPercentage() {
+                if (correct == 0) {
+                    return 0;
+                }
+                return (double) correct / (double) total * 100.0;
+            }
+        }
     }
 
     public OverviewStatsBuilder(WebView chartView, Collection collectionData, long deckId, Stats.AxisType mStatType) {
@@ -165,6 +180,14 @@ public class OverviewStatsBuilder {
         stringBuilder.append("<br>");
         stringBuilder.append(res.getString(R.string.stats_overview_longest_interval));
         stringBuilder.append(Utils.roundedTimeSpan(mWebView.getContext(), (int) Math.round(oStats.longestInterval * Stats.SECONDS_PER_DAY)));
+
+        //ANSWER BUTTONS
+        stringBuilder.append(_subtitle(res.getString(R.string.stats_answer_buttons).toUpperCase()));
+        stringBuilder.append(res.getString(R.string.stats_overview_answer_buttons_learn, oStats.newCardsOverview.getPercentage(), oStats.newCardsOverview.correct, oStats.newCardsOverview.total));
+        stringBuilder.append("<br>");
+        stringBuilder.append(res.getString(R.string.stats_overview_answer_buttons_young, oStats.youngCardsOverview.getPercentage(), oStats.youngCardsOverview.correct, oStats.youngCardsOverview.total));
+        stringBuilder.append("<br>");
+        stringBuilder.append(res.getString(R.string.stats_overview_answer_buttons_mature,  oStats.matureCardsOverview.getPercentage(), oStats.matureCardsOverview.correct, oStats.matureCardsOverview.total));
     }
 
     private void appendTodaysStats(StringBuilder stringBuilder) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/stats/OverviewStatsBuilder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/stats/OverviewStatsBuilder.java
@@ -68,6 +68,9 @@ public class OverviewStatsBuilder {
         public AnswerButtonsOverview youngCardsOverview;
         public AnswerButtonsOverview matureCardsOverview;
 
+        public long totalCards;
+        public long totalNotes;
+
         public static class AnswerButtonsOverview {
             public int total;
             public int correct;
@@ -195,6 +198,12 @@ public class OverviewStatsBuilder {
         stringBuilder.append(res.getString(R.string.stats_overview_answer_buttons_young, oStats.youngCardsOverview.getPercentage(), oStats.youngCardsOverview.correct, oStats.youngCardsOverview.total));
         stringBuilder.append("<br>");
         stringBuilder.append(res.getString(R.string.stats_overview_answer_buttons_mature,  oStats.matureCardsOverview.getPercentage(), oStats.matureCardsOverview.correct, oStats.matureCardsOverview.total));
+
+        //CARD TYPES
+        stringBuilder.append(_subtitle(res.getString(R.string.stats_cards_types).toUpperCase()));
+        stringBuilder.append(res.getString(R.string.stats_overview_card_types_total_cards, oStats.totalCards));
+        stringBuilder.append("<br>");
+        stringBuilder.append(res.getString(R.string.stats_overview_card_types_total_notes, oStats.totalNotes));
     }
 
     private void appendTodaysStats(StringBuilder stringBuilder) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/stats/OverviewStatsBuilder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/stats/OverviewStatsBuilder.java
@@ -165,7 +165,10 @@ public class OverviewStatsBuilder {
             stringBuilder.append("<br>");
             stringBuilder.append(res.getString(R.string.stats_overview_time_per_day_all, oStats.timePerDayOnAll));
         }
-        // TODO: Average answer time: x.xs (x.x cards/minute)
+        double cardsPerMinute = oStats.totalTime == 0 ? 0 : ((double)oStats.totalReviews) / oStats.totalTime;
+        double averageAnswerTime = oStats.totalReviews == 0 ? 0 : (oStats.totalTime * 60) / ((double)oStats.totalReviews);
+        stringBuilder.append("<br>");
+        stringBuilder.append(res.getString(R.string.stats_overview_average_answer_time, averageAnswerTime, cardsPerMinute));
 
         stringBuilder.append("<br>");
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/stats/OverviewStatsBuilder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/stats/OverviewStatsBuilder.java
@@ -151,11 +151,15 @@ public class OverviewStatsBuilder {
 
         stringBuilder.append("<br>");
 
+        //TODO: AnkiDroid uses 30 days on 2020-06-09, whereas Anki Desktop used 31
+
         //REVIEW TIME
         stringBuilder.append(_subtitle(res.getString(R.string.stats_review_time).toUpperCase()));
         stringBuilder.append(daysStudied);
         stringBuilder.append("<br>");
-        // TODO: Total: x minutes
+        //TODO: Anki Desktop allows changing to hours / days here.
+        stringBuilder.append(res.getString(R.string.stats_overview_total_time_in_period, Math.round(oStats.totalTime)));
+        stringBuilder.append("<br>");
         stringBuilder.append(res.getString(R.string.stats_overview_time_per_day_studydays, oStats.timePerDayOnStudyDays));
         if (!allDaysStudied) {
             stringBuilder.append("<br>");

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/stats/Stats.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/stats/Stats.java
@@ -308,6 +308,19 @@ public class Stats {
         oStats.newCardsOverview = toOverview(0, list);
         oStats.youngCardsOverview = toOverview(1, list);
         oStats.matureCardsOverview = toOverview(2, list);
+
+        String totalCountQuery = "select count(id), count(distinct nid) from cards where did in " + this._limit();
+        try {
+            cur = mCol.getDb().getDatabase().query(totalCountQuery, null);
+            if (cur.moveToFirst()) {
+                oStats.totalCards = cur.getLong(0);
+                oStats.totalNotes = cur.getLong(1);
+            }
+        } finally {
+            if (cur != null && !cur.isClosed()) {
+                cur.close();
+            }
+        }
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/stats/Stats.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/stats/Stats.java
@@ -24,6 +24,7 @@ import android.text.TextUtils;
 import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.R;
 import com.ichi2.anki.stats.OverviewStatsBuilder;
+import com.ichi2.anki.stats.OverviewStatsBuilder.OverviewStats.AnswerButtonsOverview;
 import com.ichi2.anki.stats.StatsMetaInfo;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Consts;
@@ -302,7 +303,39 @@ public class Stats {
 
         oStats.totalNewCards = getNewCards(timespan);
         oStats.newCardsPerDay = (double) oStats.totalNewCards / (double) oStats.allDays;
+
+        ArrayList<double[]> list = eases(timespan);
+        oStats.newCardsOverview = toOverview(0, list);
+        oStats.youngCardsOverview = toOverview(1, list);
+        oStats.matureCardsOverview = toOverview(2, list);
     }
+
+
+    private AnswerButtonsOverview toOverview(int type, ArrayList<double[]> list) {
+        AnswerButtonsOverview answerButtonsOverview = new AnswerButtonsOverview();
+
+        final int INDEX_TYPE = 0; //0:learn; 1:young; 2:mature
+        final int INDEX_EASE = 1; //1...4 - AGAIN - EASY
+        final int INDEX_COUNT = 2;
+
+        final double EASE_AGAIN = 1d;
+
+        for (double[] elements : list) {
+            //if we're not of the type we're looking for, continue
+            if (elements[INDEX_TYPE] != type) {
+                continue;
+            }
+
+            double answersCountForTypeAndEase = elements[INDEX_COUNT];
+            boolean isAgain = elements[INDEX_EASE] == EASE_AGAIN;
+
+            answerButtonsOverview.total += answersCountForTypeAndEase;
+            answerButtonsOverview.correct += isAgain ? 0 : answersCountForTypeAndEase;
+        }
+
+        return answerButtonsOverview;
+    }
+
 
     public boolean calculateDue(Context context, AxisType type) {
         // Not in libanki
@@ -1053,6 +1086,47 @@ public class Stats {
         mValueLabels = new int[] { R.string.statistics_learn, R.string.statistics_young, R.string.statistics_mature};
         mColors = new int[] { R.attr.stats_learn, R.attr.stats_young, R.attr.stats_mature};
         mType = type;
+        ArrayList<double[]> list = eases(type);
+
+        //TODO adjust for AnswerButton, for now only copied from intervals
+        // small adjustment for a proper chartbuilding with achartengine
+        if (list.size() == 0) {
+            list.add(0, new double[]{0, 1, 0});
+        }
+
+        mSeriesList = new double[4][list.size()+1];
+
+        for (int i = 0; i < list.size(); i++) {
+            double[] data = list.get(i);
+            int currentType = (int)data[0];
+            double ease = data[1];
+            double cnt = data[2];
+
+            if (currentType == Consts.CARD_TYPE_LRN) {
+                ease += 5;
+            } else if (currentType == 2) {
+                ease += 10;
+            }
+            mSeriesList[0][i] = ease;
+            mSeriesList[1 + currentType][i] = cnt;
+            if (cnt > mMaxCards) {
+                mMaxCards = (int) cnt;
+            }
+        }
+        mSeriesList[0][list.size()] = 15;
+
+        mFirstElement = 0.5;
+        mLastElement = 14.5;
+        mMcount = 100;
+        mMaxElements = 15;      //bars are positioned from 1 to 14
+        if(mMaxCards == 0) {
+            mMaxCards = 10;
+        }
+        return list.size() > 0;
+    }
+
+
+    private ArrayList<double[]> eases(AxisType type) {
         String lim = _getDeckFilter().replaceAll("[\\[\\]]", "");
 
         Vector<String> lims = new Vector<>();
@@ -1111,43 +1185,9 @@ public class Stats {
                 cur.close();
             }
         }
-
-        //TODO adjust for AnswerButton, for now only copied from intervals
-        // small adjustment for a proper chartbuilding with achartengine
-        if (list.size() == 0) {
-            list.add(0, new double[]{0, 1, 0});
-        }
-
-        mSeriesList = new double[4][list.size()+1];
-
-        for (int i = 0; i < list.size(); i++) {
-            double[] data = list.get(i);
-            int currentType = (int)data[0];
-            double ease = data[1];
-            double cnt = data[2];
-
-            if (currentType == Consts.CARD_TYPE_LRN) {
-                ease += 5;
-            } else if (currentType == 2) {
-                ease += 10;
-            }
-            mSeriesList[0][i] = ease;
-            mSeriesList[1 + currentType][i] = cnt;
-            if (cnt > mMaxCards) {
-                mMaxCards = (int) cnt;
-            }
-        }
-        mSeriesList[0][list.size()] = 15;
-
-        mFirstElement = 0.5;
-        mLastElement = 14.5;
-        mMcount = 100;
-        mMaxElements = 15;      //bars are positioned from 1 to 14
-        if(mMaxCards == 0) {
-            mMaxCards = 10;
-        }
-        return list.size() > 0;
+        return list;
     }
+
 
     /**
      * Card Types

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/stats/Stats.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/stats/Stats.java
@@ -321,6 +321,24 @@ public class Stats {
                 cur.close();
             }
         }
+
+        String factorQuery = "select\n" +
+                "min(factor) / 10.0,\n" +
+                "avg(factor) / 10.0,\n" +
+                "max(factor) / 10.0\n" +
+                "from cards where did in " + _limit() + " and queue = " + Consts.QUEUE_TYPE_REV;
+        try {
+            cur = mCol.getDb().getDatabase().query(factorQuery, null);
+            if (cur.moveToFirst()) {
+                oStats.lowestEase = cur.getLong(0);
+                oStats.averageEase = cur.getLong(1);
+                oStats.highestEase = cur.getLong(2);
+            }
+        } finally {
+            if (cur != null && !cur.isClosed()) {
+                cur.close();
+            }
+        }
     }
 
 

--- a/AnkiDroid/src/main/res/values/06-statistics.xml
+++ b/AnkiDroid/src/main/res/values/06-statistics.xml
@@ -83,6 +83,9 @@
     <string name="stats_overview_answer_buttons_young">Young: &lt;b&gt;%1$.2f%%&lt;/b&gt; correct (%2$d of %3$d)</string>
     <string name="stats_overview_answer_buttons_mature">Mature: &lt;b&gt;%1$.2f%%&lt;/b&gt; correct (%2$d of %3$d)</string>
 
+    <string name="stats_overview_card_types_total_cards">Total cards: &lt;b&gt;%d&lt;/b&gt;</string>
+    <string name="stats_overview_card_types_total_notes">Total notes: &lt;b&gt;%d&lt;/b&gt;</string>
+
     <string name="deck_summary_all_decks">All decks</string>
     <string name="stats_select_time_scale">Select timescale</string>
     <string-array name="due_x_axis_title">

--- a/AnkiDroid/src/main/res/values/06-statistics.xml
+++ b/AnkiDroid/src/main/res/values/06-statistics.xml
@@ -85,6 +85,9 @@
 
     <string name="stats_overview_card_types_total_cards">Total cards: &lt;b&gt;%d&lt;/b&gt;</string>
     <string name="stats_overview_card_types_total_notes">Total notes: &lt;b&gt;%d&lt;/b&gt;</string>
+    <string name="stats_overview_card_types_lowest_ease">Lowest ease: &lt;b&gt;%.0f%%&lt;/b&gt;</string>
+    <string name="stats_overview_card_types_average_ease">Average ease: &lt;b&gt;%.0f%%&lt;/b&gt;</string>
+    <string name="stats_overview_card_types_highest_ease">Highest ease: &lt;b&gt;%.0f%%&lt;/b&gt;</string>
 
     <string name="deck_summary_all_decks">All decks</string>
     <string name="stats_select_time_scale">Select timescale</string>

--- a/AnkiDroid/src/main/res/values/06-statistics.xml
+++ b/AnkiDroid/src/main/res/values/06-statistics.xml
@@ -63,6 +63,7 @@
     <string name="stats_overview_reviews_per_day_studydays">Average for days studied: &lt;b&gt;%1$.1f&lt;/b&gt; reviews/day</string>
     <string name="stats_overview_reviews_per_day_all">If you studied every day: &lt;b&gt;%1$.1f&lt;/b&gt; reviews/day</string>
 
+    <string name="stats_overview_total_time_in_period">Total: &lt;b&gt;%d&lt;/b&gt; minutes</string>
     <string name="stats_overview_time_per_day_studydays">Average for days studied: &lt;b&gt;%1$.1f&lt;/b&gt; minutes/day</string>
     <string name="stats_overview_time_per_day_all">If you studied every day:  &lt;b&gt;%1$.1f&lt;/b&gt; minutes/day</string>
 

--- a/AnkiDroid/src/main/res/values/06-statistics.xml
+++ b/AnkiDroid/src/main/res/values/06-statistics.xml
@@ -66,6 +66,7 @@
     <string name="stats_overview_total_time_in_period">Total: &lt;b&gt;%d&lt;/b&gt; minutes</string>
     <string name="stats_overview_time_per_day_studydays">Average for days studied: &lt;b&gt;%1$.1f&lt;/b&gt; minutes/day</string>
     <string name="stats_overview_time_per_day_all">If you studied every day:  &lt;b&gt;%1$.1f&lt;/b&gt; minutes/day</string>
+    <string name="stats_overview_average_answer_time">Average answer time: &lt;b&gt;%1$.1fs&lt;/b&gt; (&lt;b&gt;%2$.2f&lt;/b&gt; cards/minute)</string>
 
     <string name="stats_overview_new_cards_per_day">Average: &lt;b&gt;%1$.1f&lt;/b&gt; cards/day</string>
     <string name="stats_overview_total_new_cards">Total: &lt;b&gt;%1$d&lt;/b&gt; cards</string>

--- a/AnkiDroid/src/main/res/values/06-statistics.xml
+++ b/AnkiDroid/src/main/res/values/06-statistics.xml
@@ -77,6 +77,10 @@
     <string name="stats_overview_days">&lt;b&gt;%1$.1f&lt;/b&gt; days</string>
     <string name="stats_overview_hours">&lt;b&gt;%1$.1f&lt;/b&gt; hours</string>
 
+    <string name="stats_overview_answer_buttons_learn">Learning: &lt;b&gt;%1$.2f%%&lt;/b&gt; correct (%2$d of %3$d)</string>
+    <string name="stats_overview_answer_buttons_young">Young: &lt;b&gt;%1$.2f%%&lt;/b&gt; correct (%2$d of %3$d)</string>
+    <string name="stats_overview_answer_buttons_mature">Mature: &lt;b&gt;%1$.2f%%&lt;/b&gt; correct (%2$d of %3$d)</string>
+
     <string name="deck_summary_all_decks">All decks</string>
     <string name="stats_select_time_scale">Select timescale</string>
     <string-array name="due_x_axis_title">


### PR DESCRIPTION
## Goals 

* Compare the two images and ensure data is consistent

## Purpose / Description
This brings us in line with the data that is shown by vanilla Anki Desktop on the stats page.

The months don't completely line up, so my screenshots display years.

## Fixes
Fixes #5266 
Fixes #4326 

## Approach
* Bit 'o SQL, bit o' comparison. Then output to HTML

* The translation strings here are a nightmare

## How Has This Been Tested?

Comparison with Anki Desktop. See comment

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code