### PR TITLE
Counts reset if required

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -883,8 +883,7 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
                     newCard = col.getCard(cid);
                     newCard.startTimer();
                     col.reset();
-                    col.getSched().decrementCounts(newCard);
-                    sched.deferReset();
+                    sched.deferReset(newCard);
                 } else {
                     // cid < 0
                     /* multi-card action undone, no action to take here */

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
@@ -30,6 +30,9 @@ public abstract class AbstractSched {
     public abstract void reset();
     /** Ensures that reset is executed before the next card is selected */
     public abstract void deferReset();
+    /**
+     * @param undoneCard a card undone, send back to the reviewer.*/
+    public abstract void deferReset(Card undoneCard);
     public abstract void answerCard(Card card, int ease);
     public abstract int[] counts();
     public abstract int[] counts(Card card);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -256,6 +256,9 @@ public class SchedV2 extends AbstractSched {
 
 
     public int[] counts() {
+        if (!mHaveQueues) {
+            reset();
+        }
         return new int[] {mNewCount, mLrnCount, mRevCount};
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -90,6 +90,8 @@ public class SchedV2 extends AbstractSched {
     protected int mRevCount;
 
     private int mNewCardModulus;
+    // When an action is undone, reset counts need to take the card into account
+    private Card mUndidCard = null;
 
     private double[] mEtaCache = new double[] { -1, -1, -1, -1, -1, -1 };
 
@@ -165,8 +167,13 @@ public class SchedV2 extends AbstractSched {
     }
 
     /** Ensures that reset is executed before the next card is selected */
-    public void deferReset(){
+    public void deferReset(Card undidCard){
         mHaveQueues = false;
+        mUndidCard = undidCard;
+    }
+
+    public void deferReset(){
+        deferReset(null);
     }
 
     public void reset() {
@@ -175,6 +182,10 @@ public class SchedV2 extends AbstractSched {
         _resetRev();
         _resetNew();
         mHaveQueues = true;
+        if (mUndidCard != null) {
+            decrementCounts(mUndidCard);
+            mUndidCard = null;
+        }
     }
 
 

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/AbstractSchedTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/AbstractSchedTest.java
@@ -1,0 +1,86 @@
+/*
+ Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.libanki.sched;
+
+import com.ichi2.anki.RobolectricTest;
+import com.ichi2.anki.exception.ConfirmModSchemaException;
+import com.ichi2.async.CollectionTask;
+import com.ichi2.libanki.Card;
+import com.ichi2.libanki.Consts;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.ParameterizedRobolectricTestRunner;
+import org.robolectric.ParameterizedRobolectricTestRunner.Parameter;
+import org.robolectric.ParameterizedRobolectricTestRunner.Parameters;
+
+import java.util.Arrays;
+
+import static com.ichi2.anki.AbstractFlashcardViewer.EASE_3;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+// Note: These tests can't be run individually but can from the class-level
+// gradlew AnkiDroid:testDebug --tests "com.ichi2.libanki.sched.AbstractSchedTest.*"
+@RunWith(ParameterizedRobolectricTestRunner.class)
+public class AbstractSchedTest extends RobolectricTest {
+
+    @Parameter
+    public int schedVersion;
+
+    @Parameters(name = "SchedV{0}")
+    public static java.util.Collection<Object[]> initParameters() {
+        // This does one run with schedVersion injected as 1, and one run as 2
+        return Arrays.asList(new Object[][] { { 1 }, { 2 } });
+    }
+
+    @Before
+    @Override
+    public void setUp() {
+        super.setUp();
+        try {
+            getCol().changeSchedulerVer(schedVersion);
+        } catch (ConfirmModSchemaException e) {
+            throw new RuntimeException("Could not change schedVer", e);
+        }
+    }
+
+    @Test
+    public void testUndoResetsCardCountsToCorrectValue() throws InterruptedException {
+        // #6587
+        addNoteUsingBasicModel("Hello", "World");
+
+        AbstractSched sched = getCol().getSched();
+        sched.reset();
+
+        Card cardBeforeUndo = sched.getCard();
+        int[] countsBeforeUndo = sched.counts();
+        // Not shown in the UI, but there is a state where the card has been removed from the queue, but not answered
+        // where the counts are decremented.
+        assertThat(countsBeforeUndo, is(new int[] { 0, 0, 0 }));
+
+        sched.answerCard(cardBeforeUndo, EASE_3);
+
+        waitForTask(CollectionTask.TASK_TYPE_UNDO, 5000);
+
+        int[] countsAfterUndo = sched.counts();
+
+        assertThat("Counts after an undo should be the same as before an undo", countsAfterUndo, is(countsBeforeUndo));
+    }
+}


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

This should solve
Fixes #6587 while still
doing resets only when they are required.


## Approach

The main problem is that "counts" mean "number of cards to see today, ignoring current card if any".

The trouble here is that "current card" was not something the scheduler new about. So instead we have ad-hoc code to ignore the current card. Essentially, when "getCard" is called, it is assumed it is giving the current card. When "undo" is called, it reset the scheduler twice and manually change the count of the current card.

The good news is that https://github.com/ankidroid/Anki-Android/pull/6585 is already dealing with saving current card. So this can be easily used to correct the counting. When counting is reset, we take current card into account to know what to change. 

Of course, we may just consider https://github.com/ankidroid/Anki-Android/pull/6585 first and then consider the resetting of counts later, to make this PR simpler.

## How Has This Been Tested?

I'm testing it on my phone, trying to reproduce the bug

## Learning (optional, can help others)


How to use bisect to find where a bug is introduced. And that tests which deal only with scheduler does not simulate the reviewer very corrrectly