### PR TITLE
Clarify two columns of card browser

### DIFF
--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -79,9 +79,9 @@
         <item>Interval</item>
         <item>Ease</item>
         <item>Due</item>
-        <item>Changed</item>
+        <item>Card Modified</item>
         <item>Created</item>
-        <item>Edited</item>
+        <item>Note Modified</item>
     </string-array>
 
     <!-- Custom study options -->

--- a/AnkiDroid/src/main/res/values/07-cardbrowser.xml
+++ b/AnkiDroid/src/main/res/values/07-cardbrowser.xml
@@ -65,8 +65,8 @@
         <item>No sorting (faster)</item>
         <item>By sort field</item>
         <item>By created time</item>
-        <item>By edited time</item>
-        <item>By changed time</item>
+        <item>By note modification time</item>
+        <item>By card modification time</item>
         <item>By due time</item>
         <item>By interval</item>
         <item>By ease</item>


### PR DESCRIPTION
## Purpose / Description
The card browser has two columns "Edited" and "Changed" which refer to the Note and Card modification time respectively. This change was just recently adopted by Anki desktop (see the linked PR in #6519 which was closed instead of merged due to translations).

Edit by Arthur: upstream commit is https://github.com/ankitects/anki/commit/f3febea4b059116abf30006853974091a2998890
## Fixes
Fixes #6519 
## Approach
Changes labels XML
## How Has This Been Tested?
On device

Android 5.1.1 device (Model A571VL)

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
