### PR TITLE
Improve Login Autofill Behaviour - Don't Show Password & Auto Logon

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.java
@@ -19,6 +19,7 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import androidx.appcompat.widget.Toolbar;
 import android.view.KeyEvent;
@@ -29,11 +30,13 @@ import android.widget.EditText;
 import android.widget.TextView;
 
 import com.afollestad.materialdialogs.MaterialDialog;
+import com.google.android.material.textfield.TextInputLayout;
 import com.ichi2.anim.ActivityTransitionAnimation;
 import com.ichi2.anki.web.HostNumFactory;
 import com.ichi2.async.Connection;
 import com.ichi2.async.Connection.Payload;
 import com.ichi2.themes.StyledProgressDialog;
+import com.ichi2.ui.TextInputEditField;
 import com.ichi2.utils.AdaptionUtil;
 
 import timber.log.Timber;
@@ -46,12 +49,13 @@ public class MyAccount extends AnkiActivity {
     private View mLoggedIntoMyAccountView;
 
     private EditText mUsername;
-    private EditText mPassword;
+    private TextInputEditField mPassword;
 
     private TextView mUsernameLoggedIn;
 
     private MaterialDialog mProgressDialog;
     Toolbar mToolbar = null;
+    private TextInputLayout mPasswordLayout;
 
 
     private void switchToState(int newState) {
@@ -150,6 +154,7 @@ public class MyAccount extends AnkiActivity {
         mLoginToMyAccountView = getLayoutInflater().inflate(R.layout.my_account, null);
         mUsername = mLoginToMyAccountView.findViewById(R.id.username);
         mPassword = mLoginToMyAccountView.findViewById(R.id.password);
+        mPasswordLayout = mLoginToMyAccountView.findViewById(R.id.password_layout);
 
         mPassword.setOnKeyListener((v, keyCode, event) -> {
             if (event.getAction() == KeyEvent.ACTION_DOWN) {
@@ -180,6 +185,13 @@ public class MyAccount extends AnkiActivity {
         mUsernameLoggedIn = mLoggedIntoMyAccountView.findViewById(R.id.username_logged_in);
         Button logoutButton = mLoggedIntoMyAccountView.findViewById(R.id.logout_button);
         logoutButton.setOnClickListener(v -> logout());
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            mPassword.setAutoFillListener((value) -> {
+                //disable "show password".
+                mPasswordLayout.setEndIconVisible(false);
+            });
+        }
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.java
@@ -100,6 +100,21 @@ public class MyAccount extends AnkiActivity {
         }
     }
 
+
+    public void attemptLogin() {
+        String username = mUsername.getText().toString().trim(); // trim spaces, issue 1586
+        String password = mPassword.getText().toString();
+
+        if (!"".equalsIgnoreCase(username) && !"".equalsIgnoreCase(password)) {
+            Timber.i("Attempting auto-login");
+            Connection.login(loginListener, new Connection.Payload(new Object[]{username, password,
+                    HostNumFactory.getInstance(this) }));
+        } else {
+            Timber.i("Auto-login cancelled - username/password missing");
+        }
+    }
+
+
     private void saveUserInformation(String username, String hkey) {
         SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(getBaseContext());
         Editor editor = preferences.edit();
@@ -190,6 +205,8 @@ public class MyAccount extends AnkiActivity {
             mPassword.setAutoFillListener((value) -> {
                 //disable "show password".
                 mPasswordLayout.setEndIconVisible(false);
+                Timber.i("Attempting login from autofill");
+                attemptLogin();
             });
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/ui/TextInputEditField.java
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/TextInputEditField.java
@@ -1,0 +1,72 @@
+/*
+ Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.ui;
+
+import android.content.Context;
+import android.os.Build;
+import android.util.AttributeSet;
+import android.view.autofill.AutofillValue;
+
+import com.google.android.material.textfield.TextInputEditText;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
+
+public class TextInputEditField extends TextInputEditText {
+    @RequiresApi(Build.VERSION_CODES.O)
+    private AutoFillListener mAutoFillListener;
+
+
+    public TextInputEditField(@NonNull Context context) {
+        super(context);
+    }
+
+
+    public TextInputEditField(@NonNull Context context, @Nullable AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+
+    public TextInputEditField(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+
+    @Override
+    public void autofill(AutofillValue value) {
+        super.autofill(value);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            if (mAutoFillListener != null) {
+                mAutoFillListener.onAutoFill(value);
+            }
+        }
+
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    @FunctionalInterface
+    public interface AutoFillListener {
+        void onAutoFill(@NonNull AutofillValue value);
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    public void setAutoFillListener(@NonNull AutoFillListener listener) {
+        this.mAutoFillListener = listener;
+    }
+}

--- a/AnkiDroid/src/main/res/layout/my_account.xml
+++ b/AnkiDroid/src/main/res/layout/my_account.xml
@@ -55,12 +55,13 @@
                 </com.google.android.material.textfield.TextInputLayout>
 
                 <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/password_layout"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:hint="@string/password"
                     app:passwordToggleEnabled="true">
 
-                    <com.google.android.material.textfield.TextInputEditText
+                    <com.ichi2.ui.TextInputEditField
                         android:id="@+id/password"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"


### PR DESCRIPTION
## Purpose / Description

`app:passwordToggleEnabled="true"` will reveal the field, even if data is obtained from AutoFill

Added in 5a677a4b73d25f7a8731b582c3b03ae8c7c17a68

This fixes the issue. I'll be reporting this to Google.

Also adds an auto-login if an auto-fill entry is clicked, 

## Approach
Add a handler for an autofill event, disable the "show password", and attempt a logon if performed on the password field.

## How Has This Been Tested?

On my Android 9 device, and on an API 16 emulator (no autofill)

## Learning

Google ಠ_ಠ

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code