### PR TITLE
Add volume buttons to gestures

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -312,6 +312,8 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
     private int mGestureTapTop;
     private int mGestureTapBottom;
     private int mGestureLongclick;
+    private int mGestureVolumeUp;
+    private int mGestureVolumeDown;
 
     private Spanned mCardContent;
     private String mBaseUrl;
@@ -1338,6 +1340,32 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
     }
 
 
+    @Override
+    public boolean dispatchKeyEvent(KeyEvent event) {
+        if (event.getAction() == KeyEvent.ACTION_DOWN) {
+            // assign correct gesture code
+            int gesture = COMMAND_NOTHING;
+
+            switch (event.getKeyCode()) {
+                case KeyEvent.KEYCODE_VOLUME_UP:
+                    gesture = mGestureVolumeUp;
+                    break;
+                case KeyEvent.KEYCODE_VOLUME_DOWN:
+                    gesture = mGestureVolumeDown;
+                    break;
+            }
+
+            // Execute gesture's command, but only consume event if action is assigned. We want the volume buttons to work normally otherwise.
+            if (gesture != COMMAND_NOTHING) {
+                executeCommand(gesture);
+                return true;
+            }
+        }
+
+        return super.dispatchKeyEvent(event);
+    }
+
+
     // Set the content view to the one provided and initialize accessors.
     @SuppressWarnings("deprecation") // Tracked separately as #5023 on github for clipboard
     protected void initLayout() {
@@ -1677,6 +1705,8 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
             mGestureTapTop = Integer.parseInt(preferences.getString("gestureTapTop", "12"));
             mGestureTapBottom = Integer.parseInt(preferences.getString("gestureTapBottom", "2"));
             mGestureLongclick = Integer.parseInt(preferences.getString("gestureLongclick", "11"));
+            mGestureVolumeUp = Integer.parseInt(preferences.getString("gestureVolumeUp", "0"));
+            mGestureVolumeDown = Integer.parseInt(preferences.getString("gestureVolumeDown", "0"));
         }
 
         if (preferences.getBoolean("keepScreenOn", false)) {

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -86,6 +86,8 @@
     <string name="gestures_tap_bottom">Touch bottom</string>
     <string name="gestures_tap_left">Touch left</string>
     <string name="gestures_tap_right">Touch right</string>
+    <string name="gestures_volume_up">Volume up</string>
+    <string name="gestures_volume_down">Volume down</string>
     <string name="more_scrolling_buttons">eReader</string>
     <string name="more_scrolling_buttons_summ">Also use kanji/katakana, emoji/kao-moji buttons for scrolling</string>
     <string name="card_browser_enable_external_context_menu">‘%s’ Menu</string>

--- a/AnkiDroid/src/main/res/xml/preferences_gestures.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_gestures.xml
@@ -112,5 +112,19 @@
             android:entryValues="@array/gestures_values"
             android:key="gestureTapRight"
             android:title="@string/gestures_tap_right" />
+        <ListPreference
+            android:defaultValue="0"
+            android:dependency="gestures"
+            android:entries="@array/gestures_labels"
+            android:entryValues="@array/gestures_values"
+            android:key="gestureVolumeUp"
+            android:title="@string/gestures_volume_up" />
+        <ListPreference
+            android:defaultValue="0"
+            android:dependency="gestures"
+            android:entries="@array/gestures_labels"
+            android:entryValues="@array/gestures_values"
+            android:key="gestureVolumeDown"
+            android:title="@string/gestures_volume_down" />
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
## Purpose / Description
This commit adds the volume buttons to the gestures as discussed in #3021. Since this is unexpected behavior for most users, it's turned off by default. I realize buttons are not gestures, but it seemed like the most sensible place to put this, mainly because you can configure them for any action.

Perhaps it makes sense to add more gestures using the volume buttons and maybe even the wakup/standby button. Things like double press and press and hold could allow for more actions to be used with hardware buttons.

An interesting continuation of this would also be to make the Reviewer work with the screen turned off and TTS as output. Useful on the go and for blind people. Maybe I'll look into that.

## Approach
Simply added volume buttons to existing gestures. `AbstractFlashcardViewer.dispatchKeyEvent` then executes the assigned actions.

## How Has This Been Tested?
1. Adjust the settings (Settings > Gestures > Volume Up/Down)
2. Open deck
3. press volume button

(Only tested on an emulator)

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
