### PR TITLE
Improve automated sync rate limit error

### DIFF
--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -200,4 +200,15 @@
     <!-- Boot Service -->
     <string name="boot_service_failed_to_schedule_notifications">Failed to schedule reminders</string>
     <string name="boot_service_too_many_notifications">Too many reminders scheduled. Some will not appear</string>
+
+    <!--Sync-->
+    <plurals name="sync_automatic_sync_needs_more_time">
+        <item quantity="zero">An automatic sync may be triggered in %d seconds.</item>
+        <item quantity="one">An automatic sync may be triggered in %d second.</item>
+        <item quantity="two">An automatic sync may be triggered in %d seconds.</item>
+        <item quantity="few">An automatic sync may be triggered in %d seconds.</item>
+        <item quantity="many">An automatic sync may be triggered in %d seconds.</item>
+        <item quantity="other">An automatic sync may be triggered in %d seconds.</item>
+    </plurals>
+
 </resources>


### PR DESCRIPTION
## Purpose / Description

We have a rate limit of 2 minutes per automated sync (Tasker/ADB)

The error previously showed "Server busy. Try again later."

## Fixes
Fixes #6733

## Approach
Now it shows "Sync Error: An automatic sync may be triggered in %d seconds."

## How Has This Been Tested?

Used: `PS C:\Users\David> adb shell am start -a com.ichi2.anki.DO_SYNC`
Tested on my phone - looks good

## Learning (optional, can help others)
Slightly incorrect error messages lead to a lot of debugging

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code