### PR TITLE
Cancel load deck count on pause

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -193,8 +193,6 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
     private List<AbstractSched.DeckDueTreeNode> mDueTree;
 
-    private List<CollectionTask> tasksToCancelOnClose;
-
     /**
      * Flag to indicate whether the activity will perform a sync in its onResume.
      * Since syncing closes the database, this flag allows us to avoid doing any
@@ -385,7 +383,6 @@ public class DeckPicker extends NavigationDrawerActivity implements
     /** Called when the activity is first created. */
     @Override
     protected void onCreate(Bundle savedInstanceState) throws SQLException {
-        tasksToCancelOnClose = new ArrayList();
         Timber.d("onCreate()");
         SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(getBaseContext());
 
@@ -855,16 +852,8 @@ public class DeckPicker extends NavigationDrawerActivity implements
     @Override
     protected void onPause() {
         Timber.d("onPause()");
-        killUselessTask();
         mActivityPaused = true;
         super.onPause();
-    }
-
-    private void killUselessTask() {
-        for (CollectionTask collectionTask: tasksToCancelOnClose) {
-            collectionTask.cancel(true);
-        }
-        tasksToCancelOnClose.clear();
     }
 
     @Override
@@ -2170,7 +2159,6 @@ public class DeckPicker extends NavigationDrawerActivity implements
                 Timber.d("Startup - Deck List UI Completed");
             }
         });
-        tasksToCancelOnClose.add(task);
     }
 
     public void __renderPage() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -853,6 +853,8 @@ public class DeckPicker extends NavigationDrawerActivity implements
     protected void onPause() {
         Timber.d("onPause()");
         mActivityPaused = true;
+        // The deck count will be computed on resume. No need to compute it now
+        CollectionTask.cancelTask(CollectionTask.TASK_TYPE_LOAD_DECK_COUNTS);
         super.onPause();
     }
 


### PR DESCRIPTION
Since it's called again on onResume, it's useless to keep computing it in background.

No reason to use `tasksToCancelOnClose` since it does the same job as CancelAllTasks

Running it on my phone