### PR TITLE
Use AnkiDroid-specific ACRA pref for always send

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -343,8 +343,8 @@ public class AnkiDroidApp extends MultiDexApplication {
         UsageAnalytics.sendAnalyticsException(e, false);
 
         if (onlyIfSilent) {
-            boolean alwaysAccept = getSharedPrefs(getInstance().getApplicationContext()).getBoolean(ACRA.PREF_ALWAYS_ACCEPT, false);
-            if (!alwaysAccept) {
+            String reportMode = getSharedPrefs(getInstance().getApplicationContext()).getString(AnkiDroidApp.FEEDBACK_REPORT_KEY, FEEDBACK_REPORT_ASK);
+            if (!FEEDBACK_REPORT_ALWAYS.equals(reportMode)) {
                 Timber.i("sendExceptionReport - onlyIfSilent true, but ACRA is not 'always accept'. Skipping report send.");
                 return;
             }


### PR DESCRIPTION

## Pull Request template

## Purpose / Description

We want to send exception reports sometimes only if silent

I believe I was accessing the incorrect prefs values to do that, this attempts to use the prefs values we use to toggle the ACRA dialog or not for silent sending

## Fixes
Related #6662 - where we add telemetry on crop URI errors but only if silent

## Approach

scanning AnkiDroidApp I noticed the keys were different in how we set ACRA to send or not, I followed existing pref key usage

## How Has This Been Tested?

Admittedly I have not :cowboy_hat_face: but.....seems self-explanatory? Default pref value of "ask" (so we won't think we are good to go) then a safe string comparison with the always key...looks legit

## Learning (optional, can help others)

Always read code 4 times, especially related code.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
