### PR TITLE
NF: replace mModels by getModels()

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -263,7 +263,7 @@ public class Collection {
                 cursor.close();
             }
         }
-        mModels.load(loadColumn("models"));
+        getModels().load(loadColumn("models"));
         mDecks.load(loadColumn("decks"), deckConf);
     }
 
@@ -339,7 +339,7 @@ public class Collection {
 
     public synchronized void save(String name, long mod) {
         // let the managers conditionally flush
-        mModels.flush();
+        getModels().flush();
         mDecks.flush();
         mTags.flush();
         // and flush deck + bump mod if db has been changed
@@ -456,7 +456,7 @@ public class Collection {
         // we can save space by removing the log of deletions
         mDb.execute("delete from graves");
         mUsn += 1;
-        mModels.beforeUpload();
+        getModels().beforeUpload();
         mTags.beforeUpload();
         mDecks.beforeUpload();
         modSchemaNoCheck();
@@ -547,7 +547,7 @@ public class Collection {
      * @return The new note
      */
     public Note newNote(boolean forDeck) {
-        return newNote(mModels.current(forDeck));
+        return newNote(getModels().current(forDeck));
     }
 
     /**
@@ -618,7 +618,7 @@ public class Collection {
      */
     public ArrayList<JSONObject> findTemplates(Note note) {
         JSONObject model = note.model();
-        ArrayList<Integer> avail = mModels.availOrds(model, note.getFields());
+        ArrayList<Integer> avail = getModels().availOrds(model, note.getFields());
         return _tmplsFromOrds(model, avail);
     }
 
@@ -716,8 +716,8 @@ public class Collection {
                 long nid = cur.getLong(0);
                 long mid = cur.getLong(1);
                 String flds = cur.getString(2);
-                JSONObject model = mModels.get(mid);
-                ArrayList<Integer> avail = mModels.availOrds(model, Utils.splitFields(flds));
+                JSONObject model = getModels().get(mid);
+                ArrayList<Integer> avail = getModels().availOrds(model, Utils.splitFields(flds));
                 long did = dids.get(nid);
                 // use sibling due if there is one, else use a new id
                 long due;
@@ -997,12 +997,12 @@ public class Collection {
         ArrayList<Object[]> r = new ArrayList<>();
         for (Object[] o : _fieldData(snids)) {
             String[] fields = Utils.splitFields((String) o[2]);
-            JSONObject model = mModels.get((Long) o[1]);
+            JSONObject model = getModels().get((Long) o[1]);
             if (model == null) {
                 // note point to invalid model
                 continue;
             }
-            r.add(new Object[] { Utils.stripHTMLMedia(fields[mModels.sortIdx(model)]), Utils.fieldChecksum(fields[0]), o[0] });
+            r.add(new Object[] { Utils.stripHTMLMedia(fields[getModels().sortIdx(model)]), Utils.fieldChecksum(fields[0]), o[0] });
         }
         // apply, relying on calling code to bump usn+mod
         mDb.executeMany("UPDATE notes SET sfld=?, csum=? WHERE id=?", r);
@@ -1025,7 +1025,7 @@ public class Collection {
         // data is [cid, nid, mid, did, ord, tags, flds, cardFlags]
         // unpack fields and create dict
         Map<String, String> fields = new HashMap<>();
-        Map<String, Pair<Integer, JSONObject>> fmap = mModels.fieldMap(model);
+        Map<String, Pair<Integer, JSONObject>> fmap = getModels().fieldMap(model);
         for (String name : fmap.keySet()) {
             fields.put(name, flist[fmap.get(name).first]);
         }
@@ -1474,13 +1474,13 @@ public class Collection {
         }
         boolean badNotes = mDb.queryScalar(
                 "select 1 from notes where id not in (select distinct nid from cards) " +
-                "or mid not in " +  Utils.ids2str(mModels.ids()) + " limit 1") > 0;
+                "or mid not in " +  Utils.ids2str(getModels().ids()) + " limit 1") > 0;
         // notes without cards or models
         if (badNotes) {
             return false;
         }
         // invalid ords
-        for (JSONObject m : mModels.all()) {
+        for (JSONObject m : getModels().all()) {
             // ignore clozes
             if (m.getInt("type") != Consts.MODEL_STD) {
                 continue;
@@ -1504,7 +1504,7 @@ public class Collection {
         File file = new File(mPath);
         CheckDatabaseResult result = new CheckDatabaseResult(file.length());
         final int[] currentTask = {1};
-        int totalTasks = (mModels.all().size() * 4) + 27; // a few fixes are in all-models loops, the rest are one-offs
+        int totalTasks = (getModels().all().size() * 4) + 27; // a few fixes are in all-models loops, the rest are one-offs
         Runnable notifyProgress = () -> fixIntegrityProgress(progressCallback, currentTask[0]++, totalTasks);
         FunctionalInterfaces.Consumer<FunctionalInterfaces.FunctionThrowable<Runnable, List<String>, JSONException>> executeIntegrityTask =
                 (FunctionalInterfaces.FunctionThrowable<Runnable, List<String>, JSONException> function) -> {
@@ -1550,7 +1550,7 @@ public class Collection {
 
         executeIntegrityTask.consume(this::deleteNotesWithMissingModel);
         // for each model
-        for (JSONObject m : mModels.all()) {
+        for (JSONObject m : getModels().all()) {
             executeIntegrityTask.consume((callback) -> deleteCardsWithInvalidModelOrdinals(callback, m));
             executeIntegrityTask.consume((callback) -> deleteNotesWithWrongFieldCounts(callback, m));
         }
@@ -1694,7 +1694,7 @@ public class Collection {
         Timber.d("ensureModelsAreNotEmpty()");
         ArrayList<String> problems = new ArrayList<>();
         notifyProgress.run();
-        if (mModels.ensureNotEmpty()) {
+        if (getModels().ensureNotEmpty()) {
             problems.add("Added missing note type.");
         }
         return problems;
@@ -1780,9 +1780,9 @@ public class Collection {
     private List<String> updateFieldCache(Runnable notifyProgress) {
         Timber.d("updateFieldCache");
         // field cache
-        for (JSONObject m : mModels.all()) {
+        for (JSONObject m : getModels().all()) {
             notifyProgress.run();
-            updateFieldCache(Utils.arrayList2array(mModels.nids(m)));
+            updateFieldCache(Utils.arrayList2array(getModels().nids(m)));
         }
         return Collections.emptyList();
     }
@@ -1977,7 +1977,7 @@ public class Collection {
         // note types with a missing model
         notifyProgress.run();
         ArrayList<Long> ids = mDb.queryColumn(Long.class,
-                "SELECT id FROM notes WHERE mid NOT IN " + Utils.ids2str(mModels.ids()), 0);
+                "SELECT id FROM notes WHERE mid NOT IN " + Utils.ids2str(getModels().ids()), 0);
         notifyProgress.run();
         if (ids.size() != 0) {
             problems.add("Deleted " + ids.size() + " note(s) with missing note type.");
@@ -2110,7 +2110,7 @@ public class Collection {
     /** Check if this collection is valid. */
     public boolean validCollection() {
     	//TODO: more validation code
-    	return mModels.validateModel();
+    	return getModels().validateModel();
     }
 
     public JSONObject getConf() {


### PR DESCRIPTION
This change has a single goal, making https://github.com/ankidroid/Anki-Android/pull/6049 smaller. I believe that https://github.com/ankidroid/Anki-Android/pull/6049 is my most important opened PR, it can help ankidroid starts faster, and a big reason while it seems to be a big commit is because it requires to uses a getter instead of using a direct access to the member element. So I hope that if this commit gets merged in ankidroid, the other commit will appear to be quite simpler