### PR TITLE
Fix Crash when previewing note in dynamic deck

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.java
@@ -170,7 +170,11 @@ public class CardTemplatePreviewer extends AbstractFlashcardViewer {
         }
 
         if (mNoteEditorBundle != null) {
-            mCurrentCard.setDid(mNoteEditorBundle.getLong("did"));
+            long newDid = mNoteEditorBundle.getLong("did");
+            if (col.getDecks().isDyn(newDid)) {
+                mCurrentCard.setODid(mCurrentCard.getDid());
+            }
+            mCurrentCard.setDid(newDid);
 
             Note currentNote = mCurrentCard.note();
             ArrayList<String> tagsList = mNoteEditorBundle.getStringArrayList("tags");


### PR DESCRIPTION
I'll be happy to convert this to a draft if we want to better understand this

## Purpose / Description

A card must have some settings from the home deck.

In the previous code, we were setting the did to a dynamic deck without specifying a home deck. This caused a crash

## Fixes
Fixes #6685

## Approach
Set the Home Deck if we want to specify the did as a dynamic deck 

## How Has This Been Tested?

Tested on my phone, no longer crashes

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code