### PR TITLE
Database: Replace "queryColumn" with "list" methods

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/ImportTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/ImportTest.java
@@ -105,7 +105,7 @@ public class ImportTest {
         actual.retainAll(expected);
         assertEquals(expected.size(), actual.size());
         // and importing again will not duplicate, as the file content matches
-        empty.remCards(Utils.arrayList2array(empty.getDb().queryColumn(Long.class, "select id from cards", 0)));
+        empty.remCards(Utils.arrayList2array(empty.getDb().queryColumn(Long.class, "select id from cards")));
         imp = new Anki2Importer(empty, testCol.getPath());
         imp.run();
         expected = Collections.singletonList("foo.mp3");
@@ -115,7 +115,7 @@ public class ImportTest {
         n = empty.getNote(empty.getDb().queryLongScalar("select id from notes"));
         assertTrue(n.getFields()[0].contains("foo.mp3"));
         // if the local file content is different, and import should trigger a rename
-        empty.remCards(Utils.arrayList2array(empty.getDb().queryColumn(Long.class, "select id from cards", 0)));
+        empty.remCards(Utils.arrayList2array(empty.getDb().queryColumn(Long.class, "select id from cards")));
         os = new FileOutputStream(new File(empty.getMedia().dir(), "foo.mp3"), false);
         os.write("bar".getBytes());
         os.close();
@@ -128,7 +128,7 @@ public class ImportTest {
         n = empty.getNote(empty.getDb().queryLongScalar("select id from notes"));
         assertTrue(n.getFields()[0].contains("_"));
         // if the localized media file already exists, we rewrite the note and media
-        empty.remCards(Utils.arrayList2array(empty.getDb().queryColumn(Long.class, "select id from cards", 0)));
+        empty.remCards(Utils.arrayList2array(empty.getDb().queryColumn(Long.class, "select id from cards")));
         os = new FileOutputStream(new File(empty.getMedia().dir(), "foo.mp3"));
         os.write("bar".getBytes());
         os.close();
@@ -160,7 +160,7 @@ public class ImportTest {
         actual.retainAll(expected);
         assertEquals(expected.size(), actual.size());
         // import again should be idempotent in terms of media
-        testCol.remCards(Utils.arrayList2array(testCol.getDb().queryColumn(Long.class, "select id from cards", 0)));
+        testCol.remCards(Utils.arrayList2array(testCol.getDb().queryColumn(Long.class, "select id from cards")));
         imp = new AnkiPackageImporter(testCol, apkg);
         imp.run();
         expected = Collections.singletonList("foo.wav");
@@ -168,7 +168,7 @@ public class ImportTest {
         actual.retainAll(expected);
         assertEquals(expected.size(), actual.size());
         // but if the local file has different data, it will rename
-        testCol.remCards(Utils.arrayList2array(testCol.getDb().queryColumn(Long.class, "select id from cards", 0)));
+        testCol.remCards(Utils.arrayList2array(testCol.getDb().queryColumn(Long.class, "select id from cards")));
         FileOutputStream os;
         os = new FileOutputStream(new File(testCol.getMedia().dir(), "foo.wav"), false);
         os.write("xyz".getBytes());

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/ImportTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/ImportTest.java
@@ -105,7 +105,7 @@ public class ImportTest {
         actual.retainAll(expected);
         assertEquals(expected.size(), actual.size());
         // and importing again will not duplicate, as the file content matches
-        empty.remCards(Utils.arrayList2array(empty.getDb().queryColumn(Long.class, "select id from cards")));
+        empty.remCards(Utils.arrayList2array(empty.getDb().list(Long.class, "select id from cards")));
         imp = new Anki2Importer(empty, testCol.getPath());
         imp.run();
         expected = Collections.singletonList("foo.mp3");
@@ -115,7 +115,7 @@ public class ImportTest {
         n = empty.getNote(empty.getDb().queryLongScalar("select id from notes"));
         assertTrue(n.getFields()[0].contains("foo.mp3"));
         // if the local file content is different, and import should trigger a rename
-        empty.remCards(Utils.arrayList2array(empty.getDb().queryColumn(Long.class, "select id from cards")));
+        empty.remCards(Utils.arrayList2array(empty.getDb().list(Long.class, "select id from cards")));
         os = new FileOutputStream(new File(empty.getMedia().dir(), "foo.mp3"), false);
         os.write("bar".getBytes());
         os.close();
@@ -128,7 +128,7 @@ public class ImportTest {
         n = empty.getNote(empty.getDb().queryLongScalar("select id from notes"));
         assertTrue(n.getFields()[0].contains("_"));
         // if the localized media file already exists, we rewrite the note and media
-        empty.remCards(Utils.arrayList2array(empty.getDb().queryColumn(Long.class, "select id from cards")));
+        empty.remCards(Utils.arrayList2array(empty.getDb().list(Long.class, "select id from cards")));
         os = new FileOutputStream(new File(empty.getMedia().dir(), "foo.mp3"));
         os.write("bar".getBytes());
         os.close();
@@ -160,7 +160,7 @@ public class ImportTest {
         actual.retainAll(expected);
         assertEquals(expected.size(), actual.size());
         // import again should be idempotent in terms of media
-        testCol.remCards(Utils.arrayList2array(testCol.getDb().queryColumn(Long.class, "select id from cards")));
+        testCol.remCards(Utils.arrayList2array(testCol.getDb().list(Long.class, "select id from cards")));
         imp = new AnkiPackageImporter(testCol, apkg);
         imp.run();
         expected = Collections.singletonList("foo.wav");
@@ -168,7 +168,7 @@ public class ImportTest {
         actual.retainAll(expected);
         assertEquals(expected.size(), actual.size());
         // but if the local file has different data, it will rename
-        testCol.remCards(Utils.arrayList2array(testCol.getDb().queryColumn(Long.class, "select id from cards")));
+        testCol.remCards(Utils.arrayList2array(testCol.getDb().list(Long.class, "select id from cards")));
         FileOutputStream os;
         os = new FileOutputStream(new File(testCol.getMedia().dir(), "foo.wav"), false);
         os.write("xyz".getBytes());

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/ImportTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/ImportTest.java
@@ -105,7 +105,7 @@ public class ImportTest {
         actual.retainAll(expected);
         assertEquals(expected.size(), actual.size());
         // and importing again will not duplicate, as the file content matches
-        empty.remCards(Utils.arrayList2array(empty.getDb().list(Long.class, "select id from cards")));
+        empty.remCards(Utils.arrayList2array(empty.getDb().queryLongList("select id from cards")));
         imp = new Anki2Importer(empty, testCol.getPath());
         imp.run();
         expected = Collections.singletonList("foo.mp3");
@@ -115,7 +115,7 @@ public class ImportTest {
         n = empty.getNote(empty.getDb().queryLongScalar("select id from notes"));
         assertTrue(n.getFields()[0].contains("foo.mp3"));
         // if the local file content is different, and import should trigger a rename
-        empty.remCards(Utils.arrayList2array(empty.getDb().list(Long.class, "select id from cards")));
+        empty.remCards(Utils.arrayList2array(empty.getDb().queryLongList("select id from cards")));
         os = new FileOutputStream(new File(empty.getMedia().dir(), "foo.mp3"), false);
         os.write("bar".getBytes());
         os.close();
@@ -128,7 +128,7 @@ public class ImportTest {
         n = empty.getNote(empty.getDb().queryLongScalar("select id from notes"));
         assertTrue(n.getFields()[0].contains("_"));
         // if the localized media file already exists, we rewrite the note and media
-        empty.remCards(Utils.arrayList2array(empty.getDb().list(Long.class, "select id from cards")));
+        empty.remCards(Utils.arrayList2array(empty.getDb().queryLongList("select id from cards")));
         os = new FileOutputStream(new File(empty.getMedia().dir(), "foo.mp3"));
         os.write("bar".getBytes());
         os.close();
@@ -160,7 +160,7 @@ public class ImportTest {
         actual.retainAll(expected);
         assertEquals(expected.size(), actual.size());
         // import again should be idempotent in terms of media
-        testCol.remCards(Utils.arrayList2array(testCol.getDb().list(Long.class, "select id from cards")));
+        testCol.remCards(Utils.arrayList2array(testCol.getDb().queryLongList("select id from cards")));
         imp = new AnkiPackageImporter(testCol, apkg);
         imp.run();
         expected = Collections.singletonList("foo.wav");
@@ -168,7 +168,7 @@ public class ImportTest {
         actual.retainAll(expected);
         assertEquals(expected.size(), actual.size());
         // but if the local file has different data, it will rename
-        testCol.remCards(Utils.arrayList2array(testCol.getDb().list(Long.class, "select id from cards")));
+        testCol.remCards(Utils.arrayList2array(testCol.getDb().queryLongList("select id from cards")));
         FileOutputStream os;
         os = new FileOutputStream(new File(testCol.getMedia().dir(), "foo.wav"), false);
         os.write("xyz".getBytes());

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/MediaTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/MediaTest.java
@@ -183,12 +183,11 @@ public class MediaTest {
     }
 
     private List<String> added(Collection d) {
-
-        return d.getMedia().getDb().list(String.class, "select fname from media where csum is not null");
+        return d.getMedia().getDb().queryStringList("select fname from media where csum is not null");
     }
 
     private List<String> removed(Collection d) {
-        return d.getMedia().getDb().list(String.class, "select fname from media where csum is null");
+        return d.getMedia().getDb().queryStringList("select fname from media where csum is null");
     }
 
     @Test

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/MediaTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/MediaTest.java
@@ -183,11 +183,11 @@ public class MediaTest {
     }
 
     private List<String> added(Collection d) {
-        return d.getMedia().getDb().queryColumn(String.class, "select fname from media where csum is not null", 0);
+        return d.getMedia().getDb().queryColumn(String.class, "select fname from media where csum is not null");
     }
 
     private List<String> removed(Collection d) {
-        return d.getMedia().getDb().queryColumn(String.class, "select fname from media where csum is null", 0);
+        return d.getMedia().getDb().queryColumn(String.class, "select fname from media where csum is null");
     }
 
     @Test

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/MediaTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/MediaTest.java
@@ -183,11 +183,12 @@ public class MediaTest {
     }
 
     private List<String> added(Collection d) {
-        return d.getMedia().getDb().queryColumn(String.class, "select fname from media where csum is not null");
+
+        return d.getMedia().getDb().list(String.class, "select fname from media where csum is not null");
     }
 
     private List<String> removed(Collection d) {
-        return d.getMedia().getDb().queryColumn(String.class, "select fname from media where csum is null");
+        return d.getMedia().getDb().list(String.class, "select fname from media where csum is null");
     }
 
     @Test

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.java
@@ -64,7 +64,7 @@ class Exporter {
     public Long[] cardIds() {
         Long[] cids;
         if (mDid == null) {
-            cids = Utils.list2ObjectArray(mCol.getDb().queryColumn(Long.class, "select id from cards", 0));
+            cids = Utils.list2ObjectArray(mCol.getDb().queryColumn(Long.class, "select id from cards"));
         } else {
             cids = mCol.getDecks().cids(mDid, true);
         }
@@ -120,7 +120,7 @@ class AnkiExporter extends Exporter {
         mSrc.getDb().getDatabase()
                 .execSQL("INSERT INTO DST_DB.cards select * from cards where id in " + Utils.ids2str(cids));
         Set<Long> nids = new HashSet<>(mSrc.getDb().queryColumn(Long.class,
-                "select nid from cards where id in " + Utils.ids2str(cids), 0));
+                "select nid from cards where id in " + Utils.ids2str(cids)));
         // notes
         Timber.d("Copy notes");
         ArrayList<Long> uniqueNids = new ArrayList<>(nids);
@@ -130,7 +130,7 @@ class AnkiExporter extends Exporter {
         if (!mIncludeSched) {
             Timber.d("Stripping system tags from list");
             ArrayList<String> srcTags = mSrc.getDb().queryColumn(String.class,
-                    "select tags from notes where id in " + strnids, 0);
+                    "select tags from notes where id in " + strnids);
             ArrayList<Object[]> args = new ArrayList<>(srcTags.size());
             Object [] arg = new Object[2];
             for (int row = 0; row < srcTags.size(); row++) {
@@ -143,7 +143,7 @@ class AnkiExporter extends Exporter {
         // models used by the notes
         Timber.d("Finding models used by notes");
         ArrayList<Long> mids = mSrc.getDb().queryColumn(Long.class,
-                "select distinct mid from DST_DB.notes where id in " + strnids, 0);
+                "select distinct mid from DST_DB.notes where id in " + strnids);
         // card history and revlog
         if (mIncludeSched) {
             Timber.d("Copy history and revlog");
@@ -210,10 +210,9 @@ class AnkiExporter extends Exporter {
         JSONObject media = new JSONObject();
         mMediaDir = mSrc.getMedia().dir();
         if (mIncludeMedia) {
-            ArrayList<Long> mid = mSrc.getDb().queryColumn(Long.class, "select mid from notes where id in " + strnids,
-                    0);
+            ArrayList<Long> mid = mSrc.getDb().queryColumn(Long.class, "select mid from notes where id in " + strnids);
             ArrayList<String> flds = mSrc.getDb().queryColumn(String.class,
-                    "select flds from notes where id in " + strnids, 0);
+                    "select flds from notes where id in " + strnids);
             for (int idx = 0; idx < mid.size(); idx++) {
                 for (String file : mSrc.getMedia().filesInStr(mid.get(idx), flds.get(idx))) {
                     // skip files in subdirs

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.java
@@ -64,7 +64,7 @@ class Exporter {
     public Long[] cardIds() {
         Long[] cids;
         if (mDid == null) {
-            cids = Utils.list2ObjectArray(mCol.getDb().queryColumn(Long.class, "select id from cards"));
+            cids = Utils.list2ObjectArray(mCol.getDb().list(Long.class, "select id from cards"));
         } else {
             cids = mCol.getDecks().cids(mDid, true);
         }
@@ -119,7 +119,7 @@ class AnkiExporter extends Exporter {
         Timber.d("Copy cards");
         mSrc.getDb().getDatabase()
                 .execSQL("INSERT INTO DST_DB.cards select * from cards where id in " + Utils.ids2str(cids));
-        Set<Long> nids = new HashSet<>(mSrc.getDb().queryColumn(Long.class,
+        Set<Long> nids = new HashSet<>(mSrc.getDb().list(Long.class,
                 "select nid from cards where id in " + Utils.ids2str(cids)));
         // notes
         Timber.d("Copy notes");
@@ -129,7 +129,7 @@ class AnkiExporter extends Exporter {
         // remove system tags if not exporting scheduling info
         if (!mIncludeSched) {
             Timber.d("Stripping system tags from list");
-            ArrayList<String> srcTags = mSrc.getDb().queryColumn(String.class,
+            ArrayList<String> srcTags = mSrc.getDb().list(String.class,
                     "select tags from notes where id in " + strnids);
             ArrayList<Object[]> args = new ArrayList<>(srcTags.size());
             Object [] arg = new Object[2];
@@ -142,7 +142,7 @@ class AnkiExporter extends Exporter {
         }
         // models used by the notes
         Timber.d("Finding models used by notes");
-        ArrayList<Long> mids = mSrc.getDb().queryColumn(Long.class,
+        ArrayList<Long> mids = mSrc.getDb().list(Long.class,
                 "select distinct mid from DST_DB.notes where id in " + strnids);
         // card history and revlog
         if (mIncludeSched) {
@@ -210,8 +210,8 @@ class AnkiExporter extends Exporter {
         JSONObject media = new JSONObject();
         mMediaDir = mSrc.getMedia().dir();
         if (mIncludeMedia) {
-            ArrayList<Long> mid = mSrc.getDb().queryColumn(Long.class, "select mid from notes where id in " + strnids);
-            ArrayList<String> flds = mSrc.getDb().queryColumn(String.class,
+            ArrayList<Long> mid = mSrc.getDb().list(Long.class, "select mid from notes where id in " + strnids);
+            ArrayList<String> flds = mSrc.getDb().list(String.class,
                     "select flds from notes where id in " + strnids);
             for (int idx = 0; idx < mid.size(); idx++) {
                 for (String file : mSrc.getMedia().filesInStr(mid.get(idx), flds.get(idx))) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.java
@@ -64,7 +64,7 @@ class Exporter {
     public Long[] cardIds() {
         Long[] cids;
         if (mDid == null) {
-            cids = Utils.list2ObjectArray(mCol.getDb().list(Long.class, "select id from cards"));
+            cids = Utils.list2ObjectArray(mCol.getDb().queryLongList("select id from cards"));
         } else {
             cids = mCol.getDecks().cids(mDid, true);
         }
@@ -119,7 +119,7 @@ class AnkiExporter extends Exporter {
         Timber.d("Copy cards");
         mSrc.getDb().getDatabase()
                 .execSQL("INSERT INTO DST_DB.cards select * from cards where id in " + Utils.ids2str(cids));
-        Set<Long> nids = new HashSet<>(mSrc.getDb().list(Long.class,
+        Set<Long> nids = new HashSet<>(mSrc.getDb().queryLongList(
                 "select nid from cards where id in " + Utils.ids2str(cids)));
         // notes
         Timber.d("Copy notes");
@@ -129,7 +129,7 @@ class AnkiExporter extends Exporter {
         // remove system tags if not exporting scheduling info
         if (!mIncludeSched) {
             Timber.d("Stripping system tags from list");
-            ArrayList<String> srcTags = mSrc.getDb().list(String.class,
+            ArrayList<String> srcTags = mSrc.getDb().queryStringList(
                     "select tags from notes where id in " + strnids);
             ArrayList<Object[]> args = new ArrayList<>(srcTags.size());
             Object [] arg = new Object[2];
@@ -142,7 +142,7 @@ class AnkiExporter extends Exporter {
         }
         // models used by the notes
         Timber.d("Finding models used by notes");
-        ArrayList<Long> mids = mSrc.getDb().list(Long.class,
+        ArrayList<Long> mids = mSrc.getDb().queryLongList(
                 "select distinct mid from DST_DB.notes where id in " + strnids);
         // card history and revlog
         if (mIncludeSched) {
@@ -210,8 +210,8 @@ class AnkiExporter extends Exporter {
         JSONObject media = new JSONObject();
         mMediaDir = mSrc.getMedia().dir();
         if (mIncludeMedia) {
-            ArrayList<Long> mid = mSrc.getDb().list(Long.class, "select mid from notes where id in " + strnids);
-            ArrayList<String> flds = mSrc.getDb().list(String.class,
+            ArrayList<Long> mid = mSrc.getDb().queryLongList("select mid from notes where id in " + strnids);
+            ArrayList<String> flds = mSrc.getDb().queryStringList(
                     "select flds from notes where id in " + strnids);
             for (int idx = 0; idx < mid.size(); idx++) {
                 for (String file : mSrc.getMedia().filesInStr(mid.get(idx), flds.get(idx))) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -586,7 +586,7 @@ public class Collection {
 
     public void remNotes(long[] ids) {
         ArrayList<Long> list = mDb
-                .queryColumn(Long.class, "SELECT id FROM cards WHERE nid IN " + Utils.ids2str(ids), 0);
+                .queryColumn(Long.class, "SELECT id FROM cards WHERE nid IN " + Utils.ids2str(ids));
         long[] cids = new long[list.size()];
         int i = 0;
         for (long l : list) {
@@ -927,7 +927,7 @@ public class Collection {
         }
         String sids = Utils.ids2str(ids);
         long[] nids = Utils
-                .arrayList2array(mDb.queryColumn(Long.class, "SELECT nid FROM cards WHERE id IN " + sids, 0));
+                .arrayList2array(mDb.queryColumn(Long.class, "SELECT nid FROM cards WHERE id IN " + sids));
         // remove cards
         _logRem(ids, Consts.REM_CARD);
         mDb.execute("DELETE FROM cards WHERE id IN " + sids);
@@ -937,7 +937,7 @@ public class Collection {
         }
         nids = Utils
                 .arrayList2array(mDb.queryColumn(Long.class, "SELECT id FROM notes WHERE id IN " + Utils.ids2str(nids)
-                        + " AND id NOT IN (SELECT nid FROM cards)", 0));
+                        + " AND id NOT IN (SELECT nid FROM cards)"));
         _remNotes(nids);
     }
 
@@ -1462,8 +1462,7 @@ public class Collection {
         ArrayList<Long> cardIds = mDb.queryColumn(Long.class, "select id from cards where did in " +
                 Utils.ids2str(dynDeckIds) +
                 "and odid in " +
-                Utils.ids2str(dynIdsAndZero)
-                , 0);
+                Utils.ids2str(dynIdsAndZero));
 
         notifyProgress.run();
 
@@ -1556,7 +1555,7 @@ public class Collection {
         ArrayList<String> problems = new ArrayList<>();
         notifyProgress.run();
         // reviews should have a reasonable due #
-        ArrayList<Long> ids = mDb.queryColumn(Long.class, "SELECT id FROM cards WHERE queue = " + Consts.QUEUE_TYPE_REV + " AND due > 100000", 0);
+        ArrayList<Long> ids = mDb.queryColumn(Long.class, "SELECT id FROM cards WHERE queue = " + Consts.QUEUE_TYPE_REV + " AND due > 100000");
         notifyProgress.run();
         if (ids.size() > 0) {
             problems.add("Reviews had incorrect due date.");
@@ -1642,7 +1641,7 @@ public class Collection {
         notifyProgress.run();
         // cards with odid set when not in a dyn deck
         ArrayList<Long> ids = mDb.queryColumn(Long.class,
-                "select id from cards where odid > 0 and did in " + Utils.ids2str(dids), 0);
+                "select id from cards where odid > 0 and did in " + Utils.ids2str(dids));
         notifyProgress.run();
         if (ids.size() != 0) {
             problems.add("Fixed " + ids.size() + " card(s) with invalid properties.");
@@ -1658,7 +1657,7 @@ public class Collection {
         notifyProgress.run();
         // cards with odue set when it shouldn't be
         ArrayList<Long> ids = mDb.queryColumn(Long.class,
-                "select id from cards where odue > 0 and (type= " + Consts.CARD_TYPE_LRN + " or queue=" + Consts.QUEUE_TYPE_REV + ") and not odid", 0);
+                "select id from cards where odue > 0 and (type= " + Consts.CARD_TYPE_LRN + " or queue=" + Consts.QUEUE_TYPE_REV + ") and not odid");
         notifyProgress.run();
         if (ids.size() != 0) {
             problems.add("Fixed " + ids.size() + " card(s) with invalid properties.");
@@ -1674,7 +1673,7 @@ public class Collection {
         ArrayList<Long> ids;// cards with missing notes
         notifyProgress.run();
         ids = mDb.queryColumn(Long.class,
-                "SELECT id FROM cards WHERE nid NOT IN (SELECT id FROM notes)", 0);
+                "SELECT id FROM cards WHERE nid NOT IN (SELECT id FROM notes)");
         notifyProgress.run();
         if (ids.size() != 0) {
             problems.add("Deleted " + ids.size() + " card(s) with missing note.");
@@ -1691,7 +1690,7 @@ public class Collection {
         notifyProgress.run();
         // delete any notes with missing cards
         ids = mDb.queryColumn(Long.class,
-                "SELECT id FROM notes WHERE id NOT IN (SELECT DISTINCT nid FROM cards)", 0);
+                "SELECT id FROM notes WHERE id NOT IN (SELECT DISTINCT nid FROM cards)");
         notifyProgress.run();
         if (ids.size() != 0) {
             problems.add("Deleted " + ids.size() + " note(s) with missing no cards.");
@@ -1770,7 +1769,7 @@ public class Collection {
             // cards with invalid ordinal
             ArrayList<Long> ids = mDb.queryColumn(Long.class,
                     "SELECT id FROM cards WHERE ord NOT IN " + Utils.ids2str(ords) + " AND nid IN ( " +
-                            "SELECT id FROM notes WHERE mid = ?)", 0, new Object[] {m.getLong("id")});
+                            "SELECT id FROM notes WHERE mid = ?)", new Object[] {m.getLong("id")});
             if (ids.size() > 0) {
                 problems.add("Deleted " + ids.size() + " card(s) with missing template.");
                 remCards(Utils.arrayList2array(ids));
@@ -1786,7 +1785,7 @@ public class Collection {
         // note types with a missing model
         notifyProgress.run();
         ArrayList<Long> ids = mDb.queryColumn(Long.class,
-                "SELECT id FROM notes WHERE mid NOT IN " + Utils.ids2str(getModels().ids()), 0);
+                "SELECT id FROM notes WHERE mid NOT IN " + Utils.ids2str(getModels().ids()));
         notifyProgress.run();
         if (ids.size() != 0) {
             problems.add("Deleted " + ids.size() + " note(s) with missing note type.");

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -586,7 +586,7 @@ public class Collection {
 
     public void remNotes(long[] ids) {
         ArrayList<Long> list = mDb
-                .list(Long.class, "SELECT id FROM cards WHERE nid IN " + Utils.ids2str(ids));
+                .queryLongList("SELECT id FROM cards WHERE nid IN " + Utils.ids2str(ids));
         long[] cids = new long[list.size()];
         int i = 0;
         for (long l : list) {
@@ -927,7 +927,7 @@ public class Collection {
         }
         String sids = Utils.ids2str(ids);
         long[] nids = Utils
-                .arrayList2array(mDb.list(Long.class, "SELECT nid FROM cards WHERE id IN " + sids));
+                .arrayList2array(mDb.queryLongList("SELECT nid FROM cards WHERE id IN " + sids));
         // remove cards
         _logRem(ids, Consts.REM_CARD);
         mDb.execute("DELETE FROM cards WHERE id IN " + sids);
@@ -936,7 +936,7 @@ public class Collection {
         	return;
         }
         nids = Utils
-                .arrayList2array(mDb.list(Long.class, "SELECT id FROM notes WHERE id IN " + Utils.ids2str(nids)
+                .arrayList2array(mDb.queryLongList("SELECT id FROM notes WHERE id IN " + Utils.ids2str(nids)
                         + " AND id NOT IN (SELECT nid FROM cards)"));
         _remNotes(nids);
     }
@@ -1459,7 +1459,7 @@ public class Collection {
         List<Long> dynIdsAndZero = new ArrayList<>(Arrays.asList(dynDeckIds));
         dynIdsAndZero.add(0L);
 
-        ArrayList<Long> cardIds = mDb.list(Long.class, "select id from cards where did in " +
+        ArrayList<Long> cardIds = mDb.queryLongList("select id from cards where did in " +
                 Utils.ids2str(dynDeckIds) +
                 "and odid in " +
                 Utils.ids2str(dynIdsAndZero));
@@ -1555,7 +1555,7 @@ public class Collection {
         ArrayList<String> problems = new ArrayList<>();
         notifyProgress.run();
         // reviews should have a reasonable due #
-        ArrayList<Long> ids = mDb.list(Long.class, "SELECT id FROM cards WHERE queue = " + Consts.QUEUE_TYPE_REV + " AND due > 100000");
+        ArrayList<Long> ids = mDb.queryLongList("SELECT id FROM cards WHERE queue = " + Consts.QUEUE_TYPE_REV + " AND due > 100000");
         notifyProgress.run();
         if (ids.size() > 0) {
             problems.add("Reviews had incorrect due date.");
@@ -1640,7 +1640,7 @@ public class Collection {
         }
         notifyProgress.run();
         // cards with odid set when not in a dyn deck
-        ArrayList<Long> ids = mDb.list(Long.class,
+        ArrayList<Long> ids = mDb.queryLongList(
                 "select id from cards where odid > 0 and did in " + Utils.ids2str(dids));
         notifyProgress.run();
         if (ids.size() != 0) {
@@ -1656,7 +1656,7 @@ public class Collection {
         ArrayList<String> problems = new ArrayList<>();
         notifyProgress.run();
         // cards with odue set when it shouldn't be
-        ArrayList<Long> ids = mDb.list(Long.class,
+        ArrayList<Long> ids = mDb.queryLongList(
                 "select id from cards where odue > 0 and (type= " + Consts.CARD_TYPE_LRN + " or queue=" + Consts.QUEUE_TYPE_REV + ") and not odid");
         notifyProgress.run();
         if (ids.size() != 0) {
@@ -1672,7 +1672,7 @@ public class Collection {
         ArrayList<String> problems = new ArrayList<>();
         ArrayList<Long> ids;// cards with missing notes
         notifyProgress.run();
-        ids = mDb.list(Long.class,
+        ids = mDb.queryLongList(
                 "SELECT id FROM cards WHERE nid NOT IN (SELECT id FROM notes)");
         notifyProgress.run();
         if (ids.size() != 0) {
@@ -1689,7 +1689,7 @@ public class Collection {
         ArrayList<Long> ids;
         notifyProgress.run();
         // delete any notes with missing cards
-        ids = mDb.list(Long.class,
+        ids = mDb.queryLongList(
                 "SELECT id FROM notes WHERE id NOT IN (SELECT DISTINCT nid FROM cards)");
         notifyProgress.run();
         if (ids.size() != 0) {
@@ -1767,7 +1767,7 @@ public class Collection {
                 ords.add(tmpls.getJSONObject(t).getInt("ord"));
             }
             // cards with invalid ordinal
-            ArrayList<Long> ids = mDb.list(Long.class,
+            ArrayList<Long> ids = mDb.queryLongList(
                     "SELECT id FROM cards WHERE ord NOT IN " + Utils.ids2str(ords) + " AND nid IN ( " +
                             "SELECT id FROM notes WHERE mid = ?)", new Object[] {m.getLong("id")});
             if (ids.size() > 0) {
@@ -1784,7 +1784,7 @@ public class Collection {
         ArrayList<String> problems = new ArrayList<>();
         // note types with a missing model
         notifyProgress.run();
-        ArrayList<Long> ids = mDb.list(Long.class,
+        ArrayList<Long> ids = mDb.queryLongList(
                 "SELECT id FROM notes WHERE mid NOT IN " + Utils.ids2str(getModels().ids()));
         notifyProgress.run();
         if (ids.size() != 0) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -586,7 +586,7 @@ public class Collection {
 
     public void remNotes(long[] ids) {
         ArrayList<Long> list = mDb
-                .queryColumn(Long.class, "SELECT id FROM cards WHERE nid IN " + Utils.ids2str(ids));
+                .list(Long.class, "SELECT id FROM cards WHERE nid IN " + Utils.ids2str(ids));
         long[] cids = new long[list.size()];
         int i = 0;
         for (long l : list) {
@@ -927,7 +927,7 @@ public class Collection {
         }
         String sids = Utils.ids2str(ids);
         long[] nids = Utils
-                .arrayList2array(mDb.queryColumn(Long.class, "SELECT nid FROM cards WHERE id IN " + sids));
+                .arrayList2array(mDb.list(Long.class, "SELECT nid FROM cards WHERE id IN " + sids));
         // remove cards
         _logRem(ids, Consts.REM_CARD);
         mDb.execute("DELETE FROM cards WHERE id IN " + sids);
@@ -936,7 +936,7 @@ public class Collection {
         	return;
         }
         nids = Utils
-                .arrayList2array(mDb.queryColumn(Long.class, "SELECT id FROM notes WHERE id IN " + Utils.ids2str(nids)
+                .arrayList2array(mDb.list(Long.class, "SELECT id FROM notes WHERE id IN " + Utils.ids2str(nids)
                         + " AND id NOT IN (SELECT nid FROM cards)"));
         _remNotes(nids);
     }
@@ -1459,7 +1459,7 @@ public class Collection {
         List<Long> dynIdsAndZero = new ArrayList<>(Arrays.asList(dynDeckIds));
         dynIdsAndZero.add(0L);
 
-        ArrayList<Long> cardIds = mDb.queryColumn(Long.class, "select id from cards where did in " +
+        ArrayList<Long> cardIds = mDb.list(Long.class, "select id from cards where did in " +
                 Utils.ids2str(dynDeckIds) +
                 "and odid in " +
                 Utils.ids2str(dynIdsAndZero));
@@ -1555,7 +1555,7 @@ public class Collection {
         ArrayList<String> problems = new ArrayList<>();
         notifyProgress.run();
         // reviews should have a reasonable due #
-        ArrayList<Long> ids = mDb.queryColumn(Long.class, "SELECT id FROM cards WHERE queue = " + Consts.QUEUE_TYPE_REV + " AND due > 100000");
+        ArrayList<Long> ids = mDb.list(Long.class, "SELECT id FROM cards WHERE queue = " + Consts.QUEUE_TYPE_REV + " AND due > 100000");
         notifyProgress.run();
         if (ids.size() > 0) {
             problems.add("Reviews had incorrect due date.");
@@ -1640,7 +1640,7 @@ public class Collection {
         }
         notifyProgress.run();
         // cards with odid set when not in a dyn deck
-        ArrayList<Long> ids = mDb.queryColumn(Long.class,
+        ArrayList<Long> ids = mDb.list(Long.class,
                 "select id from cards where odid > 0 and did in " + Utils.ids2str(dids));
         notifyProgress.run();
         if (ids.size() != 0) {
@@ -1656,7 +1656,7 @@ public class Collection {
         ArrayList<String> problems = new ArrayList<>();
         notifyProgress.run();
         // cards with odue set when it shouldn't be
-        ArrayList<Long> ids = mDb.queryColumn(Long.class,
+        ArrayList<Long> ids = mDb.list(Long.class,
                 "select id from cards where odue > 0 and (type= " + Consts.CARD_TYPE_LRN + " or queue=" + Consts.QUEUE_TYPE_REV + ") and not odid");
         notifyProgress.run();
         if (ids.size() != 0) {
@@ -1672,7 +1672,7 @@ public class Collection {
         ArrayList<String> problems = new ArrayList<>();
         ArrayList<Long> ids;// cards with missing notes
         notifyProgress.run();
-        ids = mDb.queryColumn(Long.class,
+        ids = mDb.list(Long.class,
                 "SELECT id FROM cards WHERE nid NOT IN (SELECT id FROM notes)");
         notifyProgress.run();
         if (ids.size() != 0) {
@@ -1689,7 +1689,7 @@ public class Collection {
         ArrayList<Long> ids;
         notifyProgress.run();
         // delete any notes with missing cards
-        ids = mDb.queryColumn(Long.class,
+        ids = mDb.list(Long.class,
                 "SELECT id FROM notes WHERE id NOT IN (SELECT DISTINCT nid FROM cards)");
         notifyProgress.run();
         if (ids.size() != 0) {
@@ -1767,7 +1767,7 @@ public class Collection {
                 ords.add(tmpls.getJSONObject(t).getInt("ord"));
             }
             // cards with invalid ordinal
-            ArrayList<Long> ids = mDb.queryColumn(Long.class,
+            ArrayList<Long> ids = mDb.list(Long.class,
                     "SELECT id FROM cards WHERE ord NOT IN " + Utils.ids2str(ords) + " AND nid IN ( " +
                             "SELECT id FROM notes WHERE mid = ?)", new Object[] {m.getLong("id")});
             if (ids.size() > 0) {
@@ -1784,7 +1784,7 @@ public class Collection {
         ArrayList<String> problems = new ArrayList<>();
         // note types with a missing model
         notifyProgress.run();
-        ArrayList<Long> ids = mDb.queryColumn(Long.class,
+        ArrayList<Long> ids = mDb.list(Long.class,
                 "SELECT id FROM notes WHERE mid NOT IN " + Utils.ids2str(getModels().ids()));
         notifyProgress.run();
         if (ids.size() != 0) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DB.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DB.java
@@ -29,7 +29,6 @@ import android.widget.Toast;
 import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.CollectionHelper;
 import com.ichi2.anki.dialogs.DatabaseErrorDialog;
-import com.ichi2.compat.CompatHelper;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
@@ -231,11 +230,11 @@ public class DB {
      * @param query The SQL query statement.
      * @return An ArrayList with the contents of the specified column.
      */
-    public <T> ArrayList<T> queryColumn(Class<T> type, String query) {
-        return queryColumn(type, query, null);
+    public <T> ArrayList<T> list(Class<T> type, String query) {
+        return list(type, query, null);
     }
 
-    public <T> ArrayList<T> queryColumn(Class<T> type, String query, Object[] bindArgs) {
+    public <T> ArrayList<T> list(Class<T> type, String query, Object[] bindArgs) {
         int nullExceptionCount = 0;
         InvocationTargetException nullException = null; // to catch the null exception for reporting
         ArrayList<T> results = new ArrayList<>();

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DB.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DB.java
@@ -283,6 +283,35 @@ public class DB {
         return results;
     }
 
+    /**
+     * Convenience method for querying the database for an entire column of long. 
+     *
+     * @param type The class of the column's data type. Example: int.class, String.class.
+     * @param query The SQL query statement.
+     * @return An ArrayList with the contents of the specified column.
+     */
+    public ArrayList<Long> queryLongList(String query) {
+        return queryLongList(query, null);
+    }
+
+    public ArrayList<Long> queryLongList(String query, Object[] bindArgs) {
+        return list(Long.class, query, bindArgs);
+    }
+
+    /**
+     * Convenience method for querying the database for an entire column of String. 
+     *
+     * @param type The class of the column's data type. Example: int.class, String.class.
+     * @param query The SQL query statement.
+     * @return An ArrayList with the contents of the specified column.
+     */
+    public ArrayList<String> queryStringList(String query) {
+        return queryStringList(query, null);
+    }
+
+    public ArrayList<String> queryStringList(String query, Object[] bindArgs) {
+        return list(String.class, query, bindArgs);
+    }
 
     /**
      * Mapping of Java type names to the corresponding Cursor.get method.

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DB.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DB.java
@@ -229,14 +229,13 @@ public class DB {
      *
      * @param type The class of the column's data type. Example: int.class, String.class.
      * @param query The SQL query statement.
-     * @param column The column id in the result set to return.
      * @return An ArrayList with the contents of the specified column.
      */
-    public <T> ArrayList<T> queryColumn(Class<T> type, String query, int column) {
-        return queryColumn(type, query, column, null);
+    public <T> ArrayList<T> queryColumn(Class<T> type, String query) {
+        return queryColumn(type, query, null);
     }
 
-    public <T> ArrayList<T> queryColumn(Class<T> type, String query, int column, Object[] bindArgs) {
+    public <T> ArrayList<T> queryColumn(Class<T> type, String query, Object[] bindArgs) {
         int nullExceptionCount = 0;
         InvocationTargetException nullException = null; // to catch the null exception for reporting
         ArrayList<T> results = new ArrayList<>();
@@ -246,9 +245,9 @@ public class DB {
             while (cursor.moveToNext()) {
                 try {
                     // The magical line. Almost as illegible as python code ;)
-                    results.add(type.cast(Cursor.class.getMethod(methodName, int.class).invoke(cursor, column)));
+                    results.add(type.cast(Cursor.class.getMethod(methodName, int.class).invoke(cursor, 0)));
                 } catch (InvocationTargetException e) {
-                    if (cursor.isNull(column)) { // null value encountered
+                    if (cursor.isNull(0)) { // null value encountered
                         nullExceptionCount++;
                         if (nullExceptionCount == 1) { // Toast and error report first time only
                             nullException = e;
@@ -267,7 +266,7 @@ public class DB {
             if (nullExceptionCount > 0) {
                 if (nullException != null) {
                     StringBuilder sb = new StringBuilder();
-                    sb.append("DB.queryColumn (column ").append(column).append("): ");
+                    sb.append("DB.queryColumn (column ").append(0).append("): ");
                     sb.append("Exception due to null. Query: ").append(query);
                     sb.append(" Null occurrences during this query: ").append(nullExceptionCount);
                     AnkiDroidApp.sendExceptionReport(nullException, "queryColumn_encounteredNull", sb.toString());

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -380,7 +380,7 @@ public class Decks {
             // delete cards too?
             if (cardsToo) {
                 // don't use cids(), as we want cards in cram decks too
-                ArrayList<Long> cids = mCol.getDb().queryColumn(Long.class,
+                ArrayList<Long> cids = mCol.getDb().list(Long.class,
                                                                 "SELECT id FROM cards WHERE did = ? OR odid = ?", new Object[] {did, did});
                 mCol.remCards(Utils.arrayList2array(cids));
             }
@@ -833,14 +833,14 @@ public class Decks {
 
     public Long[] cids(long did, boolean children) {
         if (!children) {
-            return Utils.list2ObjectArray(mCol.getDb().queryColumn(Long.class, "select id from cards where did=?", new Object[] {did}));
+            return Utils.list2ObjectArray(mCol.getDb().list(Long.class, "select id from cards where did=?", new Object[] {did}));
         }
         List<Long> dids = new ArrayList<>();
         dids.add(did);
         for(Map.Entry<String, Long> entry : children(did).entrySet()) {
             dids.add(entry.getValue());
         }
-        return Utils.list2ObjectArray(mCol.getDb().queryColumn(Long.class,
+        return Utils.list2ObjectArray(mCol.getDb().list(Long.class,
                 "select id from cards where did in " + Utils.ids2str(Utils.arrayList2array(dids))));
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -381,7 +381,7 @@ public class Decks {
             if (cardsToo) {
                 // don't use cids(), as we want cards in cram decks too
                 ArrayList<Long> cids = mCol.getDb().queryColumn(Long.class,
-                                                                "SELECT id FROM cards WHERE did = ? OR odid = ?", 0, new Object[] {did, did});
+                                                                "SELECT id FROM cards WHERE did = ? OR odid = ?", new Object[] {did, did});
                 mCol.remCards(Utils.arrayList2array(cids));
             }
         }
@@ -833,7 +833,7 @@ public class Decks {
 
     public Long[] cids(long did, boolean children) {
         if (!children) {
-            return Utils.list2ObjectArray(mCol.getDb().queryColumn(Long.class, "select id from cards where did=?", 0, new Object[] {did}));
+            return Utils.list2ObjectArray(mCol.getDb().queryColumn(Long.class, "select id from cards where did=?", new Object[] {did}));
         }
         List<Long> dids = new ArrayList<>();
         dids.add(did);
@@ -841,7 +841,7 @@ public class Decks {
             dids.add(entry.getValue());
         }
         return Utils.list2ObjectArray(mCol.getDb().queryColumn(Long.class,
-                "select id from cards where did in " + Utils.ids2str(Utils.arrayList2array(dids)), 0));
+                "select id from cards where did in " + Utils.ids2str(Utils.arrayList2array(dids))));
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -380,8 +380,7 @@ public class Decks {
             // delete cards too?
             if (cardsToo) {
                 // don't use cids(), as we want cards in cram decks too
-                ArrayList<Long> cids = mCol.getDb().list(Long.class,
-                                                                "SELECT id FROM cards WHERE did = ? OR odid = ?", new Object[] {did, did});
+                ArrayList<Long> cids = mCol.getDb().queryLongList("SELECT id FROM cards WHERE did = ? OR odid = ?", new Object[] {did, did});
                 mCol.remCards(Utils.arrayList2array(cids));
             }
         }
@@ -833,15 +832,14 @@ public class Decks {
 
     public Long[] cids(long did, boolean children) {
         if (!children) {
-            return Utils.list2ObjectArray(mCol.getDb().list(Long.class, "select id from cards where did=?", new Object[] {did}));
+            return Utils.list2ObjectArray(mCol.getDb().queryLongList("select id from cards where did=?", new Object[] {did}));
         }
         List<Long> dids = new ArrayList<>();
         dids.add(did);
         for(Map.Entry<String, Long> entry : children(did).entrySet()) {
             dids.add(entry.getValue());
         }
-        return Utils.list2ObjectArray(mCol.getDb().list(Long.class,
-                "select id from cards where did in " + Utils.ids2str(Utils.arrayList2array(dids))));
+        return Utils.list2ObjectArray(mCol.getDb().queryLongList("select id from cards where did in " + Utils.ids2str(Utils.arrayList2array(dids))));
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -325,8 +325,7 @@ public class Models {
         long id = m.getLong("id");
         boolean current = current().getLong("id") == id;
         // delete notes/cards
-        mCol.remCards(Utils.arrayList2array(mCol.getDb().list(Long.class,
-                                                                     "SELECT id FROM cards WHERE nid IN (SELECT id FROM notes WHERE mid = ?)", new Object[] {id})));
+        mCol.remCards(Utils.arrayList2array(mCol.getDb().queryLongList("SELECT id FROM cards WHERE nid IN (SELECT id FROM notes WHERE mid = ?)", new Object[] {id})));
         // then the model
         mModels.remove(id);
         save();
@@ -385,7 +384,7 @@ public class Models {
 
     /** Note ids for M */
     public ArrayList<Long> nids(Model m) {
-        return mCol.getDb().List(Long.class, "SELECT id FROM notes WHERE mid = ?", new Object[] {m.getLong("id")});
+        return mCol.getDb().queryLongList("SELECT id FROM notes WHERE mid = ?", new Object[] {m.getLong("id")});
     }
 
     /**
@@ -790,7 +789,7 @@ public class Models {
     public @Nullable long[] getCardIdsForModel(long modelId, int[] ords) {
         String cardIdsToDeleteSql = "select c2.id from cards c2, notes n2 where c2.nid=n2.id and n2.mid = " +
                 modelId + " and c2.ord  in " + Utils.ids2str(ords);
-        long[] cids = Utils.toPrimitive(mCol.getDb().list(Long.class, cardIdsToDeleteSql));
+        long[] cids = Utils.toPrimitive(mCol.getDb().queryLongList(cardIdsToDeleteSql));
         //Timber.d("cardIdsToDeleteSql was '" + cardIdsToDeleteSql + "' and got %s", Utils.ids2str(cids));
         Timber.d("getCardIdsForModel found %s cards to delete for model %s and ords %s", cids.length, modelId, Utils.ids2str(ords));
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -325,7 +325,7 @@ public class Models {
         long id = m.getLong("id");
         boolean current = current().getLong("id") == id;
         // delete notes/cards
-        mCol.remCards(Utils.arrayList2array(mCol.getDb().queryColumn(Long.class,
+        mCol.remCards(Utils.arrayList2array(mCol.getDb().list(Long.class,
                                                                      "SELECT id FROM cards WHERE nid IN (SELECT id FROM notes WHERE mid = ?)", new Object[] {id})));
         // then the model
         mModels.remove(id);
@@ -385,7 +385,7 @@ public class Models {
 
     /** Note ids for M */
     public ArrayList<Long> nids(Model m) {
-        return mCol.getDb().queryColumn(Long.class, "SELECT id FROM notes WHERE mid = ?", new Object[] {m.getLong("id")});
+        return mCol.getDb().List(Long.class, "SELECT id FROM notes WHERE mid = ?", new Object[] {m.getLong("id")});
     }
 
     /**
@@ -790,7 +790,7 @@ public class Models {
     public @Nullable long[] getCardIdsForModel(long modelId, int[] ords) {
         String cardIdsToDeleteSql = "select c2.id from cards c2, notes n2 where c2.nid=n2.id and n2.mid = " +
                 modelId + " and c2.ord  in " + Utils.ids2str(ords);
-        long[] cids = Utils.toPrimitive(mCol.getDb().queryColumn(Long.class, cardIdsToDeleteSql));
+        long[] cids = Utils.toPrimitive(mCol.getDb().list(Long.class, cardIdsToDeleteSql));
         //Timber.d("cardIdsToDeleteSql was '" + cardIdsToDeleteSql + "' and got %s", Utils.ids2str(cids));
         Timber.d("getCardIdsForModel found %s cards to delete for model %s and ords %s", cids.length, modelId, Utils.ids2str(ords));
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -326,7 +326,7 @@ public class Models {
         boolean current = current().getLong("id") == id;
         // delete notes/cards
         mCol.remCards(Utils.arrayList2array(mCol.getDb().queryColumn(Long.class,
-                                                                     "SELECT id FROM cards WHERE nid IN (SELECT id FROM notes WHERE mid = ?)", 0, new Object[] {id})));
+                                                                     "SELECT id FROM cards WHERE nid IN (SELECT id FROM notes WHERE mid = ?)", new Object[] {id})));
         // then the model
         mModels.remove(id);
         save();
@@ -385,7 +385,7 @@ public class Models {
 
     /** Note ids for M */
     public ArrayList<Long> nids(Model m) {
-        return mCol.getDb().queryColumn(Long.class, "SELECT id FROM notes WHERE mid = ?", 0, new Object[] {m.getLong("id")});
+        return mCol.getDb().queryColumn(Long.class, "SELECT id FROM notes WHERE mid = ?", new Object[] {m.getLong("id")});
     }
 
     /**
@@ -790,7 +790,7 @@ public class Models {
     public @Nullable long[] getCardIdsForModel(long modelId, int[] ords) {
         String cardIdsToDeleteSql = "select c2.id from cards c2, notes n2 where c2.nid=n2.id and n2.mid = " +
                 modelId + " and c2.ord  in " + Utils.ids2str(ords);
-        long[] cids = Utils.toPrimitive(mCol.getDb().queryColumn(Long.class, cardIdsToDeleteSql, 0));
+        long[] cids = Utils.toPrimitive(mCol.getDb().queryColumn(Long.class, cardIdsToDeleteSql));
         //Timber.d("cardIdsToDeleteSql was '" + cardIdsToDeleteSql + "' and got %s", Utils.ids2str(cids));
         Timber.d("getCardIdsForModel found %s cards to delete for model %s and ords %s", cids.length, modelId, Utils.ids2str(ords));
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Note.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Note.java
@@ -156,7 +156,7 @@ public class Note implements Cloneable {
     }
 
     public List<Long> cids() {
-        return mCol.getDb().queryColumn(Long.class, "SELECT id FROM cards WHERE nid = ? ORDER BY ord", 0,
+        return mCol.getDb().queryColumn(Long.class, "SELECT id FROM cards WHERE nid = ? ORDER BY ord",
                 new Object[]{mId});
     }
 
@@ -299,7 +299,7 @@ public class Note implements Cloneable {
         for (String flds : mCol.getDb().queryColumn(
                 String.class,
                 "SELECT flds FROM notes WHERE csum = ? AND id != ? AND mid = ?",
-                0, new Object[] {csum, (mId != 0 ? mId : 0), mMid})) {
+                new Object[] {csum, (mId != 0 ? mId : 0), mMid})) {
             if (Utils.stripHTMLMedia(
                     Utils.splitFields(flds)[0]).equals(Utils.stripHTMLMedia(mFields[0]))) {
                 return DupeOrEmpty.DUPE;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Note.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Note.java
@@ -156,7 +156,7 @@ public class Note implements Cloneable {
     }
 
     public List<Long> cids() {
-        return mCol.getDb().list(Long.class, "SELECT id FROM cards WHERE nid = ? ORDER BY ord",
+        return mCol.getDb().queryLongList("SELECT id FROM cards WHERE nid = ? ORDER BY ord",
                 new Object[]{mId});
     }
 
@@ -296,8 +296,7 @@ public class Note implements Cloneable {
         }
         long csum = Utils.fieldChecksum(val);
         // find any matching csums and compare
-        for (String flds : mCol.getDb().list(
-                String.class,
+        for (String flds : mCol.getDb().queryStringList(
                 "SELECT flds FROM notes WHERE csum = ? AND id != ? AND mid = ?",
                 new Object[] {csum, (mId != 0 ? mId : 0), mMid})) {
             if (Utils.stripHTMLMedia(

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Note.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Note.java
@@ -156,7 +156,7 @@ public class Note implements Cloneable {
     }
 
     public List<Long> cids() {
-        return mCol.getDb().queryColumn(Long.class, "SELECT id FROM cards WHERE nid = ? ORDER BY ord",
+        return mCol.getDb().list(Long.class, "SELECT id FROM cards WHERE nid = ? ORDER BY ord",
                 new Object[]{mId});
     }
 
@@ -296,7 +296,7 @@ public class Note implements Cloneable {
         }
         long csum = Utils.fieldChecksum(val);
         // find any matching csums and compare
-        for (String flds : mCol.getDb().queryColumn(
+        for (String flds : mCol.getDb().list(
                 String.class,
                 "SELECT flds FROM notes WHERE csum = ? AND id != ? AND mid = ?",
                 new Object[] {csum, (mId != 0 ? mId : 0), mMid})) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Tags.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Tags.java
@@ -179,9 +179,9 @@ public class Tags {
             for (long id : mCol.getDecks().children(did).values()) {
                 dids.add(id);
             }
-            tags = mCol.getDb().list(String.class, "SELECT DISTINCT n.tags FROM cards c, notes n WHERE c.nid = n.id AND c.did IN " + Utils.ids2str(Utils.arrayList2array(dids)));
+            tags = mCol.getDb().queryStringList("SELECT DISTINCT n.tags FROM cards c, notes n WHERE c.nid = n.id AND c.did IN " + Utils.ids2str(Utils.arrayList2array(dids)));
         } else {
-            tags = mCol.getDb().list(String.class, "SELECT DISTINCT n.tags FROM cards c, notes n WHERE c.nid = n.id AND c.did = ?", new Object[] {did});
+            tags = mCol.getDb().queryStringList("SELECT DISTINCT n.tags FROM cards c, notes n WHERE c.nid = n.id AND c.did = ?", new Object[] {did});
         }
         // Cast to set to remove duplicates
         // Use methods used to get all tags to parse tags here as well.

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Tags.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Tags.java
@@ -179,9 +179,9 @@ public class Tags {
             for (long id : mCol.getDecks().children(did).values()) {
                 dids.add(id);
             }
-            tags = mCol.getDb().queryColumn(String.class, "SELECT DISTINCT n.tags FROM cards c, notes n WHERE c.nid = n.id AND c.did IN " + Utils.ids2str(Utils.arrayList2array(dids)), 0);
+            tags = mCol.getDb().queryColumn(String.class, "SELECT DISTINCT n.tags FROM cards c, notes n WHERE c.nid = n.id AND c.did IN " + Utils.ids2str(Utils.arrayList2array(dids)));
         } else {
-            tags = mCol.getDb().queryColumn(String.class, "SELECT DISTINCT n.tags FROM cards c, notes n WHERE c.nid = n.id AND c.did = ?", 0, new Object[] {did});
+            tags = mCol.getDb().queryColumn(String.class, "SELECT DISTINCT n.tags FROM cards c, notes n WHERE c.nid = n.id AND c.did = ?", new Object[] {did});
         }
         // Cast to set to remove duplicates
         // Use methods used to get all tags to parse tags here as well.

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Tags.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Tags.java
@@ -179,9 +179,9 @@ public class Tags {
             for (long id : mCol.getDecks().children(did).values()) {
                 dids.add(id);
             }
-            tags = mCol.getDb().queryColumn(String.class, "SELECT DISTINCT n.tags FROM cards c, notes n WHERE c.nid = n.id AND c.did IN " + Utils.ids2str(Utils.arrayList2array(dids)));
+            tags = mCol.getDb().list(String.class, "SELECT DISTINCT n.tags FROM cards c, notes n WHERE c.nid = n.id AND c.did IN " + Utils.ids2str(Utils.arrayList2array(dids)));
         } else {
-            tags = mCol.getDb().queryColumn(String.class, "SELECT DISTINCT n.tags FROM cards c, notes n WHERE c.nid = n.id AND c.did = ?", new Object[] {did});
+            tags = mCol.getDb().list(String.class, "SELECT DISTINCT n.tags FROM cards c, notes n WHERE c.nid = n.id AND c.did = ?", new Object[] {did});
         }
         // Cast to set to remove duplicates
         // Use methods used to get all tags to parse tags here as well.

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -186,7 +186,7 @@ public class Sched extends SchedV2 {
     @Override
     public void unburyCards() {
         mCol.getConf().put("lastUnburied", mToday);
-        mCol.log(mCol.getDb().queryColumn(Long.class, "select id from cards where queue = "+ Consts.QUEUE_TYPE_SIBLING_BURIED));
+        mCol.log(mCol.getDb().list(Long.class, "select id from cards where queue = "+ Consts.QUEUE_TYPE_SIBLING_BURIED));
         mCol.getDb().execute("update cards set queue=type where queue = " + Consts.QUEUE_TYPE_SIBLING_BURIED);
     }
 
@@ -199,7 +199,7 @@ public class Sched extends SchedV2 {
     private void unburyCardsForDeck(List<Long> allDecks) {
         // Refactored to allow unburying an arbitrary deck
         String sids = Utils.ids2str(allDecks);
-        mCol.log(mCol.getDb().queryColumn(Long.class, "select id from cards where queue = " + Consts.QUEUE_TYPE_SIBLING_BURIED + " and did in " + sids));
+        mCol.log(mCol.getDb().list(Long.class, "select id from cards where queue = " + Consts.QUEUE_TYPE_SIBLING_BURIED + " and did in " + sids));
         mCol.getDb().execute("update cards set mod=?,usn=?,queue=type where queue = " + Consts.QUEUE_TYPE_SIBLING_BURIED + " and did in " + sids,
                 new Object[] { Utils.intTime(), mCol.usn() });
     }
@@ -627,7 +627,7 @@ public class Sched extends SchedV2 {
                 ", usn = ?, odue = 0 where queue IN (" + Consts.QUEUE_TYPE_LRN + "," + Consts.QUEUE_TYPE_DAY_LEARN_RELEARN + ") and type = " + Consts.CARD_TYPE_REV + " " + extra,
                 new Object[] {Utils.intTime(), mCol.usn()});
         // new cards in learning
-        forgetCards(Utils.arrayList2array(mCol.getDb().queryColumn(Long.class, "SELECT id FROM cards WHERE queue IN (" + Consts.QUEUE_TYPE_LRN + "," + Consts.QUEUE_TYPE_DAY_LEARN_RELEARN + ") " + extra)));
+        forgetCards(Utils.arrayList2array(mCol.getDb().list(Long.class, "SELECT id FROM cards WHERE queue IN (" + Consts.QUEUE_TYPE_LRN + "," + Consts.QUEUE_TYPE_DAY_LEARN_RELEARN + ") " + extra)));
     }
 
     private int _lrnForDeck(long did) {
@@ -990,7 +990,7 @@ public class Sched extends SchedV2 {
         if (lim == null) {
             lim = "did = " + did;
         }
-        mCol.log(mCol.getDb().queryColumn(Long.class, "select id from cards where " + lim));
+        mCol.log(mCol.getDb().list(Long.class, "select id from cards where " + lim));
         // move out of cram queue
         mCol.getDb().execute(
                 "update cards set did = odid, queue = (case when type = " + Consts.CARD_TYPE_LRN + " then " + Consts.QUEUE_TYPE_NEW + " " +

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -186,7 +186,7 @@ public class Sched extends SchedV2 {
     @Override
     public void unburyCards() {
         mCol.getConf().put("lastUnburied", mToday);
-        mCol.log(mCol.getDb().list(Long.class, "select id from cards where queue = "+ Consts.QUEUE_TYPE_SIBLING_BURIED));
+        mCol.log(mCol.getDb().queryLongList("select id from cards where queue = "+ Consts.QUEUE_TYPE_SIBLING_BURIED));
         mCol.getDb().execute("update cards set queue=type where queue = " + Consts.QUEUE_TYPE_SIBLING_BURIED);
     }
 
@@ -199,7 +199,7 @@ public class Sched extends SchedV2 {
     private void unburyCardsForDeck(List<Long> allDecks) {
         // Refactored to allow unburying an arbitrary deck
         String sids = Utils.ids2str(allDecks);
-        mCol.log(mCol.getDb().list(Long.class, "select id from cards where queue = " + Consts.QUEUE_TYPE_SIBLING_BURIED + " and did in " + sids));
+        mCol.log(mCol.getDb().queryLongList("select id from cards where queue = " + Consts.QUEUE_TYPE_SIBLING_BURIED + " and did in " + sids));
         mCol.getDb().execute("update cards set mod=?,usn=?,queue=type where queue = " + Consts.QUEUE_TYPE_SIBLING_BURIED + " and did in " + sids,
                 new Object[] { Utils.intTime(), mCol.usn() });
     }
@@ -627,7 +627,7 @@ public class Sched extends SchedV2 {
                 ", usn = ?, odue = 0 where queue IN (" + Consts.QUEUE_TYPE_LRN + "," + Consts.QUEUE_TYPE_DAY_LEARN_RELEARN + ") and type = " + Consts.CARD_TYPE_REV + " " + extra,
                 new Object[] {Utils.intTime(), mCol.usn()});
         // new cards in learning
-        forgetCards(Utils.arrayList2array(mCol.getDb().list(Long.class, "SELECT id FROM cards WHERE queue IN (" + Consts.QUEUE_TYPE_LRN + "," + Consts.QUEUE_TYPE_DAY_LEARN_RELEARN + ") " + extra)));
+        forgetCards(Utils.arrayList2array(mCol.getDb().queryLongList("SELECT id FROM cards WHERE queue IN (" + Consts.QUEUE_TYPE_LRN + "," + Consts.QUEUE_TYPE_DAY_LEARN_RELEARN + ") " + extra)));
     }
 
     private int _lrnForDeck(long did) {
@@ -990,7 +990,7 @@ public class Sched extends SchedV2 {
         if (lim == null) {
             lim = "did = " + did;
         }
-        mCol.log(mCol.getDb().list(Long.class, "select id from cards where " + lim));
+        mCol.log(mCol.getDb().queryLongList("select id from cards where " + lim));
         // move out of cram queue
         mCol.getDb().execute(
                 "update cards set did = odid, queue = (case when type = " + Consts.CARD_TYPE_LRN + " then " + Consts.QUEUE_TYPE_NEW + " " +

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -186,7 +186,7 @@ public class Sched extends SchedV2 {
     @Override
     public void unburyCards() {
         mCol.getConf().put("lastUnburied", mToday);
-        mCol.log(mCol.getDb().queryColumn(Long.class, "select id from cards where queue = "+ Consts.QUEUE_TYPE_SIBLING_BURIED , 0));
+        mCol.log(mCol.getDb().queryColumn(Long.class, "select id from cards where queue = "+ Consts.QUEUE_TYPE_SIBLING_BURIED));
         mCol.getDb().execute("update cards set queue=type where queue = " + Consts.QUEUE_TYPE_SIBLING_BURIED);
     }
 
@@ -199,7 +199,7 @@ public class Sched extends SchedV2 {
     private void unburyCardsForDeck(List<Long> allDecks) {
         // Refactored to allow unburying an arbitrary deck
         String sids = Utils.ids2str(allDecks);
-        mCol.log(mCol.getDb().queryColumn(Long.class, "select id from cards where queue = " + Consts.QUEUE_TYPE_SIBLING_BURIED + " and did in " + sids, 0));
+        mCol.log(mCol.getDb().queryColumn(Long.class, "select id from cards where queue = " + Consts.QUEUE_TYPE_SIBLING_BURIED + " and did in " + sids));
         mCol.getDb().execute("update cards set mod=?,usn=?,queue=type where queue = " + Consts.QUEUE_TYPE_SIBLING_BURIED + " and did in " + sids,
                 new Object[] { Utils.intTime(), mCol.usn() });
     }
@@ -627,7 +627,7 @@ public class Sched extends SchedV2 {
                 ", usn = ?, odue = 0 where queue IN (" + Consts.QUEUE_TYPE_LRN + "," + Consts.QUEUE_TYPE_DAY_LEARN_RELEARN + ") and type = " + Consts.CARD_TYPE_REV + " " + extra,
                 new Object[] {Utils.intTime(), mCol.usn()});
         // new cards in learning
-        forgetCards(Utils.arrayList2array(mCol.getDb().queryColumn(Long.class, "SELECT id FROM cards WHERE queue IN (" + Consts.QUEUE_TYPE_LRN + "," + Consts.QUEUE_TYPE_DAY_LEARN_RELEARN + ") " + extra, 0)));
+        forgetCards(Utils.arrayList2array(mCol.getDb().queryColumn(Long.class, "SELECT id FROM cards WHERE queue IN (" + Consts.QUEUE_TYPE_LRN + "," + Consts.QUEUE_TYPE_DAY_LEARN_RELEARN + ") " + extra)));
     }
 
     private int _lrnForDeck(long did) {
@@ -990,7 +990,7 @@ public class Sched extends SchedV2 {
         if (lim == null) {
             lim = "did = " + did;
         }
-        mCol.log(mCol.getDb().queryColumn(Long.class, "select id from cards where " + lim, 0));
+        mCol.log(mCol.getDb().queryColumn(Long.class, "select id from cards where " + lim));
         // move out of cram queue
         mCol.getDb().execute(
                 "update cards set did = odid, queue = (case when type = " + Consts.CARD_TYPE_LRN + " then " + Consts.QUEUE_TYPE_NEW + " " +

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -1731,7 +1731,7 @@ public class SchedV2 extends AbstractSched {
         if (lim == null) {
             lim = "did = " + did;
         }
-        mCol.log(mCol.getDb().queryColumn(Long.class, "select id from cards where " + lim, 0));
+        mCol.log(mCol.getDb().queryColumn(Long.class, "select id from cards where " + lim));
 
         mCol.getDb().execute(
                 "update cards set did = odid, " + _restoreQueueSnippet() +
@@ -2292,7 +2292,7 @@ public class SchedV2 extends AbstractSched {
      * Unbury all buried cards in all decks
      */
     public void unburyCards() {
-        mCol.log(mCol.getDb().queryColumn( Long.class,"select id from cards where queue in (" + Consts.QUEUE_TYPE_SIBLING_BURIED + ", " + Consts.QUEUE_TYPE_MANUALLY_BURIED + ")", 0));
+        mCol.log(mCol.getDb().queryColumn( Long.class,"select id from cards where queue in (" + Consts.QUEUE_TYPE_SIBLING_BURIED + ", " + Consts.QUEUE_TYPE_MANUALLY_BURIED + ")"));
         mCol.getDb().execute("update cards set " + _restoreQueueSnippet() + " where queue in (" + Consts.QUEUE_TYPE_SIBLING_BURIED + ", " + Consts.QUEUE_TYPE_MANUALLY_BURIED + ")");
     }
 
@@ -2329,7 +2329,7 @@ public class SchedV2 extends AbstractSched {
 
         String sids = Utils.ids2str(allDecks != null ? allDecks : mCol.getDecks().active());
 
-        mCol.log(mCol.getDb().queryColumn(Long.class,"select id from cards where " + queue + " and did in " + sids, 0));
+        mCol.log(mCol.getDb().queryColumn(Long.class,"select id from cards where " + queue + " and did in " + sids));
         mCol.getDb().execute("update cards set mod=?,usn=?, " + _restoreQueueSnippet() + " where " + queue + " and did in " + sids,
                 new Object[]{mTime.intTime(), mCol.usn()});
     }
@@ -2341,7 +2341,7 @@ public class SchedV2 extends AbstractSched {
      */
     public void buryNote(long nid) {
         long[] cids = Utils.arrayList2array(mCol.getDb().queryColumn(Long.class,
-                "SELECT id FROM cards WHERE nid = ? AND queue >= " + Consts.CARD_TYPE_NEW, 0,
+                "SELECT id FROM cards WHERE nid = ? AND queue >= " + Consts.CARD_TYPE_NEW,
                 new Object[] {nid}));
         buryCards(cids);
     }
@@ -2440,7 +2440,7 @@ public class SchedV2 extends AbstractSched {
      */
     public void resetCards(Long[] ids) {
         long[] nonNew = Utils.arrayList2array(mCol.getDb().queryColumn(Long.class,
-                "select id from cards where id in " + Utils.ids2str(ids) + " and (queue != " + Consts.QUEUE_TYPE_NEW + " or type != " + Consts.CARD_TYPE_NEW + ")", 0));
+                "select id from cards where id in " + Utils.ids2str(ids) + " and (queue != " + Consts.QUEUE_TYPE_NEW + " or type != " + Consts.CARD_TYPE_NEW + ")"));
         mCol.getDb().execute("update cards set reps=0, lapses=0 where id in " + Utils.ids2str(nonNew));
         forgetCards(nonNew);
         mCol.log((Object[]) ids);
@@ -2514,14 +2514,14 @@ public class SchedV2 extends AbstractSched {
 
 
     public void randomizeCards(long did) {
-        List<Long> cids = mCol.getDb().queryColumn(Long.class, "select id from cards where did = ?", 0,
+        List<Long> cids = mCol.getDb().queryColumn(Long.class, "select id from cards where did = ?",
                                                    new Object[]{did});
         sortCards(Utils.toPrimitive(cids), 1, 1, true, false);
     }
 
 
     public void orderCards(long did) {
-        List<Long> cids = mCol.getDb().queryColumn(Long.class, "SELECT id FROM cards WHERE did = ? ORDER BY nid", 0,
+        List<Long> cids = mCol.getDb().queryColumn(Long.class, "SELECT id FROM cards WHERE did = ? ORDER BY nid",
                                                    new Object[]{did});
         sortCards(Utils.toPrimitive(cids), 1, 1, false, false);
     }
@@ -2585,7 +2585,7 @@ public class SchedV2 extends AbstractSched {
 
 
         // remove new cards from learning
-        forgetCards(Utils.arrayList2array(mCol.getDb().queryColumn(Long.class, "select id from cards where queue in (" + Consts.QUEUE_TYPE_LRN + "," + Consts.QUEUE_TYPE_DAY_LEARN_RELEARN + ")", 0)));
+        forgetCards(Utils.arrayList2array(mCol.getDb().queryColumn(Long.class, "select id from cards where queue in (" + Consts.QUEUE_TYPE_LRN + "," + Consts.QUEUE_TYPE_DAY_LEARN_RELEARN + ")")));
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -1731,7 +1731,7 @@ public class SchedV2 extends AbstractSched {
         if (lim == null) {
             lim = "did = " + did;
         }
-        mCol.log(mCol.getDb().queryColumn(Long.class, "select id from cards where " + lim));
+        mCol.log(mCol.getDb().list(Long.class, "select id from cards where " + lim));
 
         mCol.getDb().execute(
                 "update cards set did = odid, " + _restoreQueueSnippet() +
@@ -2292,7 +2292,7 @@ public class SchedV2 extends AbstractSched {
      * Unbury all buried cards in all decks
      */
     public void unburyCards() {
-        mCol.log(mCol.getDb().queryColumn( Long.class,"select id from cards where queue in (" + Consts.QUEUE_TYPE_SIBLING_BURIED + ", " + Consts.QUEUE_TYPE_MANUALLY_BURIED + ")"));
+        mCol.log(mCol.getDb().list( Long.class,"select id from cards where queue in (" + Consts.QUEUE_TYPE_SIBLING_BURIED + ", " + Consts.QUEUE_TYPE_MANUALLY_BURIED + ")"));
         mCol.getDb().execute("update cards set " + _restoreQueueSnippet() + " where queue in (" + Consts.QUEUE_TYPE_SIBLING_BURIED + ", " + Consts.QUEUE_TYPE_MANUALLY_BURIED + ")");
     }
 
@@ -2329,7 +2329,7 @@ public class SchedV2 extends AbstractSched {
 
         String sids = Utils.ids2str(allDecks != null ? allDecks : mCol.getDecks().active());
 
-        mCol.log(mCol.getDb().queryColumn(Long.class,"select id from cards where " + queue + " and did in " + sids));
+        mCol.log(mCol.getDb().list(Long.class,"select id from cards where " + queue + " and did in " + sids));
         mCol.getDb().execute("update cards set mod=?,usn=?, " + _restoreQueueSnippet() + " where " + queue + " and did in " + sids,
                 new Object[]{mTime.intTime(), mCol.usn()});
     }
@@ -2340,7 +2340,7 @@ public class SchedV2 extends AbstractSched {
      * @param nid The id of the targeted note.
      */
     public void buryNote(long nid) {
-        long[] cids = Utils.arrayList2array(mCol.getDb().queryColumn(Long.class,
+        long[] cids = Utils.arrayList2array(mCol.getDb().list(Long.class,
                 "SELECT id FROM cards WHERE nid = ? AND queue >= " + Consts.CARD_TYPE_NEW,
                 new Object[] {nid}));
         buryCards(cids);
@@ -2439,7 +2439,7 @@ public class SchedV2 extends AbstractSched {
      * Completely reset cards for export.
      */
     public void resetCards(Long[] ids) {
-        long[] nonNew = Utils.arrayList2array(mCol.getDb().queryColumn(Long.class,
+        long[] nonNew = Utils.arrayList2array(mCol.getDb().list(Long.class,
                 "select id from cards where id in " + Utils.ids2str(ids) + " and (queue != " + Consts.QUEUE_TYPE_NEW + " or type != " + Consts.CARD_TYPE_NEW + ")"));
         mCol.getDb().execute("update cards set reps=0, lapses=0 where id in " + Utils.ids2str(nonNew));
         forgetCards(nonNew);
@@ -2514,14 +2514,14 @@ public class SchedV2 extends AbstractSched {
 
 
     public void randomizeCards(long did) {
-        List<Long> cids = mCol.getDb().queryColumn(Long.class, "select id from cards where did = ?",
+        List<Long> cids = mCol.getDb().list(Long.class, "select id from cards where did = ?",
                                                    new Object[]{did});
         sortCards(Utils.toPrimitive(cids), 1, 1, true, false);
     }
 
 
     public void orderCards(long did) {
-        List<Long> cids = mCol.getDb().queryColumn(Long.class, "SELECT id FROM cards WHERE did = ? ORDER BY nid",
+        List<Long> cids = mCol.getDb().list(Long.class, "SELECT id FROM cards WHERE did = ? ORDER BY nid",
                                                    new Object[]{did});
         sortCards(Utils.toPrimitive(cids), 1, 1, false, false);
     }
@@ -2585,7 +2585,7 @@ public class SchedV2 extends AbstractSched {
 
 
         // remove new cards from learning
-        forgetCards(Utils.arrayList2array(mCol.getDb().queryColumn(Long.class, "select id from cards where queue in (" + Consts.QUEUE_TYPE_LRN + "," + Consts.QUEUE_TYPE_DAY_LEARN_RELEARN + ")")));
+        forgetCards(Utils.arrayList2array(mCol.getDb().list(Long.class, "select id from cards where queue in (" + Consts.QUEUE_TYPE_LRN + "," + Consts.QUEUE_TYPE_DAY_LEARN_RELEARN + ")")));
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -1731,7 +1731,7 @@ public class SchedV2 extends AbstractSched {
         if (lim == null) {
             lim = "did = " + did;
         }
-        mCol.log(mCol.getDb().list(Long.class, "select id from cards where " + lim));
+        mCol.log(mCol.getDb().queryLongList("select id from cards where " + lim));
 
         mCol.getDb().execute(
                 "update cards set did = odid, " + _restoreQueueSnippet() +
@@ -2292,7 +2292,7 @@ public class SchedV2 extends AbstractSched {
      * Unbury all buried cards in all decks
      */
     public void unburyCards() {
-        mCol.log(mCol.getDb().list( Long.class,"select id from cards where queue in (" + Consts.QUEUE_TYPE_SIBLING_BURIED + ", " + Consts.QUEUE_TYPE_MANUALLY_BURIED + ")"));
+        mCol.log(mCol.getDb().queryLongList("select id from cards where queue in (" + Consts.QUEUE_TYPE_SIBLING_BURIED + ", " + Consts.QUEUE_TYPE_MANUALLY_BURIED + ")"));
         mCol.getDb().execute("update cards set " + _restoreQueueSnippet() + " where queue in (" + Consts.QUEUE_TYPE_SIBLING_BURIED + ", " + Consts.QUEUE_TYPE_MANUALLY_BURIED + ")");
     }
 
@@ -2329,7 +2329,7 @@ public class SchedV2 extends AbstractSched {
 
         String sids = Utils.ids2str(allDecks != null ? allDecks : mCol.getDecks().active());
 
-        mCol.log(mCol.getDb().list(Long.class,"select id from cards where " + queue + " and did in " + sids));
+        mCol.log(mCol.getDb().queryLongList("select id from cards where " + queue + " and did in " + sids));
         mCol.getDb().execute("update cards set mod=?,usn=?, " + _restoreQueueSnippet() + " where " + queue + " and did in " + sids,
                 new Object[]{mTime.intTime(), mCol.usn()});
     }
@@ -2340,7 +2340,7 @@ public class SchedV2 extends AbstractSched {
      * @param nid The id of the targeted note.
      */
     public void buryNote(long nid) {
-        long[] cids = Utils.arrayList2array(mCol.getDb().list(Long.class,
+        long[] cids = Utils.arrayList2array(mCol.getDb().queryLongList(
                 "SELECT id FROM cards WHERE nid = ? AND queue >= " + Consts.CARD_TYPE_NEW,
                 new Object[] {nid}));
         buryCards(cids);
@@ -2439,7 +2439,7 @@ public class SchedV2 extends AbstractSched {
      * Completely reset cards for export.
      */
     public void resetCards(Long[] ids) {
-        long[] nonNew = Utils.arrayList2array(mCol.getDb().list(Long.class,
+        long[] nonNew = Utils.arrayList2array(mCol.getDb().queryLongList(
                 "select id from cards where id in " + Utils.ids2str(ids) + " and (queue != " + Consts.QUEUE_TYPE_NEW + " or type != " + Consts.CARD_TYPE_NEW + ")"));
         mCol.getDb().execute("update cards set reps=0, lapses=0 where id in " + Utils.ids2str(nonNew));
         forgetCards(nonNew);
@@ -2514,14 +2514,14 @@ public class SchedV2 extends AbstractSched {
 
 
     public void randomizeCards(long did) {
-        List<Long> cids = mCol.getDb().list(Long.class, "select id from cards where did = ?",
+        List<Long> cids = mCol.getDb().queryLongList("select id from cards where did = ?",
                                                    new Object[]{did});
         sortCards(Utils.toPrimitive(cids), 1, 1, true, false);
     }
 
 
     public void orderCards(long did) {
-        List<Long> cids = mCol.getDb().list(Long.class, "SELECT id FROM cards WHERE did = ? ORDER BY nid",
+        List<Long> cids = mCol.getDb().queryLongList("SELECT id FROM cards WHERE did = ? ORDER BY nid",
                                                    new Object[]{did});
         sortCards(Utils.toPrimitive(cids), 1, 1, false, false);
     }
@@ -2585,7 +2585,7 @@ public class SchedV2 extends AbstractSched {
 
 
         // remove new cards from learning
-        forgetCards(Utils.arrayList2array(mCol.getDb().list(Long.class, "select id from cards where queue in (" + Consts.QUEUE_TYPE_LRN + "," + Consts.QUEUE_TYPE_DAY_LEARN_RELEARN + ")")));
+        forgetCards(Utils.arrayList2array(mCol.getDb().queryLongList("select id from cards where queue in (" + Consts.QUEUE_TYPE_LRN + "," + Consts.QUEUE_TYPE_DAY_LEARN_RELEARN + ")")));
     }
 
 


### PR DESCRIPTION
Upstream has a method `list` to get a list of elements from the database. This is really similar to our method `queryColumn`.

I then realized that `queryColumn` is always called with `column` 0, so I removed this parameter. I renamed to be consistent with upstream. And since we only query for long and string, I created two methods for String and for Long, so that we can simplify the remaining of the code. This is consistent with `queryLongScalar` for example.

Once again, this is to help me port upstream unit test, by having them as close as possible to upstream.