### PR TITLE
NF: cancel Load_Deck_counts on pause

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -857,6 +857,8 @@ public class DeckPicker extends NavigationDrawerActivity implements
         Timber.d("onPause()");
         killUselessTask();
         mActivityPaused = true;
+        // The deck count will be computed on resume. No need to compute it now
+        CollectionTask.cancelTask(CollectionTask.TASK_TYPE_LOAD_DECK_COUNTS);
         super.onPause();
     }
 


### PR DESCRIPTION
Since it's called again on onResume, it's useless to keep computing it in background.

Running it on my phone
