### PR TITLE
Fix Card Browser Infinite Loading after edit

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1708,6 +1708,12 @@ public class CardBrowser extends NavigationDrawerActivity implements
                     null);
 
         }
+
+        @Override
+        public void onCancelled() {
+            super.onCancelled();
+            hideProgressBar();
+        }
     };
 
     public boolean hasSelectedAllDecks() {
@@ -1812,6 +1818,13 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 mActionBarMenu.findItem(R.id.action_mark_card).setTitle(getString(R.string.card_browser_unmark_card));
                 mActionBarMenu.findItem(R.id.action_mark_card).setIcon(R.drawable.ic_star_white_24dp);
             }
+        }
+
+
+        @Override
+        public void onCancelled() {
+            super.onCancelled();
+            hideProgressBar();
         }
     };
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -774,6 +774,11 @@ public class CardBrowser extends NavigationDrawerActivity implements
                     mSearchView.setQuery(mSearchTerms, false);
                 }
             });
+            // Fixes #6500 - keep the search consistent
+            if (!TextUtils.isEmpty(mSearchTerms)) {
+                mSearchItem.expandActionView();
+                mSearchView.setQuery(mSearchTerms, false);
+            }
         } else {
             // multi-select mode
             getMenuInflater().inflate(R.menu.card_browser_multiselect, menu);


### PR DESCRIPTION
## Purpose / Description
Under a certain complex set of steps, the card browser did not dismiss its progress dialog

## Fixes
Fixes #6500

## Approach
We stop the browser from unnecessarily searching after `supportInvalidateOptionsMenu` and allow the user to search again if for some reason they can still trigger this.

## How Has This Been Tested?

On my device, no longer spins infinitely

## Learning (optional, can help others)

We need a ViewModel, this is an extremely complex class

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code