### PR TITLE
NF: top level DeckDueTreeNode

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/ReminderService.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/ReminderService.java
@@ -172,7 +172,7 @@ public class ReminderService extends BroadcastReceiver {
         List<DeckDueTreeNode> decks = new ArrayList<>();
         try {
             // This loop over top level deck only. No notification will ever occur for subdecks.
-            for (DeckDueTreeNode node : col.getSched().deckDueTree()) {
+            for (DeckDueTreeNode node : col.getSched().deckDueTree().getChildren()) {
                 JSONObject deck = col.getDecks().get(node.getDid(), false);
                 // Dynamic deck has no "conf", so are not added here.
                 if (deck != null && deck.optLong("conf") == dConfId) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
@@ -98,8 +98,8 @@ public abstract class AbstractSched {
      */
     public abstract List<DeckDueTreeNode> deckDueList();
     /** load the due tree, but halt if deck task is cancelled*/
-    public abstract List<DeckDueTreeNode> deckDueTree(CollectionTask collectionTask);
-    public abstract List<DeckDueTreeNode> deckDueTree();
+    public abstract DeckDueTreeRoot deckDueTree(CollectionTask collectionTask);
+    public abstract DeckDueTreeRoot deckDueTree();
     /** New count for a single deck. */
     public abstract int _newForDeck(long did, int lim);
     /** Limit for deck without parent limits. */

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/DeckDueTreeNode.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/DeckDueTreeNode.java
@@ -169,6 +169,10 @@ public class DeckDueTreeNode implements Comparable {
                 mRevCount += ch.getRevCount();
             }
         }
+        applyLimit(addRev);
+    }
+
+    protected void applyLimit(boolean addRev) {
         // limit the counts to the deck's limits
         JSONObject conf = mCol.getDecks().confForDid(mDid);
         if (conf.getInt("dyn") == 0) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/DeckDueTreeNode.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/DeckDueTreeNode.java
@@ -18,7 +18,7 @@ import androidx.annotation.Nullable;
  * The names field is an array of names that build a deck name from a hierarchy (i.e., a nested
  * deck will have an entry for every level of nesting). While the python version interchanges
  * between a string and a list of strings throughout processing, we always use an array for
- * this field and use getNamePart(0) for those cases.
+ * this field and use getDeckNameComponent(0) for those cases.
  */
 public class DeckDueTreeNode implements Comparable {
     private final Collection mCol;
@@ -174,6 +174,7 @@ public class DeckDueTreeNode implements Comparable {
 
     protected void applyLimit(boolean addRev) {
         // limit the counts to the deck's limits
+        // Fails gracefully if the did is incorrect by using default deck/deck option
         JSONObject conf = mCol.getDecks().confForDid(mDid);
         if (conf.getInt("dyn") == 0) {
             JSONObject deck = mCol.getDecks().get(mDid);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/DeckDueTreeRoot.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/DeckDueTreeRoot.java
@@ -1,0 +1,37 @@
+package com.ichi2.libanki.sched;
+
+import com.ichi2.libanki.Collection;
+
+public class DeckDueTreeRoot extends DeckDueTreeNode {
+
+    public DeckDueTreeRoot(Collection col) {
+        super(col, "", -1, 0, 0, 0);
+    }
+
+
+    @Override
+    public String getDeckNameComponent(int part) {
+        throw new UnsupportedOperationException();
+    }
+
+
+    @Override
+    public String getLastDeckNameComponent() {
+        throw new UnsupportedOperationException();
+    }
+
+
+    @Override
+    public long getDid() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getDepth() {
+        return -1;
+    }
+
+    // Limit should not be applied at top level
+    @Override
+    protected void applyLimit(boolean addRev) {}
+}

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -225,7 +225,7 @@ public class Sched extends SchedV2 {
         mCol.getDecks().checkIntegrity();
         ArrayList<Deck> decks = mCol.getDecks().allSorted();
         HashMap<String, Integer[]> lims = new HashMap<>();
-        ArrayList<DeckDueTreeNode> data = new ArrayList<>();
+        ArrayList<DeckDueTreeNode> deckNodes = new ArrayList<>();
         for (Deck deck : decks) {
             if (collectionTask != null && collectionTask.isCancelled()) {
                 return null;
@@ -249,11 +249,11 @@ public class Sched extends SchedV2 {
             // reviews
             int rev = _revForDeck(deck.getLong("id"), rlim);
             // save to list
-            data.add(new DeckDueTreeNode(mCol, deck.getString("name"), deck.getLong("id"), rev, lrn, _new));
+            deckNodes.add(new DeckDueTreeNode(mCol, deck.getString("name"), deck.getLong("id"), rev, lrn, _new));
             // add deck as a parent
             lims.put(deck.getString("name"), new Integer[]{nlim, rlim});
         }
-        return data;
+        return deckNodes;
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -543,11 +543,13 @@ public class SchedV2 extends AbstractSched {
     }
 
 
-    public List<DeckDueTreeNode> deckDueTree() {
+    @Override
+    public DeckDueTreeRoot deckDueTree() {
         return deckDueTree(null);
     }
 
-    public List<DeckDueTreeNode> deckDueTree(CollectionTask collectionTask) {
+    @Override
+    public DeckDueTreeRoot deckDueTree(CollectionTask collectionTask) {
         List<DeckDueTreeNode> deckDueTree = deckDueList(collectionTask);
         if (deckDueTree == null) {
             return null;
@@ -556,7 +558,7 @@ public class SchedV2 extends AbstractSched {
     }
 
 
-    private List<DeckDueTreeNode> _groupChildren(List<DeckDueTreeNode> decks, boolean checkDone) {
+    private DeckDueTreeRoot _groupChildren(List<DeckDueTreeNode> decks, boolean checkDone) {
         // sort based on name's components
         Collections.sort(decks);
         // then run main function
@@ -564,10 +566,15 @@ public class SchedV2 extends AbstractSched {
     }
 
 
-    protected List<DeckDueTreeNode> _groupChildrenMain(List<DeckDueTreeNode> decks, boolean checkDone) {
+    protected DeckDueTreeRoot _groupChildrenMain(List<DeckDueTreeNode> decks, boolean checkDone) {
         return _groupChildrenMain(decks, 0, checkDone);
     }
 
+    protected DeckDueTreeRoot _groupChildrenMain(List<DeckDueTreeNode> descendants, int depth, boolean checkDone) {
+        DeckDueTreeRoot root = new DeckDueTreeRoot(mCol);
+        _groupChildrenMain(descendants, depth, checkDone, root);
+        return root;
+    }
     /**
         @return the tree structure of all decks from @descandants, starting
         at specified depth.
@@ -579,7 +586,7 @@ public class SchedV2 extends AbstractSched {
         false, we can't assume all decks have parents and that there
         is no duplicate. Instead, we'll ignore problems.
      */
-    protected List<DeckDueTreeNode> _groupChildrenMain(List<DeckDueTreeNode> descendants, int depth, boolean checkDone) {
+    protected void _groupChildrenMain(List<DeckDueTreeNode> descendants, int depth, boolean checkDone, DeckDueTreeNode parent) {
         List<DeckDueTreeNode> children = new ArrayList<>();
         // group and recurse
         ListIterator<DeckDueTreeNode> it = descendants.listIterator();
@@ -616,10 +623,10 @@ public class SchedV2 extends AbstractSched {
                 }
             }
             // the children_sDescendant set contains direct children_sDescendant but not the children_sDescendant of children_sDescendant...
-            child.setChildren(_groupChildrenMain(descendantsOfChild, depth + 1, checkDone), "std".equals(getName()));
+            _groupChildrenMain(descendantsOfChild, depth + 1, checkDone, child);
             children.add(child);
         }
-        return children;
+        parent.setChildren(children, "std".equals(getName()));
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -509,7 +509,7 @@ public class SchedV2 extends AbstractSched {
         mCol.getDecks().checkIntegrity();
         ArrayList<Deck> decks = mCol.getDecks().allSorted();
         HashMap<String, Integer[]> lims = new HashMap<>();
-        ArrayList<DeckDueTreeNode> data = new ArrayList<>();
+        ArrayList<DeckDueTreeNode> deckNodes = new ArrayList<>();
         HashMap<Long, HashMap> childMap = mCol.getDecks().childMap();
         for (Deck deck : decks) {
             if (collectionTask != null && collectionTask.isCancelled()) {
@@ -535,11 +535,11 @@ public class SchedV2 extends AbstractSched {
             int rlim = _deckRevLimitSingle(deck, plim);
             int rev = _revForDeck(deck.getLong("id"), rlim, childMap);
             // save to list
-            data.add(new DeckDueTreeNode(mCol, deck.getString("name"), deck.getLong("id"), rev, lrn, _new));
+            deckNodes.add(new DeckDueTreeNode(mCol, deck.getString("name"), deck.getLong("id"), rev, lrn, _new));
             // add deck as a parent
             lims.put(deck.getString("name"), new Integer[]{nlim, rlim});
         }
-        return data;
+        return deckNodes;
     }
 
 
@@ -556,70 +556,70 @@ public class SchedV2 extends AbstractSched {
     }
 
 
-    private List<DeckDueTreeNode> _groupChildren(List<DeckDueTreeNode> grps, boolean checkDone) {
+    private List<DeckDueTreeNode> _groupChildren(List<DeckDueTreeNode> decks, boolean checkDone) {
         // sort based on name's components
-        Collections.sort(grps);
+        Collections.sort(decks);
         // then run main function
-        return _groupChildrenMain(grps, checkDone);
+        return _groupChildrenMain(decks, checkDone);
     }
 
 
-    protected List<DeckDueTreeNode> _groupChildrenMain(List<DeckDueTreeNode> grps, boolean checkDone) {
-        return _groupChildrenMain(grps, 0, checkDone);
+    protected List<DeckDueTreeNode> _groupChildrenMain(List<DeckDueTreeNode> decks, boolean checkDone) {
+        return _groupChildrenMain(decks, 0, checkDone);
     }
 
     /**
-        @return the tree structure of all decks from @grps, starting
+        @return the tree structure of all decks from @descandants, starting
         at specified depth.
 
-        @param grps a list of decks of dept at least depth, having all
+        @param descendants a list of decks of dept at least depth, having all
         the same first depth name elements, sorted in deck order.
         @param depth The depth of the tree we are creating
         @param checkDone whether the set of deck was checked. If
         false, we can't assume all decks have parents and that there
         is no duplicate. Instead, we'll ignore problems.
      */
-    protected List<DeckDueTreeNode> _groupChildrenMain(List<DeckDueTreeNode> grps, int depth, boolean checkDone) {
-        List<DeckDueTreeNode> tree = new ArrayList<>();
+    protected List<DeckDueTreeNode> _groupChildrenMain(List<DeckDueTreeNode> descendants, int depth, boolean checkDone) {
+        List<DeckDueTreeNode> children = new ArrayList<>();
         // group and recurse
-        ListIterator<DeckDueTreeNode> it = grps.listIterator();
+        ListIterator<DeckDueTreeNode> it = descendants.listIterator();
         while (it.hasNext()) {
-            DeckDueTreeNode node = it.next();
-            String head = node.getDeckNameComponent(depth);
-            List<DeckDueTreeNode> children  = new ArrayList<>();
-            /* Compose the "children" node list. The children is a
+            DeckDueTreeNode child = it.next();
+            String head = child.getDeckNameComponent(depth);
+            List<DeckDueTreeNode> descendantsOfChild  = new ArrayList<>();
+            /* Compose the "children_sDescendant" descendant list. The children_sDescendant is a
              * list of all the nodes that proceed the current one that
              * contain the same at depth `depth`, except for the
              * current one itself.  I.e., they are subdecks that stem
-             * from this node.  This is our version of python's
+             * from this descendant.  This is our version of python's
              * itertools.groupby. */
-            if (!checkDone && node.getDepth() != depth) {
-                JSONObject deck = mCol.getDecks().get(node.getDid());
-                Timber.d("Deck %s (%d)'s parent is missing. Ignoring for quick display.", deck.getString("name"), node.getDid());
+            if (!checkDone && child.getDepth() != depth) {
+                JSONObject deck = mCol.getDecks().get(child.getDid());
+                Timber.d("Deck %s (%d)'s parent is missing. Ignoring for quick display.", deck.getString("name"), child.getDid());
                 continue;
             }
             while (it.hasNext()) {
-                DeckDueTreeNode next = it.next();
-                if (head.equals(next.getDeckNameComponent(depth))) {
+                DeckDueTreeNode descendantOfChild = it.next();
+                if (head.equals(descendantOfChild.getDeckNameComponent(depth))) {
                     // Same head - add to tail of current head.
-                    if (!checkDone && next.getDepth() == depth) {
-                        JSONObject deck = mCol.getDecks().get(next.getDid());
-                        Timber.d("Deck %s (%d)'s is a duplicate name. Ignoring for quick display.", deck.getString("name"), next.getDid());
+                    if (!checkDone && descendantOfChild.getDepth() == depth) {
+                        JSONObject deck = mCol.getDecks().get(descendantOfChild.getDid());
+                        Timber.d("Deck %s (%d)'s is a duplicate name. Ignoring for quick display.", deck.getString("name"), descendantOfChild.getDid());
                         continue;
                     }
-                    children.add(next);
+                    descendantsOfChild.add(descendantOfChild);
                 } else {
-                    // We've iterated past this head, so step back in order to use this node as the
+                    // We've iterated past this head, so step back in order to use this descendant as the
                     // head in the next iteration of the outer loop.
                     it.previous();
                     break;
                 }
             }
-            // the children set contains direct children but not the children of children...
-            node.setChildren(_groupChildrenMain(children, depth + 1, checkDone), "std".equals(getName()));
-            tree.add(node);
+            // the children_sDescendant set contains direct children_sDescendant but not the children_sDescendant of children_sDescendant...
+            child.setChildren(_groupChildrenMain(descendantsOfChild, depth + 1, checkDone), "std".equals(getName()));
+            children.add(child);
         }
-        return tree;
+        return children;
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/widget/WidgetStatus.java
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/WidgetStatus.java
@@ -29,6 +29,7 @@ import com.ichi2.anki.services.NotificationService;
 import com.ichi2.async.BaseAsyncTask;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.sched.DeckDueTreeNode;
+import com.ichi2.libanki.sched.DeckDueTreeRoot;
 
 import java.util.List;
 
@@ -124,12 +125,8 @@ public final class WidgetStatus {
             col.getSched()._checkDay();
 
             // Only count the top-level decks in the total
-            List<DeckDueTreeNode> nodes = col.getSched().deckDueTree();
-            for (DeckDueTreeNode node : nodes) {
-                total[0] += node.getNewCount();
-                total[1] += node.getLrnCount();
-                total[2] += node.getRevCount();
-            }
+            DeckDueTreeRoot root = col.getSched().deckDueTree();
+            total =  new int[] {root.getNewCount(), root.getLrnCount(), root.getRevCount()};
             int due = total[0] + total[1] + total[2];
             int eta = col.getSched().eta(total, false);
             sSmallWidgetStatus = new Pair<>(due, eta);

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedTest.java
@@ -128,9 +128,9 @@ public class SchedTest extends RobolectricTest {
 
     @NonNull
     private DeckDueTreeNode getCountsForDid(double didToFind) {
-        List<DeckDueTreeNode> tree = getCol().getSched().deckDueTree();
+        DeckDueTreeRoot tree = getCol().getSched().deckDueTree();
 
-        for (DeckDueTreeNode node : tree) {
+        for (DeckDueTreeNode node : tree.getChildren()) {
             if (node.getDid() == didToFind) {
                 return node;
             }
@@ -170,7 +170,7 @@ public class SchedTest extends RobolectricTest {
         }
         getCol().getSched().deckDueTree();
         AbstractSched sched = getCol().getSched();
-        List<DeckDueTreeNode> tree = sched.deckDueTree();
+        DeckDueTreeRoot tree = sched.deckDueTree();
         Assert.assertEquals("Tree has not the expected structure", SchedV2Test.expectedTree(getCol(), false), tree);
 
     }
@@ -853,7 +853,7 @@ public class SchedTest extends RobolectricTest {
         assertEquals(86400, col.getSched().nextIvl(c, 3));
         // delete the deck, returning the card mid-study
         col.getDecks().rem(col.getDecks().selected());
-        assertEquals(1, col.getSched().deckDueTree().size());
+        assertEquals(1, col.getSched().deckDueTree().getChildren().size());
         c.load();
         assertEquals(1, c.getIvl());
         assertEquals(col.getSched().getToday() + 1, c.getDue());
@@ -1227,7 +1227,7 @@ public class SchedTest extends RobolectricTest {
         col.addNote(note);
         col.reset();
         assertEquals(5, col.getDecks().allSortedNames().size());
-        DeckDueTreeNode tree = col.getSched().deckDueTree().get(0);
+        DeckDueTreeNode tree = col.getSched().deckDueTree().getChildren().get(0);
         assertEquals("Default", tree.getLastDeckNameComponent());
         // sum of child and parent
         assertEquals(1, tree.getDid());

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.java
@@ -80,7 +80,7 @@ import static org.junit.platform.commons.util.CollectionUtils.getOnlyElement;
 @RunWith(AndroidJUnit4.class)
 public class SchedV2Test extends RobolectricTest {
 
-    protected static List<DeckDueTreeNode> expectedTree(Collection col, boolean addRev) {
+    protected static DeckDueTreeRoot expectedTree(Collection col, boolean addRev) {
         AbstractSched sched = col.getSched();
         DeckDueTreeNode caz = new DeckDueTreeNode(col, "cmxieunwoogyxsctnjmv::abcdefgh::ZYXW", 1, 0, 0, 0);
         caz.setChildren(new ArrayList<>(), addRev);
@@ -95,7 +95,9 @@ public class SchedV2Test extends RobolectricTest {
         DeckDueTreeNode s = new DeckDueTreeNode(col, "scxipjiyozczaaczoawo", 1, 0, 0, 0);
         s.setChildren(new ArrayList<>(), addRev);
         List<DeckDueTreeNode> expected = Arrays.asList(defaul, c, s); // Default is first, because start by an Upper case
-        return expected;
+        DeckDueTreeRoot root = new DeckDueTreeRoot(col);
+        root.setChildren(expected, addRev);
+        return root;
     }
 
 
@@ -193,7 +195,7 @@ public class SchedV2Test extends RobolectricTest {
             addDeck(deckName);
         }
         AbstractSched sched = getCol().getSched();
-        List<DeckDueTreeNode> tree = sched.deckDueTree();
+        DeckDueTreeRoot tree = sched.deckDueTree();
         Assert.assertEquals("Tree has not the expected structure", expectedTree(getCol(), true), tree);
     }
 
@@ -680,7 +682,7 @@ public class SchedV2Test extends RobolectricTest {
         }
 
         // position 0 is default deck. Different from upstream
-        DeckDueTreeNode tree = col.getSched().deckDueTree().get(1);
+        DeckDueTreeNode tree = col.getSched().deckDueTree().getChildren().get(1);
         // (('parent', 1514457677462, 5, 0, 0, (('child', 1514457677463, 5, 0, 0, ()),)))
         assertEquals("parent", tree.getFullDeckName());
         assertEquals(5, tree.getRevCount());  // paren, tree.review_count)t
@@ -696,7 +698,7 @@ public class SchedV2Test extends RobolectricTest {
         col.getSched().answerCard(c, 3);
         assertArrayEquals(new int[] {0, 0, 4}, col.getSched().counts());
 
-        tree = col.getSched().deckDueTree().get(1);
+        tree = col.getSched().deckDueTree().getChildren().get(1);
         assertEquals(4, tree.getRevCount());
         assertEquals(4, tree.getChildren().get(0).getRevCount());
     }
@@ -1311,7 +1313,7 @@ public class SchedV2Test extends RobolectricTest {
         col.addNote(note);
         col.reset();
         assertEquals(5, col.getDecks().allSortedNames().size());
-        DeckDueTreeNode tree = col.getSched().deckDueTree().get(0);
+        DeckDueTreeNode tree = col.getSched().deckDueTree().getChildren().get(0);
         assertEquals("Default", tree.getLastDeckNameComponent());
         // sum of child and parent
         assertEquals(1, tree.getDid());
@@ -1337,7 +1339,7 @@ public class SchedV2Test extends RobolectricTest {
         col.getDecks().id("new2");
         // new should not appear twice in tree
         List<String> names = new ArrayList<>();
-        for (DeckDueTreeNode tree : col.getSched().deckDueTree()) {
+        for (DeckDueTreeNode tree : col.getSched().deckDueTree().getChildren()) {
             names.add(tree.getLastDeckNameComponent());
         }
         names.remove("new");


### PR DESCRIPTION
In my opinion, the whole collection should be considered as a deck whose children is the list of decks without "::". It would allow to avoid code duplication. E.g. we compute ETA in different place for the whole collection and for a deck. We compute the number of due cards differently for the collection and for decks. There is absolutely no reason to do that, the collection can be considered as a deck with no limit. 

Furthermore, I believe that the error of https://github.com/ankidroid/Anki-Android/pull/6572 would have been easier to detect if we didn't get a list of decks which was actually a list of top level decks. The method deck due tree should return a tree, not a list of tree (e.g. a forest), so we can use the same code to iterate over top level deck and over their children.

Of course, the collection should not be displayed as a deck in the GUI. I still ensure that we only display the real decks.


This will conflict with https://github.com/ankidroid/Anki-Android/pull/6572 since both touch the reminder service. The code in https://github.com/ankidroid/Anki-Android/pull/6572 can become simpler once the current PR is merged.


This PR is tested by running on my phone. It is a part of the big PR https://github.com/ankidroid/Anki-Android/pull/6522
This is particularly useful here, because it allows to have a canonical place allowing to know whether numbers are computed or not, the root of the tree.