### PR TITLE
Fix: Previewer Now Displays NoteEditor Fields

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.java
@@ -181,7 +181,7 @@ public class CardTemplatePreviewer extends AbstractFlashcardViewer {
                 for (String fieldOrd : noteFields.keySet()) {
                     // In case the fields on the card are out of sync with the bundle
                     int fieldOrdInt = Integer.parseInt(fieldOrd);
-                    if (currentNote.getFields().length < fieldOrdInt) {
+                    if (fieldOrdInt < currentNote.getFields().length) {
                         currentNote.setField(fieldOrdInt, noteFields.getString(fieldOrd));
                     }
                 }


### PR DESCRIPTION
## Purpose / Description
Previewer was not copying fields from the Note Editor. 

See 184effd4d1c47fb3308b26bd308bcce36ccdb7e4 for original change

## Fixes
Fixes #6684

## Approach
Fix obvious bug

## How Has This Been Tested?

⛔ Not tested well enough, trivial test on my phone - happy to delay for further testing

## Learning
We need more testing in this area of the code

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code