### PR TITLE
NF: collectionTask creation and launch are distinct

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1093,24 +1093,21 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
            note type could have lead to the card being deleted */
         if (data != null && data.hasExtra("reloadRequired")) {
             getCol().getSched().deferReset();
-            CollectionTask.launchCollectionTask(ANSWER_CARD, mAnswerCardHandler(false),
-                    new TaskData(null, 0));
+            new CollectionTask(ANSWER_CARD, mAnswerCardHandler(false)).launch(new TaskData(null, 0));
         }
 
         if (requestCode == EDIT_CURRENT_CARD) {
             if (resultCode == RESULT_OK) {
                 // content of note was changed so update the note and current card
                 Timber.i("AbstractFlashcardViewer:: Saving card...");
-                CollectionTask.launchCollectionTask(UPDATE_NOTE, mUpdateCardHandler,
-                        new TaskData(sEditorCard, true));
+                new CollectionTask(UPDATE_NOTE, mUpdateCardHandler).launch(new TaskData(sEditorCard, true));
             } else if (resultCode == RESULT_CANCELED && !(data!=null && data.hasExtra("reloadRequired"))) {
                 // nothing was changed by the note editor so just redraw the card
                 redrawCard();
             }
         } else if (requestCode == DECK_OPTIONS && resultCode == RESULT_OK) {
             getCol().getSched().deferReset();
-            CollectionTask.launchCollectionTask(ANSWER_CARD, mAnswerCardHandler(false),
-                    new TaskData(null, 0));
+            new CollectionTask(ANSWER_CARD, mAnswerCardHandler(false)).launch(new TaskData(null, 0));
         }
         if (!mDisableClipboard) {
             clipboardSetText("");
@@ -1199,7 +1196,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
 
     protected void undo() {
         if (isUndoAvailable()) {
-            CollectionTask.launchCollectionTask(UNDO, mAnswerCardHandler(false));
+            new CollectionTask(UNDO, mAnswerCardHandler(false)).launch();
         }
     }
 
@@ -1352,8 +1349,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         mSoundPlayer.stopSounds();
         mCurrentEase = ease;
 
-        CollectionTask.launchCollectionTask(ANSWER_CARD, mAnswerCardHandler(true),
-                new TaskData(mCurrentCard, mCurrentEase));
+        new CollectionTask(ANSWER_CARD, mAnswerCardHandler(true)).launch(new TaskData(mCurrentCard, mCurrentEase));
     }
 
 
@@ -3069,8 +3065,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
 
     protected void dismiss(Collection.DismissType type) {
         blockControls(false);
-        CollectionTask.launchCollectionTask(DISMISS, mDismissCardHandler,
-                new TaskData(new Object[]{mCurrentCard, type}));
+        new CollectionTask(DISMISS, mDismissCardHandler).launch(new TaskData(new Object[]{mCurrentCard, type}));
     }
 
     /** Signals from a WebView represent actions with no parameters */
@@ -3463,8 +3458,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
 
     @VisibleForTesting
     void loadInitialCard() {
-        CollectionTask.launchCollectionTask(ANSWER_CARD, mAnswerCardHandler(false),
-                new TaskData(null, 0));
+        new CollectionTask(ANSWER_CARD, mAnswerCardHandler(false)).launch(new TaskData(null, 0));
     }
 
     public ReviewerUi.ControlBlock getControlBlocked() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -864,9 +864,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
         }
 
         if (!mCheckedCardPositions.isEmpty()) {
-            CollectionTask.launchCollectionTask(CHECK_CARD_SELECTION,
-                    mCheckSelectedCardsHandler,
-                    new TaskData(new Object[]{mCheckedCardPositions, getCards()}));
+            new CollectionTask(CHECK_CARD_SELECTION, mCheckSelectedCardsHandler).launch(new TaskData(new Object[]{mCheckedCardPositions, getCards()}));
         }
 
         mActionBarMenu.findItem(R.id.action_select_all).setVisible(!hasSelectedAllCards());
@@ -886,9 +884,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
 
     private void flagTask (int flag) {
-        CollectionTask.launchCollectionTask(DISMISS_MULTI,
-                                mFlagCardHandler,
-                                new TaskData(new Object[]{getSelectedCardIds(), Collection.DismissType.FLAG, new Integer (flag)}));
+        new CollectionTask(DISMISS_MULTI, mFlagCardHandler).launch(new TaskData(new Object[]{getSelectedCardIds(), Collection.DismissType.FLAG, new Integer (flag)}));
     }
 
     @Override
