### PR TITLE
Import: Improve error and don't report problem if cache is cleared

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/AnkiPackageImporter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/AnkiPackageImporter.java
@@ -60,7 +60,16 @@ public class AnkiPackageImporter extends Anki2Importer {
             String colname = "collection.anki21";
             try {
                 // extract the deck from the zip file
-                mZip = new ZipFile(new File(mFile));
+                try {
+                    mZip = new ZipFile(new File(mFile));
+                } catch (FileNotFoundException fileNotFound) {
+                    // The cache can be cleared between copying the file in and importing. This is temporary
+                    if (fileNotFound.getMessage().contains("ENOENT")) {
+                        mLog.add(getRes().getString(R.string.import_log_file_cache_cleared));
+                        return;
+                    }
+                    throw fileNotFound; //displays: failed to unzip
+                }
                 // v2 scheduler?
                 if (mZip.getEntry(colname) == null) {
                     colname = CollectionHelper.COLLECTION_FILENAME;

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -161,7 +161,7 @@
     <string name="import_log_failed_copy_to">Failed to copy apkg to %s</string>
     <string name="import_log_failed_validate">apkg failed validation</string>
     <string name="import_log_insufficient_space">There is not enough space to unzip the package. Needed %1$d, available %2$d</string>
-    <string name="import_log_file_cache_cleared">Temporary error importing file.\nPlease try again</string>
+    <string name="import_log_file_cache_cleared">Error importing file, likely a cache clear during processing.\nPlease try again</string>
     <string name="import_succeeded_but_check_database">Data import succeeded but post-import cleanup failed. Run check database later. Root cause: %s</string>
     <string name="import_error_unhandled_request">Unable to process import request</string>
     <string name="import_error_exception">Failed to import package\n\n%s</string>

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -161,6 +161,7 @@
     <string name="import_log_failed_copy_to">Failed to copy apkg to %s</string>
     <string name="import_log_failed_validate">apkg failed validation</string>
     <string name="import_log_insufficient_space">There is not enough space to unzip the package. Needed %1$d, available %2$d</string>
+    <string name="import_log_file_cache_cleared">Temporary error importing file.\nPlease try again</string>
     <string name="import_succeeded_but_check_database">Data import succeeded but post-import cleanup failed. Run check database later. Root cause: %s</string>
     <string name="import_error_unhandled_request">Unable to process import request</string>
     <string name="import_error_exception">Failed to import package\n\n%s</string>


### PR DESCRIPTION
The cache can be cleared, this would cause both a crash report dialog and a generic "failed to unzip" error.

## Fixes

Fixes #6491

## Approach
Catch exception and display a better message. Don't error report.

## How Has This Been Tested?

Tested on my phone, both by throwing the normal ENOENT and throwing a generic FileNotFound, the FileNotFound raises an exception report. the ENOENT doesn't

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code