### PR TITLE
NF: listener's onProgressUpdate take a single element

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -513,9 +513,9 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
 
 
         @Override
-        public void onProgressUpdate(TaskData... values) {
+        public void onProgressUpdate(TaskData value) {
             boolean cardChanged = false;
-            if (mCurrentCard != values[0].getCard()) {
+            if (mCurrentCard != value.getCard()) {
                 /*
                  * Before updating mCurrentCard, we check whether it is changing or not. If the current card changes,
                  * then we need to display it as a new card, without showing the answer.
@@ -523,7 +523,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
                 sDisplayAnswer = false;
                 cardChanged = true;  // Keep track of that so we can run a bit of new-card code
             }
-            mCurrentCard = values[0].getCard();
+            mCurrentCard = value.getCard();
             if (mCurrentCard == null) {
                 // If the card is null means that there are no more cards scheduled for review.
                 mNoMoreCards = true;
@@ -573,8 +573,8 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
 
 
         @Override
-        public void onProgressUpdate(TaskData... values) {
-            displayNext(values[0].getCard());
+        public void onProgressUpdate(TaskData value) {
+            displayNext(value.getCard());
         }
 
         protected void displayNext(Card nextCard) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1437,8 +1437,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
     private CollectionTask.TaskListener mUpdateCardHandler = new ListenerWithProgressBarCloseOnFalse("Card Browser - mUpdateCardHandler.onPostExecute()"){
         @Override
-        public void onProgressUpdate(TaskData... values) {
-            updateCardInList(values[0].getCard(), values[0].getString());
+        public void onProgressUpdate(TaskData value) {
+            updateCardInList(value.getCard(), value.getString());
         }
 
         @Override
@@ -1633,8 +1633,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
     private CollectionTask.TaskListener mDeleteNoteHandler = new ListenerWithProgressBarCloseOnFalse() {
         @Override
-        public void onProgressUpdate(TaskData... values) {
-            Card[] cards = (Card[]) values[0].getObjArray();
+        public void onProgressUpdate(TaskData value) {
+            Card[] cards = (Card[]) value.getObjArray();
             //we don't need to reorder cards here as we've already deselected all notes,
             removeNotesView(cards, false);
         }
@@ -1754,7 +1754,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
     private CollectionTask.TaskListener mRenderQAHandler = new CollectionTask.TaskListener() {
         @Override
-        public void onProgressUpdate(TaskData... values) {
+        public void onProgressUpdate(TaskData value) {
             // Note: This is called every time a card is rendered.
             // It blocks the long-click callback while the task is running, so usage of the task should be minimized
             mCardsAdapter.notifyDataSetChanged();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -302,8 +302,8 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
 
         @Override
-        public void onProgressUpdate(TaskData... values) {
-            mProgressDialog.setContent(values[0].getString());
+        public void onProgressUpdate(TaskData value) {
+            mProgressDialog.setContent(value.getString());
         }
     };
 
@@ -340,8 +340,8 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
 
         @Override
-        public void onProgressUpdate(TaskData... values) {
-            mProgressDialog.setContent(values[0].getString());
+        public void onProgressUpdate(TaskData value) {
+            mProgressDialog.setContent(value.getString());
         }
     };
 
@@ -2574,8 +2574,8 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
 
         @Override
-        public void onProgressUpdate(TaskData... values) {
-            mProgressDialog.setContent(values[0].getString());
+        public void onProgressUpdate(TaskData value) {
+            mProgressDialog.setContent(value.getString());
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -223,8 +223,8 @@ public class NoteEditor extends AnkiActivity {
         }
 
         @Override
-        public void onProgressUpdate(TaskData... values) {
-            int count = values[0].getInt();
+        public void onProgressUpdate(TaskData value) {
+            int count = value.getInt();
             if (count > 0) {
                 mChanged = true;
                 mSourceText = null;

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -444,10 +444,10 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
 
     /** Delegates to the {@link TaskListener} for this task. */
     @Override
-    protected void onProgressUpdate(TaskData... values) {
-        super.onProgressUpdate(values);
+    protected void onProgressUpdate(TaskData... value) {
+        super.onProgressUpdate(value);
         if (mListener != null) {
-            mListener.onProgressUpdate(values);
+            mListener.onProgressUpdate(value[0]);
         }
     }
 
@@ -1745,7 +1745,7 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
          * <p>
          * The semantics of the update data depends on the task itself.
          */
-        public void onProgressUpdate(TaskData... values) {
+        public void onProgressUpdate(TaskData value) {
             // most implementations do nothing with this, provide them a default implementation
         }
 
@@ -1777,15 +1777,15 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
         }
 
 
-        public void publishProgress(TaskData values) {
+        public void publishProgress(TaskData value) {
             if (task != null) {
-                task.doProgress(values);
+                task.doProgress(value);
             }
         }
     }
 
 
-    public void doProgress(TaskData values) {
-        publishProgress(values);
+    public void doProgress(TaskData value) {
+        publishProgress(value);
     }
 }


### PR DESCRIPTION
Currently, it takes an array, and we never use it, we always use it's first element. It's even more confusing because
this first element is a task data which contains any type. Sometime it contains an array of object. I strongly believe
it will make update slightly less confusing. At least for the few time when we actually use it