### PR TITLE
Deck import: Pre-validate zip file

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
@@ -18,6 +18,7 @@ import com.ichi2.anki.R;
 import com.ichi2.anki.dialogs.DialogHandler;
 import com.ichi2.compat.CompatHelper;
 
+import org.apache.commons.compress.archivers.zip.ZipFile;
 import org.jetbrains.annotations.Contract;
 
 import java.io.File;
@@ -173,9 +174,29 @@ public class ImportUtils {
                     AnkiDroidApp.sendExceptionReport(new RuntimeException("Error importing apkg file"), "IntentHandler.java", "apkg import failed");
                     return errorMessage;
                 }
+
+                errorMessage = validateZipFile(context, tempOutDir);
+                if (errorMessage != null) {
+                    //noinspection ResultOfMethodCallIgnored
+                    new File(tempOutDir).delete();
+                    return errorMessage;
+                }
+
                 sendShowImportFileDialogMsg(tempOutDir);
                 return null;
             }
+        }
+
+
+        protected String validateZipFile(Context context, String filePath) {
+            File file = new File(filePath);
+            try {
+                new ZipFile(file);
+            } catch (Exception e) {
+                Timber.w(e, "Failed to validate zip");
+                return context.getString(R.string.import_log_failed_unzip, e.getLocalizedMessage());
+            }
+            return null;
         }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
@@ -169,13 +169,13 @@ public class ImportUtils {
                 String tempOutDir = Uri.fromFile(new File(context.getCacheDir(), filename)).getEncodedPath();
                 errorMessage = copyFileToCache(context, data, tempOutDir) ? null : context.getString(R.string.import_error_copy_file_to_cache);
                 // Show import dialog
-                if (errorMessage == null) {
-                    sendShowImportFileDialogMsg(tempOutDir);
-                } else {
+                if (errorMessage != null) {
                     AnkiDroidApp.sendExceptionReport(new RuntimeException("Error importing apkg file"), "IntentHandler.java", "apkg import failed");
+                    return errorMessage;
                 }
+                sendShowImportFileDialogMsg(tempOutDir);
+                return null;
             }
-            return errorMessage;
         }
 
 


### PR DESCRIPTION
## Purpose / Description
Previously, we performed the check inside either `AnkiPackageImporter`/`doInBackgroundReplace`. This caused exception reports to be thrown when zip files were invalid, which wasn't a great UX

## Fixes
Fixes #6489

## Approach
We move to `ImportUtil` to validate the import, which displays an error and does not raise an exception report.

## How Has This Been Tested?

On my phone:

* Empty file - no exception report, "Failed to unzip apkg: archive is not a ZIP archive"
* Corrupt file - no exception report, "Failed to unzip apkg: central directory is empty ..."
* Good file - imports as normal

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code