### PR TITLE
NF: remCards follow upstream and simplified

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.java
@@ -213,7 +213,7 @@ public class ContentProviderTest extends InstrumentedTest {
         // Delete all notes
         List<Long> remnantNotes = col.findNotes("tag:" + TEST_TAG);
         if (remnantNotes.size() > 0) {
-            long[] noteIds = Utils.arrayList2array(remnantNotes);
+            long[] noteIds = Utils.collection2Array(remnantNotes);
             col.remNotes(noteIds);
             col.save();
             assertEquals("Check that remnant notes have been deleted", 0, col.findNotes("tag:" + TEST_TAG).size());

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/ImportTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/ImportTest.java
@@ -105,7 +105,7 @@ public class ImportTest {
         actual.retainAll(expected);
         assertEquals(expected.size(), actual.size());
         // and importing again will not duplicate, as the file content matches
-        empty.remCards(Utils.arrayList2array(empty.getDb().queryLongList("select id from cards")));
+        empty.remCards(empty.getDb().queryLongList("select id from cards"));
         imp = new Anki2Importer(empty, testCol.getPath());
         imp.run();
         expected = Collections.singletonList("foo.mp3");
@@ -115,7 +115,7 @@ public class ImportTest {
         n = empty.getNote(empty.getDb().queryLongScalar("select id from notes"));
         assertTrue(n.getFields()[0].contains("foo.mp3"));
         // if the local file content is different, and import should trigger a rename
-        empty.remCards(Utils.arrayList2array(empty.getDb().queryLongList("select id from cards")));
+        empty.remCards(empty.getDb().queryLongList("select id from cards"));
         os = new FileOutputStream(new File(empty.getMedia().dir(), "foo.mp3"), false);
         os.write("bar".getBytes());
         os.close();
@@ -128,7 +128,7 @@ public class ImportTest {
         n = empty.getNote(empty.getDb().queryLongScalar("select id from notes"));
         assertTrue(n.getFields()[0].contains("_"));
         // if the localized media file already exists, we rewrite the note and media
-        empty.remCards(Utils.arrayList2array(empty.getDb().queryLongList("select id from cards")));
+        empty.remCards(empty.getDb().queryLongList("select id from cards"));
         os = new FileOutputStream(new File(empty.getMedia().dir(), "foo.mp3"));
         os.write("bar".getBytes());
         os.close();
@@ -160,7 +160,7 @@ public class ImportTest {
         actual.retainAll(expected);
         assertEquals(expected.size(), actual.size());
         // import again should be idempotent in terms of media
-        testCol.remCards(Utils.arrayList2array(testCol.getDb().queryLongList("select id from cards")));
+        testCol.remCards(testCol.getDb().queryLongList("select id from cards"));
         imp = new AnkiPackageImporter(testCol, apkg);
         imp.run();
         expected = Collections.singletonList("foo.wav");
@@ -168,7 +168,7 @@ public class ImportTest {
         actual.retainAll(expected);
         assertEquals(expected.size(), actual.size());
         // but if the local file has different data, it will rename
-        testCol.remCards(Utils.arrayList2array(testCol.getDb().queryLongList("select id from cards")));
+        testCol.remCards(testCol.getDb().queryLongList("select id from cards"));
         FileOutputStream os;
         os = new FileOutputStream(new File(testCol.getMedia().dir(), "foo.wav"), false);
         os.write("xyz".getBytes());

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -2458,7 +2458,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
                     ConfirmationDialog dialog = new ConfirmationDialog();
                     dialog.setArgs(msg);
                     Runnable confirm = () -> {
-                        getCol().remCards(Utils.collection2Array(cids));
+                        getCol().remCards(cids);
                         UIUtils.showSimpleSnackbar(DeckPicker.this, String.format(
                                 getResources().getString(R.string.empty_cards_deleted), cids.size()), false);
                     };

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -118,7 +118,6 @@ import com.ichi2.utils.VersionUtils;
 import com.ichi2.widget.WidgetStatus;
 
 import com.ichi2.utils.JSONException;
-import com.ichi2.utils.JSONObject;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -2459,7 +2458,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
                     ConfirmationDialog dialog = new ConfirmationDialog();
                     dialog.setArgs(msg);
                     Runnable confirm = () -> {
-                        getCol().remCards(Utils.arrayList2array(cids));
+                        getCol().remCards(Utils.collection2Array(cids));
                         UIUtils.showSimpleSnackbar(DeckPicker.this, String.format(
                                 getResources().getString(R.string.empty_cards_deleted), cids.size()), false);
                     };

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
@@ -711,7 +711,7 @@ public class CardContentProvider extends ContentProvider {
                     return -1;
                 }
                 List<Long> cids = col.genCards(col.getModels().nids(model));
-                col.remCards(Utils.arrayList2array(cids));
+                col.remCards(Utils.collection2Array(cids));
                 return cids.size();
             default:
                 throw new UnsupportedOperationException();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
@@ -711,7 +711,7 @@ public class CardContentProvider extends ContentProvider {
                     return -1;
                 }
                 List<Long> cids = col.genCards(col.getModels().nids(model));
-                col.remCards(Utils.collection2Array(cids));
+                col.remCards(cids);
                 return cids.size();
             default:
                 throw new UnsupportedOperationException();

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -517,6 +517,16 @@ public class Collection {
      * Deletion logging ********************************************************* **************************************
      */
 
+    public void _logRem(long[] ids, int type) {
+        for (long id : ids) {
+            ContentValues values = new ContentValues();
+            values.put("usn", usn());
+            values.put("oid", id);
+            values.put("type", type);
+            mDb.insert("graves", values);
+        }
+    }
+
     public void _logRem(java.util.Collection<Long> ids, int type) {
         for (long id : ids) {
             ContentValues values = new ContentValues();

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -649,7 +649,7 @@ public class Collection {
      * Generate cards for non-empty templates, return ids to remove.
      */
 	public ArrayList<Long> genCards(List<Long> nids) {
-	    return genCards(Utils.arrayList2array(nids));
+	    return genCards(Utils.collection2Array(nids));
 	}
     public ArrayList<Long> genCards(long[] nids) {
         // build map of (nid,ord) so we don't create dupes
@@ -924,7 +924,7 @@ public class Collection {
         }
         String sids = Utils.ids2str(ids);
         long[] nids = Utils
-                .arrayList2array(mDb.queryLongList("SELECT nid FROM cards WHERE id IN " + sids));
+                .collection2Array(mDb.queryLongList("SELECT nid FROM cards WHERE id IN " + sids));
         // remove cards
         _logRem(ids, Consts.REM_CARD);
         mDb.execute("DELETE FROM cards WHERE id IN " + sids);
@@ -933,7 +933,7 @@ public class Collection {
         	return;
         }
         nids = Utils
-                .arrayList2array(mDb.queryLongList("SELECT id FROM notes WHERE id IN " + Utils.ids2str(nids)
+                .collection2Array(mDb.queryLongList("SELECT id FROM notes WHERE id IN " + Utils.ids2str(nids)
                         + " AND id NOT IN (SELECT nid FROM cards)"));
         _remNotes(nids);
     }
@@ -1557,7 +1557,7 @@ public class Collection {
         if (ids.size() > 0) {
             problems.add("Reviews had incorrect due date.");
             mDb.execute("UPDATE cards SET due = " + mSched.getToday() + ", ivl = 1, mod = " +  Utils.intTime() +
-                    ", usn = " + usn() + " WHERE id IN " + Utils.ids2str(Utils.arrayList2array(ids)));
+                    ", usn = " + usn() + " WHERE id IN " + Utils.ids2str(Utils.collection2Array(ids)));
         }
         return problems;
     }
@@ -1587,7 +1587,7 @@ public class Collection {
         // field cache
         for (Model m : getModels().all()) {
             notifyProgress.run();
-            updateFieldCache(Utils.arrayList2array(getModels().nids(m)));
+            updateFieldCache(Utils.collection2Array(getModels().nids(m)));
         }
         return Collections.emptyList();
     }
@@ -1674,7 +1674,7 @@ public class Collection {
         notifyProgress.run();
         if (ids.size() != 0) {
             problems.add("Deleted " + ids.size() + " card(s) with missing note.");
-            remCards(Utils.arrayList2array(ids));
+            remCards(Utils.collection2Array(ids));
         }
         return problems;
     }
@@ -1691,7 +1691,7 @@ public class Collection {
         notifyProgress.run();
         if (ids.size() != 0) {
             problems.add("Deleted " + ids.size() + " note(s) with missing no cards.");
-            _remNotes(Utils.arrayList2array(ids));
+            _remNotes(Utils.collection2Array(ids));
         }
         return problems;
     }
@@ -1742,7 +1742,7 @@ public class Collection {
             notifyProgress.run();
             if (ids.size() > 0) {
                 problems.add("Deleted " + ids.size() + " note(s) with wrong field count.");
-                _remNotes(Utils.arrayList2array(ids));
+                _remNotes(Utils.collection2Array(ids));
             }
         } finally {
             if (cur != null && !cur.isClosed()) {
@@ -1769,7 +1769,7 @@ public class Collection {
                             "SELECT id FROM notes WHERE mid = ?)", m.getLong("id"));
             if (ids.size() > 0) {
                 problems.add("Deleted " + ids.size() + " card(s) with missing template.");
-                remCards(Utils.arrayList2array(ids));
+                remCards(Utils.collection2Array(ids));
             }
         }
         return problems;
@@ -1786,7 +1786,7 @@ public class Collection {
         notifyProgress.run();
         if (ids.size() != 0) {
             problems.add("Deleted " + ids.size() + " note(s) with missing note type.");
-            _remNotes(Utils.arrayList2array(ids));
+            _remNotes(Utils.collection2Array(ids));
         }
         return problems;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -589,11 +589,6 @@ public class Collection {
     public void remNotes(long[] ids) {
         ArrayList<Long> list = mDb
                 .queryLongList("SELECT id FROM cards WHERE nid IN " + Utils.ids2str(ids));
-        long[] cids = new long[list.size()];
-        int i = 0;
-        for (long l : list) {
-            cids[i++] = l;
-        }
         remCards(cids);
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -589,7 +589,7 @@ public class Collection {
     public void remNotes(long[] ids) {
         ArrayList<Long> list = mDb
                 .queryLongList("SELECT id FROM cards WHERE nid IN " + Utils.ids2str(ids));
-        remCards(cids);
+        remCards(list);
     }
 
 
@@ -915,18 +915,19 @@ public class Collection {
     /**
      * Bulk delete cards by ID.
      */
-    public void remCards(long[] ids) {
-    	remCards(ids, true);
+    public void remCards(List<Long> ids) {
+        remCards(ids, true);
     }
-    public void remCards(long[] ids, boolean notes) {
-        if (ids.length == 0) {
+
+    public void remCards(java.util.Collection<Long> ids, boolean notes) {
+        if (ids.size() == 0) {
             return;
         }
         String sids = Utils.ids2str(ids);
         long[] nids = Utils
                 .collection2Array(mDb.queryLongList("SELECT nid FROM cards WHERE id IN " + sids));
         // remove cards
-        _logRem(ids, Consts.REM_CARD);
+        _logRem(Utils.collectionOfLong2array(ids), Consts.REM_CARD);
         mDb.execute("DELETE FROM cards WHERE id IN " + sids);
         // then notes
         if (!notes) {
@@ -1674,7 +1675,7 @@ public class Collection {
         notifyProgress.run();
         if (ids.size() != 0) {
             problems.add("Deleted " + ids.size() + " card(s) with missing note.");
-            remCards(Utils.collection2Array(ids));
+            remCards(ids);
         }
         return problems;
     }
@@ -1769,7 +1770,7 @@ public class Collection {
                             "SELECT id FROM notes WHERE mid = ?)", m.getLong("id"));
             if (ids.size() > 0) {
                 problems.add("Deleted " + ids.size() + " card(s) with missing template.");
-                remCards(Utils.collection2Array(ids));
+                remCards(ids);
             }
         }
         return problems;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -517,7 +517,7 @@ public class Collection {
      * Deletion logging ********************************************************* **************************************
      */
 
-    public void _logRem(long[] ids, int type) {
+    public void _logRem(java.util.Collection<Long> ids, int type) {
         for (long id : ids) {
             ContentValues values = new ContentValues();
             values.put("usn", usn());
@@ -596,8 +596,8 @@ public class Collection {
     /**
      * Bulk delete notes by ID. Don't call this directly.
      */
-    public void _remNotes(long[] ids) {
-        if (ids.length == 0) {
+    public void _remNotes(java.util.Collection<Long> ids) {
+        if (ids.size() == 0) {
             return;
         }
         String strids = Utils.ids2str(ids);
@@ -924,18 +924,16 @@ public class Collection {
             return;
         }
         String sids = Utils.ids2str(ids);
-        long[] nids = Utils
-                .collection2Array(mDb.queryLongList("SELECT nid FROM cards WHERE id IN " + sids));
+        List<Long> nids = mDb.queryLongList("SELECT nid FROM cards WHERE id IN " + sids);
         // remove cards
-        _logRem(Utils.collectionOfLong2array(ids), Consts.REM_CARD);
+        _logRem(ids, Consts.REM_CARD);
         mDb.execute("DELETE FROM cards WHERE id IN " + sids);
         // then notes
         if (!notes) {
         	return;
         }
-        nids = Utils
-                .collection2Array(mDb.queryLongList("SELECT id FROM notes WHERE id IN " + Utils.ids2str(nids)
-                        + " AND id NOT IN (SELECT nid FROM cards)"));
+        nids = mDb.queryLongList("SELECT id FROM notes WHERE id IN " + Utils.ids2str(nids)
+                        + " AND id NOT IN (SELECT nid FROM cards)");
         _remNotes(nids);
     }
 
@@ -1692,7 +1690,7 @@ public class Collection {
         notifyProgress.run();
         if (ids.size() != 0) {
             problems.add("Deleted " + ids.size() + " note(s) with missing no cards.");
-            _remNotes(Utils.collection2Array(ids));
+            _remNotes(ids);
         }
         return problems;
     }
@@ -1743,7 +1741,7 @@ public class Collection {
             notifyProgress.run();
             if (ids.size() > 0) {
                 problems.add("Deleted " + ids.size() + " note(s) with wrong field count.");
-                _remNotes(Utils.collection2Array(ids));
+                _remNotes(ids);
             }
         } finally {
             if (cur != null && !cur.isClosed()) {
@@ -1787,7 +1785,7 @@ public class Collection {
         notifyProgress.run();
         if (ids.size() != 0) {
             problems.add("Deleted " + ids.size() + " note(s) with missing note type.");
-            _remNotes(Utils.collection2Array(ids));
+            _remNotes(ids);
         }
         return problems;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -355,7 +355,7 @@ public class Decks {
             return;
         }
         // log the removal regardless of whether we have the deck or not
-        mCol._logRem(new long[] { did }, Consts.REM_DECK);
+        mCol._logRem(Arrays.asList(new Long[] { did }), Consts.REM_DECK);
         // do nothing else if doesn't exist
         if (deck == null) {
             return;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -355,7 +355,7 @@ public class Decks {
             return;
         }
         // log the removal regardless of whether we have the deck or not
-        mCol._logRem(Arrays.asList(new Long[] { did }), Consts.REM_DECK);
+        mCol._logRem(new long[] { did }, Consts.REM_DECK);
         // do nothing else if doesn't exist
         if (deck == null) {
             return;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -381,7 +381,7 @@ public class Decks {
             if (cardsToo) {
                 // don't use cids(), as we want cards in cram decks too
                 ArrayList<Long> cids = mCol.getDb().queryLongList("SELECT id FROM cards WHERE did = ? OR odid = ?", did, did);
-                mCol.remCards(Utils.arrayList2array(cids));
+                mCol.remCards(Utils.collection2Array(cids));
             }
         }
         // delete the deck and add a grave
@@ -839,7 +839,7 @@ public class Decks {
         for(Map.Entry<String, Long> entry : children(did).entrySet()) {
             dids.add(entry.getValue());
         }
-        return Utils.list2ObjectArray(mCol.getDb().queryLongList("select id from cards where did in " + Utils.ids2str(Utils.arrayList2array(dids))));
+        return Utils.list2ObjectArray(mCol.getDb().queryLongList("select id from cards where did in " + Utils.ids2str(Utils.collection2Array(dids))));
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -381,7 +381,7 @@ public class Decks {
             if (cardsToo) {
                 // don't use cids(), as we want cards in cram decks too
                 ArrayList<Long> cids = mCol.getDb().queryLongList("SELECT id FROM cards WHERE did = ? OR odid = ?", did, did);
-                mCol.remCards(Utils.collection2Array(cids));
+                mCol.remCards(cids);
             }
         }
         // delete the deck and add a grave

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -325,7 +325,7 @@ public class Models {
         long id = m.getLong("id");
         boolean current = current().getLong("id") == id;
         // delete notes/cards
-        mCol.remCards(Utils.collection2Array(mCol.getDb().queryLongList("SELECT id FROM cards WHERE nid IN (SELECT id FROM notes WHERE mid = ?)", id)));
+        mCol.remCards(mCol.getDb().queryLongList("SELECT id FROM cards WHERE nid IN (SELECT id FROM notes WHERE mid = ?)", id));
         // then the model
         mModels.remove(id);
         save();
@@ -755,7 +755,7 @@ public class Models {
         // ok to proceed; remove cards
         Timber.d("remTemplate proceeding to delete the template and %d cards", cids.size());
         mCol.modSchema();
-        mCol.remCards(Utils.toPrimitive(cids));
+        mCol.remCards(cids);
         // shift ordinals
         mCol.getDb()
             .execute(
@@ -966,7 +966,7 @@ public class Models {
             }
         }
         mCol.getDb().executeMany("update cards set ord=?,usn=?,mod=? where id=?", d);
-        mCol.remCards(Utils.toPrimitive(deleted));
+        mCol.remCards(deleted);
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -325,7 +325,7 @@ public class Models {
         long id = m.getLong("id");
         boolean current = current().getLong("id") == id;
         // delete notes/cards
-        mCol.remCards(Utils.arrayList2array(mCol.getDb().queryLongList("SELECT id FROM cards WHERE nid IN (SELECT id FROM notes WHERE mid = ?)", id)));
+        mCol.remCards(Utils.collection2Array(mCol.getDb().queryLongList("SELECT id FROM cards WHERE nid IN (SELECT id FROM notes WHERE mid = ?)", id)));
         // then the model
         mModels.remove(id);
         save();
@@ -861,7 +861,7 @@ public class Models {
 
     @SuppressWarnings("PMD.UnusedLocalVariable") // unused upstream as well
     private void _syncTemplates(Model m) {
-        ArrayList<Long> rem = mCol.genCards(Utils.arrayList2array(nids(m)));
+        ArrayList<Long> rem = mCol.genCards(Utils.collection2Array(nids(m)));
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Tags.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Tags.java
@@ -179,7 +179,7 @@ public class Tags {
             for (long id : mCol.getDecks().children(did).values()) {
                 dids.add(id);
             }
-            tags = mCol.getDb().queryStringList("SELECT DISTINCT n.tags FROM cards c, notes n WHERE c.nid = n.id AND c.did IN " + Utils.ids2str(Utils.arrayList2array(dids)));
+            tags = mCol.getDb().queryStringList("SELECT DISTINCT n.tags FROM cards c, notes n WHERE c.nid = n.id AND c.did IN " + Utils.ids2str(Utils.collection2Array(dids)));
         } else {
             tags = mCol.getDb().queryStringList("SELECT DISTINCT n.tags FROM cards c, notes n WHERE c.nid = n.id AND c.did = ?", did);
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Undoable.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Undoable.java
@@ -181,7 +181,7 @@ public abstract class Undoable {
                 c.flush(false);
                 ids.add(c.getId());
             }
-            col.getDb().execute("DELETE FROM graves WHERE oid IN " + Utils.ids2str(Utils.arrayList2array(ids)));
+            col.getDb().execute("DELETE FROM graves WHERE oid IN " + Utils.ids2str(Utils.collection2Array(ids)));
             return mCid;
         }
     }
@@ -207,7 +207,7 @@ public abstract class Undoable {
                 c.flush(false);
                 ids.add(c.getId());
             }
-            col.getDb().execute("DELETE FROM graves WHERE oid IN " + Utils.ids2str(Utils.arrayList2array(ids)));
+            col.getDb().execute("DELETE FROM graves WHERE oid IN " + Utils.ids2str(Utils.collection2Array(ids)));
             return MULTI_CARD;  // don't fetch new card
 
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
@@ -548,6 +548,14 @@ public class Utils {
         return ar;
     }
 
+    public static List<Long> jsonArrayToLongList(JSONArray jsonArray) throws JSONException {
+        List<Long> ar = new ArrayList<>(jsonArray.length());
+        for (int i = 0; i < jsonArray.length(); i++) {
+            ar.add(jsonArray.getLong(i));
+        }
+        return ar;
+    }
+
 
     public static Object[] jsonArray2Objects(JSONArray array) {
         Object[] o = new Object[array.length()];

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
@@ -62,6 +62,7 @@ import java.util.Collection;
 import java.util.Enumeration;
 import java.util.GregorianCalendar;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -418,8 +419,8 @@ public class Utils {
         return sb.toString();
     }
 
-    /** Given a list of integers, return a string '(int1,int2,...)'. */
-    public static <T> String ids2str(List<T> ids) {
+    /** Given a list of integers, return a string '(int1,int2,...)', in order given by the iterator. */
+    public static <T> String ids2str(Iterable<T> ids) {
         StringBuilder sb = new StringBuilder(512);
         sb.append("(");
         boolean isNotFirst = false;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
@@ -460,7 +460,8 @@ public class Utils {
 
 
     /** LIBANKI: not in libanki */
-    public static long[] arrayList2array(List<Long> list) {
+    /** Transform a collection of Long into an array of Long */
+    public static long[] collection2Array(java.util.Collection<Long> list) {
         long[] ar = new long[list.size()];
         int i = 0;
         for (long l : list) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
@@ -32,7 +32,6 @@ import com.ichi2.libanki.Storage;
 import com.ichi2.libanki.Utils;
 import com.ichi2.libanki.DeckConfig;
 import com.ichi2.libanki.Deck;
-import com.ichi2.utils.JSONObject;
 
 import java.io.BufferedInputStream;
 import java.io.ByteArrayOutputStream;
@@ -308,7 +307,7 @@ public class Anki2Importer extends Importer {
                 // add to col partially, so as to avoid OOM
                 if (dirty.size() >= thresExecDirty) {
                     totalDirtyCount  += dirty.size();
-                    long[] das = Utils.arrayList2array(dirty);
+                    long[] das = Utils.collection2Array(dirty);
                     mDst.updateFieldCache(das);
                     mDst.getTags().registerNotes(das);
                     dirty.clear();
@@ -356,7 +355,7 @@ public class Anki2Importer extends Importer {
             }
         }
 
-        long[] das = Utils.arrayList2array(dirty);
+        long[] das = Utils.collection2Array(dirty);
         mDst.updateFieldCache(das);
         mDst.getTags().registerNotes(das);
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -627,7 +627,7 @@ public class Sched extends SchedV2 {
                 ", usn = ?, odue = 0 where queue IN (" + Consts.QUEUE_TYPE_LRN + "," + Consts.QUEUE_TYPE_DAY_LEARN_RELEARN + ") and type = " + Consts.CARD_TYPE_REV + " " + extra,
                 Utils.intTime(), mCol.usn());
         // new cards in learning
-        forgetCards(Utils.arrayList2array(mCol.getDb().queryLongList("SELECT id FROM cards WHERE queue IN (" + Consts.QUEUE_TYPE_LRN + "," + Consts.QUEUE_TYPE_DAY_LEARN_RELEARN + ") " + extra)));
+        forgetCards(Utils.collection2Array(mCol.getDb().queryLongList( "SELECT id FROM cards WHERE queue IN (" + Consts.QUEUE_TYPE_LRN + "," + Consts.QUEUE_TYPE_DAY_LEARN_RELEARN + ") " + extra)));
     }
 
     private int _lrnForDeck(long did) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -2340,7 +2340,7 @@ public class SchedV2 extends AbstractSched {
      * @param nid The id of the targeted note.
      */
     public void buryNote(long nid) {
-        long[] cids = Utils.arrayList2array(mCol.getDb().queryLongList(
+        long[] cids = Utils.collection2Array(mCol.getDb().queryLongList(
                 "SELECT id FROM cards WHERE nid = ? AND queue >= " + Consts.CARD_TYPE_NEW, nid));
         buryCards(cids);
     }
@@ -2389,7 +2389,7 @@ public class SchedV2 extends AbstractSched {
         }
         // then bury
         if (!toBury.isEmpty()) {
-            buryCards(Utils.arrayList2array(toBury),false);
+            buryCards(Utils.collection2Array(toBury),false);
         }
     }
 
@@ -2438,7 +2438,7 @@ public class SchedV2 extends AbstractSched {
      * Completely reset cards for export.
      */
     public void resetCards(Long[] ids) {
-        long[] nonNew = Utils.arrayList2array(mCol.getDb().queryLongList(
+        long[] nonNew = Utils.collection2Array(mCol.getDb().queryLongList(
                 "select id from cards where id in " + Utils.ids2str(ids) + " and (queue != " + Consts.QUEUE_TYPE_NEW + " or type != " + Consts.CARD_TYPE_NEW + ")"));
         mCol.getDb().execute("update cards set reps=0, lapses=0 where id in " + Utils.ids2str(nonNew));
         forgetCards(nonNew);
@@ -2582,7 +2582,7 @@ public class SchedV2 extends AbstractSched {
 
 
         // remove new cards from learning
-        forgetCards(Utils.arrayList2array(mCol.getDb().queryLongList("select id from cards where queue in (" + Consts.QUEUE_TYPE_LRN + "," + Consts.QUEUE_TYPE_DAY_LEARN_RELEARN + ")")));
+        forgetCards(Utils.collection2Array(mCol.getDb().queryLongList("select id from cards where queue in (" + Consts.QUEUE_TYPE_LRN + "," + Consts.QUEUE_TYPE_DAY_LEARN_RELEARN + ")")));
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/stats/Stats.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/stats/Stats.java
@@ -1302,7 +1302,7 @@ public class Stats {
             for (Deck d : col.getDecks().all()) {
                 ids.add(d.getLong("id"));
             }
-            return Utils.ids2str(Utils.arrayList2array(ids));
+            return Utils.ids2str(Utils.collection2Array(ids));
         } else {
             // The given deck id and its children
             ArrayList<Long> ids = new ArrayList<>();

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.java
@@ -657,7 +657,7 @@ public class Syncer {
         boolean wasServer = mCol.getServer();
         mCol.setServer(true);
         // notes first, so we don't end up with duplicate graves
-        mCol._remNotes(Utils.jsonArrayToLongArray(graves.getJSONArray("notes")));
+        mCol._remNotes(Utils.jsonArrayToLongList(graves.getJSONArray("notes")));
         // then cards
         mCol.remCards(Utils.jsonArrayToLongList(graves.getJSONArray("cards")), false);
         // and decks

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.java
@@ -659,7 +659,7 @@ public class Syncer {
         // notes first, so we don't end up with duplicate graves
         mCol._remNotes(Utils.jsonArrayToLongArray(graves.getJSONArray("notes")));
         // then cards
-        mCol.remCards(Utils.jsonArrayToLongArray(graves.getJSONArray("cards")), false);
+        mCol.remCards(Utils.jsonArrayToLongList(graves.getJSONArray("cards")), false);
         // and decks
         JSONArray decks = graves.getJSONArray("decks");
         for (int i = 0; i < decks.length(); i++) {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
@@ -23,6 +23,7 @@ import org.robolectric.android.controller.ActivityController;
 import org.robolectric.shadows.ShadowActivity;
 import org.robolectric.shadows.ShadowApplication;
 
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -346,7 +347,7 @@ public class CardBrowserTest extends RobolectricTest {
     }
 
     private void removeCardFromCollection(Long cardId) {
-        getCol().remCards(new long[] { cardId });
+        getCol().remCards(Arrays.asList(new Long[] {cardId}));
     }
 
     @CheckReturnValue


### PR DESCRIPTION
Upstream did rename `remCards` to `remove_cards_and_orphaned_notes`. I follow the name change; mainly because it's far easier to port upstream test if I can stay as close as possible to them and uses the same function name.

While looking at this method, I realized that it was inefficient, and led to a lot of useless code written. The main problem is that it used to take an array of long, and that we essentially do not uses array in this code. So I changed it to uses a list of long, which allows to removes a 18 conversions from list to array. 

I renamed `arrayList2array` to `collectionOfLong2array`, because the method can work on any collection, and I actually wanted to apply it to a collection which is not a list. Similarly ids2str accepts any iterable and not only list.