### PR TITLE
Optimize model count (performance)

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.java
@@ -214,6 +214,12 @@ public class ModelBrowser extends AnkiActivity {
         }
     }
 
+    @Override
+    public void onDestroy() {
+        CollectionTask.cancelAllTasks(COUNT_MODELS);
+        super.onDestroy();
+    }
+
 
     // ----------------------------------------------------------------------------
     // ANKI METHODS

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -1551,7 +1551,7 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
         });
 
         for (JSONObject n : models) {
-            cardCount.add(col.getModels().nids(n).size());
+            cardCount.add(col.getModels().useCount(n));
         }
 
         Object[] data = new Object[2];

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -1551,6 +1551,11 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
         });
 
         for (JSONObject n : models) {
+            if (isCancelled()) {
+                Timber.e("doInBackgroundLoadModels :: Cancelled");
+                // onPostExecute not executed if cancelled. Return value not used.
+                return new TaskData(false);
+            }
             cardCount.add(col.getModels().useCount(n));
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -1551,8 +1551,7 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
         });
 
         for (JSONObject n : models) {
-            long modID = n.getLong("id");
-            cardCount.add(col.getModels().nids(col.getModels().get(modID)).size());
+            cardCount.add(col.getModels().nids(n).size());
         }
 
         Object[] data = new Object[2];


### PR DESCRIPTION
Model count task was uselessly inefficient. And was still running even when the activity gets killed. this PR corrects that.


Running on my phone