### PR TITLE
Tests whether mCurrentEditedCard is null

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -423,6 +423,7 @@ public class NoteEditor extends AnkiActivity {
 
 
         mAedictIntent = false;
+        mCurrentEditedCard = null;
 
         switch (mCaller) {
             case CALLER_NOCALLER:


### PR DESCRIPTION
Tests throughout the whole code, even if the only problem known to date is in:
```
if (!mEditorNote.cids().contains(mCurrentEditedCard.getId())) {
```

This should solve #6719

Testing it on my merge branch and trying to reproduce the bug