### PR TITLE
NF: dupeOrEmpty returns an enum

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1462,9 +1462,9 @@ public class NoteEditor extends AnkiActivity {
         // Update the field in the Note so we can run a dupe check on it.
         updateField(field);
         // 1 is empty, 2 is dupe, null is neither.
-        Integer dupeCode = mEditorNote.dupeOrEmpty();
+        Note.DupeOrEmpty dupeCode = mEditorNote.dupeOrEmpty();
         // Change bottom line color of text field
-        if (dupeCode != null && dupeCode == 2) {
+        if (dupeCode != null && dupeCode == Note.DupeOrEmpty.DUPE) {
             field.setDupeStyle();
         } else {
             field.setDefaultStyle();

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Note.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Note.java
@@ -265,14 +265,19 @@ public class Note implements Cloneable {
      * ***********************************************************
      */
 
+    public enum DupeOrEmpty {
+        CORRECT,
+        EMPTY,
+        DUPE,
+    }
     /**
      * 
-     * @return 1 if first is empty; 2 if first is a duplicate, null otherwise.
+     * @return whether it has no content, dupe first field, or nothing remarkable.
      */
-    public Integer dupeOrEmpty() {
+    public DupeOrEmpty dupeOrEmpty() {
         String val = mFields[0];
         if (val.trim().length() == 0) {
-            return 1;
+            return DupeOrEmpty.EMPTY;
         }
         long csum = Utils.fieldChecksum(val);
         // find any matching csums and compare
@@ -282,10 +287,10 @@ public class Note implements Cloneable {
                 0, new Object[] {csum, (mId != 0 ? mId : 0), mMid})) {
             if (Utils.stripHTMLMedia(
                     Utils.splitFields(flds)[0]).equals(Utils.stripHTMLMedia(mFields[0]))) {
-                return 2;
+                return DupeOrEmpty.DUPE;
             }
         }
-        return null;
+        return DupeOrEmpty.CORRECT;
     }
 
 


### PR DESCRIPTION
I expect it to make upstream tests more clear. The actual unit test just tests whether dupeorempty return a truthy value, but since Java does not allow `if (n)` for `n` an integer, at least, test will be readable