@@ -980,9 +976,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
             case R.id.action_delete_card:
                 if (mInMultiSelectMode) {
-                    CollectionTask.launchCollectionTask(DISMISS_MULTI,
-                            mDeleteNoteHandler,
-                            new TaskData(new Object[]{getSelectedCardIds(), Collection.DismissType.DELETE_NOTE_MULTI}));
+                    new CollectionTask(DISMISS_MULTI, mDeleteNoteHandler).launch(new TaskData(new Object[]{getSelectedCardIds(), Collection.DismissType.DELETE_NOTE_MULTI}));
 
                     mCheckedCardPositions.clear();
                     endMultiSelectMode();
@@ -991,17 +985,13 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 return true;
 
             case R.id.action_mark_card:
-                CollectionTask.launchCollectionTask(DISMISS_MULTI,
-                        mMarkCardHandler,
-                        new TaskData(new Object[]{getSelectedCardIds(), Collection.DismissType.MARK_NOTE_MULTI}));
+                new CollectionTask(DISMISS_MULTI, mMarkCardHandler).launch(new TaskData(new Object[]{getSelectedCardIds(), Collection.DismissType.MARK_NOTE_MULTI}));
 
                 return true;
 
 
             case R.id.action_suspend_card:
-                CollectionTask.launchCollectionTask(DISMISS_MULTI,
-                        mSuspendCardHandler,
-                        new TaskData(new Object[]{getSelectedCardIds(), Collection.DismissType.SUSPEND_CARD_MULTI}));
+                new CollectionTask(DISMISS_MULTI, mSuspendCardHandler).launch(new TaskData(new Object[]{getSelectedCardIds(), Collection.DismissType.SUSPEND_CARD_MULTI}));
 
                 return true;
 
@@ -1039,7 +1029,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
             case R.id.action_undo:
                 if (getCol().undoAvailable()) {
-                    CollectionTask.launchCollectionTask(UNDO, mUndoHandler);
+                    new CollectionTask(UNDO, mUndoHandler).launch();
                 }
                 return true;
             case R.id.action_select_none:
@@ -1075,8 +1065,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 dialog.setArgs(title, message);
                 Runnable confirm = () -> {
                     Timber.i("CardBrowser:: ResetProgress button pressed");
-                    CollectionTask.launchCollectionTask(DISMISS_MULTI, mResetProgressCardHandler,
-                            new TaskData(new Object[]{getSelectedCardIds(), Collection.DismissType.RESET_CARDS}));
+                    new CollectionTask(DISMISS_MULTI, mResetProgressCardHandler).launch(new TaskData(new Object[]{getSelectedCardIds(), Collection.DismissType.RESET_CARDS}));
                 };
                 dialog.setConfirm(confirm);
                 showDialogFragment(dialog);
@@ -1087,9 +1076,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
                 long[] selectedCardIds = getSelectedCardIds();
                 FunctionalInterfaces.Consumer<Integer> consumer = newDays ->
-                    CollectionTask.launchCollectionTask(DISMISS_MULTI,
-                        mRescheduleCardHandler,
-                        new TaskData(new Object[]{selectedCardIds, Collection.DismissType.RESCHEDULE_CARDS, newDays}));
+                    new CollectionTask(DISMISS_MULTI, mRescheduleCardHandler).launch(new TaskData(new Object[]{selectedCardIds, Collection.DismissType.RESCHEDULE_CARDS, newDays}));
 
                 RescheduleDialog rescheduleDialog;
                 if (selectedCardIds.length == 1) {
@@ -1126,8 +1113,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
                         getString(R.string.reposition_card_dialog_message),
                         5);
                 repositionDialog.setCallbackRunnable(days ->
-                    CollectionTask.launchCollectionTask(DISMISS_MULTI, mRepositionCardHandler,
-                        new TaskData(new Object[] {cardIds, Collection.DismissType.REPOSITION_CARDS, days}))
+                    new CollectionTask(DISMISS_MULTI, mRepositionCardHandler).launch(new TaskData(new Object[] {cardIds, Collection.DismissType.REPOSITION_CARDS, days}))
                 );
                 showDialogFragment(repositionDialog);
                 return true;
@@ -1155,8 +1141,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
         if (requestCode == EDIT_CARD && resultCode != RESULT_CANCELED) {
             Timber.i("CardBrowser:: CardBrowser: Saving card...");
-            CollectionTask.launchCollectionTask(UPDATE_NOTE, mUpdateCardHandler,
-                    new TaskData(sCardBrowserCard, false));
+            new CollectionTask(UPDATE_NOTE, mUpdateCardHandler).launch(new TaskData(sCardBrowserCard, false));
         } else if (requestCode == ADD_NOTE && resultCode == RESULT_OK) {
             if (mSearchView != null) {
                 mSearchTerms = mSearchView.getQuery().toString();
@@ -1264,8 +1249,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
             int numCardsToRender = (int) Math.ceil(mCardsListView.getHeight()/
                     TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 20, getResources().getDisplayMetrics())) + 5;
             // Perform database query to get all card ids
-            CollectionTask.launchCollectionTask(SEARCH_CARDS, mSearchCardsHandler, new TaskData(
-                    new Object[] {searchText, ((mOrder != CARD_ORDER_NONE)),  numCardsToRender}));
+            new CollectionTask(SEARCH_CARDS, mSearchCardsHandler).launch(new TaskData(new Object[] {searchText, ((mOrder != CARD_ORDER_NONE)),  numCardsToRender}));
         }
     }
 
