### PR TITLE
Reload card browser when tags/fields change in note edit

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -825,9 +825,11 @@ public class NoteEditor extends AnkiActivity {
             modified = modified || mEditorNote.getTags().size() > mSelectedTags.size();
             if (modified) {
                 mEditorNote.setTagsFromStr(tagsAsString(mSelectedTags));
-                // set a flag so that changes to card object will be written to DB later via onActivityResult() in
-                // CardBrowser
+                // CardBrowser always runs CollectionTask.TASK_TYPE_UPDATE_NOTE in response to non-canceled edits
+                // so mChanged is likely not needed anymore...
                 mChanged = true;
+                // ...but we do need it to reload itself so results of tag and field edits are shown
+                mReloadRequired = true;
             }
             closeNoteEditor();
         }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

I noticed this in response to editing a note for the sole purpose
of removing leech tags in my own collection. Upon return to card
browser it was not fully in sync visually with the updated tags

## Fixes
unlogged, fixed it in less time than logging an issue takes because I happened to know about 'mReloadRequired' and how it operated from my work on CardTemplateEditor

## Approach
Minimal intervention. It's possible mChanged has no effect - my quick inspection indicated it did not - but better not to change it without testing. Removing it or altering might introduce a bug.

Adding mReloadRequired however just requests the CardBrowser do an idempotent operation, to re-execute the search that resulted in it's current list. And if tags or fields change you definitely want it to reload so that highlighting on marked or leech cards is up to date.

## How Has This Been Tested?

API29 emulator, start in card browser without this patch, select a card for edit that's part of a multi-card note, add marked tag, save and notice not all cards had highlighting change. Add this patch, and all related cards change highlighting correctly in card browser after toggling the marked tag in edit note.

## Learning (optional, can help others)
Android Activity / Intent etc control flow is super fun

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
