### PR TITLE
S tasks

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1184,7 +1184,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
     // We spawn CollectionTasks that may create memory pressure, this transmits it so polling isCancelled sees the pressure
     @Override
     public void onTrimMemory(int pressureLevel) {
-        CollectionTask.cancelTask();
+        CollectionTask.cancelCurrentlyExecutingTask();
     }
 
     private long getReviewerCardId() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -677,8 +677,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
     protected void onStop() {
         Timber.d("onStop()");
         // cancel rendering the question and answer, which has shared access to mCards
-        CollectionTask.cancelTask(SEARCH_CARDS);
-        CollectionTask.cancelTask(RENDER_BROWSER_QA);
+        CollectionTask.cancelAllTasks(SEARCH_CARDS);
+        CollectionTask.cancelAllTasks(RENDER_BROWSER_QA);
         super.onStop();
         if (!isFinishing()) {
             WidgetStatus.update(this);
@@ -1240,8 +1240,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
     private void searchCards() {
         // cancel the previous search & render tasks if still running
-        CollectionTask.cancelTask(SEARCH_CARDS);
-        CollectionTask.cancelTask(RENDER_BROWSER_QA);
+        CollectionTask.cancelAllTasks(SEARCH_CARDS);
+        CollectionTask.cancelAllTasks(RENDER_BROWSER_QA);
         String searchText;
         if (mSearchTerms == null) {
             mSearchTerms = "";
@@ -1861,7 +1861,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
                     long currentTime = SystemClock.elapsedRealtime ();
                     if ((currentTime - mLastRenderStart > 300 || lastVisibleItem >= totalItemCount)) {
                         mLastRenderStart = currentTime;
-                        CollectionTask.cancelTask(RENDER_BROWSER_QA);
+                        CollectionTask.cancelAllTasks(RENDER_BROWSER_QA);
                         CollectionTask.launchCollectionTask(RENDER_BROWSER_QA, mRenderQAHandler,
                                 new CollectionTask.TaskData(new Object[]{getCards(), firstVisibleItem, visibleItemCount}));
                     }

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -217,7 +217,7 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
 
 
     /** Cancel the current task only if it's of type taskType */
-    public static void cancelTask() {
+    public static void cancelCurrentlyExecutingTask() {
         CollectionTask latestInstance = sLatestInstance;
         if (latestInstance != null) {
             if (latestInstance.safeCancel()) {

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -225,10 +225,13 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
         mPreviousTask = previousTask;
     }
 
-
-    // This method and those that are called here are executed in a new thread
     @Override
     protected TaskData doInBackground(TaskData... params) {
+        return actualDoInBackground(params);
+    }
+
+    // This method and those that are called here are executed in a new thread
+    protected TaskData actualDoInBackground(TaskData... params) {
         super.doInBackground(params);
         // Wait for previous thread (if any) to finish before continuing
         if (mPreviousTask != null && mPreviousTask.getStatus() != AsyncTask.Status.FINISHED) {

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -199,10 +199,12 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
 
     /** Cancel the current task */
     public static void cancelTask() {
+        // Copying because there is a risk of concurrent change
+        CollectionTask latestInstance = sLatestInstance;
         try {
-            if ((sLatestInstance != null) && (sLatestInstance.getStatus() != AsyncTask.Status.FINISHED)) {
-                sLatestInstance.cancel(true);
-                Timber.i("Cancelled task %s", sLatestInstance.mType);
+            if ((latestInstance != null) && (latestInstance.getStatus() != AsyncTask.Status.FINISHED)) {
+                latestInstance.cancel(true);
+                Timber.i("Cancelled task %s", latestInstance.mType);
             }
         } catch (Exception e) {
             return;
@@ -212,7 +214,9 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
 
     /** Cancel the current task only if it's of type taskType */
     public static void cancelTask(TASK_TYPE taskType) {
-        if (sLatestInstance != null && sLatestInstance.mType == taskType) {
+        // Copying because there is a risk of concurrent change
+        CollectionTask latestInstance = sLatestInstance;
+        if (latestInstance != null && latestInstance.mType == taskType) {
             cancelTask();
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -227,14 +227,21 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
     }
 
 
-    /** Cancel the current task only if it's of type taskType */
-    public static void cancelTask(TASK_TYPE taskType) {
-        // Copying because there is a risk of concurrent change
-        CollectionTask latestInstance = sLatestInstance;
-        if (latestInstance != null && latestInstance.mType == taskType) {
-            if(latestInstance.safeCancel()) {
-                Timber.i("Cancelled task %s", latestInstance.mType);
+    /** Cancel all tasks of type taskType*/
+    public static void cancelAllTasks(TASK_TYPE taskType) {
+        int count = 0;
+        synchronized (sTasks) {
+            for (CollectionTask task: sTasks) {
+                if (task.mType != taskType) {
+                    continue;
+                }
+                if (task.safeCancel()) {
+                    count ++;
+                }
             }
+        }
+        if (count > 0) {
+            Timber.i("Cancelled %d instances of task %s", count, taskType);
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -197,9 +197,8 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
         }
     }
 
-
+    /** Cancel the current task */
     public static void cancelTask() {
-        //cancel the current task
         try {
             if ((sLatestInstance != null) && (sLatestInstance.getStatus() != AsyncTask.Status.FINISHED)) {
                 sLatestInstance.cancel(true);
@@ -211,8 +210,8 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
     }
 
 
+    /** Cancel the current task only if it's of type taskType */
     public static void cancelTask(TASK_TYPE taskType) {
-        // cancel the current task only if it's of type taskType
         if (sLatestInstance != null && sLatestInstance.mType == taskType) {
             cancelTask();
         }


### PR DESCRIPTION
`cancelTask(type)` was really strange. I was expecting it to cancel all tasks of a given type. Instead it only cancel current one, and only if it is running.

There are few call to this method in the code, and in each case, it seems that the intent of the author is to cancel of tasks of the type, so I believe that it is only going to be an improvement in term of time the user should wait.

This PR is required for my recent PR, because allowing to cancel tasks in background was useless since the cancellation event is rarely given to the actual task

I am going to test it on my phone