### PR TITLE
Refuse to compile with unsupported JDKs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import org.gradle.internal.jvm.Jvm
+
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
@@ -14,6 +16,18 @@ buildscript {
 
 ext {
 
+    jvmVersion = Jvm.current().javaVersion.majorVersion
+    if (jvmVersion != "8" && jvmVersion != "11" && jvmVersion != "14") {
+        println "\n\n\n"
+        println "**************************************************************************************************************"
+        println "\n\n\n"
+        println "ERROR: AnkiDroid builds with JVM LTS and current releases (currently major version 8, 11, or 14)."
+        println "  Incompatible major version detected: '" + jvmVersion + "'"
+        println "\n\n\n"
+        println "**************************************************************************************************************"
+        println "\n\n\n"
+        System.exit(1)
+    }
     travisBuild = System.getenv("TRAVIS") == "true"
     // allows for -Dpre-dex=false to be set
     preDexEnabled = "true" == System.getProperty("pre-dex", "true")


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
It was possible to use unsupported JDKs as a developer, leading to very obscure problems in robolectric when you ran the test harness

Part of a good developer experience is determining invalid environment states as quickly as possible, then refusing to go further, ideally with a nice message explaining the problem

## Fixes
Fixes #6428

## Approach
Use some groovy to detect the JVM major version, and abort with message if the JVM isn't one of the ones we support

## How Has This Been Tested?

I don't have an unsupported JVM but when I falsified the test (by overriding the current JVM variable to 9) I get a nice message now

![AnkiDroid_Incorrect_JDK_Error](https://user-images.githubusercontent.com/782704/84325278-03e7c900-ab40-11ea-855a-e00d4f85634a.png)


## Learning (optional, can help others)
Groovy is pretty groovy, if you know Java.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
