### PR TITLE
NF: Single Listener

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -1229,7 +1229,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
         Timber.i("undo()");
         String undoReviewString = getResources().getString(R.string.undo_action_review);
         final boolean isReview = undoReviewString.equals(getCol().undoName(getResources()));
-        CollectionTask.Listener listener = new CollectionTask.TaskListener() {
+        CollectionTask.TaskListener listener = new CollectionTask.TaskListener() {
             @Override
             public void onCancelled() {
                 hideProgressBar();
@@ -1372,7 +1372,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
     // Callback method to handle repairing deck
     public void repairCollection() {
         Timber.i("Repairing the Collection");
-        CollectionTask.Listener listener= new CollectionTask.TaskListener() {
+        CollectionTask.TaskListener listener= new CollectionTask.TaskListener() {
 
             @Override
             public void onPreExecute() {
@@ -1424,7 +1424,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
     @Override
     public void mediaCheck() {
-        CollectionTask.Listener listener = new CollectionTask.TaskListener() {
+        CollectionTask.TaskListener listener = new CollectionTask.TaskListener() {
             @Override
             public void onPreExecute() {
                 mProgressDialog = StyledProgressDialog.show(DeckPicker.this, "",
@@ -2144,7 +2144,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
      * This method also triggers an update for the widget to reflect the newly calculated counts.
      */
     private void updateDeckList() {
-        CollectionTask.Listener listener = new CollectionTask.TaskListener() {
+        CollectionTask.TaskListener listener = new CollectionTask.TaskListener() {
 
             @Override
             public void onPreExecute() {
@@ -2334,7 +2334,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
         deleteDeck(mContextMenuDid);
     }
     public void deleteDeck(final long did) {
-        CollectionTask.Listener listener = new CollectionTask.TaskListener() {
+        CollectionTask.TaskListener listener = new CollectionTask.TaskListener() {
             // Flag to indicate if the deck being deleted is the current deck.
             private boolean removingCurrent;
 
@@ -2445,7 +2445,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
     }
 
     public void handleEmptyCards() {
-        CollectionTask.Listener listener = new CollectionTask.TaskListener() {
+        CollectionTask.TaskListener listener = new CollectionTask.TaskListener() {
             @Override
             public void onPreExecute() {
                 mProgressDialog = StyledProgressDialog.show(DeckPicker.this, "",

--- a/AnkiDroid/src/main/java/com/ichi2/anki/UIUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/UIUtils.java
@@ -118,7 +118,7 @@ public class UIUtils {
 
     public static void saveCollectionInBackground() {
         if (CollectionHelper.getInstance().colIsOpen()) {
-            CollectionTask.Listener listener = new CollectionTask.TaskListener() {
+            CollectionTask.TaskListener listener = new CollectionTask.TaskListener() {
                 @Override
                 public void onPreExecute() {
                     Timber.d("saveCollectionInBackground: start");

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
@@ -478,7 +478,7 @@ public class CustomStudyDialog extends AnalyticsDialogFragment {
         dyn.put("resched", resched);
         // Rebuild the filtered deck
         Timber.i("Rebuilding Custom Study Deck");
-        CollectionTask.Listener listener = new CollectionTask.TaskListener() {
+        CollectionTask.TaskListener listener = new CollectionTask.TaskListener() {
             @Override
             public void onPreExecute() {
                 activity.showProgressBar();

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -166,7 +166,7 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
      * @param params to pass to the task
      * @return the newly created task
      */
-    public static CollectionTask launchCollectionTask(TASK_TYPE type, @Nullable Listener listener, TaskData... params) {
+    public static CollectionTask launchCollectionTask(TASK_TYPE type, @Nullable TaskListener listener, TaskData... params) {
         // Start new task
         CollectionTask newTask = new CollectionTask(type, listener, sLatestInstance);
         newTask.execute(params);
@@ -257,11 +257,11 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
 
 
     private final TASK_TYPE mType;
-    private final Listener mListener;
+    private final TaskListener mListener;
     private CollectionTask mPreviousTask;
 
 
-    private CollectionTask(TASK_TYPE type, Listener listener, CollectionTask previousTask) {
+    private CollectionTask(TASK_TYPE type, TaskListener listener, CollectionTask previousTask) {
         mType = type;
         mListener = listener;
         mPreviousTask = previousTask;
@@ -437,7 +437,7 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
     protected void onPreExecute() {
         super.onPreExecute();
         if (mListener != null) {
-            mListener.onPreExecute(this);
+            mListener.onPreExecute();
         }
     }
 
@@ -447,7 +447,7 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
     protected void onProgressUpdate(TaskData... values) {
         super.onProgressUpdate(values);
         if (mListener != null) {
-            mListener.onProgressUpdate(this, values);
+            mListener.onProgressUpdate(values);
         }
     }
 
@@ -457,7 +457,7 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
     protected void onPostExecute(TaskData result) {
         super.onPostExecute(result);
         if (mListener != null) {
-            mListener.onPostExecute(this, result);
+            mListener.onPostExecute(result);
         }
         Timber.d("enabling garbage collection of mPreviousTask...");
         mPreviousTask = null;
@@ -1726,42 +1726,7 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
      * <p>
      * Their semantics is equivalent to the methods of {@link AsyncTask}.
      */
-    public interface Listener {
-
-        /** Invoked before the task is started. */
-        void onPreExecute(CollectionTask task);
-
-
-        /**
-         * Invoked after the task has completed.
-         * <p>
-         * The semantics of the result depends on the task itself.
-         */
-        void onPostExecute(CollectionTask task, TaskData result);
-
-
-        /**
-         * Invoked when the background task publishes an update.
-         * <p>
-         * The semantics of the update data depends on the task itself.
-         */
-        void onProgressUpdate(CollectionTask task, TaskData... values);
-
-        /**
-         * Invoked when the background task is cancelled.
-         */        
-        void onCancelled();
-
-    }
-
-    /**
-     * Adapter for the old interface, where the CollectionTask itself was not passed to the listener.
-     * <p>
-     * All methods are invoked on the main thread.
-     * <p>
-     * The semantics of the methods is equivalent to the semantics of the methods in the regular {@link Listener}.
-     */
-    public static abstract class TaskListener implements Listener {
+    public static abstract class TaskListener {
 
         /** Invoked before the task is started. */
         public abstract void onPreExecute();
@@ -1784,25 +1749,6 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
             // most implementations do nothing with this, provide them a default implementation
         }
 
-
-        @Override
-        public void onPreExecute(CollectionTask task) {
-            onPreExecute();
-        }
-
-
-        @Override
-        public void onPostExecute(CollectionTask task, TaskData result) {
-            onPostExecute(result);
-        }
-
-
-        @Override
-        public void onProgressUpdate(CollectionTask task, TaskData... values) {
-            onProgressUpdate(values);
-        }
-
-        @Override
         public void onCancelled() {
             // most implementations do nothing with this, provide them a default implementation
         }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
@@ -268,7 +268,7 @@ public class RobolectricTest {
 
     protected synchronized void waitForTask(CollectionTask.TASK_TYPE taskType, int timeoutMs) throws InterruptedException {
         boolean[] completed = new boolean[] { false };
-        CollectionTask.Listener listener = new CollectionTask.TaskListener() {
+        CollectionTask.TaskListener listener = new CollectionTask.TaskListener() {
             @Override
             public void onPreExecute() {
 


### PR DESCRIPTION
This reverts 72c701db2662af07f7ce82b1841efa7b32314f48. In 2013, if I understand correctly, it was thought that some
listener will eventually uses the Tasks. This led to two similar type, Listener and TaskListener. This never occurred in
7 years, I believe that we can remove this code duplication and keep using TaskListener.

This will ensure that no more people, like me, lose time trying to understand why we have a class and an interface


This will improve, I believe, the result of https://github.com/ankidroid/Anki-Android/pull/6721