### PR TITLE
Number after load

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -2040,7 +2040,9 @@ public class DeckPicker extends NavigationDrawerActivity implements
         int pos = mDeckListAdapter.findDeckPosition(did);
         Sched.DeckDueTreeNode deckDueTreeNode = mDeckListAdapter.getDeckList().get(pos);
         // Figure out what action to take
-        if (deckDueTreeNode.newCount + deckDueTreeNode.lrnCount + deckDueTreeNode.revCount > 0) {
+        if (!deckDueTreeNode.haveNumber ||
+            // When numbers are not yet computed, we assume the user know what they want to review and accept to let them study
+            deckDueTreeNode.newCount + deckDueTreeNode.lrnCount + deckDueTreeNode.revCount > 0) {
             // If there are cards to study then either go to Reviewer or StudyOptions
             if (mFragmented || dontSkipStudyOptions) {
                 // Go to StudyOptions screen when tablet or deck counts area was clicked

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -190,7 +190,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
     private String mExportFileName;
 
-    private List<Sched.DeckDueTreeNode> mDueTree;
+    private List<Sched.DeckDueTreeNode> mDueTree = null;
 
     private List<CollectionTask> tasksToCancelOnClose;
 
@@ -820,6 +820,9 @@ public class DeckPicker extends NavigationDrawerActivity implements
             mSyncOnResume = false;
         } else if (colIsOpen()) {
             selectNavigationItem(R.id.nav_decks);
+            if (mDueTree == null) {
+                updateDeckList(true);
+            }
             updateDeckList();
             setTitle(getResources().getString(R.string.app_name));
         }
@@ -2130,7 +2133,12 @@ public class DeckPicker extends NavigationDrawerActivity implements
      * This method also triggers an update for the widget to reflect the newly calculated counts.
      */
     private void updateDeckList() {
-        CollectionTask task = CollectionTask.launchCollectionTask(CollectionTask.TASK_TYPE_LOAD_DECK_COUNTS, new CollectionTask.TaskListener() {
+        updateDeckList(false);
+    }
+
+    private void updateDeckList(boolean quick) {
+        int task_type = (quick) ? CollectionTask.TASK_TYPE_LOAD_DECK : CollectionTask.TASK_TYPE_LOAD_DECK_COUNTS;
+        CollectionTask task = CollectionTask.launchCollectionTask(task_type, new CollectionTask.TaskListener() {
 
             @Override
             public void onPreExecute() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -2191,7 +2191,11 @@ public class DeckPicker extends NavigationDrawerActivity implements
                     time = Utils.timeQuantity(AnkiDroidApp.getInstance(), eta*60);
                 }
                 if (getSupportActionBar() != null) {
-                    getSupportActionBar().setSubtitle(res.getQuantityString(R.plurals.deckpicker_title, due, due, time));
+                    if (mDeckListAdapter.getNumberSet()) {
+                        getSupportActionBar().setSubtitle(res.getQuantityString(R.plurals.deckpicker_title, due, due, time));
+                    } else {
+                        getSupportActionBar().setSubtitle("");
+                    }
                 }
             }
         } catch (RuntimeException e) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
@@ -52,6 +52,7 @@ import com.ichi2.libanki.Note;
 import com.ichi2.libanki.sched.Sched;
 import com.ichi2.libanki.Utils;
 
+import com.ichi2.utils.Assert;
 import com.ichi2.utils.JSONArray;
 import com.ichi2.utils.JSONException;
 import com.ichi2.utils.JSONObject;
@@ -409,7 +410,14 @@ public class CardContentProvider extends ContentProvider {
         }
     }
 
+    /**
+     *
+     * Used only for CardContentProvider's query.
+     * @param deck It is assumed that the numbers are set in the tree.
+     * @return The counts, as indicated in top of reviewer.
+     */
     private JSONArray getDeckCountsFromDueTreeNode(Sched.DeckDueTreeNode deck){
+        Assert.that(deck.haveNumber, "getDeckCountsFromDueTreeNode should be only called from deck with numbers.");
         JSONArray deckCounts = new JSONArray();
         deckCounts.put(deck.lrnCount);
         deckCounts.put(deck.revCount);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/ReminderService.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/ReminderService.java
@@ -32,6 +32,7 @@ import com.ichi2.anki.IntentHandler;
 import com.ichi2.anki.NotificationChannels;
 import com.ichi2.anki.R;
 import com.ichi2.libanki.sched.Sched;
+import com.ichi2.utils.Assert;
 
 public class ReminderService extends BroadcastReceiver {
 
@@ -61,6 +62,7 @@ public class ReminderService extends BroadcastReceiver {
             return;
         }
 
+        Assert.that(deckDue.haveNumber, "To test whether cards are due, we should have the counts.");
         final int total = deckDue.revCount + deckDue.lrnCount + deckDue.newCount;
 
         if (total <= 0) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.java
@@ -199,12 +199,14 @@ public class DeckAdapter extends RecyclerView.Adapter<DeckAdapter.ViewHolder> {
         }
 
         // Set the card counts and their colors
-        holder.deckNew.setText(String.valueOf(node.newCount));
-        holder.deckNew.setTextColor((node.newCount == 0) ? mZeroCountColor : mNewCountColor);
-        holder.deckLearn.setText(String.valueOf(node.lrnCount));
-        holder.deckLearn.setTextColor((node.lrnCount == 0) ? mZeroCountColor : mLearnCountColor);
-        holder.deckRev.setText(String.valueOf(node.revCount));
-        holder.deckRev.setTextColor((node.revCount == 0) ? mZeroCountColor : mReviewCountColor);
+        if (node.haveNumber) {
+            holder.deckNew.setText(String.valueOf(node.newCount));
+            holder.deckNew.setTextColor((node.newCount == 0) ? mZeroCountColor : mNewCountColor);
+            holder.deckLearn.setText(String.valueOf(node.lrnCount));
+            holder.deckLearn.setTextColor((node.lrnCount == 0) ? mZeroCountColor : mLearnCountColor);
+            holder.deckRev.setText(String.valueOf(node.revCount));
+            holder.deckRev.setTextColor((node.revCount == 0) ? mZeroCountColor : mReviewCountColor);
+        }
 
         // Store deck ID in layout's tag for easy retrieval in our click listeners
         holder.deckLayout.setTag(node.did);
@@ -266,7 +268,7 @@ public class DeckAdapter extends RecyclerView.Adapter<DeckAdapter.ViewHolder> {
             node.depth = depth;
 
             // Add this node's counts to the totals if it's a parent deck
-            if (depth == 0) {
+            if (depth == 0 && node.haveNumber) {
                 mNew += node.newCount;
                 mLrn += node.lrnCount;
                 mRev += node.revCount;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.java
@@ -68,6 +68,7 @@ public class DeckAdapter extends RecyclerView.Adapter<DeckAdapter.ViewHolder> {
     private int mNew;
     private int mLrn;
     private int mRev;
+    private boolean mNumberSet = false;
 
     // Flags
     private boolean mHasSubdecks;
@@ -145,6 +146,7 @@ public class DeckAdapter extends RecyclerView.Adapter<DeckAdapter.ViewHolder> {
         mCol = col;
         mDeckList.clear();
         mNew = mLrn = mRev = 0;
+        mNumberSet = false;
         mHasSubdecks = false;
         processNodes(nodes);
         notifyDataSetChanged();
@@ -269,6 +271,7 @@ public class DeckAdapter extends RecyclerView.Adapter<DeckAdapter.ViewHolder> {
 
             // Add this node's counts to the totals if it's a parent deck
             if (depth == 0 && node.haveNumber) {
+                mNumberSet = true;
                 mNew += node.newCount;
                 mLrn += node.lrnCount;
                 mRev += node.revCount;
@@ -307,6 +310,10 @@ public class DeckAdapter extends RecyclerView.Adapter<DeckAdapter.ViewHolder> {
 
     public int getDue() {
         return mNew + mLrn + mRev;
+    }
+
+    public boolean getNumberSet() {
+        return mNumberSet;
     }
 
     public List<Sched.DeckDueTreeNode> getDeckList() {

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -85,6 +85,7 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
     public static final int TASK_TYPE_DISMISS_MULTI = 12;
     public static final int TASK_TYPE_CHECK_DATABASE = 14;
     public static final int TASK_TYPE_REPAIR_DECK = 20;
+    public static final int TASK_TYPE_LOAD_DECK = 21;
     public static final int TASK_TYPE_LOAD_DECK_COUNTS = 22;
     public static final int TASK_TYPE_UPDATE_VALUES_FROM_DECK = 23;
     public static final int TASK_TYPE_DELETE_DECK = 25;
@@ -257,6 +258,10 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
         }
         // Actually execute the task now that we are at the front of the queue.
         switch (mType) {
+
+            case TASK_TYPE_LOAD_DECK:
+                return doInBackgroundLoadDeck();
+
             case TASK_TYPE_LOAD_DECK_COUNTS:
                 return doInBackgroundLoadDeckCounts();
 
@@ -542,6 +547,20 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
             return new TaskData(false);
         }
         return new TaskData(true);
+    }
+
+
+    private TaskData doInBackgroundLoadDeck() {
+        Timber.d("doInBackgroundLoadDeckCounts");
+        Collection col = CollectionHelper.getInstance().getCol(mContext);
+        try {
+            // Get due tree
+            Object[] o = new Object[] {col.getSched().quickDeckDueTree()};
+            return new TaskData(o);
+        } catch (RuntimeException e) {
+            Timber.e(e, "doInBackgroundLoadDeckCounts - error");
+            return null;
+        }
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
@@ -184,7 +184,14 @@ public abstract class AbstractSched {
         public int revCount;
         public int lrnCount;
         public int newCount;
+        public boolean haveNumber;
         public List<DeckDueTreeNode> children = new ArrayList<>();
+
+        public DeckDueTreeNode(String name, long did) {
+            this.names = new String[]{name};
+            this.did = did;
+            this.haveNumber = false;
+        }
 
         public DeckDueTreeNode(String[] names, long did, int revCount, int lrnCount, int newCount) {
             this.names = names;
@@ -192,6 +199,7 @@ public abstract class AbstractSched {
             this.revCount = revCount;
             this.lrnCount = lrnCount;
             this.newCount = newCount;
+            this.haveNumber = true;
         }
 
         public DeckDueTreeNode(String name, long did, int revCount, int lrnCount, int newCount) {
@@ -224,8 +232,13 @@ public abstract class AbstractSched {
 
         @Override
         public String toString() {
-            return String.format(Locale.US, "%s, %d, %d, %d, %d, %d, %s",
-                    Arrays.toString(names), did, depth, revCount, lrnCount, newCount, children);
+            if (haveNumber) {
+                return String.format(Locale.US, "%s, %d, %d, %d, %d, %d, %s",
+                        Arrays.toString(names), did, depth, revCount, lrnCount, newCount, children);
+            } else {
+                return String.format(Locale.US, "%s, %d, %d, %s",
+                        Arrays.toString(names), did, depth, children);
+            }
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
@@ -50,6 +50,7 @@ public abstract class AbstractSched {
     public abstract List<DeckDueTreeNode> deckDueList();
     /** load the due tree, but halt if deck task is cancelled*/
     public abstract List<DeckDueTreeNode> deckDueTree(CollectionTask collectionTask);
+    public abstract List<DeckDueTreeNode> quickDeckDueTree();
     public abstract List<DeckDueTreeNode> deckDueTree();
     /** New count for a single deck. */
     public abstract int _newForDeck(long did, int lim);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
@@ -198,12 +198,6 @@ public abstract class AbstractSched {
             this(new String[]{name}, did, revCount, lrnCount, newCount);
         }
 
-        public DeckDueTreeNode(String name, long did, int revCount, int lrnCount, int newCount,
-                               List<DeckDueTreeNode> children) {
-            this(new String[]{name}, did, revCount, lrnCount, newCount);
-            this.children = children;
-        }
-
         /**
          * Sort on the head of the node.
          */

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -274,9 +274,6 @@ public class Sched extends SchedV2 {
                     break;
                 }
             }
-            int rev = node.revCount;
-            int _new = node.newCount;
-            int lrn = node.lrnCount;
             for (DeckDueTreeNode c : children) {
                 // set new string to tail
                 String[] newTail = new String[c.names.length-1];
@@ -286,18 +283,18 @@ public class Sched extends SchedV2 {
             node.children = _groupChildrenMain(children);
             // tally up children counts
             for (DeckDueTreeNode ch : node.children) {
-                rev +=  ch.revCount;
-                lrn +=  ch.lrnCount;
-                _new += ch.newCount;
+                node.revCount += ch.revCount;
+                node.lrnCount += ch.lrnCount;
+                node.newCount += ch.newCount;
             }
             // limit the counts to the deck's limits
             JSONObject conf = mCol.getDecks().confForDid(node.did);
             JSONObject deck = mCol.getDecks().get(node.did);
             if (conf.getInt("dyn") == 0) {
-                rev = Math.max(0, Math.min(rev, conf.getJSONObject("rev").getInt("perDay") - deck.getJSONArray("revToday").getInt(1)));
-                _new = Math.max(0, Math.min(_new, conf.getJSONObject("new").getInt("perDay") - deck.getJSONArray("newToday").getInt(1)));
+                node.revCount = Math.max(0, Math.min(node.revCount, conf.getJSONObject("rev").getInt("perDay") - deck.getJSONArray("revToday").getInt(1)));
+                node.newCount = Math.max(0, Math.min(node.newCount, conf.getJSONObject("new").getInt("perDay") - deck.getJSONArray("newToday").getInt(1)));
             }
-            tree.add(new DeckDueTreeNode(head, node.did, rev, lrn, _new, node.children));
+            tree.add(new DeckDueTreeNode(head, node.did, node.revCount, node.lrnCount, node.newCount, node.children));
         }
         return tree;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -294,7 +294,7 @@ public class Sched extends SchedV2 {
                 node.revCount = Math.max(0, Math.min(node.revCount, conf.getJSONObject("rev").getInt("perDay") - deck.getJSONArray("revToday").getInt(1)));
                 node.newCount = Math.max(0, Math.min(node.newCount, conf.getJSONObject("new").getInt("perDay") - deck.getJSONArray("newToday").getInt(1)));
             }
-            tree.add(new DeckDueTreeNode(head, node.did, node.revCount, node.lrnCount, node.newCount, node.children));
+            tree.add(node);
         }
         return tree;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -274,7 +274,6 @@ public class Sched extends SchedV2 {
                     break;
                 }
             }
-            Long did = node.did;
             int rev = node.revCount;
             int _new = node.newCount;
             int lrn = node.lrnCount;
@@ -292,13 +291,13 @@ public class Sched extends SchedV2 {
                 _new += ch.newCount;
             }
             // limit the counts to the deck's limits
-            JSONObject conf = mCol.getDecks().confForDid(did);
-            JSONObject deck = mCol.getDecks().get(did);
+            JSONObject conf = mCol.getDecks().confForDid(node.did);
+            JSONObject deck = mCol.getDecks().get(node.did);
             if (conf.getInt("dyn") == 0) {
                 rev = Math.max(0, Math.min(rev, conf.getJSONObject("rev").getInt("perDay") - deck.getJSONArray("revToday").getInt(1)));
                 _new = Math.max(0, Math.min(_new, conf.getJSONObject("new").getInt("perDay") - deck.getJSONArray("newToday").getInt(1)));
             }
-            tree.add(new DeckDueTreeNode(head, did, rev, lrn, _new, node.children));
+            tree.add(new DeckDueTreeNode(head, node.did, rev, lrn, _new, node.children));
         }
         return tree;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -290,9 +290,9 @@ public class Sched extends SchedV2 {
                     children.add(c);
                 }
             }
-            children = _groupChildrenMain(children);
+            node.children = _groupChildrenMain(children);
             // tally up children counts
-            for (DeckDueTreeNode ch : children) {
+            for (DeckDueTreeNode ch : node.children) {
                 rev +=  ch.revCount;
                 lrn +=  ch.lrnCount;
                 _new += ch.newCount;
@@ -304,7 +304,7 @@ public class Sched extends SchedV2 {
                 rev = Math.max(0, Math.min(rev, conf.getJSONObject("rev").getInt("perDay") - deck.getJSONArray("revToday").getInt(1)));
                 _new = Math.max(0, Math.min(_new, conf.getJSONObject("new").getInt("perDay") - deck.getJSONArray("newToday").getInt(1)));
             }
-            tree.add(new DeckDueTreeNode(head, did, rev, lrn, _new, children));
+            tree.add(new DeckDueTreeNode(head, did, rev, lrn, _new, node.children));
         }
         return tree;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -470,9 +470,6 @@ public class SchedV2 extends AbstractSched {
                     break;
                 }
             }
-            int rev = node.revCount;
-            int _new = node.newCount;
-            int lrn = node.lrnCount;
             for (DeckDueTreeNode c : children) {
                     // set new string to tail
                 String[] newTail = new String[c.names.length-1];
@@ -482,16 +479,16 @@ public class SchedV2 extends AbstractSched {
             node.children = _groupChildrenMain(node.children);
             // tally up children counts
             for (DeckDueTreeNode ch : node.children) {
-                lrn +=  ch.lrnCount;
-                _new += ch.newCount;
+                node.lrnCount += ch.lrnCount;
+                node.newCount += ch.newCount;
             }
             // limit the counts to the deck's limits
             JSONObject conf = mCol.getDecks().confForDid(node.did);
             JSONObject deck = mCol.getDecks().get(node.did);
             if (conf.getInt("dyn") == 0) {
-                _new = Math.max(0, Math.min(_new, conf.getJSONObject("new").getInt("perDay") - deck.getJSONArray("newToday").getInt(1)));
+                node.newCount = Math.max(0, Math.min(node.newCount, conf.getJSONObject("new").getInt("perDay") - deck.getJSONArray("newToday").getInt(1)));
             }
-            tree.add(new DeckDueTreeNode(head, node.did, rev, lrn, _new, node.children));
+            tree.add(new DeckDueTreeNode(head, node.did, node.revCount, node.lrnCount, node.newCount, node.children));
         }
         return tree;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -488,7 +488,7 @@ public class SchedV2 extends AbstractSched {
             if (conf.getInt("dyn") == 0) {
                 node.newCount = Math.max(0, Math.min(node.newCount, conf.getJSONObject("new").getInt("perDay") - deck.getJSONArray("newToday").getInt(1)));
             }
-            tree.add(new DeckDueTreeNode(head, node.did, node.revCount, node.lrnCount, node.newCount, node.children));
+            tree.add(node);
         }
         return tree;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -470,7 +470,6 @@ public class SchedV2 extends AbstractSched {
                     break;
                 }
             }
-            Long did = node.did;
             int rev = node.revCount;
             int _new = node.newCount;
             int lrn = node.lrnCount;
@@ -487,12 +486,12 @@ public class SchedV2 extends AbstractSched {
                 _new += ch.newCount;
             }
             // limit the counts to the deck's limits
-            JSONObject conf = mCol.getDecks().confForDid(did);
-            JSONObject deck = mCol.getDecks().get(did);
+            JSONObject conf = mCol.getDecks().confForDid(node.did);
+            JSONObject deck = mCol.getDecks().get(node.did);
             if (conf.getInt("dyn") == 0) {
                 _new = Math.max(0, Math.min(_new, conf.getJSONObject("new").getInt("perDay") - deck.getJSONArray("newToday").getInt(1)));
             }
-            tree.add(new DeckDueTreeNode(head, did, rev, lrn, _new, node.children));
+            tree.add(new DeckDueTreeNode(head, node.did, rev, lrn, _new, node.children));
         }
         return tree;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -486,9 +486,9 @@ public class SchedV2 extends AbstractSched {
                     children.add(c);
                 }
             }
-            children = _groupChildrenMain(children);
+            node.children = _groupChildrenMain(node.children);
             // tally up children counts
-            for (DeckDueTreeNode ch : children) {
+            for (DeckDueTreeNode ch : node.children) {
                 lrn +=  ch.lrnCount;
                 _new += ch.newCount;
             }
@@ -498,7 +498,7 @@ public class SchedV2 extends AbstractSched {
             if (conf.getInt("dyn") == 0) {
                 _new = Math.max(0, Math.min(_new, conf.getJSONObject("new").getInt("perDay") - deck.getJSONArray("newToday").getInt(1)));
             }
-            tree.add(new DeckDueTreeNode(head, did, rev, lrn, _new, children));
+            tree.add(new DeckDueTreeNode(head, did, rev, lrn, _new, node.children));
         }
         return tree;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -417,6 +417,26 @@ public class SchedV2 extends AbstractSched {
         return data;
     }
 
+    /** Similar to deck due tree, but ignore the number of cards.
+
+     It may takes a lot of time to compute the number of card, it
+     requires multiple database access by deck.  Ignoring this number
+     lead to the creation of a tree more quickly.*/
+    @Override
+    public List<DeckDueTreeNode> quickDeckDueTree() {
+        // Similar to deckDueTree, ignoring the numbers
+
+        // Similar to deckDueList
+        ArrayList<DeckDueTreeNode> data = new ArrayList<>();
+        for (JSONObject deck : mCol.getDecks().allSorted()) {
+            DeckDueTreeNode g = new DeckDueTreeNode(deck.getString("name"), deck.getLong("id"));
+            data.add(g);
+        }
+        // End of the similar part.
+
+        return _groupChildren(data, false);
+    }
+
 
     public List<DeckDueTreeNode> deckDueTree() {
         return deckDueTree(null);

--- a/AnkiDroid/src/main/java/com/ichi2/widget/WidgetStatus.java
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/WidgetStatus.java
@@ -29,6 +29,7 @@ import com.ichi2.anki.services.NotificationService;
 import com.ichi2.async.BaseAsyncTask;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.sched.Sched;
+import com.ichi2.utils.Assert;
 
 import java.util.List;
 
@@ -126,6 +127,7 @@ public final class WidgetStatus {
             // Only count the top-level decks in the total
             List<Sched.DeckDueTreeNode> nodes = col.getSched().deckDueTree();
             for (Sched.DeckDueTreeNode node : nodes) {
+                Assert.that(node.haveNumber, "Numbers are required in node to update counts.");
                 total[0] += node.newCount;
                 total[1] += node.lrnCount;
                 total[2] += node.revCount;


### PR DESCRIPTION
This is an entirely new version of https://github.com/ankidroid/Anki-Android/pull/6039
Hopefully, I took into account all of your remarks. In particular, the change in the scheduler code is smaller (appart from the debugging prints)

There are no numbers near the deck. I hope that it means that screen reader will process it correctly.

To load the deck picker quickly at initialization, I avoided deck's safety check. Instead, if I found an error (duplicate name, deck without parent) I just ignore it.

If a deck is clicked before numbers are loaded, I assume the user know what they want and open the reviewer. If actually there was no card to review, the reviewer will just close, and no harm is done. This choice can easily be changed, instead I can just record the click, wait for the number, and then execute it. As a user, I believe it's a waist of time, but that's just a personal opinion
![Screenshot_20200617-011248_Samsung capture](https://user-images.githubusercontent.com/357361/84837444-7244f380-b038-11ea-84a5-d5a61e59c9ec.jpg)


I'm testing it simply by loading it on my phone and reviewing with it.