### PR TITLE
Schedv2 testing

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.java
@@ -38,6 +38,7 @@ import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Consts;
 import com.ichi2.libanki.Decks;
+import com.ichi2.libanki.Models;
 import com.ichi2.libanki.Note;
 import com.ichi2.libanki.sched.AbstractSched;
 import com.ichi2.libanki.StdModels;
@@ -54,9 +55,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -114,28 +115,27 @@ public class ContentProviderTest {
      * Initially create one note for each model.
      */
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         Log.i(AnkiDroidApp.TAG, "setUp()");
         mCreatedNotes = new ArrayList<>();
         final Collection col = getCol();
         // Add a new basic model that we use for testing purposes (existing models could potentially be corrupted)
         JSONObject model = StdModels.basicModel.add(col, BASIC_MODEL_NAME);
         mModelId = model.getLong("id");
-        ArrayList<String> flds = col.getModels().fieldNames(model);
+        ArrayList<String> fields = Models.fieldNames(model);
         // Use the names of the fields as test values for the notes which will be added
-        mDummyFields = flds.toArray(new String[flds.size()]);
+        mDummyFields = fields.toArray(new String[0]);
         // create test decks and add one note for every deck
         mNumDecksBeforeTest = col.getDecks().count();
-        for(int i = 0; i < TEST_DECKS.length; i++) {
-            String fullName = TEST_DECKS[i];
-            String[] path = col.getDecks().path(fullName);
+        for (String fullName : TEST_DECKS) {
+            String[] path = Decks.path(fullName);
             String partialName = "";
             /* Looping over all parents of full name. Adding them to
              * mTestDeckIds ensures the deck parents decks get deleted
              * too at tear-down.
              */
-            for (int j = 0; j < path.length; j++) {
-                partialName += path[j];
+            for (String s : path) {
+                partialName += s;
                 /* If parent already exists, don't add the deck, so
                  * that we are sure it won't get deleted at
                  * set-down, */
@@ -152,10 +152,10 @@ public class ContentProviderTest {
         mCreatedNotes.add(setupNewNote(col, mModelId, 1, mDummyFields, TEST_TAG));
     }
 
-    private static Uri setupNewNote(Collection col, long mid, long did, String[] flds, String tag) {
+    private static Uri setupNewNote(Collection col, long mid, long did, String[] fields, @SuppressWarnings("SameParameterValue") String tag) {
         Note newNote = new Note(col, col.getModels().get(mid));
-        for (int idx=0; idx < flds.length; idx++) {
-            newNote.setField(idx, flds[idx]);
+        for (int idx = 0; idx < fields.length; idx++) {
+            newNote.setField(idx, fields[idx]);
         }
         newNote.addTag(tag);
         assertTrue("At least one card added for note", col.addNote(newNote) >= 1);
@@ -176,11 +176,11 @@ public class ContentProviderTest {
         // Delete all notes
         List<Long> remnantNotes = col.findNotes("tag:" + TEST_TAG);
         if (remnantNotes.size() > 0) {
-            long[] nids = new long[remnantNotes.size()];
+            long[] noteIds = new long[remnantNotes.size()];
             for (int i = 0; i < remnantNotes.size(); i++) {
-                nids[i] = remnantNotes.get(i);
+                noteIds[i] = remnantNotes.get(i);
             }
-            col.remNotes(nids);
+            col.remNotes(noteIds);
             col.save();
             assertEquals("Check that remnant notes have been deleted", 0, col.findNotes("tag:" + TEST_TAG).size());
         }
@@ -211,7 +211,7 @@ public class ContentProviderTest {
      * Check that inserting and removing a note into default deck works as expected
      */
     @Test
-    public void testInsertAndRemoveNote() throws Exception {
+    public void testInsertAndRemoveNote() {
         // Get required objects for test
         final ContentResolver cr = InstrumentationRegistry.getInstrumentation().getTargetContext().getContentResolver();
         // Add the note
@@ -223,11 +223,14 @@ public class ContentProviderTest {
         assertNotNull("Check that URI returned from addNewNote is not null", newNoteUri);
         final Collection col = reopenCol();  // test that the changes are physically saved to the DB
         // Check that it looks as expected
+        assertNotNull("check note URI path", newNoteUri.getLastPathSegment());
         Note addedNote = new Note(col, Long.parseLong(newNoteUri.getLastPathSegment()));
         addedNote.load();
-        assertTrue("Check that fields were set correctly", Arrays.equals(addedNote.getFields(), TEST_NOTE_FIELDS));
+        assertArrayEquals("Check that fields were set correctly", addedNote.getFields(), TEST_NOTE_FIELDS);
         assertEquals("Check that tag was set correctly", TEST_TAG, addedNote.getTags().get(0));
-        int expectedNumCards = col.getModels().get(mModelId).getJSONArray("tmpls").length();
+        JSONObject model = col.getModels().get(mModelId);
+        assertNotNull("Check model", model);
+        int expectedNumCards = model.getJSONArray("tmpls").length();
         assertEquals("Check that correct number of cards generated", expectedNumCards, addedNote.cards().size());
         // Now delete the note
         cr.delete(newNoteUri, null, null);
@@ -265,7 +268,9 @@ public class ContentProviderTest {
         col = reopenCol();  // test that the changes are physically saved to the DB
         assertNotNull("Check template uri", templateUri);
         assertEquals("Check template uri ord", expectedOrd, ContentUris.parseId(templateUri));
-        JSONObject template = col.getModels().get(modelId).getJSONArray("tmpls").getJSONObject(expectedOrd);
+        model = col.getModels().get(modelId);
+        assertNotNull("Check model", model);
+        JSONObject template = model.getJSONArray("tmpls").getJSONObject(expectedOrd);
         assertEquals("Check template JSONObject ord", expectedOrd, template.getInt("ord"));
         assertEquals("Check template name", TEST_MODEL_CARDS[testIndex], template.getString("name"));
         assertEquals("Check qfmt", TEST_MODEL_QFMT[testIndex], template.getString("qfmt"));
@@ -285,8 +290,8 @@ public class ContentProviderTest {
         Collection col = getCol();
         JSONObject model = StdModels.basicModel.add(col, BASIC_MODEL_NAME);
         long modelId = model.getLong("id");
-        JSONArray initialFldsArr = model.getJSONArray("flds");
-        int initialFieldCount = initialFldsArr.length();
+        JSONArray initialFieldsArr = model.getJSONArray("flds");
+        int initialFieldCount = initialFieldsArr.length();
         Uri noteTypeUri = ContentUris.withAppendedId(FlashCardsContract.Model.CONTENT_URI, modelId);
         ContentValues insertFieldValues = new ContentValues();
         insertFieldValues.put(FlashCardsContract.Model.FIELD_NAME, TEST_FIELD_NAME);
@@ -298,6 +303,7 @@ public class ContentProviderTest {
         // Test the field is as expected
         long fieldId = ContentUris.parseId(fieldUri);
         assertEquals("Check field id", initialFieldCount, fieldId);
+        assertNotNull("Check model", model);
         JSONArray fldsArr = model.getJSONArray("flds");
         assertEquals("Check fields length", initialFieldCount + 1, fldsArr.length());
         assertEquals("Check last field name", TEST_FIELD_NAME, fldsArr.getJSONObject(fldsArr.length() - 1).optString("name", ""));
@@ -392,11 +398,10 @@ public class ContentProviderTest {
         }
     }
 
-    private String[] removeFromProjection(String[] inputProjection, int idx) {
+    private String[] removeFromProjection(@SuppressWarnings("SameParameterValue") String[] inputProjection, int idx) {
         String[] outputProjection = new String[inputProjection.length - 1];
-        for (int i = 0; i < idx; i++) {
-            outputProjection[i] = inputProjection[i];
-        }
+        if (idx >= 0) System.arraycopy(inputProjection, 0, outputProjection, 0, idx);
+        //noinspection ManualArrayCopy
         for (int i = idx + 1; i < inputProjection.length; i++) {
             outputProjection[i - 1] = inputProjection[i];
         }
@@ -423,9 +428,9 @@ public class ContentProviderTest {
                 assertNotNull("Check that there is a valid cursor for detail data after update", noteCursor);
                 assertEquals("Check that there is one and only one entry after update", 1, noteCursor.getCount());
                 assertTrue("Move to first item in cursor", noteCursor.moveToFirst());
-                String[] newFlds = Utils.splitFields(
+                String[] newFields = Utils.splitFields(
                         noteCursor.getString(noteCursor.getColumnIndex(FlashCardsContract.Note.FLDS)));
-                assertTrue("Check that the flds have been updated correctly", Arrays.equals(newFlds, dummyFields2));
+                assertArrayEquals("Check that the flds have been updated correctly", newFields, dummyFields2);
             }
         }
     }
@@ -435,7 +440,7 @@ public class ContentProviderTest {
      * Check that inserting a new model works as expected
      */
     @Test
-    public void testInsertAndUpdateModel() throws Exception {
+    public void testInsertAndUpdateModel() {
         final ContentResolver cr = InstrumentationRegistry.getInstrumentation().getTargetContext().getContentResolver();
         ContentValues cv = new ContentValues();
         // Insert a new model
@@ -444,23 +449,27 @@ public class ContentProviderTest {
         cv.put(FlashCardsContract.Model.NUM_CARDS, TEST_MODEL_CARDS.length);
         Uri modelUri = cr.insert(FlashCardsContract.Model.CONTENT_URI, cv);
         assertNotNull("Check inserted model isn't null", modelUri);
+        assertNotNull("Check last path segment exists", modelUri.getLastPathSegment());
         long mid = Long.parseLong(modelUri.getLastPathSegment());
         Collection col = reopenCol();
         try {
             JSONObject model = col.getModels().get(mid);
+            assertNotNull("Check model", model);
             assertEquals("Check model name", TEST_MODEL_NAME, model.getString("name"));
             assertEquals("Check templates length", TEST_MODEL_CARDS.length, model.getJSONArray("tmpls").length());
             assertEquals("Check field length", TEST_MODEL_FIELDS.length, model.getJSONArray("flds").length());
-            JSONArray flds = model.getJSONArray("flds");
-            for (int i = 0; i < flds.length(); i++) {
-                assertEquals("Check name of fields", TEST_MODEL_FIELDS[i], flds.getJSONObject(i).getString("name"));
+            JSONArray fields = model.getJSONArray("flds");
+            for (int i = 0; i < fields.length(); i++) {
+                assertEquals("Check name of fields", TEST_MODEL_FIELDS[i], fields.getJSONObject(i).getString("name"));
             }
             // Test updating the model CSS (to test updating MODELS_ID Uri)
             cv = new ContentValues();
             cv.put(FlashCardsContract.Model.CSS, TEST_MODEL_CSS);
             assertTrue(cr.update(modelUri, cv, null, null) > 0);
             col = reopenCol();
-            assertEquals("Check css", TEST_MODEL_CSS, col.getModels().get(mid).getString("css"));
+            model = col.getModels().get(mid);
+            assertNotNull("Check model", model);
+            assertEquals("Check css", TEST_MODEL_CSS, model.getString("css"));
             // Update each of the templates in model (to test updating MODELS_ID_TEMPLATES_ID Uri)
             for (int i = 0; i < TEST_MODEL_CARDS.length; i++) {
                 cv = new ContentValues();
@@ -472,7 +481,9 @@ public class ContentProviderTest {
                 Uri tmplUri = Uri.withAppendedPath(Uri.withAppendedPath(modelUri, "templates"), Integer.toString(i));
                 assertTrue("Update rows", cr.update(tmplUri, cv, null, null) > 0);
                 col = reopenCol();
-                JSONObject template = col.getModels().get(mid).getJSONArray("tmpls").getJSONObject(i);
+                model = col.getModels().get(mid);
+                assertNotNull("Check model", model);
+                JSONObject template = model.getJSONArray("tmpls").getJSONObject(i);
                 assertEquals("Check template name", TEST_MODEL_CARDS[i], template.getString("name"));
                 assertEquals("Check qfmt", TEST_MODEL_QFMT[i], template.getString("qfmt"));
                 assertEquals("Check afmt", TEST_MODEL_AFMT[i], template.getString("afmt"));
@@ -483,7 +494,9 @@ public class ContentProviderTest {
             // Delete the model (this will force a full-sync)
             col.modSchemaNoCheck();
             try {
-                col.getModels().rem(col.getModels().get(mid));
+                JSONObject model = col.getModels().get(mid);
+                assertNotNull("Check model", model);
+                col.getModels().rem(model);
             } catch (ConfirmModSchemaException e) {
                 // This will never happen
             }
@@ -514,7 +527,7 @@ public class ContentProviderTest {
                     assertEquals("Check that model names are the same", nameFromModel, nameFromModels);
                     String flds = allModels.getString(allModels.getColumnIndex(FlashCardsContract.Model.FIELD_NAMES));
                     assertTrue("Check that valid number of fields", Utils.splitFields(flds).length >= 1);
-                    Integer numCards = allModels.getInt(allModels.getColumnIndex(FlashCardsContract.Model.NUM_CARDS));
+                    int numCards = allModels.getInt(allModels.getColumnIndex(FlashCardsContract.Model.NUM_CARDS));
                     assertTrue("Check that valid number of cards", numCards >= 1);
                 } finally {
                     singleModel.close();
@@ -675,7 +688,7 @@ public class ContentProviderTest {
      * Test query to decks table
      */
     @Test
-    public void testQueryAllDecks() throws Exception{
+    public void testQueryAllDecks() {
         Collection col = getCol();
         Decks decks = col.getDecks();
 
@@ -702,7 +715,7 @@ public class ContentProviderTest {
      * Test query to specific deck ID
      */
     @Test
-    public void testQueryCertainDeck() throws Exception {
+    public void testQueryCertainDeck() {
         Collection col = getCol();
 
         long deckId = mTestDeckIds.get(0);
@@ -725,7 +738,7 @@ public class ContentProviderTest {
      * Test that query for the next card in the schedule returns a valid result without any deck selector
      */
     @Test
-    public void testQueryNextCard(){
+    public void testQueryNextCard() {
         Collection col = getCol();
         AbstractSched sched = col.getSched();
 
@@ -758,7 +771,7 @@ public class ContentProviderTest {
     public void testQueryCardFromCertainDeck(){
         long deckToTest = mTestDeckIds.get(0);
         String deckSelector = "deckID=?";
-        String deckArguments[] = {Long.toString(deckToTest)};
+        String[] deckArguments = {Long.toString(deckToTest)};
         Collection col = getCol();
         AbstractSched sched = col.getSched();
         long selectedDeckBeforeTest = col.getDecks().selected();
@@ -966,13 +979,12 @@ public class ContentProviderTest {
 
         // update tags
         // -----------
-        String tag1 = TEST_TAG;
         String tag2 = "mynewtag";
 
         ContentResolver cr = InstrumentationRegistry.getInstrumentation().getTargetContext().getContentResolver();
         Uri updateNoteUri = Uri.withAppendedPath(FlashCardsContract.Note.CONTENT_URI, Long.toString(noteId));
         ContentValues values = new ContentValues();
-        values.put(FlashCardsContract.Note.TAGS, tag1 + " " + tag2);
+        values.put(FlashCardsContract.Note.TAGS, TEST_TAG + " " + tag2);
         int updateCount = cr.update(updateNoteUri, values, null, null);
 
         assertEquals("updateCount is 1", 1, updateCount);

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/InstrumentedTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/InstrumentedTest.java
@@ -1,0 +1,46 @@
+/***************************************************************************************
+ *                                                                                      *
+ * Copyright (c) 2020 Mike Hardy <github@mikehardy.net>                                 *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+
+package com.ichi2.anki.tests;
+import android.os.Build;
+
+public abstract class InstrumentedTest {
+
+    /**
+     * This is how google detects emulators in flutter and how react-native does it in the device info module
+     * https://github.com/react-native-community/react-native-device-info/blob/bb505716ff50e5900214fcbcc6e6434198010d95/android/src/main/java/com/learnium/RNDeviceInfo/RNDeviceModule.java#L185
+     * @return boolean true if the execution environment is most likely an emulator
+     */
+    protected static boolean isEmulator() {
+        return (Build.BRAND.startsWith("generic") && Build.DEVICE.startsWith("generic"))
+                || Build.FINGERPRINT.startsWith("generic")
+                || Build.FINGERPRINT.startsWith("unknown")
+                || Build.HARDWARE.contains("goldfish")
+                || Build.HARDWARE.contains("ranchu")
+                || Build.MODEL.contains("google_sdk")
+                || Build.MODEL.contains("Emulator")
+                || Build.MODEL.contains("Android SDK built for x86")
+                || Build.MANUFACTURER.contains("Genymotion")
+                || Build.PRODUCT.contains("sdk_google")
+                || Build.PRODUCT.contains("google_sdk")
+                || Build.PRODUCT.contains("sdk")
+                || Build.PRODUCT.contains("sdk_x86")
+                || Build.PRODUCT.contains("vbox86p")
+                || Build.PRODUCT.contains("emulator")
+                || Build.PRODUCT.contains("simulator");
+    }
+}


### PR DESCRIPTION

This parameterizes the ContentProviderTest across the two scheduler versions, in an attempt to get us a bit more coverage across v2 scheduler which I don't think was being exercised much

@david-allison-1 you'll notice I added an "isEmulator" check and removed your `@Ignore` on the content provider test - this implies the assertion: if you are running the instrumented tests on an emulator you accept corruption may occur. I believe that's a valid assertion. Feel free to disagree! We can change it back

I also use the isEmulator check to only toggle the scheduler change on the collection if it is an emulator: same assertion applies.

@Arthur-Milchior two tests fail on SchedV2 - can you essentially take over this branch and investigate? I only made the PR as a convenient way to show how to parameterize across the scheduler versions and expose potential problems, but I don't have the scheduler expertise to be useful in fixing things... you can either push directly to the branch or just copy it, I am not sensitive to the method of getting it done