### PR TITLE
Reminder for all decks

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/ReminderService.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/ReminderService.java
@@ -31,7 +31,11 @@ import com.ichi2.anki.CollectionHelper;
 import com.ichi2.anki.IntentHandler;
 import com.ichi2.anki.NotificationChannels;
 import com.ichi2.anki.R;
+import com.ichi2.libanki.sched.AbstractSched;
 import com.ichi2.libanki.sched.Sched;
+
+import java.util.LinkedList;
+import java.util.List;
 
 public class ReminderService extends BroadcastReceiver {
 
@@ -113,8 +117,10 @@ public class ReminderService extends BroadcastReceiver {
 
         try {
             for (Sched.DeckDueTreeNode node : CollectionHelper.getInstance().getCol(context).getSched().deckDueTree()) {
-                if (node.getDid() == deckId) {
-                    return node;
+                for (Sched.DeckDueTreeNode node_ : node.toList()) {
+                    if (node_.getDid() == deckId) {
+                        return node_;
+                    }
                 }
             }
         } catch (Exception e) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
@@ -15,6 +15,7 @@ import com.ichi2.utils.JSONObject;
 
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 
@@ -320,6 +321,29 @@ public abstract class AbstractSched {
                 limitNewCount(conf.getJSONObject("new").getInt("perDay") - deck.getJSONArray("newToday").getInt(1));
                 if (addRev) {
                     limitRevCount(conf.getJSONObject("rev").getInt("perDay") - deck.getJSONArray("revToday").getInt(1));
+                }
+            }
+        }
+
+        /**
+         * deckDueTree().toList is not the same as deckDueList because:
+         * * the list obtained here is ordered
+         * * the number takes children into account
+         *
+         * @return This deck and all its descendants.
+         */
+        public List<DeckDueTreeNode> toList() {
+            List<DeckDueTreeNode> list = new LinkedList<>();
+            toList(list);
+            return list;
+        }
+
+        /** Add this elements and all of its children to list.*/
+        private void toList(List<DeckDueTreeNode> list) {
+            list.add(this);
+            if (mChildren != null) {
+                for (DeckDueTreeNode child : mChildren) {
+                    child.toList(list);
                 }
             }
         }


### PR DESCRIPTION
While working on https://github.com/ankidroid/Anki-Android/pull/6571 I realized there is a problem. Reminders only appear for top level decks. I correct this.

It has been tested by setting a reminder and seeing dozens of notification occur (because suddenly I had one reminder by deck and not only one for my top level deck) 

Note that we may expect "bug" report from people who start seing a lot of notification if they have a lot of subdecks.
