### PR TITLE
Add Exception reports on more import failures

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -1114,6 +1114,7 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
             }
             Utils.unzipFiles(zip, dir.getAbsolutePath(), new String[] { colname, "media" }, null);
         } catch (IOException e) {
+            AnkiDroidApp.sendExceptionReport(e, "doInBackgroundImportReplace - unzip");
             return new TaskData(-2, null, false);
         }
         String colFile = new File(dir, colname).getAbsolutePath();
@@ -1135,6 +1136,7 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
             } catch (Exception e2) {
                 // do nothing
             }
+            AnkiDroidApp.sendExceptionReport(e, "doInBackgroundImportReplace - open col");
             return new TaskData(-2, null, false);
         } finally {
             if (tmpCol != null) {


### PR DESCRIPTION
## Purpose / Description
We'll probably need to tune this more later on, but for now it's near impossible to diagnose "This isn't a valid apkg file" as we don't get an exception report.

Hopefully allows us to get to the root cause of #6419.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code