### PR TITLE
DeckPicker Background - Catch OutOfMemoryError

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -451,7 +451,11 @@ public class DeckPicker extends NavigationDrawerActivity implements
         View view = mFragmented ? findViewById(R.id.deckpicker_view) : findViewById(R.id.root_layout);
         try {
             applyDeckPickerBackground(view);
+        } catch (OutOfMemoryError e) { //6608 - OOM should be catchable here.
+            Timber.w(e, "Failed to apply background - OOM");
+            UIUtils.showThemedToast(this, getString(R.string.background_image_too_large), false);
         } catch (Exception e) {
+            Timber.w(e, "Failed to apply background");
             UIUtils.showThemedToast(this, getString(R.string.failed_to_apply_background_image, e.getLocalizedMessage()), false);
         }
 
@@ -483,7 +487,8 @@ public class DeckPicker extends NavigationDrawerActivity implements
         }
     }
 
-    private void applyDeckPickerBackground(View view) {
+    // throws doesn't seem to be checked by the compiler - consider it to be documentation
+    private void applyDeckPickerBackground(View view) throws OutOfMemoryError {
         //Allow the user to clear data and get back to a good state if they provide an invalid background.
         if (!AnkiDroidApp.getSharedPrefs(this).getBoolean("deckPickerBackground", false)) {
             Timber.d("No DeckPicker background preference");

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -187,6 +187,7 @@
     <string name="error_selecting_image">Error selecting image. Please see manual. %s</string>
     <string name="error_deleting_image">Error deleting image</string>
     <string name="failed_to_apply_background_image">Failed to apply background image %s</string>
+    <string name="background_image_too_large">Deck Picker background too large</string>
     <string name="image_max_size_allowed">Maximum image size %d MB allowed</string>
     
     <!-- Global Intent handler -->


### PR DESCRIPTION
## Purpose / Description
This should be recoverable assuming no other threads crashed.

I would hope that this is fine, as it should be a large allocation which fails


## Fixes
Fixes #6608

## How Has This Been Tested?

Untested

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code