### PR TITLE
JSON class simple

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.java
@@ -39,6 +39,7 @@ import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Consts;
 import com.ichi2.libanki.Deck;
 import com.ichi2.libanki.Decks;
+import com.ichi2.libanki.Model;
 import com.ichi2.libanki.Models;
 import com.ichi2.libanki.Note;
 import com.ichi2.libanki.sched.AbstractSched;
@@ -139,7 +140,7 @@ public class ContentProviderTest extends InstrumentedTest {
         }
 
         // Add a new basic model that we use for testing purposes (existing models could potentially be corrupted)
-        JSONObject model = StdModels.basicModel.add(col, BASIC_MODEL_NAME);
+        Model model = StdModels.basicModel.add(col, BASIC_MODEL_NAME);
         mModelId = model.getLong("id");
         ArrayList<String> fields = Models.fieldNames(model);
         // Use the names of the fields as test values for the notes which will be added
@@ -215,7 +216,7 @@ public class ContentProviderTest extends InstrumentedTest {
 
 
     private void removeAllModelsByName(Collection col, String name) throws Exception {
-        JSONObject testModel = col.getModels().byName(name);
+        Model testModel = col.getModels().byName(name);
         while (testModel != null) {
             col.getModels().rem(testModel);
             testModel = col.getModels().byName(name);
@@ -267,7 +268,7 @@ public class ContentProviderTest extends InstrumentedTest {
         final ContentResolver cr = InstrumentationRegistry.getInstrumentation().getTargetContext().getContentResolver();
         Collection col = getCol();
         // Add a new basic model that we use for testing purposes (existing models could potentially be corrupted)
-        JSONObject model = StdModels.basicModel.add(col, BASIC_MODEL_NAME);
+        Model model = StdModels.basicModel.add(col, BASIC_MODEL_NAME);
         long modelId = model.getLong("id");
         // Add the note
         Uri modelUri = ContentUris.withAppendedId(FlashCardsContract.Model.CONTENT_URI, modelId);
@@ -304,7 +305,7 @@ public class ContentProviderTest extends InstrumentedTest {
         // Get required objects for test
         final ContentResolver cr = InstrumentationRegistry.getInstrumentation().getTargetContext().getContentResolver();
         Collection col = getCol();
-        JSONObject model = StdModels.basicModel.add(col, BASIC_MODEL_NAME);
+        Model model = StdModels.basicModel.add(col, BASIC_MODEL_NAME);
         long modelId = model.getLong("id");
         JSONArray initialFieldsArr = model.getJSONArray("flds");
         int initialFieldCount = initialFieldsArr.length();
@@ -512,7 +513,7 @@ public class ContentProviderTest extends InstrumentedTest {
             // Delete the model (this will force a full-sync)
             col.modSchemaNoCheck();
             try {
-                JSONObject model = col.getModels().get(mid);
+                Model model = col.getModels().get(mid);
                 assertNotNull("Check model", model);
                 col.getModels().rem(model);
             } catch (ConfirmModSchemaException e) {

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.java
@@ -37,6 +37,7 @@ import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Consts;
+import com.ichi2.libanki.Deck;
 import com.ichi2.libanki.Decks;
 import com.ichi2.libanki.Models;
 import com.ichi2.libanki.Note;
@@ -719,7 +720,7 @@ public class ContentProviderTest extends InstrumentedTest {
                 long deckID = decksCursor.getLong(decksCursor.getColumnIndex(FlashCardsContract.Deck.DECK_ID));
                 String deckName = decksCursor.getString(decksCursor.getColumnIndex(FlashCardsContract.Deck.DECK_NAME));
 
-                JSONObject deck = decks.get(deckID);
+                Deck deck = decks.get(deckID);
                 assertNotNull("Check that the deck we received actually exists", deck);
                 assertEquals("Check that the received deck has the correct name", deck.getString("name"), deckName);
             }
@@ -744,7 +745,7 @@ public class ContentProviderTest extends InstrumentedTest {
                 long returnedDeckID = decksCursor.getLong(decksCursor.getColumnIndex(FlashCardsContract.Deck.DECK_ID));
                 String returnedDeckName = decksCursor.getString(decksCursor.getColumnIndex(FlashCardsContract.Deck.DECK_NAME));
 
-                JSONObject realDeck = col.getDecks().get(deckId);
+                Deck realDeck = col.getDecks().get(deckId);
                 assertEquals("Check that received deck ID equals real deck ID", deckId, returnedDeckID);
                 assertEquals("Check that received deck name equals real deck name", realDeck.getString("name"), returnedDeckName);
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -102,6 +102,7 @@ import com.ichi2.libanki.sched.AbstractSched;
 import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Consts;
+import com.ichi2.libanki.DeckConfig;
 import com.ichi2.libanki.Note;
 import com.ichi2.libanki.Sound;
 import com.ichi2.libanki.Utils;
@@ -2286,7 +2287,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
      *
      * @return The configuration for the current {@link Card}
      */
-    private JSONObject getConfigForCurrentCard() {
+    private DeckConfig getConfigForCurrentCard() {
         return getCol().getDecks().confForDid(getDeckIdForCard(mCurrentCard));
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -77,6 +77,7 @@ import com.ichi2.libanki.Consts;
 import com.ichi2.libanki.Decks;
 import com.ichi2.libanki.Note;
 import com.ichi2.libanki.Utils;
+import com.ichi2.libanki.Deck;
 import com.ichi2.themes.Themes;
 import com.ichi2.upgrade.Upgrade;
 import com.ichi2.utils.FunctionalInterfaces;
@@ -131,7 +132,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
     private static Pattern sMarkedPattern = Pattern.compile(".*[Mm]arked.*");
 
     private List<Map<String, String>> mCards;
-    private ArrayList<JSONObject> mDropDownDecks;
+    private ArrayList<Deck> mDropDownDecks;
     private ListView mCardsListView;
     private SearchView mSearchView;
     private MultiColumnListAdapter mCardsAdapter;
@@ -390,7 +391,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
     void changeDeck(int deckPosition) {
         long[] ids = getSelectedCardIds();
 
-        JSONObject selectedDeck = getValidDecksForChangeDeck().get(deckPosition);
+        Deck selectedDeck = getValidDecksForChangeDeck().get(deckPosition);
 
         try {
             //#5932 - can't be dynamic
@@ -1010,7 +1011,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
                 //WARNING: changeDeck depends on this index, so any changes should be reflected there.
                 final ArrayAdapter<String> arrayAdapter = new ArrayAdapter<String>(this, R.layout.dropdown_deck_item);
-                for (JSONObject deck : getValidDecksForChangeDeck()) {
+                for (Deck deck : getValidDecksForChangeDeck()) {
                     try {
                         arrayAdapter.add(deck.getString("name"));
                     } catch (JSONException e) {
@@ -1217,7 +1218,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
             mRestrictOnDeck = "";
             saveLastDeckId(ALL_DECKS_ID);
         } else {
-            JSONObject deck = mDropDownDecks.get(position - 1);
+            Deck deck = mDropDownDecks.get(position - 1);
             mRestrictOnDeck = "deck:\"" + deck.getString("name") + "\" ";
             saveLastDeckId(deck.getLong("id"));
         }
@@ -1319,9 +1320,9 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
     /** Returns the decks which are valid targets for "Change Deck" */
     @VisibleForTesting
-    List<JSONObject> getValidDecksForChangeDeck() {
-        List<JSONObject> nonDynamicDecks = new ArrayList<>();
-        for (JSONObject d : mDropDownDecks) {
+    List<Deck> getValidDecksForChangeDeck() {
+        List<Deck> nonDynamicDecks = new ArrayList<>();
+        for (Deck d : mDropDownDecks) {
             if (Decks.isDynamic(d)) {
                 continue;
             }
@@ -2273,9 +2274,9 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     public int getChangeDeckPositionFromId(long deckId) {
-        List<JSONObject> decks = getValidDecksForChangeDeck();
+        List<Deck> decks = getValidDecksForChangeDeck();
         for (int i = 0; i < decks.size(); i++) {
-            JSONObject deck = decks.get(i);
+            Deck deck = decks.get(i);
             if (deck.getLong(ID) == deckId) {
                 return i;
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
@@ -50,6 +50,7 @@ import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.async.CollectionTask;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Consts;
+import com.ichi2.libanki.Model;
 import com.ichi2.libanki.Models;
 import com.ichi2.themes.StyledProgressDialog;
 
@@ -161,7 +162,7 @@ public class CardTemplateEditor extends AnkiActivity {
         // The first time the activity loads it has a model id but no edits yet, so no edited model
         // take the passed model id load it up for editing
         if (getTempModel() == null) {
-            mTempModel = new TemporaryModel(new JSONObject(col.getModels().get(mModelId).toString()));
+            mTempModel = new TemporaryModel(new Model(col.getModels().get(mModelId).toString()));
             //Timber.d("onCollectionLoaded() model is %s", mTempModel.getModel().toString(2));
         }
         // Set up the ViewPager with the sections adapter.
@@ -578,7 +579,7 @@ public class CardTemplateEditor extends AnkiActivity {
          * @param model model to remove template from, modified in place by reference
          * @param numAffectedCards number of cards which will be affected
          */
-        private void confirmDeleteCards(final JSONObject tmpl, final JSONObject model,  int numAffectedCards) {
+        private void confirmDeleteCards(final JSONObject tmpl, final Model model,  int numAffectedCards) {
             ConfirmationDialog d = new ConfirmationDialog();
             Resources res = getResources();
             String msg = String.format(res.getQuantityString(R.plurals.card_template_editor_confirm_delete,
@@ -600,7 +601,7 @@ public class CardTemplateEditor extends AnkiActivity {
          * @param tmpl template to remove
          * @param model model to remove template from, modified in place by reference
          */
-        private void deleteTemplateWithCheck(final JSONObject tmpl, final JSONObject model) {
+        private void deleteTemplateWithCheck(final JSONObject tmpl, final Model model) {
             try {
                 mTemplateEditor.getCol().modSchema();
                 deleteTemplate(tmpl, model);
@@ -622,7 +623,7 @@ public class CardTemplateEditor extends AnkiActivity {
          * @param tmpl template to remove
          * @param model model to remove from, updated in place by reference
          */
-        private void deleteTemplate(JSONObject tmpl, JSONObject model) {
+        private void deleteTemplate(JSONObject tmpl, Model model) {
             JSONArray oldTemplates = model.getJSONArray("tmpls");
             JSONArray newTemplates = new JSONArray();
             for (int i = 0; i < oldTemplates.length(); i++) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.java
@@ -22,6 +22,7 @@ import android.view.View;
 import com.ichi2.anim.ActivityTransitionAnimation;
 import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
+import com.ichi2.libanki.Model;
 import com.ichi2.libanki.Models;
 import com.ichi2.libanki.Note;
 import com.ichi2.libanki.utils.NoteUtils;
@@ -40,7 +41,7 @@ import timber.log.Timber;
  */
 public class CardTemplatePreviewer extends AbstractFlashcardViewer {
     private String mEditedModelFileName = null;
-    private JSONObject mEditedModel = null;
+    private Model mEditedModel = null;
     private int mOrdinal;
     private long[] mCardList;
     private Bundle mNoteEditorBundle = null;
@@ -201,7 +202,7 @@ public class CardTemplatePreviewer extends AbstractFlashcardViewer {
     }
 
     /** Get a dummy card */
-    protected @Nullable Card getDummyCard(JSONObject model, int ordinal) {
+    protected @Nullable Card getDummyCard(Model model, int ordinal) {
         Timber.d("getDummyCard() Creating dummy note for ordinal %s", ordinal);
         if (model == null) {
             return null;
@@ -277,7 +278,7 @@ public class CardTemplatePreviewer extends AbstractFlashcardViewer {
 
         @Override
         /** Override the method that fetches the model so we can render unsaved models */
-        public JSONObject model() {
+        public Model model() {
             if (mEditedModel != null) {
                 return mEditedModel;
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
@@ -77,7 +77,7 @@ import static com.ichi2.async.CollectionTask.TASK_TYPE.*;
  */
 public class DeckOptions extends AppCompatPreferenceActivity implements OnSharedPreferenceChangeListener {
 
-    private JSONObject mOptions;
+    private DeckConfig mOptions;
     private JSONObject mDeck;
     private Collection mCol;
     private boolean mPreferenceChanged = false;
@@ -163,7 +163,7 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
         }
 
 
-        private boolean parseTimerValue(JSONObject options) {
+        private boolean parseTimerValue(DeckConfig options) {
             return DeckConfig.parseTimerOpt(options, true);
         }
 
@@ -793,12 +793,12 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
     @SuppressWarnings("deprecation") // Tracked as #5019 on github
     protected void buildLists() {
         ListPreference deckConfPref = (ListPreference) findPreference("deckConf");
-        ArrayList<JSONObject> confs = mCol.getDecks().allConf();
+        ArrayList<DeckConfig> confs = mCol.getDecks().allConf();
         Collections.sort(confs, NamedJSONComparator.instance);
         String[] confValues = new String[confs.size()];
         String[] confLabels = new String[confs.size()];
         for (int i = 0; i < confs.size(); i++) {
-            JSONObject o = confs.get(i);
+            DeckConfig o = confs.get(i);
             confValues[i] = o.getString("id");
             confLabels[i] = o.getString("name");
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
@@ -47,6 +47,7 @@ import com.ichi2.async.CollectionTask;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Consts;
 import com.ichi2.libanki.DeckConfig;
+import com.ichi2.libanki.Deck;
 import com.ichi2.preferences.StepsPreference;
 import com.ichi2.preferences.TimePreference;
 import com.ichi2.themes.StyledProgressDialog;
@@ -78,7 +79,7 @@ import static com.ichi2.async.CollectionTask.TASK_TYPE.*;
 public class DeckOptions extends AppCompatPreferenceActivity implements OnSharedPreferenceChangeListener {
 
     private DeckConfig mOptions;
-    private JSONObject mDeck;
+    private Deck mDeck;
     private Collection mCol;
     private boolean mPreferenceChanged = false;
     private BroadcastReceiver mUnmountReceiver = null;
@@ -824,7 +825,7 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
     private int getOptionsGroupCount() {
         int count = 0;
         long conf = mDeck.getLong("conf");
-        for (JSONObject deck : mCol.getDecks().all()) {
+        for (Deck deck : mCol.getDecks().all()) {
             if (deck.getInt("dyn") == 1) {
                 continue;
             }
@@ -853,7 +854,7 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
         long did = mDeck.getLong("id");
         TreeMap<String, Long> children = mCol.getDecks().children(did);
         for (Map.Entry<String, Long> entry : children.entrySet()) {
-            JSONObject child = mCol.getDecks().get(entry.getValue());
+            Deck child = mCol.getDecks().get(entry.getValue());
             if (child.getInt("dyn") == 1) {
                 continue;
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -104,6 +104,7 @@ import com.ichi2.async.CollectionTask.TaskData;
 import com.ichi2.compat.CompatHelper;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Decks;
+import com.ichi2.libanki.Model;
 import com.ichi2.libanki.Models;
 import com.ichi2.libanki.sched.AbstractSched;
 import com.ichi2.libanki.Utils;
@@ -1062,7 +1063,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
                 Timber.i("Fixing font-family definition in templates");
                 try {
                     Models models = getCol().getModels();
-                    for (JSONObject m : models.all()) {
+                    for (Model m : models.all()) {
                         String css = m.getString("css");
                         if (css.contains("font-familiy")) {
                             m.put("css", css.replace("font-familiy", "font-family"));

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FilteredDeckOptions.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FilteredDeckOptions.java
@@ -36,6 +36,7 @@ import android.view.MenuItem;
 import com.ichi2.anim.ActivityTransitionAnimation;
 import com.ichi2.anki.receiver.SdCardReceiver;
 import com.ichi2.libanki.Collection;
+import com.ichi2.libanki.Deck;
 import com.ichi2.preferences.StepsPreference;
 import com.ichi2.themes.Themes;
 import com.ichi2.ui.AppCompatPreferenceActivity;
@@ -59,7 +60,7 @@ import timber.log.Timber;
  */
 public class FilteredDeckOptions extends AppCompatPreferenceActivity implements OnSharedPreferenceChangeListener {
 
-    private JSONObject mDeck;
+    private Deck mDeck;
     private Collection mCol;
     private boolean mAllowCommit = true;
     private boolean mPrefChanged = false;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.java
@@ -45,6 +45,7 @@ import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.async.CollectionTask;
 import com.ichi2.async.CollectionTask.TaskData;
 import com.ichi2.libanki.Collection;
+import com.ichi2.libanki.Model;
 import com.ichi2.libanki.StdModels;
 import com.ichi2.widget.WidgetStatus;
 
@@ -70,7 +71,7 @@ public class ModelBrowser extends AnkiActivity {
     private int mModelListPosition;
 
     //Used exclusively to display model name
-    private ArrayList<JSONObject> mModels;
+    private ArrayList<Model> mModels;
     private ArrayList<Integer> mCardCounts;
     private ArrayList<Long> mModelIds;
     private ArrayList<DisplayPair> mModelDisplayList;
@@ -114,7 +115,7 @@ public class ModelBrowser extends AnkiActivity {
                 throw new RuntimeException();
             }
             hideProgressBar();
-            mModels = (ArrayList<JSONObject>) result.getObjArray()[0];
+            mModels = (ArrayList<Model>) result.getObjArray()[0];
             mCardCounts = (ArrayList<Integer>) result.getObjArray()[1];
 
             fillModelList();
@@ -313,7 +314,7 @@ public class ModelBrowser extends AnkiActivity {
         final int numStdModels = mNewModelLabels.size();
 
         if (mModels != null) {
-            for (JSONObject model : mModels) {
+            for (Model model : mModels) {
                 String name = model.getString("name");
                 mNewModelLabels.add(String.format(clone, name));
                 mNewModelNames.add(name);
@@ -370,7 +371,7 @@ public class ModelBrowser extends AnkiActivity {
      * @param position position in dialog the user selected to add / clone the model type from
      */
     private void addNewNoteType(String modelName, int position) {
-        JSONObject model;
+        Model model;
         if (modelName.length() > 0) {
             int nbStdModels = StdModels.stdModels.length;
             if (position < nbStdModels) {
@@ -378,8 +379,8 @@ public class ModelBrowser extends AnkiActivity {
             } else {
                 //New model
                 //Model that is being cloned
-                JSONObject oldModel = mModels.get(position - nbStdModels).deepClone();
-                JSONObject newModel = StdModels.basicModel.add(col);
+                Model oldModel = mModels.get(position - nbStdModels).deepClone();
+                Model newModel = StdModels.basicModel.add(col);
                 oldModel.put("id", newModel.get("id"));
                 model = oldModel;
             }
@@ -452,7 +453,7 @@ public class ModelBrowser extends AnkiActivity {
                             .negativeText(R.string.dialog_cancel)
                             .customView(mModelNameInput, true)
                             .onPositive((dialog, which) -> {
-                                    JSONObject model = mModels.get(mModelListPosition);
+                                    Model model = mModels.get(mModelListPosition);
                                     String deckName = mModelNameInput.getText().toString()
                                             // Anki desktop doesn't allow double quote characters in deck names
                                             .replaceAll("[\"\\n\\r]", "");

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.java
@@ -32,6 +32,7 @@ import com.ichi2.anki.dialogs.ModelEditorContextMenu;
 import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.async.CollectionTask;
 import com.ichi2.libanki.Collection;
+import com.ichi2.libanki.Model;
 import com.ichi2.themes.StyledProgressDialog;
 import com.ichi2.widget.WidgetStatus;
 
@@ -55,7 +56,7 @@ public class ModelFieldEditor extends AnkiActivity {
 
     private Collection mCol;
     private JSONArray mNoteFields;
-    private JSONObject mMod;
+    private Model mMod;
 
     private ModelEditorContextMenu mContextMenu;
     private EditText mFieldNameInput;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -80,6 +80,7 @@ import com.ichi2.libanki.Consts;
 import com.ichi2.libanki.Note;
 import com.ichi2.libanki.Note.ClozeUtils;
 import com.ichi2.libanki.Utils;
+import com.ichi2.libanki.Deck;
 import com.ichi2.themes.StyledProgressDialog;
 import com.ichi2.themes.Themes;
 import com.ichi2.anki.widgets.PopupMenuWithIcons;
@@ -497,9 +498,9 @@ public class NoteEditor extends AnkiActivity {
         mAllDeckIds = new ArrayList<>();
         final ArrayList<String> deckNames = new ArrayList<>();
 
-        ArrayList<JSONObject> decks = getCol().getDecks().all();
+        ArrayList<Deck> decks = getCol().getDecks().all();
         Collections.sort(decks, DeckComparator.instance);
-        for (JSONObject d : decks) {
+        for (Deck d : decks) {
             // add current deck and all other non-filtered decks to deck list
             long thisDid = d.getLong("id");
             if (d.getInt("dyn") == 0 || (!mAddNote && mCurrentEditedCard != null && mCurrentEditedCard.getDid() == thisDid)) {
@@ -1704,7 +1705,7 @@ public class NoteEditor extends AnkiActivity {
                     return;
                 }
                 getCol().getModels().setCurrent(model);
-                JSONObject currentDeck = getCol().getDecks().current();
+                Deck currentDeck = getCol().getDecks().current();
                 currentDeck.put("mid", newId);
                 getCol().getDecks().save(currentDeck);
                 // Update deck

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -77,6 +77,7 @@ import com.ichi2.compat.CompatHelper;
 import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Consts;
+import com.ichi2.libanki.Model;
 import com.ichi2.libanki.Note;
 import com.ichi2.libanki.Note.ClozeUtils;
 import com.ichi2.libanki.Utils;
@@ -476,7 +477,7 @@ public class NoteEditor extends AnkiActivity {
         mNoteTypeSpinner = findViewById(R.id.note_type_spinner);
         mAllModelIds = new ArrayList<>();
         final ArrayList<String> modelNames = new ArrayList<>();
-        ArrayList<JSONObject> models = getCol().getModels().all();
+        ArrayList<Model> models = getCol().getModels().all();
         Collections.sort(models, NamedJSONComparator.instance);
         for (JSONObject m : models) {
             modelNames.add(m.getString("name"));
@@ -788,8 +789,8 @@ public class NoteEditor extends AnkiActivity {
             CollectionTask.launchCollectionTask(ADD_NOTE, mSaveNoteHandler, new CollectionTask.TaskData(mEditorNote));
         } else {
             // Check whether note type has been changed
-            final JSONObject newModel = getCurrentlySelectedModel();
-            final JSONObject oldModel = mCurrentEditedCard.model();
+            final Model newModel = getCurrentlySelectedModel();
+            final Model oldModel = mCurrentEditedCard.model();
             if (!newModel.equals(oldModel)) {
                 mReloadRequired = true;
                 if (mModelChangeCardMap.size() < mEditorNote.cards().size() || mModelChangeCardMap.containsKey(null)) {
@@ -844,7 +845,7 @@ public class NoteEditor extends AnkiActivity {
     /**
      * Change the note type from oldModel to newModel, handling the case where a full sync will be required
      */
-    private void changeNoteTypeWithErrorHandling(final JSONObject oldModel, final JSONObject newModel) {
+    private void changeNoteTypeWithErrorHandling(final Model oldModel, final Model newModel) {
         Resources res = getResources();
         try {
             changeNoteType(oldModel, newModel);
@@ -871,7 +872,7 @@ public class NoteEditor extends AnkiActivity {
      * Change the note type from oldModel to newModel
      * @throws ConfirmModSchemaException If a full sync will be required
      */
-    private void changeNoteType(JSONObject oldModel, JSONObject newModel) throws ConfirmModSchemaException {
+    private void changeNoteType(Model oldModel, Model newModel) throws ConfirmModSchemaException {
         final long [] noteIds = {mEditorNote.getId()};
         getCol().getModels().change(oldModel, noteIds, newModel, mModelChangeFieldMap, mModelChangeCardMap);
         // refresh the note object to reflect the database changes
@@ -1530,7 +1531,7 @@ public class NoteEditor extends AnkiActivity {
 
     private void setNote(Note note) {
         if (note == null || mAddNote) {
-            JSONObject model = getCol().getModels().current();
+            Model model = getCol().getModels().current();
             mEditorNote = new Note(getCol(), model);
         } else {
             mEditorNote = note;
@@ -1611,7 +1612,7 @@ public class NoteEditor extends AnkiActivity {
         return TextUtils.join(" ", tags);
     }
 
-    private JSONObject getCurrentlySelectedModel() {
+    private Model getCurrentlySelectedModel() {
         return getCol().getModels().get(mAllModelIds.get(mNoteTypeSpinner.getSelectedItemPosition()));
     }
 
@@ -1699,7 +1700,7 @@ public class NoteEditor extends AnkiActivity {
             long newId = mAllModelIds.get(pos);
             Timber.i("Changing note type to '%d", newId);
             if (oldModelId != newId) {
-                JSONObject model = getCol().getModels().get(newId);
+                Model model = getCol().getModels().get(newId);
                 if (model == null) {
                     Timber.w("New model %s not found, not changing note type", newId);
                     return;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.java
@@ -44,6 +44,7 @@ import com.ichi2.anki.widgets.DeckDropDownAdapter;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Decks;
 import com.ichi2.libanki.stats.Stats;
+import com.ichi2.libanki.Deck;
 import com.ichi2.ui.SlidingTabLayout;
 
 import com.ichi2.utils.JSONException;
@@ -71,7 +72,7 @@ public class Statistics extends NavigationDrawerActivity implements DeckDropDown
     private ViewPager mViewPager;
     private AnkiStatsTaskHandler mTaskHandler = null;
     private long mDeckId;
-    private ArrayList<JSONObject> mDropDownDecks;
+    private ArrayList<Deck> mDropDownDecks;
     private Spinner mActionBarSpinner;
     private static boolean sIsSubtitle;
 
@@ -221,7 +222,7 @@ public class Statistics extends NavigationDrawerActivity implements DeckDropDown
         if (position == 0) {
             mDeckId = Stats.ALL_DECKS_ID;
         } else {
-            JSONObject deck = mDropDownDecks.get(position - 1);
+            Deck deck = mDropDownDecks.get(position - 1);
             try {
                 mDeckId = deck.getLong("id");
             } catch (JSONException e) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
@@ -45,6 +45,7 @@ import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Consts;
 import com.ichi2.libanki.Decks;
 import com.ichi2.libanki.Utils;
+import com.ichi2.libanki.Deck;
 import com.ichi2.themes.StyledProgressDialog;
 import com.ichi2.utils.HtmlUtils;
 
@@ -443,7 +444,7 @@ public class StudyOptionsFragment extends Fragment implements Toolbar.OnMenuItem
         if (requestCode == DECK_OPTIONS) {
             if (mLoadWithDeckOptions) {
                 mLoadWithDeckOptions = false;
-                JSONObject deck = getCol().getDecks().current();
+                Deck deck = getCol().getDecks().current();
                 if (deck.getInt("dyn") != 0 && deck.has("empty")) {
                     deck.remove("empty");
                 }
@@ -554,7 +555,7 @@ public class StudyOptionsFragment extends Fragment implements Toolbar.OnMenuItem
                     initAllContentViews(mStudyOptionsView);
                     // Set the deck name
                     String fullName;
-                    JSONObject deck = getCol().getDecks().current();
+                    Deck deck = getCol().getDecks().current();
                     // Main deck name
                     fullName = deck.getString("name");
                     String[] name = Decks.path(fullName);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/TemporaryModel.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/TemporaryModel.java
@@ -33,6 +33,7 @@ import timber.log.Timber;
 
 import com.ichi2.async.CollectionTask;
 import com.ichi2.compat.CompatHelper;
+import com.ichi2.libanki.Model;
 import com.ichi2.utils.JSONObject;
 import static com.ichi2.async.CollectionTask.TASK_TYPE.*;
 
@@ -43,10 +44,10 @@ public class TemporaryModel {
     public static final String INTENT_MODEL_FILENAME = "editedModelFilename";
     private ArrayList<Object[]> mTemplateChanges = new ArrayList<>();
     private String mEditedModelFileName = null;
-    private final @NonNull JSONObject mEditedModel;
+    private final @NonNull Model mEditedModel;
 
 
-    public TemporaryModel(@NonNull JSONObject model) {
+    public TemporaryModel(@NonNull Model model) {
         Timber.d("Constructor called with model");
         mEditedModel = model;
     }
@@ -67,7 +68,7 @@ public class TemporaryModel {
         }
 
         Timber.d("onCreate() loading saved model file %s", mEditedModelFileName);
-        JSONObject tempModelJSON;
+        Model tempModelJSON;
         try {
             tempModelJSON = getTempModel((mEditedModelFileName));
         } catch (IOException e) {
@@ -153,7 +154,7 @@ public class TemporaryModel {
     }
 
 
-    public JSONObject getModel() {
+    public Model getModel() {
         return mEditedModel;
     }
 
@@ -191,11 +192,11 @@ public class TemporaryModel {
      * Get the model temporarily saved into the file represented by the given path
      * @return JSONObject holding the model, or null if there was a problem
      */
-    public static JSONObject getTempModel(@NonNull String tempModelFileName) throws IOException {
+    public static Model getTempModel(@NonNull String tempModelFileName) throws IOException {
         Timber.d("getTempModel() fetching tempModel %s", tempModelFileName);
         try (ByteArrayOutputStream target = new ByteArrayOutputStream()) {
             CompatHelper.getCompat().copyFile(tempModelFileName, target);
-            return new JSONObject(target.toString());
+            return new Model(target.toString());
         } catch (IOException e) {
             Timber.e(e, "Unable to read+parse tempModel from file %s", tempModelFileName);
             throw e;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
@@ -47,6 +47,7 @@ import com.ichi2.async.CollectionTask;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Consts;
 
+import com.ichi2.libanki.Deck;
 import com.ichi2.utils.JSONArray;
 import com.ichi2.utils.JSONObject;
 
@@ -220,7 +221,7 @@ public class CustomStudyDialog extends AnalyticsDialogFragment {
                     switch (dialogId) {
                         case CUSTOM_STUDY_NEW: {
                             AnkiDroidApp.getSharedPrefs(getActivity()).edit().putInt("extendNew", n).commit();
-                            JSONObject deck = col.getDecks().get(did);
+                            Deck deck = col.getDecks().get(did);
                             deck.put("extendNew", n);
                             col.getDecks().save(deck);
                             col.getSched().extendLimits(n, 0);
@@ -229,7 +230,7 @@ public class CustomStudyDialog extends AnalyticsDialogFragment {
                         }
                         case CUSTOM_STUDY_REV: {
                             AnkiDroidApp.getSharedPrefs(getActivity()).edit().putInt("extendRev", n).commit();
-                            JSONObject deck = col.getDecks().get(did);
+                            Deck deck = col.getDecks().get(did);
                             deck.put("extendRev", n);
                             col.getDecks().save(deck);
                             col.getSched().extendLimits(0, n);
@@ -425,13 +426,13 @@ public class CustomStudyDialog extends AnalyticsDialogFragment {
      * @param resched whether to reschedule the cards based on the answers given (or ignore them if false)
      */
     private void createCustomStudySession(JSONArray delays, Object[] terms, Boolean resched) {
-        JSONObject dyn;
+        Deck dyn;
         final AnkiActivity activity = getAnkiActivity();
         Collection col = CollectionHelper.getInstance().getCol(activity);
         long did = getArguments().getLong("did");
         String deckToStudyName = col.getDecks().get(did).getString("name");
         String customStudyDeck = getResources().getString(R.string.custom_study_deck_name);
-        JSONObject cur = col.getDecks().byName(customStudyDeck);
+        Deck cur = col.getDecks().byName(customStudyDeck);
         if (cur != null) {
             Timber.i("Found deck: '%s'", customStudyDeck);
             if (cur.getInt("dyn") != 1) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
@@ -52,6 +52,7 @@ import com.ichi2.libanki.Models;
 import com.ichi2.libanki.Note;
 import com.ichi2.libanki.Utils;
 
+import com.ichi2.libanki.Deck;
 import com.ichi2.utils.JSONArray;
 import com.ichi2.utils.JSONException;
 import com.ichi2.utils.JSONObject;
@@ -1015,7 +1016,7 @@ public class CardContentProvider extends ContentProvider {
                     throw new IllegalArgumentException("Invalid deck name '" + deckName + "'");
                 }
                 did = col.getDecks().id(deckName, true);
-                JSONObject deck = col.getDecks().get(did);
+                Deck deck = col.getDecks().get(did);
                 if (deck != null) {
                     try {
                         String deckDesc = values.getAsString(FlashCardsContract.Deck.DECK_DESC);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
@@ -44,6 +44,7 @@ import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.compat.CompatHelper;
 import com.ichi2.libanki.Consts;
 import com.ichi2.libanki.Decks;
+import com.ichi2.libanki.Model;
 import com.ichi2.libanki.sched.AbstractSched;
 import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
@@ -286,7 +287,7 @@ public class CardContentProvider extends ContentProvider {
             case MODELS_ID_TEMPLATES: {
                 /* Direct access model templates */
                 Models models = col.getModels();
-                JSONObject currentModel = models.get(getModelIdFromUri(uri, col));
+                Model currentModel = models.get(getModelIdFromUri(uri, col));
                 String[] columns = ((projection != null) ? projection : CardTemplate.DEFAULT_PROJECTION);
                 MatrixCursor rv = new MatrixCursor(columns, 1);
                 try {
@@ -304,7 +305,7 @@ public class CardContentProvider extends ContentProvider {
                 /* Direct access model template with specific ID */
                 Models models = col.getModels();
                 int ord = Integer.parseInt(uri.getLastPathSegment());
-                JSONObject currentModel = models.get(getModelIdFromUri(uri, col));
+                Model currentModel = models.get(getModelIdFromUri(uri, col));
                 String[] columns = ((projection != null) ? projection : CardTemplate.DEFAULT_PROJECTION);
                 MatrixCursor rv = new MatrixCursor(columns, 1);
                 try {
@@ -529,7 +530,7 @@ public class CardContentProvider extends ContentProvider {
                 String newLatexPost = values.getAsString(FlashCardsContract.Model.LATEX_POST);
                 String newLatexPre = values.getAsString(FlashCardsContract.Model.LATEX_PRE);
                 // Get the original note JSON
-                JSONObject model = col.getModels().get(getModelIdFromUri(uri, col));
+                Model model = col.getModels().get(getModelIdFromUri(uri, col));
                 try {
                     // Update model name and/or css
                     if (newModelName != null) {
@@ -586,7 +587,7 @@ public class CardContentProvider extends ContentProvider {
                 // Update the model
                 try {
                     Integer templateOrd = Integer.parseInt(uri.getLastPathSegment());
-                    JSONObject existingModel = col.getModels().get(getModelIdFromUri(uri, col));
+                    Model existingModel = col.getModels().get(getModelIdFromUri(uri, col));
                     JSONArray templates = existingModel.getJSONArray("tmpls");
                     JSONObject template = templates.getJSONObject(templateOrd);
                     if (name != null) {
@@ -705,7 +706,7 @@ public class CardContentProvider extends ContentProvider {
                 col.remNotes(new long[]{Long.parseLong(uri.getPathSegments().get(1))});
                 return 1;
             case MODELS_ID_EMPTY_CARDS:
-                JSONObject model = col.getModels().get(getModelIdFromUri(uri, col));
+                Model model = col.getModels().get(getModelIdFromUri(uri, col));
                 if (model == null) {
                     return -1;
                 }
@@ -768,7 +769,7 @@ public class CardContentProvider extends ContentProvider {
 
         // for caching model information (so we don't have to query for each note)
         long modelId = -1L;
-        JSONObject model = null;
+        Model model = null;
 
         col.getDecks().flush(); // is it okay to move this outside the for-loop? Is it needed at all?
         SupportSQLiteDatabase sqldb = col.getDb().getDatabase();
@@ -898,7 +899,7 @@ public class CardContentProvider extends ContentProvider {
                 }
                 // Create a new model
                 Models mm = col.getModels();
-                JSONObject newModel = mm.newModel(modelName);
+                Model newModel = mm.newModel(modelName);
                 try {
                     // Add the fields
                     String[] allFields = Utils.splitFields(fieldNames);
@@ -952,7 +953,7 @@ public class CardContentProvider extends ContentProvider {
             case MODELS_ID_TEMPLATES: {
                 Models models = col.getModels();
                 Long mid = getModelIdFromUri(uri, col);
-                JSONObject existingModel = models.get(mid);
+                Model existingModel = models.get(mid);
                 if (existingModel == null) {
                     throw new IllegalArgumentException("model missing: " + mid);
                 }
@@ -982,7 +983,7 @@ public class CardContentProvider extends ContentProvider {
             case MODELS_ID_FIELDS: {
                 Models models = col.getModels();
                 Long mid = getModelIdFromUri(uri, col);
-                JSONObject existingModel = models.get(mid);
+                Model existingModel = models.get(mid);
                 if (existingModel == null) {
                     throw new IllegalArgumentException("model missing: " + mid);
                 }
@@ -1068,7 +1069,7 @@ public class CardContentProvider extends ContentProvider {
     }
 
     private void addModelToCursor(Long modelId, Models models, MatrixCursor rv, String[] columns) {
-        JSONObject jsonObject = models.get(modelId);
+        Model jsonObject = models.get(modelId);
         MatrixCursor.RowBuilder rb = rv.newRow();
         try {
             for (String column : columns) {
@@ -1213,7 +1214,7 @@ public class CardContentProvider extends ContentProvider {
         }
     }
 
-    private void addTemplateToCursor(JSONObject tmpl, JSONObject model, int id, Models models, MatrixCursor rv, String[] columns) {
+    private void addTemplateToCursor(JSONObject tmpl, Model model, int id, Models models, MatrixCursor rv, String[] columns) {
         try {
             MatrixCursor.RowBuilder rb = rv.newRow();
             for (String column : columns) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.java
@@ -13,6 +13,7 @@ import com.ichi2.anki.Preferences;
 import com.ichi2.anki.R;
 import com.ichi2.anki.UIUtils;
 import com.ichi2.libanki.Collection;
+import com.ichi2.libanki.DeckConfig;
 import com.ichi2.utils.Permissions;
 
 import com.ichi2.utils.JSONObject;
@@ -90,7 +91,7 @@ public class BootService extends BroadcastReceiver {
 
     private void scheduleDeckReminder(Context context) {
         AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
-        for (JSONObject deckConfiguration : CollectionHelper.getInstance().getCol(context).getDecks().allConf()) {
+        for (DeckConfig deckConfiguration : CollectionHelper.getInstance().getCol(context).getDecks().allConf()) {
             Collection col = CollectionHelper.getInstance().getCol(context);
             if (deckConfiguration.has("reminder")) {
                 final JSONObject reminder = deckConfiguration.getJSONObject("reminder");

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.java
@@ -14,6 +14,7 @@ import com.ichi2.anki.R;
 import com.ichi2.anki.UIUtils;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.DeckConfig;
+import com.ichi2.libanki.Deck;
 import com.ichi2.utils.Permissions;
 
 import com.ichi2.utils.JSONObject;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.java
@@ -36,6 +36,7 @@ import com.ichi2.compat.CompatHelper;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.sched.AbstractSched;
 
+import com.ichi2.libanki.Deck;
 import com.ichi2.utils.JSONObject;
 
 import java.util.ArrayList;
@@ -250,7 +251,7 @@ public class DeckAdapter extends RecyclerView.Adapter<DeckAdapter.ViewHolder> {
                 }
             }
             // If any of this node's parents are collapsed, don't add it to the deck list
-            for (JSONObject parent : mCol.getDecks().parents(node.getDid())) {
+            for (Deck parent : mCol.getDecks().parents(node.getDid())) {
                 mHasSubdecks = true;    // If a deck has a parent it means it's a subdeck so set a flag
                 if (parent.optBoolean("collapsed")) {
                     return;
@@ -283,7 +284,7 @@ public class DeckAdapter extends RecyclerView.Adapter<DeckAdapter.ViewHolder> {
             }
         }
         // If the deck is not in our list, we search again using the immediate parent
-        List<JSONObject> parents = mCol.getDecks().parents(did);
+        List<Deck> parents = mCol.getDecks().parents(did);
         if (parents.size() == 0) {
             return 0;
         } else {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckDropDownAdapter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckDropDownAdapter.java
@@ -9,6 +9,7 @@ import android.widget.TextView;
 
 import com.ichi2.anki.R;
 
+import com.ichi2.libanki.Deck;
 import com.ichi2.utils.JSONObject;
 
 import java.util.ArrayList;
@@ -22,9 +23,9 @@ public final class DeckDropDownAdapter extends BaseAdapter {
     }
 
     private Context context;
-    private ArrayList<JSONObject> decks;
+    private ArrayList<Deck> decks;
 
-    public DeckDropDownAdapter(Context context, ArrayList<JSONObject> decks) {
+    public DeckDropDownAdapter(Context context, ArrayList<Deck> decks) {
         this.context = context;
         this.decks = decks;
     }
@@ -78,7 +79,7 @@ public final class DeckDropDownAdapter extends BaseAdapter {
         if (position == 0) {
             deckNameView.setText(context.getResources().getString(R.string.deck_summary_all_decks));
         } else {
-            JSONObject deck = decks.get(position - 1);
+            Deck deck = decks.get(position - 1);
             String deckName = deck.getString("name");
             deckNameView.setText(deckName);
         }
@@ -100,7 +101,7 @@ public final class DeckDropDownAdapter extends BaseAdapter {
         if (position == 0) {
             deckNameView.setText(context.getResources().getString(R.string.deck_summary_all_decks));
         } else {
-            JSONObject deck = decks.get(position - 1);
+            Deck deck = decks.get(position - 1);
             String deckName = deck.getString("name");
             deckNameView.setText(deckName);
         }

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -44,6 +44,7 @@ import com.ichi2.libanki.Note;
 import com.ichi2.libanki.Storage;
 import com.ichi2.libanki.Utils;
 import com.ichi2.libanki.DeckConfig;
+import com.ichi2.libanki.Deck;
 import com.ichi2.libanki.importer.AnkiPackageImporter;
 
 import com.ichi2.utils.JSONArray;
@@ -806,7 +807,7 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
                         long newDid = (long) data[2];
 
                         Timber.i("Changing %d cards to deck: '%d'", cards.length, newDid);
-                        JSONObject deckData = col.getDecks().get(newDid);
+                        Deck deckData = col.getDecks().get(newDid);
 
                         if (Decks.isDynamic(deckData)) {
                             //#5932 - can't change to a dynamic deck. Use "Rebuild"
@@ -1333,7 +1334,7 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
         Timber.d("doInBackgroundConfChange");
         Collection col = CollectionHelper.getInstance().getCol(mContext);
         Object[] data = params[0].getObjArray();
-        JSONObject deck = (JSONObject) data[0];
+        Deck deck = (Deck) data[0];
         DeckConfig conf = (DeckConfig) data[1];
         try {
             long newConfId = conf.getLong("id");
@@ -1399,12 +1400,12 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
         Timber.d("doInBackgroundConfSetSubdecks");
         Collection col = CollectionHelper.getInstance().getCol(mContext);
         Object[] data = params[0].getObjArray();
-        JSONObject deck = (JSONObject) data[0];
+        Deck deck = (Deck) data[0];
         DeckConfig conf = (DeckConfig) data[1];
         try {
             TreeMap<String, Long> children = col.getDecks().children(deck.getLong("id"));
             for (Map.Entry<String, Long> entry : children.entrySet()) {
-                JSONObject child = col.getDecks().get(entry.getValue());
+                Deck child = col.getDecks().get(entry.getValue());
                 if (child.getInt("dyn") == 1) {
                     continue;
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -32,6 +32,7 @@ import com.ichi2.anki.R;
 import com.ichi2.anki.TemporaryModel;
 import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.anki.exception.ImportExportException;
+import com.ichi2.libanki.Model;
 import com.ichi2.libanki.WrongId;
 import com.ichi2.libanki.sched.AbstractSched;
 import com.ichi2.libanki.AnkiPackageExporter;
@@ -1444,7 +1445,7 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
         Timber.d("doInBackgroundAddTemplate");
         Collection col = CollectionHelper.getInstance().getCol(mContext);
         Object [] args = params[0].getObjArray();
-        JSONObject model = (JSONObject) args[0];
+        Model model = (Model) args[0];
         JSONObject template = (JSONObject) args[1];
         // add the new template
         col.getModels().addTemplateModChanged(model, template);
@@ -1459,7 +1460,7 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
         Timber.d("doInBackgroundRemoveTemplate");
         Collection col = CollectionHelper.getInstance().getCol(mContext);
         Object [] args = params[0].getObjArray();
-        JSONObject model = (JSONObject) args[0];
+        Model model = (Model) args[0];
         JSONObject template = (JSONObject) args[1];
         try {
             boolean success = col.getModels().remTemplate(model, template);
@@ -1481,9 +1482,9 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
         Timber.d("doInBackgroundSaveModel");
         Collection col = CollectionHelper.getInstance().getCol(mContext);
         Object [] args = params[0].getObjArray();
-        JSONObject model = (JSONObject) args[0];
+        Model model = (Model) args[0];
         ArrayList<Object[]> templateChanges = (ArrayList<Object[]>)args[1];
-        JSONObject oldModel = col.getModels().get(model.getLong("id"));
+        Model oldModel = col.getModels().get(model.getLong("id"));
 
         // TODO need to save all the cards that will go away, for undo
         //  (do I need to remove them from graves during undo also?)
@@ -1551,7 +1552,7 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
         Timber.d("doInBackgroundLoadModels");
         Collection col = CollectionHelper.getInstance().getCol(mContext);
 
-        ArrayList<JSONObject> models = col.getModels().all();
+        ArrayList<Model> models = col.getModels().all();
         ArrayList<Integer> cardCount = new ArrayList<>();
         Collections.sort(models, new Comparator<JSONObject>() {
             @Override
@@ -1560,7 +1561,7 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
             }
         });
 
-        for (JSONObject n : models) {
+        for (Model n : models) {
             if (isCancelled()) {
                 Timber.e("doInBackgroundLoadModels :: Cancelled");
                 // onPostExecute not executed if cancelled. Return value not used.
@@ -1601,7 +1602,7 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
         Timber.d("doInBackGroundDeleteField");
         Object[] objects = params[0].getObjArray();
 
-        JSONObject model = (JSONObject) objects[0];
+        Model model = (Model) objects[0];
         JSONObject field = (JSONObject) objects[1];
 
 
@@ -1623,7 +1624,7 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
         Timber.d("doInBackgroundRepositionField");
         Object[] objects = params[0].getObjArray();
 
-        JSONObject model = (JSONObject) objects[0];
+        Model model = (Model) objects[0];
         JSONObject field = (JSONObject) objects[1];
         int index = (Integer) objects[2];
 
@@ -1646,7 +1647,7 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
         Timber.d("doInBackgroundRepositionField");
         Object[] objects = params[0].getObjArray();
 
-        JSONObject model = (JSONObject) objects[0];
+        Model model = (Model) objects[0];
         String fieldName = (String) objects[1];
 
         Collection col = CollectionHelper.getInstance().getCol(mContext);
@@ -1663,7 +1664,7 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
             Timber.d("doInBackgroundChangeSortField");
             Object[] objects = params[0].getObjArray();
 
-            JSONObject model = (JSONObject) objects[0];
+            Model model = (Model) objects[0];
             int idx = (int) objects[1];
 
             Collection col = CollectionHelper.getInstance().getCol(mContext);

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -43,6 +43,7 @@ import com.ichi2.libanki.Decks;
 import com.ichi2.libanki.Note;
 import com.ichi2.libanki.Storage;
 import com.ichi2.libanki.Utils;
+import com.ichi2.libanki.DeckConfig;
 import com.ichi2.libanki.importer.AnkiPackageImporter;
 
 import com.ichi2.utils.JSONArray;
@@ -1322,7 +1323,7 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
         Timber.d("doInBackgroundReorder");
         Collection col = CollectionHelper.getInstance().getCol(mContext);
         Object[] data = params[0].getObjArray();
-        JSONObject conf = (JSONObject) data[0];
+        DeckConfig conf = (DeckConfig) data[0];
         col.getSched().resortConf(conf);
         return new TaskData(true);
     }
@@ -1333,7 +1334,7 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
         Collection col = CollectionHelper.getInstance().getCol(mContext);
         Object[] data = params[0].getObjArray();
         JSONObject deck = (JSONObject) data[0];
-        JSONObject conf = (JSONObject) data[1];
+        DeckConfig conf = (DeckConfig) data[1];
         try {
             long newConfId = conf.getLong("id");
             // If new config has a different sorting order, reorder the cards
@@ -1362,7 +1363,7 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
         Timber.d("doInBackgroundConfReset");
         Collection col = CollectionHelper.getInstance().getCol(mContext);
         Object[] data = params[0].getObjArray();
-        JSONObject conf = (JSONObject) data[0];
+        DeckConfig conf = (DeckConfig) data[0];
         col.getDecks().restoreToDefault(conf);
         col.save();
         return new TaskData(true);
@@ -1373,7 +1374,7 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
         Timber.d("doInBackgroundConfRemove");
         Collection col = CollectionHelper.getInstance().getCol(mContext);
         Object[] data = params[0].getObjArray();
-        JSONObject conf = (JSONObject) data[0];
+        DeckConfig conf = (DeckConfig) data[0];
         try {
             // Note: We do the actual removing of the options group in the main thread so that we 
             // can ask the user to confirm if they're happy to do a full sync, and just do the resorting here
@@ -1399,7 +1400,7 @@ public class CollectionTask extends BaseAsyncTask<CollectionTask.TaskData, Colle
         Collection col = CollectionHelper.getInstance().getCol(mContext);
         Object[] data = params[0].getObjArray();
         JSONObject deck = (JSONObject) data[0];
-        JSONObject conf = (JSONObject) data[1];
+        DeckConfig conf = (DeckConfig) data[1];
         try {
             TreeMap<String, Long> children = col.getDecks().children(deck.getLong("id"));
             for (Map.Entry<String, Long> entry : children.entrySet()) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.java
@@ -163,7 +163,7 @@ class AnkiExporter extends Exporter {
         }
         // models - start with zero
         Timber.d("Copy models");
-        for (JSONObject m : mSrc.getModels().all()) {
+        for (Model m : mSrc.getModels().all()) {
             if (mids.contains(m.getLong("id"))) {
                 dst.getModels().update(m);
             }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.java
@@ -178,7 +178,7 @@ class AnkiExporter extends Exporter {
             }
         }
         JSONObject dconfs = new JSONObject();
-        for (JSONObject d : mSrc.getDecks().all()) {
+        for (Deck d : mSrc.getDecks().all()) {
             if ("1".equals(d.getString("id"))) {
                 continue;
             }
@@ -191,7 +191,7 @@ class AnkiExporter extends Exporter {
                 }
             }
 
-            JSONObject destinationDeck = d.deepClone();
+            Deck destinationDeck = d.deepClone();
             if (!mIncludeSched) {
                 // scheduling not included, so reset deck settings to default
                 destinationDeck.put("conf", 1);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.java
@@ -22,7 +22,6 @@ import android.database.sqlite.SQLiteDatabase;
 import com.ichi2.anki.CollectionHelper;
 import com.ichi2.anki.R;
 import com.ichi2.anki.exception.ImportExportException;
-import com.ichi2.compat.CompatHelper;
 import com.ichi2.utils.JSONArray;
 import com.ichi2.utils.JSONException;
 import com.ichi2.utils.JSONObject;
@@ -201,7 +200,7 @@ class AnkiExporter extends Exporter {
         }
         // copy used deck confs
         Timber.d("Copy deck options");
-        for (JSONObject dc : mSrc.getDecks().allConf()) {
+        for (DeckConfig dc : mSrc.getDecks().allConf()) {
             if (dconfs.has(dc.getString("id"))) {
                 dst.getDecks().updateConf(dc);
             }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.java
@@ -278,7 +278,7 @@ public class Card implements Cloneable {
     public HashMap<String, String> _getQA(boolean reload, boolean browser) {
         if (mQA == null || reload) {
             Note f = note(reload);
-            JSONObject m = model();
+            Model m = model();
             JSONObject t = template();
             long did = mODid != 0L ? mODid : mDid;
             if (browser) {
@@ -307,7 +307,7 @@ public class Card implements Cloneable {
 
 
     // not in upstream
-    public JSONObject model() {
+    public Model model() {
         return note().model();
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.java
@@ -331,7 +331,7 @@ public class Card implements Cloneable {
      * Time limit for answering in milliseconds.
      */
     public int timeLimit() {
-        JSONObject conf = mCol.getDecks().confForDid(mODid == 0 ? mDid : mODid);
+        DeckConfig conf = mCol.getDecks().confForDid(mODid == 0 ? mDid : mODid);
         return conf.getInt("maxTaken") * 1000;
     }
 
@@ -584,7 +584,7 @@ public class Card implements Cloneable {
 
 
     public boolean showTimer() {
-        JSONObject options = mCol.getDecks().confForDid(mODid == 0 ? mDid : mODid);
+        DeckConfig options = mCol.getDecks().confForDid(mODid == 0 ? mDid : mODid);
         return DeckConfig.parseTimerOpt(options, true);
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -882,7 +882,7 @@ public class Collection {
 
 
     public int _dueForDid(long did, int due) {
-        JSONObject conf = mDecks.confForDid(did);
+        DeckConfig conf = mDecks.confForDid(did);
         // in order due?
         if (conf.getJSONObject("new").getInt("order") == Consts.NEW_CARDS_DUE) {
             return due;
@@ -1599,10 +1599,10 @@ public class Collection {
         notifyProgress.run();
 
         //obtain a list of all valid dconf IDs
-        List<JSONObject> allConf = getDecks().allConf();
+        List<DeckConfig> allConf = getDecks().allConf();
         HashSet<Long> configIds  = new HashSet<>();
 
-        for (JSONObject conf : allConf) {
+        for (DeckConfig conf : allConf) {
             configIds.add(conf.getLong("id"));
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -866,7 +866,7 @@ public class Collection {
         }
         card.setDid(did);
         // if invalid did, use default instead
-        JSONObject deck = mDecks.get(card.getDid());
+        Deck deck = mDecks.get(card.getDid());
         if (deck.getInt("dyn") == 1) {
             // must not be a filtered deck
             card.setDid(1);
@@ -1610,7 +1610,7 @@ public class Collection {
 
         int changed = 0;
 
-        for (JSONObject d : getDecks().all()) {
+        for (Deck d : getDecks().all()) {
             //dynamic decks do not have dconf
             if (Decks.isDynamic(d)) {
                 continue;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -558,7 +558,7 @@ public class Collection {
      * @param m The model to use for the new note
      * @return The new note
      */
-    public Note newNote(JSONObject m) {
+    public Note newNote(Model m) {
         return new Note(this, m);
     }
 
@@ -620,7 +620,7 @@ public class Collection {
      * @return (active), non-empty templates.
      */
     public ArrayList<JSONObject> findTemplates(Note note) {
-        JSONObject model = note.model();
+        Model model = note.model();
         ArrayList<Integer> avail = getModels().availOrds(model, note.getFields());
         return _tmplsFromOrds(model, avail);
     }
@@ -719,7 +719,7 @@ public class Collection {
                 long nid = cur.getLong(0);
                 long mid = cur.getLong(1);
                 String flds = cur.getString(2);
-                JSONObject model = getModels().get(mid);
+                Model model = getModels().get(mid);
                 ArrayList<Integer> avail = getModels().availOrds(model, Utils.splitFields(flds));
                 long did = dids.get(nid);
                 // use sibling due if there is one, else use a new id
@@ -945,7 +945,7 @@ public class Collection {
 
     public List<Long> emptyCids() {
         List<Long> rem = new ArrayList<>();
-        for (JSONObject m : getModels().all()) {
+        for (Model m : getModels().all()) {
             rem.addAll(genCards(getModels().nids(m)));
         }
         return rem;
@@ -1000,7 +1000,7 @@ public class Collection {
         ArrayList<Object[]> r = new ArrayList<>();
         for (Object[] o : _fieldData(snids)) {
             String[] fields = Utils.splitFields((String) o[2]);
-            JSONObject model = getModels().get((Long) o[1]);
+            Model model = getModels().get((Long) o[1]);
             if (model == null) {
                 // note point to invalid model
                 continue;
@@ -1019,12 +1019,12 @@ public class Collection {
     /**
      * Returns hash of id, question, answer.
      */
-    public HashMap<String, String> _renderQA(long cid, JSONObject model, long did, int ord, String tags, String[] flist, int flags) {
+    public HashMap<String, String> _renderQA(long cid, Model model, long did, int ord, String tags, String[] flist, int flags) {
         return _renderQA(cid, model, did, ord, tags, flist, flags, false, null, null);
     }
 
 
-    public HashMap<String, String> _renderQA(long cid, JSONObject model, long did, int ord, String tags, String[] flist, int flags, boolean browser, String qfmt, String afmt) {
+    public HashMap<String, String> _renderQA(long cid, Model model, long did, int ord, String tags, String[] flist, int flags, boolean browser, String qfmt, String afmt) {
         // data is [cid, nid, mid, did, ord, tags, flds, cardFlags]
         // unpack fields and create dict
         Map<String, String> fields = new HashMap<>();
@@ -1783,7 +1783,7 @@ public class Collection {
     private List<String> updateFieldCache(Runnable notifyProgress) {
         Timber.d("updateFieldCache");
         // field cache
-        for (JSONObject m : getModels().all()) {
+        for (Model m : getModels().all()) {
             notifyProgress.run();
             updateFieldCache(Utils.arrayList2array(getModels().nids(m)));
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Deck.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Deck.java
@@ -1,0 +1,25 @@
+package com.ichi2.libanki;
+
+import com.ichi2.utils.JSONArray;
+import com.ichi2.utils.JSONObject;
+
+public class Deck extends JSONObject {
+    public Deck(JSONObject json) {
+        super(json);
+    }
+
+    public Deck(String json) {
+        super(json);
+    }
+
+    public Deck() {
+        super();
+    }
+
+    @Override
+    public Deck deepClone() {
+        Deck clone = new Deck();
+        deepClonedInto(clone);
+        return clone;
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DeckConfig.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DeckConfig.java
@@ -1,5 +1,6 @@
 /*
  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ Copyright (c) 2020 Arthur Milchior <Arthur@Milchior.fr>
 
  This program is free software; you can redistribute it and/or modify it under
  the terms of the GNU General Public License as published by the Free Software
@@ -13,14 +14,20 @@
  You should have received a copy of the GNU General Public License along with
  this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 package com.ichi2.libanki;
 
 import com.ichi2.utils.JSONObject;
 
 import androidx.annotation.Nullable;
 
-public class DeckConfig {
+public class DeckConfig extends JSONObject{
+    public DeckConfig(JSONObject json) {
+        super(json);
+    }
+
+    public DeckConfig(String json) {
+        super(json);
+    }
 
     public static @Nullable Boolean parseTimer(JSONObject config) {
         //Note: Card.py used != 0, DeckOptions used == 1

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
@@ -27,6 +27,7 @@ import android.util.Pair;
 import com.ichi2.anki.CardBrowser;
 import com.ichi2.async.CollectionTask;
 
+import com.ichi2.libanki.Deck;
 import com.ichi2.utils.JSONArray;
 import com.ichi2.utils.JSONObject;
 
@@ -646,7 +647,7 @@ public class Finder {
             ids = new ArrayList<>();
             val = val.replace("*", ".*");
             val = val.replace("+", "\\+");
-            for (JSONObject d : mCol.getDecks().all()) {
+            for (Deck d : mCol.getDecks().all()) {
                 String deckName = d.getString("name");
                 deckName = Normalizer.normalize(deckName, Normalizer.Form.NFC);
                 if (deckName.matches("(?i)" + val)) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Model.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Model.java
@@ -1,0 +1,25 @@
+package com.ichi2.libanki;
+
+
+import com.ichi2.utils.JSONObject;
+
+public class Model extends JSONObject {
+    public Model() {
+        super();
+    }
+
+    public Model(JSONObject json) {
+        super(json);
+    }
+
+    public Model(String json) {
+        super(json);
+    }
+
+    @Override
+    public Model deepClone() {
+        Model clone = new Model();
+        deepClonedInto(clone);
+        return clone;
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -96,7 +96,7 @@ public class Models {
 
     private Collection mCol;
     private boolean mChanged;
-    private HashMap<Long, JSONObject> mModels;
+    private HashMap<Long, Model> mModels;
 
     // BEGIN SQL table entries
     private int mId;
@@ -155,7 +155,7 @@ public class Models {
         if (ids != null) {
             for (int i = 0; i < ids.length(); i++) {
                 String id = ids.getString(i);
-                JSONObject o = modelarray.getJSONObject(id);
+                Model o = new Model(modelarray.getJSONObject(id));
                 mModels.put(o.getLong("id"), o);
             }
         }
@@ -170,7 +170,7 @@ public class Models {
     }
 
 
-    public void save(JSONObject m) {
+    public void save(Model m) {
         save(m, false);
     }
 
@@ -179,7 +179,7 @@ public class Models {
      * @param m model to save
      * @param templates flag which (when true) re-generates the cards for each note which uses the model
      */
-    public void save(JSONObject m, boolean templates) {
+    public void save(Model m, boolean templates) {
         if (m != null && m.has("id")) {
             m.put("mod", Utils.intTime());
             m.put("usn", mCol.usn());
@@ -204,7 +204,7 @@ public class Models {
         if (mChanged) {
             ensureNotEmpty();
             JSONObject array = new JSONObject();
-            for (Map.Entry<Long, JSONObject> o : mModels.entrySet()) {
+            for (Map.Entry<Long, Model> o : mModels.entrySet()) {
                 array.put(Long.toString(o.getKey()), o.getValue());
             }
             ContentValues val = new ContentValues();
@@ -231,9 +231,9 @@ public class Models {
 
     /**
      * Get current model.
-     * @return The JSONObject of the model, or null if not found in the deck and in the configuration.
+     * @return The model, or null if not found in the deck and in the configuration.
      */
-    public JSONObject current() {
+    public Model current() {
         return current(true);
     }
 
@@ -241,10 +241,10 @@ public class Models {
      * Get current model.
      * @param forDeck If true, it tries to get the deck specified in deck by mid, otherwise or if the former is not
      *                found, it uses the configuration`s field curModel.
-     * @return The JSONObject of the model, or null if not found in the deck and in the configuration.
+     * @return The model, or null if not found in the deck and in the configuration.
      */
-    public JSONObject current(boolean forDeck) {
-        JSONObject m = null;
+    public Model current(boolean forDeck) {
+        Model m = null;
         if (forDeck) {
             m = get(mCol.getDecks().current().optLong("mid", -1));
         }
@@ -260,14 +260,14 @@ public class Models {
     }
 
 
-    public void setCurrent(JSONObject m) {
+    public void setCurrent(Model m) {
         mCol.getConf().put("curModel", m.get("id"));
         mCol.setMod();
     }
 
 
     /** get model with ID, or null. */
-    public @Nullable JSONObject get(long id) {
+    public @Nullable Model get(long id) {
         if (mModels.containsKey(id)) {
             return mModels.get(id);
         } else {
@@ -277,9 +277,9 @@ public class Models {
 
 
     /** get all models */
-    public ArrayList<JSONObject> all() {
-        ArrayList<JSONObject> models = new ArrayList<>();
-        for (JSONObject jsonObject : mModels.values()) {
+    public ArrayList<Model> all() {
+        ArrayList<Model> models = new ArrayList<>();
+        for (Model jsonObject : mModels.values()) {
             models.add(jsonObject);
         }
         return models;
@@ -287,8 +287,8 @@ public class Models {
 
 
     /** get model with NAME. */
-    public JSONObject byName(String name) {
-        for (JSONObject m : mModels.values()) {
+    public Model byName(String name) {
+        for (Model m : mModels.values()) {
             if (m.getString("name").equals(name)) {
                 return m;
             }
@@ -300,10 +300,10 @@ public class Models {
     /** Create a new model, save it in the registry, and return it. */
 	// Called `new` in Anki's code. New is a reserved word in java,
 	// not in python. Thus the method has to be renamed.
-    public JSONObject newModel(String name) {
+    public Model newModel(String name) {
         // caller should call save() after modifying
-        JSONObject m;
-        m = new JSONObject(defaultModel);
+        Model m;
+        m = new Model(defaultModel);
         m.put("name", name);
         m.put("mod", Utils.intTime());
         m.put("flds", new JSONArray());
@@ -314,13 +314,13 @@ public class Models {
     }
 
     // not in anki
-    public static boolean isModelNew(JSONObject m) {
+    public static boolean isModelNew(Model m) {
         return m.getLong("id") == 0;
     }
 
     /** Delete model, and all its cards/notes. 
      * @throws ConfirmModSchemaException */
-    public void rem(JSONObject m) throws ConfirmModSchemaException {
+    public void rem(Model m) throws ConfirmModSchemaException {
         mCol.modSchema();
         long id = m.getLong("id");
         boolean current = current().getLong("id") == id;
@@ -337,7 +337,7 @@ public class Models {
     }
 
 
-    public void add(JSONObject m) {
+    public void add(Model m) {
         _setID(m);
         update(m);
         setCurrent(m);
@@ -346,14 +346,14 @@ public class Models {
 
 
     /** Add or update an existing model. Used for syncing and merging. */
-    public void update(JSONObject m) {
+    public void update(Model m) {
         mModels.put(m.getLong("id"), m);
         // mark registry changed, but don't bump mod time
         save();
     }
 
 
-    private void _setID(JSONObject m) {
+    private void _setID(Model m) {
         long id = Utils.intTime(1000);
         while (mModels.containsKey(id)) {
             id = Utils.intTime(1000);
@@ -384,7 +384,7 @@ public class Models {
      */
 
     /** Note ids for M */
-    public ArrayList<Long> nids(JSONObject m) {
+    public ArrayList<Long> nids(Model m) {
         return mCol.getDb().queryColumn(Long.class, "SELECT id FROM notes WHERE mid = ?", 0, new Object[] {m.getLong("id")});
     }
 
@@ -393,7 +393,7 @@ public class Models {
      * @param m The model to the count the notes of.
      * @return The number of notes with that model.
      */
-    public int useCount(JSONObject m) {
+    public int useCount(Model m) {
         return mCol.getDb().queryScalar("select count() from notes where mid = ?", new Object[] {m.getLong("id")});
     }
 
@@ -403,7 +403,7 @@ public class Models {
      * @param ord The index of the card template
      * @return The number of notes with that model.
      */
-    public int tmplUseCount(JSONObject m, int ord) {
+    public int tmplUseCount(Model m, int ord) {
         return mCol.getDb().queryScalar("select count() from cards, notes where cards.nid = notes.id and notes.mid = ? and cards.ord = ?", new Object[] {m.getLong("id"), ord});
     }
 
@@ -412,9 +412,8 @@ public class Models {
      */
 
     /** Copy, save and return. */
-    public JSONObject copy(JSONObject m) {
-        JSONObject m2 = null;
-        m2 = m.deepClone();
+    public Model copy(Model m) {
+        Model m2 = m.deepClone();        
         m2.put("name", m2.getString("name") + " copy");
         add(m2);
         return m2;
@@ -447,7 +446,7 @@ public class Models {
     }
 
 
-    public static ArrayList<String> fieldNames(JSONObject m) {
+    public static ArrayList<String> fieldNames(Model m) {
         JSONArray ja;
         ja = m.getJSONArray("flds");
         ArrayList<String> names = new ArrayList<>();
@@ -459,12 +458,12 @@ public class Models {
     }
 
 
-    public int sortIdx(JSONObject m) {
+    public int sortIdx(Model m) {
         return m.getInt("sortf");
     }
 
 
-    public void setSortIdx(JSONObject m, int idx) throws ConfirmModSchemaException{
+    public void setSortIdx(Model m, int idx) throws ConfirmModSchemaException{
         mCol.modSchema();
         m.put("sortf", idx);
         mCol.updateFieldCache(Utils.toPrimitive(nids(m)));
@@ -472,7 +471,7 @@ public class Models {
     }
 
 
-    private void _addField(JSONObject m, JSONObject field) {
+    private void _addField(Model m, JSONObject field) {
         // do the actual work of addField. Do not check whether model
         // is not new.
 		JSONArray ja = m.getJSONArray("flds");
@@ -483,7 +482,7 @@ public class Models {
 		_transformFields(m, new TransformFieldAdd());
     }
 
-    public void addField(JSONObject m, JSONObject field) throws ConfirmModSchemaException {
+    public void addField(Model m, JSONObject field) throws ConfirmModSchemaException {
         // only mod schema if model isn't new
         // this is Anki's addField.
         if (!isModelNew(m)) {
@@ -492,7 +491,7 @@ public class Models {
         _addField(m, field);
     }
 
-    public void addFieldInNewModel(JSONObject m, JSONObject field) {
+    public void addFieldInNewModel(Model m, JSONObject field) {
         // similar to Anki's addField; but thanks to assumption that
         // model is new, it never has to throw
         // ConfirmModSchemaException.
@@ -500,7 +499,7 @@ public class Models {
         _addField(m, field);
     }
 
-    public void addFieldModChanged(JSONObject m, JSONObject field) {
+    public void addFieldModChanged(Model m, JSONObject field) {
         // similar to Anki's addField; but thanks to assumption that
         // mod is already changed, it never has to throw
         // ConfirmModSchemaException.
@@ -519,7 +518,7 @@ public class Models {
     }
 
 
-    public void remField(JSONObject m, JSONObject field) throws ConfirmModSchemaException {
+    public void remField(Model m, JSONObject field) throws ConfirmModSchemaException {
         mCol.modSchema();
         JSONArray ja = m.getJSONArray("flds");
         JSONArray ja2 = new JSONArray();
@@ -564,7 +563,7 @@ public class Models {
     }
 
 
-    public void moveField(JSONObject m, JSONObject field, int idx) throws ConfirmModSchemaException {
+    public void moveField(Model m, JSONObject field, int idx) throws ConfirmModSchemaException {
         mCol.modSchema();
         JSONArray ja = m.getJSONArray("flds");
         ArrayList<JSONObject> l = new ArrayList<>();
@@ -620,7 +619,7 @@ public class Models {
     }
 
 
-    public void renameField(JSONObject m, JSONObject field, String newName) throws ConfirmModSchemaException {
+    public void renameField(Model m, JSONObject field, String newName) throws ConfirmModSchemaException {
         mCol.modSchema();
         String pat = String.format("\\{\\{([^{}]*)([:#^/]|[^:#/^}][^:}]*?:|)%s\\}\\}",
                                    Pattern.quote(field.getString("name")));
@@ -659,7 +658,7 @@ public class Models {
     }
 
 
-    public void _transformFields(JSONObject m, TransformFieldVisitor fn) {
+    public void _transformFields(Model m, TransformFieldVisitor fn) {
         // model hasn't been added yet?
         if (isModelNew(m)) {
             return;
@@ -691,7 +690,7 @@ public class Models {
 
 
     /** Note: should col.genCards() afterwards. */
-    private void _addTemplate(JSONObject m, JSONObject template) {
+    private void _addTemplate(Model m, JSONObject template) {
         // do the actual work of addTemplate. Do not consider whether
         // model is new or not.
         JSONArray ja = m.getJSONArray("tmpls");
@@ -702,7 +701,7 @@ public class Models {
     }
 
     /** @throws ConfirmModSchemaException */
-    public void addTemplate(JSONObject m, JSONObject template) throws ConfirmModSchemaException {
+    public void addTemplate(Model m, JSONObject template) throws ConfirmModSchemaException {
         //That is Anki's addTemplate method
         if (!isModelNew(m)) {
             mCol.modSchema();
@@ -710,14 +709,14 @@ public class Models {
         _addTemplate(m, template);
     }
 
-    public void addTemplateInNewModel(JSONObject m, JSONObject template)  {
+    public void addTemplateInNewModel(Model m, JSONObject template)  {
         // similar to addTemplate, but doesn't throw exception;
         // asserting the model is new.
         Assert.that(isModelNew(m), "Model was assumed to be new, but is not");
         _addTemplate(m, template);
     }
 
-    public void addTemplateModChanged(JSONObject m, JSONObject template)  {
+    public void addTemplateModChanged(Model m, JSONObject template)  {
         // similar to addTemplate, but doesn't throw exception;
         // asserting the model is new.
         Assert.that(mCol.schemaChanged(), "Mod was assumed to be already changed, but is not");
@@ -730,7 +729,7 @@ public class Models {
      * @return False if removing template would leave orphan notes.
      * @throws ConfirmModSchemaException 
      */
-    public boolean remTemplate(JSONObject m, JSONObject template) throws ConfirmModSchemaException {
+    public boolean remTemplate(Model m, JSONObject template) throws ConfirmModSchemaException {
         if (m.getJSONArray("tmpls").length() <= 1) {
             return false;
         }
@@ -814,7 +813,7 @@ public class Models {
     }
 
 
-    public static void _updateTemplOrds(JSONObject m) {
+    public static void _updateTemplOrds(Model m) {
         JSONArray ja;
         ja = m.getJSONArray("tmpls");
         for (int i = 0; i < ja.length(); i++) {
@@ -824,7 +823,7 @@ public class Models {
     }
 
 
-    public void moveTemplate(JSONObject m, JSONObject template, int idx) {
+    public void moveTemplate(Model m, JSONObject template, int idx) {
         JSONArray ja = m.getJSONArray("tmpls");
         int oldidx = -1;
         ArrayList<JSONObject> l = new ArrayList<>();
@@ -862,7 +861,7 @@ public class Models {
     }
 
     @SuppressWarnings("PMD.UnusedLocalVariable") // unused upstream as well
-    private void _syncTemplates(JSONObject m) {
+    private void _syncTemplates(Model m) {
         ArrayList<Long> rem = mCol.genCards(Utils.arrayList2array(nids(m)));
     }
 
@@ -880,7 +879,7 @@ public class Models {
      * @param cmap Map for switching cards. This is ord->ord and there should not be duplicate targets
      * @throws ConfirmModSchemaException 
      */
-    public void change(JSONObject m, long[] nids, JSONObject newModel, Map<Integer, Integer> fmap, Map<Integer, Integer> cmap) throws ConfirmModSchemaException {
+    public void change(Model m, long[] nids, Model newModel, Map<Integer, Integer> fmap, Map<Integer, Integer> cmap) throws ConfirmModSchemaException {
         mCol.modSchema();
         assert (newModel.getLong("id") == m.getLong("id")) || (fmap != null && cmap != null);
         if (fmap != null) {
@@ -892,7 +891,7 @@ public class Models {
         mCol.genCards(nids);
     }
 
-    private void _changeNotes(long[] nids, JSONObject newModel, Map<Integer, Integer> map) {
+    private void _changeNotes(long[] nids, Model newModel, Map<Integer, Integer> map) {
         List<Object[]> d = new ArrayList<>();
         int nfields;
         long mid;
@@ -924,7 +923,7 @@ public class Models {
         mCol.updateFieldCache(nids);
     }
 
-    private void _changeCards(long[] nids, JSONObject oldModel, JSONObject newModel, Map<Integer, Integer> map) {
+    private void _changeCards(long[] nids, Model oldModel, Model newModel, Map<Integer, Integer> map) {
         List<Object[]> d = new ArrayList<>();
         List<Long> deleted = new ArrayList<>();
         Cursor cur = null;
@@ -976,7 +975,7 @@ public class Models {
      */
 
     /** Return a hash of the schema, to see if models are compatible. */
-    public String scmhash(JSONObject m) {
+    public String scmhash(Model m) {
         String s = "";
         JSONArray flds = m.getJSONArray("flds");
         for (int i = 0; i < flds.length(); ++i) {
@@ -996,7 +995,7 @@ public class Models {
      * ***********************************************************************************************
      */
 
-    private void _updateRequired(JSONObject m) {
+    private void _updateRequired(Model m) {
         if (m.getInt("type") == Consts.MODEL_CLOZE) {
             // nothing to do
             return;
@@ -1022,7 +1021,7 @@ public class Models {
     }
 
     @SuppressWarnings("PMD.UnusedLocalVariable") // 'String f' is unused upstream as well
-    private Object[] _reqForTemplate(JSONObject m, ArrayList<String> flds, JSONObject t) {
+    private Object[] _reqForTemplate(Model m, ArrayList<String> flds, JSONObject t) {
         int nbFields = flds.size();
         String[] a = new String[nbFields];
         String[] b = new String[nbFields];
@@ -1064,7 +1063,7 @@ public class Models {
 
 
     /** Given a joined field string, return available template ordinals */
-    public ArrayList<Integer> availOrds(JSONObject m, String[] sfld) {
+    public ArrayList<Integer> availOrds(Model m, String[] sfld) {
         if (m.getInt("type") == Consts.MODEL_CLOZE) {
             return _availClozeOrds(m, sfld);
         }
@@ -1120,12 +1119,12 @@ public class Models {
     }
 
 
-    public ArrayList<Integer> _availClozeOrds(JSONObject m, String[] sflds) {
+    public ArrayList<Integer> _availClozeOrds(Model m, String[] sflds) {
         return _availClozeOrds(m, sflds, true);
     }
 
 
-    public ArrayList<Integer> _availClozeOrds(JSONObject m, String[] sflds, boolean allowEmpty) {
+    public ArrayList<Integer> _availClozeOrds(Model m, String[] sflds, boolean allowEmpty) {
         Map<String, Pair<Integer, JSONObject>> map = fieldMap(m);
         Set<Integer> ords = new HashSet<>();
         List<String> matches = new ArrayList<>();
@@ -1183,7 +1182,7 @@ public class Models {
 
     public HashMap<Long, HashMap<Integer, String>> getTemplateNames() {
         HashMap<Long, HashMap<Integer, String>> result = new HashMap<>();
-        for (JSONObject m : mModels.values()) {
+        for (Model m : mModels.values()) {
             JSONArray templates;
             templates = m.getJSONArray("tmpls");
             HashMap<Integer, String> names = new HashMap<>();
@@ -1213,13 +1212,13 @@ public class Models {
     }
 
 
-    public HashMap<Long, JSONObject> getModels() {
+    public HashMap<Long, Model> getModels() {
         return mModels;
     }
 
     /** Validate model entries. */
 	public boolean validateModel() {
-        for (Entry<Long, JSONObject> longJSONObjectEntry : mModels.entrySet()) {
+        for (Entry<Long, Model> longJSONObjectEntry : mModels.entrySet()) {
             if (!validateBrackets(longJSONObjectEntry.getValue())) {
                 return false;
             }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Note.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Note.java
@@ -41,7 +41,7 @@ public class Note implements Cloneable {
 
     private long mId;
     private String mGuId;
-    private JSONObject mModel;
+    private Model mModel;
     private long mMid;
     private ArrayList<String> mTags;
     private String[] mFields;
@@ -59,12 +59,12 @@ public class Note implements Cloneable {
     }
 
 
-    public Note(Collection col, JSONObject model) {
+    public Note(Collection col, Model model) {
         this(col, model, null);
     }
 
 
-    public Note(Collection col, JSONObject model, Long id) {
+    public Note(Collection col, Model model, Long id) {
         assert !(model != null && id != null);
         mCol = col;
         if (id != null) {
@@ -163,7 +163,7 @@ public class Note implements Cloneable {
     }
 
 
-    public JSONObject model() {
+    public Model model() {
         return mModel;
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/StdModels.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/StdModels.java
@@ -17,7 +17,7 @@ public class StdModels {
     private CreateStdModels fun;
 
     interface CreateStdModels {
-        JSONObject create(Models mm, String name);
+        Model create(Models mm, String name);
     }
 
     public StdModels(CreateStdModels fun, @StringRes int defaultName) {
@@ -25,25 +25,25 @@ public class StdModels {
         this.defaultName = defaultName;
     }
 
-    private JSONObject _new(Models mm) {
+    private Model _new(Models mm) {
         String name = getDefaultName();
         return _new(mm, name);
     }
 
-    private JSONObject _new(Models mm, String name) {
+    private Model _new(Models mm, String name) {
         return fun.create(mm, name);
     }
 
-    public JSONObject add(Collection col, String name) {
+    public Model add(Collection col, String name) {
         Models mm = col.getModels();
-        JSONObject model = _new(mm, name);
+        Model model = _new(mm, name);
         mm.add(model);
         return model;
     }
 
-    public JSONObject add(Collection col) {
+    public Model add(Collection col) {
         Models mm = col.getModels();
-        JSONObject model = _new(mm);
+        Model model = _new(mm);
         mm.add(model);
         return model;
     }
@@ -57,7 +57,7 @@ public class StdModels {
 
     public static final StdModels basicModel = new StdModels(
             (Models mm, String name) -> {
-                JSONObject m = mm.newModel(name);
+                Model m = mm.newModel(name);
                 String frontName = AnkiDroidApp.getAppResources().getString(R.string.front_field_name);
                 JSONObject fm = mm.newField(frontName);
                 mm.addFieldInNewModel(m, fm);
@@ -75,7 +75,7 @@ public class StdModels {
 
     public static final StdModels basicTypingModel = new StdModels
         ( (Models mm, String name) -> {
-        JSONObject m = basicModel._new(mm, name);
+        Model m = basicModel._new(mm, name);
         JSONObject t = m.getJSONArray("tmpls").getJSONObject(0);
         String frontName = m.getJSONArray("flds").getJSONObject(0).getString("name");
         String backName = m.getJSONArray("flds").getJSONObject(1).getString("name");
@@ -87,7 +87,7 @@ public class StdModels {
 
     public static final StdModels forwardReverseModel = new StdModels
         ( (Models mm, String name) -> {
-        JSONObject m = basicModel._new(mm, name);
+        Model m = basicModel._new(mm, name);
         String frontName = m.getJSONArray("flds").getJSONObject(0).getString("name");
         String backName = m.getJSONArray("flds").getJSONObject(1).getString("name");
         String cardTwoName = AnkiDroidApp.getAppResources().getString(R.string.card_two_name);
@@ -101,7 +101,7 @@ public class StdModels {
 
     public static final StdModels forwardOptionalReverseModel = new StdModels
         ( (Models mm, String name) -> {
-        JSONObject m = forwardReverseModel._new(mm, name);
+        Model m = forwardReverseModel._new(mm, name);
         String av = AnkiDroidApp.getAppResources().getString(R.string.field_to_ask_front_name);
         JSONObject fm = mm.newField(av);
         mm.addFieldInNewModel(m, fm);
@@ -113,7 +113,7 @@ public class StdModels {
 
     public static final StdModels clozeModel = new StdModels
         ( (Models mm, String name) -> {
-        JSONObject m = mm.newModel(name);
+        Model m = mm.newModel(name);
         m.put("type", Consts.MODEL_CLOZE);
         String txt = AnkiDroidApp.getAppResources().getString(R.string.text_field_name);
         JSONObject fm = mm.newField(txt);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Storage.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Storage.java
@@ -118,15 +118,15 @@ public class Storage {
             }
             if (ver < 4) {
                 col.modSchemaNoCheck();
-                ArrayList<JSONObject> clozes = new ArrayList<>();
-                for (JSONObject m : col.getModels().all()) {
+                ArrayList<Model> clozes = new ArrayList<>();
+                for (Model m : col.getModels().all()) {
                     if (!m.getJSONArray("tmpls").getJSONObject(0).getString("qfmt").contains("{{cloze:")) {
                         m.put("type", Consts.MODEL_STD);
                     } else {
                         clozes.add(m);
                     }
                 }
-                for (JSONObject m : clozes) {
+                for (Model m : clozes) {
                     try {
                         _upgradeClozeModel(col, m);
                     } catch (ConfirmModSchemaException e) {
@@ -142,7 +142,7 @@ public class Storage {
             }
             if (ver < 6) {
                 col.modSchemaNoCheck();
-                for (JSONObject m : col.getModels().all()) {
+                for (Model m : col.getModels().all()) {
                     m.put("css", new JSONObject(Models.defaultModel).getString("css"));
                     JSONArray ar = m.getJSONArray("tmpls");
                     for (int i = 0; i < ar.length(); i++) {
@@ -211,7 +211,7 @@ public class Storage {
                     r.put("maxIvl", 36500);
                     col.getDecks().save(c);
                 }
-                for (JSONObject m : col.getModels().all()) {
+                for (Model m : col.getModels().all()) {
                     JSONArray tmpls = m.getJSONArray("tmpls");
                     for (int ti = 0; ti < tmpls.length(); ++ti) {
                         JSONObject t = tmpls.getJSONObject(ti);
@@ -228,7 +228,7 @@ public class Storage {
     }
 
 
-    private static void _upgradeClozeModel(Collection col, JSONObject m) throws ConfirmModSchemaException {
+    private static void _upgradeClozeModel(Collection col, Model m) throws ConfirmModSchemaException {
         m.put("type", Consts.MODEL_CLOZE);
         // convert first template
         JSONObject t = m.getJSONArray("tmpls").getJSONObject(0);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Storage.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Storage.java
@@ -202,7 +202,7 @@ public class Storage {
                     }
                     col.getDecks().save(d);
                 }
-                for (JSONObject c : col.getDecks().allConf()) {
+                for (DeckConfig c : col.getDecks().allConf()) {
                     JSONObject r = c.getJSONObject("rev");
                     r.put("ivlFct", r.optDouble("ivlFct", 1));
                     if (r.has("ivlfct")) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Storage.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Storage.java
@@ -110,7 +110,7 @@ public class Storage {
         try {
             if (ver < 3) {
                 // new deck properties
-                for (JSONObject d : col.getDecks().all()) {
+                for (Deck d : col.getDecks().all()) {
                     d.put("dyn", 0);
                     d.put("collapsed", false);
                     col.getDecks().save(d);
@@ -178,7 +178,7 @@ public class Storage {
             }
             if (ver < 11) {
                 col.modSchemaNoCheck();
-                for (JSONObject d : col.getDecks().all()) {
+                for (Deck d : col.getDecks().all()) {
                     if (d.getInt("dyn") != 0) {
                         int order = d.getInt("order");
                         // failed order was removed

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
@@ -1093,7 +1093,7 @@ public class Utils {
        @return whether there was a non-zero usn; in this case the list
        should be saved before the upload.
      */
-    public static boolean markAsUploaded(ArrayList<JSONObject> ar) {
+    public static boolean markAsUploaded(ArrayList<? extends JSONObject> ar) {
         boolean changed = false;
         for (JSONObject obj: ar) {
             if (obj.optInt("usn", 1) != 0) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
@@ -27,6 +27,7 @@ import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Consts;
 import com.ichi2.libanki.Decks;
 import com.ichi2.libanki.Media;
+import com.ichi2.libanki.Model;
 import com.ichi2.libanki.Storage;
 import com.ichi2.libanki.Utils;
 import com.ichi2.libanki.DeckConfig;
@@ -408,13 +409,13 @@ public class Anki2Importer extends Importer {
             return mModelMap.get(srcMid);
         }
         long mid = srcMid;
-        JSONObject srcModel = mSrc.getModels().get(srcMid);
+        Model srcModel = mSrc.getModels().get(srcMid);
         String srcScm = mSrc.getModels().scmhash(srcModel);
         while (true) {
             // missing from target col?
             if (!mDst.getModels().have(mid)) {
                 // copy it over
-                JSONObject model = srcModel.deepClone();
+                Model model = srcModel.deepClone();
                 model.put("id", mid);
                 model.put("mod", Utils.intTime());
                 model.put("usn", mCol.usn());
@@ -422,11 +423,11 @@ public class Anki2Importer extends Importer {
                 break;
             }
             // there's an existing model; do the schemas match?
-            JSONObject dstModel = mDst.getModels().get(mid);
+            Model dstModel = mDst.getModels().get(mid);
             String dstScm = mDst.getModels().scmhash(dstModel);
             if (srcScm.equals(dstScm)) {
                 // they do; we can reuse this mid
-                JSONObject model = srcModel.deepClone();
+                Model model = srcModel.deepClone();
                 model.put("id", mid);
                 model.put("mod", Utils.intTime());
                 model.put("usn", mCol.usn());

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
@@ -30,6 +30,7 @@ import com.ichi2.libanki.Media;
 import com.ichi2.libanki.Storage;
 import com.ichi2.libanki.Utils;
 import com.ichi2.libanki.DeckConfig;
+import com.ichi2.libanki.Deck;
 import com.ichi2.utils.JSONObject;
 
 import java.io.BufferedInputStream;
@@ -453,7 +454,7 @@ public class Anki2Importer extends Importer {
             return mDecks.get(did);
         }
         // get the name in src
-        JSONObject g = mSrc.getDecks().get(did);
+        Deck g = mSrc.getDecks().get(did);
         String name = g.getString("name");
         // if there's a prefix, replace the top level deck
         if (!TextUtils.isEmpty(mDeckPrefix)) {
@@ -482,12 +483,12 @@ public class Anki2Importer extends Importer {
             DeckConfig conf = mSrc.getDecks().getConf(g.getLong("conf"));
             mDst.getDecks().save(conf);
             mDst.getDecks().updateConf(conf);
-            JSONObject g2 = mDst.getDecks().get(newid);
+            Deck g2 = mDst.getDecks().get(newid);
             g2.put("conf", g.getLong("conf"));
             mDst.getDecks().save(g2);
         }
         // save desc
-        JSONObject deck = mDst.getDecks().get(newid);
+        Deck deck = mDst.getDecks().get(newid);
         deck.put("desc", g.getString("desc"));
         mDst.getDecks().save(deck);
         // add to deck map and return

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
@@ -29,6 +29,7 @@ import com.ichi2.libanki.Decks;
 import com.ichi2.libanki.Media;
 import com.ichi2.libanki.Storage;
 import com.ichi2.libanki.Utils;
+import com.ichi2.libanki.DeckConfig;
 import com.ichi2.utils.JSONObject;
 
 import java.io.BufferedInputStream;
@@ -478,7 +479,7 @@ public class Anki2Importer extends Importer {
         long newid = mDst.getDecks().id(name);
         // pull conf over
         if (g.has("conf") && g.getLong("conf") != 1) {
-            JSONObject conf = mSrc.getDecks().getConf(g.getLong("conf"));
+            DeckConfig conf = mSrc.getDecks().getConf(g.getLong("conf"));
             mDst.getDecks().save(conf);
             mDst.getDecks().updateConf(conf);
             JSONObject g2 = mDst.getDecks().get(newid);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
@@ -11,6 +11,7 @@ import com.ichi2.anki.R;
 import com.ichi2.async.CollectionTask;
 import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Consts;
+import com.ichi2.libanki.Deck;
 import com.ichi2.libanki.Decks;
 import com.ichi2.libanki.DeckConfig;
 import com.ichi2.libanki.Collection;
@@ -65,7 +66,7 @@ public abstract class AbstractSched {
     /** New count for a single deck. */
     public abstract int _newForDeck(long did, int lim);
     /** Limit for deck without parent limits. */
-    public abstract int _deckNewLimitSingle(JSONObject g);
+    public abstract int _deckNewLimitSingle(Deck g);
     public abstract int totalNewForCurrentDeck();
     public abstract int totalRevForCurrentDeck();
     public abstract Pair<Integer, Integer> _fuzzIvlRange(int ivl);
@@ -376,7 +377,7 @@ public abstract class AbstractSched {
 
 
     public interface LimitMethod {
-        int operation(JSONObject g);
+        int operation(Deck g);
     }
 
     public interface CountMethod {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
@@ -12,6 +12,7 @@ import com.ichi2.async.CollectionTask;
 import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Consts;
 import com.ichi2.libanki.Decks;
+import com.ichi2.libanki.DeckConfig;
 import com.ichi2.libanki.Collection;
 import com.ichi2.utils.JSONObject;
 
@@ -22,8 +23,6 @@ import java.util.Locale;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import timber.log.Timber;
-
-import androidx.annotation.NonNull;
 
 
 public abstract class AbstractSched {
@@ -76,7 +75,7 @@ public abstract class AbstractSched {
     public abstract void emptyDyn(long did);
     public abstract void emptyDyn(long did, String lim);
     public abstract void remFromDyn(long[] cids);
-    public abstract JSONObject _cardConf(Card card);
+    public abstract DeckConfig _cardConf(Card card);
     public abstract String _deckLimit();
     public abstract void _checkDay();
     public abstract CharSequence finishedMsg(Context context);
@@ -138,7 +137,7 @@ public abstract class AbstractSched {
     public abstract void sortCards(long[] cids, int start, int step, boolean shuffle, boolean shift);
     public abstract void randomizeCards(long did);
     public abstract void orderCards(long did);
-    public abstract void resortConf(JSONObject conf);
+    public abstract void resortConf(DeckConfig conf);
     /**
      * for post-import
      */

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -36,6 +36,7 @@ import com.ichi2.libanki.Consts;
 import com.ichi2.libanki.Decks;
 import com.ichi2.libanki.Note;
 import com.ichi2.libanki.Utils;
+import com.ichi2.libanki.DeckConfig;
 
 import com.ichi2.utils.JSONArray;
 import com.ichi2.utils.JSONException;
@@ -661,7 +662,7 @@ public class Sched extends SchedV2 {
             return mReportLimit;
         }
         long did = d.getLong("id");
-        JSONObject c = mCol.getDecks().confForDid(did);
+        DeckConfig c = mCol.getDecks().confForDid(did);
         int lim = Math.max(0, c.getJSONObject("rev").getInt("perDay") - d.getJSONArray("revToday").getInt(1));
         if (currentCardIsInQueueWithDeck(Consts.QUEUE_TYPE_REV, did)) {
             lim--;
@@ -1125,20 +1126,20 @@ public class Sched extends SchedV2 {
      */
 
     @Override
-    public JSONObject _cardConf(Card card) {
+    public DeckConfig _cardConf(Card card) {
         return mCol.getDecks().confForDid(card.getDid());
     }
 
 
     @Override
     protected JSONObject _newConf(Card card) {
-        JSONObject conf = _cardConf(card);
+        DeckConfig conf = _cardConf(card);
         // normal deck
         if (card.getODid() == 0) {
             return conf.getJSONObject("new");
         }
         // dynamic deck; override some attributes, use original deck for others
-        JSONObject oconf = mCol.getDecks().confForDid(card.getODid());
+        DeckConfig oconf = mCol.getDecks().confForDid(card.getODid());
         JSONArray delays = conf.optJSONArray("delays");
         if (delays == null) {
             delays = oconf.getJSONObject("new").getJSONArray("delays");
@@ -1159,13 +1160,13 @@ public class Sched extends SchedV2 {
 
     @Override
     protected JSONObject _lapseConf(Card card) {
-        JSONObject conf = _cardConf(card);
+        DeckConfig conf = _cardConf(card);
         // normal deck
         if (card.getODid() == 0) {
             return conf.getJSONObject("lapse");
         }
         // dynamic deck; override some attributes, use original deck for others
-        JSONObject oconf = mCol.getDecks().confForDid(card.getODid());
+        DeckConfig oconf = mCol.getDecks().confForDid(card.getODid());
         JSONArray delays = conf.optJSONArray("delays");
         if (delays == null) {
             delays = oconf.getJSONObject("lapse").getJSONArray("delays");
@@ -1184,7 +1185,7 @@ public class Sched extends SchedV2 {
 
 
     private boolean _resched(Card card) {
-        JSONObject conf = _cardConf(card);
+        DeckConfig conf = _cardConf(card);
         if (conf.getInt("dyn") == 0) {
             return true;
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -36,6 +36,7 @@ import com.ichi2.libanki.Consts;
 import com.ichi2.libanki.Decks;
 import com.ichi2.libanki.Note;
 import com.ichi2.libanki.Utils;
+import com.ichi2.libanki.Deck;
 import com.ichi2.libanki.DeckConfig;
 
 import com.ichi2.utils.JSONArray;
@@ -215,10 +216,10 @@ public class Sched extends SchedV2 {
     public List<DeckDueTreeNode> deckDueList(CollectionTask collectionTask) {
         _checkDay();
         mCol.getDecks().checkIntegrity();
-        ArrayList<JSONObject> decks = mCol.getDecks().allSorted();
+        ArrayList<Deck> decks = mCol.getDecks().allSorted();
         HashMap<String, Integer[]> lims = new HashMap<>();
         ArrayList<DeckDueTreeNode> data = new ArrayList<>();
-        for (JSONObject deck : decks) {
+        for (Deck deck : decks) {
             if (collectionTask != null && collectionTask.isCancelled()) {
                 return null;
             }
@@ -307,12 +308,12 @@ public class Sched extends SchedV2 {
         if (fn == null) {
             fn = (g -> _deckNewLimitSingle(g));
         }
-        List<JSONObject> decks = mCol.getDecks().parents(did);
+        List<Deck> decks = mCol.getDecks().parents(did);
         decks.add(mCol.getDecks().get(did));
         int lim = -1;
         // for the deck and each of its parents
         int rem = 0;
-        for (JSONObject g : decks) {
+        for (Deck g : decks) {
             rem = fn.operation(g);
             if (lim == -1) {
                 lim = rem;
@@ -657,7 +658,7 @@ public class Sched extends SchedV2 {
 
 
     @Override
-    protected int _deckRevLimitSingle(JSONObject d) {
+    protected int _deckRevLimitSingle(Deck d) {
         if (d.getInt("dyn") != 0) {
             return mReportLimit;
         }
@@ -938,7 +939,7 @@ public class Sched extends SchedV2 {
         if (did == 0) {
             did = mCol.getDecks().selected();
         }
-        JSONObject deck = mCol.getDecks().get(did);
+        Deck deck = mCol.getDecks().get(did);
         if (deck.getInt("dyn") == 0) {
             Timber.e("error: deck is not a filtered deck");
             return null;
@@ -955,7 +956,7 @@ public class Sched extends SchedV2 {
     }
 
 
-    private List<Long> _fillDyn(JSONObject deck) {
+    private List<Long> _fillDyn(Deck deck) {
         JSONArray terms;
         List<Long> ids;
         terms = deck.getJSONArray("terms").getJSONArray(0);
@@ -1210,7 +1211,7 @@ public class Sched extends SchedV2 {
         }
         // update all daily counts, but don't save decks to prevent needless conflicts. we'll save on card answer
         // instead
-        for (JSONObject deck : mCol.getDecks().all()) {
+        for (Deck deck : mCol.getDecks().all()) {
             update(deck);
         }
         // unbury if the day has rolled over
@@ -1222,7 +1223,7 @@ public class Sched extends SchedV2 {
 
 
     @Override
-    protected void update(JSONObject g) {
+    protected void update(Deck g) {
         for (String t : new String[] { "new", "rev", "lrn", "time" }) {
             String key = t + "Today";
             JSONArray ja = g.getJSONArray(key);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -39,6 +39,7 @@ import com.ichi2.libanki.Consts;
 import com.ichi2.libanki.Decks;
 import com.ichi2.libanki.Note;
 import com.ichi2.libanki.Utils;
+import com.ichi2.libanki.DeckConfig;
 
 import com.ichi2.libanki.utils.SystemTime;
 import com.ichi2.libanki.utils.Time;
@@ -340,7 +341,7 @@ public class SchedV2 extends AbstractSched {
 
 
     public int answerButtons(Card card) {
-        JSONObject conf = _cardConf(card);
+        DeckConfig conf = _cardConf(card);
         if (card.getODid() != 0 && !conf.getBoolean("resched")) {
             return 2;
         }
@@ -823,7 +824,7 @@ public class SchedV2 extends AbstractSched {
             return mDynReportLimit;
         }
         long did = g.getLong("id");
-        JSONObject c = mCol.getDecks().confForDid(did);
+        DeckConfig c = mCol.getDecks().confForDid(did);
         int lim = Math.max(0, c.getJSONObject("new").getInt("perDay") - g.getJSONArray("newToday").getInt(1));
         if (currentCardIsInQueueWithDeck(Consts.QUEUE_TYPE_NEW, did)) {
             lim--;
@@ -1190,7 +1191,7 @@ public class SchedV2 extends AbstractSched {
     protected int _startingLeft(Card card) {
         JSONObject conf;
         if (card.getType() == Consts.CARD_TYPE_RELEARNING) {
-        conf = _lapseConf(card);
+            conf = _lapseConf(card);
         } else {
             conf = _lrnConf(card);
         }
@@ -1324,7 +1325,7 @@ public class SchedV2 extends AbstractSched {
             return mDynReportLimit;
         }
         long did = d.getLong("id");
-        JSONObject c = mCol.getDecks().confForDid(did);
+        DeckConfig c = mCol.getDecks().confForDid(did);
         int lim = Math.max(0, c.getJSONObject("rev").getInt("perDay") - d.getJSONArray("revToday").getInt(1));
         if (currentCardIsInQueueWithDeck(Consts.QUEUE_TYPE_REV, did)) {
             lim --;
@@ -1879,19 +1880,19 @@ public class SchedV2 extends AbstractSched {
      * Tools ******************************************************************** ***************************
      */
 
-    public JSONObject _cardConf(Card card) {
+    public DeckConfig _cardConf(Card card) {
         return mCol.getDecks().confForDid(card.getDid());
     }
 
 
     protected JSONObject _newConf(Card card) {
-        JSONObject conf = _cardConf(card);
+        DeckConfig conf = _cardConf(card);
         // normal deck
         if (card.getODid() == 0) {
             return conf.getJSONObject("new");
         }
         // dynamic deck; override some attributes, use original deck for others
-        JSONObject oconf = mCol.getDecks().confForDid(card.getODid());
+        DeckConfig oconf = mCol.getDecks().confForDid(card.getODid());
         JSONObject dict = new JSONObject();
         // original deck
         dict.put("ints", oconf.getJSONObject("new").getJSONArray("ints"));
@@ -1907,13 +1908,13 @@ public class SchedV2 extends AbstractSched {
 
 
     protected JSONObject _lapseConf(Card card) {
-        JSONObject conf = _cardConf(card);
+        DeckConfig conf = _cardConf(card);
         // normal deck
         if (card.getODid() == 0) {
             return conf.getJSONObject("lapse");
         }
         // dynamic deck; override some attributes, use original deck for others
-        JSONObject oconf = mCol.getDecks().confForDid(card.getODid());
+        DeckConfig oconf = mCol.getDecks().confForDid(card.getODid());
         JSONObject dict = new JSONObject();
         // original deck
         dict.put("minInt", oconf.getJSONObject("lapse").getInt("minInt"));
@@ -1928,7 +1929,7 @@ public class SchedV2 extends AbstractSched {
 
 
     protected JSONObject _revConf(Card card) {
-        JSONObject conf = _cardConf(card);
+        DeckConfig conf = _cardConf(card);
         // normal deck
         if (card.getODid() == 0) {
             return conf.getJSONObject("rev");
@@ -1944,7 +1945,7 @@ public class SchedV2 extends AbstractSched {
 
 
     private boolean _previewingCard(Card card) {
-        JSONObject conf = _cardConf(card);
+        DeckConfig conf = _cardConf(card);
 
         return conf.getInt("dyn") != 0 && !conf.getBoolean("resched");
     }
@@ -2525,7 +2526,7 @@ public class SchedV2 extends AbstractSched {
     }
 
 
-    public void resortConf(JSONObject conf) {
+    public void resortConf(DeckConfig conf) {
         List<Long> dids = mCol.getDecks().didsForConf(conf);
         for (long did : dids) {
             if (conf.getJSONObject("new").getLong("order") == 0) {
@@ -2548,7 +2549,7 @@ public class SchedV2 extends AbstractSched {
         if (did == null) {
             did = mCol.getDecks().selected();
         }
-        JSONObject conf = mCol.getDecks().confForDid(did);
+        DeckConfig conf = mCol.getDecks().confForDid(did);
         // in order due?
         if (conf.getJSONObject("new").getInt("order") == Consts.NEW_CARDS_RANDOM) {
             randomizeCards(did);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -39,6 +39,7 @@ import com.ichi2.libanki.Consts;
 import com.ichi2.libanki.Decks;
 import com.ichi2.libanki.Note;
 import com.ichi2.libanki.Utils;
+import com.ichi2.libanki.Deck;
 import com.ichi2.libanki.DeckConfig;
 
 import com.ichi2.libanki.utils.SystemTime;
@@ -362,9 +363,9 @@ public class SchedV2 extends AbstractSched {
     public void _updateStats(Card card, String type, long cnt) {
         String key = type + "Today";
         long did = card.getDid();
-        List<JSONObject> list = mCol.getDecks().parents(did);
+        List<Deck> list = mCol.getDecks().parents(did);
         list.add(mCol.getDecks().get(did));
-        for (JSONObject g : list) {
+        for (Deck g : list) {
             JSONArray a = g.getJSONArray(key);
             // add
             a.put(1, a.getLong(1) + cnt);
@@ -374,14 +375,14 @@ public class SchedV2 extends AbstractSched {
 
 
     public void extendLimits(int newc, int rev) {
-        JSONObject cur = mCol.getDecks().current();
-        ArrayList<JSONObject> decks = new ArrayList<>();
+        Deck cur = mCol.getDecks().current();
+        ArrayList<Deck> decks = new ArrayList<>();
         decks.add(cur);
         decks.addAll(mCol.getDecks().parents(cur.getLong("id")));
         for (long did : mCol.getDecks().children(cur.getLong("id")).values()) {
             decks.add(mCol.getDecks().get(did));
         }
-        for (JSONObject g : decks) {
+        for (Deck g : decks) {
             // add
             JSONArray ja = g.getJSONArray("newToday");
             ja.put(1, ja.getInt(1) - newc);
@@ -403,8 +404,8 @@ public class SchedV2 extends AbstractSched {
                 continue;
             }
             // check the parents
-            List<JSONObject> parents = mCol.getDecks().parents(did);
-            for (JSONObject p : parents) {
+            List<Deck> parents = mCol.getDecks().parents(did);
+            for (Deck p : parents) {
                 // add if missing
                 long id = p.getLong("id");
                 if (!pcounts.containsKey(id)) {
@@ -416,7 +417,7 @@ public class SchedV2 extends AbstractSched {
             // see how many cards we actually have
             int cnt = cntFn.operation(did, lim);
             // if non-zero, decrement from parents counts
-            for (JSONObject p : parents) {
+            for (Deck p : parents) {
                 long id = p.getLong("id");
                 pcounts.put(id, pcounts.get(id) - cnt);
             }
@@ -446,11 +447,11 @@ public class SchedV2 extends AbstractSched {
     public List<DeckDueTreeNode> deckDueList(CollectionTask collectionTask) {
         _checkDay();
         mCol.getDecks().checkIntegrity();
-        ArrayList<JSONObject> decks = mCol.getDecks().allSorted();
+        ArrayList<Deck> decks = mCol.getDecks().allSorted();
         HashMap<String, Integer[]> lims = new HashMap<>();
         ArrayList<DeckDueTreeNode> data = new ArrayList<>();
         HashMap<Long, HashMap> childMap = mCol.getDecks().childMap();
-        for (JSONObject deck : decks) {
+        for (Deck deck : decks) {
             if (collectionTask != null && collectionTask.isCancelled()) {
                 return null;
             }
@@ -625,7 +626,7 @@ public class SchedV2 extends AbstractSched {
     }
 
     protected void _resetNewCount() {
-        mNewCount = _walkingCount((JSONObject g) -> _deckNewLimitSingle(g),
+        mNewCount = _walkingCount((Deck g) -> _deckNewLimitSingle(g),
                                   (long did, int lim) -> _cntFnNew(did, lim));
     }
 
@@ -790,12 +791,12 @@ public class SchedV2 extends AbstractSched {
         if (fn == null) {
             fn = (g -> _deckNewLimitSingle(g));
         }
-        List<JSONObject> decks = mCol.getDecks().parents(did);
+        List<Deck> decks = mCol.getDecks().parents(did);
         decks.add(mCol.getDecks().get(did));
         int lim = -1;
         // for the deck and each of its parents
         int rem = 0;
-        for (JSONObject g : decks) {
+        for (Deck g : decks) {
             rem = fn.operation(g);
             if (lim == -1) {
                 lim = rem;
@@ -818,8 +819,8 @@ public class SchedV2 extends AbstractSched {
     }
 
 
-    /** Limit for deck without parent limits. */
-    public int _deckNewLimitSingle(JSONObject g) {
+    /* Limit for deck without parent limits. */
+    public int _deckNewLimitSingle(Deck g) {
         if (g.getInt("dyn") != 0) {
             return mDynReportLimit;
         }
@@ -1306,17 +1307,17 @@ public class SchedV2 extends AbstractSched {
      */
 
     private int _currentRevLimit() {
-        JSONObject d = mCol.getDecks().get(mCol.getDecks().selected(), false);
+        Deck d = mCol.getDecks().get(mCol.getDecks().selected(), false);
         return _deckRevLimitSingle(d);
     }
 
 
-    protected int _deckRevLimitSingle(JSONObject d) {
+    protected int _deckRevLimitSingle(Deck d) {
         return _deckRevLimitSingle(d, null);
     }
 
 
-    private int _deckRevLimitSingle(JSONObject d, Integer parentLimit) {
+    private int _deckRevLimitSingle(Deck d, Integer parentLimit) {
         // invalid deck selected?
         if (d == null) {
             return 0;
@@ -1336,7 +1337,7 @@ public class SchedV2 extends AbstractSched {
         } else if (!d.getString("name").contains("::")) {
             return lim;
         } else {
-            for (JSONObject parent : mCol.getDecks().parents(did)) {
+            for (Deck parent : mCol.getDecks().parents(did)) {
                 // pass in dummy parentLimit so we don't do parent lookup again
                 lim = Math.min(lim, _deckRevLimitSingle(parent, lim));
             }
@@ -1674,7 +1675,7 @@ public class SchedV2 extends AbstractSched {
         if (did == 0) {
             did = mCol.getDecks().selected();
         }
-        JSONObject deck = mCol.getDecks().get(did);
+        Deck deck = mCol.getDecks().get(did);
         if (deck.getInt("dyn") == 0) {
             Timber.e("error: deck is not a filtered deck");
             return null;
@@ -1691,7 +1692,7 @@ public class SchedV2 extends AbstractSched {
     }
 
 
-    private int _fillDyn(JSONObject deck) {
+    private int _fillDyn(Deck deck) {
         int start = -100000;
         int total = 0;
         JSONArray terms;
@@ -1793,7 +1794,7 @@ public class SchedV2 extends AbstractSched {
 
 
     protected void _moveToDyn(long did, List<Long> ids, int start) {
-        JSONObject deck = mCol.getDecks().get(did);
+        Deck deck = mCol.getDecks().get(did);
         ArrayList<Object[]> data = new ArrayList<>();
         int u = mCol.usn();
         int due = start;
@@ -1972,7 +1973,7 @@ public class SchedV2 extends AbstractSched {
         }
         // update all daily counts, but don't save decks to prevent needless conflicts. we'll save on card answer
         // instead
-        for (JSONObject deck : mCol.getDecks().all()) {
+        for (Deck deck : mCol.getDecks().all()) {
             update(deck);
         }
         // unbury if the day has rolled over
@@ -2018,7 +2019,7 @@ public class SchedV2 extends AbstractSched {
     }
 
 
-    protected void update(JSONObject g) {
+    protected void update(Deck g) {
         for (String t : new String[] { "new", "rev", "lrn", "time" }) {
             String key = t + "Today";
             JSONArray ja = g.getJSONArray(key);
@@ -2884,7 +2885,7 @@ public class SchedV2 extends AbstractSched {
     public void setCurrentCard(@NonNull Card card) {
         mCurrentCard = card;
         long did = card.getDid();
-        List<JSONObject> parents = mCol.getDecks().parents(did);
+        List<Deck> parents = mCol.getDecks().parents(did);
         List<Long> currentCardParentsDid = new ArrayList<>(parents.size() + 1);
         for (JSONObject parent : parents) {
             currentCardParentsDid.add(parent.getLong("id"));

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/stats/AdvancedStatistics.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/stats/AdvancedStatistics.java
@@ -29,9 +29,7 @@ import com.ichi2.anki.stats.StatsMetaInfo;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Consts;
 import com.ichi2.libanki.Decks;
-import com.ichi2.libanki.stats.Stats;
-
-import com.ichi2.utils.JSONObject;
+import com.ichi2.libanki.DeckConfig;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -498,7 +496,7 @@ public class AdvancedStatistics {
 
             Timber.d("Trying to get deck settings for deck with id=" + did);
 
-            JSONObject conf = decks.confForDid(did);
+            DeckConfig conf = decks.confForDid(did);
 
             int newPerDay = Settings.getMaxNewPerDay();
             int revPerDay = Settings.getMaxReviewsPerDay();

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/stats/Stats.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/stats/Stats.java
@@ -29,8 +29,7 @@ import com.ichi2.anki.stats.StatsMetaInfo;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Consts;
 import com.ichi2.libanki.Utils;
-
-import com.ichi2.utils.JSONObject;
+import com.ichi2.libanki.Deck;
 
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -1300,7 +1299,7 @@ public class Stats {
         if (deckId == ALL_DECKS_ID) {
             // All decks
             ArrayList<Long> ids = new ArrayList<>();
-            for (JSONObject d : col.getDecks().all()) {
+            for (Deck d : col.getDecks().all()) {
                 ids.add(d.getLong("id"));
             }
             return Utils.ids2str(Utils.arrayList2array(ids));

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.java
@@ -30,6 +30,7 @@ import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Consts;
 import com.ichi2.libanki.Utils;
 
+import com.ichi2.libanki.Deck;
 import com.ichi2.libanki.DeckConfig;
 import com.ichi2.utils.JSONArray;
 import com.ichi2.utils.JSONException;
@@ -364,7 +365,7 @@ public class Syncer {
                 result.put("client", "graves had usn = -1");
                 return result;
             }
-            for (JSONObject g : mCol.getDecks().all()) {
+            for (Deck g : mCol.getDecks().all()) {
                 if (g.getInt("usn") == -1) {
                     Timber.e("Sync - SanityCheck: unsynced deck: " + g.getString("name"));
                     result.put("client", "deck had usn = -1");
@@ -723,7 +724,7 @@ public class Syncer {
         JSONArray result = new JSONArray();
         if (mCol.getServer()) {
             JSONArray decks = new JSONArray();
-            for (JSONObject g : mCol.getDecks().all()) {
+            for (Deck g : mCol.getDecks().all()) {
                 if (g.getInt("usn") >= mMinUsn) {
                     decks.put(g);
                 }
@@ -738,7 +739,7 @@ public class Syncer {
             result.put(dconfs);
         } else {
             JSONArray decks = new JSONArray();
-            for (JSONObject g : mCol.getDecks().all()) {
+            for (Deck g : mCol.getDecks().all()) {
                 if (g.getInt("usn") == -1) {
                     g.put("usn", mMaxUsn);
                     decks.put(g);
@@ -762,8 +763,8 @@ public class Syncer {
     private void mergeDecks(JSONArray rchg) {
         JSONArray decks = rchg.getJSONArray(0);
         for (int i = 0; i < decks.length(); i++) {
-            JSONObject r = decks.getJSONObject(i);
-            JSONObject l = mCol.getDecks().get(r.getLong("id"), false);
+            Deck r = new Deck(decks.getJSONObject(i));
+            Deck l = mCol.getDecks().get(r.getLong("id"), false);
             // if missing locally or server is newer, update
             if (l == null || r.getLong("mod") > l.getLong("mod")) {
                 mCol.getDecks().update(r);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.java
@@ -30,6 +30,7 @@ import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Consts;
 import com.ichi2.libanki.Utils;
 
+import com.ichi2.libanki.DeckConfig;
 import com.ichi2.utils.JSONArray;
 import com.ichi2.utils.JSONException;
 import com.ichi2.utils.JSONObject;
@@ -728,7 +729,7 @@ public class Syncer {
                 }
             }
             JSONArray dconfs = new JSONArray();
-            for (JSONObject g : mCol.getDecks().allConf()) {
+            for (DeckConfig g : mCol.getDecks().allConf()) {
                 if (g.getInt("usn") >= mMinUsn) {
                     dconfs.put(g);
                 }
@@ -744,7 +745,7 @@ public class Syncer {
                 }
             }
             JSONArray dconfs = new JSONArray();
-            for (JSONObject g : mCol.getDecks().allConf()) {
+            for (DeckConfig g : mCol.getDecks().allConf()) {
                 if (g.getInt("usn") == -1) {
                     g.put("usn", mMaxUsn);
                     dconfs.put(g);
@@ -770,8 +771,8 @@ public class Syncer {
         }
         JSONArray confs = rchg.getJSONArray(1);
         for (int i = 0; i < confs.length(); i++) {
-            JSONObject r = confs.getJSONObject(i);
-            JSONObject l = mCol.getDecks().getConf(r.getLong("id"));
+            DeckConfig r = new DeckConfig(confs.getJSONObject(i));
+            DeckConfig l = mCol.getDecks().getConf(r.getLong("id"));
             // if missing locally or server is newer, update
             if (l == null || r.getLong("mod") > l.getLong("mod")) {
                 mCol.getDecks().updateConf(r);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.java
@@ -25,6 +25,7 @@ import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.R;
 import com.ichi2.anki.exception.UnknownHttpResponseException;
 import com.ichi2.async.Connection;
+import com.ichi2.libanki.Model;
 import com.ichi2.libanki.sched.AbstractSched;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Consts;
@@ -695,8 +696,8 @@ public class Syncer {
 
     private void mergeModels(JSONArray rchg) throws UnexpectedSchemaChange {
         for (int i = 0; i < rchg.length(); i++) {
-            JSONObject r = rchg.getJSONObject(i);
-            JSONObject l = mCol.getModels().get(r.getLong("id"));
+            Model r = new Model(rchg.getJSONObject(i));
+            Model l = mCol.getModels().get(r.getLong("id"));
             // if missing locally or server is newer, update
             if (l == null || r.getLong("mod") > l.getLong("mod")) {
                 // This is a hack to detect when the note type has been altered

--- a/AnkiDroid/src/main/java/com/ichi2/utils/DeckComparator.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/DeckComparator.java
@@ -1,5 +1,9 @@
 package com.ichi2.utils;
 
+import com.ichi2.libanki.Deck;
+import com.ichi2.utils.DeckNameComparator;
+import com.ichi2.utils.JSONObject;
+
 import java.util.Comparator;
 
 public class DeckComparator implements Comparator<JSONObject> {

--- a/AnkiDroid/src/main/java/com/ichi2/utils/JSONObject.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/JSONObject.java
@@ -328,6 +328,19 @@ public class JSONObject extends org.json.JSONObject implements Iterable<String> 
 
     public JSONObject deepClone() {
         JSONObject clone = new JSONObject();
+        deepClonedInto(clone);
+        return clone;
+    }
+
+    /** deep clone this into clone.
+
+        Given a subtype `T` of JSONObject, and a JSONObject `j`, we could do
+        ```
+        T t = new T();
+        j.deepClonedInto(t);
+        ```
+        in order to obtain a deep clone of `j` of type ```T```. */
+    protected <T extends JSONObject> T deepClonedInto(T clone) {
         for (String key: this) {
             if (get(key) instanceof JSONObject) {
                 clone.put(key, getJSONObject(key).deepClone());

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
@@ -10,6 +10,7 @@ import android.widget.ListView;
 
 import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Note;
+import com.ichi2.libanki.Deck;
 import com.ichi2.testutils.AnkiAssert;
 import com.ichi2.utils.JSONObject;
 
@@ -154,9 +155,9 @@ public class CardBrowserTest extends RobolectricTest {
         addDeck("Hello");
         CardBrowser b = getBrowserWithNotes(5);
 
-        List<JSONObject> decks = b.getValidDecksForChangeDeck();
+        List<Deck> decks = b.getValidDecksForChangeDeck();
 
-        for (JSONObject d : decks) {
+        for (Deck d : decks) {
             if (d.getString("name").equals("Hello")) {
                 return;
             }
@@ -170,9 +171,9 @@ public class CardBrowserTest extends RobolectricTest {
         addDynamicDeck("World");
         CardBrowser b = getBrowserWithNotes(5);
 
-        List<JSONObject> decks = b.getValidDecksForChangeDeck();
+        List<Deck> decks = b.getValidDecksForChangeDeck();
 
-        for (JSONObject d : decks) {
+        for (Deck d : decks) {
             if (d.getString("name").equals("World")) {
                 Assert.fail("Dynamic decks should not be transferred to by the browser.");
             }
@@ -191,8 +192,8 @@ public class CardBrowserTest extends RobolectricTest {
 
         CardBrowser b = getBrowserWithNotes(5);
 
-        List<JSONObject> decks = b.getValidDecksForChangeDeck();
-        for (JSONObject d : decks) {
+        List<Deck> decks = b.getValidDecksForChangeDeck();
+        for (Deck d : decks) {
             assertThat(validNames, hasItem(d.getString("name")));
         }
         assertThat("Additional unexpected decks were present", decks.size(), is(2));

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateEditorTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateEditorTest.java
@@ -33,6 +33,7 @@ import org.robolectric.annotation.LooperMode;
 import org.robolectric.shadows.ShadowActivity;
 import org.robolectric.shadows.ShadowIntent;
 
+import com.ichi2.libanki.Model;
 import com.ichi2.libanki.Note;
 import com.ichi2.utils.JSONObject;
 
@@ -236,7 +237,7 @@ public class CardTemplateEditorTest extends RobolectricTest {
     public void testDeleteTemplateWithSelectivelyGeneratedCards() {
 
         String modelName = "Basic (optional reversed card)";
-        JSONObject collectionBasicModelOriginal = getCurrentDatabaseModelCopy(modelName);
+        Model collectionBasicModelOriginal = getCurrentDatabaseModelCopy(modelName);
 
         // Start the CardTemplateEditor with a specific model, and make sure the model starts unchanged
         Intent intent = new Intent(Intent.ACTION_VIEW);
@@ -319,7 +320,7 @@ public class CardTemplateEditorTest extends RobolectricTest {
     public void testDeleteTemplateWithGeneratedCards() {
 
         String modelName = "Basic (and reversed card)";
-        JSONObject collectionBasicModelOriginal = getCurrentDatabaseModelCopy(modelName);
+        Model collectionBasicModelOriginal = getCurrentDatabaseModelCopy(modelName);
 
         // Start the CardTemplateEditor with a specific model, and make sure the model starts unchanged
         Intent intent = new Intent(Intent.ACTION_VIEW);
@@ -444,7 +445,7 @@ public class CardTemplateEditorTest extends RobolectricTest {
     public void testDeletePendingAddExistingCardCount() {
 
         String modelName = "Basic (optional reversed card)";
-        JSONObject collectionBasicModelOriginal = getCurrentDatabaseModelCopy(modelName);
+        Model collectionBasicModelOriginal = getCurrentDatabaseModelCopy(modelName);
 
         // Start the CardTemplateEditor with a specific model, and make sure the model starts unchanged
         Intent intent = new Intent(Intent.ACTION_VIEW);
@@ -514,7 +515,7 @@ public class CardTemplateEditorTest extends RobolectricTest {
         Assert.assertEquals("card generation should result in 1 card", 1, getModelCardCount(collectionBasicModelOriginal));
     }
 
-    private int getModelCardCount(JSONObject model) {
+    private int getModelCardCount(Model model) {
         int cardCount = 0;
         for (Long noteId : getCol().getModels().nids(model)) {
             cardCount += getCol().getNote(noteId).cards().size();

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplatePreviewerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplatePreviewerTest.java
@@ -21,6 +21,7 @@ import android.os.Bundle;
 import android.widget.LinearLayout;
 
 import com.ichi2.libanki.Card;
+import com.ichi2.libanki.Model;
 import com.ichi2.libanki.Models;
 import com.ichi2.libanki.Note;
 import com.ichi2.utils.JSONObject;
@@ -41,7 +42,7 @@ public class CardTemplatePreviewerTest extends RobolectricTest {
     public void testPreviewUnsavedTemplate() throws Exception {
 
         String modelName = "Basic";
-        JSONObject collectionBasicModelOriginal = getCurrentDatabaseModelCopy(modelName);
+        Model collectionBasicModelOriginal = getCurrentDatabaseModelCopy(modelName);
         JSONObject template = (JSONObject)collectionBasicModelOriginal.getJSONArray("tmpls").get(0);
         template.put("qfmt", template.getString("qfmt").concat("PREVIEWER_TEST"));
         String tempModelPath = TemporaryModel.saveTempModel(getTargetContext(), collectionBasicModelOriginal);
@@ -81,7 +82,7 @@ public class CardTemplatePreviewerTest extends RobolectricTest {
 
         // Make sure we test previewing a new card template
         String modelName = "Basic (and reversed card)";
-        JSONObject collectionBasicModelOriginal = getCurrentDatabaseModelCopy(modelName);
+        Model collectionBasicModelOriginal = getCurrentDatabaseModelCopy(modelName);
         Card testCard1 = getSavedCard(collectionBasicModelOriginal, 0);
         Card testCard2 = getSavedCard(collectionBasicModelOriginal, 1);
 
@@ -108,7 +109,7 @@ public class CardTemplatePreviewerTest extends RobolectricTest {
         Assert.assertTrue("Not showing the answer?", testCardTemplatePreviewer.getShowingAnswer());
     }
 
-    private Card getSavedCard(JSONObject model, int ordinal) throws Exception {
+    private Card getSavedCard(Model model, int ordinal) throws Exception {
         Note n = getCol().newNote(model);
         ArrayList<String> fieldNames = Models.fieldNames(model);
         for (int i = 0; i < fieldNames.size(); i++) {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.java
@@ -25,6 +25,7 @@ import android.widget.TextView;
 import com.ichi2.anki.multimediacard.activity.MultimediaEditFieldActivity;
 import com.ichi2.anki.multimediacard.fields.IField;
 import com.ichi2.libanki.Consts;
+import com.ichi2.libanki.Model;
 import com.ichi2.libanki.Note;
 import com.ichi2.utils.JSONObject;
 
@@ -242,12 +243,12 @@ public class NoteEditorTest extends RobolectricTest {
     }
 
     private NoteEditorTestBuilder getNoteEditorAdding(NoteType noteType) {
-        JSONObject n = makeNoteForType(noteType);
+        Model n = makeNoteForType(noteType);
         return new NoteEditorTestBuilder(n);
     }
 
 
-    private JSONObject makeNoteForType(NoteType noteType) {
+    private Model makeNoteForType(NoteType noteType) {
         switch (noteType) {
             case BASIC: return getCol().getModels().byName("Basic");
             case CLOZE: return getCol().getModels().byName("Cloze");
@@ -329,13 +330,13 @@ public class NoteEditorTest extends RobolectricTest {
     @SuppressWarnings("WeakerAccess")
     public class NoteEditorTestBuilder {
 
-        private final JSONObject mModel;
+        private final Model mModel;
         private String mFirstField;
         private String mSecondField;
         private String mThirdField;
 
 
-        public NoteEditorTestBuilder(JSONObject model) {
+        public NoteEditorTestBuilder(Model model) {
             if (model == null) {
                 throw new IllegalArgumentException("model was null");
             }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
@@ -27,6 +27,7 @@ import com.ichi2.async.CollectionTask;
 import com.ichi2.compat.customtabs.CustomTabActivityHelper;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.DB;
+import com.ichi2.libanki.Model;
 import com.ichi2.libanki.Models;
 
 import com.ichi2.libanki.Note;
@@ -179,9 +180,9 @@ public class RobolectricTest {
         CollectionHelper.LazyHolder.INSTANCE = new CollectionHelper();
     }
 
-    protected JSONObject getCurrentDatabaseModelCopy(String modelName) throws JSONException {
+    protected Model getCurrentDatabaseModelCopy(String modelName) throws JSONException {
         Models collectionModels = getCol().getModels();
-        return new JSONObject(collectionModels.byName(modelName).toString().trim());
+        return new Model(collectionModels.byName(modelName).toString().trim());
     }
 
     protected <T extends AnkiActivity> T startActivityNormallyOpenCollectionWithIntent(Class<T> clazz, Intent i) {
@@ -196,7 +197,7 @@ public class RobolectricTest {
     }
 
     protected Note addNoteUsingModelName(String name, String... fields) {
-        JSONObject model = getCol().getModels().byName(name);
+        Model model = getCol().getModels().byName(name);
         //PERF: if we modify newNote(), we can return the card and return a Pair<Note, Card> here.
         //Saves a database trip afterwards.
         if (model == null) {
@@ -214,7 +215,7 @@ public class RobolectricTest {
 
 
     protected String addNonClozeModel(String name, String[] fields, String qfmt, String afmt) {
-        JSONObject model = getCol().getModels().newModel(name);
+        Model model = getCol().getModels().newModel(name);
         for (int i = 0; i < fields.length; i++) {
             addField(model, fields[i]);
         }
@@ -226,7 +227,7 @@ public class RobolectricTest {
     }
 
 
-    private void addField(JSONObject model, String name) {
+    private void addField(Model model, String name) {
         Models models = getCol().getModels();
 
         try {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/TemporaryModelTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/TemporaryModelTest.java
@@ -23,6 +23,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import com.ichi2.libanki.Model;
 import com.ichi2.utils.JSONObject;
 
 import java.io.IOException;
@@ -68,7 +69,7 @@ public class TemporaryModelTest extends RobolectricTest {
         // Assume you start with a 2 template model (like "Basic (and reversed)")
         // Add a 3rd new template, remove the 2nd, remove the 1st, add a new now-2nd, remove 1st again
         // ...and it should reduce to just removing the original 1st/2nd and adding the final as first
-        TemporaryModel tempModel = new TemporaryModel(new JSONObject("{ foo: bar }"));
+        TemporaryModel tempModel = new TemporaryModel(new Model("{ foo: bar }"));
 
         tempModel.addTemplateChange(ADD, 3);
         Object[][] expected1 = {{3, ADD}};

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.java
@@ -24,6 +24,7 @@ import com.ichi2.anki.AnkiActivity;
 import com.ichi2.anki.CardTemplateBrowserAppearanceEditor;
 import com.ichi2.anki.RobolectricTest;
 import com.ichi2.anki.dialogs.CustomStudyDialog.CustomStudyListener;
+import com.ichi2.libanki.Deck;
 import com.ichi2.utils.JSONObject;
 
 import org.junit.Test;
@@ -57,7 +58,7 @@ public class CustomStudyDialogTest extends RobolectricTest {
         });
 
 
-        JSONObject customStudy = getCol().getDecks().current();
+        Deck customStudy = getCol().getDecks().current();
         assertThat("Custom Study should be dynamic", customStudy.getInt("dyn") == 1);
         assertThat("could not find deck: Custom study session", customStudy, notNullValue());
         customStudy.remove("id");

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.java
@@ -20,6 +20,7 @@ import com.ichi2.anki.RobolectricTest;
 import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Consts;
 import com.ichi2.libanki.Note;
+import com.ichi2.libanki.DeckConfig;
 import com.ichi2.testutils.MockTime;
 import com.ichi2.utils.JSONArray;
 import com.ichi2.utils.JSONObject;
@@ -69,7 +70,7 @@ public class SchedV2Test extends RobolectricTest {
 
         long homeDeckId = addDeck("Poorretention");
 
-        JSONObject homeDeckConf = getCol().getDecks().confForDid(homeDeckId);
+        DeckConfig homeDeckConf = getCol().getDecks().confForDid(homeDeckId);
         JSONObject lapse = homeDeckConf.getJSONObject("lapse");
 
         lapse.put("minInt", 2);


### PR DESCRIPTION
I do strongly believe that having type indication is helpful. While creating real types for Deck and Note Types is not something that is going to be considered now, at least, having a type which simply inherits JSONObjects seems a nice step. The code becomes more clear (at least according to me), there is almost no computation cost. 

Furthermore, when porting unit test from upstream, I do believe that it's far easier to directly uses clear type instead of using the generic JSONObject. Because porting those tests is going to be a lot of work, and anything that can simplify the porting is really welcome