### PR TITLE
Improved blue flag contrast against blue app bar

### DIFF
--- a/AnkiDroid/src/main/res/drawable/ic_flag_blue.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_flag_blue.xml
@@ -5,5 +5,5 @@
     android:viewportHeight="24">
   <path
       android:pathData="M14.4,6L14,4H5v17h2v-7h5.6l0.4,2h7V6z"
-      android:fillColor="#77AAFF"/>
+      android:fillColor="@color/material_blue_700"/>
 </vector>


### PR DESCRIPTION
## Purpose / Description
The new blue flag `#77AAFF` had little contrast against the app bar.

But, `#0000FF` was too blue.

## Fixes
Fixes #6591

## Approach
Compromise: `#1976d2`

## How Has This Been Tested?

![image](https://user-images.githubusercontent.com/62114487/86156086-4ed07d00-bafd-11ea-8c3b-f31fd6b641b5.png)


## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code