### PR TITLE
Note editor cloze more available

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1782,28 +1782,7 @@ public class NoteEditor extends AnkiActivity {
         @Override
         public boolean onActionItemClicked(ActionMode mode, MenuItem item) {
             if (item.getItemId() == mMenuId) {
-                // get the current text and selection locations
-                int selectionStart = mTextBox.getSelectionStart();
-                int selectionEnd = mTextBox.getSelectionEnd();
-                String text = "";
-                if (mTextBox.getText() != null) {
-                    text = mTextBox.getText().toString();
-                }
-
-                // Split the text in the places where the cloze deletion will be inserted
-                String beforeText = text.substring(0, selectionStart);
-                String selectedText = text.substring(selectionStart, selectionEnd);
-                String afterText = text.substring(selectionEnd);
-                int nextClozeIndex = getNextClozeIndex();
-
-                // Format the cloze deletion open bracket
-                String clozeOpenBracket = "{{c" + (nextClozeIndex) + "::";
-
-                // Update text field with updated text and selection
-                mTextBox.setText(beforeText + clozeOpenBracket + selectedText + "}}" + afterText);
-                int clozeOpenSize = clozeOpenBracket.length();
-                mTextBox.setSelection(selectionStart+clozeOpenSize, selectionEnd+clozeOpenSize);
-
+                convertSelectedTextToCloze(mTextBox);
                 mode.finish();
                 return true;
             } else {
@@ -1817,6 +1796,31 @@ public class NoteEditor extends AnkiActivity {
             // Left empty on purpose
         }
     }
+
+    private void convertSelectedTextToCloze(FieldEditText textBox) {
+        // get the current text and selection locations
+        int selectionStart = textBox.getSelectionStart();
+        int selectionEnd = textBox.getSelectionEnd();
+        String text = "";
+        if (textBox.getText() != null) {
+            text = textBox.getText().toString();
+        }
+
+        // Split the text in the places where the cloze deletion will be inserted
+        String beforeText = text.substring(0, selectionStart);
+        String selectedText = text.substring(selectionStart, selectionEnd);
+        String afterText = text.substring(selectionEnd);
+        int nextClozeIndex = getNextClozeIndex();
+
+        // Format the cloze deletion open bracket
+        String clozeOpenBracket = "{{c" + (nextClozeIndex) + "::";
+
+        // Update text field with updated text and selection
+        textBox.setText(beforeText + clozeOpenBracket + selectedText + "}}" + afterText);
+        int clozeOpenSize = clozeOpenBracket.length();
+        textBox.setSelection(selectionStart+clozeOpenSize, selectionEnd+clozeOpenSize);
+    }
+
 
     private boolean hasClozeDeletions() {
         return getNextClozeIndex() > 1;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1816,7 +1816,7 @@ public class NoteEditor extends AnkiActivity {
         String clozeOpenBracket = "{{c" + (nextClozeIndex) + "::";
 
         // Update text field with updated text and selection
-        textBox.setText(beforeText + clozeOpenBracket + selectedText + "}}" + afterText);
+        textBox.setText(String.format("%s%s%s}}%s", beforeText, clozeOpenBracket, selectedText, afterText));
         int clozeOpenSize = clozeOpenBracket.length();
         textBox.setSelection(selectionStart+clozeOpenSize, selectionEnd+clozeOpenSize);
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1265,6 +1265,9 @@ public class NoteEditor extends AnkiActivity {
                 PopupMenuWithIcons popup = new PopupMenuWithIcons(NoteEditor.this, v, false);
                 MenuInflater inflater = popup.getMenuInflater();
                 inflater.inflate(R.menu.popupmenu_multimedia_options, popup.getMenu());
+                if (isClozeType()) {
+                    popup.getMenu().findItem(R.id.menu_multimedia_add_cloze).setVisible(true);
+                }
                 popup.setOnMenuItemClickListener(item -> {
 
                     switch (item.getItemId()) {
@@ -1286,6 +1289,11 @@ public class NoteEditor extends AnkiActivity {
                         case R.id.menu_multimedia_text: {
                             Timber.i("NoteEditor:: Advanced editor button pressed");
                             startAdvancedTextEditor(index);
+                            return true;
+                        }
+                        case R.id.menu_multimedia_add_cloze: {
+                            Timber.i("NoteEditor:: Insert cloze button pressed");
+                            convertSelectedTextToCloze(index);
                             return true;
                         }
                         default:
@@ -1795,6 +1803,13 @@ public class NoteEditor extends AnkiActivity {
         public void onDestroyActionMode(ActionMode mode) {
             // Left empty on purpose
         }
+    }
+
+    private void convertSelectedTextToCloze(int fieldIndex) {
+        if (fieldIndex < 0 || fieldIndex > mEditFields.size()) {
+            Timber.w("Invalid field index %d requested for cloze insertion.", fieldIndex);
+        }
+        convertSelectedTextToCloze(mEditFields.get(fieldIndex));
     }
 
     private void convertSelectedTextToCloze(FieldEditText textBox) {

--- a/AnkiDroid/src/main/res/menu/popupmenu_multimedia_options.xml
+++ b/AnkiDroid/src/main/res/menu/popupmenu_multimedia_options.xml
@@ -15,6 +15,10 @@
         <item
             android:id="@+id/menu_multimedia_text"
             android:title="@string/multimedia_editor_popup_text"/>
+        <item
+            android:id="@+id/menu_multimedia_add_cloze"
+            android:title="@string/multimedia_editor_popup_cloze"
+            android:visible="false"/>
     </group>
 
 </menu>


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
We have been getting terrible reviews, all focused on cloze deletion, from Vietnam.

I just couldn't figure it out.

Finally it turns out it's Xiaomi devices! They apparently just don't do action mode callbacks well.

Also we didn't set action mode callbacks for lower APIs so anything below API23 was out of luck too.

This PR adds cloze as an option on the paperclip menu so it's usable everywhere now.

## Fixes
Fixes #6494 

## Approach
If it's a cloze type card, make a cloze menu item visible on the paperclip menu, and hook that to all the existing cloze insertion code


## How Has This Been Tested?
For both cloze and non-cloze card types, on an API29 and API22 emulator, verify that cloze deletion is visible when it should be on the paperclip menu, and that it works.

I will note there is some crap behavior on API22 where your text selection goes away when any other activity on the screen happens, but that also happened when I tried context menus, so we just can't win there. At least users can actually get a properly formatted set of cloze brackets automatically now.

## Learning (optional, can help others)
Xiaomi is a terrible Android vendor. Seriously, they implement multiple Android APIs incorrectly, over years, with no fixes.

## Checklist


- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
