### PR TITLE
NF: cache the result of "parent"

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -1131,15 +1131,21 @@ public class Decks {
         return deckName != null && !deckName.trim().isEmpty();
     }
 
+
+    private static HashMap<String, String> sParentCache = new HashMap();
     public static String parent(String deckName) {
         // method parent, from sched's method deckDueList in python
-        List<String> parts = Arrays.asList(path(deckName));
-        if (parts.size() < 2) {
-            return null;
-        } else {
-            parts = parts.subList(0, parts.size() - 1);
-            return TextUtils.join("::", parts);
+        if (!sParentCache.containsKey(deckName)) {
+            List<String> parts = Arrays.asList(path(deckName));
+            if (parts.size() < 2) {
+                sParentCache.put(deckName, null);
+            } else {
+                parts = parts.subList(0, parts.size() - 1);
+                String parentName = TextUtils.join("::", parts);
+                sParentCache.put(deckName, parentName);
+            }
         }
+        return sParentCache.get(deckName);
     }
 
     public String getActualDescription() {


### PR DESCRIPTION
## Pull Request template

This require to recreate string from an array of string, it is
uselessly long, and caching it should win fraction of seconds when
creating deckDueList and checking the set of decks, by allowing to
access parents faster


## How Has This Been Tested?

I added it into my "merge" branch and tries it on my phone
