### PR TITLE
NF: deckDueList only if required (performance)

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -299,8 +299,8 @@ public class Sched extends SchedV2 {
             }
             // limit the counts to the deck's limits
             JSONObject conf = mCol.getDecks().confForDid(did);
-            JSONObject deck = mCol.getDecks().get(did);
             if (conf.getInt("dyn") == 0) {
+                JSONObject deck = mCol.getDecks().get(did);
                 rev = Math.max(0, Math.min(rev, conf.getJSONObject("rev").getInt("perDay") - deck.getJSONArray("revToday").getInt(1)));
                 _new = Math.max(0, Math.min(_new, conf.getJSONObject("new").getInt("perDay") - deck.getJSONArray("newToday").getInt(1)));
             }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -494,8 +494,8 @@ public class SchedV2 extends AbstractSched {
             }
             // limit the counts to the deck's limits
             JSONObject conf = mCol.getDecks().confForDid(did);
-            JSONObject deck = mCol.getDecks().get(did);
             if (conf.getInt("dyn") == 0) {
+                JSONObject deck = mCol.getDecks().get(did);
                 _new = Math.max(0, Math.min(_new, conf.getJSONObject("new").getInt("perDay") - deck.getJSONArray("newToday").getInt(1)));
             }
             tree.add(new DeckDueTreeNode(head, did, rev, lrn, _new, children));


### PR DESCRIPTION
This is a commit in https://github.com/ankidroid/Anki-Android/pull/6522 that can easily be moved outside of it. By itself it present almost no interest, it only remove some access to a hashmap when the value is not used. 