### PR TITLE
Add Database check for decks with invalid config

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -55,6 +55,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
@@ -1504,7 +1505,7 @@ public class Collection {
         File file = new File(mPath);
         CheckDatabaseResult result = new CheckDatabaseResult(file.length());
         final int[] currentTask = {1};
-        int totalTasks = (mModels.all().size() * 4) + 25; // a few fixes are in all-models loops, the rest are one-offs
+        int totalTasks = (mModels.all().size() * 4) + 27; // a few fixes are in all-models loops, the rest are one-offs
         Runnable notifyProgress = () -> fixIntegrityProgress(progressCallback, currentTask[0]++, totalTasks);
         FunctionalInterfaces.Consumer<FunctionalInterfaces.FunctionThrowable<Runnable, List<String>, JSONException>> executeIntegrityTask =
                 (FunctionalInterfaces.FunctionThrowable<Runnable, List<String>, JSONException> function) -> {
@@ -1559,6 +1560,7 @@ public class Collection {
         executeIntegrityTask.consume(this::removeOriginalDuePropertyWhereInvalid);
         executeIntegrityTask.consume(this::removeDynamicPropertyFromNonDynamicDecks);
         executeIntegrityTask.consume(this::removeDeckOptionsFromDynamicDecks);
+        executeIntegrityTask.consume(this::resetInvalidDeckOptions);
         executeIntegrityTask.consume(this::rebuildTags);
         executeIntegrityTask.consume(this::updateFieldCache);
         executeIntegrityTask.consume(this::fixNewCardDuePositionOverflow);
@@ -1586,6 +1588,47 @@ public class Collection {
         }
         logProblems(result.getProblems());
         return result;
+    }
+
+
+    private List<String> resetInvalidDeckOptions(Runnable notifyProgress) {
+        Timber.d("resetInvalidDeckOptions");
+        //6454
+        notifyProgress.run();
+
+        //obtain a list of all valid dconf IDs
+        List<JSONObject> allConf = getDecks().allConf();
+        HashSet<Long> configIds  = new HashSet<>();
+
+        for (JSONObject conf : allConf) {
+            configIds.add(conf.getLong("id"));
+        }
+
+        notifyProgress.run();
+
+        int changed = 0;
+
+        for (JSONObject d : getDecks().all()) {
+            //dynamic decks do not have dconf
+            if (Decks.isDynamic(d)) {
+                continue;
+            }
+
+            if (!configIds.contains(d.getLong("conf"))) {
+                Timber.d("Reset %s's config to default", d.optString("name", "unknown deck"));
+                d.put("conf", Consts.DEFAULT_DECK_CONFIG_ID);
+                changed++;
+            }
+        }
+
+        List<String> ret = new ArrayList<>();
+
+        if (changed > 0) {
+            ret.add("Fixed " + changed + " decks with invalid config");
+            getDecks().save();
+        }
+
+        return ret;
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Consts.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Consts.java
@@ -104,4 +104,6 @@ public class Consts {
     // The labels defined in consts.py are in AnkiDroid's resources files.
 
     public static final long DEFAULT_DECK_ID = 1;
+    /** Default dconf - can't be removed */
+    public static final long DEFAULT_DECK_CONFIG_ID = 1;
 }


### PR DESCRIPTION
## Notes

ℹ️ Happy for this to be rejected/taken to the drawing board as a "let's get to the root cause rather than work around it", I feel it's more likely that this was caused by Anki Desktop, as it's a syncing issue. 

## Purpose / Description
A user had invalid "conf" values when syncing from Anki Desktop

This meant that they could sync from Anki Desktop, but their collection was reported as corrupt in AnkiDroid, as the deck list could not be displayed

## Fixes
Fixes #6454

## Approach
Check Database

## How Has This Been Tested?

Tested on my phone - supplied collection no longer crashes after check database. My main collection showed no problems


## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code