@@ -1467,7 +1451,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
             mUndoSnackbar = UIUtils.showSnackbar(CardBrowser.this, String.format(getString(R.string.changed_deck_message), deckName), SNACKBAR_DURATION, R.string.undo, new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
-                    CollectionTask.launchCollectionTask(UNDO, mUndoHandler);
+                    new CollectionTask(UNDO, mUndoHandler).launch();
                 }
             }, mCardsListView, null);
         }
@@ -1649,7 +1633,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
             mUndoSnackbar = UIUtils.showSnackbar(CardBrowser.this, getString(R.string.deleted_message), SNACKBAR_DURATION, R.string.undo, new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
-                    CollectionTask.launchCollectionTask(UNDO, mUndoHandler);
+                    new CollectionTask(UNDO, mUndoHandler).launch();
                 }
             }, mCardsListView, null);
         }
@@ -1863,8 +1847,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
                     if ((currentTime - mLastRenderStart > 300 || lastVisibleItem >= totalItemCount)) {
                         mLastRenderStart = currentTime;
                         CollectionTask.cancelAllTasks(RENDER_BROWSER_QA);
-                        CollectionTask.launchCollectionTask(RENDER_BROWSER_QA, mRenderQAHandler,
-                                new TaskData(new Object[]{getCards(), firstVisibleItem, visibleItemCount}));
+                        new CollectionTask(RENDER_BROWSER_QA, mRenderQAHandler).launch(new TaskData(new Object[]{getCards(), firstVisibleItem, visibleItemCount}));
                     }
                 }
             }
@@ -1877,8 +1860,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
             if (scrollState == SCROLL_STATE_IDLE) {
                 int startIdx = listView.getFirstVisiblePosition();
                 int numVisible = listView.getLastVisiblePosition() - startIdx;
-                CollectionTask.launchCollectionTask(RENDER_BROWSER_QA, mRenderQAHandler,
-                        new TaskData(new Object[]{getCards(), startIdx - 5, 2 * numVisible + 5}));
+                new CollectionTask(RENDER_BROWSER_QA, mRenderQAHandler).launch(new TaskData(new Object[]{getCards(), startIdx - 5, 2 * numVisible + 5}));
             }
         }
     }
@@ -2239,8 +2221,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     void rerenderAllCards() {
-        CollectionTask.launchCollectionTask(RENDER_BROWSER_QA, mRenderQAHandler,
-                new TaskData(new Object[]{getCards(), 0, mCards.size()-1}));
+        new CollectionTask(RENDER_BROWSER_QA, mRenderQAHandler).launch(new TaskData(new Object[]{getCards(), 0, mCards.size()-1}));
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
@@ -2298,8 +2279,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
     @VisibleForTesting(otherwise = VisibleForTesting.NONE) //should only be called from changeDeck()
     void executeChangeCollectionTask(long[] ids, long newDid) {
         mNewDid = newDid; //line required for unit tests, not necessary, but a noop in regular call.
-        CollectionTask.launchCollectionTask(DISMISS_MULTI, mChangeDeckHandler,
-                new TaskData(new Object[]{ids, Collection.DismissType.CHANGE_DECK_MULTI, newDid}));
+        new CollectionTask(DISMISS_MULTI, mChangeDeckHandler).launch(new TaskData(new Object[]{ids, Collection.DismissType.CHANGE_DECK_MULTI, newDid}));
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
@@ -206,8 +206,7 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
                                 int oldValue = mOptions.getJSONObject("new").getInt("order");
                                 if (oldValue != newValue) {
                                     mOptions.getJSONObject("new").put("order", newValue);
-                                    CollectionTask.launchCollectionTask(REORDER, mConfChangeHandler,
-                                            new TaskData(new Object[] {mOptions}));
+                                    new CollectionTask(REORDER, mConfChangeHandler).launch(new TaskData(new Object[] {mOptions}));
                                 }
                                 mOptions.getJSONObject("new").put("order", Integer.parseInt((String) value));
                                 break;
@@ -296,8 +295,7 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
                             case "deckConf": {
                                 long newConfId = Long.parseLong((String) value);
                                 mOptions = mCol.getDecks().getConf(newConfId);
-                                CollectionTask.launchCollectionTask(CONF_CHANGE, mConfChangeHandler,
-                                        new TaskData(new Object[] {mDeck, mOptions}));
+                                new CollectionTask(CONF_CHANGE, mConfChangeHandler).launch(new TaskData(new Object[] {mDeck, mOptions}));
                                 break;
                             }
                             case "confRename": {
@@ -309,8 +307,7 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
                             }
                             case "confReset":
                                 if ((Boolean) value) {
-                                    CollectionTask.launchCollectionTask(CONF_RESET, mConfChangeHandler,
-                                            new TaskData(new Object[] {mOptions}));
+                                    new CollectionTask(CONF_RESET, mConfChangeHandler).launch(new TaskData(new Object[] {mOptions}));
                                 }
                                 break;
                             case "confAdd": {
@@ -355,8 +352,7 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
                                 break;
                             case "confSetSubdecks":
                                 if ((Boolean) value) {
-                                    CollectionTask.launchCollectionTask(CONF_SET_SUBDECKS, mConfChangeHandler,
-                                            new TaskData(new Object[] {mDeck, mOptions}));
+                                    new CollectionTask(CONF_SET_SUBDECKS, mConfChangeHandler).launch(new TaskData(new Object[] {mDeck, mOptions}));
                                 }
                                 break;
                             case "reminderEnabled": {
@@ -547,8 +543,7 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
                 // Remove options group, asking user to confirm full sync if necessary
                 mCol.getDecks().remConf(mOptions.getLong("id"));
                 // Run the CPU intensive re-sort operation in a background thread
-                CollectionTask.launchCollectionTask(CONF_REMOVE, mConfChangeHandler,
-                                        new TaskData(new Object[] { mOptions }));
+                new CollectionTask(CONF_REMOVE, mConfChangeHandler).launch(new TaskData(new Object[] { mOptions }));
                 mDeck.put("conf", 1);
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -841,7 +841,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
         }
         /** Complete task and enqueue fetching nonessential data for
          * startup. */
-        CollectionTask.launchCollectionTask(LOAD_COLLECTION_COMPLETE);
+        new CollectionTask(LOAD_COLLECTION_COMPLETE).launch();
     }
 
 
@@ -1229,7 +1229,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
         Timber.i("undo()");
         String undoReviewString = getResources().getString(R.string.undo_action_review);
         final boolean isReview = undoReviewString.equals(getCol().undoName(getResources()));
-        CollectionTask.launchCollectionTask(UNDO, new CollectionTask.TaskListener() {
+        new CollectionTask(UNDO, new CollectionTask.TaskListener() {
             @Override
             public void onCancelled() {
                 hideProgressBar();
@@ -1249,7 +1249,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
                     openReviewer();
                 }
             }
-        });
+        }).launch();
     }
 
 
