### PR TITLE
Display sync data in KB not kB

### DIFF
--- a/AnkiDroid/src/main/res/values/04-network.xml
+++ b/AnkiDroid/src/main/res/values/04-network.xml
@@ -85,7 +85,7 @@
     <string name="sync_writing_db">Writing changes into database…</string>
     <string name="sync_download_chunk">Downloading changes…</string>
     <string name="sync_upload_chunk">Uploading changes…</string>
-    <string name="sync_up_down_size">Up: %1$d kB, down: %2$d kB</string>
+    <string name="sync_up_down_size">Up: %1$d KB, down: %2$d KB</string>
     <string name="sync_generic_error">An error has occurred. Try again later.</string>
     <string name="sync_check_upload_file">Checking file before upload…</string>
     <string name="sync_check_download_file">Checking downloaded file…</string>


### PR DESCRIPTION
One is the correct unit, one is not. We were using the one that is not.

Fixes #6456

Thanks to @gaul :-)