### PR TITLE
Filter tags by "contains" instead of "startswith"

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TagsDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TagsDialog.java
@@ -352,7 +352,7 @@ public class TagsDialog extends AnalyticsDialogFragment {
                 } else {
                     final String filterPattern = constraint.toString().toLowerCase().trim();
                     for (String tag : mAllTags) {
-                        if (tag.toLowerCase().startsWith(filterPattern)) {
+                        if (tag.toLowerCase().contains(filterPattern)) {
                             mFilteredTags.add(tag);
                         }
                     }


### PR DESCRIPTION
## Purpose / Description
I often find that it's much easier to search for "chinese" to list potential tags, rather than needing to know the tag beforehand

If I knew the name, I wouldn't need to search.

## How Has This Been Tested?

Tested on my phone, works as expected

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code