@@ -1371,7 +1371,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
     // Callback method to handle repairing deck
     public void repairCollection() {
         Timber.i("Repairing the Collection");
-        CollectionTask.launchCollectionTask(REPAIR_COLLECTION, new CollectionTask.TaskListener() {
+        new CollectionTask(REPAIR_COLLECTION, new CollectionTask.TaskListener() {
 
             @Override
             public void onPreExecute() {
@@ -1390,7 +1390,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
                     showCollectionErrorDialog();
                 }
             }
-        });
+        }).launch();
     }
 
 
@@ -1416,13 +1416,13 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
     private void performIntegrityCheck() {
         Timber.i("performIntegrityCheck()");
-        CollectionTask.launchCollectionTask(CHECK_DATABASE, new CheckDatabaseListener());
+        new CollectionTask(CHECK_DATABASE, new CheckDatabaseListener()).launch();
     }
 
 
     @Override
     public void mediaCheck() {
-        CollectionTask.launchCollectionTask(CHECK_MEDIA, new CollectionTask.TaskListener() {
+        new CollectionTask(CHECK_MEDIA, new CollectionTask.TaskListener() {
             @Override
             public void onPreExecute() {
                 mProgressDialog = StyledProgressDialog.show(DeckPicker.this, "",
@@ -1443,7 +1443,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
                     showSimpleMessageDialog(getResources().getString(R.string.check_media_failed));
                 }
             }
-        });
+        }).launch();
     }
 
 
@@ -1864,15 +1864,14 @@ public class DeckPicker extends NavigationDrawerActivity implements
     @Override
     public void importAdd(String importPath) {
         Timber.d("importAdd() for file %s", importPath);
-        CollectionTask.launchCollectionTask(IMPORT, mImportAddListener,
-                new TaskData(importPath));
+        new CollectionTask(IMPORT, mImportAddListener).launch(new TaskData(importPath, false));
     }
 
 
     // Callback to import a file -- replacing the existing collection
     @Override
     public void importReplace(String importPath) {
-        CollectionTask.launchCollectionTask(IMPORT_REPLACE, mImportReplaceListener, new TaskData(importPath));
+        new CollectionTask(IMPORT_REPLACE, mImportReplaceListener).launch(new TaskData(importPath));
     }
 
 
@@ -1904,7 +1903,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
         inputArgs[2] = did;
         inputArgs[3] = includeSched;
         inputArgs[4] = includeMedia;
-        CollectionTask.launchCollectionTask(EXPORT_APKG, mExportListener, new TaskData(inputArgs));
+        new CollectionTask(EXPORT_APKG, mExportListener).launch(new TaskData(inputArgs));
     }
 
 
