### PR TITLE
Correcting copy of JSONObject

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/utils/JSONObject.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/JSONObject.java
@@ -136,7 +136,7 @@ public class JSONObject extends org.json.JSONObject implements Iterable<String> 
 
     public JSONObject(JSONObject copyFrom) {
         this();
-        for (String key: this) {
+        for (String key: copyFrom) {
             put(key, copyFrom.get(key));
         }
     }


### PR DESCRIPTION
While trying to port upstream test, I found a bug. I realized that I was unable to copy object, they always ended
empty. I've now found why.

This method is not used anywhere in the code, so it did not lead to any real bug.
