### PR TITLE
Decks: Strip whitespace in children as well as parents

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -846,9 +846,14 @@ public class Decks {
     }
 
 
-    private static final Pattern spaceAroundSeparator = Pattern.compile(" *:: *");
+    private static final Pattern spaceAroundSeparator = Pattern.compile("\\s*::\\s*");
     private static String strip(String deckName) {
-        return spaceAroundSeparator.matcher(deckName.trim()).replaceAll( "::");
+        //Ends of components are either the ends of the deck name, or near the ::.
+        //Deal with all spaces around ::
+        deckName = spaceAroundSeparator.matcher(deckName).replaceAll("::");
+        //Deal with spaces at start/end of the deck name.
+        deckName = deckName.trim();
+        return deckName;
     }
 
     private void _recoverOrphans() {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -49,6 +49,7 @@ import java.util.regex.Pattern;
 import androidx.annotation.CheckResult;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 import timber.log.Timber;
 
 // fixmes:
@@ -847,7 +848,8 @@ public class Decks {
 
 
     private static final Pattern spaceAroundSeparator = Pattern.compile("\\s*::\\s*");
-    private static String strip(String deckName) {
+    @VisibleForTesting
+    static String strip(String deckName) {
         //Ends of components are either the ends of the deck name, or near the ::.
         //Deal with all spaces around ::
         deckName = spaceAroundSeparator.matcher(deckName).replaceAll("::");

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/DecksTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/DecksTest.java
@@ -56,4 +56,11 @@ public class DecksTest extends RobolectricTest {
             }
         }
     }
+
+    @Test
+    public void trim() {
+        assertThat(Decks.strip("A\nB C\t D"), is("A\nB C\t D"));
+        assertThat(Decks.strip("\n A\n\t"), is("A"));
+        assertThat(Decks.strip("Z::\n A\n\t::Y"), is("Z::A::Y"));
+    }
 }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Fun fact, did you know in Java, ".trim" remove only the ' ' character https://docs.oracle.com/javase/7/docs/api/java/lang/String.html#trim() https://github.com/ankidroid/Anki-Android/blob/master/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java#L851
while in rust, it removes all "Unicode Derived Core Property White_Space."
https://doc.rust-lang.org/std/string/struct.String.html
https://github.com/ankitects/anki/blob/master/rslib/src/decks/mod.rs#L128

So I'm moving the "strip" function so that it deals with all whitespace.

Not sure it will solve https://github.com/ankidroid/Anki-Android/issues/6383 but it should be a way forward at least. 
The main trouble with https://github.com/ankidroid/Anki-Android/issues/6383 being that I have no clue where we did remove some new line symbol, it seems we never strip them. The best explanation I would see would be if the method ".trim" does not always follow java documentation and sometime trim more than just ' '.

This should also improve validation of deck name, even if it's still not perfect https://github.com/ankidroid/Anki-Android/issues/6639

I should note that this method should also be cached; because checking whethe a deck name is correct needs to do a lot of string processing while we could easily cache the set of deck name we already know to be correct.

## Approach
Using \s instead of ' '

## How Has This Been Tested?

On emulator, I pasted a new line at the end of a deck name and saw it was correctly stripped

## Learning (optional, can help others)
I wish more and more that I had a deck class. Ensuring that names are not changed with only .put("name", "new name") would have clearly improved the safety, because i could at least search easily for each place the deck name is considered