### PR TITLE
Disallow invalid (null || only whitespace) deck names

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
@@ -43,6 +43,7 @@ import com.ichi2.anki.FlashCardsContract.CardTemplate;
 import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.compat.CompatHelper;
 import com.ichi2.libanki.Consts;
+import com.ichi2.libanki.Decks;
 import com.ichi2.libanki.sched.AbstractSched;
 import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
@@ -1009,6 +1010,9 @@ public class CardContentProvider extends ContentProvider {
                 did = col.getDecks().id(deckName, false);
                 if (did != null) {
                     throw new IllegalArgumentException("Deck name already exists: " + deckName);
+                }
+                if (!Decks.isValidDeckName(deckName)) {
+                    throw new IllegalArgumentException("Invalid deck name '" + deckName + "'");
                 }
                 did = col.getDecks().id(deckName, true);
                 JSONObject deck = col.getDecks().get(did);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -1105,6 +1105,10 @@ public class Decks {
     * ***********************************************************
     */
 
+    public static boolean isValidDeckName(@Nullable String deckName) {
+        return deckName != null && !deckName.trim().isEmpty();
+    }
+
     public static String parent(String deckName) {
         // method parent, from sched's method deckDueList in python
         List<String> parts = Arrays.asList(path(deckName));

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -143,6 +143,7 @@
     <string name="custom_study_deck_name">Custom study session</string>
     <string name="custom_study_deck_exists">Rename the existing custom study deck first</string>
     <string name="empty_deck">This deck is empty</string>
+    <string name="invalid_deck_name">Invalid deck name</string>
     <string name="studyoptions_empty">This deck is empty. Press the + button to add new content.</string>
     <string name="studyoptions_limit_reached">Daily study limit reached</string>
     <string name="studyoptions_empty_schedule">No cards scheduled to study</string>


### PR DESCRIPTION

## Pull Request template

## Purpose / Description

For some reason we used to allow almost anything as a deck name. Even nulls (!?)

Upstream seems to silently disallow empty decknames, and I think we can reasonably go further and say deck names that don't have at least one non-whitespace character are nonsense

## Fixes
Fixes #6590

## Approach

Create a quick valid deck name method, use it everywhere that Decks.id or Decks.rename is called to pre-validate

Toast with a new invalid deck name message if it's invalid

## How Has This Been Tested?

emulator, create a blank-named deck, rename a deck to blank name, create a filtered deck and try an empty name

Can't do any of those now

## Learning (optional, can help others)

String.trim().isEmpty() (once you have null-checked) is efficient and "good enough" for non-whitespace checking. You can do a regex on `\\w+` or similar, and maybe there are UTF-16 or HTML people can get through but that's okay I think. This will stop the majority of silly deck names and if people go to that trouble, they really mean it, let them have an empty-looking name.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
