### PR TITLE
Factorize main children2

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
@@ -186,13 +186,17 @@ public abstract class AbstractSched {
         private int mNewCount;
         private List<DeckDueTreeNode> mChildren = new ArrayList<>();
 
-        public DeckDueTreeNode(String mName, long mDid, int mRevCount, int mLrnCount, int mNewCount) {
+        private DeckDueTreeNode(String mName, long mDid) {
             this.mName = mName;
             this.mDid = mDid;
+            this.mNameComponents = Decks.path(mName);
+        }
+
+        public DeckDueTreeNode(String mName, long mDid, int mRevCount, int mLrnCount, int mNewCount) {
+            this(mName, mDid);
             this.mRevCount = mRevCount;
             this.mLrnCount = mLrnCount;
             this.mNewCount = mNewCount;
-            this.mNameComponents = Decks.path(mName);
         }
 
         public DeckDueTreeNode(String mName, long mDid, int mRevCount, int mLrnCount, int mNewCount,

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -271,24 +271,7 @@ public class Sched extends SchedV2 {
                     break;
                 }
             }
-            int rev = node.getRevCount();
-            int _new = node.getNewCount();
-            int lrn = node.getLrnCount();
-            children = _groupChildrenMain(children, depth + 1);
-            // tally up children counts
-            for (DeckDueTreeNode ch : children) {
-                rev += ch.getRevCount();
-                lrn += ch.getLrnCount();
-                _new += ch.getNewCount();
-            }
-            // limit the counts to the deck's limits
-            JSONObject conf = mCol.getDecks().confForDid(node.getDid());
-            if (conf.getInt("dyn") == 0) {
-                JSONObject deck = mCol.getDecks().get(node.getDid());
-                rev = Math.max(0, Math.min(rev, conf.getJSONObject("rev").getInt("perDay") - deck.getJSONArray("revToday").getInt(1)));
-                _new = Math.max(0, Math.min(_new, conf.getJSONObject("new").getInt("perDay") - deck.getJSONArray("newToday").getInt(1)));
-            }
-            tree.add(new DeckDueTreeNode(head, node.getDid(), rev, lrn, _new, children));
+            tree.add(new DeckDueTreeNode(node, children, true));
         }
         return tree;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -76,7 +76,6 @@ public class SchedV2 extends AbstractSched {
     private String mName = "std2";
     private boolean mHaveCustomStudy = true;
 
-    protected Collection mCol;
     protected int mQueueLimit;
     protected int mReportLimit;
     private int mDynReportLimit;
@@ -468,22 +467,7 @@ public class SchedV2 extends AbstractSched {
                     break;
                 }
             }
-            int rev = node.getRevCount();
-            int _new = node.getNewCount();
-            int lrn = node.getLrnCount();
-            children = _groupChildrenMain(children, depth + 1);
-            // tally up children counts
-            for (DeckDueTreeNode ch : children) {
-                lrn +=  ch.getLrnCount();
-                _new += ch.getNewCount();
-            }
-            // limit the counts to the deck's limits
-            JSONObject conf = mCol.getDecks().confForDid(node.getDid());
-            if (conf.getInt("dyn") == 0) {
-                JSONObject deck = mCol.getDecks().get(node.getDid());
-                _new = Math.max(0, Math.min(_new, conf.getJSONObject("new").getInt("perDay") - deck.getJSONArray("newToday").getInt(1)));
-            }
-            tree.add(new DeckDueTreeNode(head, node.getDid(), rev, lrn, _new, children));
+            tree.add(new DeckDueTreeNode(node, children, false));
         }
         return tree;
     }


### PR DESCRIPTION
This is similar to https://github.com/ankidroid/Anki-Android/pull/6563 but the class is not mutable.

I still factorize code from both schedulers. The difference is that, instead of adding children when they are computed, I create a new node and discard the currently existing node. I hope it satisfies the request, even if I am not sure how it is an improvement, it is still a step in my real goal: having the deck picker load quicker