### PR TITLE
CardViewer - Fix crash viewing card after close

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -2603,6 +2603,17 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
             super(context);
         }
 
+
+        @Override
+        public void loadDataWithBaseURL(@Nullable String baseUrl, String data, @Nullable String mimeType, @Nullable String encoding, @Nullable String historyUrl) {
+            if (!AbstractFlashcardViewer.this.wasDestroyed()) {
+                super.loadDataWithBaseURL(baseUrl, data, mimeType, encoding, historyUrl);
+            } else {
+                Timber.w("Not loading card - Activity is in the process of being destroyed.");
+            }
+        }
+
+
         @Override
         protected void onScrollChanged(int horiz, int vert, int oldHoriz, int oldVert) {
             super.onScrollChanged(horiz, vert, oldHoriz, oldVert);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
@@ -12,6 +12,7 @@ import android.graphics.BitmapFactory;
 import android.graphics.Color;
 import android.media.AudioManager;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 
 import androidx.annotation.Nullable;
@@ -55,6 +56,8 @@ public class AnkiActivity extends AppCompatActivity implements SimpleMessageDial
 
     // custom tabs
     private CustomTabActivityHelper mCustomTabActivityHelper;
+
+    private boolean mIsDestroyed = false;
 
 
     @Override
@@ -108,6 +111,7 @@ public class AnkiActivity extends AppCompatActivity implements SimpleMessageDial
 
     @Override
     protected void onDestroy() {
+        this.mIsDestroyed = true;
         Timber.i("AnkiActivity::onDestroy");
         super.onDestroy();
     }
@@ -249,6 +253,14 @@ public class AnkiActivity extends AppCompatActivity implements SimpleMessageDial
 
     protected void disableViewAnimation(View view) {
         view.clearAnimation();
+    }
+
+    /** Compat shim for API 16 */
+    public boolean wasDestroyed() {
+        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.JELLY_BEAN) {
+            return super.isDestroyed();
+        }
+        return mIsDestroyed;
     }
 
 


### PR DESCRIPTION
## Purpose / Description

`loadDataWithBaseURL` throws a `NullPointerException` if called after onDestroy

https://stackoverflow.com/questions/28856883/java-nullpointer-exception-from-webview-in-android-webkit-webviewclassic-loaddat

## Fixes
Fixes #6446

## Approach
Detect if `onDestroy()` was called, and stop rendering if that happeend,

## How Has This Been Tested?

API 16 emulator (hit the `Timber.w` with no crashes) and Android 9 device.

## Learning

⚠️ Please read: https://developer.android.com/reference/android/app/Activity#isDestroyed() - mentions "final onDestroy" - This goes against my knowledge of the lifecycle.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code