### PR TITLE
Automated deck renaming

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -792,7 +792,9 @@ public class Decks {
             // two decks with the same name?
             if (names.contains(normalizeName(deck.getString("name")))) {
                 Timber.i("fix duplicate deck name %s", deck.getString("name"));
-                deck.put("name", deck.getString("name") + Utils.intTime(1000));
+                do {
+                    deck.put("name", deck.getString("name") + "+");
+                } while (names.contains(normalizeName(deck.getString("name"))));
                 save(deck);
             }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -789,19 +789,19 @@ public class Decks {
         Set<String> names = new HashSet<String>();
 
         for (JSONObject deck: decks) {
+            // ensure no sections are blank
+            if (deck.getString("name").indexOf("::::") != -1) {
+                Timber.i("fix deck with missing sections %s", deck.getString("name"));
+                deck.put("name", "recovered"+Utils.intTime(1000));
+                save(deck);
+            }
+
             // two decks with the same name?
             if (names.contains(normalizeName(deck.getString("name")))) {
                 Timber.i("fix duplicate deck name %s", deck.getString("name"));
                 do {
                     deck.put("name", deck.getString("name") + "+");
                 } while (names.contains(normalizeName(deck.getString("name"))));
-                save(deck);
-            }
-
-            // ensure no sections are blank
-            if (deck.getString("name").indexOf("::::") != -1) {
-                Timber.i("fix deck with missing sections %s", deck.getString("name"));
-                deck.put("name", "recovered"+Utils.intTime(1000));
                 save(deck);
             }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -792,7 +792,10 @@ public class Decks {
             // ensure no sections are blank
             if (deck.getString("name").indexOf("::::") != -1) {
                 Timber.i("fix deck with missing sections %s", deck.getString("name"));
-                deck.put("name", "recovered"+Utils.intTime(1000));
+                do {
+                    deck.put("name", deck.getString("name").replace("::::", "::blank::"));
+                    // We may need to iterate, in order to replace "::::::" and adding to "blank" in it.
+                } while (deck.getString("name").indexOf("::::") != -1);
                 save(deck);
             }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -790,6 +790,12 @@ public class Decks {
 
         for (JSONObject deck: decks) {
             // ensure no sections are blank
+            if ("".equals(deck.getString("name"))) {
+                Timber.i("Fix deck with empty name");
+                deck.put("name", "blank");
+                save(deck);
+            }
+
             if (deck.getString("name").indexOf("::::") != -1) {
                 Timber.i("fix deck with missing sections %s", deck.getString("name"));
                 do {


### PR DESCRIPTION
Anki is changing the way it deals with deck name in case of trouble. 
* "" is replaced by "blank"
* "::::" is replaced by "::blank::"
* duplicate name just replace a name `n` by `n+` (actually, it now allows to rename deck to give it the name of an already existing deck. It seems quite strange and probably an accident, so I won't port this feature yet)

I made the first two changes before looking for duplicate name, otherwise it would make little sens.

Tested:
* Deck with "::::::"
* deck ""

I didn't test duplicate name, mostly because there is no easy way to create duplicate name in ankidroid