### PR TITLE
Scheduler: _fuzzIvlRange - Return Pair instead of Array

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
@@ -68,7 +68,7 @@ public abstract class AbstractSched {
     public abstract int _deckNewLimitSingle(JSONObject g);
     public abstract int totalNewForCurrentDeck();
     public abstract int totalRevForCurrentDeck();
-    public abstract int[] _fuzzedIvlRange(int ivl);
+    public abstract int[] _fuzzIvlRange(int ivl);
     /** Rebuild a dynamic deck. */
     public abstract void rebuildDyn();
     public abstract List<Long> rebuildDyn(long did);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
@@ -3,6 +3,7 @@ package com.ichi2.libanki.sched;
 import android.app.Activity;
 import android.content.Context;
 import android.content.res.Resources;
+import android.util.Pair;
 import android.widget.Toast;
 
 
@@ -68,7 +69,7 @@ public abstract class AbstractSched {
     public abstract int _deckNewLimitSingle(JSONObject g);
     public abstract int totalNewForCurrentDeck();
     public abstract int totalRevForCurrentDeck();
-    public abstract int[] _fuzzIvlRange(int ivl);
+    public abstract Pair<Integer, Integer> _fuzzIvlRange(int ivl);
     /** Rebuild a dynamic deck. */
     public abstract void rebuildDyn();
     public abstract List<Long> rebuildDyn(long did);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -29,6 +29,7 @@ import android.graphics.Typeface;
 import android.text.SpannableStringBuilder;
 import android.text.TextUtils;
 import android.text.style.StyleSpan;
+import android.util.Pair;
 
 import com.ichi2.anki.R;
 import com.ichi2.async.CollectionTask;
@@ -1554,19 +1555,19 @@ public class SchedV2 extends AbstractSched {
     }
 
     protected int _fuzzedIvl(int ivl) {
-        int[] minMax = _fuzzIvlRange(ivl);
+        Pair<Integer, Integer> minMax = _fuzzIvlRange(ivl);
         // Anki's python uses random.randint(a, b) which returns x in [a, b] while the eq Random().nextInt(a, b)
         // returns x in [0, b-a), hence the +1 diff with libanki
-        return (new Random().nextInt(minMax[1] - minMax[0] + 1)) + minMax[0];
+        return (new Random().nextInt(minMax.second - minMax.first + 1)) + minMax.first;
     }
 
 
-    public int[] _fuzzIvlRange(int ivl) {
+    public Pair<Integer, Integer> _fuzzIvlRange(int ivl) {
         int fuzz;
         if (ivl < 2) {
-            return new int[]{1, 1};
+            return new Pair<>(1, 1);
         } else if (ivl == 2) {
-            return new int[]{2, 3};
+            return new Pair<>(2, 3);
         } else if (ivl < 7) {
             fuzz = (int)(ivl * 0.25);
         } else if (ivl < 30) {
@@ -1576,7 +1577,7 @@ public class SchedV2 extends AbstractSched {
         }
         // fuzz at least a day
         fuzz = Math.max(fuzz, 1);
-        return new int[]{ivl - fuzz, ivl + fuzz};
+        return new Pair<>(ivl - fuzz, ivl + fuzz);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -1554,14 +1554,14 @@ public class SchedV2 extends AbstractSched {
     }
 
     protected int _fuzzedIvl(int ivl) {
-        int[] minMax = _fuzzedIvlRange(ivl);
+        int[] minMax = _fuzzIvlRange(ivl);
         // Anki's python uses random.randint(a, b) which returns x in [a, b] while the eq Random().nextInt(a, b)
         // returns x in [0, b-a), hence the +1 diff with libanki
         return (new Random().nextInt(minMax[1] - minMax[0] + 1)) + minMax[0];
     }
 
 
-    public int[] _fuzzedIvlRange(int ivl) {
+    public int[] _fuzzIvlRange(int ivl) {
         int fuzz;
         if (ivl < 2) {
             return new int[]{1, 1};


### PR DESCRIPTION
While porting upstream test, I realized a method's name was badly ported. I also change its type because the method always return two elements, so an array is less precise than a Pair