### PR TITLE
Mutate Drawables before mutating alpha

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -521,7 +521,7 @@ public class Reviewer extends AbstractFlashcardViewer {
         }
         int alpha = (undoEnabled && getControlBlocked() != ReviewerUi.ControlBlock.SLOW) ? Themes.ALPHA_ICON_ENABLED_LIGHT : Themes.ALPHA_ICON_DISABLED_LIGHT ;
         menu.findItem(R.id.action_undo).setIcon(undoIcon);
-        menu.findItem(R.id.action_undo).setEnabled(undoEnabled).getIcon().setAlpha(alpha);
+        menu.findItem(R.id.action_undo).setEnabled(undoEnabled).getIcon().mutate().setAlpha(alpha);
 
         // White board button
         if (mPrefWhiteboard) {
@@ -534,7 +534,7 @@ public class Reviewer extends AbstractFlashcardViewer {
                 menu.findItem(R.id.action_clear_whiteboard).setVisible(true);
             }
 
-            Drawable whiteboardIcon = ContextCompat.getDrawable(this, R.drawable.ic_gesture_white_24dp);
+            Drawable whiteboardIcon = ContextCompat.getDrawable(this, R.drawable.ic_gesture_white_24dp).mutate();
             if (mShowWhiteboard) {
                 whiteboardIcon.setAlpha(255);
                 menu.findItem(R.id.action_hide_whiteboard).setIcon(whiteboardIcon);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -536,11 +536,11 @@ public class Reviewer extends AbstractFlashcardViewer {
 
             Drawable whiteboardIcon = ContextCompat.getDrawable(this, R.drawable.ic_gesture_white_24dp).mutate();
             if (mShowWhiteboard) {
-                whiteboardIcon.setAlpha(255);
+                whiteboardIcon.setAlpha(Themes.ALPHA_ICON_ENABLED_LIGHT);
                 menu.findItem(R.id.action_hide_whiteboard).setIcon(whiteboardIcon);
                 menu.findItem(R.id.action_hide_whiteboard).setTitle(R.string.hide_whiteboard);
             } else {
-                whiteboardIcon.setAlpha(77);
+                whiteboardIcon.setAlpha(Themes.ALPHA_ICON_DISABLED_LIGHT);
                 menu.findItem(R.id.action_hide_whiteboard).setIcon(whiteboardIcon);
                 menu.findItem(R.id.action_hide_whiteboard).setTitle(R.string.show_whiteboard);
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtonStatus.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtonStatus.java
@@ -87,10 +87,11 @@ public class ActionButtonStatus {
                     color only if the buttons are blocked and we
                     expect the next card to take time to arrive.
                     */
+                    Drawable mutableIcon = icon.mutate();
                     if (mReviewerUi.getControlBlocked() == ReviewerUi.ControlBlock.SLOW) {
-                        icon.setAlpha(Themes.ALPHA_ICON_DISABLED_LIGHT);
+                        mutableIcon.setAlpha(Themes.ALPHA_ICON_DISABLED_LIGHT);
                     } else {
-                        icon.setAlpha(Themes.ALPHA_ICON_ENABLED_LIGHT);
+                        mutableIcon.setAlpha(Themes.ALPHA_ICON_ENABLED_LIGHT);
                     }
                 }
             } else {


### PR DESCRIPTION
## Purpose / Description

Drawables from a shared source share "constant state". One mutation to an icon will mutate all other uses of the icon.

This means any other uses of undo may obtain a disabled alpha level.

Discovered in the Visual Editor - Alpha values of the undo icon were saved from the card viewer.

## Approach
call `.mutate()`

## How Has This Been Tested?

On my phone - alpha levels are no longer copied.

## Learning (optional, can help others)

http://web.archive.org/web/20100302003802/http://www.curious-creature.org/2009/05/02/drawable-mutations/

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code