### PR TITLE
Fix overflow in getAvailableBytes (API 16)

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
@@ -33,6 +33,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
+import androidx.annotation.CheckResult;
+
 
 /**
  * This interface defines a set of functions that are not available on all platforms.
@@ -71,6 +73,7 @@ public interface Compat {
     boolean isImmersiveSystemUiVisible(AnkiActivity activity);
     void setupNotificationChannel(Context context, String id, String name);
     Spanned fromHtml(String html);
+    @CheckResult
     long getAvailableBytes(StatFs stat);
     void setTime(TimePicker picker, int hour, int minute);
     int getHour(TimePicker picker);

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV16.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV16.java
@@ -106,7 +106,11 @@ public class CompatV16 implements Compat {
     @Override
     @CheckResult
     @SuppressWarnings("deprecation")
-    public long getAvailableBytes(StatFs stat) { return stat.getAvailableBlocks() * stat.getBlockSize(); }
+    public long getAvailableBytes(StatFs stat) {
+        long availableBlocks = stat.getAvailableBlocks();
+        long blockSize = stat.getBlockSize();
+        return availableBlocks * blockSize;
+    }
 
     // Until API 23 the methods have "current" in the name
     @Override

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV16.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV16.java
@@ -6,6 +6,7 @@ import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.res.TypedArray;
 
+import androidx.annotation.CheckResult;
 import androidx.annotation.NonNull;
 import androidx.core.content.ContextCompat;
 
@@ -103,6 +104,7 @@ public class CompatV16 implements Compat {
 
     // Until API 18 it's not a long it's an int
     @Override
+    @CheckResult
     @SuppressWarnings("deprecation")
     public long getAvailableBytes(StatFs stat) { return stat.getAvailableBlocks() * stat.getBlockSize(); }
 

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV18.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV18.java
@@ -3,9 +3,12 @@ package com.ichi2.compat;
 import android.annotation.TargetApi;
 import android.os.StatFs;
 
+import androidx.annotation.CheckResult;
+
 @TargetApi(18)
 public class CompatV18 extends CompatV17 implements Compat {
 
     @Override
+    @CheckResult
     public long getAvailableBytes(StatFs stat) { return stat.getAvailableBytes(); }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/compat/CompatV16Test.java
+++ b/AnkiDroid/src/test/java/com/ichi2/compat/CompatV16Test.java
@@ -1,0 +1,42 @@
+/*
+ Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.compat;
+
+import android.os.StatFs;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class CompatV16Test {
+    @Test
+    @SuppressWarnings( {"deprecation", "RedundantSuppression"})
+    public void getAvailableBytesDoesNotOverflowOnMultiplication() {
+
+        StatFs statFs = mock(StatFs.class);
+        when(statFs.getAvailableBlocks()).thenReturn(2000000000);
+        when(statFs.getBlockSize()).thenReturn(8);
+        long bytes = new CompatV16().getAvailableBytes(statFs);
+
+        assertThat(bytes, greaterThan(0L));
+        assertThat(bytes, is(8L * 2000000000L));
+    }
+}


### PR DESCRIPTION
## Questions

Should we throw an `IllegalArgumentException` if either of the ints are negative. `getFreeDiskSpace` handles this and returns a default value

## Purpose / Description
`getAvailableBytes` had an overflow bug, we fix this for most inputs.

## Fixes
Fixes #6442 
Fixes #6441
Fixes #5777

## Approach
int * int = int
long * long = long

## How Has This Been Tested?

Unit Tested

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code