### PR TITLE
ACRA: Fix crash when restarting app

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -48,6 +48,7 @@ import com.ichi2.compat.CompatHelper;
 import com.ichi2.utils.LanguageUtil;
 import com.ichi2.anki.analytics.UsageAnalytics;
 import com.ichi2.utils.Permissions;
+import com.ichi2.utils.WebViewDebugging;
 
 import org.acra.ACRA;
 import org.acra.ReportField;
@@ -240,6 +241,16 @@ public class AnkiDroidApp extends MultiDexApplication {
         Timber.tag(TAG);
 
         Timber.d("Startup - Application Start");
+
+        // The ACRA process needs a WebView for optimal UsageAnalytics values but it can't have the same data directory.
+        // Analytics falls back to a sensible default if this is not set.
+        if (ACRA.isACRASenderServiceProcess() && Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            try {
+                WebViewDebugging.setDataDirectorySuffix("acra");
+            } catch (Exception e) {
+                Timber.w(e, "Failed to set WebView data directory");
+            }
+        }
 
         // analytics after ACRA, they both install UncaughtExceptionHandlers but Analytics chains while ACRA does not
         UsageAnalytics.initialize(this);

--- a/AnkiDroid/src/main/java/com/ichi2/utils/WebViewDebugging.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/WebViewDebugging.java
@@ -4,9 +4,13 @@ import android.content.SharedPreferences;
 import android.os.Build;
 import android.webkit.WebView;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
 import androidx.annotation.UiThread;
 
 public class WebViewDebugging {
+
+    private static boolean sHasSetDataDirectory = false;
 
     @UiThread
     public static void initializeDebugging(SharedPreferences sharedPrefs) {
@@ -22,5 +26,17 @@ public class WebViewDebugging {
             boolean enableDebugging = sharedPrefs.getBoolean("html_javascript_debugging", false);
             WebView.setWebContentsDebuggingEnabled(enableDebugging);
         }
+    }
+
+    /** Throws IllegalStateException if a WebView has been initialized */
+    @RequiresApi(api = Build.VERSION_CODES.P)
+    public static void setDataDirectorySuffix(@NonNull String suffix) {
+        WebView.setDataDirectorySuffix(suffix);
+        sHasSetDataDirectory = true;
+    }
+
+    public static boolean hasSetDataDirectory() {
+        // Implicitly truth requires API >= P
+        return sHasSetDataDirectory;
     }
 }


### PR DESCRIPTION
## Purpose / Description
Fixes error: "Using WebView from more than one process at once with the same data directory is not supported. https://crbug.com/558377"

This is caused by the following factors:

* The ACRA process (:acra) does not terminate if an error dialog is shown
* We want analytics in :acra
* UsageAnalytics gives much better data if using the WebView user agent
* WebSettings.getDefaultUserAgent now creates the WebView process

## Fixes
Fixes #5502

## Approach
We do have an API to fix this >= API 28: WebView.setDataDirectorySuffix

< API 28, we use an imprecise user agent.

## How Has This Been Tested?

I did not unit test this, as instrumented tests use AnkiDroidApp, and `WebSettings.getDefaultUserAgent` does not create WebView under Robolectric

Instead, commented out the Debug Timber code, and tested on my device. Can no longer cause a crash.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code