### PR TITLE
Show keyboard when adding note in NoteEditor

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -390,7 +390,6 @@ public class NoteEditor extends AnkiActivity {
     @Override
     protected void onCollectionLoaded(Collection col) {
         super.onCollectionLoaded(col);
-        this.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN);
 
         Intent intent = getIntent();
         Timber.d("NoteEditor() onCollectionLoaded: caller: %d", mCaller);
@@ -577,10 +576,14 @@ public class NoteEditor extends AnkiActivity {
             Timber.i("onCollectionLoaded() Edit note activity successfully started in add card mode with node id %d", mEditorNote.getId());
         }
 
+        // don't open keyboard if not adding note
+        if (!mAddNote) {
+            this.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN);
+        }
+
         //set focus to FieldEditText 'first' on startup like Anki desktop
         if (mEditFields != null && !mEditFields.isEmpty()) {
-            FieldEditText first = mEditFields.getFirst();
-            first.requestFocus();
+            mEditFields.getFirst().requestFocus();
         }
     }
 


### PR DESCRIPTION
fixes #3213

## Approach
Only set soft input mode to always hidden when not adding a note (`setSoftInputMode`). Normally it would open on focus because of AndroidManifest's `adjustResize` option.

## How Has This Been Tested?
1. Add note and edit existing note
2. See whether keyboard opens automatically

## Learning (optional, can help others)
https://developer.android.com/training/keyboard-input/visibility

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
