### PR TITLE
Reload CardBrowser but not reviewer when note edited

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1165,8 +1165,10 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
         }
 
-        if (requestCode == EDIT_CARD &&  data!=null && data.hasExtra("reloadRequired")) {
-            // if reloadRequired flag was sent from note editor then reload card list
+        if (requestCode == EDIT_CARD &&  data != null &&
+                (data.getBooleanExtra("reloadRequired", false) ||
+                        data.getBooleanExtra("noteChanged", false))) {
+            // if reloadRequired or noteChanged flag was sent from note editor then reload card list
             searchCards();
             // in use by reviewer?
             if (getReviewerCardId() == mCurrentCardId) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -832,11 +832,7 @@ public class NoteEditor extends AnkiActivity {
             modified = modified || mEditorNote.getTags().size() > mSelectedTags.size();
             if (modified) {
                 mEditorNote.setTagsFromStr(tagsAsString(mSelectedTags));
-                // CardBrowser always runs CollectionTask.TASK_TYPE_UPDATE_NOTE in response to non-canceled edits
-                // so mChanged is likely not needed anymore...
                 mChanged = true;
-                // ...but we do need it to reload itself so results of tag and field edits are shown
-                mReloadRequired = true;
             }
             closeNoteEditor();
         }
@@ -1048,11 +1044,14 @@ public class NoteEditor extends AnkiActivity {
         } else {
             result = RESULT_CANCELED;
         }
+        if (intent == null) {
+            intent = new Intent();
+        }
         if (mReloadRequired) {
-            if (intent == null) {
-                intent = new Intent();
-            }
             intent.putExtra("reloadRequired", true);
+        }
+        if (mChanged) {
+            intent.putExtra("noteChanged", true);
         }
 
         closeNoteEditor(result, intent);


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
There was an issue where certain note edits (tag changes etc) were not reflected in the card browser after returning from the note editor, an initial fix attempt used mReloadRequired to trigger that

But if you pass mReloadRequired back to flaschard reviewer you might get unexpected behavior, 

## Fixes
Partially fixes #6556 

## Approach
Use the mChanged toggle to do trigger addition of "noteChanged" intent extra boolean in place of mReloadRequired

## How Has This Been Tested?

API29 emulator, reverting the previous change should fix the issue, and the noteChanged toggle is additive so should have predictable results - only consumed in the new place I added it in the card browser, which I tested and worked

## Learning (optional, can help others)
@david-allison-1 and @Anthropos888  did the research on the related issue (thank you!)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