@@ -2141,7 +2140,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
      * This method also triggers an update for the widget to reflect the newly calculated counts.
      */
     private void updateDeckList() {
-        CollectionTask task = CollectionTask.launchCollectionTask(LOAD_DECK_COUNTS, new CollectionTask.TaskListener() {
+        new CollectionTask(LOAD_DECK_COUNTS, new CollectionTask.TaskListener() {
 
             @Override
             public void onPreExecute() {
@@ -2171,7 +2170,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
                 AnkiStatsTaskHandler.createReviewSummaryStatistics(getCol(), mReviewSummaryTextView);
                 Timber.d("Startup - Deck List UI Completed");
             }
-        });
+        }).launch();
     }
 
     public void __renderPage() {
@@ -2330,7 +2329,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
         deleteDeck(mContextMenuDid);
     }
     public void deleteDeck(final long did) {
-        CollectionTask.launchCollectionTask(DELETE_DECK, new CollectionTask.TaskListener() {
+        new CollectionTask(DELETE_DECK, new CollectionTask.TaskListener() {
             // Flag to indicate if the deck being deleted is the current deck.
             private boolean removingCurrent;
 
@@ -2370,7 +2369,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
                 // TODO: if we had "undo delete note" like desktop client then we won't need this.
                 getCol().clearUndo();
             }
-        }, new TaskData(did));
+        }).launch( new TaskData(did));
     }
 
     /**
@@ -2395,12 +2394,12 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
     public void rebuildFiltered() {
         getCol().getDecks().select(mContextMenuDid);
-        CollectionTask.launchCollectionTask(REBUILD_CRAM, mSimpleProgressListener);
+        new CollectionTask(REBUILD_CRAM, mSimpleProgressListener).launch(new TaskData(mFragmented));
     }
 
     public void emptyFiltered() {
         getCol().getDecks().select(mContextMenuDid);
-        CollectionTask.launchCollectionTask(EMPTY_CRAM, mSimpleProgressListener);
+        new CollectionTask(EMPTY_CRAM, mSimpleProgressListener).launch(new TaskData(mFragmented));
     }
 
     @Override
@@ -2440,7 +2439,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
     }
 
     public void handleEmptyCards() {
-        CollectionTask.launchCollectionTask(FIND_EMPTY_CARDS, new CollectionTask.TaskListener() {
+        new CollectionTask(FIND_EMPTY_CARDS, new CollectionTask.TaskListener() {
             @Override
             public void onPreExecute() {
                 mProgressDialog = StyledProgressDialog.show(DeckPicker.this, "",
@@ -2469,7 +2468,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
                     mProgressDialog.dismiss();
                 }
             }
-        });
+        }).launch();
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.java
@@ -228,7 +228,7 @@ public class ModelBrowser extends AnkiActivity {
     public void onCollectionLoaded(Collection col) {
         super.onCollectionLoaded(col);
         this.col = col;
-        CollectionTask.launchCollectionTask(COUNT_MODELS, mLoadingModelsHandler);
+        new CollectionTask(COUNT_MODELS, mLoadingModelsHandler).launch();
     }
 
 
@@ -507,15 +507,14 @@ public class ModelBrowser extends AnkiActivity {
      * Reloads everything
      */
     private void fullRefresh() {
-        CollectionTask.launchCollectionTask(COUNT_MODELS, mLoadingModelsHandler);
+        new CollectionTask(COUNT_MODELS, mLoadingModelsHandler);
     }
 
     /*
      * Deletes the currently selected model
      */
     private void deleteModel() throws ConfirmModSchemaException {
-        CollectionTask.launchCollectionTask(DELETE_MODEL, mDeleteModelHandler,
-                new TaskData(mCurrentID));
+        new CollectionTask(DELETE_MODEL, mDeleteModelHandler).launch(new TaskData(mCurrentID));
         mModels.remove(mModelListPosition);
         mModelIds.remove(mModelListPosition);
         mModelDisplayList.remove(mModelListPosition);
@@ -615,7 +614,7 @@ public class ModelBrowser extends AnkiActivity {
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
         if (requestCode == REQUEST_TEMPLATE_EDIT) {
-            CollectionTask.launchCollectionTask(COUNT_MODELS, mLoadingModelsHandler);
+            new CollectionTask(COUNT_MODELS, mLoadingModelsHandler).launch();
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.java
@@ -181,8 +181,7 @@ public class ModelFieldEditor extends AnkiActivity {
                         //Name is valid, now field is added
                         try {
                             mCol.modSchema();
-                            CollectionTask.launchCollectionTask(ADD_FIELD, mChangeFieldHandler,
-                                    new TaskData(new Object[]{mMod, fieldName}));
+                            new CollectionTask(ADD_FIELD, mChangeFieldHandler).launch(new TaskData(new Object[]{mMod, fieldName}));
                         } catch (ConfirmModSchemaException e) {
 
                             //Create dialogue to for schema change
@@ -192,8 +191,7 @@ public class ModelFieldEditor extends AnkiActivity {
                                 mCol.modSchemaNoCheck();
                                 String fieldName1 = mFieldNameInput.getText().toString()
                                         .replaceAll("[\\n\\r]", "");
-                                CollectionTask.launchCollectionTask(ADD_FIELD, mChangeFieldHandler,
-                                        new TaskData(new Object[]{mMod, fieldName1}));
+                                new CollectionTask(ADD_FIELD, mChangeFieldHandler).launch(new TaskData(new Object[]{mMod, fieldName1}));
                                 dismissContextMenu();
                             };
 
@@ -242,8 +240,7 @@ public class ModelFieldEditor extends AnkiActivity {
     }
 
     private void deleteField() {
-        CollectionTask.launchCollectionTask(DELETE_FIELD, mChangeFieldHandler,
-                                new TaskData(new Object[]{mMod, mNoteFields.getJSONObject(mCurrentPos)}));
+        new CollectionTask(DELETE_FIELD, mChangeFieldHandler).launch(new TaskData(new Object[]{mMod, mNoteFields.getJSONObject(mCurrentPos)}));
     }
 
 
@@ -325,8 +322,7 @@ public class ModelFieldEditor extends AnkiActivity {
                             // Input is valid, now attempt to modify
                             try {
                                 mCol.modSchema();
-                                CollectionTask.launchCollectionTask(REPOSITION_FIELD, mChangeFieldHandler,
-                                        new TaskData(new Object[]{mMod,
+                                new CollectionTask(REPOSITION_FIELD, mChangeFieldHandler).launch(new TaskData(new Object[]{mMod,
                                                 mNoteFields.getJSONObject(mCurrentPos), pos - 1}));
                             } catch (ConfirmModSchemaException e) {
 
@@ -338,8 +334,7 @@ public class ModelFieldEditor extends AnkiActivity {
                                         mCol.modSchemaNoCheck();
                                         String newPosition1 = mFieldNameInput.getText().toString();
                                         int pos1 = Integer.parseInt(newPosition1);
-                                        CollectionTask.launchCollectionTask(REPOSITION_FIELD,
-                                                mChangeFieldHandler, new TaskData(new Object[]{mMod,
+                                        new CollectionTask(REPOSITION_FIELD, mChangeFieldHandler).launch(new TaskData(new Object[]{mMod,
                                                         mNoteFields.getJSONObject(mCurrentPos), pos1 - 1}));
                                         dismissContextMenu();
                                     } catch (JSONException e1) {
@@ -400,16 +395,14 @@ public class ModelFieldEditor extends AnkiActivity {
     private void sortByField() {
         try {
             mCol.modSchema();
-            CollectionTask.launchCollectionTask(CHANGE_SORT_FIELD, mChangeFieldHandler,
-                    new TaskData(new Object[]{mMod, mCurrentPos}));
+            new CollectionTask(CHANGE_SORT_FIELD, mChangeFieldHandler).launch(new TaskData(new Object[]{mMod, mCurrentPos}));
         } catch (ConfirmModSchemaException e) {
             // Handler mMod schema confirmation
             ConfirmationDialog c = new ConfirmationDialog();
             c.setArgs(getResources().getString(R.string.full_sync_confirmation));
             Runnable confirm = () -> {
                 mCol.modSchemaNoCheck();
-                CollectionTask.launchCollectionTask(CHANGE_SORT_FIELD, mChangeFieldHandler,
-                        new TaskData(new Object[]{mMod, mCurrentPos}));
+                new CollectionTask(CHANGE_SORT_FIELD, mChangeFieldHandler).launch(new TaskData(new Object[]{mMod, mCurrentPos}));
                 dismissContextMenu();
             };
             c.setConfirm(confirm);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -789,7 +789,7 @@ public class NoteEditor extends AnkiActivity {
             }
             getCol().getModels().current().put("tags", ja);
             getCol().getModels().setChanged();
-            CollectionTask.launchCollectionTask(ADD_NOTE, mSaveNoteHandler, new TaskData(mEditorNote));
+            new CollectionTask(ADD_NOTE, mSaveNoteHandler).launch(new TaskData(mEditorNote));
         } else {
             // Check whether note type has been changed
             final Model newModel = getCurrentlySelectedModel();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -234,8 +234,7 @@ public class Reviewer extends AbstractFlashcardViewer {
         }
 
         col.getSched().deferReset();     // Reset schedule in case card was previously loaded
-        CollectionTask.launchCollectionTask(ANSWER_CARD, mAnswerCardHandler(false),
-                new TaskData(null, 0));
+        new CollectionTask(ANSWER_CARD, mAnswerCardHandler(false)).launch(new TaskData(null, 0));
 
         disableDrawerSwipeOnConflicts();
         // Add a weak reference to current activity so that scheduler can talk to to Activity
@@ -452,8 +451,7 @@ public class Reviewer extends AbstractFlashcardViewer {
 
     private void showRescheduleCardDialog() {
         Consumer<Integer> runnable = days ->
-            CollectionTask.launchCollectionTask(DISMISS_MULTI, mRescheduleCardHandler,
-                    new TaskData(new Object[]{new long[]{mCurrentCard.getId()},
+            new CollectionTask(DISMISS_MULTI, mRescheduleCardHandler).launch(new TaskData(new Object[]{new long[]{mCurrentCard.getId()},
                     Collection.DismissType.RESCHEDULE_CARDS, days})
             );
         RescheduleDialog dialog = RescheduleDialog.rescheduleSingleCard(getResources(), mCurrentCard, runnable);
@@ -472,8 +470,7 @@ public class Reviewer extends AbstractFlashcardViewer {
         dialog.setArgs(title, message);
         Runnable confirm = () -> {
             Timber.i("NoteEditor:: ResetProgress button pressed");
-            CollectionTask.launchCollectionTask(DISMISS_MULTI, mResetProgressCardHandler,
-                    new TaskData(new Object[]{new long[]{mCurrentCard.getId()}, Collection.DismissType.RESET_CARDS}));
+            new CollectionTask(DISMISS_MULTI, mResetProgressCardHandler).launch(new TaskData(new Object[]{new long[]{mCurrentCard.getId()}, Collection.DismissType.RESET_CARDS}));
         };
         dialog.setConfirm(confirm);
         showDialogFragment(dialog);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
@@ -323,13 +323,13 @@ public class StudyOptionsFragment extends Fragment implements Toolbar.OnMenuItem
                 Timber.i("StudyOptionsFragment:: rebuild cram deck button pressed");
                 mProgressDialog = StyledProgressDialog.show(getActivity(), "",
                         getResources().getString(R.string.rebuild_cram_deck), true);
-                CollectionTask.launchCollectionTask(REBUILD_CRAM, getCollectionTaskListener(true));
+                new CollectionTask(REBUILD_CRAM, getCollectionTaskListener(true)).launch(new TaskData(mFragmented));
                 return true;
             case R.id.action_empty:
                 Timber.i("StudyOptionsFragment:: empty cram deck button pressed");
                 mProgressDialog = StyledProgressDialog.show(getActivity(), "",
                         getResources().getString(R.string.empty_cram_deck), false);
-                CollectionTask.launchCollectionTask(EMPTY_CRAM, getCollectionTaskListener(true));
+                new CollectionTask(EMPTY_CRAM, getCollectionTaskListener(true)).launch(new TaskData(mFragmented));
                 return true;
             case R.id.action_rename:
                 ((DeckPicker) getActivity()).renameDeckDialog(getCol().getDecks().selected());
@@ -449,7 +449,7 @@ public class StudyOptionsFragment extends Fragment implements Toolbar.OnMenuItem
                 }
                     mProgressDialog = StyledProgressDialog.show(getActivity(), "",
                             getResources().getString(R.string.rebuild_cram_deck), true);
-                    CollectionTask.launchCollectionTask(REBUILD_CRAM, getCollectionTaskListener(true));
+                    new CollectionTask(REBUILD_CRAM, getCollectionTaskListener(true)).launch(new TaskData(mFragmented));
             } else {
                 CollectionTask.waitToFinish();
                 refreshInterface(true);
@@ -506,8 +506,7 @@ public class StudyOptionsFragment extends Fragment implements Toolbar.OnMenuItem
     protected void refreshInterface(boolean resetSched, boolean resetDecklist) {
         Timber.d("Refreshing StudyOptionsFragment");
         // Load the deck counts for the deck from Collection asynchronously
-        CollectionTask.launchCollectionTask(UPDATE_VALUES_FROM_DECK, getCollectionTaskListener(resetDecklist),
-                new TaskData(new Object[]{resetSched}));
+        new CollectionTask(UPDATE_VALUES_FROM_DECK, getCollectionTaskListener(resetDecklist)).launch(new TaskData(new Object[]{resetSched}));
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/TemporaryModel.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/TemporaryModel.java
@@ -150,7 +150,7 @@ public class TemporaryModel {
         dumpChanges();
         TemporaryModel.clearTempModelFiles();
         TaskData args = new TaskData(new Object[] {mEditedModel, getAdjustedTemplateChanges()});
-        CollectionTask.launchCollectionTask(SAVE_MODEL, listener, args);
+        new CollectionTask(SAVE_MODEL, listener).launch(args);
 
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/UIUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/UIUtils.java
@@ -118,7 +118,7 @@ public class UIUtils {
 
     public static void saveCollectionInBackground() {
         if (CollectionHelper.getInstance().colIsOpen()) {
-            CollectionTask.launchCollectionTask(SAVE_COLLECTION, new CollectionTask.TaskListener() {
+            new CollectionTask(SAVE_COLLECTION, new CollectionTask.TaskListener() {
                 @Override
                 public void onPreExecute() {
                     Timber.d("saveCollectionInBackground: start");

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
@@ -478,7 +478,7 @@ public class CustomStudyDialog extends AnalyticsDialogFragment {
         dyn.put("resched", resched);
         // Rebuild the filtered deck
         Timber.i("Rebuilding Custom Study Deck");
-        CollectionTask.launchCollectionTask(REBUILD_CRAM, new CollectionTask.TaskListener() {
+        new CollectionTask(REBUILD_CRAM, new CollectionTask.TaskListener() {
                 @Override
                 public void onPreExecute() {
                     activity.showProgressBar();
@@ -489,7 +489,7 @@ public class CustomStudyDialog extends AnalyticsDialogFragment {
                     activity.hideProgressBar();
                     ((CustomStudyListener) activity).onCreateCustomStudySession();
                 }
-            });
+            }).launch();
 
         // Hide the dialogs
         activity.dismissAllDialogFragments();

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -140,38 +140,19 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
 
 
     /**
-     * Starts a new {@link CollectionTask}, with no listener
-     * <p>
-     * Tasks will be executed serially, in the order in which they are started.
-     * <p>
-     * This method must be called on the main thread.
-     *
-     * @param type of the task to start
-     * @param params to pass to the task
-     * @return the newly created task
-     */
-    public static CollectionTask launchCollectionTask(TASK_TYPE type, TaskData... params) {
-        return launchCollectionTask(type, null, params);
-    }
-
-    /**
      * Starts a new {@link CollectionTask}, with a listener provided for callbacks during execution
      * <p>
      * Tasks will be executed serially, in the order in which they are started.
      * <p>
      * This method must be called on the main thread.
      *
-     * @param type of the task to start
-     * @param listener to the status and result of the task, may be null
      * @param params to pass to the task
      * @return the newly created task
      */
-    public static CollectionTask launchCollectionTask(TASK_TYPE type, @Nullable Listener listener, TaskData... params) {
+    public void launch(TaskData... params) {
         // Start new task
-        CollectionTask newTask = new CollectionTask(type, listener);
-        newTask.mPreviousTask = sLatestInstance;
-        newTask.execute(params);
-        return newTask;
+        mPreviousTask = sLatestInstance;
+        execute(params);
     }
 
 
@@ -262,6 +243,12 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
     private CollectionTask mPreviousTask;
 
 
+    public CollectionTask(TASK_TYPE type) {
+        this(type, null);
+    }
+    /**
+     * @param listener to the status and result of the task, may be null
+     * */
     public CollectionTask(TASK_TYPE type, Listener listener) {
         mType = type;
         mListener = listener;

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -168,7 +168,8 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
      */
     public static CollectionTask launchCollectionTask(TASK_TYPE type, @Nullable Listener listener, TaskData... params) {
         // Start new task
-        CollectionTask newTask = new CollectionTask(type, listener, sLatestInstance);
+        CollectionTask newTask = new CollectionTask(type, listener);
+        newTask.mPreviousTask = sLatestInstance;
         newTask.execute(params);
         return newTask;
     }
@@ -261,10 +262,9 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
     private CollectionTask mPreviousTask;
 
 
-    public CollectionTask(TASK_TYPE type, Listener listener, CollectionTask previousTask) {
+    public CollectionTask(TASK_TYPE type, Listener listener) {
         mType = type;
         mListener = listener;
-        mPreviousTask = previousTask;
         sTasks.add(this);
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
@@ -37,6 +37,8 @@ import com.ichi2.libanki.sched.Sched;
 import com.ichi2.libanki.sched.SchedV2;
 import com.ichi2.utils.JSONException;
 import com.ichi2.utils.JSONObject;
+
+import org.apache.tools.ant.Task;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -265,10 +267,8 @@ public class RobolectricTest {
         return (SchedV2) sched;
     }
 
-
-    protected synchronized void waitForTask(CollectionTask.TASK_TYPE taskType, int timeoutMs) throws InterruptedException {
-        boolean[] completed = new boolean[] { false };
-        CollectionTask.launchCollectionTask(taskType, new CollectionTask.TaskListener() {
+    protected synchronized CollectionTask.TaskListener listenerForWait(boolean[] completed) {
+        return new CollectionTask.TaskListener() {
             @Override
             public void onPreExecute() {
 
@@ -282,7 +282,13 @@ public class RobolectricTest {
                     RobolectricTest.this.notify();
                 }
             }
-        });
+        };
+    }
+
+
+    protected synchronized void waitForTask(CollectionTask.TASK_TYPE taskType, int timeoutMs) throws InterruptedException {
+        boolean[] completed = new boolean[] { false };
+        CollectionTask.launchCollectionTask(taskType, listenerForWait(completed));
 
         wait(timeoutMs);
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
@@ -288,7 +288,7 @@ public class RobolectricTest {
 
     protected synchronized void waitForTask(CollectionTask.TASK_TYPE taskType, int timeoutMs) throws InterruptedException {
         boolean[] completed = new boolean[] { false };
-        CollectionTask.launchCollectionTask(taskType, listenerForWait(completed));
+        new CollectionTask(taskType, listenerForWait(completed)).launch();
 
         wait(timeoutMs);
 

--- a/AnkiDroid/src/test/java/com/ichi2/async/AbstractCollectionTaskTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/async/AbstractCollectionTaskTest.java
@@ -31,7 +31,8 @@ import static org.hamcrest.Matchers.notNullValue;
 public abstract class AbstractCollectionTaskTest extends RobolectricTest {
 
     protected TaskData execute(CollectionTask.TASK_TYPE taskType) {
-        CollectionTask task = CollectionTask.launchCollectionTask(taskType);
+        CollectionTask task = new CollectionTask(taskType);
+        task.launch();
         try {
             return task.execute().get();
         } catch (Exception e) {


### PR DESCRIPTION
This is part of https://github.com/ankidroid/Anki-Android/pull/6721 

By itself, it does no actual change. However, when Collection Tasks will get created and then launched, it ensures that the value of mPreviousTask is the previously launched tasks instead of the previously created task. 

The main reason of this change are: 
* to ensure that constructors of subclass will remain small
* to avoid doing anything in constructor, appart from setting values, because otherwise I know that David would ask me to change my PR anyway