### PR TITLE
Deck name in node

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
@@ -374,7 +374,7 @@ public class CardContentProvider extends ContentProvider {
                 MatrixCursor rv = new MatrixCursor(columns, allDecks.size());
                 for (Sched.DeckDueTreeNode deck : allDecks) {
                     long id = deck.getDid();
-                    String name = deck.getNamePart(0);
+                    String name = deck.getDeckNameComponent(0);
                     addDeckToCursor(id, name, getDeckCountsFromDueTreeNode(deck), rv, col, columns);
                 }
                 return rv;
@@ -388,7 +388,7 @@ public class CardContentProvider extends ContentProvider {
                 deckId = Long.parseLong(uri.getPathSegments().get(1));
                 for (Sched.DeckDueTreeNode deck : allDecks) {
                     if(deck.getDid() == deckId){
-                        addDeckToCursor(deckId, deck.getNamePart(0), getDeckCountsFromDueTreeNode(deck), rv, col, columns);
+                        addDeckToCursor(deckId, deck.getDeckNameComponent(0), getDeckCountsFromDueTreeNode(deck), rv, col, columns);
                         return rv;
                     }
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
@@ -374,7 +374,7 @@ public class CardContentProvider extends ContentProvider {
                 MatrixCursor rv = new MatrixCursor(columns, allDecks.size());
                 for (Sched.DeckDueTreeNode deck : allDecks) {
                     long id = deck.getDid();
-                    String name = deck.getDeckNameComponent(0);
+                    String name = deck.getFullDeckName();
                     addDeckToCursor(id, name, getDeckCountsFromDueTreeNode(deck), rv, col, columns);
                 }
                 return rv;
@@ -388,7 +388,7 @@ public class CardContentProvider extends ContentProvider {
                 deckId = Long.parseLong(uri.getPathSegments().get(1));
                 for (Sched.DeckDueTreeNode deck : allDecks) {
                     if(deck.getDid() == deckId){
-                        addDeckToCursor(deckId, deck.getDeckNameComponent(0), getDeckCountsFromDueTreeNode(deck), rv, col, columns);
+                        addDeckToCursor(deckId, deck.getFullDeckName(), getDeckCountsFromDueTreeNode(deck), rv, col, columns);
                         return rv;
                     }
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.java
@@ -191,7 +191,7 @@ public class DeckAdapter extends RecyclerView.Adapter<DeckAdapter.ViewHolder> {
             CompatHelper.getCompat().setSelectableBackground(holder.deckLayout);
         }
         // Set deck name and colour. Filtered decks have their own colour
-        holder.deckName.setText(node.getDeckNameComponent(0));
+        holder.deckName.setText(node.getLastDeckNameComponent());
         if (mCol.getDecks().isDyn(node.getDid())) {
             holder.deckName.setTextColor(mDeckNameDynColor);
         } else {
@@ -262,8 +262,6 @@ public class DeckAdapter extends RecyclerView.Adapter<DeckAdapter.ViewHolder> {
                 }
             }
             mDeckList.add(node);
-            // Keep track of the depth. It's used to determine visual properties like indenting later
-            node.setDepth(depth);
 
             // Add this node's counts to the totals if it's a parent deck
             if (depth == 0) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.java
@@ -241,11 +241,6 @@ public class DeckAdapter extends RecyclerView.Adapter<DeckAdapter.ViewHolder> {
 
 
     private void processNodes(List<Sched.DeckDueTreeNode> nodes) {
-        processNodes(nodes, 0);
-    }
-
-
-    private void processNodes(List<Sched.DeckDueTreeNode> nodes, int depth) {
         for (Sched.DeckDueTreeNode node : nodes) {
             // If the default deck is empty, hide it by not adding it to the deck list.
             // We don't hide it if it's the only deck or if it has sub-decks.
@@ -264,13 +259,13 @@ public class DeckAdapter extends RecyclerView.Adapter<DeckAdapter.ViewHolder> {
             mDeckList.add(node);
 
             // Add this node's counts to the totals if it's a parent deck
-            if (depth == 0) {
+            if (node.getDepth() == 0) {
                 mNew += node.getNewCount();
                 mLrn += node.getLrnCount();
                 mRev += node.getRevCount();
             }
             // Process sub-decks
-            processNodes(node.getChildren(), depth + 1);
+            processNodes(node.getChildren());
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.java
@@ -191,7 +191,7 @@ public class DeckAdapter extends RecyclerView.Adapter<DeckAdapter.ViewHolder> {
             CompatHelper.getCompat().setSelectableBackground(holder.deckLayout);
         }
         // Set deck name and colour. Filtered decks have their own colour
-        holder.deckName.setText(node.getNamePart(0));
+        holder.deckName.setText(node.getDeckNameComponent(0));
         if (mCol.getDecks().isDyn(node.getDid())) {
             holder.deckName.setTextColor(mDeckNameDynColor);
         } else {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
@@ -210,8 +210,9 @@ public abstract class AbstractSched {
         @Override
         public int compareTo(Object other) {
             DeckDueTreeNode rhs = (DeckDueTreeNode) other;
+            int minDepth = Math.min(mName.length, rhs.mName.length);
             // Consider each subdeck name in the ordering
-            for (int i = 0; i < mName.length && i < rhs.mName.length; i++) {
+            for (int i = 0; i < minDepth; i++) {
                 int cmp = mName[i].compareTo(rhs.mName[i]);
                 if (cmp == 0) {
                     continue;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
@@ -9,11 +9,11 @@ import android.widget.Toast;
 import com.ichi2.anki.R;
 import com.ichi2.async.CollectionTask;
 import com.ichi2.libanki.Card;
+import com.ichi2.libanki.Decks;
 import com.ichi2.utils.JSONObject;
 
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 
@@ -178,29 +178,26 @@ public abstract class AbstractSched {
      * this field and use getNamePart(0) for those cases.
      */
     public class DeckDueTreeNode implements Comparable {
-        private String[] mName;
+        private final String mName;
+        private final String[] mNameComponents;
         private long mDid;
-        private int mDepth;
         private int mRevCount;
         private int mLrnCount;
         private int mNewCount;
         private List<DeckDueTreeNode> mChildren = new ArrayList<>();
 
-        public DeckDueTreeNode(String[] mName, long mDid, int mRevCount, int mLrnCount, int mNewCount) {
+        public DeckDueTreeNode(String mName, long mDid, int mRevCount, int mLrnCount, int mNewCount) {
             this.mName = mName;
             this.mDid = mDid;
             this.mRevCount = mRevCount;
             this.mLrnCount = mLrnCount;
             this.mNewCount = mNewCount;
+            this.mNameComponents = Decks.path(mName);
         }
 
-        public DeckDueTreeNode(String name, long mDid, int mRevCount, int mLrnCount, int mNewCount) {
-            this(new String[]{name}, mDid, mRevCount, mLrnCount, mNewCount);
-        }
-
-        public DeckDueTreeNode(String name, long mDid, int mRevCount, int mLrnCount, int mNewCount,
+        public DeckDueTreeNode(String mName, long mDid, int mRevCount, int mLrnCount, int mNewCount,
                                List<DeckDueTreeNode> mChildren) {
-            this(new String[]{name}, mDid, mRevCount, mLrnCount, mNewCount);
+            this(mName, mDid, mRevCount, mLrnCount, mNewCount);
             this.mChildren = mChildren;
         }
 
@@ -210,10 +207,10 @@ public abstract class AbstractSched {
         @Override
         public int compareTo(Object other) {
             DeckDueTreeNode rhs = (DeckDueTreeNode) other;
-            int minDepth = Math.min(mName.length, rhs.mName.length);
+            int minDepth = Math.min(getDepth(), rhs.getDepth()) + 1;
             // Consider each subdeck name in the ordering
             for (int i = 0; i < minDepth; i++) {
-                int cmp = mName[i].compareTo(rhs.mName[i]);
+                int cmp = mNameComponents[i].compareTo(rhs.mNameComponents[i]);
                 if (cmp == 0) {
                     continue;
                 }
@@ -222,7 +219,7 @@ public abstract class AbstractSched {
             // If we made it this far then the arrays are of different length. The longer one should
             // always come after since it contains all of the sections of the shorter one inside it
             // (i.e., the short one is an ancestor of the longer one).
-            if (rhs.mName.length > mName.length) {
+            if (rhs.getDepth() > getDepth()) {
                 return -1;
             } else {
                 return 1;
@@ -231,32 +228,45 @@ public abstract class AbstractSched {
 
         @Override
         public String toString() {
-            return String.format(Locale.US, "%s, %d, %d, %d, %d, %d, %s",
-                    Arrays.toString(mName), mDid, mDepth, mRevCount, mLrnCount, mNewCount, mChildren);
+            return String.format(Locale.US, "%s, %d, %d, %d, %d, %s",
+                    mName, mDid, mRevCount, mLrnCount, mNewCount, mChildren);
         }
 
-        public String[] getNames() {
+        /**
+         * @return The full deck name, e.g. "A::B::C"
+         * */
+        public String getFullDeckName() {
             return mName;
         }
 
+        /**
+         * For deck "A::B::C", `getDeckNameComponent(0)` returns "A",
+         * `getDeckNameComponent(1)` returns "B", etc...
+         */
         public String getDeckNameComponent(int part) {
-            return mName[part];
+            return mNameComponents[part];
         }
-        
-        public void setNames(String[] mName) {
-            this.mName = mName;
+
+        /**
+         * The part of the name displayed in deck picker, i.e. the
+         * part that does not belong to its parents. E.g.  for deck
+         * "A::B::C", returns "C".
+         */
+        public String getLastDeckNameComponent() {
+            return getDeckNameComponent(getDepth());
         }
 
         public long getDid() {
             return mDid;
         }
 
+        /**
+         * @return The depth of a deck. Top level decks have depth 0,
+         * their children have depth 1, etc... So "A::B::C" would have
+         * depth 2.
+         */
         public int getDepth() {
-            return mDepth;
-        }
-
-        public void setDepth(int mDepth) {
-            this.mDepth = mDepth;
+            return mNameComponents.length - 1;
         }
 
         public int getRevCount() {
@@ -271,10 +281,17 @@ public abstract class AbstractSched {
             return mLrnCount;
         }
 
+        /**
+         * @return The children of this deck. Note that they are set
+         * in the data structure returned by DeckDueTree but are
+         * always empty when the data structure is returned by
+         * deckDueList.*/
         public List<DeckDueTreeNode> getChildren() {
             return mChildren;
         }
 
+        /**
+         * @return whether this node as any children. */
         public boolean hasChildren() {
             return !mChildren.isEmpty();
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
@@ -239,7 +239,7 @@ public abstract class AbstractSched {
             return mName;
         }
 
-        public String getNamePart(int part) {
+        public String getDeckNameComponent(int part) {
             return mName[part];
         }
         

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -245,21 +245,23 @@ public class Sched extends SchedV2 {
 
 
     @Override
-    protected List<DeckDueTreeNode> _groupChildrenMain(List<DeckDueTreeNode> grps) {
+    protected List<DeckDueTreeNode> _groupChildrenMain(List<DeckDueTreeNode> grps, int depth) {
         List<DeckDueTreeNode> tree = new ArrayList<>();
         // group and recurse
         ListIterator<DeckDueTreeNode> it = grps.listIterator();
         while (it.hasNext()) {
             DeckDueTreeNode node = it.next();
-            String head = node.getDeckNameComponent(0);
-            // Compose the "children" node list. The children is a list of all the nodes that proceed
-            // the current one that contain the same name[0], except for the current one itself.
-            // I.e., they are subdecks that stem from this node.
-            // This is our version of python's itertools.groupby.
+            String head = node.getDeckNameComponent(depth);
             List<DeckDueTreeNode> children  = new ArrayList<>();
+            /* Compose the "children" node list. The children is a
+             * list of all the nodes that proceed the current one that
+             * contain the same at depth `depth`, except for the
+             * current one itself.  I.e., they are subdecks that stem
+             * from this node.  This is our version of python's
+             * itertools.groupby. */
             while (it.hasNext()) {
                 DeckDueTreeNode next = it.next();
-                if (head.equals(next.getDeckNameComponent(0))) {
+                if (head.equals(next.getDeckNameComponent(depth))) {
                     // Same head - add to tail of current head.
                     children.add(next);
                 } else {
@@ -272,13 +274,7 @@ public class Sched extends SchedV2 {
             int rev = node.getRevCount();
             int _new = node.getNewCount();
             int lrn = node.getLrnCount();
-            for (DeckDueTreeNode c : children) {
-                // set new string to tail
-                String[] newTail = new String[c.getNames().length-1];
-                System.arraycopy(c.getNames(), 1, newTail, 0, c.getNames().length-1);
-                c.setNames(newTail);
-            }
-            children = _groupChildrenMain(children);
+            children = _groupChildrenMain(children, depth + 1);
             // tally up children counts
             for (DeckDueTreeNode ch : children) {
                 rev += ch.getRevCount();

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -251,7 +251,7 @@ public class Sched extends SchedV2 {
         ListIterator<DeckDueTreeNode> it = grps.listIterator();
         while (it.hasNext()) {
             DeckDueTreeNode node = it.next();
-            String head = node.getNamePart(0);
+            String head = node.getDeckNameComponent(0);
             // Compose the "children" node list. The children is a list of all the nodes that proceed
             // the current one that contain the same name[0], except for the current one itself.
             // I.e., they are subdecks that stem from this node.
@@ -259,7 +259,7 @@ public class Sched extends SchedV2 {
             List<DeckDueTreeNode> children  = new ArrayList<>();
             while (it.hasNext()) {
                 DeckDueTreeNode next = it.next();
-                if (head.equals(next.getNamePart(0))) {
+                if (head.equals(next.getDeckNameComponent(0))) {
                     // Same head - add to tail of current head.
                     children.add(next);
                 } else {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -433,7 +433,7 @@ public class SchedV2 extends AbstractSched {
     private List<DeckDueTreeNode> _groupChildren(List<DeckDueTreeNode> grps) {
         // first, split the group names into components
         for (DeckDueTreeNode g : grps) {
-            g.setNames(Decks.path(g.getNamePart(0)));
+            g.setNames(Decks.path(g.getDeckNameComponent(0)));
         }
         // and sort based on those components
         Collections.sort(grps);
@@ -448,11 +448,11 @@ public class SchedV2 extends AbstractSched {
         ListIterator<DeckDueTreeNode> it = grps.listIterator();
         while (it.hasNext()) {
             DeckDueTreeNode node = it.next();
-            String head = node.getNamePart(0);
+            String head = node.getDeckNameComponent(0);
             List<DeckDueTreeNode> children  = new ArrayList<>();
             while (it.hasNext()) {
                 DeckDueTreeNode next = it.next();
-                if (head.equals(next.getNamePart(0))) {
+                if (head.equals(next.getDeckNameComponent(0))) {
                     // Same head - add to tail of current head.
                     children.add(next);
                 } else {


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
The whole story is https://github.com/ankidroid/Anki-Android/pull/6481

The short story of this PR is that `mName` makes NO sens. For a deck "A::B::C", it's value is `{"A::B::C"}`, then `{"A", "B", "C"}` then `{"B", "C"}`, and finally `{"C"}`.

Instead of giving multiple meaning to the same parameter, I just:
* put a variable `mName`, which is final and set to `"A::B::C"`
* put a variable `mSplittedName` which is final and set to `{"A::B::C"}`
* use method with proper name (as suggested in https://github.com/ankidroid/Anki-Android/pull/6522#discussion_r444348710 ) to get the part of the name we want, i.e. last part of the name to display in the deck picker, full name in the card content provider.

## Fixes
* Confusing method `getName` which returns very different result depending on which function created the object
* For a deck of depth `n`, copying its array `n` times
* hopefully, decrease the complexity of https://github.com/ankidroid/Anki-Android/pull/6522 

## Approach
_How does this change address the problem?_

## How Has This Been Tested?

* Running on my phone
* deck tests ensure that the name obtained by col.getDecks().get and the deck name obtained through this object are the same. This is tested with nested decks

