### PR TITLE
NF: remove a method unused

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -1976,8 +1976,4 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
             return clazz.isAssignableFrom(val.getClass());
         }
     }
-
-    public static synchronized CollectionTask getInstance() {
-        return sLatestInstance;
-    }
 }


### PR DESCRIPTION
Actually, it would be a bad idea to use it ever. If we want to allow
multiple background tasks simultaneously, we certainly don't want to
ever have this static access


As required here https://github.com/ankidroid/Anki-Android/pull/6609#discussion_r449800784