### PR TITLE
NF: remove a try catch

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -1544,14 +1544,9 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
             }
         });
 
-        try{
-            for (JSONObject n : models) {
-                long modID = n.getLong("id");
-                cardCount.add(col.getModels().nids(col.getModels().get(modID)).size());
-            }
-        } catch (JSONException e) {
-                Timber.e("doInBackgroundLoadModels :: JSONException");
-                return new TaskData(false);
+        for (JSONObject n : models) {
+            long modID = n.getLong("id");
+            cardCount.add(col.getModels().nids(col.getModels().get(modID)).size());
         }
 
         Object[] data = new Object[2];


### PR DESCRIPTION
If the exception is catched, the method returns false. If it is the case, mLoadingModelsHandler will throw a new run
time exception without any context.

I believe in this case, it's better to avoid doing try/catch, because if the app crash anyway, at least, the error
message will have slightly more context.

It's on my phone, but I don't expect to ever have a note type without id, so this case should not present itself anyway. Furthermore, since the only difference is going to be that the error message should get more information, it would be hard to test