### PR TITLE
Factorize main children

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
@@ -295,6 +295,10 @@ public abstract class AbstractSched {
         public boolean hasChildren() {
             return !mChildren.isEmpty();
         }
+
+        public void setChildren(List<DeckDueTreeNode> children) {
+            mChildren = children;
+        }
     }
 
     public interface LimitMethod {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -274,9 +274,10 @@ public class Sched extends SchedV2 {
             int rev = node.getRevCount();
             int _new = node.getNewCount();
             int lrn = node.getLrnCount();
-            children = _groupChildrenMain(children, depth + 1);
+            // the children set contains direct children but not the children of children...
+            node.setChildren(_groupChildrenMain(children, depth + 1));
             // tally up children counts
-            for (DeckDueTreeNode ch : children) {
+            for (DeckDueTreeNode ch : node.getChildren()) {
                 rev += ch.getRevCount();
                 lrn += ch.getLrnCount();
                 _new += ch.getNewCount();

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -271,25 +271,9 @@ public class Sched extends SchedV2 {
                     break;
                 }
             }
-            int rev = node.getRevCount();
-            int _new = node.getNewCount();
-            int lrn = node.getLrnCount();
             // the children set contains direct children but not the children of children...
-            node.setChildren(_groupChildrenMain(children, depth + 1));
-            // tally up children counts
-            for (DeckDueTreeNode ch : node.getChildren()) {
-                rev += ch.getRevCount();
-                lrn += ch.getLrnCount();
-                _new += ch.getNewCount();
-            }
-            // limit the counts to the deck's limits
-            JSONObject conf = mCol.getDecks().confForDid(node.getDid());
-            if (conf.getInt("dyn") == 0) {
-                JSONObject deck = mCol.getDecks().get(node.getDid());
-                rev = Math.max(0, Math.min(rev, conf.getJSONObject("rev").getInt("perDay") - deck.getJSONArray("revToday").getInt(1)));
-                _new = Math.max(0, Math.min(_new, conf.getJSONObject("new").getInt("perDay") - deck.getJSONArray("newToday").getInt(1)));
-            }
-            tree.add(new DeckDueTreeNode(head, node.getDid(), rev, lrn, _new, children));
+            node.setChildren(_groupChildrenMain(children, depth + 1), true);
+            tree.add(node);
         }
         return tree;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -471,9 +471,10 @@ public class SchedV2 extends AbstractSched {
             int rev = node.getRevCount();
             int _new = node.getNewCount();
             int lrn = node.getLrnCount();
-            children = _groupChildrenMain(children, depth + 1);
+            // the children set contains direct children but not the children of children...
+            node.setChildren(_groupChildrenMain(children, depth + 1));
             // tally up children counts
-            for (DeckDueTreeNode ch : children) {
+            for (DeckDueTreeNode ch : node.getChildren()) {
                 lrn +=  ch.getLrnCount();
                 _new += ch.getNewCount();
             }
@@ -483,7 +484,7 @@ public class SchedV2 extends AbstractSched {
                 JSONObject deck = mCol.getDecks().get(node.getDid());
                 _new = Math.max(0, Math.min(_new, conf.getJSONObject("new").getInt("perDay") - deck.getJSONArray("newToday").getInt(1)));
             }
-            tree.add(new DeckDueTreeNode(head, node.getDid(), rev, lrn, _new, children));
+            tree.add(new DeckDueTreeNode(head, node.getDid(), rev, lrn, _new, node.getChildren()));
         }
         return tree;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -76,7 +76,6 @@ public class SchedV2 extends AbstractSched {
     private String mName = "std2";
     private boolean mHaveCustomStudy = true;
 
-    protected Collection mCol;
     protected int mQueueLimit;
     protected int mReportLimit;
     private int mDynReportLimit;
@@ -468,23 +467,9 @@ public class SchedV2 extends AbstractSched {
                     break;
                 }
             }
-            int rev = node.getRevCount();
-            int _new = node.getNewCount();
-            int lrn = node.getLrnCount();
             // the children set contains direct children but not the children of children...
-            node.setChildren(_groupChildrenMain(children, depth + 1));
-            // tally up children counts
-            for (DeckDueTreeNode ch : node.getChildren()) {
-                lrn +=  ch.getLrnCount();
-                _new += ch.getNewCount();
-            }
-            // limit the counts to the deck's limits
-            JSONObject conf = mCol.getDecks().confForDid(node.getDid());
-            if (conf.getInt("dyn") == 0) {
-                JSONObject deck = mCol.getDecks().get(node.getDid());
-                _new = Math.max(0, Math.min(_new, conf.getJSONObject("new").getInt("perDay") - deck.getJSONArray("newToday").getInt(1)));
-            }
-            tree.add(new DeckDueTreeNode(head, node.getDid(), rev, lrn, _new, node.getChildren()));
+            node.setChildren(_groupChildrenMain(node.getChildren(), depth + 1), false);
+            tree.add(node);
         }
         return tree;
     }


### PR DESCRIPTION
This is the next step in order to load names before numbers: https://github.com/ankidroid/Anki-Android/pull/6522 

By itself, it would be nice to factorize code.
However, the main reason to do it is that it allows to create a second class, DeckTreeNode, which has no number. The tree can be created the same way in both class. In the class with numbers, numbers are added, limits are respected, while in the simpler class, setChildren simply change the value of mChildren.

In order to ease readability, I keep this PR small