### PR TITLE
NF: add path and root exception to StorageAccessException

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
@@ -170,10 +170,10 @@ public class CollectionHelper {
         // Create specified directory if it doesn't exit
         File dir = new File(path);
         if (!dir.exists() && !dir.mkdirs()) {
-            throw new StorageAccessException("Failed to create AnkiDroid directory");
+            throw new StorageAccessException("Failed to create AnkiDroid directory " + path);
         }
         if (!dir.canWrite()) {
-            throw new StorageAccessException("No write access to AnkiDroid directory");
+            throw new StorageAccessException("No write access to AnkiDroid directory " + path);
         }
         // Add a .nomedia file to it if it doesn't exist
         File nomedia = new File(dir, ".nomedia");
@@ -181,7 +181,7 @@ public class CollectionHelper {
             try {
                 nomedia.createNewFile();
             } catch (IOException e) {
-                throw new StorageAccessException("Failed to create .nomedia file");
+                throw new StorageAccessException("Failed to create .nomedia file", e);
             }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/exception/StorageAccessException.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/exception/StorageAccessException.java
@@ -3,7 +3,8 @@ package com.ichi2.anki.exception;
 
 public class StorageAccessException extends Exception {
 
-    public StorageAccessException() {
+    public StorageAccessException(String msg, Throwable e) {
+        super(msg, e);
     }
 
 


### PR DESCRIPTION
I noticed while testing API30 emulator for another reason that it
still has problems with it's sdcard mounting (frequently starts unmounted),
and that secondarily we lose a lot of potentially useful information in
our exception handling in that case
