### PR TITLE
CollectionTask: Refactor sLatestInstance

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -173,7 +173,6 @@ public class CollectionTask<ProgressListener, ProgressBackground extends Progres
         mTask = task;
         mListener = listener;
         mPreviousTask = previousTask;
-        TaskManager.addTasks(this);
     }
 
     @Override

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -206,7 +206,7 @@ public class CollectionTask<ProgressListener, ProgressBackground extends Progres
                 Timber.d(e, "previously running task was cancelled: %s", mPreviousTask.mTask.getClass());
             }
         }
-        setLatestInstance(this);
+        TaskManager.setLatestInstance(this);
         mContext = AnkiDroidApp.getInstance().getApplicationContext();
 
         // Skip the task if the collection cannot be opened

--- a/AnkiDroid/src/main/java/com/ichi2/async/TaskManager.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/TaskManager.java
@@ -33,6 +33,10 @@ public class TaskManager {
      * The most recently started {@link CollectionTask} instance.
      */
     private static CollectionTask sLatestStartedInstance;
+    /**
+     * The most recently created {@link CollectionTask} instance.
+     */
+    private static CollectionTask sLatestCreatedInstance;
 
     protected static void setLatestInstance(CollectionTask task) {
         sLatestStartedInstance = task;
@@ -54,8 +58,7 @@ public class TaskManager {
         return launchCollectionTask(task, null);
     }
 
-
-
+    private static Object lock = new Object();
     /**
      * Starts a new {@link CollectionTask}, with a listener provided for callbacks during execution
      * <p>
@@ -70,8 +73,11 @@ public class TaskManager {
     public static <ProgressListener, ProgressBackground extends ProgressListener, ResultListener, ResultBackground extends ResultListener> CollectionTask<ProgressListener, ProgressBackground, ResultListener, ResultBackground> launchCollectionTask(@NonNull CollectionTask.Task<ProgressBackground, ResultBackground> task,
                                                                                                                                                                                                                                                        @Nullable TaskListener<ProgressListener, ResultListener> listener) {
         // Start new task
-        CollectionTask<ProgressListener, ProgressBackground, ResultListener, ResultBackground> newTask = new CollectionTask<>(task, listener, sLatestStartedInstance);
-        sTasks.add(newTask);
+        CollectionTask<ProgressListener, ProgressBackground, ResultListener, ResultBackground> newTask;
+        synchronized(lock) {
+            newTask = new CollectionTask<>(task, listener, sLatestStartedInstance);
+            sTasks.add(newTask);
+        }
         newTask.execute();
         return newTask;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/async/TaskManager.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/TaskManager.java
@@ -71,6 +71,7 @@ public class TaskManager {
                                                                                                                                                                                                                                                        @Nullable TaskListener<ProgressListener, ResultListener> listener) {
         // Start new task
         CollectionTask<ProgressListener, ProgressBackground, ResultListener, ResultBackground> newTask = new CollectionTask<>(task, listener, sLatestInstance);
+        sTasks.add(newTask);
         newTask.execute();
         return newTask;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/async/TaskManager.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/TaskManager.java
@@ -32,10 +32,10 @@ public class TaskManager {
     /**
      * The most recently started {@link CollectionTask} instance.
      */
-    private static CollectionTask sLatestInstance;
+    private static CollectionTask sLatestStartedInstance;
 
     protected static void setLatestInstance(CollectionTask task) {
-        sLatestInstance = task;
+        sLatestStartedInstance = task;
     }
 
 
@@ -70,7 +70,7 @@ public class TaskManager {
     public static <ProgressListener, ProgressBackground extends ProgressListener, ResultListener, ResultBackground extends ResultListener> CollectionTask<ProgressListener, ProgressBackground, ResultListener, ResultBackground> launchCollectionTask(@NonNull CollectionTask.Task<ProgressBackground, ResultBackground> task,
                                                                                                                                                                                                                                                        @Nullable TaskListener<ProgressListener, ResultListener> listener) {
         // Start new task
-        CollectionTask<ProgressListener, ProgressBackground, ResultListener, ResultBackground> newTask = new CollectionTask<>(task, listener, sLatestInstance);
+        CollectionTask<ProgressListener, ProgressBackground, ResultListener, ResultBackground> newTask = new CollectionTask<>(task, listener, sLatestStartedInstance);
         sTasks.add(newTask);
         newTask.execute();
         return newTask;
@@ -91,12 +91,12 @@ public class TaskManager {
      */
     public static boolean waitToFinish(Integer timeoutSeconds) {
         try {
-            if ((sLatestInstance != null) && (sLatestInstance.getStatus() != AsyncTask.Status.FINISHED)) {
-                Timber.d("CollectionTask: waiting for task %s to finish...", sLatestInstance.getTask().getClass());
+            if ((sLatestStartedInstance != null) && (sLatestStartedInstance.getStatus() != AsyncTask.Status.FINISHED)) {
+                Timber.d("CollectionTask: waiting for task %s to finish...", sLatestStartedInstance.getTask().getClass());
                 if (timeoutSeconds != null) {
-                    sLatestInstance.get(timeoutSeconds, TimeUnit.SECONDS);
+                    sLatestStartedInstance.get(timeoutSeconds, TimeUnit.SECONDS);
                 } else {
-                    sLatestInstance.get();
+                    sLatestStartedInstance.get();
                 }
 
             }
@@ -110,7 +110,7 @@ public class TaskManager {
 
     /** Cancel the current task only if it's of type taskType */
     public static void cancelCurrentlyExecutingTask() {
-        CollectionTask latestInstance = sLatestInstance;
+        CollectionTask latestInstance = sLatestStartedInstance;
         if (latestInstance != null) {
             if (latestInstance.safeCancel()) {
                 Timber.i("Cancelled task %s", latestInstance.getTask().getClass());


### PR DESCRIPTION
It is my belief that `sLatestInstance` is an ambiguous name. I would expect it to mean "the last created instance" while it means "the last started instance" (I admit that documentation is clear about this fact)

Renaming it should allow to make this clearer.

It seems clear to me, when this change is done, that if a tasks T waits for another tasks to ends before it starts, this other tasks should be the last task created before T was created. Looking only at the task running while T was created seems useless.

So I add a variable which keeps track of the last created task, and uses this as mPreviousTask

Furthermore, the last tasks may be cancelled. In this case, it would be finished, but that does not mean T has a right to start, since previous previous task may still need to run. So I ensure that I am looking at previous uncancelled task before starting to run


Adding it to my phone