### PR TITLE
Reviewer App Bar: Allowed all items to be disabled

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -87,8 +87,11 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
 import timber.log.Timber;
 
 interface PreferenceContext {
@@ -923,6 +926,14 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
         if (getCol() != null && getCol().getDb()!= null) {
             getCol().save();
         }
+    }
+
+
+    /** This is not fit for purpose (other than testing a single screen) */
+    @NonNull
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    public Set<String> getLoadedPreferenceKeys() {
+        return mOriginalSumarries.keySet();
     }
 
     // ----------------------------------------------------------------------------

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -552,9 +552,12 @@ public class Reviewer extends AbstractFlashcardViewer {
             if (!mActionButtons.getStatus().clearWhiteboardIsDisabled()) {
                 menu.findItem(R.id.action_clear_whiteboard).setVisible(true);
             }
-
-            menu.findItem(R.id.action_save_whiteboard).setVisible(true);
-            menu.findItem(R.id.action_change_whiteboard_pen_color).setVisible(true);
+            if (!mActionButtons.getStatus().saveWhiteboardIsDisabled()) {
+                menu.findItem(R.id.action_save_whiteboard).setVisible(true);
+            }
+            if (!mActionButtons.getStatus().whiteboardPenColorIsDisabled()) {
+                menu.findItem(R.id.action_change_whiteboard_pen_color).setVisible(true);
+            }
 
             Drawable whiteboardIcon = ContextCompat.getDrawable(this, R.drawable.ic_gesture_white_24dp).mutate();
             Drawable whiteboardColorPaletteIcon = VectorDrawableCompat.create(getResources(), R.drawable.ic_color_lens_white_24dp, null).mutate();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -546,6 +546,9 @@ public class Reviewer extends AbstractFlashcardViewer {
         if (mPrefWhiteboard) {
             // Configure the whiteboard related items in the action bar
             menu.findItem(R.id.action_enable_whiteboard).setTitle(R.string.disable_whiteboard);
+            // Always allow "Disable Whiteboard", even if the preference
+            menu.findItem(R.id.action_enable_whiteboard).setVisible(true);
+
             if (!mActionButtons.getStatus().hideWhiteboardIsDisabled()) {
                 menu.findItem(R.id.action_hide_whiteboard).setVisible(true);
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -360,18 +360,8 @@ public class Reviewer extends AbstractFlashcardViewer {
                 refreshActionBar();
                 break;
 
-            case R.id.action_enable_whiteboard:
-                // toggle whiteboard enabled state (and show/hide whiteboard item in action bar)
-                mPrefWhiteboard = ! mPrefWhiteboard;
-                Timber.i("Reviewer:: Whiteboard enabled state set to %b", mPrefWhiteboard);
-                //Even though the visibility is now stored in its own setting, we want it to be dependent
-                //on the enabled status
-                setWhiteboardEnabledState(mPrefWhiteboard);
-                setWhiteboardVisibility(mPrefWhiteboard);
-                if (!mPrefWhiteboard) {
-                    colorPalette.setVisibility(View.GONE);
-                }
-                refreshActionBar();
+            case R.id.action_toggle_whiteboard:
+                toggleWhiteboard();
                 break;
 
             case R.id.action_search_dictionary:
@@ -418,6 +408,21 @@ public class Reviewer extends AbstractFlashcardViewer {
                 return super.onOptionsItemSelected(item);
         }
         return true;
+    }
+
+
+    protected void toggleWhiteboard() {
+        // toggle whiteboard enabled state (and show/hide whiteboard item in action bar)
+        mPrefWhiteboard = ! mPrefWhiteboard;
+        Timber.i("Reviewer:: Whiteboard enabled state set to %b", mPrefWhiteboard);
+        //Even though the visibility is now stored in its own setting, we want it to be dependent
+        //on the enabled status
+        setWhiteboardEnabledState(mPrefWhiteboard);
+        setWhiteboardVisibility(mPrefWhiteboard);
+        if (!mPrefWhiteboard) {
+            colorPalette.setVisibility(View.GONE);
+        }
+        refreshActionBar();
     }
 
 
@@ -545,9 +550,9 @@ public class Reviewer extends AbstractFlashcardViewer {
         // White board button
         if (mPrefWhiteboard) {
             // Configure the whiteboard related items in the action bar
-            menu.findItem(R.id.action_enable_whiteboard).setTitle(R.string.disable_whiteboard);
-            // Always allow "Disable Whiteboard", even if the preference
-            menu.findItem(R.id.action_enable_whiteboard).setVisible(true);
+            menu.findItem(R.id.action_toggle_whiteboard).setTitle(R.string.disable_whiteboard);
+            // Always allow "Disable Whiteboard", even if "Enable Whiteboard" is disabled
+            menu.findItem(R.id.action_toggle_whiteboard).setVisible(true);
 
             if (!mActionButtons.getStatus().hideWhiteboardIsDisabled()) {
                 menu.findItem(R.id.action_hide_whiteboard).setVisible(true);
@@ -583,7 +588,7 @@ public class Reviewer extends AbstractFlashcardViewer {
                 colorPalette.setVisibility(View.GONE);
             }
         } else {
-            menu.findItem(R.id.action_enable_whiteboard).setTitle(R.string.enable_whiteboard);
+            menu.findItem(R.id.action_toggle_whiteboard).setTitle(R.string.enable_whiteboard);
         }
         if (colIsOpen() && getCol().getDecks().isDyn(getParentDid())) {
             menu.findItem(R.id.action_open_deck_options).setVisible(false);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtonStatus.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtonStatus.java
@@ -61,7 +61,7 @@ public class ActionButtonStatus {
         setupButton(preferences, R.id.action_mark_card, "customButtonMarkCard", SHOW_AS_ACTION_IF_ROOM);
         setupButton(preferences, R.id.action_delete, "customButtonDelete", SHOW_AS_ACTION_NEVER);
         setupButton(preferences, R.id.action_toggle_mic_tool_bar, "customButtonToggleMicToolBar", SHOW_AS_ACTION_NEVER);
-        setupButton(preferences, R.id.action_enable_whiteboard, "customButtonEnableWhiteboard", SHOW_AS_ACTION_NEVER);
+        setupButton(preferences, R.id.action_toggle_whiteboard, "customButtonEnableWhiteboard", SHOW_AS_ACTION_NEVER);
         setupButton(preferences, R.id.action_save_whiteboard, "customButtonSaveWhiteboard", SHOW_AS_ACTION_NEVER);
         setupButton(preferences, R.id.action_change_whiteboard_pen_color, "customButtonWhiteboardPenColor", SHOW_AS_ACTION_IF_ROOM);
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtonStatus.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtonStatus.java
@@ -114,4 +114,12 @@ public class ActionButtonStatus {
     public boolean selectTtsIsDisabled() {
         return mCustomButtons.get(R.id.action_select_tts) == MENU_DISABLED;
     }
+
+    public boolean saveWhiteboardIsDisabled() {
+        return mCustomButtons.get(R.id.action_save_whiteboard) == MENU_DISABLED;
+    }
+
+    public boolean whiteboardPenColorIsDisabled() {
+        return mCustomButtons.get(R.id.action_change_whiteboard_pen_color) == MENU_DISABLED;
+    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtonStatus.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtonStatus.java
@@ -48,7 +48,7 @@ public class ActionButtonStatus {
         setupButton(preferences, R.id.action_undo, "customButtonUndo", SHOW_AS_ACTION_ALWAYS);
         setupButton(preferences, R.id.action_schedule, "customButtonScheduleCard", SHOW_AS_ACTION_NEVER);
         setupButton(preferences, R.id.action_flag, "customButtonFlag", SHOW_AS_ACTION_ALWAYS);
-        setupButton(preferences, R.id.action_tag, "customButtonTag", SHOW_AS_ACTION_NEVER);
+        setupButton(preferences, R.id.action_tag, "customButtonTags", SHOW_AS_ACTION_NEVER);
         setupButton(preferences, R.id.action_edit, "customButtonEditCard", SHOW_AS_ACTION_IF_ROOM);
         setupButton(preferences, R.id.action_add_note_reviewer, "customButtonAddCard", MENU_DISABLED);
         setupButton(preferences, R.id.action_replay, "customButtonReplay", SHOW_AS_ACTION_IF_ROOM);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtonStatus.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtonStatus.java
@@ -61,6 +61,7 @@ public class ActionButtonStatus {
         setupButton(preferences, R.id.action_mark_card, "customButtonMarkCard", SHOW_AS_ACTION_IF_ROOM);
         setupButton(preferences, R.id.action_delete, "customButtonDelete", SHOW_AS_ACTION_NEVER);
         setupButton(preferences, R.id.action_toggle_mic_tool_bar, "customButtonToggleMicToolBar", SHOW_AS_ACTION_NEVER);
+        setupButton(preferences, R.id.action_enable_whiteboard, "customButtonEnableWhiteboard", SHOW_AS_ACTION_NEVER);
         setupButton(preferences, R.id.action_save_whiteboard, "customButtonSaveWhiteboard", SHOW_AS_ACTION_NEVER);
         setupButton(preferences, R.id.action_change_whiteboard_pen_color, "customButtonWhiteboardPenColor", SHOW_AS_ACTION_IF_ROOM);
     }

--- a/AnkiDroid/src/main/res/menu/reviewer.xml
+++ b/AnkiDroid/src/main/res/menu/reviewer.xml
@@ -60,7 +60,8 @@
     <item
         android:id="@+id/action_enable_whiteboard"
         android:title="@string/enable_whiteboard"
-        android:icon="@drawable/ic_gesture_white_24dp" />
+        android:icon="@drawable/ic_gesture_white_24dp"
+        ankidroid:showAsAction="never"/>
     <item
         android:id="@+id/action_edit"
         android:icon="@drawable/ic_mode_edit_white_24dp"

--- a/AnkiDroid/src/main/res/menu/reviewer.xml
+++ b/AnkiDroid/src/main/res/menu/reviewer.xml
@@ -58,7 +58,7 @@
         android:visible="false"
         ankidroid:showAsAction="never"/>
     <item
-        android:id="@+id/action_enable_whiteboard"
+        android:id="@+id/action_toggle_whiteboard"
         android:title="@string/enable_whiteboard"
         android:icon="@drawable/ic_gesture_white_24dp"
         ankidroid:showAsAction="never"/>

--- a/AnkiDroid/src/main/res/xml/preferences_custom_buttons.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_custom_buttons.xml
@@ -119,6 +119,12 @@ MENU_DISABLED = 3
             android:defaultValue="0"
             android:entries="@array/custom_button_labels"
             android:entryValues="@array/custom_button_values"
+            android:key="customButtonEnableWhiteboard"
+            android:title="@string/enable_whiteboard" />
+        <ListPreference
+            android:defaultValue="0"
+            android:entries="@array/custom_button_labels"
+            android:entryValues="@array/custom_button_values"
             android:key="customButtonSaveWhiteboard"
             android:title="@string/save_whiteboard" />
         <ListPreference

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.java
@@ -1,28 +1,42 @@
 package com.ichi2.anki;
 
 import android.content.Intent;
+import android.content.SharedPreferences;
+import android.view.Menu;
+import android.view.MenuItem;
 
 import com.ichi2.anki.AbstractFlashcardViewer.JavaScriptFunction;
 import com.ichi2.anki.cardviewer.ViewerCommand;
+import com.ichi2.anki.reviewer.ActionButtonStatus;
 import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Consts;
 import com.ichi2.libanki.Note;
+import com.ichi2.testutils.PreferenceUtils;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.LooperMode;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import androidx.annotation.NonNull;
 import androidx.test.core.app.ActivityScenario;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import static com.ichi2.anki.AbstractFlashcardViewer.EASE_4;
 import static com.ichi2.anki.AbstractFlashcardViewer.RESULT_DEFAULT;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isEmptyString;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assume.assumeTrue;
 
 @RunWith(AndroidJUnit4.class)
 @LooperMode(LooperMode.Mode.PAUSED)
@@ -85,6 +99,52 @@ public class ReviewerTest extends RobolectricTest {
         assertThat("If the 4th button is not visible, there should be no time4 in JS", learnTime, isEmptyString());
     }
 
+    @Test
+    public void nothingAppearsInAppBarIfAllAppBarButtonsAreDisabled() {
+        disableAllReviewerAppBarButtons();
+
+        ReviewerForMenuItems reviewer = startReviewer(ReviewerForMenuItems.class);
+
+        List<String> visibleButtons = reviewer.getVisibleButtonNames();
+
+        assertThat("No menu items should be visible if all are disabled in Settings - Reviewer - App Bar Buttons", visibleButtons, empty());
+    }
+
+    @Test
+    public void onlyDisableWhiteboardAppearsInAppBarIfAllAppBarButtonsAreDisabledWithWhiteboard() {
+        disableAllReviewerAppBarButtons();
+
+        ReviewerForMenuItems reviewer = startReviewer(ReviewerForMenuItems.class);
+
+        toggleWhiteboard(reviewer);
+
+        List<String> visibleButtons = reviewer.getVisibleButtonNamesExcept(R.id.action_toggle_whiteboard);
+
+        assertThat("No menu items should be visible if all are disabled in Settings - Reviewer - App Bar Buttons", visibleButtons, empty());
+    }
+
+
+    private void toggleWhiteboard(ReviewerForMenuItems reviewer) {
+        reviewer.toggleWhiteboard();
+
+        assumeTrue("Whiteboard should now be enabled", reviewer.mPrefWhiteboard);
+
+        super.advanceRobolectricLooper();
+    }
+
+
+    private void disableAllReviewerAppBarButtons() {
+        Set<String> keys = PreferenceUtils.getAllCustomButtonKeys(getTargetContext());
+
+        SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(getTargetContext());
+
+        SharedPreferences.Editor e =  preferences.edit();
+        for (String k : keys) {
+            e.putString(k, Integer.toString(ActionButtonStatus.MENU_DISABLED));
+        }
+        e.apply();
+    }
+
 
     private void displayAnswer(Reviewer reviewer) {
         waitForAsyncTasksToComplete();
@@ -92,9 +152,12 @@ public class ReviewerTest extends RobolectricTest {
         waitForAsyncTasksToComplete();
     }
 
-
     private Reviewer startReviewer() {
-        Reviewer reviewer = super.startActivityNormallyOpenCollectionWithIntent(Reviewer.class, new Intent());
+        return startReviewer(Reviewer.class);
+    }
+
+    private <T extends Reviewer> T startReviewer(Class<T> clazz) {
+        T reviewer = super.startActivityNormallyOpenCollectionWithIntent(clazz, new Intent());
         waitForAsyncTasksToComplete();
         return reviewer;
     }
@@ -105,6 +168,46 @@ public class ReviewerTest extends RobolectricTest {
         reviewCard.setType(Consts.CARD_TYPE_REV);
         reviewCard.setDue(0);
         reviewCard.flush();
+    }
+
+    private static class ReviewerForMenuItems extends Reviewer {
+        private Menu mMenu;
+
+
+        @Override
+        public boolean onCreateOptionsMenu(Menu menu) {
+            this.mMenu = menu;
+            return super.onCreateOptionsMenu(menu);
+        }
+
+
+        public Menu getMenu() {
+            return mMenu;
+        }
+
+        @NonNull
+        private List<String> getVisibleButtonNames() {
+            return getVisibleButtonNamesExcept();
+        }
+
+
+        @NonNull
+        private List<String> getVisibleButtonNamesExcept(Integer... doNotReturn) {
+            ArrayList<String> visibleButtons = new ArrayList<>();
+            HashSet<Integer> toSkip = new HashSet<>(Arrays.asList(doNotReturn));
+
+            Menu menu = getMenu();
+            for(int i = 0; i < menu.size(); i++ ){
+                MenuItem item =  menu.getItem(i);
+                if (toSkip.contains(item.getItemId())) {
+                    continue;
+                }
+                if (item.isVisible()) {
+                    visibleButtons.add(item.getTitle().toString());
+                }
+            }
+            return visibleButtons;
+        }
     }
 }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/ActionButtonStatusTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/ActionButtonStatusTest.java
@@ -16,11 +16,10 @@
 
 package com.ichi2.anki.reviewer;
 
-import android.content.Intent;
 import android.content.SharedPreferences;
 
-import com.ichi2.anki.Preferences;
 import com.ichi2.anki.RobolectricTest;
+import com.ichi2.testutils.PreferenceUtils;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -28,10 +27,7 @@ import org.junit.runner.RunWith;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicReference;
 
-import androidx.lifecycle.Lifecycle;
-import androidx.test.core.app.ActivityScenario;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -46,7 +42,7 @@ public class ActionButtonStatusTest extends RobolectricTest {
     @Test
     public void allCustomButtonsCanBeDisabled() {
         Set<String> reviewerExpectedKeys = getCustomButtonsExpectedKeys();
-        Set<String> actualPreferenceKeys = getAllCustomButtonPreferenceKeys();
+        Set<String> actualPreferenceKeys = PreferenceUtils.getAllCustomButtonKeys(getTargetContext());
 
         assertThat("Each button in the Action Bar must be modifiable in Preferences - Reviewer - App Bar Buttons",
                 reviewerExpectedKeys,
@@ -67,21 +63,5 @@ public class ActionButtonStatusTest extends RobolectricTest {
         status.setup(preferences);
 
         return ret;
-    }
-
-
-    private Set<String> getAllCustomButtonPreferenceKeys() {
-        AtomicReference<Set<String>> ret = new AtomicReference<>();
-        Intent i = Preferences.getPreferenceSubscreenIntent(getTargetContext(), "com.ichi2.anki.prefs.custom_buttons");
-        try (ActivityScenario<Preferences> scenario = ActivityScenario.launch(i)) {
-            scenario.moveToState(Lifecycle.State.STARTED);
-            scenario.onActivity(a -> ret.set(a.getLoadedPreferenceKeys()));
-        }
-        Set<String> preferenceKeys = ret.get();
-        if (preferenceKeys == null) {
-            throw new IllegalStateException("no keys were set");
-        }
-        preferenceKeys.remove("reset_custom_buttons");
-        return preferenceKeys;
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/ActionButtonStatusTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/ActionButtonStatusTest.java
@@ -1,0 +1,87 @@
+/*
+ Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.reviewer;
+
+import android.content.Intent;
+import android.content.SharedPreferences;
+
+import com.ichi2.anki.Preferences;
+import com.ichi2.anki.RobolectricTest;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+
+import androidx.lifecycle.Lifecycle;
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(AndroidJUnit4.class)
+public class ActionButtonStatusTest extends RobolectricTest {
+
+    @Test
+    public void allCustomButtonsCanBeDisabled() {
+        Set<String> reviewerExpectedKeys = getCustomButtonsExpectedKeys();
+        Set<String> actualPreferenceKeys = getAllCustomButtonPreferenceKeys();
+
+        assertThat("Each button in the Action Bar must be modifiable in Preferences - Reviewer - App Bar Buttons",
+                reviewerExpectedKeys,
+                containsInAnyOrder(Objects.requireNonNull(actualPreferenceKeys.toArray())));
+    }
+
+
+    private Set<String> getCustomButtonsExpectedKeys() {
+        SharedPreferences preferences = mock(SharedPreferences.class);
+        Set<String> ret = new HashSet<>();
+        when(preferences.getString(any(), any())).then(a -> {
+            String key = a.getArgument(0);
+            ret.add(key);
+            return "0";
+        }
+        );
+        ActionButtonStatus status = new ActionButtonStatus(mock(ReviewerUi.class));
+        status.setup(preferences);
+
+        return ret;
+    }
+
+
+    private Set<String> getAllCustomButtonPreferenceKeys() {
+        AtomicReference<Set<String>> ret = new AtomicReference<>();
+        Intent i = Preferences.getPreferenceSubscreenIntent(getTargetContext(), "com.ichi2.anki.prefs.custom_buttons");
+        try (ActivityScenario<Preferences> scenario = ActivityScenario.launch(i)) {
+            scenario.moveToState(Lifecycle.State.STARTED);
+            scenario.onActivity(a -> ret.set(a.getLoadedPreferenceKeys()));
+        }
+        Set<String> preferenceKeys = ret.get();
+        if (preferenceKeys == null) {
+            throw new IllegalStateException("no keys were set");
+        }
+        preferenceKeys.remove("reset_custom_buttons");
+        return preferenceKeys;
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/PreferenceUtils.java
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/PreferenceUtils.java
@@ -1,0 +1,46 @@
+/*
+ Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.testutils;
+
+import android.content.Context;
+import android.content.Intent;
+
+import com.ichi2.anki.Preferences;
+
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+
+import androidx.lifecycle.Lifecycle;
+import androidx.test.core.app.ActivityScenario;
+
+public class PreferenceUtils {
+
+    public static Set<String> getAllCustomButtonKeys(Context context) {
+        AtomicReference<Set<String>> ret = new AtomicReference<>();
+        Intent i = Preferences.getPreferenceSubscreenIntent(context, "com.ichi2.anki.prefs.custom_buttons");
+        try (ActivityScenario<Preferences> scenario = ActivityScenario.launch(i)) {
+            scenario.moveToState(Lifecycle.State.STARTED);
+            scenario.onActivity(a -> ret.set(a.getLoadedPreferenceKeys()));
+        }
+        Set<String> preferenceKeys = ret.get();
+        if (preferenceKeys == null) {
+            throw new IllegalStateException("no keys were set");
+        }
+        preferenceKeys.remove("reset_custom_buttons");
+        return preferenceKeys;
+    }
+}


### PR DESCRIPTION
## Purpose / Description
* Previously, a user could not hide "Edit Tags" as the key was set incorrectly
* Users could not hide "Enable Whiteboard" as there were no preferences
* Users could not hide "Whiteboard pen color" and "Save Whiteboard" as they were re-enabled after being disabled

* Disable Whiteboard still appears - this is intentional

## Fixes
Fixes #6717

## Approach
* Fix the key for tags
* Conditionally enable whiteboard preferences
* Add Enable Whiteboard to the preferences screen

## How Has This Been Tested?
Unit tested, and tested on my mobile, no buttons appear if all are disabled

## Learning

The first unit test is always the hardest - getting preference keys was complex

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code