### PR TITLE
Remove useless task data

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -1865,7 +1865,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
     public void importAdd(String importPath) {
         Timber.d("importAdd() for file %s", importPath);
         CollectionTask.launchCollectionTask(IMPORT, mImportAddListener,
-                new TaskData(importPath, false));
+                new TaskData(importPath));
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -2395,8 +2395,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
     public void rebuildFiltered() {
         getCol().getDecks().select(mContextMenuDid);
-        CollectionTask.launchCollectionTask(REBUILD_CRAM, mSimpleProgressListener,
-                new TaskData(mFragmented));
+        CollectionTask.launchCollectionTask(REBUILD_CRAM, mSimpleProgressListener);
     }
 
     public void emptyFiltered() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -2401,8 +2401,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
     public void emptyFiltered() {
         getCol().getDecks().select(mContextMenuDid);
-        CollectionTask.launchCollectionTask(EMPTY_CRAM, mSimpleProgressListener,
-                new TaskData(mFragmented));
+        CollectionTask.launchCollectionTask(EMPTY_CRAM, mSimpleProgressListener);
     }
 
     @Override

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
@@ -323,8 +323,7 @@ public class StudyOptionsFragment extends Fragment implements Toolbar.OnMenuItem
                 Timber.i("StudyOptionsFragment:: rebuild cram deck button pressed");
                 mProgressDialog = StyledProgressDialog.show(getActivity(), "",
                         getResources().getString(R.string.rebuild_cram_deck), true);
-                CollectionTask.launchCollectionTask(REBUILD_CRAM, getCollectionTaskListener(true),
-                        new TaskData(mFragmented));
+                CollectionTask.launchCollectionTask(REBUILD_CRAM, getCollectionTaskListener(true));
                 return true;
             case R.id.action_empty:
                 Timber.i("StudyOptionsFragment:: empty cram deck button pressed");
@@ -450,8 +449,7 @@ public class StudyOptionsFragment extends Fragment implements Toolbar.OnMenuItem
                 }
                     mProgressDialog = StyledProgressDialog.show(getActivity(), "",
                             getResources().getString(R.string.rebuild_cram_deck), true);
-                    CollectionTask.launchCollectionTask(REBUILD_CRAM, getCollectionTaskListener(true),
-                            new TaskData(mFragmented));
+                    CollectionTask.launchCollectionTask(REBUILD_CRAM, getCollectionTaskListener(true));
             } else {
                 CollectionTask.waitToFinish();
                 refreshInterface(true);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
@@ -330,8 +330,7 @@ public class StudyOptionsFragment extends Fragment implements Toolbar.OnMenuItem
                 Timber.i("StudyOptionsFragment:: empty cram deck button pressed");
                 mProgressDialog = StyledProgressDialog.show(getActivity(), "",
                         getResources().getString(R.string.empty_cram_deck), false);
-                CollectionTask.launchCollectionTask(EMPTY_CRAM, getCollectionTaskListener(true),
-                        new TaskData(mFragmented));
+                CollectionTask.launchCollectionTask(EMPTY_CRAM, getCollectionTaskListener(true));
                 return true;
             case R.id.action_rename:
                 ((DeckPicker) getActivity()).renameDeckDialog(getCol().getDecks().selected());


### PR DESCRIPTION
While creating https://github.com/ankidroid/Anki-Android/pull/6721 , I realized that some background tasks received task data that are never actually used. This PR remove them.

I'm sorry, in this case, I can't prove to you that this PR is okay, you'll need to go and check that Import does not uses the boolean, Rebuild_cram and Empty_cram does not uses any task data.

I'm testing it on my phone, in my Merge branch