### PR TITLE
NF: _groupChildrenMain simplification

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -252,16 +252,16 @@ public class Sched extends SchedV2 {
         while (it.hasNext()) {
             DeckDueTreeNode node = it.next();
             String head = node.getNamePart(0);
-            // Compose the "tail" node list. The tail is a list of all the nodes that proceed
-            // the current one that contain the same name[0]. I.e., they are subdecks that stem
-            // from this node. This is our version of python's itertools.groupby.
-            List<DeckDueTreeNode> tail  = new ArrayList<>();
-            tail.add(node);
+            // Compose the "children" node list. The children is a list of all the nodes that proceed
+            // the current one that contain the same name[0], except for the current one itself.
+            // I.e., they are subdecks that stem from this node.
+            // This is our version of python's itertools.groupby.
+            List<DeckDueTreeNode> children  = new ArrayList<>();
             while (it.hasNext()) {
                 DeckDueTreeNode next = it.next();
                 if (head.equals(next.getNamePart(0))) {
                     // Same head - add to tail of current head.
-                    tail.add(next);
+                    children.add(next);
                 } else {
                     // We've iterated past this head, so step back in order to use this node as the
                     // head in the next iteration of the outer loop.
@@ -269,25 +269,15 @@ public class Sched extends SchedV2 {
                     break;
                 }
             }
-            Long did = null;
-            int rev = 0;
-            int _new = 0;
-            int lrn = 0;
-            List<DeckDueTreeNode> children = new ArrayList<>();
-            for (DeckDueTreeNode c : tail) {
-                if (c.getNames().length == 1) {
-                    // current node
-                    did = c.getDid();
-                    rev += c.getRevCount();
-                    lrn += c.getLrnCount();
-                    _new += c.getNewCount();
-                } else {
-                    // set new string to tail
-                    String[] newTail = new String[c.getNames().length-1];
-                    System.arraycopy(c.getNames(), 1, newTail, 0, c.getNames().length-1);
-                    c.setNames(newTail);
-                    children.add(c);
-                }
+            int rev = node.getRevCount();
+            int _new = node.getNewCount();
+            int lrn = node.getLrnCount();
+            for (DeckDueTreeNode c : children) {
+                // set new string to tail
+                String[] newTail = new String[c.getNames().length-1];
+                System.arraycopy(c.getNames(), 1, newTail, 0, c.getNames().length-1);
+                c.setNames(newTail);
+                children.add(c);
             }
             children = _groupChildrenMain(children);
             // tally up children counts
@@ -297,13 +287,13 @@ public class Sched extends SchedV2 {
                 _new += ch.getNewCount();
             }
             // limit the counts to the deck's limits
-            JSONObject conf = mCol.getDecks().confForDid(did);
+            JSONObject conf = mCol.getDecks().confForDid(node.getDid());
             if (conf.getInt("dyn") == 0) {
-                JSONObject deck = mCol.getDecks().get(did);
+                JSONObject deck = mCol.getDecks().get(node.getDid());
                 rev = Math.max(0, Math.min(rev, conf.getJSONObject("rev").getInt("perDay") - deck.getJSONArray("revToday").getInt(1)));
                 _new = Math.max(0, Math.min(_new, conf.getJSONObject("new").getInt("perDay") - deck.getJSONArray("newToday").getInt(1)));
             }
-            tree.add(new DeckDueTreeNode(head, did, rev, lrn, _new, children));
+            tree.add(new DeckDueTreeNode(head, node.getDid(), rev, lrn, _new, children));
         }
         return tree;
     }


### PR DESCRIPTION
NF: _groupChildrenMain simplificitation

This use the fact that _groupChildrenMain is called only after the
deck collection is checked, so there is no duplicate and each nested
deck has a parent.

Currently what occurs is that, if you have the list of deck ["A",
"A::B", "A::C", "A::C::D", "E"], the function will first process the
sublist ["A", "A::B", "A::C", "A::C::D"] and then the sublist
["E"] (this is because it looks only as the first component of the
name)

Then, in the first sublist, it will look for the parent "A" and the
children ["A::B", "A::C", "A::C::D"], by looking at which deck has
depth 0... that is useles, because, thanks to the sorting, we know the
parent exists and is the first element of the list. Therefore, I
removing the condition dealing with the first element of the list and
use the fact that I know that it is the first element.

By itself it should be a really really small improvement. However, it
allows to simplify the code and eventually to add great improvement
into it.
