### PR TITLE
Add Crop functionality

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
@@ -70,7 +70,7 @@ public class MultimediaEditFieldActivity extends AnkiActivity
     private static final int REQUEST_AUDIO_PERMISSION = 0;
     private static final int REQUEST_CAMERA_PERMISSION = 1;
 
-    public static final int sImageLimit = 1024 * 1024;
+    public static final int sImageLimit = 1024 * 1024; // 1MB in bytes
 
     private IField mField;
     private IMultimediaEditableNote mNote;
@@ -393,7 +393,7 @@ public class MultimediaEditFieldActivity extends AnkiActivity
         new MaterialDialog.Builder(this)
                 .content(content)
                 .positiveText(R.string.dialog_ok)
-                .negativeText(R.string.dialog_cancel)
+                .negativeText(R.string.dialog_no)
                 .onPositive((dialog, which) -> imageFieldController.requestCrop(uri))
                 .onNegative((dialog, which) -> saveAndExit())
                 .build().show();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
@@ -237,10 +237,7 @@ public class MultimediaEditFieldActivity extends AnkiActivity
 
 
     protected void done() {
-
         mFieldController.onDone();
-
-        Intent resultData = new Intent();
 
         boolean bChangeToText = false;
 
@@ -271,13 +268,7 @@ public class MultimediaEditFieldActivity extends AnkiActivity
         if (bChangeToText) {
             mField = new TextField();
         }
-
-        resultData.putExtra(EXTRA_RESULT_FIELD, mField);
-        resultData.putExtra(EXTRA_RESULT_FIELD_INDEX, mFieldIndex);
-
-        setResult(RESULT_OK, resultData);
-
-        finishWithoutAnimation();
+        saveAndExit();
     }
 
 
@@ -379,6 +370,14 @@ public class MultimediaEditFieldActivity extends AnkiActivity
         recreateEditingUi(ChangeUIRequest.fieldChange(newField));
     }
 
+
+    private void saveAndExit() {
+        Intent resultData = new Intent();
+        resultData.putExtra(EXTRA_RESULT_FIELD, mField);
+        resultData.putExtra(EXTRA_RESULT_FIELD_INDEX, mFieldIndex);
+        setResult(RESULT_OK, resultData);
+        finishWithoutAnimation();
+    }
 
     @Override
     protected void onDestroy() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
