### PR TITLE
Card browser show even on close

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -697,7 +697,6 @@ public class CardBrowser extends NavigationDrawerActivity implements
     protected void onStop() {
         Timber.d("onStop()");
         // cancel rendering the question and answer, which has shared access to mCards
-        invalidate();
         super.onStop();
         if (!isFinishing()) {
             WidgetStatus.update(this);
@@ -709,6 +708,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
     @Override
     protected void onDestroy() {
         Timber.d("onDestroy()");
+        invalidate();
         super.onDestroy();
         if (mUnmountReceiver != null) {
             unregisterReceiver(mUnmountReceiver);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1262,6 +1262,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
     private void invalidate() {
         CollectionTask.cancelAllTasks(SEARCH_CARDS);
         CollectionTask.cancelAllTasks(RENDER_BROWSER_QA);
+        CollectionTask.cancelAllTasks(CHECK_CARD_SELECTION);
         mCards.clear();
         mCheckedCards.clear();
     }
@@ -1831,6 +1832,9 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
         @Override
         public void actualOnPostExecute(@NonNull CardBrowser browser, TaskData result) {
+            if (result == null) {
+                return;
+            }
             browser.hideProgressBar();
 
             Object[] resultArr = result.getObjArray();

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -1872,13 +1872,17 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
      * Goes through selected cards and checks selected and marked attribute
      * @return If there are unselected cards, if there are unmarked cards
      */
-    public TaskData doInBackgroundCheckCardSelection(TaskData param) {
+    public @Nullable TaskData doInBackgroundCheckCardSelection(TaskData param) {
         Object[] objects = param.getObjArray();
         Set<CardBrowser.CardCache> checkedCards = (Set<CardBrowser.CardCache>) objects[0];
 
         boolean hasUnsuspended = false;
         boolean hasUnmarked = false;
         for (CardBrowser.CardCache c: checkedCards) {
+            if (isCancelled()) {
+                Timber.v("doInBackgroundCheckCardSelection: cancelled.");
+                return null;
+            }
             Card card = c.getCard();
             hasUnsuspended = hasUnsuspended || card.getQueue() != Consts.QUEUE_TYPE_SUSPENDED;
             hasUnmarked = hasUnmarked || !card.note().hasTag("marked");


### PR DESCRIPTION
There is currently the following problem in ankidroid:
* Search for a big number of card
* quickly change app on android. The window should not be displayed anymore
* wait some time
* come back to AnkiDroid

It should show the list of card, or being processing. Instead it shows
there are 0 card found.

This is because, when the app change, onStop is called, and this
cancel the search. Instead, the cancellation should occur in
onDestroy, whene there the search is not used anymore.

I also allow to cancel another background task if it is not useful anymore.

Testing it on my phone

Fixes #7017 