### PR TITLE
Dependency updates 20200625

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -219,7 +219,7 @@ dependencies {
     implementation "androidx.multidex:multidex:2.0.1"
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
     implementation 'androidx.sqlite:sqlite-framework:2.1.0'
-    implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.0.0'
+    implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     implementation 'androidx.viewpager2:viewpager2:1.0.0'
     implementation 'io.requery:sqlite-android:3.31.0'
     implementation 'com.afollestad.material-dialogs:core:0.9.6.0'


### PR DESCRIPTION
Bumps swiperefreshlayout from 1.0.0 to 1.1.0.

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>