@@ -395,18 +395,10 @@ public class MultimediaEditFieldActivity extends AnkiActivity
 
     public void showLargeFileCropDialog(float length) {
         BasicImageFieldController imageFieldController = (BasicImageFieldController) mFieldController;
-        File file = new File(mField.getImagePath());
-        Uri uri = FileProvider.getUriForFile(this, this.getApplicationContext().getPackageName() + ".apkgfileprovider", file);
         DecimalFormat decimalFormat = new DecimalFormat(".00");
         String size = decimalFormat.format(length);
         String content = getString(R.string.save_dialog_content, size);
-        new MaterialDialog.Builder(this)
-                .content(content)
-                .positiveText(R.string.dialog_ok)
-                .negativeText(R.string.dialog_no)
-                .onPositive((dialog, which) -> imageFieldController.requestCrop(uri))
-                .onNegative((dialog, which) -> saveAndExit())
-                .build().show();
+        imageFieldController.showCropDialog(content, (dialog, which) -> saveAndExit());
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
@@ -22,7 +22,6 @@ package com.ichi2.anki.multimediacard.activity;
 import android.Manifest;
 import android.content.Intent;
 import android.content.pm.PackageManager;
-import android.net.Uri;
 import android.os.Bundle;
 
 import androidx.annotation.NonNull;
@@ -34,7 +33,6 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.LinearLayout;
 
-import com.afollestad.materialdialogs.MaterialDialog;
 import com.ichi2.anki.AnkiActivity;
 import com.ichi2.anki.R;
 import com.ichi2.anki.UIUtils;
@@ -54,7 +52,6 @@ import com.ichi2.utils.Permissions;
 import java.io.File;
 import java.text.DecimalFormat;
 
-import androidx.core.content.FileProvider;
 import timber.log.Timber;
 
 public class MultimediaEditFieldActivity extends AnkiActivity
@@ -90,11 +87,11 @@ public class MultimediaEditFieldActivity extends AnkiActivity
 
         Bundle controllerBundle = null;
         if (savedInstanceState != null) {
-            Timber.d("onCreate - saved bundle exists");
+            Timber.i("onCreate - saved bundle exists");
             boolean b = savedInstanceState.getBoolean(BUNDLE_KEY_SHUT_OFF, false);
             controllerBundle = savedInstanceState.getBundle("controllerBundle");
             if (controllerBundle == null && b) {
-                Timber.d("onCreate - saved bundle does has BUNDLE_KEY_SHUT_OFF and no controller bundle, terminating");
+                Timber.i("onCreate - saved bundle has BUNDLE_KEY_SHUT_OFF and no controller bundle, terminating");
                 finishCancel();
                 return;
             }
@@ -184,7 +181,7 @@ public class MultimediaEditFieldActivity extends AnkiActivity
         IFieldController fieldController = controllerFactory.createControllerForField(newUI.getField());
 
         if (fieldController == null) {
-            Timber.d("Field controller creation failed");
+            Timber.w("Field controller creation failed");
             UIRecreationHandler.onControllerCreationFailed(newUI, this);
             return;
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
@@ -20,7 +20,6 @@
 
 package com.ichi2.anki.multimediacard.fields;
 
-import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.ClipData;
 import android.content.ContentUris;
@@ -110,11 +109,11 @@ public class BasicImageFieldController extends FieldControllerBase implements IF
 
     public void loadInstanceState(Bundle savedInstanceState) {
         if (savedInstanceState == null) {
-            Timber.d("loadInstanceState but null so nothing to load");
+            Timber.i("loadInstanceState but null so nothing to load");
             return;
         }
 
-        Timber.d("loadInstanceState loading saved state...");
+        Timber.i("loadInstanceState loading saved state...");
         mImagePath = savedInstanceState.getString("mImagePath");
         mImageUri = savedInstanceState.getParcelable("mImageUri");
         mPreviousImagePath = savedInstanceState.getString("mPreviousImagePath");
@@ -131,8 +130,6 @@ public class BasicImageFieldController extends FieldControllerBase implements IF
         return savedInstanceState;
     }
 
-    // The NewApi deprecation should be removed with API21
-    @SuppressLint("NewApi")
     @Override
     public void createUI(Context context, LinearLayout layout) {
         Timber.d("createUI()");
@@ -252,7 +249,6 @@ public class BasicImageFieldController extends FieldControllerBase implements IF
     }
 
 
-    @SuppressLint("NewApi") //Conditionally called anything which requires API 16+.
     private void drawUIComponents(Context context) {
         mImagePreview = new ImageView(mActivity);
 
@@ -422,7 +418,7 @@ public class BasicImageFieldController extends FieldControllerBase implements IF
             try {
                 inputStream = mActivity.getContentResolver().openInputStream(uri);
             } catch (Exception e) {
-                Timber.i(e, "internalizeUri() unable to open input stream from content resolver for Uri %s", uri);
+                Timber.w(e, "internalizeUri() unable to open input stream from content resolver for Uri %s", uri);
                 showSomethingWentWrong();
                 return null;
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
@@ -440,7 +440,7 @@ public class BasicImageFieldController extends FieldControllerBase implements IF
         rotateAndCompress();
         mField.setImagePath(mImagePath);
         mField.setHasTemporaryMedia(true);
-        showCropDialog(getUriForFile(new File(mImagePath)));
+        showCropDialog(mActivity.getString(R.string.crop_image), null);
     }
 
 
@@ -501,17 +501,23 @@ public class BasicImageFieldController extends FieldControllerBase implements IF
     }
 
 
-    private void showCropDialog(Uri uri) {
-        if (uri == null) {
-            Timber.w("showCropDialog called with null URI");
+    public void showCropDialog(String content, @Nullable MaterialDialog.SingleButtonCallback negativeCallBack) {
+        if (mImagePath == null || mImageUri == null) {
+            Timber.w("showCropDialog called with null URI or Path");
             return;
         }
-        new MaterialDialog.Builder(mActivity)
-                .content(R.string.crop_image)
+
+        MaterialDialog.Builder builder = new MaterialDialog.Builder(mActivity)
+                .content(content)
                 .positiveText(R.string.dialog_ok)
                 .negativeText(R.string.dialog_no)
-                .onPositive((dialog, which) -> requestCrop(uri))
-                .build().show();
+                .onPositive((dialog, which) -> requestCrop());
+
+        if (negativeCallBack != null) {
+            builder.onNegative(negativeCallBack);
+        }
+
+        builder.build().show();
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
@@ -169,7 +169,8 @@ public class BasicImageFieldController extends FieldControllerBase implements IF
         Button mBtnGallery = new Button(mActivity);
         mBtnGallery.setText(gtxt(R.string.multimedia_editor_image_field_editing_galery));
         mBtnGallery.setOnClickListener(v -> {
-            Intent i = new Intent(Intent.ACTION_PICK, MediaStore.Images.Media.EXTERNAL_CONTENT_URI);
+            Intent i = new Intent(Intent.ACTION_PICK);
+            i.setDataAndType(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, "image/*");
             mActivity.startActivityForResultWithoutAnimation(i, ACTIVITY_SELECT_IMAGE);
         });
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
@@ -248,7 +248,7 @@ public class BasicImageFieldController extends FieldControllerBase implements IF
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
         Timber.d("onActivityResult()");
-        if (resultCode == Activity.RESULT_CANCELED) {
+        if (resultCode != Activity.RESULT_OK) {
             Timber.d("Activity was cancelled");
             // Restore the old version of the image if the user cancelled
             switch (requestCode) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
@@ -320,7 +320,7 @@ public class BasicImageFieldController extends FieldControllerBase implements IF
             }
 
             // Some apps send this back with app-specific data, direct the user to another app
-            if (resultCode == Activity.RESULT_FIRST_USER) {
+            if (resultCode >= Activity.RESULT_FIRST_USER) {
                 UIUtils.showThemedToast(mActivity, mActivity.getString(R.string.activity_result_unexpected), true);
             }
             return;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
@@ -313,7 +313,10 @@ public class BasicImageFieldController extends FieldControllerBase implements IF
                 case ACTIVITY_CROP_PICTURE:
                     if (!TextUtils.isEmpty(mPreviousImagePath)) {
                         mImagePath = mPreviousImagePath;
+                        mField.setImagePath(mImagePath);
                         mImageUri = mPreviousImageUri;
+                        mPreviousImagePath = null;
+                        mPreviousImageUri = null;
                     }
                     break;
                 default:

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
@@ -276,7 +276,7 @@ public class BasicImageFieldController extends FieldControllerBase implements IF
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
         Timber.d("onActivityResult()");
         if (resultCode != Activity.RESULT_OK) {
-            Timber.d("Activity was cancelled");
+            Timber.d("Activity was not successful");
             // Restore the old version of the image if the user cancelled
             switch (requestCode) {
                 case ACTIVITY_TAKE_PICTURE:
@@ -288,6 +288,11 @@ public class BasicImageFieldController extends FieldControllerBase implements IF
                     break;
                 default:
                     break;
+            }
+
+            // Some apps send this back with app-specific data, direct the user to another app
+            if (resultCode == Activity.RESULT_FIRST_USER) {
+                UIUtils.showThemedToast(mActivity, mActivity.getString(R.string.activity_result_unexpected), true);
             }
             return;
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
@@ -91,8 +91,8 @@ public class BasicImageFieldController extends FieldControllerBase implements IF
         return (int) Math.min(height * 0.4, width * 0.6);
     }
 
-    // The NewApi deprecation should be removed with API21. UnsupportedChromeOsCameraSystemFeature can be fixed in API16
-    @SuppressLint( {"UnsupportedChromeOsCameraSystemFeature", "NewApi"})
+    // The NewApi deprecation should be removed with API21
+    @SuppressLint("NewApi")
     @Override
     public void createUI(Context context, LinearLayout layout) {
         LinearLayout.LayoutParams p = new LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
@@ -127,7 +127,7 @@ public class BasicImageFieldController extends FieldControllerBase implements IF
                 cameraIntent.putExtra(MediaStore.EXTRA_OUTPUT, uriSavedImage);
 
                 // Until Android API21 (maybe 22) you must manually handle permissions for image capture w/FileProvider
-                // It does not exist on API15 so they will still crash sadly. This can be removed once minSDK is >= 22
+                // This can be removed once minSDK is >= 22
                 // https://medium.com/@quiro91/sharing-files-through-intents-part-2-fixing-the-permissions-before-lollipop-ceb9bb0eec3a
                 if (CompatHelper.getSdkVersion() <= Build.VERSION_CODES.LOLLIPOP) {
                     cameraIntent.setClipData(ClipData.newRawUri("", uriSavedImage));

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
@@ -33,6 +33,7 @@ import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.net.Uri;
 import android.os.Build;
+import android.os.Bundle;
 import android.provider.MediaStore;
 
 import androidx.annotation.Nullable;
@@ -103,6 +104,32 @@ public class BasicImageFieldController extends FieldControllerBase implements IF
         int width = metrics.widthPixels;
 
         return (int) Math.min(height * 0.4, width * 0.6);
+    }
+
+    public void loadInstanceState(Bundle savedInstanceState) {
+        if (savedInstanceState == null) {
+            Timber.d("loadInstanceState but null so nothing to load");
+            return;
+        }
+
+        Timber.d("loadInstanceState loading saved state...");
+        mImagePath = savedInstanceState.getString("mImagePath");
+        mPreviousImagePath = savedInstanceState.getString("mPreviousImagePath");
+
+        if (mImagePath != null) {
+            mImageUri = getUriForFile(new File(mImagePath));
+        }
+        if (mPreviousImagePath != null) {
+            mPreviousImageUri = getUriForFile(new File(mPreviousImagePath));
+        }
+    }
+
+    public Bundle saveInstanceState() {
+        Timber.d("saveInstanceState");
+        Bundle savedInstanceState = new Bundle();
+        savedInstanceState.putString("mImagePath", mImagePath);
+        savedInstanceState.putString("mPreviousImagePath", mPreviousImagePath);
+        return savedInstanceState;
     }
 
     // The NewApi deprecation should be removed with API21

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
@@ -627,7 +627,7 @@ public class BasicImageFieldController extends FieldControllerBase implements IF
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             uri = FileProvider.getUriForFile(mActivity, mActivity.getApplicationContext().getPackageName() + ".apkgfileprovider", file);
         } else {
-            uri = getUriForFile(file);
+            uri = Uri.fromFile(file);
         }
         return uri;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/FieldControllerBase.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/FieldControllerBase.java
@@ -19,8 +19,12 @@
 
 package com.ichi2.anki.multimediacard.fields;
 
+import android.os.Bundle;
+
 import com.ichi2.anki.multimediacard.IMultimediaEditableNote;
 import com.ichi2.anki.multimediacard.activity.MultimediaEditFieldActivity;
+
+import androidx.annotation.Nullable;
 
 public abstract class FieldControllerBase implements IFieldController {
 
@@ -53,4 +57,14 @@ public abstract class FieldControllerBase implements IFieldController {
         mActivity = activity;
     };
 
+
+    @Override
+    public void loadInstanceState(Bundle savedInstancedState) { /* Default implementation does nothing */ }
+
+
+    @Override
+    @Nullable
+    public Bundle saveInstanceState() {
+        return null;
+    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/IFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/IFieldController.java
@@ -21,13 +21,14 @@ package com.ichi2.anki.multimediacard.fields;
 
 import android.content.Context;
 import android.content.Intent;
+import android.os.Bundle;
 import android.widget.LinearLayout;
 
 import com.ichi2.anki.multimediacard.IMultimediaEditableNote;
 import com.ichi2.anki.multimediacard.activity.MultimediaEditFieldActivity;
 
 /**
- * A not in anki has fields. Each of the fields can be edited.
+ * A note in anki has fields. Each of the fields can be edited.
  * <p>
  * A controller is about to decide, which UI elements have to be on the activity and what has to be done there to edit a
  * field.
@@ -52,6 +53,14 @@ public interface IFieldController {
 
     // Called before other
     void setEditingActivity(MultimediaEditFieldActivity activity);
+
+
+    // Called after setting field/note/index/activity, allows state persistence across Activity restarts
+    void loadInstanceState(Bundle savedInstanceState);
+
+
+    // Called during editing Activity pause, allows state persistence across Activity restarts
+    Bundle saveInstanceState();
 
 
     // Layout is vertical inside a scroll view already

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV26.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV26.java
@@ -7,6 +7,7 @@ import android.content.Context;
 import android.os.VibrationEffect;
 import android.os.Vibrator;
 
+import androidx.annotation.NonNull;
 import androidx.core.app.NotificationCompat;
 
 import java.io.IOException;
@@ -53,17 +54,17 @@ public class CompatV26 extends CompatV24 implements Compat {
     }
 
     @Override
-    public void copyFile(String source, String target) throws IOException {
+    public void copyFile(@NonNull String source, @NonNull String target) throws IOException {
         Files.copy(Paths.get(source), Paths.get(target), StandardCopyOption.REPLACE_EXISTING);
     }
 
     @Override
-    public long copyFile(String source, OutputStream target) throws IOException {
+    public long copyFile(@NonNull String source, @NonNull OutputStream target) throws IOException {
         return Files.copy(Paths.get(source), target);
     }
 
     @Override
-    public long copyFile(InputStream source, String target) throws IOException {
+    public long copyFile(@NonNull InputStream source, @NonNull String target) throws IOException {
         return Files.copy(source, Paths.get(target), StandardCopyOption.REPLACE_EXISTING);
     }
 }

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -104,6 +104,7 @@
 
     <string name="dialog_cancel">Cancel</string>
     <string name="dialog_ok">OK</string>
+    <string name="dialog_no">No</string>
     <string name="dialog_continue">Continue</string>
     <string name="dialog_positive_create">Create</string>
     <string name="dialog_positive_delete">Delete</string>

--- a/AnkiDroid/src/main/res/values/16-multimedia-editor.xml
+++ b/AnkiDroid/src/main/res/values/16-multimedia-editor.xml
@@ -114,9 +114,9 @@
 	<string name="network_no_connection">No connection</string>
 
     <!-- Crop function-->
-    <string name="crop_image" translatable="false">Do you want to crop this image?</string>
-    <string name="crop_button" translatable="false">Crop image</string>
-    <string name="save_dialog_content" translatable="false">Current image size is %sMB. Default image size limit is 1MB. Do you want to crop it?</string>
-    <string name="select_image_failed" translatable="false">"Select image failed, Please retry"</string>
+    <string name="crop_image">Do you want to crop this image?</string>
+    <string name="crop_button">Crop image</string>
+    <string name="save_dialog_content">Current image size is %sMB. Default image size limit is 1MB. Do you want to crop it?</string>
+    <string name="select_image_failed">"Select image failed, Please retry"</string>
 
 </resources>

--- a/AnkiDroid/src/main/res/values/16-multimedia-editor.xml
+++ b/AnkiDroid/src/main/res/values/16-multimedia-editor.xml
@@ -118,5 +118,6 @@
     <string name="crop_button">Crop image</string>
     <string name="save_dialog_content">Current image size is %sMB. Default image size limit is 1MB. Do you want to crop it?</string>
     <string name="select_image_failed">"Select image failed, Please retry"</string>
+    <string name="activity_result_unexpected">App returned an unexpected value. You may need to use a different app</string>
 
 </resources>

--- a/AnkiDroid/src/main/res/values/16-multimedia-editor.xml
+++ b/AnkiDroid/src/main/res/values/16-multimedia-editor.xml
@@ -112,4 +112,11 @@
 
 	<!-- Network failure -->
 	<string name="network_no_connection">No connection</string>
+
+    <!-- Crop function-->
+    <string name="crop_image" translatable="false">Do you want to crop this image?</string>
+    <string name="crop_button" translatable="false">Crop image</string>
+    <string name="save_dialog_content" translatable="false">Current image size is %sMB. Default image size limit is 1MB. Do you want to crop it?</string>
+    <string name="select_image_failed" translatable="false">"Select image failed, Please retry"</string>
+
 </resources>

--- a/AnkiDroid/src/main/res/xml/filepaths.xml
+++ b/AnkiDroid/src/main/res/xml/filepaths.xml
@@ -2,4 +2,5 @@
 <paths>
     <external-cache-path path="export/" name="export-directory" />
     <cache-path path="/" name="cache-directory" />
+    <external-path path="." name="photos" />
 </paths>

--- a/AnkiDroid/src/main/res/xml/filepaths.xml
+++ b/AnkiDroid/src/main/res/xml/filepaths.xml
@@ -3,4 +3,5 @@
     <external-cache-path path="export/" name="export-directory" />
     <cache-path path="/" name="cache-directory" />
     <external-path path="." name="photos" />
+    <external-cache-path name="temp-photos" path="temp-photos" />
 </paths>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldControllerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldControllerTest.java
@@ -102,9 +102,9 @@ public class BasicImageFieldControllerTest extends MultimediaEditFieldActivityTe
         return new ImageField();
     }
 
-    private static IField imageFieldWithData() {
+    private IField imageFieldWithData() {
         IField field = emptyImageField();
-        field.setImagePath("test");
+        field.setImagePath(getTargetContext().getExternalCacheDir() + "/temp-photos/test");
         return field;
     }
 }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

There was no way to crop images previously, but cameras especially are generating very large images these days

This allows the advanced editor's image field component to crop images, and prompts users to do so for photos or if the image is large

This is entirely based on the work from @NightXlt - everything about how to do the Intent correctly, to the URI / File path conversion is their work

I took the PR contents of #5301 and re-factored them to fit better with the work done since @NightXlt originally submitted the work, then I tested, tested, and tested some more with little fixes related to preview handling and button visibility added in.

Finally, I deconstructed the work into chunks as small as I could so review would be easier.

**Please understand the commit separation was done after the fact and there may be a couple cross-dependencies still present in the commit**. The separate commits are for easier review but I make no guarantee they will function separately, testing has only been performed with the complete work


## Fixes
Fixes #2554 
Obsoletes #5301 

## Approach

The basic idea is to 

- handle the path internally with a path backup
- add the general ability to create temporary files
- add the general ability to generate URIs for our cache files
- add the general ability to translate between URIs and Paths
- ask the system to crop when we want, with a URI to a new internal file for the result



## How Has This Been Tested?

API16, 18, 24, 29, 30 emulators

The scenarios I ran are:

- add note, paperclip, add image, gallery, verify preview, choose crop, do the crop, verify preview, save, note editor preview
- same as above but camera
- save note, view note verify images

Note that after adding images but before you save the note, the field has data and the paperclip menu behaves differently than if you were editing a note and it had data because the paperclip menu listener hasn't re-been rebound. This is an existing bug and not addressed here

Same as above but with an existing note with image data:
- edit note (with image data), paperclip (opens advanced image editor w/preview), crop, do crop+return, verify image, save, preview from note editor, verify image, return and save note, view note and verify images


## Learning (optional, can help others)

Of interest from this PR:

Attempting to implement an "EDIT" intent vs stricly crop is better but fails in mysterious ways, especially with API30

API30 in general may require more testing

Of interest that existed prior to the PR and still exist:

The advanced editor is rough to deal with, it's pretty fluffy with regard to number of objects and how control passes around

The paperclip menu behaves inconsistently right now based on whether the note had data in the field to start or was empty. If empty to start it will show a popup menu, if it had data to start it sends you right to the advanced editor.

The advanced editor doesn't handle the case of multiple things in the same a field very well.

The advanced editor doesn't handle the case of editing a multimedia field very well (it just keeps appending the edits) but at least with preview from note editor this is easy to fix



## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
