### PR TITLE
NF: _groupChildrenMain simplificitation

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.java
@@ -88,6 +88,7 @@ public class ContentProviderTest {
             "pdsqoelhmemmmbwjunnu",
             "scxipjiyozczaaczoawo",
             "cmxieunwoogyxsctnjmv::abcdefgh::ZYXW",
+            "cmxieunwoogyxsctnjmv::INSBGDS",
     };
     private static final String TEST_MODEL_NAME = "com.ichi2.anki.provider.test.a1x6h9l";
     private static final String[] TEST_MODEL_FIELDS = {"FRONTS","BACK"};

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -252,16 +252,16 @@ public class Sched extends SchedV2 {
         while (it.hasNext()) {
             DeckDueTreeNode node = it.next();
             String head = node.getNamePart(0);
-            // Compose the "tail" node list. The tail is a list of all the nodes that proceed
-            // the current one that contain the same name[0]. I.e., they are subdecks that stem
-            // from this node. This is our version of python's itertools.groupby.
-            List<DeckDueTreeNode> tail  = new ArrayList<>();
-            tail.add(node);
+            // Compose the "children" node list. The children is a list of all the nodes that proceed
+            // the current one that contain the same name[0], except for the current one itself.
+            // I.e., they are subdecks that stem from this node.
+            // This is our version of python's itertools.groupby.
+            List<DeckDueTreeNode> children  = new ArrayList<>();
             while (it.hasNext()) {
                 DeckDueTreeNode next = it.next();
                 if (head.equals(next.getNamePart(0))) {
                     // Same head - add to tail of current head.
-                    tail.add(next);
+                    children.add(next);
                 } else {
                     // We've iterated past this head, so step back in order to use this node as the
                     // head in the next iteration of the outer loop.
@@ -269,25 +269,14 @@ public class Sched extends SchedV2 {
                     break;
                 }
             }
-            Long did = null;
-            int rev = 0;
-            int _new = 0;
-            int lrn = 0;
-            List<DeckDueTreeNode> children = new ArrayList<>();
-            for (DeckDueTreeNode c : tail) {
-                if (c.getNames().length == 1) {
-                    // current node
-                    did = c.getDid();
-                    rev += c.getRevCount();
-                    lrn += c.getLrnCount();
-                    _new += c.getNewCount();
-                } else {
-                    // set new string to tail
-                    String[] newTail = new String[c.getNames().length-1];
-                    System.arraycopy(c.getNames(), 1, newTail, 0, c.getNames().length-1);
-                    c.setNames(newTail);
-                    children.add(c);
-                }
+            int rev = node.getRevCount();
+            int _new = node.getNewCount();
+            int lrn = node.getLrnCount();
+            for (DeckDueTreeNode c : children) {
+                // set new string to tail
+                String[] newTail = new String[c.getNames().length-1];
+                System.arraycopy(c.getNames(), 1, newTail, 0, c.getNames().length-1);
+                c.setNames(newTail);
             }
             children = _groupChildrenMain(children);
             // tally up children counts
@@ -297,13 +286,13 @@ public class Sched extends SchedV2 {
                 _new += ch.getNewCount();
             }
             // limit the counts to the deck's limits
-            JSONObject conf = mCol.getDecks().confForDid(did);
+            JSONObject conf = mCol.getDecks().confForDid(node.getDid());
             if (conf.getInt("dyn") == 0) {
-                JSONObject deck = mCol.getDecks().get(did);
+                JSONObject deck = mCol.getDecks().get(node.getDid());
                 rev = Math.max(0, Math.min(rev, conf.getJSONObject("rev").getInt("perDay") - deck.getJSONArray("revToday").getInt(1)));
                 _new = Math.max(0, Math.min(_new, conf.getJSONObject("new").getInt("perDay") - deck.getJSONArray("newToday").getInt(1)));
             }
-            tree.add(new DeckDueTreeNode(head, did, rev, lrn, _new, children));
+            tree.add(new DeckDueTreeNode(head, node.getDid(), rev, lrn, _new, children));
         }
         return tree;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -449,16 +449,12 @@ public class SchedV2 extends AbstractSched {
         while (it.hasNext()) {
             DeckDueTreeNode node = it.next();
             String head = node.getNamePart(0);
-            // Compose the "tail" node list. The tail is a list of all the nodes that proceed
-            // the current one that contain the same name[0]. I.e., they are subdecks that stem
-            // from this node. This is our version of python's itertools.groupby.
-            List<DeckDueTreeNode> tail  = new ArrayList<>();
-            tail.add(node);
+            List<DeckDueTreeNode> children  = new ArrayList<>();
             while (it.hasNext()) {
                 DeckDueTreeNode next = it.next();
                 if (head.equals(next.getNamePart(0))) {
                     // Same head - add to tail of current head.
-                    tail.add(next);
+                    children.add(next);
                 } else {
                     // We've iterated past this head, so step back in order to use this node as the
                     // head in the next iteration of the outer loop.
@@ -466,25 +462,14 @@ public class SchedV2 extends AbstractSched {
                     break;
                 }
             }
-            Long did = null;
-            int rev = 0;
-            int _new = 0;
-            int lrn = 0;
-            List<DeckDueTreeNode> children = new ArrayList<>();
-            for (DeckDueTreeNode c : tail) {
-                if (c.getNames().length == 1) {
-                    // current node
-                    did = c.getDid();
-                    rev += c.getRevCount();
-                    lrn += c.getLrnCount();
-                    _new += c.getNewCount();
-                } else {
-                    // set new string to tail
-                    String[] newTail = new String[c.getNames().length-1];
-                    System.arraycopy(c.getNames(), 1, newTail, 0, c.getNames().length-1);
-                    c.setNames(newTail);
-                    children.add(c);
-                }
+            int rev = node.getRevCount();
+            int _new = node.getNewCount();
+            int lrn = node.getLrnCount();
+            for (DeckDueTreeNode c : children) {
+                // set new string to tail
+                String[] newTail = new String[c.getNames().length-1];
+                System.arraycopy(c.getNames(), 1, newTail, 0, c.getNames().length-1);
+                c.setNames(newTail);
             }
             children = _groupChildrenMain(children);
             // tally up children counts
@@ -493,12 +478,12 @@ public class SchedV2 extends AbstractSched {
                 _new += ch.getNewCount();
             }
             // limit the counts to the deck's limits
-            JSONObject conf = mCol.getDecks().confForDid(did);
+            JSONObject conf = mCol.getDecks().confForDid(node.getDid());
             if (conf.getInt("dyn") == 0) {
-                JSONObject deck = mCol.getDecks().get(did);
+                JSONObject deck = mCol.getDecks().get(node.getDid());
                 _new = Math.max(0, Math.min(_new, conf.getJSONObject("new").getInt("perDay") - deck.getJSONArray("newToday").getInt(1)));
             }
-            tree.add(new DeckDueTreeNode(head, did, rev, lrn, _new, children));
+            tree.add(new DeckDueTreeNode(head, node.getDid(), rev, lrn, _new, children));
         }
         return tree;
     }


### PR DESCRIPTION
# What differs from last PR: 

I added a test which should have detected this bug (by having multiple children of a deck at the same depth)

Previously, `tail` contained both "A" and all of its descendants. Then `tail` was used to compute `children` which contains all descendants of "A" but not "A" itself. I've changed it so that we directly compute "children". What I forgot to cherry pick in the previous PR is : stop adding elements to "children" when it is already constructed. Now, it is done, I removed the line which iterated over children and added its elements to children.

I would like to note that this bug did not occur in the big PR, because this line was removed in another commit. My main problem here was simply that my PR could not be as easily cut in multiple independant sub PR as what I thought. 

# Copy of the last explanation, as in https://github.com/ankidroid/Anki-Android/pull/6539



This use the fact that _groupChildrenMain is called only after the
deck collection is checked, so there is no duplicate and each nested
deck has a parent.

Currently what occurs is that, if you have the list of deck ["A",
"A::B", "A::C", "A::C::D", "E"], the function will first process the
sublist ["A", "A::B", "A::C", "A::C::D"] and then the sublist
["E"] (this is because it looks only as the first component of the
name)

Then, in the first sublist, it will look for the parent "A" and the
children ["A::B", "A::C", "A::C::D"], by looking at which deck has
depth 0... that is useles, because, thanks to the sorting, we know the
parent exists and is the first element of the list. Therefore, I
removing the condition dealing with the first element of the list and
use the fact that I know that it is the first element.

By itself it should be a really really small improvement. However, it
allows to simplify the code and eventually to add great improvement
into it.
