### PR TITLE
Dependency updates 20200615

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -248,7 +248,7 @@ dependencies {
     testImplementation 'androidx.test:core:1.2.0'
     testImplementation 'androidx.test.ext:junit:1.1.1'
     // debugImplementation required vs testImplementation: https://issuetracker.google.com/issues/128612536
-    debugImplementation 'androidx.fragment:fragment-testing:1.2.4'
+    debugImplementation 'androidx.fragment:fragment-testing:1.2.5'
 
     // May need a resolution strategy for support libs to our versions
     androidTestImplementation 'com.azimolabs.conditionwatcher:conditionwatcher:0.2'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Bumps fragment-testing from 1.2.4 to 1.2.5.

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>
