### PR TITLE
Handle Exception from FileProvider in crop

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -335,12 +335,25 @@ public class AnkiDroidApp extends MultiDexApplication {
 
 
     public static void sendExceptionReport(Throwable e, String origin, String additionalInfo) {
+        sendExceptionReport(e, origin, additionalInfo, false);
+    }
+
+
+    public static void sendExceptionReport(Throwable e, String origin, String additionalInfo, boolean onlyIfSilent) {
         UsageAnalytics.sendAnalyticsException(e, false);
+
+        if (onlyIfSilent) {
+            boolean alwaysAccept = getSharedPrefs(getInstance().getApplicationContext()).getBoolean(ACRA.PREF_ALWAYS_ACCEPT, false);
+            if (!alwaysAccept) {
+                Timber.i("sendExceptionReport - onlyIfSilent true, but ACRA is not 'always accept'. Skipping report send.");
+                return;
+            }
+        }
+
         ACRA.getErrorReporter().putCustomData("origin", origin);
         ACRA.getErrorReporter().putCustomData("additionalInfo", additionalInfo);
         ACRA.getErrorReporter().handleException(e);
     }
-
 
     /**
      * If you want to make sure that the next exception of any time is posted, you need to clear limiter data

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
@@ -654,13 +654,15 @@ public class BasicImageFieldController extends FieldControllerBase implements IF
      */
     private Uri getUriForFile(File file) {
         Timber.d("getUriForFile() %s", file);
-        Uri uri;
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            uri = FileProvider.getUriForFile(mActivity, mActivity.getApplicationContext().getPackageName() + ".apkgfileprovider", file);
-        } else {
-            uri = Uri.fromFile(file);
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                return FileProvider.getUriForFile(mActivity, mActivity.getApplicationContext().getPackageName() + ".apkgfileprovider", file);
+            }
+        } catch (Exception e) {
+            Timber.w("getUriForFile failed on %s - attempting fallback", file);
         }
-        return uri;
+
+        return Uri.fromFile(file);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
@@ -659,7 +659,9 @@ public class BasicImageFieldController extends FieldControllerBase implements IF
                 return FileProvider.getUriForFile(mActivity, mActivity.getApplicationContext().getPackageName() + ".apkgfileprovider", file);
             }
         } catch (Exception e) {
-            Timber.w("getUriForFile failed on %s - attempting fallback", file);
+            // #6628 - What would cause this? Is the fallback is effective? Telemetry to diagnose more:
+            Timber.w(e, "getUriForFile failed on %s - attempting fallback", file);
+            AnkiDroidApp.sendExceptionReport(e, "BasicImageFieldController", "Unexpected getUriForFile failure on " + file, true);
         }
 
         return Uri.fromFile(file);


### PR DESCRIPTION

## Pull Request template

## Purpose / Description

FileProvider can throw unchecked exceptions

Not a fan of system APIs throwing RuntimeExceptions, they catch me out like this too frequently

## Fixes
Fixes #6628 

## Approach

Pokemon error handling, fall back to non-FileProvider URI, consumers of the method already have hardening against the image still being non-existent in case fallback / non-FileProvider style results in invalid URI

## How Has This Been Tested?

Difficult to test unfortunately but when I feed bad data as image references into the image field editor I can't make it crash. I couldn't make it crash before though unfortunately and there is no good test infrastructure here yet

## Learning (optional, can help others)

Always always always check underlying APIs to see if they can throw RuntimeExceptions

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
