### PR TITLE
Synchronize deck name

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -139,6 +139,7 @@ public class Decks {
     private Collection mCol;
     private HashMap<Long, JSONObject> mDecks;
     private HashMap<Long, JSONObject> mDconf;
+    // Never access mNameMap directly. Uses byName
     private HashMap<String, JSONObject> mNameMap;
     private boolean mChanged;
 
@@ -1024,7 +1025,7 @@ public class Decks {
             List<String> parts = Arrays.asList(path(deck.getString("name")));
             if (parts.size() > 1) {
                 String immediateParent = TextUtils.join("::", parts.subList(0, parts.size() - 1));
-                long pid = mNameMap.get(immediateParent).getLong("id");
+                long pid = byName(immediateParent).getLong("id");
                 childMap.get(pid).put(deck.getLong("id"), node);
             }
         }
@@ -1052,7 +1053,7 @@ public class Decks {
         List<JSONObject> oParents = new ArrayList<>();
         for (int i = 0; i < parents.size(); i++) {
             String parentName = parents.get(i);
-            JSONObject deck = mNameMap.get(parentName);
+            JSONObject deck = byName(parentName);
             oParents.add(i, deck);
         }
         return oParents;

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/DecksTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/DecksTest.java
@@ -1,0 +1,45 @@
+package com.ichi2.libanki;
+
+import com.ichi2.anki.RobolectricTest;
+import com.ichi2.libanki.sched.AbstractSched;
+import com.ichi2.utils.Assert;
+import com.ichi2.utils.JSONObject;
+
+import org.apache.http.util.Asserts;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.List;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+@RunWith(AndroidJUnit4.class)
+public class DecksTest extends RobolectricTest {
+    // Used in other class to populate decks.
+    public static final String[] TEST_DECKS = {
+            "scxipjiyozczaaczoawo",
+            "cmxieunwoogyxsctnjmv::abcdefgh::ZYXW",
+            "cmxieunwoogyxsctnjmv::INSBGDS",
+    };
+
+    @Test
+    public void ensureDeckList() {
+        Decks decks = getCol().getDecks();
+        for (String deckName: TEST_DECKS) {
+            addDeck(deckName);
+        }
+        JSONObject brokenDeck = decks.byName("cmxieunwoogyxsctnjmv::INSBGDS");
+        Asserts.notNull(brokenDeck,"We should get deck with given name");
+        // Changing the case. That could exists in an old collection or during sync.
+        brokenDeck.put("name", "CMXIEUNWOOGYXSCTNJMV::INSBGDS");
+        decks.save(brokenDeck);
+
+        decks.childMap();
+        for (JSONObject deck: decks.all()) {
+            long did = deck.getLong("id");
+            for (JSONObject parent: decks.parents(did)) {
+                Asserts.notNull(parent, "Parent should not be null");
+            }
+        }
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedTest.java
@@ -32,7 +32,7 @@ import java.util.List;
 import androidx.annotation.NonNull;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
-import static com.ichi2.libanki.sched.SchedV2Test.TEST_DECKS;
+import static com.ichi2.libanki.DecksTest.TEST_DECKS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.java
@@ -35,18 +35,13 @@ import java.util.List;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import edu.emory.mathcs.backport.java.util.Arrays;
 
+import static com.ichi2.libanki.DecksTest.TEST_DECKS;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.platform.commons.util.CollectionUtils.getOnlyElement;
 
 @RunWith(AndroidJUnit4.class)
 public class SchedV2Test extends RobolectricTest {
-
-    protected static final String[] TEST_DECKS = {
-            "scxipjiyozczaaczoawo",
-            "cmxieunwoogyxsctnjmv::abcdefgh::ZYXW",
-            "cmxieunwoogyxsctnjmv::INSBGDS",
-    };
 
     protected static List<AbstractSched.DeckDueTreeNode> expectedTree(AbstractSched sched, boolean addRev) {
         AbstractSched.DeckDueTreeNode caz = sched.new DeckDueTreeNode("cmxieunwoogyxsctnjmv::abcdefgh::ZYXW", 1, 0, 0, 0);


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

Uses normalize name for nameMap and ensure it is impossible not to do so

## Fixes
Hopefully
* Fixes #6612 
* Fixes #6613 

## Approach
Hidding the hash map in a data structure, so that it can be accessed only in the expected ways.

## How Has This Been Tested?

Running on my phone

I can't test that #6612 and #6613 won't occur again, as I don't know how it did occur, even if I would expect that in this case, there is a deck "A" with a child "a::B" and the change in case (or any other normalization process) may have created the problem in the first place
