### PR TITLE
Fix Audio Whitespace Handling

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.java
@@ -36,6 +36,7 @@ import android.widget.VideoView;
 import com.ichi2.anki.AbstractFlashcardViewer;
 import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.ReadText;
+import com.ichi2.utils.StringUtil;
 
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
@@ -135,7 +136,7 @@ public class Sound {
             }
 
             // Get the sound file name
-            String sound = matcher.group(1).trim();
+            String sound = matcher.group(1);
 
             // Construct the sound path and store it
             Timber.d("Adding Sound to side: %d", qa);
@@ -193,7 +194,7 @@ public class Sound {
         // While there is matches of the pattern for sound markers
         while (matcher.find()) {
             // Get the sound file name
-            String sound = matcher.group(1).trim();
+            String sound = matcher.group(1);
 
             // Construct the sound path
             String soundPath = getSoundPath(soundDir, sound);
@@ -472,10 +473,12 @@ public class Sound {
      * @return absolute URI to the sound file.
      */
     private static String getSoundPath(String soundDir, String sound) {
-        if (hasURIScheme(sound)) {
-            return sound;
+        String trimmedSound = sound.trim();
+        if (hasURIScheme(trimmedSound)) {
+            return trimmedSound;
         }
-        return soundDir + Uri.encode(sound);
+
+        return soundDir + Uri.encode(StringUtil.trimRight(sound));
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/utils/StringUtil.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/StringUtil.java
@@ -1,0 +1,40 @@
+/*
+ Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+
+ */
+
+package com.ichi2.utils;
+
+import org.jetbrains.annotations.Contract;
+
+import androidx.annotation.Nullable;
+
+public class StringUtil {
+
+    /** Trims from the right hand side of a string */
+    @Nullable
+    @Contract("null -> null; !null -> !null")
+    public static String trimRight(@Nullable String s) {
+        if (s == null) {
+            return null;
+        }
+
+        int newLength = s.length();
+        while (newLength > 0 && Character.isWhitespace(s.charAt(newLength - 1))) {
+            newLength--;
+        }
+        return newLength < s.length() ? s.substring(0, newLength) : s;
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/utils/StringUtilTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/StringUtilTest.java
@@ -1,0 +1,49 @@
+/*
+ Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.utils;
+
+import org.junit.Test;
+
+import static com.ichi2.utils.StringUtil.trimRight;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
+
+public class StringUtilTest {
+
+    @Test
+    public void trimRightNullIsSetToNull() {
+        assertThat(trimRight(null), is(nullValue()));
+    }
+
+    @Test
+    public void trimRightWhiteSpaceIsBlankString() {
+        assertThat(trimRight(" "), is(""));
+    }
+
+    @Test
+    public void trimRightOnlyTrimsRight() {
+        assertThat(trimRight(" a "), is(" a"));
+    }
+
+    @Test
+    public void trimRightDoesNothingOnTrimmedString() {
+        String input = " foo";
+        assertThat(trimRight(input), sameInstance(input));
+    }
+}


### PR DESCRIPTION
## Purpose / Description
In Anki, whitespace before a filename matters, whereas whitespace after a file is ignored.

This is visible in the following decks:

https://ankiweb.net/shared/info/1616679068
"GENKI I Grammar Deck with native speaker audio and images"

https://ankiweb.net/shared/info/1833515795
"GENKI II Grammar Deck with native speaker audio and images"

One defines "5.mp3", and the other defines " 5.mp3".

This works in Anki Desktop.


## Fixes
Fixes #6693

## Approach
We fix this by only performing a trim on the right hand side, and only if the string is not a URI


## How Has This Been Tested?

Tested on my phone:

* With the above decks
* Added trailing whitespace, both passed.

## Learning 

See #6693 

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code