### PR TITLE
Split reset

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -1310,7 +1310,7 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
             boolean reset = (Boolean) obj[0];
             if (reset) {
                 // reset actually required because of counts, which is used in getCollectionTaskListener
-                sched.reset();
+                sched.resetCounts();
             }
             int[] counts = sched.counts();
             int totalNewCount = sched.totalNewForCurrentDeck();

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
@@ -40,7 +40,8 @@ public abstract class AbstractSched {
      */
     public abstract void reset();
 
-
+    public abstract void resetCounts();
+    public abstract void resetQueues();
     /** Ensures that reset is executed before the next card is selected */
     public abstract void deferReset();
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -353,13 +353,6 @@ public class Sched extends SchedV2 {
                 mToday, mReportLimit);
     }
 
-
-    @Override
-    protected void _resetLrn() {
-        _resetLrnCount();
-        _resetLrnQueue();
-    }
-
     @Override
     protected void _resetLrnQueue() {
         mLrnQueue.clear();
@@ -717,12 +710,6 @@ public class Sched extends SchedV2 {
                         + " LIMIT ?)", did, mToday, lim);
     }
 
-
-    @Override
-    protected void _resetRev() {
-        _resetRevCount();
-        _resetRevQueue();
-    }
 
     @Override
     protected void _resetRevQueue() {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -357,6 +357,11 @@ public class Sched extends SchedV2 {
     @Override
     protected void _resetLrn() {
         _resetLrnCount();
+        _resetLrnQueue();
+    }
+
+    @Override
+    protected void _resetLrnQueue() {
         mLrnQueue.clear();
         mLrnDayQueue.clear();
         mLrnDids = mCol.getDecks().active();
@@ -716,6 +721,11 @@ public class Sched extends SchedV2 {
     @Override
     protected void _resetRev() {
         _resetRevCount();
+        _resetRevQueue();
+    }
+
+    @Override
+    protected void _resetRevQueue() {
         mRevQueue.clear();
         mRevDids = mCol.getDecks().active();
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -227,9 +227,12 @@ public class SchedV2 extends AbstractSched {
 
     public void reset() {
         _updateCutoff();
-        _resetLrn();
-        _resetRev();
-        _resetNew();
+        _resetLrnCount();
+        _resetLrnQueue();
+        _resetRevCount();
+        _resetRevQueue();
+        _resetNewCount();
+        _resetNewQueue();
         mHaveQueues = true;
         decrementCounts(mUndidCard);
         if (mUndidCard == null) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -894,6 +894,7 @@ public class SchedV2 extends AbstractSched {
 
     // Overridden: V1 has less queues
     protected void _resetLrnCount() {
+        _updateLrnCutoff(true);
         // sub-day
         mLrnCount = mCol.getDb().queryScalar(
                 "SELECT count() FROM cards WHERE did IN " + _deckLimit()
@@ -912,7 +913,6 @@ public class SchedV2 extends AbstractSched {
 
     // Overriden: _updateLrnCutoff not called in V1
     protected void _resetLrn() {
-        _updateLrnCutoff(true);
         _resetLrnCount();
         _resetLrnQueue();
     }
@@ -2959,7 +2959,6 @@ public class SchedV2 extends AbstractSched {
     /** not in libAnki. Added due to #5666: inconsistent selected deck card counts on sync */
     @Override
     public int[] recalculateCounts() {
-        _updateLrnCutoff(true);
         _resetLrnCount();
         _resetNewCount();
         _resetRevCount();

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -89,6 +89,7 @@ public class SchedV2 extends AbstractSched {
     private int mDynReportLimit;
     protected int mReps;
     protected boolean mHaveQueues;
+    protected boolean mHaveCounts;
     protected Integer mToday;
     public long mDayCutoff;
     private long mLrnCutoff;
@@ -180,6 +181,7 @@ public class SchedV2 extends AbstractSched {
         mReps = 0;
         mToday = null;
         mHaveQueues = false;
+        mHaveCounts = false;
         mLrnCutoff = 0;
         _updateCutoff();
     }
@@ -190,7 +192,7 @@ public class SchedV2 extends AbstractSched {
      */
     public Card getCard() {
         _checkDay();
-        if (!mHaveQueues) {
+        if (!mHaveQueues || !mHaveCounts) {
             reset();
         }
         Card card = _getCard();
@@ -215,6 +217,7 @@ public class SchedV2 extends AbstractSched {
     /** Ensures that reset is executed before the next card is selected */
     public void deferReset(Card undidCard){
         mHaveQueues = false;
+        mHaveCounts = false;
         mUndidCard = undidCard;
     }
 
@@ -235,6 +238,7 @@ public class SchedV2 extends AbstractSched {
             setCurrentCard(mUndidCard);
         }
         mUndidCard = null;
+        mHaveCounts = true;
     }
 
 
@@ -316,7 +320,7 @@ public class SchedV2 extends AbstractSched {
 
 
     public int[] counts() {
-        if (!mHaveQueues) {
+        if (!mHaveCounts) {
             reset();
         }
         return new int[] {mNewCount, mLrnCount, mRevCount};

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -667,6 +667,10 @@ public class SchedV2 extends AbstractSched {
 
     private void _resetNew() {
         _resetNewCount();
+        _resetNewQueue();
+    }
+
+    private void _resetNewQueue() {
         mNewDids = new LinkedList<>(mCol.getDecks().active());
         mNewQueue.clear();
         _updateNewCardRatio();
@@ -910,6 +914,10 @@ public class SchedV2 extends AbstractSched {
     protected void _resetLrn() {
         _updateLrnCutoff(true);
         _resetLrnCount();
+        _resetLrnQueue();
+    }
+
+    protected void _resetLrnQueue() {
         mLrnQueue.clear();
         mLrnDayQueue.clear();
         mLrnDids = mCol.getDecks().active();
@@ -1433,6 +1441,10 @@ public class SchedV2 extends AbstractSched {
     // Overridden: V1 remove clear
     protected void _resetRev() {
         _resetRevCount();
+        _resetRevQueue();
+    }
+
+    protected void _resetRevQueue() {
         mRevQueue.clear();
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -354,7 +354,7 @@ public class SchedV2 extends AbstractSched {
 
     public int[] counts() {
         if (!mHaveCounts) {
-            reset();
+            resetCounts();
         }
         return new int[] {mNewCount, mLrnCount, mRevCount};
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -192,8 +192,12 @@ public class SchedV2 extends AbstractSched {
      */
     public Card getCard() {
         _checkDay();
-        if (!mHaveQueues || !mHaveCounts) {
-            reset();
+        // check day deal with cutoff if required. No need to do it in resets
+        if (!mHaveCounts) {
+            resetCounts(false);
+        }
+        if (!mHaveQueues) {
+            resetQueues(false);
         }
         Card card = _getCard();
         if (card != null) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -228,12 +228,8 @@ public class SchedV2 extends AbstractSched {
     public void reset() {
         _updateCutoff();
         _resetLrnCount();
-        _resetLrnQueue();
         _resetRevCount();
-        _resetRevQueue();
         _resetNewCount();
-        _resetNewQueue();
-        mHaveQueues = true;
         decrementCounts(mUndidCard);
         if (mUndidCard == null) {
             discardCurrentCard();
@@ -242,6 +238,10 @@ public class SchedV2 extends AbstractSched {
         }
         mUndidCard = null;
         mHaveCounts = true;
+        _resetLrnQueue();
+        _resetRevQueue();
+        _resetNewQueue();
+        mHaveQueues = true;
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -227,6 +227,20 @@ public class SchedV2 extends AbstractSched {
 
     public void reset() {
         _updateCutoff();
+        resetCounts(false);
+        resetQueues(false);
+    }
+
+    @Override
+    public void resetCounts() {
+        resetCounts(true);
+    }
+
+    /** @param checkCutoff whether we should check cutoff before resetting*/
+    private void resetCounts(boolean checkCutoff) {
+        if (checkCutoff) {
+            _updateCutoff();
+        }
         _resetLrnCount();
         _resetRevCount();
         _resetNewCount();
@@ -238,6 +252,18 @@ public class SchedV2 extends AbstractSched {
         }
         mUndidCard = null;
         mHaveCounts = true;
+    }
+
+    @Override
+    public void resetQueues() {
+        resetQueues(true);
+    }
+
+    /** @param checkCutoff whether we should check cutoff before resetting*/
+    private void resetQueues(boolean checkCutoff) {
+        if (checkCutoff) {
+            _updateCutoff();
+        }
         _resetLrnQueue();
         _resetRevQueue();
         _resetNewQueue();


### PR DESCRIPTION
This is a first part of https://github.com/ankidroid/Anki-Android/pull/6035

It splits reset in two: counts and queues. In cases where it is obvious, the counts only is used.

This is mostly going to be useful in future PR, where we get the first card without doing the costly operation of computing counts