### PR TITLE
Protect against stale field info in CardTemplatePreviewer

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -154,6 +154,7 @@ public class NoteEditor extends AnkiActivity {
     public static final int REQUEST_ADD = 0;
     public static final int REQUEST_MULTIMEDIA_EDIT = 2;
     public static final int REQUEST_TEMPLATE_EDIT = 3;
+    public static final int REQUEST_PREVIEW = 4;
 
     private boolean mChanged = false;
     private boolean mTagsEdited = false;
@@ -936,7 +937,7 @@ public class NoteEditor extends AnkiActivity {
                 Bundle noteEditorBundle = new Bundle();
                 onSaveInstanceState(noteEditorBundle);
                 previewer.putExtra("noteEditorBundle", noteEditorBundle);
-                startActivityWithoutAnimation(previewer);
+                startActivityForResultWithoutAnimation(previewer, REQUEST_PREVIEW);
                 return true;
 
             case R.id.action_save:
@@ -1065,6 +1066,8 @@ public class NoteEditor extends AnkiActivity {
         } else {
             setResult(result);
         }
+        // ensure there are no orphans from possible edit previews
+        TemporaryModel.clearTempModelFiles();
         if (mCaller == CALLER_CARDEDITOR_INTENT_ADD) {
             finishWithAnimation(ActivityTransitionAnimation.NONE);
         } else {


### PR DESCRIPTION

## Pull Request template

## Purpose / Description

Apparently it is possible for the model and the preview bundle to
be out of sync, unsure how it came about but now we won't populate off
the end of the field array and we will carefully clean up after
CardTemplatePreviewer where before no cleanup was done

## Fixes
Fixes #6644

## Approach

I harden the array access that caused the crash so that is not possible at all, so we shouldn't crash

Why did we get there though? I'm not 100% sure and don't have the time to run it to ground completely unfortunately

What I did add was cleanup though - perhaps the fields and model were out of sync because no cleanup was done? So now I do a start-for-result to open the card template previewer and I close it carefully while cleaning up the TemporaryModel file which had been orphaned before

## How Has This Been Tested?

API29 testing - I could not replicate the crash unfortunately but I could replicate crashing when I started trying to clean up after ourselves! Required a bit of internal state hardening which is an improvement I think

I know that with array length checks during array traversal we won't crash in the same way at least and since it's just a preview hopefully we don't crash at all

## Learning (optional, can help others)

I learned that to get control of the little back arrows at top left you have to override onNavigation, that was unexpected, I was thinking onOptionItem etc

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
