### PR TITLE
Ignore content provider test until we can change collections in instrumented tests.

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.java
@@ -48,6 +48,7 @@ import com.ichi2.utils.JSONObject;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -968,6 +969,7 @@ public class ContentProviderTest {
 
     /** Test that a null did will not crash the provider (#6378) */
      @Test
+     @Ignore("#6025 - This causes mild data corruption - should not be run on actual collection")
      public void testProviderProvidesDefaultForEmptyModelDeck() {
          Collection col = getCol();
          col.getModels().all().get(0).put("did", JSONObject.NULL);


### PR DESCRIPTION
This test could be run on real devices. Will not impact users (as the bug was fixed), but still shouldn't be done. This setting will be fixed via use of the app.

This requires #6025 to go in before we start mutating collections for the content provider tests

## Learning

We should have an automated warning on changes to the `androidTest` directory. That, or a review checklist

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code