### PR TITLE
NoteEditor: Made mCurrentEditedCard non-static

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -183,7 +183,8 @@ public class NoteEditor extends AnkiActivity {
 
     private Note mEditorNote;
     @Nullable
-    public static Card mCurrentEditedCard;
+    /** Null if adding a new card. Presently NonNull if editing an existing note - but this is subject to change */
+    private Card mCurrentEditedCard;
     private ArrayList<String> mSelectedTags;
     private long mCurrentDid;
     private ArrayList<Long> mAllDeckIds;


### PR DESCRIPTION
## Purpose / Description

Field did not need to be static.

Fixed in 0033ac17616d2accb8cdc1ab8cb301fc6cd3477b - null safety
Reset to null in onCollectionLoaded at cd6a9e6b2d8dbc6eee584823d7e3323742a82f1c

## Fixes
Fixes #6728

## Approach
Make field non-static

## How Has This Been Tested?

On my personal device - no crashes. 

## Learning (optional, can help others)

We may want to lint variables to see if they meet the naming conventions

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code