### PR TITLE
NF: card search: cancelling checked more often

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.java
@@ -214,6 +214,12 @@ public class ModelBrowser extends AnkiActivity {
         }
     }
 
+    @Override
+    public void onDestroy() {
+        CollectionTask.cancelAllTasks(COUNT_MODELS);
+        super.onDestroy();
+    }
+
 
     // ----------------------------------------------------------------------------
     // ANKI METHODS

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -1559,7 +1559,7 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
         });
 
         for (JSONObject n : models) {
-            cardCount.add(col.getModels().nids(n).size());
+            cardCount.add(col.getModels().useCount(n));
         }
 
         Object[] data = new Object[2];

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -1559,6 +1559,11 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
         });
 
         for (JSONObject n : models) {
+            if (isCancelled()) {
+                Timber.e("doInBackgroundLoadModels :: Cancelled");
+                // onPostExecute not executed if cancelled. Return value not used.
+                return new TaskData(false);
+            }
             cardCount.add(col.getModels().useCount(n));
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -1559,8 +1559,7 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
         });
 
         for (JSONObject n : models) {
-            long modID = n.getLong("id");
-            cardCount.add(col.getModels().nids(col.getModels().get(modID)).size());
+            cardCount.add(col.getModels().nids(n).size());
         }
 
         Object[] data = new Object[2];

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -959,7 +959,11 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
         String query = (String) params[0].getObjArray()[0];
         Boolean order = (Boolean) params[0].getObjArray()[1];
         int numCardsToRender = (int) params[0].getObjArray()[2];
-        List<Long> searchResult_ = col.findCards(query, order);
+        List<Long> searchResult_ = col.findCards(query, order, this);
+        if (isCancelled()) {
+            Timber.d("doInBackgroundSearchCards was cancelled so return null");
+            return null;
+        }
         int resultSize = searchResult_.size();
         List<Map<String,String>> searchResult = new ArrayList<>(resultSize);
         Timber.d("The search found %d cards", resultSize);
@@ -970,6 +974,10 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
         }
         // Render the first few items
         for (int i = 0; i < Math.min(numCardsToRender, searchResult.size()); i++) {
+            if (isCancelled()) {
+                Timber.d("doInBackgroundSearchCards was cancelled so return null");
+                return null;
+            }
             Card c = col.getCard(Long.parseLong(searchResult.get(i).get("id")));
             CardBrowser.updateSearchItemQA(mContext, searchResult.get(i), c, col);
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1134,8 +1134,8 @@ public class Collection {
         return new Finder(this).findCards(search, order);
     }
 
-    public List<Long> findCards(String search, boolean order) {
-        return new Finder(this).findCards(search, order);
+    public List<Long> findCards(String search, boolean order, CollectionTask task) {
+        return new Finder(this).findCards(search, order, task);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
@@ -77,11 +77,22 @@ public class Finder {
 
     @CheckResult
     public List<Long> findCards(String query, boolean _order) {
-        return _findCards(query, _order);
+        return findCards(query, _order, null);
+    }
+
+    @CheckResult
+    public List<Long> findCards(String query, boolean _order, CollectionTask task) {
+        return _findCards(query, _order, task);
     }
 
 
+    @CheckResult
     private List<Long> _findCards(String query, Object _order) {
+        return _findCards(query, _order, null);
+    }
+
+    @CheckResult
+    private List<Long> _findCards(String query, Object _order, CollectionTask task) {
         String[] tokens = _tokenize(query);
         Pair<String, String[]> res1 = _where(tokens);
         String preds = res1.first;
@@ -96,6 +107,9 @@ public class Finder {
         String sql = _query(preds, order);
         try (Cursor cur = mCol.getDb().getDatabase().query(sql, args)) {
             while (cur.moveToNext()) {
+                if (task != null && task.isCancelled()) {
+                    return new ArrayList<>();
+                }
                 res.add(cur.getLong(0));
             }
         } catch (SQLException e) {


### PR DESCRIPTION
doing a second search can take time if a search is still processing. Cancelling task had no effect if the task was already started. this is now changed

Testing on my phone