### PR TITLE
Travis: Rename API R to API 30

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ env:
    - API=27 LOCALE="fr_FR"
    - API=28 # API28 does not handle locale changes for some reason, so it is our default locale test
    - API=29 LOCALE="pt_BR"
-   - API=R EMU_FLAVOR=google_apis LOCALE="de_DE" # This will be API30 when released, until now it is R, with intermittent failure
+   - API=30 EMU_FLAVOR=google_apis LOCALE="de_DE" # This will be API30 when released, until now it is R, with intermittent failure
    - API=24 JDK="1.11" # make sure we work in future dev environments
    - API=24 JDK="1.14" # make sure we work in future dev environments
 
@@ -75,7 +75,7 @@ jobs:
       install: skip
       script: echo finalize codacy coverage uploads
   allow_failures:
-    - env: API=R EMU_FLAVOR=google_apis LOCALE="de_DE" # unreleased Android API30 is failing in local builds, let's expose that on Travis
+    - env: API=30 EMU_FLAVOR=google_apis LOCALE="de_DE" # unreleased Android API30 is failing in local builds, let's expose that on Travis
     - env: API=24 JDK="1.11" # non-default JDKs should not hold up success reporting
     - env: API=24 JDK="1.14" # non-default JDKs should not hold up success reporting
     - env: LINT=Debug API=NONE # we want to see the full lint report vs baseline but not fail on it


### PR DESCRIPTION
Fixes the Travis Build

Note: We should likely enable `requestLegacyExternalStorage`

## Learning (optional, can help others)

⚠️  https://developer.android.com/preview/behavior-changes-11

https://developer.android.com/preview/setup-sdk - now shows to use `30` instead of `R`


> Sometime later this year, we will be able to switch to using targetSdkVersion 30, at which point normal behavior returns with respect to minSdkVersion.

https://stackoverflow.com/a/61027613/13121290


## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code