### PR TITLE
sync: fix media sync with trailing slash on media sync url

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -21,6 +21,7 @@
 package com.ichi2.anki;
 
 import android.app.AlarmManager;
+import android.app.AlertDialog;
 import android.app.PendingIntent;
 import android.content.ActivityNotFoundException;
 import android.content.ComponentName;
@@ -44,6 +45,7 @@ import android.provider.MediaStore;
 import android.text.TextUtils;
 import android.view.MenuItem;
 import android.view.WindowManager.BadTokenException;
+import android.webkit.URLUtil;
 import android.widget.Toast;
 
 import com.afollestad.materialdialogs.MaterialDialog;
@@ -380,6 +382,35 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
             case "com.ichi2.anki.prefs.custom_sync_server":
                 getSupportActionBar().setTitle(R.string.custom_sync_server_title);
                 listener.addPreferencesFromResource(R.xml.preferences_custom_sync_server);
+                screen = listener.getPreferenceScreen();
+                Preference syncUrlPreference = screen.findPreference("syncBaseUrl");
+                Preference mSyncUrlPreference = screen.findPreference("syncMediaUrl");
+                syncUrlPreference.setOnPreferenceChangeListener((Preference preference, Object newValue) -> {
+                    String newUrl = newValue.toString();
+                    if (!URLUtil.isValidUrl(newUrl)) {
+                         new AlertDialog.Builder(this)
+                                .setTitle(R.string.custom_sync_server_base_url_invalid)
+                                .setPositiveButton(R.string.dialog_ok, null)
+                                .show();
+
+                        return false;
+                    }
+
+                    return true;
+                });
+                mSyncUrlPreference.setOnPreferenceChangeListener((Preference preference, Object newValue) -> {
+                    String newUrl = newValue.toString();
+                    if (!URLUtil.isValidUrl(newUrl)) {
+                        new AlertDialog.Builder(this)
+                                .setTitle(R.string.custom_sync_server_media_url_invalid)
+                                .setPositiveButton(R.string.dialog_ok, null)
+                                .show();
+
+                        return false;
+                    }
+
+                    return true;
+                });
                 break;
             case "com.ichi2.anki.prefs.advanced_statistics":
                 getSupportActionBar().setTitle(R.string.advanced_statistics_title);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HttpSyncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HttpSyncer.java
@@ -221,7 +221,7 @@ public class HttpSyncer {
             bos.close();
             // connection headers
 
-            String url = syncURL() + method;
+            String url = Uri.parse(syncURL()).buildUpon().appendPath(method).toString();
 
             Request.Builder requestBuilder = new Request.Builder();
             requestBuilder.url(url);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteMediaServer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteMediaServer.java
@@ -66,7 +66,7 @@ public class RemoteMediaServer extends HttpSyncer {
             }
             //Note: the preference did not necessarily contain /msync/, so we can't concat with the default as done in
             // getDefaultAnkiWebUrl
-            return Uri.parse(mediaSyncBase).toString() + "/";
+            return Uri.parse(mediaSyncBase).toString();
         }
         // Usual case
         return getDefaultAnkiWebUrl();

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -180,7 +180,9 @@
     <string name="custom_sync_server_enable_title">Use custom sync server</string>
     <string name="custom_sync_server_enable_summary">If you don\'t want to use the proprietary AnkiWeb service you can specify an alternative server here</string>
     <string name="custom_sync_server_base_url_title">Sync url</string>
+    <string name="custom_sync_server_base_url_invalid">Sync url invalid</string>
     <string name="custom_sync_server_media_url_title">Media sync url</string>
+    <string name="custom_sync_server_media_url_invalid">Media sync url invalid</string>
 
     <!-- studyoptions -->
     <string name="deck_conf_group_summ">Changes to deck group options will affect multiple decks. If you wish to change only the current deck, please add a new options group first</string>

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sync/RemoteMediaServerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sync/RemoteMediaServerTest.java
@@ -67,7 +67,7 @@ public class RemoteMediaServerTest {
 
         String syncUrl = underTest.syncURL();
 
-        assertThat(syncUrl, is("https://sync.example.com/msync/"));
+        assertThat(syncUrl, is("https://sync.example.com/msync"));
     }
 
 
@@ -79,7 +79,7 @@ public class RemoteMediaServerTest {
 
         String syncUrl = underTest.syncURL();
 
-        assertThat(syncUrl, is("https://sync1.example.com/msync/"));
+        assertThat(syncUrl, is("https://sync1.example.com/msync"));
     }
 
     @Test
@@ -89,7 +89,7 @@ public class RemoteMediaServerTest {
 
         String syncUrl = underTest.syncURL();
 
-        assertThat(syncUrl, is("https://sync.example.com/msync/"));
+        assertThat(syncUrl, is("https://sync.example.com/msync"));
     }
 
     @Test
@@ -99,7 +99,7 @@ public class RemoteMediaServerTest {
 
         String syncUrl = underTest.syncURL();
 
-        assertThat(syncUrl, is("https://sync.example.com/msync/"));
+        assertThat(syncUrl, is("https://sync.example.com/msync"));
     }
 
     @Test


### PR DESCRIPTION
Prevent duplicated slashes in the media sync url

## Pull Request template

## Purpose / Description

If my Media sync url under **Settings** -> **Advanced** -> **Custom sync server**  ends with a slash, I get a 404 on synchronization because of a duplicate slash (`/`) in the url. 

This PR adds a check, that prevents the duplicate slash.

## Fixes
Fixes #6436

## Approach

I add a check to [`RemoteMediaServer::syncURL`][remotemediaserver] that prevents the second slash from being added to the url if it already ends with an slash.

## How Has This Been Tested?

I installed [ankicommunity/anki-sync-server][ankisyncserver] locally.
Then I added my custom sync server under **Settings** -> **Advanced** -> **Custom sync server**.
My _Media sync url_  ends with a slash (`\`).
When I tap the sync button in the main activity everything synchronizes without an error.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] ~~You have commented your code, particularly in hard-to-understand areas~~
- [x] You have performed a self-review of your own code

  [ankisyncserver]: https://github.com/ankicommunity/anki-sync-server
  [remotemediaserver]: https://github.com/ankidroid/Anki-Android/blob/bd641a86a179f4a4f2431e110f2f74d732b2002d/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteMediaServer.java#L69