### PR TITLE
NF: AutoSync error - Fix plural translations

### DIFF
--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -203,12 +203,8 @@
 
     <!--Sync-->
     <plurals name="sync_automatic_sync_needs_more_time">
-        <item quantity="zero">An automatic sync may be triggered in %d seconds.</item>
-        <item quantity="one">An automatic sync may be triggered in %d second.</item>
-        <item quantity="two">An automatic sync may be triggered in %d seconds.</item>
-        <item quantity="few">An automatic sync may be triggered in %d seconds.</item>
-        <item quantity="many">An automatic sync may be triggered in %d seconds.</item>
-        <item quantity="other">An automatic sync may be triggered in %d seconds.</item>
+        <item quantity="one">An automatic sync may be triggered in %d second</item>
+        <item quantity="other">An automatic sync may be triggered in %d seconds</item>
     </plurals>
 
 </resources>


### PR DESCRIPTION
* We don't end single sentences with a full stop
* We don't need superfluous translations as CrowdIn handles them

From Review: #6735

https://github.com/ankidroid/Anki-Android/pull/6735#discussion_r460383795