### PR TITLE
Optimize obtaining card metadata from Note

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.java
@@ -246,7 +246,7 @@ public class ContentProviderTest extends InstrumentedTest {
         JSONObject model = col.getModels().get(mModelId);
         assertNotNull("Check model", model);
         int expectedNumCards = model.getJSONArray("tmpls").length();
-        assertEquals("Check that correct number of cards generated", expectedNumCards, addedNote.cids().size());
+        assertEquals("Check that correct number of cards generated", expectedNumCards, addedNote.numberOfCards());
         // Now delete the note
         cr.delete(newNoteUri, null, null);
         try {

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.java
@@ -246,7 +246,7 @@ public class ContentProviderTest extends InstrumentedTest {
         JSONObject model = col.getModels().get(mModelId);
         assertNotNull("Check model", model);
         int expectedNumCards = model.getJSONArray("tmpls").length();
-        assertEquals("Check that correct number of cards generated", expectedNumCards, addedNote.cards().size());
+        assertEquals("Check that correct number of cards generated", expectedNumCards, addedNote.cids().size());
         // Now delete the note
         cr.delete(newNoteUri, null, null);
         try {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
@@ -57,6 +57,7 @@ import com.ichi2.utils.JSONArray;
 import com.ichi2.utils.JSONException;
 import com.ichi2.utils.JSONObject;
 
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -413,8 +414,11 @@ public class CardTemplateEditor extends AnkiActivity {
                     i.putExtra("ordinal", ordinal);
 
                     // If we have a card for this position, send it, otherwise an empty cardlist signals to show a blank
-                    if (noteId != -1L && ordinal < col.getNote(noteId).cids().size()) {
-                        i.putExtra("cardList", new long[] { col.getNote(noteId).cids().get(ordinal) });
+                    if (noteId != -1L) {
+                        List<Long> cids = col.getNote(noteId).cids();
+                        if (ordinal < cids.size()) {
+                            i.putExtra("cardList", new long[] { cids.get(ordinal) });
+                        }
                     }
                     // Save the model and pass the filename if updated
                     tempModel.setEditedModelFileName(TemporaryModel.saveTempModel(mTemplateEditor, tempModel.getModel()));

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
@@ -413,8 +413,8 @@ public class CardTemplateEditor extends AnkiActivity {
                     i.putExtra("ordinal", ordinal);
 
                     // If we have a card for this position, send it, otherwise an empty cardlist signals to show a blank
-                    if (noteId != -1L && ordinal < col.getNote(noteId).cards().size()) {
-                        i.putExtra("cardList", new long[] { col.getNote(noteId).cards().get(ordinal).getId() });
+                    if (noteId != -1L && ordinal < col.getNote(noteId).cids().size()) {
+                        i.putExtra("cardList", new long[] { col.getNote(noteId).cids().get(ordinal) });
                     }
                     // Save the model and pass the filename if updated
                     tempModel.setEditedModelFileName(TemporaryModel.saveTempModel(mTemplateEditor, tempModel.getModel()));

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -791,7 +791,7 @@ public class NoteEditor extends AnkiActivity {
             final JSONObject oldModel = mCurrentEditedCard.model();
             if (!newModel.equals(oldModel)) {
                 mReloadRequired = true;
-                if (mModelChangeCardMap.size() < mEditorNote.cids().size() || mModelChangeCardMap.containsKey(null)) {
+                if (mModelChangeCardMap.size() < mEditorNote.numberOfCards() || mModelChangeCardMap.containsKey(null)) {
                     // If cards will be lost via the new mapping then show a confirmation dialog before proceeding with the change
                     ConfirmationDialog dialog = new ConfirmationDialog ();
                     dialog.setArgs(res.getString(R.string.confirm_map_cards_to_nothing));
@@ -1753,7 +1753,7 @@ public class NoteEditor extends AnkiActivity {
                 // Initialize mapping between cards new model -> old model
                 mModelChangeCardMap = new HashMap<>();
                 for (int i = 0; i < newModel.getJSONArray("tmpls").length() ; i++) {
-                    if (i < mEditorNote.cids().size()) {
+                    if (i < mEditorNote.numberOfCards()) {
                         mModelChangeCardMap.put(i, i);
                     } else {
                         mModelChangeCardMap.put(i, null);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -791,7 +791,7 @@ public class NoteEditor extends AnkiActivity {
             final JSONObject oldModel = mCurrentEditedCard.model();
             if (!newModel.equals(oldModel)) {
                 mReloadRequired = true;
-                if (mModelChangeCardMap.size() < mEditorNote.cards().size() || mModelChangeCardMap.containsKey(null)) {
+                if (mModelChangeCardMap.size() < mEditorNote.cids().size() || mModelChangeCardMap.containsKey(null)) {
                     // If cards will be lost via the new mapping then show a confirmation dialog before proceeding with the change
                     ConfirmationDialog dialog = new ConfirmationDialog ();
                     dialog.setArgs(res.getString(R.string.confirm_map_cards_to_nothing));
@@ -1166,7 +1166,7 @@ public class NoteEditor extends AnkiActivity {
                     // Model can change regardless of exit type - update ourselves and CardBrowser
                     mReloadRequired = true;
                     mEditorNote.reloadModel();
-                    if (!mEditorNote.cards().contains(mCurrentEditedCard)) {
+                    if (!mEditorNote.cids().contains(mCurrentEditedCard.getId())) {
                         if (!mAddNote) {
                             /* This can occur, for example, if the
                              * card type was deleted or if the note
@@ -1753,7 +1753,7 @@ public class NoteEditor extends AnkiActivity {
                 // Initialize mapping between cards new model -> old model
                 mModelChangeCardMap = new HashMap<>();
                 for (int i = 0; i < newModel.getJSONArray("tmpls").length() ; i++) {
-                    if (i < mEditorNote.cards().size()) {
+                    if (i < mEditorNote.cids().size()) {
                         mModelChangeCardMap.put(i, i);
                     } else {
                         mModelChangeCardMap.put(i, null);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Note.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Note.java
@@ -151,13 +151,18 @@ public class Note implements Cloneable {
     }
 
 
+    public List<Long> cids() {
+        return mCol.getDb().queryColumn(Long.class, "SELECT id FROM cards WHERE nid = ? ORDER BY ord", 0,
+                new Object[]{mId});
+    }
+
     public ArrayList<Card> cards() {
         ArrayList<Card> cards = new ArrayList<>();
-        try (Cursor cur = mCol.getDb().getDatabase()
-                .query("SELECT id FROM cards WHERE nid = " + mId + " ORDER BY ord", null)) {
-            while (cur.moveToNext()) {
-                cards.add(mCol.getCard(cur.getLong(0)));
-            }
+        for (long cid : cids()) {
+            // each getCard access database. This is inneficient.
+            // Seems impossible to solve without creating a constructor of a list of card.
+            // Not a big trouble since most note have a small number of cards.
+            cards.add(mCol.getCard(cid));
         }
         return cards;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Note.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Note.java
@@ -171,6 +171,12 @@ public class Note implements Cloneable {
         return cards;
     }
 
+    /** The first card, assuming it exists.*/
+    public Card firstCard() {
+        return mCol.getCard(mCol.getDb().queryLongScalar("SELECT id FROM cards WHERE nid = ? ORDER BY ord LIMIT 1",
+                new Object[] {mId}));
+    }
+
 
     public JSONObject model() {
         return mModel;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Note.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Note.java
@@ -151,6 +151,10 @@ public class Note implements Cloneable {
     }
 
 
+    public int numberOfCards() {
+        return (int) mCol.getDb().queryLongScalar("SELECT count() FROM cards WHERE nid = ?", new Object[]{mId});
+    }
+
     public List<Long> cids() {
         return mCol.getDb().queryColumn(Long.class, "SELECT id FROM cards WHERE nid = ? ORDER BY ord", 0,
                 new Object[]{mId});

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
@@ -246,7 +246,7 @@ public class CardBrowserTest extends RobolectricTest {
         Note n = addNoteUsingBasicModel("1", "back");
         flagCardForNote(n, 1);
 
-        long cardId = n.cards().get(0).getId();
+        long cardId = n.cids().get(0);
 
         CardBrowser b = getBrowserWithNoNewCards();
         Map<String, String> cardProperties = b.getPropertiesForCardId(cardId);

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
@@ -282,7 +282,7 @@ public class CardBrowserTest extends RobolectricTest {
 
 
     private void flagCardForNote(Note n, int flag) {
-        Card c = n.cards().get(0);
+        Card c = n.firstCard();
         c.setUserFlag(flag);
         c.flush();
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateEditorTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateEditorTest.java
@@ -517,7 +517,7 @@ public class CardTemplateEditorTest extends RobolectricTest {
     private int getModelCardCount(JSONObject model) {
         int cardCount = 0;
         for (Long noteId : getCol().getModels().nids(model)) {
-            cardCount += getCol().getNote(noteId).cids().size();
+            cardCount += getCol().getNote(noteId).numberOfCards();
         }
         return cardCount;
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateEditorTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateEditorTest.java
@@ -517,7 +517,7 @@ public class CardTemplateEditorTest extends RobolectricTest {
     private int getModelCardCount(JSONObject model) {
         int cardCount = 0;
         for (Long noteId : getCol().getModels().nids(model)) {
-            cardCount += getCol().getNote(noteId).cards().size();
+            cardCount += getCol().getNote(noteId).cids().size();
         }
         return cardCount;
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.java
@@ -300,7 +300,7 @@ public class NoteEditorTest extends RobolectricTest {
         switch (from) {
             case REVIEWER:
                 i.putExtra(NoteEditor.EXTRA_CALLER, NoteEditor.CALLER_REVIEWER);
-                AbstractFlashcardViewer.setEditorCard(n.cards().get(0));
+                AbstractFlashcardViewer.setEditorCard(n.firstCard());
                 break;
             case DECK_LIST:
                 i.putExtra(NoteEditor.EXTRA_CALLER, NoteEditor.CALLER_DECKPICKER);

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.java
@@ -59,7 +59,7 @@ public class ReviewerTest extends RobolectricTest {
     public void jsTime4ShouldBeBlankIfButtonUnavailable() {
         // #6623 - easy should be blank when displaying a card with 3 buttons (after displaying a review)
         Note firstNote = addNoteUsingBasicModel("Hello", "World");
-        moveToReviewQueue(firstNote.cards().get(0));
+        moveToReviewQueue(firstNote.firstCard());
 
         addNoteUsingBasicModel("Hello", "World2");
 

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/ClozeTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/ClozeTest.java
@@ -42,19 +42,19 @@ public class ClozeTest extends RobolectricTest {
         f = d.newNote(d.getModels().byName("Cloze"));
         f.setItem("Text", "hello {{c1::world}}");
         assertEquals(1, d.addNote(f));
-        assertTrue(f.cards().get(0).q().contains("hello <span class=cloze>[...]</span>"));
-        assertTrue(f.cards().get(0).a().contains("hello <span class=cloze>world</span>"));
+        assertTrue(f.firstCard().q().contains("hello <span class=cloze>[...]</span>"));
+        assertTrue(f.firstCard().a().contains("hello <span class=cloze>world</span>"));
         // and with a comment
         f = d.newNote(d.getModels().byName("Cloze"));
         f.setItem("Text", "hello {{c1::world::typical}}");
         assertEquals(1, d.addNote(f));
-        assertTrue(f.cards().get(0).q().contains("<span class=cloze>[typical]</span>"));
-        assertTrue(f.cards().get(0).a().contains("<span class=cloze>world</span>"));
+        assertTrue(f.firstCard().q().contains("<span class=cloze>[typical]</span>"));
+        assertTrue(f.firstCard().a().contains("<span class=cloze>world</span>"));
         // and with two clozes
         f = d.newNote(d.getModels().byName("Cloze"));
         f.setItem("Text", "hello {{c1::world}} {{c2::bar}}");
         assertEquals(2, d.addNote(f));
-        Card c1 = f.cards().get(0);
+        Card c1 = f.firstCard();
         Card c2 = f.cards().get(1);
         assertTrue(c1.q().contains("<span class=cloze>[...]</span> bar"));
         assertTrue(c1.a().contains("<span class=cloze>world</span> bar"));
@@ -65,7 +65,7 @@ public class ClozeTest extends RobolectricTest {
         f = d.newNote(d.getModels().byName("Cloze"));
         f.setItem("Text", "a {{c1::b}} {{c1::c}}");
         assertEquals(1, d.addNote(f));
-        assertTrue(f.cards().get(0).a().contains("<span class=cloze>b</span> <span class=cloze>c</span>"));
+        assertTrue(f.firstCard().a().contains("<span class=cloze>b</span> <span class=cloze>c</span>"));
         // if we add another cloze, a card should be generated
         int cnt = d.cardCount();
         f.setItem("Text", "{{c2::hello}} {{c1::foo}}");
@@ -80,17 +80,17 @@ public class ClozeTest extends RobolectricTest {
                 "string}}");
         f.flush();
         assertEquals(1, d.addNote(f));
-        String a = f.cards().get(0).q();
-        String b = f.cards().get(0).a();
-        assertTrue(f.cards().get(0).q().contains("Cloze with <span class=cloze>[...]</span>"));
-        assertTrue(f.cards().get(0).a().contains("Cloze with <span class=cloze>multi-line\nstring</span>"));
+        String a = f.firstCard().q();
+        String b = f.firstCard().a();
+        assertTrue(f.firstCard().q().contains("Cloze with <span class=cloze>[...]</span>"));
+        assertTrue(f.firstCard().a().contains("Cloze with <span class=cloze>multi-line\nstring</span>"));
         //try a multiline cloze in p tag
         f.setItem("Text", "<p>Cloze in html tag with {{c1::multi-line\n" +
                 "string}}</p>");
         f.flush();
         assertEquals(1, d.addNote(f));
-        assertTrue(f.cards().get(0).q().contains("<p>Cloze in html tag with <span class=cloze>[...]</span>"));
-        assertTrue(f.cards().get(0).a().contains("<p>Cloze in html tag with <span class=cloze>multi-line\nstring</span>"));
+        assertTrue(f.firstCard().q().contains("<p>Cloze in html tag with <span class=cloze>[...]</span>"));
+        assertTrue(f.firstCard().a().contains("<p>Cloze in html tag with <span class=cloze>multi-line\nstring</span>"));
 
         //make sure multiline cloze things aren't too greedy
         f.setItem("Text", "<p>Cloze in html tag with {{c1::multi-line\n" +
@@ -98,10 +98,10 @@ public class ClozeTest extends RobolectricTest {
                 "one}}</p>");
         f.flush();
         assertEquals(1, d.addNote(f));
-        assertTrue(f.cards().get(0).q().contains("<p>Cloze in html tag with <span class=cloze>[...]</span> and then {{c2:another\n" +
+        assertTrue(f.firstCard().q().contains("<p>Cloze in html tag with <span class=cloze>[...]</span> and then {{c2:another\n" +
                 "one}}</p>"));
 
-        assertTrue(f.cards().get(0).a().contains("<p>Cloze in html tag with <span class=cloze>multi-line\n" +
+        assertTrue(f.firstCard().a().contains("<p>Cloze in html tag with <span class=cloze>multi-line\n" +
                 "string</span> and then {{c2:another\n" +
                 "one}}</p>"));
     }

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/MathJaxClozeTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/MathJaxClozeTest.java
@@ -3,20 +3,13 @@ package com.ichi2.libanki;
 import android.content.Context;
 
 import com.ichi2.anki.RobolectricTest;
-import com.ichi2.libanki.Card;
-import com.ichi2.libanki.Collection;
-import com.ichi2.libanki.Models;
-import com.ichi2.libanki.Note;
 import com.ichi2.libanki.template.Template;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
 
-import androidx.test.core.app.ActivityScenario;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
@@ -52,7 +45,7 @@ public class MathJaxClozeTest extends RobolectricTest {
         Note f = c.newNote(c.getModels().byName("Cloze"));
         f.setItem("Text", "{{c1::ok}} \\(2^2\\) {{c2::not ok}} \\(2^{{c3::2}}\\) \\(x^3\\) {{c4::blah}} {{c5::text with \\(x^2\\) jax}}");
         c.addNote(f);
-        assertEquals(5, f.cids().size());
+        assertEquals(5, f.numberOfCards());
 
         ArrayList<Card> cards = f.cards();
 

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/MathJaxClozeTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/MathJaxClozeTest.java
@@ -52,7 +52,7 @@ public class MathJaxClozeTest extends RobolectricTest {
         Note f = c.newNote(c.getModels().byName("Cloze"));
         f.setItem("Text", "{{c1::ok}} \\(2^2\\) {{c2::not ok}} \\(2^{{c3::2}}\\) \\(x^3\\) {{c4::blah}} {{c5::text with \\(x^2\\) jax}}");
         c.addNote(f);
-        assertEquals(5, f.cards().size());
+        assertEquals(5, f.cids().size());
 
         ArrayList<Card> cards = f.cards();
 

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedTest.java
@@ -114,7 +114,7 @@ public class SchedTest extends RobolectricTest {
     @NonNull
     private Card createBuriedCardInDefaultDeck() {
         Note n = addNoteUsingBasicModel("Hello", "World");
-        Card c = n.cards().get(0);
+        Card c = n.firstCard();
         c.setQueue(Consts.QUEUE_TYPE_SIBLING_BURIED);
         c.flush();
         return c;


### PR DESCRIPTION
While porting upstream test, I did realize that sometime I only needed ids of cards of a note and not the cards itself. I added the method; I then realized that this method could be used in a lot of place. While replacing this method, I then realized that, often, either we only take the first card, or we take the size, so I created method to do it more efficiently and with less code