### PR TITLE
Load deck tree before number on start

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -2154,6 +2154,16 @@ public class DeckPicker extends NavigationDrawerActivity implements
         }
     }
 
+    private void openReviewerOrStudyOptions(boolean dontSkipStudyOptions) {
+        if (mFragmented || dontSkipStudyOptions) {
+            // Go to StudyOptions screen when tablet or deck counts area was clicked
+            openStudyOptions(false);
+        } else {
+            // Otherwise jump straight to the reviewer
+            openReviewer();
+        }
+    }
+
     private void handleDeckSelection(long did, boolean dontSkipStudyOptions) {
         // Clear the undo history when selecting a new deck
         if (getCol().getDecks().selected() != did) {
@@ -2171,13 +2181,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
         // Figure out what action to take
         if (deckDueTreeNode.getNewCount() + deckDueTreeNode.getLrnCount() + deckDueTreeNode.getRevCount() > 0) {
             // If there are cards to study then either go to Reviewer or StudyOptions
-            if (mFragmented || dontSkipStudyOptions) {
-                // Go to StudyOptions screen when tablet or deck counts area was clicked
-                openStudyOptions(false);
-            } else {
-                // Otherwise jump straight to the reviewer
-                openReviewer();
-            }
+            openReviewerOrStudyOptions(dontSkipStudyOptions);
             return;
         }
         if (getCol().getSched().hasCardsTodayAfterStudyAheadLimit()) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -916,6 +916,9 @@ public class DeckPicker extends NavigationDrawerActivity implements
             mSyncOnResume = false;
         } else if (colIsOpen()) {
             selectNavigationItem(R.id.nav_decks);
+            if (mDueTree == null) {
+                updateDeckList(true);
+            }
             updateDeckList();
             setTitle(getResources().getString(R.string.app_name));
         }
@@ -2307,8 +2310,13 @@ public class DeckPicker extends NavigationDrawerActivity implements
      * This method also triggers an update for the widget to reflect the newly calculated counts.
      */
     private void updateDeckList() {
+        updateDeckList(false);
+    }
+
+    private void updateDeckList(boolean quick) {
         TaskListener listener = updateDeckListListener();
-        CollectionTask task = CollectionTask.launchCollectionTask(LOAD_DECK_COUNTS, listener);
+        CollectionTask.TASK_TYPE taskType = quick ? LOAD_DECK_QUICK : LOAD_DECK_COUNTS;
+        CollectionTask.launchCollectionTask(taskType, listener);
     }
 
     public void __renderPage() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -2182,7 +2182,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
         // Get some info about the deck to handle special cases
         int pos = mDeckListAdapter.findDeckPosition(did);
         AbstractDeckTreeNode deckDueTreeNode = mDeckListAdapter.getDeckList().get(pos);
-        if (!deckDueTreeNode.shouldDisplayCounts()) {
+        if (!deckDueTreeNode.shouldDisplayCounts() || deckDueTreeNode.knownToHaveRep()) {
             // If we don't yet have numbers, we trust the user that they knows what they opens, tries to open it.
             // If there is nothing to review, it'll come back to deck picker.
             openReviewerOrStudyOptions(dontSkipStudyOptions);
@@ -2190,11 +2190,6 @@ public class DeckPicker extends NavigationDrawerActivity implements
         }
         // There are numbers
         // Figure out what action to take
-        if (deckDueTreeNode.getNewCount() + deckDueTreeNode.getLrnCount() + deckDueTreeNode.getRevCount() > 0) {
-            // If there are cards to study then either go to Reviewer or StudyOptions
-            openReviewerOrStudyOptions(dontSkipStudyOptions);
-            return;
-        }
         if (getCol().getSched().hasCardsTodayAfterStudyAheadLimit()) {
             // If there are cards due that can't be studied yet (due to the learn ahead limit) then go to study options
             openStudyOptions(false);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.java
@@ -40,6 +40,7 @@ import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Deck;
 import com.ichi2.libanki.sched.AbstractDeckTreeNode;
 import com.ichi2.libanki.sched.DeckDueTreeNode;
+import com.ichi2.libanki.sched.DeckTreeNode;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -97,6 +97,7 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
         DISMISS_MULTI,
         CHECK_DATABASE,
         REPAIR_COLLECTION,
+        LOAD_DECK_QUICK,
         LOAD_DECK_COUNTS,
         UPDATE_VALUES_FROM_DECK,
         DELETE_DECK,
@@ -341,6 +342,9 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
         }
         // Actually execute the task now that we are at the front of the queue.
         switch (mType) {
+            case LOAD_DECK_QUICK:
+                return doInBackgroundLoadDeck();
+
             case LOAD_DECK_COUNTS:
                 return doInBackgroundLoadDeckCounts();
 
@@ -595,6 +599,20 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
             return new TaskData(false);
         }
         return new TaskData(true);
+    }
+
+
+    private TaskData doInBackgroundLoadDeck() {
+        Timber.d("doInBackgroundLoadDeckCounts");
+        Collection col = CollectionHelper.getInstance().getCol(mContext);
+        try {
+            // Get due tree
+            Object[] o = new Object[] {col.getSched().quickDeckDueTree()};
+            return new TaskData(o);
+        } catch (RuntimeException e) {
+            Timber.w(e, "doInBackgroundLoadDeckCounts - error");
+            return null;
+        }
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractDeckTreeNode.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractDeckTreeNode.java
@@ -186,4 +186,9 @@ public abstract class AbstractDeckTreeNode<T extends AbstractDeckTreeNode<T>> im
         throw new UnsupportedOperationException();
     }
 
+
+    public boolean knownToHaveRep() {
+        return false;
+    }
+
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractDeckTreeNode.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractDeckTreeNode.java
@@ -1,0 +1,189 @@
+package com.ichi2.libanki.sched;
+
+import com.ichi2.libanki.Collection;
+import com.ichi2.libanki.Decks;
+
+import java.util.List;
+import java.util.Locale;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+/**
+ * Holds the data for a single node (row) in the deck due tree (the user-visible list
+ * of decks and their counts). A node also contains a list of nodes that refer to the
+ * next level of sub-decks for that particular deck (which can be an empty list).
+ *
+ * The names field is an array of names that build a deck name from a hierarchy (i.e., a nested
+ * deck will have an entry for every level of nesting). While the python version interchanges
+ * between a string and a list of strings throughout processing, we always use an array for
+ * this field and use getNamePart(0) for those cases.
+ *
+ * T represents the type of children. Required for typing purpose only.
+ */
+public abstract class AbstractDeckTreeNode<T extends AbstractDeckTreeNode<T>> implements Comparable<AbstractDeckTreeNode<T>> {
+    private final String mName;
+    private final String[] mNameComponents;
+    private final Collection mCol;
+    private long mDid;
+    @Nullable
+    private List<T> mChildren = null;
+
+    public AbstractDeckTreeNode(Collection col, String mName, long mDid) {
+        this.mCol = col;
+        this.mName = mName;
+        this.mDid = mDid;
+        this.mNameComponents = Decks.path(mName);
+    }
+
+    /**
+     * Sort on the head of the node.
+     */
+    @Override
+    public int compareTo(AbstractDeckTreeNode<T> rhs) {
+        int minDepth = Math.min(getDepth(), rhs.getDepth()) + 1;
+        // Consider each subdeck name in the ordering
+        for (int i = 0; i < minDepth; i++) {
+            int cmp = mNameComponents[i].compareTo(rhs.mNameComponents[i]);
+            if (cmp == 0) {
+                continue;
+            }
+            return cmp;
+        }
+        // If we made it this far then the arrays are of different length. The longer one should
+        // always come after since it contains all of the sections of the shorter one inside it
+        // (i.e., the short one is an ancestor of the longer one).
+        return Integer.compare(getDepth(), rhs.getDepth());
+    }
+
+    /** Line representing this string without its children. Used in timbers only. */
+    protected String toStringLine() {
+        return String.format(Locale.US, "%s, %d, %s",
+                             mName, mDid, mChildren);
+    }
+
+    @Override
+    public String toString() {
+        StringBuffer buf = new StringBuffer();
+        toString(buf);
+        return buf.toString();
+    }
+
+    protected void toString(StringBuffer buf) {
+        for (int i = 0; i < getDepth(); i++ ) {
+            buf.append("  ");
+        }
+        buf.append(toStringLine());
+        if (mChildren == null) {
+            return;
+        }
+        for (T children : mChildren) {
+            children.toString(buf);
+        }
+    }
+
+    /**
+     * @return The full deck name, e.g. "A::B::C"
+     * */
+    public String getFullDeckName() {
+        return mName;
+    }
+
+    /**
+     * For deck "A::B::C", `getDeckNameComponent(0)` returns "A",
+     * `getDeckNameComponent(1)` returns "B", etc...
+     */
+    public String getDeckNameComponent(int part) {
+        return mNameComponents[part];
+    }
+
+    /**
+     * The part of the name displayed in deck picker, i.e. the
+     * part that does not belong to its parents. E.g.  for deck
+     * "A::B::C", returns "C".
+     */
+    public String getLastDeckNameComponent() {
+        return getDeckNameComponent(getDepth());
+    }
+
+    public long getDid() {
+        return mDid;
+    }
+
+    /**
+     * @return The depth of a deck. Top level decks have depth 0,
+     * their children have depth 1, etc... So "A::B::C" would have
+     * depth 2.
+     */
+    public int getDepth() {
+        return mNameComponents.length - 1;
+    }
+
+    /**
+     * @return The children of this deck. Note that they are set
+     * in the data structure returned by DeckDueTree but are
+     * always empty when the data structure is returned by
+     * deckDueList.*/
+    public List<T> getChildren() {
+        return mChildren;
+    }
+
+    /**
+     * @return whether this node as any children. */
+    public boolean hasChildren() {
+        return mChildren != null && !mChildren.isEmpty();
+    }
+
+    public void setChildren(@NonNull List<T> children, boolean addRev) {
+        // addRev present here because it needs to be overriden
+        mChildren = children;
+    }
+
+    @Override
+    public int hashCode() {
+        int childrenHash = mChildren == null ? 0 : mChildren.hashCode();
+        return getFullDeckName().hashCode() + (int) (childrenHash ^ (childrenHash >>> 32));
+    }
+
+
+    /**
+     * Whether both elements have the same structure and numbers.
+     * @param object
+     * @return
+     */
+    @Override
+    public boolean equals(Object object) {
+        if (object == null || !(object instanceof AbstractDeckTreeNode)) {
+            return false;
+        }
+        AbstractDeckTreeNode tree = (AbstractDeckTreeNode) object;
+        return Decks.equalName(getFullDeckName(), tree.getFullDeckName()) &&
+            (mChildren == null && tree.mChildren == null) || // Would be the case if both are null, or the same pointer
+            (mChildren != null && mChildren.equals(tree.mChildren))
+            ;
+    }
+
+    public Collection getCol() {
+        return mCol;
+    }
+
+    public boolean shouldDisplayCounts() {
+        return false;
+    }
+
+    /* Number of new cards to see today known to be in this deck and its descendants. The number to show to user*/
+    public int getNewCount() {
+        throw new UnsupportedOperationException();
+    }
+
+    /* Number of lrn cards (or repetition) to see today known to be in this deck and its descendants. The number to show to user*/
+    public int getLrnCount() {
+        throw new UnsupportedOperationException();
+    }
+
+    /* Number of rev cards to see today known to be in this deck and its descendants. The number to show to user*/
+    public int getRevCount() {
+        throw new UnsupportedOperationException();
+    }
+
+}

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
@@ -131,6 +131,7 @@ public abstract class AbstractSched {
     /** load the due tree, but halt if deck task is cancelled*/
     public abstract List<DeckDueTreeNode> deckDueTree(CollectionTask collectionTask);
     public abstract List<DeckDueTreeNode> deckDueTree();
+    public abstract List<DeckTreeNode> quickDeckDueTree();
     /** New count for a single deck. */
     public abstract int _newForDeck(long did, int lim);
     /** Limit for deck without parent limits. */

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/DeckDueTreeNode.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/DeckDueTreeNode.java
@@ -116,4 +116,8 @@ public class DeckDueTreeNode extends AbstractDeckTreeNode<DeckDueTreeNode> {
     public boolean shouldDisplayCounts() {
         return true;
     }
+
+    public boolean knownToHaveRep() {
+        return mRevCount > 0 || mNewCount > 0 || mNewCount > 0;
+    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/DeckDueTreeNode.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/DeckDueTreeNode.java
@@ -20,105 +20,24 @@ import androidx.annotation.Nullable;
  * between a string and a list of strings throughout processing, we always use an array for
  * this field and use getNamePart(0) for those cases.
  */
-public class DeckDueTreeNode implements Comparable {
-    private final Collection mCol;
-    private final String mName;
-    private final String[] mNameComponents;
-    private long mDid;
+public class DeckDueTreeNode extends AbstractDeckTreeNode<DeckDueTreeNode> {
     private int mRevCount;
     private int mLrnCount;
     private int mNewCount;
-    @Nullable
-    private List<DeckDueTreeNode> mChildren = null;
 
     public DeckDueTreeNode(Collection col, String mName, long mDid, int mRevCount, int mLrnCount, int mNewCount) {
-        this.mCol = col;
-        this.mName = mName;
-        this.mDid = mDid;
+        super(col, mName, mDid);
         this.mRevCount = mRevCount;
         this.mLrnCount = mLrnCount;
         this.mNewCount = mNewCount;
-        this.mNameComponents = Decks.path(mName);
-    }
-
-    /**
-     * Sort on the head of the node.
-     */
-    @Override
-    public int compareTo(Object other) {
-        DeckDueTreeNode rhs = (DeckDueTreeNode) other;
-        int minDepth = Math.min(getDepth(), rhs.getDepth()) + 1;
-        // Consider each subdeck name in the ordering
-        for (int i = 0; i < minDepth; i++) {
-            int cmp = mNameComponents[i].compareTo(rhs.mNameComponents[i]);
-            if (cmp == 0) {
-                continue;
-            }
-            return cmp;
-        }
-        // If we made it this far then the arrays are of different length. The longer one should
-        // always come after since it contains all of the sections of the shorter one inside it
-        // (i.e., the short one is an ancestor of the longer one).
-        return Integer.compare(getDepth(), rhs.getDepth());
     }
 
     @Override
     public String toString() {
-        StringBuffer buf = new StringBuffer();
-        toString(buf);
-        return buf.toString();
+        return String.format(Locale.US, "%s, %d, %d, %d, %d, %s",
+                             getFullDeckName(), getDid(), mRevCount, mLrnCount, mNewCount, getChildren());
     }
 
-    public void toString(StringBuffer buf) {
-        for (int i = 0; i < getDepth(); i++ ) {
-            buf.append("  ");
-        }
-        buf.append(String.format(Locale.US, "%s, %d, %d, %d, %d\n",
-                mName, mDid, mRevCount, mLrnCount, mNewCount));
-        if (mChildren == null) {
-            return;
-        }
-        for (DeckDueTreeNode children : mChildren) {
-            children.toString(buf);
-        }
-    }
-
-    /**
-     * @return The full deck name, e.g. "A::B::C"
-     * */
-    public String getFullDeckName() {
-        return mName;
-    }
-
-    /**
-     * For deck "A::B::C", `getDeckNameComponent(0)` returns "A",
-     * `getDeckNameComponent(1)` returns "B", etc...
-     */
-    public String getDeckNameComponent(int part) {
-        return mNameComponents[part];
-    }
-
-    /**
-     * The part of the name displayed in deck picker, i.e. the
-     * part that does not belong to its parents. E.g.  for deck
-     * "A::B::C", returns "C".
-     */
-    public String getLastDeckNameComponent() {
-        return getDeckNameComponent(getDepth());
-    }
-
-    public long getDid() {
-        return mDid;
-    }
-
-    /**
-     * @return The depth of a deck. Top level decks have depth 0,
-     * their children have depth 1, etc... So "A::B::C" would have
-     * depth 2.
-     */
-    public int getDepth() {
-        return mNameComponents.length - 1;
-    }
 
     public int getRevCount() {
         return mRevCount;
@@ -140,23 +59,8 @@ public class DeckDueTreeNode implements Comparable {
         return mLrnCount;
     }
 
-    /**
-     * @return The children of this deck. Note that they are set
-     * in the data structure returned by DeckDueTree but are
-     * always empty when the data structure is returned by
-     * deckDueList.*/
-    public List<DeckDueTreeNode> getChildren() {
-        return mChildren;
-    }
-
-    /**
-     * @return whether this node as any children. */
-    public boolean hasChildren() {
-        return mChildren != null && !mChildren.isEmpty();
-    }
-
     public void setChildren(@NonNull List<DeckDueTreeNode> children, boolean addRev) {
-        mChildren = children;
+        super.setChildren(children, addRev);
         // tally up children counts
         for (DeckDueTreeNode ch : children) {
             mLrnCount += ch.getLrnCount();
@@ -166,9 +70,9 @@ public class DeckDueTreeNode implements Comparable {
             }
         }
         // limit the counts to the deck's limits
-        JSONObject conf = mCol.getDecks().confForDid(mDid);
+        JSONObject conf = getCol().getDecks().confForDid(getDid());
         if (conf.getInt("dyn") == 0) {
-            JSONObject deck = mCol.getDecks().get(mDid);
+            JSONObject deck = getCol().getDecks().get(getDid());
             limitNewCount(conf.getJSONObject("new").getInt("perDay") - deck.getJSONArray("newToday").getInt(1));
             if (addRev) {
                 limitRevCount(conf.getJSONObject("rev").getInt("perDay") - deck.getJSONArray("revToday").getInt(1));
@@ -178,7 +82,7 @@ public class DeckDueTreeNode implements Comparable {
 
     @Override
     public int hashCode() {
-        int childrenHash = mChildren.hashCode();
+        int childrenHash = getChildren() == null ? 0 : getChildren().hashCode();
         return getFullDeckName().hashCode() + mRevCount + mLrnCount + mNewCount + (int) (childrenHash ^ (childrenHash >>> 32));
     }
 
@@ -190,16 +94,26 @@ public class DeckDueTreeNode implements Comparable {
      */
     @Override
     public boolean equals(Object object) {
-        if (!(object instanceof DeckDueTreeNode)) {
+        if (object == null || !(object instanceof DeckDueTreeNode)) {
             return false;
         }
         DeckDueTreeNode tree = (DeckDueTreeNode) object;
         return Decks.equalName(getFullDeckName(), tree.getFullDeckName()) &&
-                mRevCount == tree.mRevCount &&
-                mLrnCount == tree.mLrnCount &&
-                mNewCount == tree.mNewCount &&
-                (mChildren == tree.mChildren || // Would be the case if both are null, or the same pointer
-                mChildren.equals(tree.mChildren))
-                ;
+            mRevCount == tree.mRevCount &&
+            mLrnCount == tree.mLrnCount &&
+            mNewCount == tree.mNewCount &&
+            (getChildren() == tree.getChildren() || // Would be the case if both are null, or the same pointer
+             getChildren().equals(tree.getChildren()))
+            ;
+    }
+
+    /** Line representing this string without its children. Used in timbers only. */
+    protected String toStringLine() {
+        return String.format(Locale.US, "%s, %d, %d, %d, %d\n",
+                             getFullDeckName(), getDid(), mRevCount, mLrnCount, mNewCount);
+    }
+
+    public boolean shouldDisplayCounts() {
+        return true;
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/DeckTreeNode.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/DeckTreeNode.java
@@ -1,0 +1,9 @@
+package com.ichi2.libanki.sched;
+
+import com.ichi2.libanki.Collection;
+
+public class DeckTreeNode extends AbstractDeckTreeNode<DeckTreeNode> {
+    public DeckTreeNode(Collection col, String mName, long mDid) {
+        super(col, mName, mDid);
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -523,6 +523,26 @@ public class SchedV2 extends AbstractSched {
         return data;
     }
 
+    /** Similar to deck due tree, but ignore the number of cards.
+
+     It may takes a lot of time to compute the number of card, it
+     requires multiple database access by deck.  Ignoring this number
+     lead to the creation of a tree more quickly.*/
+    @Override
+    public List<DeckTreeNode> quickDeckDueTree() {
+        // Similar to deckDueTree, ignoring the numbers
+
+        // Similar to deckDueList
+        ArrayList<DeckTreeNode> data = new ArrayList<>();
+        for (JSONObject deck : mCol.getDecks().allSorted()) {
+            DeckTreeNode g = new DeckTreeNode(mCol, deck.getString("name"), deck.getLong("id"));
+            data.add(g);
+        }
+        // End of the similar part.
+
+        return _groupChildren(data, false);
+    }
+
 
     public List<DeckDueTreeNode> deckDueTree() {
         return deckDueTree(null);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -537,7 +537,7 @@ public class SchedV2 extends AbstractSched {
     }
 
 
-    private List<DeckDueTreeNode> _groupChildren(List<DeckDueTreeNode> grps, boolean checkDone) {
+    private <T extends AbstractDeckTreeNode> List<T> _groupChildren(List<T> grps, boolean checkDone) {
         // sort based on name's components
         Collections.sort(grps);
         // then run main function
@@ -545,7 +545,7 @@ public class SchedV2 extends AbstractSched {
     }
 
 
-    protected List<DeckDueTreeNode> _groupChildrenMain(List<DeckDueTreeNode> grps, boolean checkDone) {
+    protected <T extends AbstractDeckTreeNode> List<T> _groupChildrenMain(List<T> grps, boolean checkDone) {
         return _groupChildrenMain(grps, 0, checkDone);
     }
 
@@ -560,14 +560,14 @@ public class SchedV2 extends AbstractSched {
         false, we can't assume all decks have parents and that there
         is no duplicate. Instead, we'll ignore problems.
      */
-    protected List<DeckDueTreeNode> _groupChildrenMain(List<DeckDueTreeNode> grps, int depth, boolean checkDone) {
-        List<DeckDueTreeNode> tree = new ArrayList<>();
+    protected <T extends AbstractDeckTreeNode> List<T> _groupChildrenMain(List<T> grps, int depth, boolean checkDone) {
+        List<T> tree = new ArrayList<>();
         // group and recurse
-        ListIterator<DeckDueTreeNode> it = grps.listIterator();
+        ListIterator<T> it = grps.listIterator();
         while (it.hasNext()) {
-            DeckDueTreeNode node = it.next();
+            T node = it.next();
             String head = node.getDeckNameComponent(depth);
-            List<DeckDueTreeNode> children  = new ArrayList<>();
+            List<AbstractDeckTreeNode> children  = new ArrayList<>();
             /* Compose the "children" node list. The children is a
              * list of all the nodes that proceed the current one that
              * contain the same at depth `depth`, except for the
@@ -580,7 +580,7 @@ public class SchedV2 extends AbstractSched {
                 continue;
             }
             while (it.hasNext()) {
-                DeckDueTreeNode next = it.next();
+                AbstractDeckTreeNode next = it.next();
                 if (head.equals(next.getDeckNameComponent(depth))) {
                     // Same head - add to tail of current head.
                     if (!checkDone && next.getDepth() == depth) {


### PR DESCRIPTION
As David requested some time ago, I use the type system to determines whether deck nodes have numbers or not. I first compute deck nodes without numbers in order to be quick, and then with numbers. 

This lead to ![Screenshot_20200808-004202_AnkiDroid.jpg](https://user-images.githubusercontent.com/357361/89693896-2f085200-d910-11ea-8264-363b0f617521.jpg) almost immediately instead of waiting 10 seconds to get all numbers.

It has been tested on my phone for months now
