### PR TITLE
Use fork of Gravis-CI to test resilient features

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
     - ANDROID_TOOLS_URL="https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip"
     - EMU_FLAVOR=default # use google_apis flavor if no default flavor emulator
     - LOCALE="NONE"
-    - GRAVIS_REPO="https://github.com/DanySK/Gravis-CI.git"
+    - GRAVIS_REPO="https://github.com/mikehardy/Gravis-CI.git"
     - GRAVIS="$HOME/gravis"
     - JDK="1.8"
     - TOOLS=${ANDROID_HOME}/tools
@@ -87,7 +87,7 @@ before_install:
   # It should not make assumptions about os platform or desired tool installation
 
   # Set up JDK 8 for Android SDK - Java is universally needed: codacy, unit tests, emulators
-  - travis_retry git clone --depth 1 $GRAVIS_REPO $GRAVIS
+  - travis_retry git clone --single-branch --branch resilience --depth 1 $GRAVIS_REPO $GRAVIS
   - export TARGET_JDK="${JDK}"
   - JDK="1.8"
   - source $GRAVIS/install-jdk


### PR DESCRIPTION
This may be reverted if/when the upstream PR is merged:
https://github.com/DanySK/Gravis-CI/pull/16

We are still seeing lots of transient CI failures

https://travis-ci.org/github/ankidroid/Anki-Android/builds/702330392

I was in the area so I got to work in the upstream repo to make it more resilient
- prefix all Gravis-CI echos so we can tell what's going on
- re-use local resources (jabba.sh install, installed JDK) where ever possible
- hit github softer with curl via bigger initial retry delay
- use github's CDN URLs

It's my guess based on jabba being our predominant failure mode that since these changes cut jabba's remote resource usage down from 5 to 3 in most cases and 4 remote calls only on our allow-failure cases that it decreases our transient failures by 2/5ths at least and more if the curl retry softening and CDN usage helps the other 3/5ths