### PR TITLE
Use upstream JDK install scripts for CI again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
     - ANDROID_TOOLS_URL="https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip"
     - EMU_FLAVOR=default # use google_apis flavor if no default flavor emulator
     - LOCALE="NONE"
-    - GRAVIS_REPO="https://github.com/mikehardy/Gravis-CI.git"
+    - GRAVIS_REPO="https://github.com/DanySK/Gravis-CI.git"
     - GRAVIS="$HOME/gravis"
     - JDK="1.8"
     - TOOLS=${ANDROID_HOME}/tools
@@ -87,7 +87,7 @@ before_install:
   # It should not make assumptions about os platform or desired tool installation
 
   # Set up JDK 8 for Android SDK - Java is universally needed: codacy, unit tests, emulators
-  - travis_retry git clone --single-branch --branch resilience --depth 1 $GRAVIS_REPO $GRAVIS
+  - travis_retry git clone --depth 1 $GRAVIS_REPO $GRAVIS
   - export TARGET_JDK="${JDK}"
   - JDK="1.8"
   - source $GRAVIS/install-jdk


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

My PR for increased resilience in JDK installation was merged upstream,
this moves us back to using upstream vs my local branch

## Fixes
Related https://github.com/DanySK/Gravis-CI/pull/16

## Approach
Just re-point the git repo we use

## How Has This Been Tested?

Travis will work or not

## Learning (optional, can help others)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
