### PR TITLE
Strip spaces in deck name

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -785,7 +785,7 @@ public class Decks {
         return spaceAroundSeparator.matcher(deckName.trim()).replaceAll( "::");
     }
 
-    /** With .28, anki started strips whitespace of deck name.
+    /** With 2.1.28, anki started strips whitespace of deck name.
      * This method is here for compatibility while we wait for rust.
      * It should be executed before other methods, because both "FOO " and "FOO" will be renamed to the same name,
      * and so this will need to be renamed by _checkDeckTree.*/


### PR DESCRIPTION
Starting with 2.1.28, anki strip deck's name. I imitate it. I don't
use the same code as they do it in rust and we don't have rust yet.

However, since this create compatibility problems between anki and
ankidroid during some sync ( see
https://forums.ankiweb.net/t/decks-with-trailing-spaces/89/4?u=arthurmilchior
) I believe it should be considered without waiting for
rust. Especially since it's a small change in term of code.

The spaces are stripped in two places: when checking for deck
integrity, and when changing deck name (i.e. through `id` which
creates deck, and through `rename`). No need currently to use it in
byName, since it is only called with names already stripped and with
the constant "Custom study session".



This was tested by:
* creating a deck name " A B :: C D:: E" and seeing that it created deck "A B", "A B::C D" and "A B::C D::E"
* Opening a collection with deck "Foo " and seeing it got renamed in "Foo"
* opening a collection with decks "Foo" and "Foo " and checking that "Foo " got renamed to "Foorandomstring"

----
_Edit by @david-allison-1_

Fixes #6452 