### PR TITLE
Get value of fullscreen status in JavaScript

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -3497,5 +3497,11 @@ see card.js for available functions
         public long ankiGetCardDue() {
             return mCurrentCard.getDue();
          }
+
+        @JavascriptInterface
+        public boolean ankiIsInFullscreen() {
+            isInFullscreen = !getSupportActionBar().isShowing();
+            return isInFullscreen;
+        }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -851,6 +851,11 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         return R.layout.reviewer;
     }
 
+    protected boolean isFullscreen() {
+        isInFullscreen = !getSupportActionBar().isShowing();
+        return isInFullscreen;
+    }
+
     @ Override
     public void onConfigurationChanged(Configuration config) {
         // called when screen rotated, etc, since recreating the Webview is too expensive
@@ -3120,8 +3125,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
             }
             // Show options menu from WebView
             if (url.startsWith("signal:anki_show_options_menu")) {
-                isInFullscreen = !getSupportActionBar().isShowing();
-                if (isInFullscreen) {
+                if (isFullscreen()) {
                     openOptionsMenu();
                 } else {
                     UIUtils.showThemedToast(AbstractFlashcardViewer.this, getString(R.string.ankidroid_turn_on_fullscreen_options_menu), true);
@@ -3131,8 +3135,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
 
             // Show Navigation Drawer from WebView
             if (url.startsWith("signal:anki_show_navigation_drawer")) {
-                isInFullscreen = !getSupportActionBar().isShowing();
-                if (isInFullscreen) {
+                if (isFullscreen()) {
                     AbstractFlashcardViewer.this.onNavigationPressed();
                 } else {
                     UIUtils.showThemedToast(AbstractFlashcardViewer.this, getString(R.string.ankidroid_turn_on_fullscreen_nav_drawer), true);
@@ -3500,8 +3503,7 @@ see card.js for available functions
 
         @JavascriptInterface
         public boolean ankiIsInFullscreen() {
-            isInFullscreen = !getSupportActionBar().isShowing();
-            return isInFullscreen;
+            return isFullscreen();
         }
     }
 }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
When adding some function / text eg. ```showAnswer();``` then user have to turn on full screen.
But if user turn off full screen then for hiding that buttons / text, there is way to know if full screen or not in JavaScript. 

## Fixes
Fixes _Link to the issues._

## Approach
Using ```JavascriptInterface```, passing ```Action Bar isShowing``` 

## How Has This Been Tested?
Tested on emulator 

```false``` when ```Action Bar``` showing

![full](https://user-images.githubusercontent.com/12841290/84667562-2878e200-af40-11ea-8c75-422a31ae0dda.PNG)

```true``` when ```Action Bar``` not showing

![full2](https://user-images.githubusercontent.com/12841290/84667563-29117880-af40-11ea-8d4a-78fc8cc11355.PNG)

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [ x ] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [ x ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ x ] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ x ] You have commented your code, particularly in hard-to-understand areas
- [ x ] You have performed a self-review of your own code
