### PR TITLE
Publish universal apk

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -69,6 +69,7 @@ android {
     buildTypes {
         debug {
             debuggable true
+            splits.abi.universalApk = true // Build universal APK for debug always
             // Check Crash Reports page on developer wiki for info on ACRA testing
             buildConfigField "String", "ACRA_URL", '"https://918f7f55-f238-436c-b34f-c8b5f1331fe5-bluemix.cloudant.com/acra-ankidroid/_design/acra-storage/_update/report"'
 
@@ -85,6 +86,7 @@ android {
         }
         release {
             minifyEnabled true
+            splits.abi.universalApk = universalApkEnabled // Build universal APK for release with `-Duniversal-apk=true`
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             signingConfig signingConfigs.release
             buildConfigField "String", "ACRA_URL", '"https://ankidroid.org/acra/report"'
@@ -106,7 +108,7 @@ android {
         abi {
             reset()
             enable enableSeparateBuildPerCPUArchitecture
-            universalApk false  // If true, also generate a universal APK
+            //universalApk enableUniversalApk  // set in debug + release config blocks above
             include "armeabi-v7a", "x86", "arm64-v8a", "x86_64"
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,8 @@ ext {
     travisBuild = System.getenv("TRAVIS") == "true"
     // allows for -Dpre-dex=false to be set
     preDexEnabled = "true" == System.getProperty("pre-dex", "true")
+    // allows for universal APKs to be generated
+    universalApkEnabled = "true" == System.getProperty("universal-apk", "false")
 
     // Travis may report host CPU counts vs guest, but runs 2 cores everywhere
     // everyone else gets 50% of cores to account for SMT which doesn't help this workload

--- a/tools/local-release.sh
+++ b/tools/local-release.sh
@@ -13,4 +13,4 @@ read -sp "Enter keystore password: " KSTOREPWD; echo
 read -sp "Enter key password: " KEYPWD; echo
 export KSTOREPWD
 export KEYPWD
-./gradlew assembleRelease
+./gradlew assembleRelease -Duniversal-apk=true

--- a/tools/parallel-package-release.sh
+++ b/tools/parallel-package-release.sh
@@ -33,6 +33,6 @@ for BUILD in $BUILDNAMES; do
     git clean -f
     LCBUILD=`tr '[:upper:]' '[:lower:]' <<< $BUILD`
     ./tools/parallel-package-name.sh com.ichi2.anki.$LCBUILD AnkiDroid.$BUILD
-    ./gradlew assembleRelease
-    cp AnkiDroid/build/outputs/apk/release/AnkiDroid-armeabi-v7a-release.apk ../AnkiDroid-$TAG.parallel.$BUILD.apk
+    ./gradlew assembleRelease -Duniversal-apk=true
+    cp AnkiDroid/build/outputs/apk/release/AnkiDroid-universal-release.apk ./AnkiDroid-$TAG.parallel.$BUILD.apk
 done

--- a/tools/parallel-package-release.sh
+++ b/tools/parallel-package-release.sh
@@ -36,3 +36,5 @@ for BUILD in $BUILDNAMES; do
     ./gradlew assembleRelease -Duniversal-apk=true
     cp AnkiDroid/build/outputs/apk/release/AnkiDroid-universal-release.apk ./AnkiDroid-$TAG.parallel.$BUILD.apk
 done
+git reset --hard
+git clean -f

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -100,8 +100,16 @@ then
   exit
 fi
 
-# Copy exported file to cwd
-cp AnkiDroid/build/outputs/apk/release/AnkiDroid-armeabi-v7a-release.apk AnkiDroid-"$VERSION".apk
+# Now build the universal release also
+if ! ./gradlew assembleRelease -Duniversal-apk=true
+then
+  # APK contains problems, abort release
+  git checkout -- $GRADLEFILE # Revert version change
+  exit
+fi
+
+# Copy universal APK to cwd
+cp AnkiDroid/build/outputs/apk/release/AnkiDroid-universal-release.apk AnkiDroid-"$VERSION".apk
 
 # Commit modified AndroidManifest.xml (and changelog.html if it changed)
 git add $GRADLEFILE $CHANGELOG

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -137,3 +137,13 @@ fi
 
 github-release release --tag v"$VERSION" --name "AnkiDroid $VERSION" $PRE_RELEASE
 github-release upload --tag v"$VERSION" --name AnkiDroid-"$VERSION".apk --file AnkiDroid-"$VERSION".apk
+
+# Now that Git is clean and the main release is done, run the parallel-release script and upload them
+./tools/parallel-release.sh "$VERSION"
+BUILDNAMES='A' # For all releases we will post one parallel release for testers to use
+if [ "$PUBLIC" != "public" ]; then
+  BUILDNAMES='A B C D E' # For public releases we will post 5 parallel builds for everyone to use
+fi
+for BUILD in $BUILDNAMES; do
+  github-release upload --tag v"$VERSION" --name AnkiDroid-"$VERSION".parallel."$BUILD".apk --file AnkiDroid-"$VERSION".parallel."$BUILD".apk
+done


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
@david-allison-1 here is the mop-up after the unexpected need to merge my ABI splits change post-haste yesterday #6464 

This re-enables universal APK in debug, makes it possible in release, and "uses it where appropriate"

Appropriate is: when posting to github or when building local or parallel releases

Further, this automates the publish of parallel releases so we will always post an 'A' parallel build (for drive-by testers to just download and try) and on public release it will automatically post the 5 instead of me manually posting

## Fixes
Fixes #6472 

## Approach
Command-line gradle toggle to `-Duniversal-apk=true` that takes effect in release builds, with debug just having universal apk on all the time

## How Has This Been Tested?
Quite a few local builds, but the real testing will happen with 2.12alpha9 once this has a look

## Learning (optional, can help others)
I still suck at groovy but variable scoping isn't really that hard.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
