### PR TITLE
Convert import/export zip file usage to library: commons-compress - Allows >2GB imports

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -148,6 +148,10 @@ dependencies {
     implementation 'com.afollestad.material-dialogs:core:0.9.6.0'
     implementation 'com.getbase:floatingactionbutton:1.10.1'
     implementation 'org.bitbucket.cowwoc:diff-match-patch:1.2'
+    // #6419  - API 27 (& maybe others) could not perform new ZipFile() on a 2GB+ apkg
+    // noinspection GradleDependency - pinned at 1.12 until API21 minSdkVersion (File.toPath usage)
+    implementation 'org.apache.commons:commons-compress:1.12'
+
 
     // May need a resolution strategy for support libs to our versions
     implementation'ch.acra:acra-http:5.5.1'

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -64,7 +64,7 @@ import java.util.TreeMap;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.zip.ZipFile;
+import org.apache.commons.compress.archivers.zip.ZipFile;
 
 import androidx.annotation.Nullable;
 import timber.log.Timber;
@@ -1115,7 +1115,7 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
         String colname = "collection.anki21";
         ZipFile zip;
         try {
-            zip = new ZipFile(new File(path), ZipFile.OPEN_READ);
+            zip = new ZipFile(new File(path));
         } catch (IOException e) {
             Timber.e(e, "doInBackgroundImportReplace - Error while unzipping");
             AnkiDroidApp.sendExceptionReport(e, "doInBackgroundImportReplace0");

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.java
@@ -39,8 +39,8 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipOutputStream;
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
+import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
 
 import timber.log.Timber;
 
@@ -461,17 +461,17 @@ public final class AnkiPackageExporter extends AnkiExporter {
  */
 class ZipFile {
     private final int BUFFER_SIZE = 1024;
-    private ZipOutputStream mZos;
+    private ZipArchiveOutputStream mZos;
 
 
     public ZipFile(String path) throws FileNotFoundException {
-        mZos = new ZipOutputStream(new BufferedOutputStream(new FileOutputStream(path)));
+        mZos = new ZipArchiveOutputStream(new BufferedOutputStream(new FileOutputStream(path)));
     }
 
 
     public void write(String path, String entry) throws IOException {
         BufferedInputStream bis = new BufferedInputStream(new FileInputStream(path), BUFFER_SIZE);
-        ZipEntry ze = new ZipEntry(entry);
+        ZipArchiveEntry ze = new ZipArchiveEntry(entry);
         writeEntry(bis, ze);
     }
 
@@ -480,19 +480,19 @@ class ZipFile {
         // TODO: Does this work with abnormal characters?
         InputStream is = new ByteArrayInputStream(value.getBytes());
         BufferedInputStream bis = new BufferedInputStream(is, BUFFER_SIZE);
-        ZipEntry ze = new ZipEntry(entry);
+        ZipArchiveEntry ze = new ZipArchiveEntry(entry);
         writeEntry(bis, ze);
     }
 
 
-    private void writeEntry(BufferedInputStream bis, ZipEntry ze) throws IOException {
+    private void writeEntry(BufferedInputStream bis, ZipArchiveEntry ze) throws IOException {
         byte[] buf = new byte[BUFFER_SIZE];
-        mZos.putNextEntry(ze);
+        mZos.putArchiveEntry(ze);
         int len;
         while ((len = bis.read(buf, 0, BUFFER_SIZE)) != -1) {
             mZos.write(buf, 0, len);
         }
-        mZos.closeEntry();
+        mZos.closeArchiveEntry();
         bis.close();
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
@@ -67,8 +67,8 @@ import java.util.Random;
 import java.util.TimeZone;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipFile;
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
+import org.apache.commons.compress.archivers.zip.ZipFile;
 
 import timber.log.Timber;
 
@@ -677,7 +677,7 @@ public class Utils {
             zipEntryToFilenameMap = new HashMap<>();
         }
         for (String requestedEntry : zipEntries) {
-            ZipEntry ze = zipFile.getEntry(requestedEntry);
+            ZipArchiveEntry ze = zipFile.getEntry(requestedEntry);
             if (ze != null) {
                 String name = ze.getName();
                 if (zipEntryToFilenameMap.containsKey(name)) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/AnkiPackageImporter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/AnkiPackageImporter.java
@@ -33,7 +33,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.zip.ZipFile;
+import org.apache.commons.compress.archivers.zip.ZipFile;
 
 import timber.log.Timber;
 
@@ -58,7 +58,7 @@ public class AnkiPackageImporter extends Anki2Importer {
             String colname = "collection.anki21";
             try {
                 // extract the deck from the zip file
-                mZip = new ZipFile(new File(mFile), ZipFile.OPEN_READ);
+                mZip = new ZipFile(new File(mFile));
                 // v2 scheduler?
                 if (mZip.getEntry(colname) == null) {
                     colname = CollectionHelper.COLLECTION_FILENAME;

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/UtilsTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/UtilsTest.java
@@ -27,8 +27,8 @@ import java.net.URL;
 import java.nio.file.Paths;
 import java.util.Enumeration;
 import java.util.Objects;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipFile;
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
+import org.apache.commons.compress.archivers.zip.ZipFile;
 
 public class UtilsTest {
 
@@ -40,9 +40,9 @@ public class UtilsTest {
         try {
             File file = new File(resource.toURI());
             ZipFile zipFile = new ZipFile(file);
-            Enumeration zipEntries = zipFile.entries();
+            Enumeration zipEntries = zipFile.getEntries();
             while (zipEntries.hasMoreElements()) {
-                ZipEntry ze2 = (ZipEntry) zipEntries.nextElement();
+                ZipArchiveEntry ze2 = (ZipArchiveEntry) zipEntries.nextElement();
                 Utils.unzipFiles(zipFile, "/tmp", new String[]{ze2.getName()}, null);
             }
             Assert.fail("Expected an IOException");


### PR DESCRIPTION
## Query

Since this is a library change, I wouldn't feel totally comfortable in putting this in a point release. Not sure how this works with semver.

## Goals

* Check the constructor to ensure that there's no nastiness in the change.

## Purpose / Description

Allows import of apkg >2GB.

`new java.util.zip.ZipFile()` failed with:

`java.util.zip.ZipException: error in opening zip file`

This was also performed in the export side to keep library use consistent

Sadly, syncing uses `ZipFile.OPEN_READ | ZipFile.OPEN_DELETE`, and there does not seem to be a direct replacement in the library so I've kept this as using `java.util.zip` for now.

## Fixes
Fixes #6419

## Approach
Switch to commons-compress for import/export of apkg/colpkg files.

## How Has This Been Tested?

Tested on an API 27 emulator, which failed, and now handles a 2.4GB file

Tested on my device (Android 9) via in import/export cycle of a known good profile

Currently testing on an API 16 emulator

* TBC - timing details

## Learning

Apparently reported in 2007... https://bugs.java.com/bugdatabase/view_bug.do?bug_id=6599383

https://stackoverflow.com/questions/53186835/error-in-opening-zip-file-opening-of-big-zip-files-2gb

https://commons.apache.org/proper/commons-compress/

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code