### PR TITLE
Correcting test on phone

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.java
@@ -50,6 +50,7 @@ import com.ichi2.utils.JSONArray;
 import com.ichi2.utils.JSONObject;
 import org.junit.After;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -60,11 +61,13 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeThat;
 import static org.junit.Assume.assumeTrue;
 
 /**
@@ -137,6 +140,12 @@ public class ContentProviderTest extends InstrumentedTest {
         // (so it is safe) we will try to run with multiple scheduler versions
         if (InstrumentedTest.isEmulator()) {
             col.changeSchedulerVer(schedVersion);
+        } else {
+            if (schedVersion == 1) {
+                assumeThat(col.getSched().getName(), is("std"));
+            } else {
+                assumeThat(col.getSched().getName(), is("std2"));
+            }
         }
 
         // Add a new basic model that we use for testing purposes (existing models could potentially be corrupted)

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.java
@@ -114,6 +114,8 @@ public class ContentProviderTest extends InstrumentedTest {
     private static final String[] TEST_MODEL_AFMT = {"{{BACK}}", "{{FRONTS}}"};
     private static final String[] TEST_NOTE_FIELDS = {"dis is za Fr0nt", "Te$t"};
     private static final String TEST_MODEL_CSS = "styleeeee";
+    // Whether tear down should be executed. I.e. if set up was not cancelled.
+    private boolean tearDown;
 
     private int mNumDecksBeforeTest;
     /* initialCapacity set to expected value when the test is written.
@@ -138,6 +140,7 @@ public class ContentProviderTest extends InstrumentedTest {
 
         // We have parameterized the "schedVersion" variable, if we are on an emulator
         // (so it is safe) we will try to run with multiple scheduler versions
+        tearDown = false;
         if (InstrumentedTest.isEmulator()) {
             col.changeSchedulerVer(schedVersion);
         } else {
@@ -147,6 +150,8 @@ public class ContentProviderTest extends InstrumentedTest {
                 assumeThat(col.getSched().getName(), is("std2"));
             }
         }
+        tearDown = true;
+        // Do not teardown if setup was aborted
 
         // Add a new basic model that we use for testing purposes (existing models could potentially be corrupted)
         Model model = StdModels.basicModel.add(col, BASIC_MODEL_NAME);
@@ -201,6 +206,9 @@ public class ContentProviderTest extends InstrumentedTest {
     @After
     public void tearDown() throws Exception {
         Log.i(AnkiDroidApp.TAG, "tearDown()");
+        if (!tearDown) {
+            return;
+        }
         final Collection col = getCol();
         // Delete all notes
         List<Long> remnantNotes = col.findNotes("tag:" + TEST_TAG);


### PR DESCRIPTION
On my phone, tests break, because the schedVersion is checked even if the sched version was not actually changed. So I
used real test instead.
I believe that what would be even better would be to run the tests only once if we are on phone, but I don't know how to
do it


I tried to follow https://github.com/ankidroid/Anki-Android/pull/6712#pullrequestreview-453227021 but it does not work for reason I don't really understand. Probably because setup halts but teardown is still executed