### PR TITLE
Shrink published APK by ~3MB w/ABI splits

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -40,8 +40,8 @@ android {
         //
         // This ensures the correct ordering between the various types of releases (dev < alpha < beta < release) which is
         // needed for upgrades to be offered correctly.
-        versionCode=21200107
-        versionName="2.12alpha7"
+        versionCode=21200108
+        versionName="2.12alpha8"
         minSdkVersion 16
         //noinspection OldTargetApi - also performed in api/build.fradle
         targetSdkVersion 28

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -1,4 +1,5 @@
 import com.android.ddmlib.DdmPreferences
+import com.android.build.OutputFile
 
 plugins {
  // Gradle plugin portal 
@@ -17,6 +18,30 @@ android {
 
     defaultConfig {
         applicationId "com.ichi2.anki"
+
+        // The version number is of the form:
+        // <major>.<minor>.<maintenance>[dev|alpha<build>|beta<build>|]
+        // The <build> is only present for alpha and beta releases (e.g., 2.0.4alpha2 or 2.0.4beta4), developer builds do
+        // not have a build number (e.g., 2.0.4dev) and official releases only have three components (e.g., 2.0.4).
+        //
+        // The version code is derived from the version name as follows:
+        // AbbCCtDD
+        // A: 1-digit decimal number representing the major version
+        // bb: 2-digit decimal number representing the minor version
+        // CC: 2-digit decimal number representing the maintenance version
+        // t: 1-digit decimal number representing the type of the build
+        // 0: developer build
+        // 1: alpha release
+        // 2: beta release
+        // 3: public release
+        // DD: 2-digit decimal number representing the build
+        // 00 for internal builds and public releases
+        // alpha/beta build number for alpha/beta releases
+        //
+        // This ensures the correct ordering between the various types of releases (dev < alpha < beta < release) which is
+        // needed for upgrades to be offered correctly.
+        versionCode=21200107
+        versionName="2.12alpha7"
         minSdkVersion 16
         //noinspection OldTargetApi - also performed in api/build.fradle
         targetSdkVersion 28
@@ -63,6 +88,49 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             signingConfig signingConfigs.release
             buildConfigField "String", "ACRA_URL", '"https://ankidroid.org/acra/report"'
+        }
+    }
+
+    /**
+     * Set this to true to create five separate APKs instead of one:
+     *   - 2 APKs that only work on ARM/ARM64 devices
+     *   - 2 APKs that only works on x86/x86_64 devices
+     *   - a universal APK that works on all devices
+     * The advantage is the size of most APKs is reduced by about 2.5MB.
+     * Upload all the APKs to the Play Store and people will download
+     * the correct one based on the CPU architecture of their device.
+     */
+    def enableSeparateBuildPerCPUArchitecture = true
+
+    splits {
+        abi {
+            reset()
+            enable enableSeparateBuildPerCPUArchitecture
+            universalApk false  // If true, also generate a universal APK
+            include "armeabi-v7a", "x86", "arm64-v8a", "x86_64"
+        }
+    }
+    // applicationVariants are e.g. debug, release
+    applicationVariants.all { variant ->
+        // purge debug sounds from react-native-background-geolocation-android
+        if (variant.buildType.name == 'release') {
+            // We want the same version stream for all ABIs in debug but for release we can split them
+            variant.outputs.each { output ->
+                // For each separate APK per architecture, set a unique version code as described here:
+                // https://developer.android.com/studio/build/configure-apk-splits.html
+                def versionCodes = ["armeabi-v7a": 1, "x86": 2, "arm64-v8a": 3, "x86_64": 4]
+                def abi = output.getFilter(OutputFile.ABI)
+                if (abi != null) {  // null for the universal-debug, universal-release variants
+                    //  From: https://developer.android.com/studio/publish/versioning#appversioning
+                    //  "Warning: The greatest value Google Play allows for versionCode is 2100000000"
+                    //  AnkiDroid versionCodes have a budget 8 digits (through AnkiDroid 9)
+                    //  This style does ABI version code ranges with the 9th digit as 0-4.
+                    //  This consumes ~20% of the version range space, w/50 years of versioning at our major-version pace
+                    output.versionCodeOverride =
+                            // ex:  321200106 = 3 * 100000000 + 21200106
+                            versionCodes.get(abi) * 100000000 + defaultConfig.versionCode
+                }
+            }
         }
     }
 

--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -22,34 +22,7 @@
           xmlns:tools="http://schemas.android.com/tools"
           package="com.ichi2.anki"
           android:installLocation="auto"
-          android:versionCode="21200106"
-          android:versionName="2.12alpha6"
           >
-
-    <!--
-        The version number is of the form:
-          <major>.<minor>.<maintenance>[dev|alpha<build>|beta<build>|]
-        The <build> is only present for alpha and beta releases (e.g., 2.0.4alpha2 or 2.0.4beta4), developer builds do
-        not have a build number (e.g., 2.0.4dev) and official releases only have three components (e.g., 2.0.4).
-
-        The version code is derived from the version name as follows:
-          AAbbCCtDD
-        AA: 2-digit decimal number (with leading zeros omitted) representing the major version
-        bb: 2-digit decimal number representing the minor version
-        CC: 2-digit decimal number representing the maintenance version
-        t: 1-digit decimal number representing the type of the build
-          0: developer build
-          1: alpha release
-          2: beta release
-          3: public release
-        DD: 2-digit decimal number representing the build
-          00 for internal builds and public releases
-          alpha/beta build number for alpha/beta releases
-
-        This ensures the correct ordering between the various types of releases (dev < alpha < beta < release) which is
-        needed for upgrades to be offered correctly.
-    -->
-
     <uses-feature android:name="android.hardware.camera" android:required="false" />
     <uses-feature android:name="android.hardware.camera.any" android:required="false" />
     <uses-feature android:name="android.hardware.audio.output" android:required="false" />

--- a/tools/local-release.sh
+++ b/tools/local-release.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# This script assumes a few things -
+#
+# 1) you are in the main directory of the Anki source code (e.g. 'Anki-Android' is the current working directory)
+# 2) you have a Java keystore at the file path $home/src/android-keystore
+# 3) In that java keystore you have the key alias 'nrkeystorealias'
+
+# It will ask you for your keystore and key password
+
+# Read the key passwords
+read -sp "Enter keystore password: " KSTOREPWD; echo
+read -sp "Enter key password: " KEYPWD; echo
+export KSTOREPWD
+export KEYPWD
+./gradlew assembleRelease

--- a/tools/parallel-package-release.sh
+++ b/tools/parallel-package-release.sh
@@ -34,5 +34,5 @@ for BUILD in $BUILDNAMES; do
     LCBUILD=`tr '[:upper:]' '[:lower:]' <<< $BUILD`
     ./tools/parallel-package-name.sh com.ichi2.anki.$LCBUILD AnkiDroid.$BUILD
     ./gradlew assembleRelease
-    cp AnkiDroid/build/outputs/apk/release/AnkiDroid-release.apk ../AnkiDroid-$TAG.parallel.$BUILD.apk
+    cp AnkiDroid/build/outputs/apk/release/AnkiDroid-armeabi-v7a-release.apk ../AnkiDroid-$TAG.parallel.$BUILD.apk
 done


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
We include native code now and that will only continue with Rust

We must implement a 64-bit native build by Play store guidelines but we still have devices that use ARM and x86.

The only way to include 64-bit binaries and support all the users without bloating the APK as it is currently is to split via ABI

So this PR does binary ABI splits so platforms only get the binary code they need from our libraries.

That takes it from 10.5MB to 7.5MB or so

## Approach

I cribbed the style used by react-native, which I have used successfully for a couple years, and adapted the ABI-versionCode-ranges to match our versioning style

## How Has This Been Tested?

Unfortunately this is the sort of thing that you test by releasing, so this is already released as 2.12alpha7 and 2.12alpha8 to make sure it was working :fearful: 

## Learning (optional, can help others)

I put links in the comments in the code for versionCode range since that is vital to understand now and in the future.

Maximum versionCode is 2.1billion FWIW. We'll be fine.

https://github.com/facebook/react-native/blob/6d6268e903def9e4a8609e5dee6de2d2c4ab8c5e/template/android/app/build.gradle#L167-L180

## Checklist
_Please, go through these checks before submitting the PR._

- [ ] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
