### PR TITLE
Quicker start: load tree and then numbers

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -2040,7 +2040,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
         int pos = mDeckListAdapter.findDeckPosition(did);
         Sched.DeckDueTreeNode deckDueTreeNode = mDeckListAdapter.getDeckList().get(pos);
         // Figure out what action to take
-        if (deckDueTreeNode.newCount + deckDueTreeNode.lrnCount + deckDueTreeNode.revCount > 0) {
+        if (deckDueTreeNode.getNewCount() + deckDueTreeNode.getLrnCount() + deckDueTreeNode.getRevCount() > 0) {
             // If there are cards to study then either go to Reviewer or StudyOptions
             if (mFragmented || dontSkipStudyOptions) {
                 // Go to StudyOptions screen when tablet or deck counts area was clicked
@@ -2076,7 +2076,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
         } else if (getCol().getDecks().isDyn(did)) {
             // Go to the study options screen if filtered deck with no cards to study
             openStudyOptions(false);
-        } else if (deckDueTreeNode.children.size() == 0 && getCol().cardCount(new Long[]{did}) == 0) {
+        } else if (deckDueTreeNode.getChildren().size() == 0 && getCol().cardCount(new Long[]{did}) == 0) {
             // If the deck is empty and has no children then show a message saying it's empty
             final Uri helpUrl = Uri.parse(getResources().getString(R.string.link_manual_getting_started));
             mayOpenUrl(helpUrl);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -190,7 +190,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
     private String mExportFileName;
 
-    private List<Sched.DeckDueTreeNode> mDueTree;
+    private Sched.DeckDueTreeNode mDueTree;
 
     private List<CollectionTask> tasksToCancelOnClose;
 
@@ -2151,7 +2151,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
                     showCollectionErrorDialog();
                     return;
                 }
-                mDueTree = (List<Sched.DeckDueTreeNode>) result.getObjArray()[0];
+                mDueTree = (Sched.DeckDueTreeNode) result.getObjArray()[0];
 
                 __renderPage();
                 // Update the mini statistics bar as well
@@ -2172,8 +2172,8 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
         // Set the "x due in y minutes" subtitle
         try {
-            int eta = mDeckListAdapter.getEta();
-            int due = mDeckListAdapter.getDue();
+            int eta = mDueTree.getEta();
+            int due = mDueTree.getDue();
             Resources res = getResources();
             if (getCol().cardCount() != -1) {
                 String time = "-";

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -191,7 +191,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
     private String mExportFileName;
 
-    private Sched.DeckDueTreeNode mDueTree;
+    private Sched.DeckDueTreeNode mDueTree = null;
 
     private List<CollectionTask> tasksToCancelOnClose;
 
@@ -821,6 +821,9 @@ public class DeckPicker extends NavigationDrawerActivity implements
             mSyncOnResume = false;
         } else if (colIsOpen()) {
             selectNavigationItem(R.id.nav_decks);
+            if (mDueTree == null) {
+                updateDeckList(true);
+            }
             updateDeckList();
             setTitle(getResources().getString(R.string.app_name));
         }
@@ -2143,7 +2146,12 @@ public class DeckPicker extends NavigationDrawerActivity implements
      * This method also triggers an update for the widget to reflect the newly calculated counts.
      */
     private void updateDeckList() {
-        CollectionTask task = CollectionTask.launchCollectionTask(CollectionTask.TASK_TYPE_LOAD_DECK_COUNTS, new CollectionTask.TaskListener() {
+        updateDeckList(false);
+    }
+
+    private void updateDeckList(boolean quick) {
+        int task_type = (quick) ? CollectionTask.TASK_TYPE_LOAD_DECK : CollectionTask.TASK_TYPE_LOAD_DECK_COUNTS;
+        CollectionTask task = CollectionTask.launchCollectionTask(task_type, new CollectionTask.TaskListener() {
 
             @Override
             public void onPreExecute() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
@@ -373,8 +373,8 @@ public class CardContentProvider extends ContentProvider {
                 String[] columns = ((projection != null) ? projection : FlashCardsContract.Deck.DEFAULT_PROJECTION);
                 MatrixCursor rv = new MatrixCursor(columns, allDecks.size());
                 for (Sched.DeckDueTreeNode deck : allDecks) {
-                    long id = deck.did;
-                    String name = deck.names[0];
+                    long id = deck.getDid();
+                    String name = deck.getName()[0];
                     addDeckToCursor(id, name, getDeckCountsFromDueTreeNode(deck), rv, col, columns);
                 }
                 return rv;
@@ -387,8 +387,8 @@ public class CardContentProvider extends ContentProvider {
                 long deckId;
                 deckId = Long.parseLong(uri.getPathSegments().get(1));
                 for (Sched.DeckDueTreeNode deck : allDecks) {
-                    if(deck.did == deckId){
-                        addDeckToCursor(deckId, deck.names[0], getDeckCountsFromDueTreeNode(deck), rv, col, columns);
+                    if(deck.getDid() == deckId){
+                        addDeckToCursor(deckId, deck.getName()[0], getDeckCountsFromDueTreeNode(deck), rv, col, columns);
                         return rv;
                     }
                 }
@@ -411,9 +411,9 @@ public class CardContentProvider extends ContentProvider {
 
     private JSONArray getDeckCountsFromDueTreeNode(Sched.DeckDueTreeNode deck){
         JSONArray deckCounts = new JSONArray();
-        deckCounts.put(deck.lrnCount);
-        deckCounts.put(deck.revCount);
-        deckCounts.put(deck.newCount);
+        deckCounts.put(deck.getLrnCount());
+        deckCounts.put(deck.getRevCount());
+        deckCounts.put(deck.getNewCount());
         return deckCounts;
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
@@ -369,10 +369,10 @@ public class CardContentProvider extends ContentProvider {
                 return rv;
             }
             case DECKS: {
-                List<Sched.DeckDueTreeNode> allDecks = col.getSched().deckDueList();
+                List<Sched.DeckDueTreeNodeNumbered> allDecks = col.getSched().deckDueList();
                 String[] columns = ((projection != null) ? projection : FlashCardsContract.Deck.DEFAULT_PROJECTION);
                 MatrixCursor rv = new MatrixCursor(columns, allDecks.size());
-                for (Sched.DeckDueTreeNode deck : allDecks) {
+                for (Sched.DeckDueTreeNodeNumbered deck : allDecks) {
                     long id = deck.getDid();
                     String name = deck.getLastPart();
                     addDeckToCursor(id, name, getDeckCountsFromDueTreeNode(deck), rv, col, columns);
@@ -383,10 +383,10 @@ public class CardContentProvider extends ContentProvider {
                 /* Direct access deck */
                 String[] columns = ((projection != null) ? projection : FlashCardsContract.Deck.DEFAULT_PROJECTION);
                 MatrixCursor rv = new MatrixCursor(columns, 1);
-                List<Sched.DeckDueTreeNode> allDecks = col.getSched().deckDueList();
+                List<Sched.DeckDueTreeNodeNumbered> allDecks = col.getSched().deckDueList();
                 long deckId;
                 deckId = Long.parseLong(uri.getPathSegments().get(1));
-                for (Sched.DeckDueTreeNode deck : allDecks) {
+                for (Sched.DeckDueTreeNodeNumbered deck : allDecks) {
                     if(deck.getDid() == deckId){
                         addDeckToCursor(deckId, deck.getLastPart(), getDeckCountsFromDueTreeNode(deck), rv, col, columns);
                         return rv;
@@ -409,7 +409,7 @@ public class CardContentProvider extends ContentProvider {
         }
     }
 
-    private JSONArray getDeckCountsFromDueTreeNode(Sched.DeckDueTreeNode deck){
+    private JSONArray getDeckCountsFromDueTreeNode(Sched.DeckDueTreeNodeNumbered deck){
         JSONArray deckCounts = new JSONArray();
         deckCounts.put(deck.getLrnCount());
         deckCounts.put(deck.getRevCount());

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
@@ -374,7 +374,7 @@ public class CardContentProvider extends ContentProvider {
                 MatrixCursor rv = new MatrixCursor(columns, allDecks.size());
                 for (Sched.DeckDueTreeNode deck : allDecks) {
                     long id = deck.getDid();
-                    String name = deck.getNamePart(0);
+                    String name = deck.getLastPart();
                     addDeckToCursor(id, name, getDeckCountsFromDueTreeNode(deck), rv, col, columns);
                 }
                 return rv;
@@ -388,7 +388,7 @@ public class CardContentProvider extends ContentProvider {
                 deckId = Long.parseLong(uri.getPathSegments().get(1));
                 for (Sched.DeckDueTreeNode deck : allDecks) {
                     if(deck.getDid() == deckId){
-                        addDeckToCursor(deckId, deck.getNamePart(0), getDeckCountsFromDueTreeNode(deck), rv, col, columns);
+                        addDeckToCursor(deckId, deck.getLastPart(), getDeckCountsFromDueTreeNode(deck), rv, col, columns);
                         return rv;
                     }
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
@@ -374,7 +374,7 @@ public class CardContentProvider extends ContentProvider {
                 MatrixCursor rv = new MatrixCursor(columns, allDecks.size());
                 for (Sched.DeckDueTreeNode deck : allDecks) {
                     long id = deck.getDid();
-                    String name = deck.getName()[0];
+                    String name = deck.getNamePart(0);
                     addDeckToCursor(id, name, getDeckCountsFromDueTreeNode(deck), rv, col, columns);
                 }
                 return rv;
@@ -388,7 +388,7 @@ public class CardContentProvider extends ContentProvider {
                 deckId = Long.parseLong(uri.getPathSegments().get(1));
                 for (Sched.DeckDueTreeNode deck : allDecks) {
                     if(deck.getDid() == deckId){
-                        addDeckToCursor(deckId, deck.getName()[0], getDeckCountsFromDueTreeNode(deck), rv, col, columns);
+                        addDeckToCursor(deckId, deck.getNamePart(0), getDeckCountsFromDueTreeNode(deck), rv, col, columns);
                         return rv;
                     }
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/ReminderService.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/ReminderService.java
@@ -61,7 +61,7 @@ public class ReminderService extends BroadcastReceiver {
             return;
         }
 
-        final int total = deckDue.revCount + deckDue.lrnCount + deckDue.newCount;
+        final int total = deckDue.getRevCount() + deckDue.getLrnCount() + deckDue.getNewCount();
 
         if (total <= 0) {
             return;
@@ -113,7 +113,7 @@ public class ReminderService extends BroadcastReceiver {
 
         try {
             for (Sched.DeckDueTreeNode node : CollectionHelper.getInstance().getCol(context).getSched().deckDueTree()) {
-                if (node.did == deckId) {
+                if (node.getDid() == deckId) {
                     return node;
                 }
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/ReminderService.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/ReminderService.java
@@ -112,7 +112,7 @@ public class ReminderService extends BroadcastReceiver {
         }
 
         try {
-            for (Sched.DeckDueTreeNode node : CollectionHelper.getInstance().getCol(context).getSched().deckDueTree()) {
+            for (Sched.DeckDueTreeNode node : CollectionHelper.getInstance().getCol(context).getSched().deckDueTree().getChildren()) {
                 if (node.getDid() == deckId) {
                     return node;
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/ReminderService.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/ReminderService.java
@@ -55,7 +55,7 @@ public class ReminderService extends BroadcastReceiver {
             alarmManager.cancel(reminderIntent);
         }
 
-        Sched.DeckDueTreeNode deckDue = getDeckDue(context, deckId, true);
+        Sched.DeckDueTreeNodeNumbered deckDue = getDeckDue(context, deckId, true);
 
         if (null == deckDue) {
             return;
@@ -103,7 +103,7 @@ public class ReminderService extends BroadcastReceiver {
 
 
     // getDeckDue information, will recur one time to workaround collection close if recur is true
-    private Sched.DeckDueTreeNode getDeckDue(Context context, long deckId, boolean recur) {
+    private Sched.DeckDueTreeNodeNumbered getDeckDue(Context context, long deckId, boolean recur) {
 
         // Avoid crashes if the deck is deleted while we are working
         if (CollectionHelper.getInstance().getCol(context).getDecks().get(deckId, false) == null) {
@@ -112,7 +112,7 @@ public class ReminderService extends BroadcastReceiver {
         }
 
         try {
-            for (Sched.DeckDueTreeNode node : CollectionHelper.getInstance().getCol(context).getSched().deckDueTree().getChildren()) {
+            for (Sched.DeckDueTreeNodeNumbered node : CollectionHelper.getInstance().getCol(context).getSched().deckDueTree().getChildren()) {
                 if (node.getDid() == deckId) {
                     return node;
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.java
@@ -177,38 +177,38 @@ public class DeckAdapter extends RecyclerView.Adapter<DeckAdapter.ViewHolder> {
             deckLayout.setPadding(normalPadding, 0, rightPadding, 0);
         }
 
-        if (node.children.size() > 0) {
-            holder.deckExpander.setTag(node.did);
+        if (node.getChildren().size() > 0) {
+            holder.deckExpander.setTag(node.getDid());
             holder.deckExpander.setOnClickListener(mDeckExpanderClickListener);
         } else {
             holder.deckExpander.setOnClickListener(null);
         }
         holder.deckLayout.setBackgroundResource(mRowCurrentDrawable);
         // Set background colour. The current deck has its own color
-        if (node.did == mCol.getDecks().current().optLong("id")) {
+        if (node.getDid() == mCol.getDecks().current().optLong("id")) {
             holder.deckLayout.setBackgroundResource(mRowCurrentDrawable);
         } else {
             CompatHelper.getCompat().setSelectableBackground(holder.deckLayout);
         }
         // Set deck name and colour. Filtered decks have their own colour
-        holder.deckName.setText(node.names[0]);
-        if (mCol.getDecks().isDyn(node.did)) {
+        holder.deckName.setText(node.getName()[0]);
+        if (mCol.getDecks().isDyn(node.getDid())) {
             holder.deckName.setTextColor(mDeckNameDynColor);
         } else {
             holder.deckName.setTextColor(mDeckNameDefaultColor);
         }
 
         // Set the card counts and their colors
-        holder.deckNew.setText(String.valueOf(node.newCount));
-        holder.deckNew.setTextColor((node.newCount == 0) ? mZeroCountColor : mNewCountColor);
-        holder.deckLearn.setText(String.valueOf(node.lrnCount));
-        holder.deckLearn.setTextColor((node.lrnCount == 0) ? mZeroCountColor : mLearnCountColor);
-        holder.deckRev.setText(String.valueOf(node.revCount));
-        holder.deckRev.setTextColor((node.revCount == 0) ? mZeroCountColor : mReviewCountColor);
+        holder.deckNew.setText(String.valueOf(node.getNewCount()));
+        holder.deckNew.setTextColor((node.getNewCount() == 0) ? mZeroCountColor : mNewCountColor);
+        holder.deckLearn.setText(String.valueOf(node.getLrnCount()));
+        holder.deckLearn.setTextColor((node.getLrnCount() == 0) ? mZeroCountColor : mLearnCountColor);
+        holder.deckRev.setText(String.valueOf(node.getRevCount()));
+        holder.deckRev.setTextColor((node.getRevCount() == 0) ? mZeroCountColor : mReviewCountColor);
 
         // Store deck ID in layout's tag for easy retrieval in our click listeners
-        holder.deckLayout.setTag(node.did);
-        holder.countsLayout.setTag(node.did);
+        holder.deckLayout.setTag(node.getDid());
+        holder.countsLayout.setTag(node.getDid());
 
         // Set click listeners
         holder.deckLayout.setOnClickListener(mDeckClickListener);
@@ -223,19 +223,19 @@ public class DeckAdapter extends RecyclerView.Adapter<DeckAdapter.ViewHolder> {
 
 
     private void setDeckExpander(ImageButton expander, ImageButton indent, Sched.DeckDueTreeNode node){
-        boolean collapsed = mCol.getDecks().get(node.did).optBoolean("collapsed", false);
+        boolean collapsed = mCol.getDecks().get(node.getDid()).optBoolean("collapsed", false);
         // Apply the correct expand/collapse drawable
         if (collapsed) {
             expander.setImageDrawable(mExpandImage);
             expander.setContentDescription(expander.getContext().getString(R.string.expand));
-        } else if (node.children.size() > 0) {
+        } else if (node.getChildren().size() > 0) {
             expander.setImageDrawable(mCollapseImage);
             expander.setContentDescription(expander.getContext().getString(R.string.collapse));
         } else {
             expander.setImageDrawable(mNoExpander);
         }
         // Add some indenting for each nested level
-        int width = (int) indent.getResources().getDimension(R.dimen.keyline_1) * node.depth;
+        int width = (int) indent.getResources().getDimension(R.dimen.keyline_1) * node.getDepth();
         indent.setMinimumWidth(width);
     }
 
@@ -249,13 +249,13 @@ public class DeckAdapter extends RecyclerView.Adapter<DeckAdapter.ViewHolder> {
         for (Sched.DeckDueTreeNode node : nodes) {
             // If the default deck is empty, hide it by not adding it to the deck list.
             // We don't hide it if it's the only deck or if it has sub-decks.
-            if (node.did == 1 && nodes.size() > 1 && node.children.size() == 0) {
+            if (node.getDid() == 1 && nodes.size() > 1 && node.getChildren().size() == 0) {
                 if (mCol.getDb().queryScalar("select 1 from cards where did = 1") == 0) {
                     continue;
                 }
             }
             // If any of this node's parents are collapsed, don't add it to the deck list
-            for (JSONObject parent : mCol.getDecks().parents(node.did)) {
+            for (JSONObject parent : mCol.getDecks().parents(node.getDid())) {
                 mHasSubdecks = true;    // If a deck has a parent it means it's a subdeck so set a flag
                 if (parent.optBoolean("collapsed")) {
                     return;
@@ -263,16 +263,16 @@ public class DeckAdapter extends RecyclerView.Adapter<DeckAdapter.ViewHolder> {
             }
             mDeckList.add(node);
             // Keep track of the depth. It's used to determine visual properties like indenting later
-            node.depth = depth;
+            node.setDepth(depth);
 
             // Add this node's counts to the totals if it's a parent deck
             if (depth == 0) {
-                mNew += node.newCount;
-                mLrn += node.lrnCount;
-                mRev += node.revCount;
+                mNew += node.getNewCount();
+                mLrn += node.getLrnCount();
+                mRev += node.getRevCount();
             }
             // Process sub-decks
-            processNodes(node.children, depth + 1);
+            processNodes(node.getChildren(), depth + 1);
         }
     }
 
@@ -285,7 +285,7 @@ public class DeckAdapter extends RecyclerView.Adapter<DeckAdapter.ViewHolder> {
      */
     public int findDeckPosition(long did) {
         for (int i = 0; i < mDeckList.size(); i++) {
-            if (mDeckList.get(i).did == did) {
+            if (mDeckList.get(i).getDid() == did) {
                 return i;
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.java
@@ -191,7 +191,7 @@ public class DeckAdapter extends RecyclerView.Adapter<DeckAdapter.ViewHolder> {
             CompatHelper.getCompat().setSelectableBackground(holder.deckLayout);
         }
         // Set deck name and colour. Filtered decks have their own colour
-        holder.deckName.setText(node.getName()[0]);
+        holder.deckName.setText(node.getNamePart(0));
         if (mCol.getDecks().isDyn(node.getDid())) {
             holder.deckName.setTextColor(mDeckNameDynColor);
         } else {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.java
@@ -194,12 +194,19 @@ public class DeckAdapter extends RecyclerView.Adapter<DeckAdapter.ViewHolder> {
         }
 
         // Set the card counts and their colors
-        holder.deckNew.setText(String.valueOf(node.getNewCount()));
-        holder.deckNew.setTextColor((node.getNewCount() == 0) ? mZeroCountColor : mNewCountColor);
-        holder.deckLearn.setText(String.valueOf(node.getLrnCount()));
-        holder.deckLearn.setTextColor((node.getLrnCount() == 0) ? mZeroCountColor : mLearnCountColor);
-        holder.deckRev.setText(String.valueOf(node.getRevCount()));
-        holder.deckRev.setTextColor((node.getRevCount() == 0) ? mZeroCountColor : mReviewCountColor);
+        if (node instanceof AbstractSched.DeckDueTreeNodeNumbered) {
+            AbstractSched.DeckDueTreeNodeNumbered node_ = (AbstractSched.DeckDueTreeNodeNumbered) node;
+            holder.deckNew.setText(String.valueOf(node_.getNewCount()));
+            holder.deckNew.setTextColor((node_.getNewCount() == 0) ? mZeroCountColor : mNewCountColor);
+            holder.deckLearn.setText(String.valueOf(node_.getLrnCount()));
+            holder.deckLearn.setTextColor((node_.getLrnCount() == 0) ? mZeroCountColor : mLearnCountColor);
+            holder.deckRev.setText(String.valueOf(node_.getRevCount()));
+            holder.deckRev.setTextColor((node_.getRevCount() == 0) ? mZeroCountColor : mReviewCountColor);
+        } else {
+            holder.deckNew.setText("");
+            holder.deckRev.setText("");
+            holder.deckLearn.setText("");
+        }
 
         // Store deck ID in layout's tag for easy retrieval in our click listeners
         holder.deckLayout.setTag(node.getDid());

--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.java
@@ -262,8 +262,6 @@ public class DeckAdapter extends RecyclerView.Adapter<DeckAdapter.ViewHolder> {
                 }
             }
             mDeckList.add(node);
-            // Keep track of the depth. It's used to determine visual properties like indenting later
-            node.setDepth(depth);
 
             // Add this node's counts to the totals if it's a parent deck
             if (depth == 0) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.java
@@ -241,11 +241,6 @@ public class DeckAdapter extends RecyclerView.Adapter<DeckAdapter.ViewHolder> {
 
 
     private void processNodes(List<Sched.DeckDueTreeNode> nodes) {
-        processNodes(nodes, 0);
-    }
-
-
-    private void processNodes(List<Sched.DeckDueTreeNode> nodes, int depth) {
         for (Sched.DeckDueTreeNode node : nodes) {
             // If the default deck is empty, hide it by not adding it to the deck list.
             // We don't hide it if it's the only deck or if it has sub-decks.
@@ -264,13 +259,13 @@ public class DeckAdapter extends RecyclerView.Adapter<DeckAdapter.ViewHolder> {
             mDeckList.add(node);
 
             // Add this node's counts to the totals if it's a parent deck
-            if (depth == 0) {
+            if (node.getDepth() == 0) {
                 mNew += node.getNewCount();
                 mLrn += node.getLrnCount();
                 mRev += node.getRevCount();
             }
             // Process sub-decks
-            processNodes(node.getChildren(), depth + 1);
+            processNodes(node.getChildren());
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.java
@@ -191,7 +191,7 @@ public class DeckAdapter extends RecyclerView.Adapter<DeckAdapter.ViewHolder> {
             CompatHelper.getCompat().setSelectableBackground(holder.deckLayout);
         }
         // Set deck name and colour. Filtered decks have their own colour
-        holder.deckName.setText(node.getNamePart(0));
+        holder.deckName.setText(node.getLastPart());
         if (mCol.getDecks().isDyn(node.getDid())) {
             holder.deckName.setTextColor(mDeckNameDynColor);
         } else {

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -85,6 +85,7 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
     public static final int TASK_TYPE_DISMISS_MULTI = 12;
     public static final int TASK_TYPE_CHECK_DATABASE = 14;
     public static final int TASK_TYPE_REPAIR_DECK = 20;
+    public static final int TASK_TYPE_LOAD_DECK = 21;
     public static final int TASK_TYPE_LOAD_DECK_COUNTS = 22;
     public static final int TASK_TYPE_UPDATE_VALUES_FROM_DECK = 23;
     public static final int TASK_TYPE_DELETE_DECK = 25;
@@ -257,6 +258,10 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
         }
         // Actually execute the task now that we are at the front of the queue.
         switch (mType) {
+
+            case TASK_TYPE_LOAD_DECK:
+                return doInBackgroundLoadDeck();
+
             case TASK_TYPE_LOAD_DECK_COUNTS:
                 return doInBackgroundLoadDeckCounts();
 
@@ -542,6 +547,20 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
             return new TaskData(false);
         }
         return new TaskData(true);
+    }
+
+
+    private TaskData doInBackgroundLoadDeck() {
+        Timber.d("doInBackgroundLoadDeckCounts");
+        Collection col = CollectionHelper.getInstance().getCol(mContext);
+        try {
+            // Get due tree
+            Object[] o = new Object[] {col.getSched().quickDeckDueTree()};
+            return new TaskData(o);
+        } catch (RuntimeException e) {
+            Timber.e(e, "doInBackgroundLoadDeckCounts - error");
+            return null;
+        }
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
@@ -178,30 +178,30 @@ public abstract class AbstractSched {
      * this field and use names[0] for those cases.
      */
     public class DeckDueTreeNode implements Comparable {
-        public String[] names;
-        public long did;
-        public int depth;
-        public int revCount;
-        public int lrnCount;
-        public int newCount;
-        public List<DeckDueTreeNode> children = new ArrayList<>();
+        private String[] mName;
+        private long mDid;
+        private int mDepth;
+        private int mRevCount;
+        private int mLrnCount;
+        private int mNewCount;
+        private List<DeckDueTreeNode> mChildren = new ArrayList<>();
 
-        public DeckDueTreeNode(String[] names, long did, int revCount, int lrnCount, int newCount) {
-            this.names = names;
-            this.did = did;
-            this.revCount = revCount;
-            this.lrnCount = lrnCount;
-            this.newCount = newCount;
+        public DeckDueTreeNode(String[] mName, long mDid, int mRevCount, int mLrnCount, int mNewCount) {
+            this.mName = mName;
+            this.mDid = mDid;
+            this.mRevCount = mRevCount;
+            this.mLrnCount = mLrnCount;
+            this.mNewCount = mNewCount;
         }
 
-        public DeckDueTreeNode(String name, long did, int revCount, int lrnCount, int newCount) {
-            this(new String[]{name}, did, revCount, lrnCount, newCount);
+        public DeckDueTreeNode(String name, long mDid, int mRevCount, int mLrnCount, int mNewCount) {
+            this(new String[]{name}, mDid, mRevCount, mLrnCount, mNewCount);
         }
 
-        public DeckDueTreeNode(String name, long did, int revCount, int lrnCount, int newCount,
-                               List<DeckDueTreeNode> children) {
-            this(new String[]{name}, did, revCount, lrnCount, newCount);
-            this.children = children;
+        public DeckDueTreeNode(String name, long mDid, int mRevCount, int mLrnCount, int mNewCount,
+                               List<DeckDueTreeNode> mChildren) {
+            this(new String[]{name}, mDid, mRevCount, mLrnCount, mNewCount);
+            this.mChildren = mChildren;
         }
 
         /**
@@ -211,8 +211,8 @@ public abstract class AbstractSched {
         public int compareTo(Object other) {
             DeckDueTreeNode rhs = (DeckDueTreeNode) other;
             // Consider each subdeck name in the ordering
-            for (int i = 0; i < names.length && i < rhs.names.length; i++) {
-                int cmp = names[i].compareTo(rhs.names[i]);
+            for (int i = 0; i < mName.length && i < rhs.mName.length; i++) {
+                int cmp = mName[i].compareTo(rhs.mName[i]);
                 if (cmp == 0) {
                     continue;
                 }
@@ -221,7 +221,7 @@ public abstract class AbstractSched {
             // If we made it this far then the arrays are of different length. The longer one should
             // always come after since it contains all of the sections of the shorter one inside it
             // (i.e., the short one is an ancestor of the longer one).
-            if (rhs.names.length > names.length) {
+            if (rhs.mName.length > mName.length) {
                 return -1;
             } else {
                 return 1;
@@ -231,7 +231,43 @@ public abstract class AbstractSched {
         @Override
         public String toString() {
             return String.format(Locale.US, "%s, %d, %d, %d, %d, %d, %s",
-                    Arrays.toString(names), did, depth, revCount, lrnCount, newCount, children);
+                    Arrays.toString(mName), mDid, mDepth, mRevCount, mLrnCount, mNewCount, mChildren);
+        }
+
+        public String[] getName() {
+            return mName;
+        }
+        
+        public void setNames(String[] mName) {
+            this.mName = mName;
+        }
+
+        public long getDid() {
+            return mDid;
+        }
+
+        public int getDepth() {
+            return mDepth;
+        }
+
+        public void setDepth(int mDepth) {
+            this.mDepth = mDepth;
+        }
+
+        public int getRevCount() {
+            return mRevCount;
+        }
+
+        public int getNewCount() {
+            return mNewCount;
+        }
+
+        public int getLrnCount() {
+            return mLrnCount;
+        }
+
+        public List<DeckDueTreeNode> getChildren() {
+            return mChildren;
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
@@ -52,6 +52,7 @@ public abstract class AbstractSched {
     /** load the due tree, but halt if deck task is cancelled*/
     public abstract DeckDueTreeNodeNumbered deckDueTree(CollectionTask collectionTask);
     public abstract DeckDueTreeNodeNumbered deckDueTree();
+    public abstract DeckDueTreeNodeQuick quickDeckDueTree();
     /** New count for a single deck. */
     public abstract int _newForDeck(long did, int lim);
     /** Limit for deck without parent limits. */

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
@@ -262,6 +262,11 @@ public abstract class AbstractSched {
         public List<DeckDueTreeNode> getChildren() {
             return mChildren;
         }
+
+
+        public void setChildren(List<DeckDueTreeNode> children) {
+            mChildren = children;
+        }
     }
 
     public interface LimitMethod {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
@@ -182,13 +182,13 @@ public abstract class AbstractSched {
     public class DeckDueTreeNode implements Comparable {
         private String mName;
         private String[] mSplittedName;
-        private long mDid;
+        private Long mDid;
         private int mRevCount;
         private int mLrnCount;
         private int mNewCount;
         private List<DeckDueTreeNode> mChildren = new ArrayList<>();
 
-        public DeckDueTreeNode(String name, long mDid, int mRevCount, int mLrnCount, int mNewCount) {
+        public DeckDueTreeNode(String name, Long mDid, int mRevCount, int mLrnCount, int mNewCount) {
             this.mDid = mDid;
             this.mRevCount = mRevCount;
             this.mLrnCount = mLrnCount;
@@ -278,12 +278,14 @@ public abstract class AbstractSched {
                 }
             }
             // limit the counts to the deck's limits
-            JSONObject conf = mCol.getDecks().confForDid(mDid);
-            if (conf.getInt("dyn") == 0) {
-                JSONObject deck = mCol.getDecks().get(mDid);
-                limitNewCount(conf.getJSONObject("new").getInt("perDay") - deck.getJSONArray("newToday").getInt(1));
-                if (addRev) {
-                    limitRevCount(conf.getJSONObject("rev").getInt("perDay") - deck.getJSONArray("revToday").getInt(1));
+            if (mDid != null) {
+                JSONObject conf = mCol.getDecks().confForDid(mDid);
+                if (conf.getInt("dyn") == 0) {
+                    JSONObject deck = mCol.getDecks().get(mDid);
+                    limitNewCount(conf.getJSONObject("new").getInt("perDay") - deck.getJSONArray("newToday").getInt(1));
+                    if (addRev) {
+                        limitRevCount(conf.getJSONObject("rev").getInt("perDay") - deck.getJSONArray("revToday").getInt(1));
+                    }
                 }
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
@@ -51,8 +51,8 @@ public abstract class AbstractSched {
      */
     public abstract List<DeckDueTreeNode> deckDueList();
     /** load the due tree, but halt if deck task is cancelled*/
-    public abstract List<DeckDueTreeNode> deckDueTree(CollectionTask collectionTask);
-    public abstract List<DeckDueTreeNode> deckDueTree();
+    public abstract DeckDueTreeNode deckDueTree(CollectionTask collectionTask);
+    public abstract DeckDueTreeNode deckDueTree();
     /** New count for a single deck. */
     public abstract int _newForDeck(long did, int lim);
     /** Limit for deck without parent limits. */
@@ -288,6 +288,13 @@ public abstract class AbstractSched {
                     }
                 }
             }
+        }
+        public int getEta() {
+            return mCol.getSched().eta(new int[]{mNewCount, mLrnCount, mRevCount});
+        }
+
+        public int getDue() {
+            return mNewCount + mLrnCount + mRevCount;
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
@@ -195,12 +195,6 @@ public abstract class AbstractSched {
             this.mSplittedName = name.split("::");
         }
 
-        public DeckDueTreeNode(String name, long mDid, int mRevCount, int mLrnCount, int mNewCount,
-                               List<DeckDueTreeNode> mChildren) {
-            this(name, mDid, mRevCount, mLrnCount, mNewCount);
-            this.mChildren = mChildren;
-        }
-
         /**
          * Sort on the head of the node.
          */
@@ -251,18 +245,37 @@ public abstract class AbstractSched {
             return mRevCount;
         }
 
+        public void addRevCount(int count) {
+            mRevCount += count;
+        }
+
+        public void limitRevCount(int limit) {
+            mRevCount = Math.max(0, Math.min(mRevCount, limit));
+        }
+
         public int getNewCount() {
             return mNewCount;
+        }
+
+        public void addNewCount(int count) {
+            mNewCount += count;
+        }
+
+        public void limitNewCount(int limit) {
+            mNewCount = Math.max(0, Math.min(mNewCount, limit));
         }
 
         public int getLrnCount() {
             return mLrnCount;
         }
 
+        public void addLrnCount(int count) {
+            mLrnCount += count;
+        }
+
         public List<DeckDueTreeNode> getChildren() {
             return mChildren;
         }
-
 
         public void setChildren(List<DeckDueTreeNode> children) {
             mChildren = children;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
@@ -241,6 +241,10 @@ public abstract class AbstractSched {
         public String getNamePart(int part) {
             return mName[part];
         }
+
+        public String getLastPart() {
+            return mName[mName.length - 1];
+        }
         
         public void setNames(String[] mName) {
             this.mName = mName;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
@@ -237,6 +237,10 @@ public abstract class AbstractSched {
         public String[] getName() {
             return mName;
         }
+
+        public String getNamePart(int part) {
+            return mName[part];
+        }
         
         public void setNames(String[] mName) {
             this.mName = mName;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
@@ -178,29 +178,26 @@ public abstract class AbstractSched {
      * this field and use names[0] for those cases.
      */
     public class DeckDueTreeNode implements Comparable {
-        private String[] mName;
+        private String mName;
+        private String[] mSplittedName;
         private long mDid;
-        private int mDepth;
         private int mRevCount;
         private int mLrnCount;
         private int mNewCount;
         private List<DeckDueTreeNode> mChildren = new ArrayList<>();
 
-        public DeckDueTreeNode(String[] mName, long mDid, int mRevCount, int mLrnCount, int mNewCount) {
-            this.mName = mName;
+        public DeckDueTreeNode(String name, long mDid, int mRevCount, int mLrnCount, int mNewCount) {
             this.mDid = mDid;
             this.mRevCount = mRevCount;
             this.mLrnCount = mLrnCount;
             this.mNewCount = mNewCount;
-        }
-
-        public DeckDueTreeNode(String name, long mDid, int mRevCount, int mLrnCount, int mNewCount) {
-            this(new String[]{name}, mDid, mRevCount, mLrnCount, mNewCount);
+            this.mName = name;
+            this.mSplittedName = name.split("::");
         }
 
         public DeckDueTreeNode(String name, long mDid, int mRevCount, int mLrnCount, int mNewCount,
                                List<DeckDueTreeNode> mChildren) {
-            this(new String[]{name}, mDid, mRevCount, mLrnCount, mNewCount);
+            this(name, mDid, mRevCount, mLrnCount, mNewCount);
             this.mChildren = mChildren;
         }
 
@@ -211,8 +208,8 @@ public abstract class AbstractSched {
         public int compareTo(Object other) {
             DeckDueTreeNode rhs = (DeckDueTreeNode) other;
             // Consider each subdeck name in the ordering
-            for (int i = 0; i < mName.length && i < rhs.mName.length; i++) {
-                int cmp = mName[i].compareTo(rhs.mName[i]);
+            for (int i = 0; i < mSplittedName.length && i < rhs.mSplittedName.length; i++) {
+                int cmp = mSplittedName[i].compareTo(rhs.mSplittedName[i]);
                 if (cmp == 0) {
                     continue;
                 }
@@ -221,7 +218,7 @@ public abstract class AbstractSched {
             // If we made it this far then the arrays are of different length. The longer one should
             // always come after since it contains all of the sections of the shorter one inside it
             // (i.e., the short one is an ancestor of the longer one).
-            if (rhs.mName.length > mName.length) {
+            if (rhs.mSplittedName.length > mSplittedName.length) {
                 return -1;
             } else {
                 return 1;
@@ -230,24 +227,16 @@ public abstract class AbstractSched {
 
         @Override
         public String toString() {
-            return String.format(Locale.US, "%s, %d, %d, %d, %d, %d, %s",
-                    Arrays.toString(mName), mDid, mDepth, mRevCount, mLrnCount, mNewCount, mChildren);
-        }
-
-        public String[] getName() {
-            return mName;
+            return String.format(Locale.US, "%s, %d, %d, %d, %d, %s",
+                    mName, mDid, mRevCount, mLrnCount, mNewCount, mChildren);
         }
 
         public String getNamePart(int part) {
-            return mName[part];
+            return mSplittedName[part];
         }
 
         public String getLastPart() {
-            return mName[mName.length - 1];
-        }
-        
-        public void setNames(String[] mName) {
-            this.mName = mName;
+            return mSplittedName[mSplittedName.length - 1];
         }
 
         public long getDid() {
@@ -255,11 +244,7 @@ public abstract class AbstractSched {
         }
 
         public int getDepth() {
-            return mDepth;
-        }
-
-        public void setDepth(int mDepth) {
-            this.mDepth = mDepth;
+            return mSplittedName.length - 1;
         }
 
         public int getRevCount() {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -43,7 +43,6 @@ import com.ichi2.utils.JSONObject;
 
 
 import java.lang.ref.WeakReference;
-import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -252,7 +251,7 @@ public class Sched extends SchedV2 {
         ListIterator<DeckDueTreeNode> it = grps.listIterator();
         while (it.hasNext()) {
             DeckDueTreeNode node = it.next();
-            String head = node.names[0];
+            String head = node.getName()[0];
             // Compose the "tail" node list. The tail is a list of all the nodes that proceed
             // the current one that contain the same name[0]. I.e., they are subdecks that stem
             // from this node. This is our version of python's itertools.groupby.
@@ -260,7 +259,7 @@ public class Sched extends SchedV2 {
             tail.add(node);
             while (it.hasNext()) {
                 DeckDueTreeNode next = it.next();
-                if (head.equals(next.names[0])) {
+                if (head.equals(next.getName()[0])) {
                     // Same head - add to tail of current head.
                     tail.add(next);
                 } else {
@@ -276,26 +275,26 @@ public class Sched extends SchedV2 {
             int lrn = 0;
             List<DeckDueTreeNode> children = new ArrayList<>();
             for (DeckDueTreeNode c : tail) {
-                if (c.names.length == 1) {
+                if (c.getName().length == 1) {
                     // current node
-                    did = c.did;
-                    rev += c.revCount;
-                    lrn += c.lrnCount;
-                    _new += c.newCount;
+                    did = c.getDid();
+                    rev += c.getRevCount();
+                    lrn += c.getLrnCount();
+                    _new += c.getNewCount();
                 } else {
                     // set new string to tail
-                    String[] newTail = new String[c.names.length-1];
-                    System.arraycopy(c.names, 1, newTail, 0, c.names.length-1);
-                    c.names = newTail;
+                    String[] newTail = new String[c.getName().length-1];
+                    System.arraycopy(c.getName(), 1, newTail, 0, c.getName().length-1);
+                    c.setNames(newTail);
                     children.add(c);
                 }
             }
             children = _groupChildrenMain(children);
             // tally up children counts
             for (DeckDueTreeNode ch : children) {
-                rev +=  ch.revCount;
-                lrn +=  ch.lrnCount;
-                _new += ch.newCount;
+                rev += ch.getRevCount();
+                lrn += ch.getLrnCount();
+                _new += ch.getNewCount();
             }
             // limit the counts to the deck's limits
             JSONObject conf = mCol.getDecks().confForDid(did);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -245,13 +245,13 @@ public class Sched extends SchedV2 {
 
 
     @Override
-    protected List<DeckDueTreeNode> _groupChildrenMain(List<DeckDueTreeNode> grps) {
+    protected List<DeckDueTreeNode> _groupChildrenMain(List<DeckDueTreeNode> grps, int depth) {
         List<DeckDueTreeNode> tree = new ArrayList<>();
         // group and recurse
         ListIterator<DeckDueTreeNode> it = grps.listIterator();
         while (it.hasNext()) {
             DeckDueTreeNode node = it.next();
-            String head = node.getNamePart(0);
+            String head = node.getNamePart(depth);
             // Compose the "tail" node list. The tail is a list of all the nodes that proceed
             // the current one that contain the same name[0]. I.e., they are subdecks that stem
             // from this node. This is our version of python's itertools.groupby.
@@ -275,7 +275,7 @@ public class Sched extends SchedV2 {
             int lrn = 0;
             List<DeckDueTreeNode> children = new ArrayList<>();
             for (DeckDueTreeNode c : tail) {
-                if (c.getName().length == 1) {
+                if (c.getName().length -1 == depth) {
                     // current node
                     did = c.getDid();
                     rev += c.getRevCount();
@@ -283,13 +283,10 @@ public class Sched extends SchedV2 {
                     _new += c.getNewCount();
                 } else {
                     // set new string to tail
-                    String[] newTail = new String[c.getName().length-1];
-                    System.arraycopy(c.getName(), 1, newTail, 0, c.getName().length-1);
-                    c.setNames(newTail);
                     children.add(c);
                 }
             }
-            children = _groupChildrenMain(children);
+            children = _groupChildrenMain(children, depth + 1);
             // tally up children counts
             for (DeckDueTreeNode ch : children) {
                 rev += ch.getRevCount();

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -210,12 +210,12 @@ public class Sched extends SchedV2 {
      * Returns [deckname, did, rev, lrn, new]
      */
     @Override
-    public List<DeckDueTreeNode> deckDueList(CollectionTask collectionTask) {
+    public List<DeckDueTreeNodeNumbered> deckDueList(CollectionTask collectionTask) {
         _checkDay();
         mCol.getDecks().checkIntegrity();
         ArrayList<JSONObject> decks = mCol.getDecks().allSorted();
         HashMap<String, Integer[]> lims = new HashMap<>();
-        ArrayList<DeckDueTreeNode> data = new ArrayList<>();
+        ArrayList<DeckDueTreeNodeNumbered> data = new ArrayList<>();
         for (JSONObject deck : decks) {
             if (collectionTask != null && collectionTask.isCancelled()) {
                 return null;
@@ -236,7 +236,7 @@ public class Sched extends SchedV2 {
             }
             int rev = _revForDeck(deck.getLong("id"), rlim);
             // save to list
-            data.add(new DeckDueTreeNode(deck.getString("name"), deck.getLong("id"), rev, lrn, _new));
+            data.add(new DeckDueTreeNodeNumbered(deck.getString("name"), deck.getLong("id"), rev, lrn, _new));
             // add deck as a parent
             lims.put(deck.getString("name"), new Integer[]{nlim, rlim});
         }
@@ -245,20 +245,20 @@ public class Sched extends SchedV2 {
 
 
     @Override
-    protected void _groupChildrenMain(DeckDueTreeNode parent, List<DeckDueTreeNode> grps, int depth) {
-        List<DeckDueTreeNode> tree = new ArrayList<>();
+    protected <T extends DeckDueTreeNode> void _groupChildrenMain(T parent, List<T> grps, int depth) {
+        List<T> tree = new ArrayList<>();
         // group and recurse
-        ListIterator<DeckDueTreeNode> it = grps.listIterator();
+        ListIterator<T> it = grps.listIterator();
         while (it.hasNext()) {
-            DeckDueTreeNode node = it.next();
+            T node = it.next();
             String head = node.getNamePart(depth);
             // Compose the "tail" node list. The tail is a list of all the nodes that proceed
             // the current one that contain the same name[0]. I.e., they are subdecks that stem
             // from this node. This is our version of python's itertools.groupby.
-            List<DeckDueTreeNode> children = new ArrayList<>();
+            List<T> children = new ArrayList<>();
             while (it.hasNext()) {
-                DeckDueTreeNode next = it.next();
-                if (head.equals(next.getNamePart(0))) {
+                T next = it.next();
+                if (head.equals(next.getNamePart(depth))) {
                     // Same head - add to tail of current head.
                     children.add(next);
                 } else {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -268,25 +268,21 @@ public class Sched extends SchedV2 {
                     break;
                 }
             }
-            Long did = node.getDid();
-            int rev = node.getRevCount();
-            int _new = node.getNewCount();
-            int lrn = node.getLrnCount();
             node.setChildren(_groupChildrenMain(children, depth + 1));
             // tally up children counts
             for (DeckDueTreeNode ch : node.getChildren()) {
-                rev += ch.getRevCount();
-                lrn += ch.getLrnCount();
-                _new += ch.getNewCount();
+                node.addRevCount(ch.getRevCount());
+                node.addLrnCount(ch.getLrnCount());
+                node.addNewCount(ch.getNewCount());
             }
             // limit the counts to the deck's limits
-            JSONObject conf = mCol.getDecks().confForDid(did);
+            JSONObject conf = mCol.getDecks().confForDid(node.getDid());
             if (conf.getInt("dyn") == 0) {
-                JSONObject deck = mCol.getDecks().get(did);
-                rev = Math.max(0, Math.min(rev, conf.getJSONObject("rev").getInt("perDay") - deck.getJSONArray("revToday").getInt(1)));
-                _new = Math.max(0, Math.min(_new, conf.getJSONObject("new").getInt("perDay") - deck.getJSONArray("newToday").getInt(1)));
+                JSONObject deck = mCol.getDecks().get(node.getDid());
+                node.limitNewCount(conf.getJSONObject("new").getInt("perDay") - deck.getJSONArray("newToday").getInt(1));
+                node.limitRevCount(conf.getJSONObject("rev").getInt("perDay") - deck.getJSONArray("revToday").getInt(1));
             }
-            tree.add(new DeckDueTreeNode(head, did, rev, lrn, _new, node.getChildren()));
+            tree.add(node);
         }
         return tree;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -268,20 +268,7 @@ public class Sched extends SchedV2 {
                     break;
                 }
             }
-            node.setChildren(_groupChildrenMain(children, depth + 1));
-            // tally up children counts
-            for (DeckDueTreeNode ch : node.getChildren()) {
-                node.addRevCount(ch.getRevCount());
-                node.addLrnCount(ch.getLrnCount());
-                node.addNewCount(ch.getNewCount());
-            }
-            // limit the counts to the deck's limits
-            JSONObject conf = mCol.getDecks().confForDid(node.getDid());
-            if (conf.getInt("dyn") == 0) {
-                JSONObject deck = mCol.getDecks().get(node.getDid());
-                node.limitNewCount(conf.getJSONObject("new").getInt("perDay") - deck.getJSONArray("newToday").getInt(1));
-                node.limitRevCount(conf.getJSONObject("rev").getInt("perDay") - deck.getJSONArray("revToday").getInt(1));
-            }
+            node.setChildren(_groupChildrenMain(children, depth + 1), true);
             tree.add(node);
         }
         return tree;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -245,7 +245,7 @@ public class Sched extends SchedV2 {
 
 
     @Override
-    protected List<DeckDueTreeNode> _groupChildrenMain(List<DeckDueTreeNode> grps, int depth) {
+    protected void _groupChildrenMain(DeckDueTreeNode parent, List<DeckDueTreeNode> grps, int depth) {
         List<DeckDueTreeNode> tree = new ArrayList<>();
         // group and recurse
         ListIterator<DeckDueTreeNode> it = grps.listIterator();
@@ -268,10 +268,10 @@ public class Sched extends SchedV2 {
                     break;
                 }
             }
-            node.setChildren(_groupChildrenMain(children, depth + 1), true);
+            _groupChildrenMain(node, children, depth + 1);
             tree.add(node);
         }
-        return tree;
+        parent.setChildren(tree, true);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -286,9 +286,9 @@ public class Sched extends SchedV2 {
                     children.add(c);
                 }
             }
-            children = _groupChildrenMain(children, depth + 1);
+            node.setChildren(_groupChildrenMain(children, depth + 1));
             // tally up children counts
-            for (DeckDueTreeNode ch : children) {
+            for (DeckDueTreeNode ch : node.getChildren()) {
                 rev += ch.getRevCount();
                 lrn += ch.getLrnCount();
                 _new += ch.getNewCount();
@@ -300,7 +300,7 @@ public class Sched extends SchedV2 {
                 rev = Math.max(0, Math.min(rev, conf.getJSONObject("rev").getInt("perDay") - deck.getJSONArray("revToday").getInt(1)));
                 _new = Math.max(0, Math.min(_new, conf.getJSONObject("new").getInt("perDay") - deck.getJSONArray("newToday").getInt(1)));
             }
-            tree.add(new DeckDueTreeNode(head, did, rev, lrn, _new, children));
+            tree.add(new DeckDueTreeNode(head, did, rev, lrn, _new, node.getChildren()));
         }
         return tree;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -251,7 +251,7 @@ public class Sched extends SchedV2 {
         ListIterator<DeckDueTreeNode> it = grps.listIterator();
         while (it.hasNext()) {
             DeckDueTreeNode node = it.next();
-            String head = node.getName()[0];
+            String head = node.getNamePart(0);
             // Compose the "tail" node list. The tail is a list of all the nodes that proceed
             // the current one that contain the same name[0]. I.e., they are subdecks that stem
             // from this node. This is our version of python's itertools.groupby.
@@ -259,7 +259,7 @@ public class Sched extends SchedV2 {
             tail.add(node);
             while (it.hasNext()) {
                 DeckDueTreeNode next = it.next();
-                if (head.equals(next.getName()[0])) {
+                if (head.equals(next.getNamePart(0))) {
                     // Same head - add to tail of current head.
                     tail.add(next);
                 } else {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -255,13 +255,12 @@ public class Sched extends SchedV2 {
             // Compose the "tail" node list. The tail is a list of all the nodes that proceed
             // the current one that contain the same name[0]. I.e., they are subdecks that stem
             // from this node. This is our version of python's itertools.groupby.
-            List<DeckDueTreeNode> tail  = new ArrayList<>();
-            tail.add(node);
+            List<DeckDueTreeNode> children = new ArrayList<>();
             while (it.hasNext()) {
                 DeckDueTreeNode next = it.next();
                 if (head.equals(next.getNamePart(0))) {
                     // Same head - add to tail of current head.
-                    tail.add(next);
+                    children.add(next);
                 } else {
                     // We've iterated past this head, so step back in order to use this node as the
                     // head in the next iteration of the outer loop.
@@ -269,23 +268,10 @@ public class Sched extends SchedV2 {
                     break;
                 }
             }
-            Long did = null;
-            int rev = 0;
-            int _new = 0;
-            int lrn = 0;
-            List<DeckDueTreeNode> children = new ArrayList<>();
-            for (DeckDueTreeNode c : tail) {
-                if (c.getDepth() == depth) {
-                    // current node
-                    did = c.getDid();
-                    rev += c.getRevCount();
-                    lrn += c.getLrnCount();
-                    _new += c.getNewCount();
-                } else {
-                    // set new string to tail
-                    children.add(c);
-                }
-            }
+            Long did = node.getDid();
+            int rev = node.getRevCount();
+            int _new = node.getNewCount();
+            int lrn = node.getLrnCount();
             node.setChildren(_groupChildrenMain(children, depth + 1));
             // tally up children counts
             for (DeckDueTreeNode ch : node.getChildren()) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -295,8 +295,8 @@ public class Sched extends SchedV2 {
             }
             // limit the counts to the deck's limits
             JSONObject conf = mCol.getDecks().confForDid(did);
-            JSONObject deck = mCol.getDecks().get(did);
             if (conf.getInt("dyn") == 0) {
+                JSONObject deck = mCol.getDecks().get(did);
                 rev = Math.max(0, Math.min(rev, conf.getJSONObject("rev").getInt("perDay") - deck.getJSONArray("revToday").getInt(1)));
                 _new = Math.max(0, Math.min(_new, conf.getJSONObject("new").getInt("perDay") - deck.getJSONArray("newToday").getInt(1)));
             }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -275,7 +275,7 @@ public class Sched extends SchedV2 {
             int lrn = 0;
             List<DeckDueTreeNode> children = new ArrayList<>();
             for (DeckDueTreeNode c : tail) {
-                if (c.getName().length -1 == depth) {
+                if (c.getDepth() == depth) {
                     // current node
                     did = c.getDid();
                     rev += c.getRevCount();

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -433,7 +433,7 @@ public class SchedV2 extends AbstractSched {
     private List<DeckDueTreeNode> _groupChildren(List<DeckDueTreeNode> grps) {
         // first, split the group names into components
         for (DeckDueTreeNode g : grps) {
-            g.names = Decks.path(g.names[0]);
+            g.setNames(Decks.path(g.getName()[0]));
         }
         // and sort based on those components
         Collections.sort(grps);
@@ -448,7 +448,7 @@ public class SchedV2 extends AbstractSched {
         ListIterator<DeckDueTreeNode> it = grps.listIterator();
         while (it.hasNext()) {
             DeckDueTreeNode node = it.next();
-            String head = node.names[0];
+            String head = node.getName()[0];
             // Compose the "tail" node list. The tail is a list of all the nodes that proceed
             // the current one that contain the same name[0]. I.e., they are subdecks that stem
             // from this node. This is our version of python's itertools.groupby.
@@ -456,7 +456,7 @@ public class SchedV2 extends AbstractSched {
             tail.add(node);
             while (it.hasNext()) {
                 DeckDueTreeNode next = it.next();
-                if (head.equals(next.names[0])) {
+                if (head.equals(next.getName()[0])) {
                     // Same head - add to tail of current head.
                     tail.add(next);
                 } else {
@@ -472,25 +472,25 @@ public class SchedV2 extends AbstractSched {
             int lrn = 0;
             List<DeckDueTreeNode> children = new ArrayList<>();
             for (DeckDueTreeNode c : tail) {
-                if (c.names.length == 1) {
+                if (c.getName().length == 1) {
                     // current node
-                    did = c.did;
-                    rev += c.revCount;
-                    lrn += c.lrnCount;
-                    _new += c.newCount;
+                    did = c.getDid();
+                    rev += c.getRevCount();
+                    lrn += c.getLrnCount();
+                    _new += c.getNewCount();
                 } else {
                     // set new string to tail
-                    String[] newTail = new String[c.names.length-1];
-                    System.arraycopy(c.names, 1, newTail, 0, c.names.length-1);
-                    c.names = newTail;
+                    String[] newTail = new String[c.getName().length-1];
+                    System.arraycopy(c.getName(), 1, newTail, 0, c.getName().length-1);
+                    c.setNames(newTail);
                     children.add(c);
                 }
             }
             children = _groupChildrenMain(children);
             // tally up children counts
             for (DeckDueTreeNode ch : children) {
-                lrn +=  ch.lrnCount;
-                _new += ch.newCount;
+                lrn +=  ch.getLrnCount();
+                _new += ch.getNewCount();
             }
             // limit the counts to the deck's limits
             JSONObject conf = mCol.getDecks().confForDid(did);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -76,7 +76,6 @@ public class SchedV2 extends AbstractSched {
     private String mName = "std2";
     private boolean mHaveCustomStudy = true;
 
-    protected Collection mCol;
     protected int mQueueLimit;
     protected int mReportLimit;
     private int mDynReportLimit;
@@ -465,18 +464,7 @@ public class SchedV2 extends AbstractSched {
                     break;
                 }
             }
-            node.setChildren(_groupChildrenMain(node.getChildren(), depth + 1));
-            // tally up children counts
-            for (DeckDueTreeNode ch : node.getChildren()) {
-                node.addLrnCount(ch.getLrnCount());
-                node.addNewCount(ch.getNewCount());
-            }
-            // limit the counts to the deck's limits
-            JSONObject conf = mCol.getDecks().confForDid(node.getDid());
-            if (conf.getInt("dyn") == 0) {
-                JSONObject deck = mCol.getDecks().get(node.getDid());
-                node.limitNewCount(conf.getJSONObject("new").getInt("perDay") - deck.getJSONArray("newToday").getInt(1));
-            }
+            node.setChildren(_groupChildrenMain(node.getChildren(), depth + 1), false);
             tree.add(node);
         }
         return tree;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -483,9 +483,9 @@ public class SchedV2 extends AbstractSched {
                     children.add(c);
                 }
             }
-            children = _groupChildrenMain(children, depth + 1);
+            node.setChildren(_groupChildrenMain(node.getChildren(), depth + 1));
             // tally up children counts
-            for (DeckDueTreeNode ch : children) {
+            for (DeckDueTreeNode ch : node.getChildren()) {
                 lrn +=  ch.getLrnCount();
                 _new += ch.getNewCount();
             }
@@ -495,7 +495,7 @@ public class SchedV2 extends AbstractSched {
             if (conf.getInt("dyn") == 0) {
                 _new = Math.max(0, Math.min(_new, conf.getJSONObject("new").getInt("perDay") - deck.getJSONArray("newToday").getInt(1)));
             }
-            tree.add(new DeckDueTreeNode(head, did, rev, lrn, _new, children));
+            tree.add(new DeckDueTreeNode(head, did, rev, lrn, _new, node.getChildren()));
         }
         return tree;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -433,7 +433,7 @@ public class SchedV2 extends AbstractSched {
     private List<DeckDueTreeNode> _groupChildren(List<DeckDueTreeNode> grps) {
         // first, split the group names into components
         for (DeckDueTreeNode g : grps) {
-            g.setNames(Decks.path(g.getName()[0]));
+            g.setNames(Decks.path(g.getNamePart(0)));
         }
         // and sort based on those components
         Collections.sort(grps);
@@ -448,7 +448,7 @@ public class SchedV2 extends AbstractSched {
         ListIterator<DeckDueTreeNode> it = grps.listIterator();
         while (it.hasNext()) {
             DeckDueTreeNode node = it.next();
-            String head = node.getName()[0];
+            String head = node.getNamePart(0);
             // Compose the "tail" node list. The tail is a list of all the nodes that proceed
             // the current one that contain the same name[0]. I.e., they are subdecks that stem
             // from this node. This is our version of python's itertools.groupby.
@@ -456,7 +456,7 @@ public class SchedV2 extends AbstractSched {
             tail.add(node);
             while (it.hasNext()) {
                 DeckDueTreeNode next = it.next();
-                if (head.equals(next.getName()[0])) {
+                if (head.equals(next.getNamePart(0))) {
                     // Same head - add to tail of current head.
                     tail.add(next);
                 } else {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -443,12 +443,16 @@ public class SchedV2 extends AbstractSched {
 
 
     protected List<DeckDueTreeNode> _groupChildrenMain(List<DeckDueTreeNode> grps) {
+        return _groupChildrenMain(grps, 0);
+    }
+
+    protected List<DeckDueTreeNode> _groupChildrenMain(List<DeckDueTreeNode> grps, int depth) {
         List<DeckDueTreeNode> tree = new ArrayList<>();
         // group and recurse
         ListIterator<DeckDueTreeNode> it = grps.listIterator();
         while (it.hasNext()) {
             DeckDueTreeNode node = it.next();
-            String head = node.getNamePart(0);
+            String head = node.getNamePart(depth);
             // Compose the "tail" node list. The tail is a list of all the nodes that proceed
             // the current one that contain the same name[0]. I.e., they are subdecks that stem
             // from this node. This is our version of python's itertools.groupby.
@@ -456,7 +460,7 @@ public class SchedV2 extends AbstractSched {
             tail.add(node);
             while (it.hasNext()) {
                 DeckDueTreeNode next = it.next();
-                if (head.equals(next.getNamePart(0))) {
+                if (head.equals(next.getNamePart(depth))) {
                     // Same head - add to tail of current head.
                     tail.add(next);
                 } else {
@@ -472,7 +476,7 @@ public class SchedV2 extends AbstractSched {
             int lrn = 0;
             List<DeckDueTreeNode> children = new ArrayList<>();
             for (DeckDueTreeNode c : tail) {
-                if (c.getName().length == 1) {
+                if (c.getName().length - 1 == depth) {
                     // current node
                     did = c.getDid();
                     rev += c.getRevCount();
@@ -480,13 +484,10 @@ public class SchedV2 extends AbstractSched {
                     _new += c.getNewCount();
                 } else {
                     // set new string to tail
-                    String[] newTail = new String[c.getName().length-1];
-                    System.arraycopy(c.getName(), 1, newTail, 0, c.getName().length-1);
-                    c.setNames(newTail);
                     children.add(c);
                 }
             }
-            children = _groupChildrenMain(children);
+            children = _groupChildrenMain(children, depth + 1);
             // tally up children counts
             for (DeckDueTreeNode ch : children) {
                 lrn +=  ch.getLrnCount();

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -416,32 +416,34 @@ public class SchedV2 extends AbstractSched {
     }
 
 
-    public List<DeckDueTreeNode> deckDueTree() {
+    public DeckDueTreeNode deckDueTree() {
         return deckDueTree(null);
     }
 
-    public List<DeckDueTreeNode> deckDueTree(CollectionTask collectionTask) {
+    public DeckDueTreeNode deckDueTree(CollectionTask collectionTask) {
         List<DeckDueTreeNode> deckDueTree = deckDueList(collectionTask);
         if (deckDueTree == null) {
             return null;
         }
-        return _groupChildren(deckDueTree);
+        DeckDueTreeNode topLevel = new DeckDueTreeNode("", null, 0, 0, 0);
+        _groupChildren(topLevel, deckDueTree);
+        return topLevel;
     }
 
 
-    private List<DeckDueTreeNode> _groupChildren(List<DeckDueTreeNode> grps) {
+    private void _groupChildren(DeckDueTreeNode topLevel, List<DeckDueTreeNode> grps) {
         // sort based on name's components
         Collections.sort(grps);
         // then run main function
-        return _groupChildrenMain(grps);
+        _groupChildrenMain(topLevel, grps);
     }
 
 
-    protected List<DeckDueTreeNode> _groupChildrenMain(List<DeckDueTreeNode> grps) {
-        return _groupChildrenMain(grps, 0);
+    protected void _groupChildrenMain(DeckDueTreeNode topLevel, List<DeckDueTreeNode> grps) {
+        _groupChildrenMain(topLevel, grps, 0);
     }
 
-    protected List<DeckDueTreeNode> _groupChildrenMain(List<DeckDueTreeNode> grps, int depth) {
+    protected void _groupChildrenMain(DeckDueTreeNode parent, List<DeckDueTreeNode> grps, int depth) {
         List<DeckDueTreeNode> tree = new ArrayList<>();
         // group and recurse
         ListIterator<DeckDueTreeNode> it = grps.listIterator();
@@ -464,10 +466,10 @@ public class SchedV2 extends AbstractSched {
                     break;
                 }
             }
-            node.setChildren(_groupChildrenMain(node.getChildren(), depth + 1), false);
             tree.add(node);
+            _groupChildrenMain(node, children, depth + 1);
         }
-        return tree;
+        parent.setChildren(tree, false);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -416,6 +416,28 @@ public class SchedV2 extends AbstractSched {
         return data;
     }
 
+    /** Similar to deck due tree, but ignore the number of cards.
+
+     It may takes a lot of time to compute the number of card, it
+     requires multiple database access by deck.  Ignoring this number
+     lead to the creation of a tree more quickly.*/
+    @Override
+    public DeckDueTreeNodeQuick quickDeckDueTree() {
+        // Similar to deckDueTree, ignoring the numbers
+
+        // Similar to deckDueList
+        ArrayList<DeckDueTreeNode> data = new ArrayList<>();
+        for (JSONObject deck : mCol.getDecks().allSorted()) {
+            DeckDueTreeNodeQuick g = new DeckDueTreeNodeQuick(deck.getString("name"), deck.getLong("id"));
+            data.add(g);
+        }
+        // End of the similar part.
+
+        DeckDueTreeNodeQuick topLevel = new DeckDueTreeNodeQuick("", null);
+        _groupChildren(topLevel, data, false);
+        return topLevel;
+    }
+
 
     public DeckDueTreeNodeNumbered deckDueTree() {
         return deckDueTree(null);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -491,8 +491,8 @@ public class SchedV2 extends AbstractSched {
             }
             // limit the counts to the deck's limits
             JSONObject conf = mCol.getDecks().confForDid(did);
-            JSONObject deck = mCol.getDecks().get(did);
             if (conf.getInt("dyn") == 0) {
+                JSONObject deck = mCol.getDecks().get(did);
                 _new = Math.max(0, Math.min(_new, conf.getJSONObject("new").getInt("perDay") - deck.getJSONArray("newToday").getInt(1)));
             }
             tree.add(new DeckDueTreeNode(head, did, rev, lrn, _new, node.getChildren()));

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -431,11 +431,7 @@ public class SchedV2 extends AbstractSched {
 
 
     private List<DeckDueTreeNode> _groupChildren(List<DeckDueTreeNode> grps) {
-        // first, split the group names into components
-        for (DeckDueTreeNode g : grps) {
-            g.setNames(Decks.path(g.getNamePart(0)));
-        }
-        // and sort based on those components
+        // sort based on name's components
         Collections.sort(grps);
         // then run main function
         return _groupChildrenMain(grps);
@@ -476,7 +472,7 @@ public class SchedV2 extends AbstractSched {
             int lrn = 0;
             List<DeckDueTreeNode> children = new ArrayList<>();
             for (DeckDueTreeNode c : tail) {
-                if (c.getName().length - 1 == depth) {
+                if (c.getDepth() == depth) {
                     // current node
                     did = c.getDid();
                     rev += c.getRevCount();

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -452,13 +452,12 @@ public class SchedV2 extends AbstractSched {
             // Compose the "tail" node list. The tail is a list of all the nodes that proceed
             // the current one that contain the same name[0]. I.e., they are subdecks that stem
             // from this node. This is our version of python's itertools.groupby.
-            List<DeckDueTreeNode> tail  = new ArrayList<>();
-            tail.add(node);
+            List<DeckDueTreeNode> children = new ArrayList<>();
             while (it.hasNext()) {
                 DeckDueTreeNode next = it.next();
                 if (head.equals(next.getNamePart(depth))) {
                     // Same head - add to tail of current head.
-                    tail.add(next);
+                    children.add(next);
                 } else {
                     // We've iterated past this head, so step back in order to use this node as the
                     // head in the next iteration of the outer loop.
@@ -466,23 +465,10 @@ public class SchedV2 extends AbstractSched {
                     break;
                 }
             }
-            Long did = null;
-            int rev = 0;
-            int _new = 0;
-            int lrn = 0;
-            List<DeckDueTreeNode> children = new ArrayList<>();
-            for (DeckDueTreeNode c : tail) {
-                if (c.getDepth() == depth) {
-                    // current node
-                    did = c.getDid();
-                    rev += c.getRevCount();
-                    lrn += c.getLrnCount();
-                    _new += c.getNewCount();
-                } else {
-                    // set new string to tail
-                    children.add(c);
-                }
-            }
+            Long did = node.getDid();
+            int rev = node.getRevCount();
+            int _new = node.getNewCount();
+            int lrn = node.getLrnCount();
             node.setChildren(_groupChildrenMain(node.getChildren(), depth + 1));
             // tally up children counts
             for (DeckDueTreeNode ch : node.getChildren()) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -465,23 +465,19 @@ public class SchedV2 extends AbstractSched {
                     break;
                 }
             }
-            Long did = node.getDid();
-            int rev = node.getRevCount();
-            int _new = node.getNewCount();
-            int lrn = node.getLrnCount();
             node.setChildren(_groupChildrenMain(node.getChildren(), depth + 1));
             // tally up children counts
             for (DeckDueTreeNode ch : node.getChildren()) {
-                lrn +=  ch.getLrnCount();
-                _new += ch.getNewCount();
+                node.addLrnCount(ch.getLrnCount());
+                node.addNewCount(ch.getNewCount());
             }
             // limit the counts to the deck's limits
-            JSONObject conf = mCol.getDecks().confForDid(did);
+            JSONObject conf = mCol.getDecks().confForDid(node.getDid());
             if (conf.getInt("dyn") == 0) {
-                JSONObject deck = mCol.getDecks().get(did);
-                _new = Math.max(0, Math.min(_new, conf.getJSONObject("new").getInt("perDay") - deck.getJSONArray("newToday").getInt(1)));
+                JSONObject deck = mCol.getDecks().get(node.getDid());
+                node.limitNewCount(conf.getJSONObject("new").getInt("perDay") - deck.getJSONArray("newToday").getInt(1));
             }
-            tree.add(new DeckDueTreeNode(head, did, rev, lrn, _new, node.getChildren()));
+            tree.add(node);
         }
         return tree;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/widget/WidgetStatus.java
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/WidgetStatus.java
@@ -126,9 +126,9 @@ public final class WidgetStatus {
             // Only count the top-level decks in the total
             List<Sched.DeckDueTreeNode> nodes = col.getSched().deckDueTree();
             for (Sched.DeckDueTreeNode node : nodes) {
-                total[0] += node.newCount;
-                total[1] += node.lrnCount;
-                total[2] += node.revCount;
+                total[0] += node.getNewCount();
+                total[1] += node.getLrnCount();
+                total[2] += node.getRevCount();
             }
             int due = total[0] + total[1] + total[2];
             int eta = col.getSched().eta(total, false);

--- a/AnkiDroid/src/main/java/com/ichi2/widget/WidgetStatus.java
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/WidgetStatus.java
@@ -124,7 +124,7 @@ public final class WidgetStatus {
             col.getSched()._checkDay();
 
             // Only count the top-level decks in the total
-            AbstractSched.DeckDueTreeNode topLevel = col.getSched().deckDueTree();
+            AbstractSched.DeckDueTreeNodeNumbered topLevel = col.getSched().deckDueTree();
             int[] total = {topLevel.getNewCount(), topLevel.getLrnCount(), topLevel.getRevCount()};
             int due = total[0] + total[1] + total[2];
             int eta = col.getSched().eta(total, false);

--- a/AnkiDroid/src/main/java/com/ichi2/widget/WidgetStatus.java
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/WidgetStatus.java
@@ -28,6 +28,7 @@ import com.ichi2.anki.MetaDB;
 import com.ichi2.anki.services.NotificationService;
 import com.ichi2.async.BaseAsyncTask;
 import com.ichi2.libanki.Collection;
+import com.ichi2.libanki.sched.AbstractSched;
 import com.ichi2.libanki.sched.Sched;
 
 import java.util.List;
@@ -118,18 +119,13 @@ public final class WidgetStatus {
 
 
         private void updateCounts(Context context) {
-            int[] total = {0, 0, 0};
             Collection col = CollectionHelper.getInstance().getCol(context);
             // Ensure queues are reset if we cross over to the next day.
             col.getSched()._checkDay();
 
             // Only count the top-level decks in the total
-            List<Sched.DeckDueTreeNode> nodes = col.getSched().deckDueTree();
-            for (Sched.DeckDueTreeNode node : nodes) {
-                total[0] += node.getNewCount();
-                total[1] += node.getLrnCount();
-                total[2] += node.getRevCount();
-            }
+            AbstractSched.DeckDueTreeNode topLevel = col.getSched().deckDueTree();
+            int[] total = {topLevel.getNewCount(), topLevel.getLrnCount(), topLevel.getRevCount()};
             int due = total[0] + total[1] + total[2];
             int eta = col.getSched().eta(total, false);
             sSmallWidgetStatus = new Pair<>(due, eta);

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedTest.java
@@ -74,9 +74,9 @@ public class SchedTest extends RobolectricTest {
         //Assert
         DeckDueTreeNode dynamicDeck = getCountsForDid(dynDeck);
 
-        assertThat("A learn card should not be moved into a dyn deck", dynamicDeck.lrnCount, is(0));
-        assertThat("A learn card should not be moved into a dyn deck", dynamicDeck.newCount, is(0));
-        assertThat("A learn card should not be moved into a dyn deck", dynamicDeck.revCount, is(0));
+        assertThat("A learn card should not be moved into a dyn deck", dynamicDeck.getLrnCount(), is(0));
+        assertThat("A learn card should not be moved into a dyn deck", dynamicDeck.getNewCount(), is(0));
+        assertThat("A learn card should not be moved into a dyn deck", dynamicDeck.getRevCount(), is(0));
     }
 
 
@@ -93,7 +93,7 @@ public class SchedTest extends RobolectricTest {
         List<DeckDueTreeNode> tree =  getCol().getSched().deckDueTree();
 
         for (DeckDueTreeNode node: tree) {
-            if (node.did == didToFind) {
+            if (node.getDid() == didToFind) {
                 return node;
             }
         }

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedTest.java
@@ -21,7 +21,6 @@ import com.ichi2.anki.RobolectricTest;
 import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Consts;
 import com.ichi2.libanki.Note;
-import com.ichi2.libanki.sched.AbstractSched.DeckDueTreeNode;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -72,7 +71,7 @@ public class SchedTest extends RobolectricTest {
         sched.rebuildDyn(dynDeck);
 
         //Assert
-        DeckDueTreeNode dynamicDeck = getCountsForDid(dynDeck);
+        AbstractSched.DeckDueTreeNodeNumbered dynamicDeck = getCountsForDid(dynDeck);
 
         assertThat("A learn card should not be moved into a dyn deck", dynamicDeck.getLrnCount(), is(0));
         assertThat("A learn card should not be moved into a dyn deck", dynamicDeck.getNewCount(), is(0));
@@ -89,10 +88,10 @@ public class SchedTest extends RobolectricTest {
 
 
     @NonNull
-    private DeckDueTreeNode getCountsForDid(double didToFind) {
-        DeckDueTreeNode topLevel =  getCol().getSched().deckDueTree();
+    private AbstractSched.DeckDueTreeNodeNumbered getCountsForDid(double didToFind) {
+        AbstractSched.DeckDueTreeNodeNumbered topLevel =  getCol().getSched().deckDueTree();
 
-        for (DeckDueTreeNode node: topLevel.getChildren()) {
+        for (AbstractSched.DeckDueTreeNodeNumbered node: topLevel.getChildren()) {
             if (node.getDid() == didToFind) {
                 return node;
             }

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedTest.java
@@ -90,9 +90,9 @@ public class SchedTest extends RobolectricTest {
 
     @NonNull
     private DeckDueTreeNode getCountsForDid(double didToFind) {
-        List<DeckDueTreeNode> tree =  getCol().getSched().deckDueTree();
+        DeckDueTreeNode topLevel =  getCol().getSched().deckDueTree();
 
-        for (DeckDueTreeNode node: tree) {
+        for (DeckDueTreeNode node: topLevel.getChildren()) {
             if (node.getDid() == didToFind) {
                 return node;
             }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
![image](https://user-images.githubusercontent.com/357361/85224754-d0712e00-b3cc-11ea-8d05-3b03a9ef3ff0.png)

The main goal is to win seconds during loading. Ensuring deck picker gets interactive sooner.
## Fixes
Starting is slow.

## Approach
Instead of computing all numbers, we just deal with the tree (which does not require any database access when the decks are loaded).

I should note in particular that I followed @david-allison-1 advice and used type safe way to know whether a node has number or not. I also put members private and used getter when it makes sens. However, I didn't go as far as I wanted to go previously and the node is still distinct from the Deck class, even if I do not see the sens of this change.

I did not put any assertions. The deck checker is code which have been here for years, there was no reason to check whether it did it works correctly.

## How Has This Been Tested?

Adding it to my "merge" branch. Opening the app, seing that numbers appear after the deck. Putting a reminder and seing that it works.

## Learning (optional, can help others)
I can't believe how hard it is to create good code to win seconds.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
