### PR TITLE
NF: _groupChildrenMain deal with unchecked deck collection (performance)

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -424,23 +424,34 @@ public class SchedV2 extends AbstractSched {
         if (deckDueTree == null) {
             return null;
         }
-        return _groupChildren(deckDueTree);
+        return _groupChildren(deckDueTree, true);
     }
 
 
-    private List<DeckDueTreeNode> _groupChildren(List<DeckDueTreeNode> grps) {
+    private List<DeckDueTreeNode> _groupChildren(List<DeckDueTreeNode> grps, boolean checkDone) {
         // sort based on name's components
         Collections.sort(grps);
         // then run main function
-        return _groupChildrenMain(grps);
+        return _groupChildrenMain(grps, checkDone);
     }
 
 
-    protected List<DeckDueTreeNode> _groupChildrenMain(List<DeckDueTreeNode> grps) {
-        return _groupChildrenMain(grps, 0);
+    protected List<DeckDueTreeNode> _groupChildrenMain(List<DeckDueTreeNode> grps, boolean checkDone) {
+        return _groupChildrenMain(grps, 0, checkDone);
     }
 
-    protected List<DeckDueTreeNode> _groupChildrenMain(List<DeckDueTreeNode> grps, int depth) {
+    /**
+        @return the tree structure of all decks from @grps, starting
+        at specified depth.
+
+        @param grps a list of decks of dept at least depth, having all
+        the same first depth name elements, sorted in deck order.
+        @param depth The depth of the tree we are creating
+        @param checkDone whether the set of deck was checked. If
+        false, we can't assume all decks have parents and that there
+        is no duplicate. Instead, we'll ignore problems.
+     */
+    protected List<DeckDueTreeNode> _groupChildrenMain(List<DeckDueTreeNode> grps, int depth, boolean checkDone) {
         List<DeckDueTreeNode> tree = new ArrayList<>();
         // group and recurse
         ListIterator<DeckDueTreeNode> it = grps.listIterator();
@@ -454,10 +465,20 @@ public class SchedV2 extends AbstractSched {
              * current one itself.  I.e., they are subdecks that stem
              * from this node.  This is our version of python's
              * itertools.groupby. */
+            if (!checkDone && node.getDepth() != depth) {
+                JSONObject deck = mCol.getDecks().get(node.getDid());
+                Timber.d("Deck %s (%d)'s parent is missing. Ignoring for quick display.", deck.getString("name"), node.getDid());
+                continue;
+            }
             while (it.hasNext()) {
                 DeckDueTreeNode next = it.next();
                 if (head.equals(next.getDeckNameComponent(depth))) {
                     // Same head - add to tail of current head.
+                    if (!checkDone && next.getDepth() == depth) {
+                        JSONObject deck = mCol.getDecks().get(next.getDid());
+                        Timber.d("Deck %s (%d)'s is a duplicate name. Ignoring for quick display.", deck.getString("name"), next.getDid());
+                        continue;
+                    }
                     children.add(next);
                 } else {
                     // We've iterated past this head, so step back in order to use this node as the
@@ -467,7 +488,7 @@ public class SchedV2 extends AbstractSched {
                 }
             }
             // the children set contains direct children but not the children of children...
-            node.setChildren(_groupChildrenMain(children, depth + 1), "std".equals(getName()));
+            node.setChildren(_groupChildrenMain(children, depth + 1, checkDone), "std".equals(getName()));
             tree.add(node);
         }
         return tree;


### PR DESCRIPTION
One of the reason loading a lot of deck takes time at startup is long is that we must do a lot of operations to check the deck collection. This is less computationally expensive than computing numbers, but still takes seconds. So this PR allows the method to take a parameter warning it that the deck is not yet checked, and that it should Timber in case of problem and just ignore the faulty deck. 

Right now, this feature si never used. It is of course a part of my bigger PR for improving starting time. I expect to use this new feature to make starting faster. And the few cases where the collection start with duplicate name or missing parents, the faulty deck will take a few seconds to appear while everything else will appear correctly immediately