### PR TITLE
Avoid fully qualified name

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -861,7 +861,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
         Timber.d("onPause()");
         mActivityPaused = true;
         // The deck count will be computed on resume. No need to compute it now
-        CollectionTask.cancelAllTasks(CollectionTask.TASK_TYPE.LOAD_DECK_COUNTS);
+        CollectionTask.cancelAllTasks(LOAD_DECK_COUNTS);
         super.onPause();
     }
 


### PR DESCRIPTION
For consistency with remaining of the code