### PR TITLE
Fix Browser "Edit Note" Multiselect crash when changing Note Type

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -657,6 +657,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
         editCard.putExtra(NoteEditor.EXTRA_CALLER, NoteEditor.CALLER_CARDBROWSER_EDIT);
         editCard.putExtra(NoteEditor.EXTRA_CARD_ID, sCardBrowserCard.getId());
         startActivityForResultWithAnimation(editCard, EDIT_CARD, ActivityTransitionAnimation.LEFT);
+        //#6432 - FIXME - onCreateOptionsMenu crashes if receiving an activity result from edit card when in multiselect
+        endMultiSelectMode();
     }
 
     private void openNoteEditorForCurrentlySelectedNote() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -125,7 +125,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
     public static final String EDITED = "edited";
     public static final String INTERVAL = "interval";
     public static final String LAPSES = "lapses";
-    public static final String NOTE = "note";
+    public static final String NOTE_TYPE = "note";
     public static final String REVIEWS = "reviews";
     private static Pattern sMarkedPattern = Pattern.compile(".*[Mm]arked.*");
 
@@ -180,7 +180,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
     private static final String[] COLUMN2_KEYS = {ANSWER,
         CARD,
         DECK,
-        NOTE,
+        NOTE_TYPE,
         QUESTION,
         TAGS,
         LAPSES,
@@ -1512,7 +1512,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 break;
         }
         item.put(LAPSES, Integer.toString(c.getLapses()));
-        item.put(NOTE, c.model().optString("name"));
+        item.put(NOTE_TYPE, c.model().optString("name"));
         item.put(QUESTION, formatQA(q, context));
         item.put(REVIEWS, Integer.toString(c.getReps()));
         String tags = note.stringTags();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -380,30 +380,9 @@ public class CardBrowser extends NavigationDrawerActivity implements
         return ids;
     }
 
-    private boolean hasSelectedSingleNoteId() {
-        //Heuristic to skip a large array copy
-        if (checkedCardCount() > 50) {
-            return false;
-        }
-        //copy to array to ensure threadsafe iteration
-        Integer[] checkedPositions = mCheckedCardPositions.toArray(new Integer[0]);
-        List<Map<String, String>> cards = mCards;
-
-        HashSet<String> notes = new HashSet<>();
-        for (Integer position : checkedPositions) {
-            String noteId;
-            try {
-                noteId = cards.get(position).get(NOTE);
-            } catch (IndexOutOfBoundsException e) {
-                //#6384
-                Timber.w(e, "concurrent modification of mCards array - assume more than one note selected");
-                return false;
-            }
-            if (notes.add(noteId) && notes.size() > 1) {
-                return false;
-            }
-        }
-        return mCards == cards && notes.size() == 1;
+    private boolean canPerformMultiSelectEditNote() {
+        //The noteId is not currently available. Only allow if a single card is selected for now.
+        return checkedCardCount() == 1;
     }
 
     @VisibleForTesting
@@ -884,7 +863,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
         mActionBarMenu.findItem(R.id.action_select_all).setVisible(!hasSelectedAllCards());
         //Note: Theoretically should not happen, as this should kick us back to the menu
         mActionBarMenu.findItem(R.id.action_select_none).setVisible(hasSelectedCards());
-        mActionBarMenu.findItem(R.id.action_edit_note).setVisible(hasSelectedSingleNoteId());
+        mActionBarMenu.findItem(R.id.action_edit_note).setVisible(canPerformMultiSelectEditNote());
     }
 
 


### PR DESCRIPTION
## Purpose / Description

Two bugs (sorry):

* The ActionItem should only have been visible if selecting cards from a single note. I was using `NOTE` to ensure uniqueness. `NOTE` was the name of the note type, not the `NoteId`.
* This did not cause bugs, as only one card ID was sent to the note editor, but it was confusing.
  * Now, we only show "Edit Note" if a single card is active.

* There is currently a bug that a result from the NoteEditor will cause a crash if the CardBrowser is in multiselect mode.
  * We move to single-select mode just before we show the Note Editor, this change is visible on the screen for a fraction of a second

I would personally like to keep this functionality, as it makes "Edit Note" more discoverable.

## Fixes
Fixes #6432 

## How Has This Been Tested?

On my Android Device - new collection. Can now edit a note's note type via the ActionItem without a crash.

Unit tests pass

## Learning 

If Arthur wasn't already working on merging the positions and cards data structure, this would be my next move. It's a large source of bugs.

The stringly typing also obscured the issue, so I'm glad that's going away.

I feel I've moved strayed too far to the velocity side of "velocity vs quality" with the change that caused this. I'll be more cautious and will perform more automated testing in the future.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code