### PR TITLE
Use Try With Resources on Import (close streams)

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
@@ -777,6 +777,7 @@ public class Utils {
 
     /**
      * Calls {@link #writeToFileImpl(InputStream, String)} and handles IOExceptions
+     * Does not close the provided stream
      * @throws IOException Rethrows exception after a set number of retries
      */
     public static void writeToFile(InputStream source, String destination) throws IOException {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
@@ -100,8 +100,8 @@ public class Anki2Importer extends Importer {
             } finally {
                 mSrc.close(false);
             }
-        } catch (RuntimeException e) {
-            Timber.e(e, "RuntimeException while importing");
+        } catch (Exception e) {
+            Timber.e(e, "Exception while importing");
             throw new ImportExportException(e.getMessage());
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
@@ -136,12 +136,17 @@ public class Anki2Importer extends Importer {
                 long id = mDst.getDecks().id(mDeckPrefix);
                 mDst.getDecks().select(id);
             }
+            Timber.i("Preparing Import");
             _prepareTS();
             _prepareModels();
+            Timber.i("Importing notes");
             _importNotes();
+            Timber.i("Importing Cards");
             _importCards();
+            Timber.i("Importing Media");
             _importStaticMedia();
             publishProgress(100, 100, 25);
+            Timber.i("Performing post-import");
             _postImport();
             publishProgress(100, 100, 50);
             mDst.getDb().getDatabase().setTransactionSuccessful();
@@ -158,6 +163,7 @@ public class Anki2Importer extends Importer {
                 try { mDst.getMedia().getDb().getDatabase().endTransaction(); } catch (Exception e) { Timber.w(e); }
             }
         }
+        Timber.i("Performing vacuum/analyze");
         try {
             mDst.getDb().execute("vacuum");
         } catch (Exception e) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/AnkiPackageImporter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/AnkiPackageImporter.java
@@ -118,8 +118,7 @@ public class AnkiPackageImporter extends Anki2Importer {
             File dir = new File(dirPath);
             // We need the opposite mapping in AnkiDroid since our extraction method requires it.
             Map<String, String> numToName = new HashMap<>();
-            try {
-                JsonReader jr = new JsonReader(new FileReader(mediaMapFile));
+            try (JsonReader jr = new JsonReader(new FileReader(mediaMapFile))) {
                 jr.beginObject();
                 String name; // v in anki
                 String num; // k in anki
@@ -135,7 +134,6 @@ public class AnkiPackageImporter extends Anki2Importer {
                     numToName.put(num, name);
                 }
                 jr.endObject();
-                jr.close();
             } catch (FileNotFoundException e) {
                 Timber.e("Apkg did not contain a media dict. No media will be imported.");
             } catch (IOException e) {

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
@@ -190,11 +190,20 @@ public class ImportUtils {
 
         protected String validateZipFile(Context context, String filePath) {
             File file = new File(filePath);
+            ZipFile zf = null;
             try {
-                new ZipFile(file);
+                zf = new ZipFile(file);
             } catch (Exception e) {
                 Timber.w(e, "Failed to validate zip");
                 return context.getString(R.string.import_log_failed_unzip, e.getLocalizedMessage());
+            } finally {
+                if (zf != null) {
+                    try {
+                        zf.close();
+                    } catch (IOException e) {
+                        Timber.w(e, "Failed to close zip");
+                    }
+                }
             }
             return null;
         }


### PR DESCRIPTION
## Purpose / Description
This is a pure guess about fixing an issue: #6606. When importing, I saw lots of warnings about files not being closed.

## Approach
We close the files

## How Has This Been Tested?

A few large and small imports on my phone.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code