### PR TITLE
Load SVG in compat mode for lower APIs

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -26,15 +26,6 @@ import android.content.pm.PackageManager;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.os.Bundle;
-
-import androidx.annotation.DrawableRes;
-import androidx.annotation.NonNull;
-import androidx.annotation.VisibleForTesting;
-import androidx.core.app.ActivityCompat;
-import androidx.core.content.ContextCompat;
-import androidx.core.view.ActionProvider;
-import androidx.core.view.MenuItemCompat;
-
 import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -43,6 +34,15 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.FrameLayout;
 import android.widget.LinearLayout;
+
+import androidx.annotation.DrawableRes;
+import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
+import androidx.core.app.ActivityCompat;
+import androidx.core.content.ContextCompat;
+import androidx.core.view.ActionProvider;
+import androidx.core.view.MenuItemCompat;
+import androidx.vectordrawable.graphics.drawable.VectorDrawableCompat;
 
 import com.ichi2.anim.ActivityTransitionAnimation;
 import com.ichi2.anki.dialogs.ConfirmationDialog;
@@ -62,7 +62,6 @@ import com.ichi2.themes.Themes;
 import com.ichi2.utils.FunctionalInterfaces.Consumer;
 import com.ichi2.utils.Permissions;
 import com.ichi2.widget.WidgetStatus;
-
 
 import java.lang.ref.WeakReference;
 
@@ -550,7 +549,7 @@ public class Reviewer extends AbstractFlashcardViewer {
             menu.findItem(R.id.action_change_whiteboard_pen_color).setVisible(true);
 
             Drawable whiteboardIcon = ContextCompat.getDrawable(this, R.drawable.ic_gesture_white_24dp).mutate();
-            Drawable whiteboardColorPaletteIcon = ContextCompat.getDrawable(this, R.drawable.ic_color_lens_white_24dp).mutate();
+            Drawable whiteboardColorPaletteIcon = VectorDrawableCompat.create(getResources(), R.drawable.ic_color_lens_white_24dp, null).mutate();
 
             if (mShowWhiteboard) {
                 whiteboardIcon.setAlpha(Themes.ALPHA_ICON_ENABLED_LIGHT);


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

Fix a crash loading SVGs on Android API levels that don't natively support them

## Fixes
Fixes #6665

## Approach

Note there are two ways to successfully use SVGs, one is to do:

AppCompatDelegate.setCompatVectorFromResourcesEnabled(true)

...but they warn there that if you change Configuration it is not recommended.
I believe we might be doing that for our language handling, so I chose the
other method, directly using the VectorCompatDrawable class, which works fine

## How Has This Been Tested?

#6665 was easily reproduced by setting AppBar Buttons to always show the whiteboard color pallete and opening the reviewer in an API16 emulator

Both methods mentioned above solved the crash independently, but one appears safer so I chose that.

It no longer crashes

## Learning (optional, can help others)

Be really careful with vector icons, this will be important to do correctly in #5134  which is mostly complete (and I just revived on a personal branch)

https://stackoverflow.com/questions/48413124/binary-xml-file-line-1-invalid-drawable-tag-vector
https://android-developers.googleblog.com/2016/02/android-support-library-232.html
https://developer.android.com/studio/write/vector-asset-studio.html

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
