### PR TITLE
Improve Whiteboard Pen Color - App Bar Position, Settings and Text

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtonStatus.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtonStatus.java
@@ -62,7 +62,7 @@ public class ActionButtonStatus {
         setupButton(preferences, R.id.action_delete, "customButtonDelete", SHOW_AS_ACTION_NEVER);
         setupButton(preferences, R.id.action_toggle_mic_tool_bar, "customButtonToggleMicToolBar", SHOW_AS_ACTION_NEVER);
         setupButton(preferences, R.id.action_save_whiteboard, "customButtonSaveWhiteboard", SHOW_AS_ACTION_NEVER);
-        setupButton(preferences, R.id.action_change_whiteboard_pen_color, "customButtonWhiteboardPenColor", SHOW_AS_ACTION_ALWAYS);
+        setupButton(preferences, R.id.action_change_whiteboard_pen_color, "customButtonWhiteboardPenColor", SHOW_AS_ACTION_IF_ROOM);
     }
 
 

--- a/AnkiDroid/src/main/res/menu/reviewer.xml
+++ b/AnkiDroid/src/main/res/menu/reviewer.xml
@@ -18,7 +18,7 @@
         android:icon="@drawable/ic_color_lens_white_24dp"
         android:title="@string/title_whiteboard_pen_color"
         android:visible="false"
-        ankidroid:showAsAction="always"/>
+        ankidroid:showAsAction="ifRoom"/>
     <item
         android:id="@+id/action_undo"
         android:enabled="false"

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -278,5 +278,5 @@
     <string name="white_board_image_save_failed">Failed to save whiteboard image. %s</string>
     <string name="white_board_image_saved">Whiteboard image saved to %s</string>
 
-    <string name="title_whiteboard_pen_color">Pen color</string>
+    <string name="title_whiteboard_pen_color">Whiteboard pen color</string>
 </resources>

--- a/AnkiDroid/src/main/res/xml/preferences_custom_buttons.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_custom_buttons.xml
@@ -122,6 +122,12 @@ MENU_DISABLED = 3
             android:key="customButtonSaveWhiteboard"
             android:title="@string/save_whiteboard" />
         <ListPreference
+            android:defaultValue="1"
+            android:entries="@array/custom_button_labels"
+            android:entryValues="@array/custom_button_values"
+            android:key="customButtonWhiteboardPenColor"
+            android:title="@string/title_whiteboard_pen_color" />
+        <ListPreference
             android:defaultValue="2"
             android:entries="@array/custom_button_labels"
             android:entryValues="@array/custom_button_values"


### PR DESCRIPTION
## Purpose / Description

Changes were requested for the `Pen Color` feature:

* Set as `ifRoom`
* Add Pen Color Preference to "App Bar Buttons" in Reviewer

I also made the following change to make the app bar text consistent
* Rename the menu item to be consistent


## Fixes
Fixes #6601 

## How Has This Been Tested?

On my device - no longer in the app bar, and the preference works.

⚠️ Didn't want to block the PR, but two issues. Happy to have the PR blocked on me fixing them:

* Clicking the app bar icon again doesn't dismiss the color picker. A color needs to be selected
* The white swatch only has a shadow on a white background - worse for dark on dark

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code