### PR TITLE
NF: doInBackgroundDeleteDeck don't return

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -2349,10 +2349,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
             @SuppressWarnings("unchecked")
             @Override
-            public void onPostExecute(TaskData result) {
-                if (result == null) {
-                    return;
-                }
+            public void onPostExecute(@Nullable TaskData result) {
                 // In fragmented mode, if the deleted deck was the current deck, we need to reload
                 // the study options fragment with a valid deck and re-center the deck list to the
                 // new current deck. Otherwise we just update the list normally.

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -350,7 +350,8 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
                 return doInBackgroundUpdateValuesFromDeck(params);
 
             case DELETE_DECK:
-                return doInBackgroundDeleteDeck(params);
+                doInBackgroundDeleteDeck(params);
+                break;
 
             case REBUILD_CRAM:
                 return doInBackgroundRebuildCram();
@@ -1122,13 +1123,11 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
     }
 
 
-    private TaskData doInBackgroundDeleteDeck(TaskData... params) {
+    private void doInBackgroundDeleteDeck(TaskData... params) {
         Timber.d("doInBackgroundDeleteDeck");
         Collection col = getCol();
         long did = params[0].getLong();
         col.getDecks().rem(did, true);
-
-        return new TaskData(true);
     }
 
 


### PR DESCRIPTION
onPostExecute can't get null. It's not returned by doInBackgroundDeleteDeck, and if the task is cancelled, then
onPostExecute is not called.

This avoid useless code
