### PR TITLE
Reminder becomes quicker

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
@@ -373,9 +373,9 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
                                 final AlarmManager alarmManager = (AlarmManager) getSystemService(ALARM_SERVICE);
                                 final PendingIntent reminderIntent = PendingIntent.getBroadcast(
                                         getApplicationContext(),
-                                        (int) mDeck.getLong("id"),
+                                        (int) mOptions.getLong("id"),
                                         new Intent(getApplicationContext(), ReminderService.class).putExtra
-                                                (ReminderService.EXTRA_DECK_ID, mDeck.getLong("id")),
+                                                (ReminderService.EXTRA_DECK_OPTION_ID, mOptions.getLong("id")),
                                         0
                                 );
 
@@ -408,9 +408,9 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
                                 final AlarmManager alarmManager = (AlarmManager) getSystemService(ALARM_SERVICE);
                                 final PendingIntent reminderIntent = PendingIntent.getBroadcast(
                                         getApplicationContext(),
-                                        (int) mDeck.getLong("id"),
+                                        (int) mOptions.getLong("id"),
                                         new Intent(getApplicationContext(), ReminderService.class).putExtra
-                                                (ReminderService.EXTRA_DECK_ID, mDeck.getLong("id")),
+                                                (ReminderService.EXTRA_DECK_OPTION_ID, mOptions.getLong("id")),
                                         0
                                 );
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.java
@@ -90,23 +90,17 @@ public class BootService extends BroadcastReceiver {
 
     private void scheduleDeckReminder(Context context) {
         AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
-        for (JSONObject deck : CollectionHelper.getInstance().getCol(context).getDecks().all()) {
+        for (JSONObject deckConfiguration : CollectionHelper.getInstance().getCol(context).getDecks().allConf()) {
             Collection col = CollectionHelper.getInstance().getCol(context);
-            if (col.getDecks().isDyn(deck.getLong("id"))) {
-                continue;
-            }
-            final long deckConfigurationId = deck.getLong("conf");
-            final JSONObject deckConfiguration = col.getDecks().getConf(deckConfigurationId);
-
             if (deckConfiguration.has("reminder")) {
                 final JSONObject reminder = deckConfiguration.getJSONObject("reminder");
 
                 if (reminder.getBoolean("enabled")) {
                     final PendingIntent reminderIntent = PendingIntent.getBroadcast(
                                                                                     context,
-                                                                                    (int) deck.getLong("id"),
-                                                                                    new Intent(context, ReminderService.class).putExtra(ReminderService.EXTRA_DECK_ID,
-                                                                                                                                        deck.getLong("id")),
+                                                                                    (int) deckConfiguration.getLong("id"),
+                                                                                    new Intent(context, ReminderService.class).putExtra(ReminderService.EXTRA_DECK_OPTION_ID,
+                                                                                            deckConfiguration.getLong("id")),
                                                                                     0
                                                                                     );
                     final Calendar calendar = Calendar.getInstance();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/ReminderService.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/ReminderService.java
@@ -63,6 +63,10 @@ public class ReminderService extends BroadcastReceiver {
             alarmManager.cancel(reminderIntent);
         }
 
+        final NotificationManagerCompat notificationManager = NotificationManagerCompat.from(context);
+        if (!notificationManager.areNotificationsEnabled()) {
+            return;
+        }
         List<Sched.DeckDueTreeNode> decksDue = getDeckOptionDue(context, dConfId, true);
 
         if (null == decksDue) {
@@ -77,33 +81,30 @@ public class ReminderService extends BroadcastReceiver {
                 continue;
             }
 
-            final NotificationManagerCompat notificationManager = NotificationManagerCompat.from(context);
 
             Timber.v("Notify: study deck %s", deckDue.getFullDeckName());
-            if (notificationManager.areNotificationsEnabled()) {
-                final Notification notification =
-                        new NotificationCompat.Builder(context,
-                                NotificationChannels.getId(NotificationChannels.Channel.DECK_REMINDERS))
-                                .setCategory(NotificationCompat.CATEGORY_REMINDER)
-                                .setContentTitle(context.getString(R.string.reminder_title))
-                                .setContentText(context.getResources().getQuantityString(
-                                        R.plurals.reminder_text,
-                                        total,
-                                        CollectionHelper.getInstance().getCol(context).getDecks().name(deckId),
-                                        total
-                                ))
-                                .setSmallIcon(R.drawable.ic_stat_notify)
-                                .setColor(ContextCompat.getColor(context, R.color.material_light_blue_700))
-                                .setContentIntent(PendingIntent.getActivity(
-                                        context,
-                                        (int) deckId,
-                                        getReviewDeckIntent(context, deckId),
-                                        PendingIntent.FLAG_UPDATE_CURRENT
-                                ))
-                                .setAutoCancel(true)
-                                .build();
+            final Notification notification =
+                new NotificationCompat.Builder(context,
+                    NotificationChannels.getId(NotificationChannels.Channel.DECK_REMINDERS))
+                        .setCategory(NotificationCompat.CATEGORY_REMINDER)
+                        .setContentTitle(context.getString(R.string.reminder_title))
+                        .setContentText(context.getResources().getQuantityString(
+                                R.plurals.reminder_text,
+                                total,
+                                CollectionHelper.getInstance().getCol(context).getDecks().name(deckId),
+                                total
+                        ))
+                        .setSmallIcon(R.drawable.ic_stat_notify)
+                        .setColor(ContextCompat.getColor(context, R.color.material_light_blue_700))
+                        .setContentIntent(PendingIntent.getActivity(
+                                context,
+                                (int) deckId,
+                                getReviewDeckIntent(context, deckId),
+                                PendingIntent.FLAG_UPDATE_CURRENT
+                        ))
+                        .setAutoCancel(true)
+                        .build();
                 notificationManager.notify((int) deckId, notification);
-            }
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/ReminderService.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/ReminderService.java
@@ -45,8 +45,28 @@ public class ReminderService extends BroadcastReceiver {
     public static final String EXTRA_DECK_OPTION_ID = "EXTRA_DECK_OPTION_ID";
     public static final String EXTRA_DECK_ID = "EXTRA_DECK_ID";
 
+
+    /** Cancelling all deck reminder. We used to use them, now we have deck option reminders. */
+    private void cancelDeckReminder(Context context, Intent intent) {
+        // 0 Is not a valid deck id.
+        final long deckId = intent.getLongExtra(EXTRA_DECK_ID, 0);
+        if (deckId == 0) {
+            return;
+        }
+        final AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
+        
+        final PendingIntent reminderIntent = PendingIntent.getBroadcast(
+            context,
+            (int) deckId,
+            new Intent(context, ReminderService.class).putExtra(EXTRA_DECK_OPTION_ID, deckId),
+            0);
+
+        alarmManager.cancel(reminderIntent);
+    }
+
     @Override
     public void onReceive(Context context, Intent intent) {
+        cancelDeckReminder(context, intent);
 
         final long dConfId = intent.getLongExtra(EXTRA_DECK_OPTION_ID, 0);
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/ReminderService.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/ReminderService.java
@@ -68,7 +68,11 @@ public class ReminderService extends BroadcastReceiver {
     public void onReceive(Context context, Intent intent) {
         cancelDeckReminder(context, intent);
 
+        // 0 is not a valid dconf id.
         final long dConfId = intent.getLongExtra(EXTRA_DECK_OPTION_ID, 0);
+        if (dConfId == 0) {
+            return;
+        }
 
         if (CollectionHelper.getInstance().getCol(context).getDecks().getConf(dConfId) == null) {
             final AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/ReminderService.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/ReminderService.java
@@ -22,6 +22,7 @@ import android.content.Context;
 import android.content.Intent;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.core.app.NotificationCompat;
 import androidx.core.app.NotificationManagerCompat;
 import androidx.core.content.ContextCompat;
@@ -31,67 +32,78 @@ import com.ichi2.anki.CollectionHelper;
 import com.ichi2.anki.IntentHandler;
 import com.ichi2.anki.NotificationChannels;
 import com.ichi2.anki.R;
+import com.ichi2.libanki.Collection;
+import com.ichi2.libanki.sched.AbstractSched;
 import com.ichi2.libanki.sched.Sched;
+import com.ichi2.utils.JSONObject;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class ReminderService extends BroadcastReceiver {
 
+    public static final String EXTRA_DECK_OPTION_ID = "EXTRA_DECK_OPTION_ID";
     public static final String EXTRA_DECK_ID = "EXTRA_DECK_ID";
 
     @Override
     public void onReceive(Context context, Intent intent) {
 
-        final long deckId = intent.getLongExtra(EXTRA_DECK_ID, 0);
+        final long dConfId = intent.getLongExtra(EXTRA_DECK_OPTION_ID, 0);
 
-        if (CollectionHelper.getInstance().getCol(context).getDecks().get(deckId, false) == null) {
+        if (CollectionHelper.getInstance().getCol(context).getDecks().getConf(dConfId) == null) {
             final AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
 
             final PendingIntent reminderIntent = PendingIntent.getBroadcast(
                     context,
-                    (int) deckId,
-                    new Intent(context, ReminderService.class).putExtra(EXTRA_DECK_ID, deckId),
+                    (int) dConfId,
+                    new Intent(context, ReminderService.class).putExtra(EXTRA_DECK_OPTION_ID, dConfId),
                     0
             );
 
             alarmManager.cancel(reminderIntent);
         }
 
-        Sched.DeckDueTreeNode deckDue = getDeckDue(context, deckId, true);
+        List<Sched.DeckDueTreeNode> decksDue = getDeckOptionDue(context, dConfId, true);
 
-        if (null == deckDue) {
+        if (null == decksDue) {
             return;
         }
 
-        final int total = deckDue.getRevCount() + deckDue.getLrnCount() + deckDue.getNewCount();
+        for (Sched.DeckDueTreeNode deckDue: decksDue) {
+            long deckId = deckDue.getDid();
+            final int total = deckDue.getRevCount() + deckDue.getLrnCount() + deckDue.getNewCount();
 
-        if (total <= 0) {
-            return;
-        }
+            if (total <= 0) {
+                continue;
+            }
 
-        final NotificationManagerCompat notificationManager = NotificationManagerCompat.from(context);
+            final NotificationManagerCompat notificationManager = NotificationManagerCompat.from(context);
 
-        if (notificationManager.areNotificationsEnabled()) {
-            final Notification notification =
-                    new NotificationCompat.Builder(context,
-                            NotificationChannels.getId(NotificationChannels.Channel.DECK_REMINDERS))
-                    .setCategory(NotificationCompat.CATEGORY_REMINDER)
-                    .setContentTitle(context.getString(R.string.reminder_title))
-                    .setContentText(context.getResources().getQuantityString(
-                            R.plurals.reminder_text,
-                            total,
-                            CollectionHelper.getInstance().getCol(context).getDecks().name(deckId),
-                            total
-                    ))
-                    .setSmallIcon(R.drawable.ic_stat_notify)
-                    .setColor(ContextCompat.getColor(context, R.color.material_light_blue_700))
-                    .setContentIntent(PendingIntent.getActivity(
-                            context,
-                            (int) deckId,
-                            getReviewDeckIntent(context, deckId),
-                            PendingIntent.FLAG_UPDATE_CURRENT
-                    ))
-                    .setAutoCancel(true)
-                    .build();
-            notificationManager.notify((int) deckId, notification);
+            Timber.v("Notify: study deck %s", deckDue.getFullDeckName());
+            if (notificationManager.areNotificationsEnabled()) {
+                final Notification notification =
+                        new NotificationCompat.Builder(context,
+                                NotificationChannels.getId(NotificationChannels.Channel.DECK_REMINDERS))
+                                .setCategory(NotificationCompat.CATEGORY_REMINDER)
+                                .setContentTitle(context.getString(R.string.reminder_title))
+                                .setContentText(context.getResources().getQuantityString(
+                                        R.plurals.reminder_text,
+                                        total,
+                                        CollectionHelper.getInstance().getCol(context).getDecks().name(deckId),
+                                        total
+                                ))
+                                .setSmallIcon(R.drawable.ic_stat_notify)
+                                .setColor(ContextCompat.getColor(context, R.color.material_light_blue_700))
+                                .setContentIntent(PendingIntent.getActivity(
+                                        context,
+                                        (int) deckId,
+                                        getReviewDeckIntent(context, deckId),
+                                        PendingIntent.FLAG_UPDATE_CURRENT
+                                ))
+                                .setAutoCancel(true)
+                                .build();
+                notificationManager.notify((int) deckId, notification);
+            }
         }
     }
 
@@ -102,32 +114,39 @@ public class ReminderService extends BroadcastReceiver {
     }
 
 
-    // getDeckDue information, will recur one time to workaround collection close if recur is true
-    private Sched.DeckDueTreeNode getDeckDue(Context context, long deckId, boolean recur) {
+    // getDeckOptionDue information, will recur one time to workaround collection close if recur is true
+    @Nullable
+    private List<Sched.DeckDueTreeNode> getDeckOptionDue(Context context, long dConfId, boolean recur) {
 
-        // Avoid crashes if the deck is deleted while we are working
-        if (CollectionHelper.getInstance().getCol(context).getDecks().get(deckId, false) == null) {
-            Timber.d("Deck %s deleted while ReminderService was working. Ignoring", deckId);
+        Collection col = CollectionHelper.getInstance().getCol(context);
+        // Avoid crashes if the deck option group is deleted while we
+        // are working
+        if (col.getDecks().getConf(dConfId) == null) {
+            Timber.d("Deck option %s deleted while ReminderService was working. Ignoring", dConfId);
             return null;
         }
 
+        List<Sched.DeckDueTreeNode> decks = new ArrayList<>();
         try {
             // This loop over top level deck only. No notification will ever occur for subdecks.
             for (Sched.DeckDueTreeNode node : CollectionHelper.getInstance().getCol(context).getSched().deckDueTree()) {
-                if (node.getDid() == deckId) {
-                    return node;
+                JSONObject deck = col.getDecks().get(node.getDid(), false);
+                // Dynamic deck has no "conf", so are not added here.
+                if (deck != null && deck.optLong("conf") == dConfId) {
+                    decks.add(node);
                 }
             }
+            return decks;
         } catch (Exception e) {
             if (recur) {
-                Timber.i(e, "getDeckDue exception - likely database re-initialization from auto-sync. Will re-try after sleep.");
+                Timber.i(e, "getDeckOptionDue exception - likely database re-initialization from auto-sync. Will re-try after sleep.");
                 try {
                     Thread.sleep(1000);
                 } catch (InterruptedException ex) {
                     Timber.i(ex, "Thread interrupted while waiting to retry. Likely unimportant.");
                     Thread.currentThread().interrupt();
                 }
-                return getDeckDue(context, deckId, false);
+                return getDeckOptionDue(context, dConfId, false);
             } else {
                 Timber.w(e, "Database unavailable while working. No re-tries left.");
             }


### PR DESCRIPTION
Hopefully partially solving https://github.com/ankidroid/Anki-Android/issues/6524

AnkiDroid planifies reminder for specific deck option and not for specific deck. When the reminder is executed, it loops over decks to check which one has the correct type and have cards to review.

It is still slightly silly that the reminders run while anki starts, however that's still an improvement because instead of doing the action once by deck, it is done one by deck option, and the number of deck option is necessarily smaller than the number of deck.

I tested it by adding a reminder on my phone, seeing it working, and still being able to use ankidroid