### PR TITLE
Carefully install JDKs, sensitive to transient failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,8 @@ env:
     - ANDROID_TOOLS_URL="https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip"
     - EMU_FLAVOR=default # use google_apis flavor if no default flavor emulator
     - LOCALE="NONE"
-    - GRAVIS="https://raw.githubusercontent.com/DanySK/Gravis-CI/master/"
+    - GRAVIS_REPO="https://github.com/DanySK/Gravis-CI.git"
+    - GRAVIS="$HOME/gravis"
     - JDK="1.8"
     - TOOLS=${ANDROID_HOME}/tools
     # PATH order is incredibly important. e.g. the 'emulator' script exists in more than one place!
@@ -86,10 +87,10 @@ before_install:
   # It should not make assumptions about os platform or desired tool installation
 
   # Set up JDK 8 for Android SDK - Java is universally needed: codacy, unit tests, emulators
-  - travis_retry curl "${GRAVIS}.install-jdk-travis.sh" --output ~/.install-jdk-travis.sh
+  - travis_retry git clone --depth 1 $GRAVIS_REPO $GRAVIS
   - export TARGET_JDK="${JDK}"
   - JDK="1.8"
-  - source ~/.install-jdk-travis.sh
+  - source $GRAVIS/install-jdk
 
   # Set up Android SDK - this is needed everywhere but coverage finalization, so toggle on that
   - if [ "$FINALIZE_COVERAGE" = "FALSE" ]; then travis_retry wget -q "${ANDROID_TOOLS_URL}" -O android-sdk-tools.zip; fi
@@ -135,7 +136,7 @@ install:
 
   # Switch back to our target JDK version to build and run tests
   - JDK="${TARGET_JDK}"
-  - source ~/.install-jdk-travis.sh
+  - source $GRAVIS/install-jdk
 
 script:
   - travis_retry ./gradlew :AnkiDroid:compileReleaseJavaWithJavac compileLint # warm gradle w/travis_retry to handle network blips
@@ -148,8 +149,7 @@ after_success:
 
 before_cache:
   - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
-  - curl "${GRAVIS}.clean_gradle_cache.sh" --output ~/.clean_gradle_cache.sh
-  - bash ~/.clean_gradle_cache.sh > /dev/null
+  - $GRAVIS/clean-gradle-cache
 
 cache:
   directories:


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Travis CI continues to have flakiness issues and the JDK install is one of the largest sources of failure

This takes the JDK install process and extracts it to a script that is a lot more patient about retrying the install


## Fixes
Related to #5605 and #6186 


## Approach
travis_retry could not wrap the JDK install for various reasons so this is a custom script to implement retry logic and exponential backup for the JDK install

## How Has This Been Tested?
On my own travis instance, I built the script slowly such that basically every failure mode was tested while constructing - all the retries etc. Seems to work? Definitely works on the happy path right now which is as good as current at least, and if it has errors in the failure mode handling we can get them over time

## Learning (optional, can help others)

The Android Studio shellcheck extension is a nice aide when writing bash scripts

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
