### PR TITLE
Dependency updates 20200730

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -254,7 +254,7 @@ dependencies {
     api project(":api")
 
     testImplementation 'org.junit.vintage:junit-vintage-engine:5.6.2'
-    testImplementation 'org.mockito:mockito-inline:3.4.0'
+    testImplementation 'org.mockito:mockito-inline:3.4.2'
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
     testImplementation 'net.lachlanmckee:timber-junit-rule:1.0.1'
     testImplementation "org.robolectric:robolectric:4.3.1"

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -254,7 +254,7 @@ dependencies {
     api project(":api")
 
     testImplementation 'org.junit.vintage:junit-vintage-engine:5.6.2'
-    testImplementation 'org.mockito:mockito-inline:3.4.2'
+    testImplementation 'org.mockito:mockito-inline:3.4.4'
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
     testImplementation 'net.lachlanmckee:timber-junit-rule:1.0.1'
     testImplementation "org.robolectric:robolectric:4.3.1"

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -254,7 +254,7 @@ dependencies {
     api project(":api")
 
     testImplementation 'org.junit.vintage:junit-vintage-engine:5.6.2'
-    testImplementation 'org.mockito:mockito-inline:3.4.4'
+    testImplementation 'org.mockito:mockito-inline:3.4.6'
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
     testImplementation 'net.lachlanmckee:timber-junit-rule:1.0.1'
     testImplementation "org.robolectric:robolectric:4.3.1"

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -219,7 +219,7 @@ dependencies {
     // Note: the design support library can be quite buggy, so test everything thoroughly before updating it
     implementation 'com.google.android.material:material:1.1.0'
     implementation 'androidx.annotation:annotation:1.1.0'
-    implementation 'androidx.appcompat:appcompat:1.2.0-rc01'
+    implementation 'androidx.appcompat:appcompat:1.2.0-rc02'
     implementation 'androidx.browser:browser:1.2.0'
     implementation 'androidx.exifinterface:exifinterface:1.2.0'
     implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'


### PR DESCRIPTION
# AppCompat

They released rc02 of appcompat 1.2.0 we were on 1.2.0-rc01, should be okay to update?

# Mockito: 
They're iterating quickly after the major functionality release in 3.4.x, might as well track them since we are using their new MockStatic feature

They've slowed down a touch as they have gotten past the 3.4.0 release, 3.4.6 is out now and it seems as good a time as any to merge them in now
