### PR TITLE
Copy DeckID when copying/adding note

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -941,23 +941,36 @@ public class NoteEditor extends AnkiActivity {
                 return true;
 
             case R.id.action_add_note_from_note_editor:
+                Timber.i("NoteEditor:: Add Note button pressed");
+                addNewNote();
+                return true;
             case R.id.action_copy_note: {
-                Timber.i("NoteEditor:: Copy or add card button pressed");
-                Intent intent = new Intent(NoteEditor.this, NoteEditor.class);
-                intent.putExtra(EXTRA_CALLER, CALLER_CARDEDITOR);
-                if (item.getItemId() == R.id.action_copy_note) {
-                    intent.putExtra(EXTRA_CONTENTS, getFieldsText());
-                    if (mSelectedTags != null) {
-                        intent.putExtra(EXTRA_TAGS, mSelectedTags.toArray(new String[0]));
-                    }
-                }
-                startActivityForResultWithAnimation(intent, REQUEST_ADD, ActivityTransitionAnimation.LEFT);
+                Timber.i("NoteEditor:: Copy Note button pressed");
+                copyNote();
                 return true;
             }
             default:
                 return super.onOptionsItemSelected(item);
 
         }
+    }
+
+
+    public void addNewNote() {
+        Intent intent = new Intent(NoteEditor.this, NoteEditor.class);
+        intent.putExtra(EXTRA_CALLER, CALLER_CARDEDITOR);
+        startActivityForResultWithAnimation(intent, REQUEST_ADD, ActivityTransitionAnimation.LEFT);
+    }
+
+
+    public void copyNote() {
+        Intent intent = new Intent(NoteEditor.this, NoteEditor.class);
+        intent.putExtra(EXTRA_CALLER, CALLER_CARDEDITOR);
+        intent.putExtra(EXTRA_CONTENTS, getFieldsText());
+        if (mSelectedTags != null) {
+            intent.putExtra(EXTRA_TAGS, mSelectedTags.toArray(new String[0]));
+        }
+        startActivityForResultWithAnimation(intent, REQUEST_ADD, ActivityTransitionAnimation.LEFT);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -85,6 +85,7 @@ import com.ichi2.themes.Themes;
 import com.ichi2.anki.widgets.PopupMenuWithIcons;
 import com.ichi2.utils.AdaptionUtil;
 import com.ichi2.utils.DeckComparator;
+import com.ichi2.utils.FunctionalInterfaces.Consumer;
 import com.ichi2.utils.NamedJSONComparator;
 import com.ichi2.widget.WidgetStatus;
 
@@ -957,19 +958,24 @@ public class NoteEditor extends AnkiActivity {
 
 
     public void addNewNote() {
-        Intent intent = new Intent(NoteEditor.this, NoteEditor.class);
-        intent.putExtra(EXTRA_CALLER, CALLER_CARDEDITOR);
-        startActivityForResultWithAnimation(intent, REQUEST_ADD, ActivityTransitionAnimation.LEFT);
+        openNewNoteEditor(intent -> { });
     }
 
 
     public void copyNote() {
+        openNewNoteEditor(intent -> {
+            intent.putExtra(EXTRA_CONTENTS, getFieldsText());
+            if (mSelectedTags != null) {
+                intent.putExtra(EXTRA_TAGS, mSelectedTags.toArray(new String[0]));
+            }
+        });
+    }
+
+    private void openNewNoteEditor(Consumer<Intent> intentEnricher) {
         Intent intent = new Intent(NoteEditor.this, NoteEditor.class);
         intent.putExtra(EXTRA_CALLER, CALLER_CARDEDITOR);
-        intent.putExtra(EXTRA_CONTENTS, getFieldsText());
-        if (mSelectedTags != null) {
-            intent.putExtra(EXTRA_TAGS, mSelectedTags.toArray(new String[0]));
-        }
+        //mutate event with additional properties
+        intentEnricher.consume(intent);
         startActivityForResultWithAnimation(intent, REQUEST_ADD, ActivityTransitionAnimation.LEFT);
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -131,6 +131,7 @@ public class NoteEditor extends AnkiActivity {
     public static final String EXTRA_CONTENTS = "CONTENTS";
     public static final String EXTRA_TAGS = "TAGS";
     public static final String EXTRA_ID = "ID";
+    public static final String EXTRA_DID = "DECK_ID";
 
     private static final String ACTION_CREATE_FLASHCARD = "org.openintents.action.CREATE_FLASHCARD";
     private static final String ACTION_CREATE_FLASHCARD_SEND = "android.intent.action.SEND";
@@ -521,6 +522,8 @@ public class NoteEditor extends AnkiActivity {
                 // Do Nothing
             }
         });
+
+        mCurrentDid = intent.getLongExtra(EXTRA_DID, mCurrentDid);
 
         setDid(mEditorNote);
 
@@ -974,6 +977,7 @@ public class NoteEditor extends AnkiActivity {
     private void openNewNoteEditor(Consumer<Intent> intentEnricher) {
         Intent intent = new Intent(NoteEditor.this, NoteEditor.class);
         intent.putExtra(EXTRA_CALLER, CALLER_CARDEDITOR);
+        intent.putExtra(EXTRA_DID, mCurrentDid);
         //mutate event with additional properties
         intentEnricher.consume(intent);
         startActivityForResultWithAnimation(intent, REQUEST_ADD, ActivityTransitionAnimation.LEFT);
@@ -1888,5 +1892,12 @@ public class NoteEditor extends AnkiActivity {
     @VisibleForTesting
     void setFieldValueFromUi(int i, String newText) {
         mEditFields.get(i).setText(newText);
+    }
+
+
+
+    @VisibleForTesting
+    long getDeckId() {
+        return mCurrentDid;
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1867,7 +1867,7 @@ public class NoteEditor extends AnkiActivity {
     }
 
     private int getNextClozeIndex() {
-        /** BUG: This assumes all fields are inserted as: {{cloze:Text}} */
+        // BUG: This assumes all fields are inserted as: {{cloze:Text}}
         List<String> fieldValues = new ArrayList<>(mEditFields.size());
         for (FieldEditText e : mEditFields) {
             Editable editable = e.getText();

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.java
@@ -183,7 +183,7 @@ public class NoteEditorTest extends RobolectricTest {
     @Test
     @Ignore("Not yet implemented")
     public void clozeNoteWithClozeInWrongFieldDoesNotSave() {
-        //Anki Desktop blocks with "Continue?", we sould just block to match the above test
+        //Anki Desktop blocks with "Continue?", we should just block to match the above test
         int initialCards = getCardCount();
         NoteEditor editor = getNoteEditorAdding(NoteType.CLOZE)
                 .withSecondField("{{c1::AnkiDroid}} is fantastic")


### PR DESCRIPTION
## Purpose / Description
Reported in #6507  - Copy Note does not copy to the correct deck.

## Fixes
Fixes #6507 

## Approach
Place the DeckId in the intent, and restore to this. `mCurrentDid` overrides anything set in the model in `NoteEditor.setDid`

## How Has This Been Tested?

Tested on my phone, then added a unit test

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code