### PR TITLE
Card Template Editor: Add Deck Override

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
@@ -394,18 +394,23 @@ public class AnkiActivity extends AppCompatActivity implements SimpleMessageDial
      * @param newFragment  the DialogFragment you want to show
      */
     public void showDialogFragment(DialogFragment newFragment) {
+        showDialogFragment(this, newFragment);
+    }
+
+    public static void showDialogFragment(AnkiActivity activity, DialogFragment newFragment) {
         // DialogFragment.show() will take care of adding the fragment
         // in a transaction. We also want to remove any currently showing
         // dialog, so make our own transaction and take care of that here.
-        FragmentTransaction ft = getSupportFragmentManager().beginTransaction();
-        Fragment prev = getSupportFragmentManager().findFragmentByTag("dialog");
+        FragmentManager manager = activity.getSupportFragmentManager();
+        FragmentTransaction ft = manager.beginTransaction();
+        Fragment prev = manager.findFragmentByTag("dialog");
         if (prev != null) {
             ft.remove(prev);
         }
         // save transaction to the back stack
         ft.addToBackStack("dialog");
         newFragment.show(ft, "dialog");
-        getSupportFragmentManager().executePendingTransactions();
+        manager.executePendingTransactions();
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
@@ -26,6 +26,7 @@ import android.os.Bundle;
 import androidx.annotation.CheckResult;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
 import androidx.annotation.VisibleForTesting;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
@@ -45,15 +46,20 @@ import com.google.android.material.tabs.TabLayout;
 import com.google.android.material.tabs.TabLayoutMediator;
 import com.ichi2.anim.ActivityTransitionAnimation;
 import com.ichi2.anki.dialogs.ConfirmationDialog;
+import com.ichi2.anki.dialogs.DeckSelectionDialog;
+import com.ichi2.anki.dialogs.DeckSelectionDialog.SelectableDeck;
 import com.ichi2.anki.dialogs.DiscardChangesDialog;
 import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.async.CollectionTask;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Consts;
+import com.ichi2.libanki.Deck;
+import com.ichi2.libanki.Decks;
 import com.ichi2.libanki.Model;
 import com.ichi2.libanki.Models;
 import com.ichi2.themes.StyledProgressDialog;
 
+import com.ichi2.utils.FunctionalInterfaces;
 import com.ichi2.utils.JSONArray;
 import com.ichi2.utils.JSONException;
 import com.ichi2.utils.JSONObject;
@@ -71,7 +77,7 @@ import com.ichi2.async.TaskData;
  * Allows the user to view the template for the current note type
  */
 @SuppressWarnings({"PMD.AvoidThrowingRawExceptionTypes"})
-public class CardTemplateEditor extends AnkiActivity {
+public class CardTemplateEditor extends AnkiActivity implements DeckSelectionDialog.DeckSelectionListener {
     @VisibleForTesting
     protected ViewPager2 mViewPager;
     private TabLayout mSlidingTabLayout;
@@ -209,6 +215,43 @@ public class CardTemplateEditor extends AnkiActivity {
                 .build();
         discardDialog.show();
         return discardDialog;
+    }
+
+    /** When a deck is selected via Deck Override */
+    @Override
+    public void onDeckSelected(@Nullable SelectableDeck deck) {
+        if (Models.isCloze(getTempModel().getModel())) {
+            Timber.w("Attempted to set deck for cloze model");
+            UIUtils.showThemedToast(this, getString(R.string.model_manager_deck_override_cloze_error), true);
+            return;
+        }
+
+
+        int ordinal = mViewPager.getCurrentItem();
+        JSONObject template = getTempModel().getTemplate(ordinal);
+        String templateName = template.getString("name");
+
+        if (deck != null && Decks.isDynamic(getCol(), deck.getDeckId())) {
+            Timber.w("Attempted to set default deck of %s to dynamic deck %s", templateName, deck.getName());
+            UIUtils.showThemedToast(this, getString(R.string.model_manager_deck_override_dynamic_deck_error), true);
+            return;
+        }
+
+        String message;
+        if (deck == null) {
+            Timber.i("Removing default template from template '%s'", templateName);
+            template.put("did", null);
+            message = getString(R.string.model_manager_deck_override_removed_message, templateName);
+        } else {
+            Timber.i("Setting template '%s' to '%s'", templateName, deck.getName());
+            template.put("did", deck.getDeckId());
+            message = getString(R.string.model_manager_deck_override_added_message, templateName, deck.getName());
+        }
+
+        UIUtils.showThemedToast(this, message, true);
+
+        // Deck Override can change from "on" <-> "off"
+        supportInvalidateOptionsMenu();
     }
 
 
@@ -359,8 +402,16 @@ public class CardTemplateEditor extends AnkiActivity {
             inflater.inflate(R.menu.card_template_editor, menu);
 
             if (mTemplateEditor.getTempModel().getModel().getInt("type") == Consts.MODEL_CLOZE) {
-                Timber.d("Editing cloze model, disabling add/delete card template functionality");
+                Timber.d("Editing cloze model, disabling add/delete card template and deck override functionality");
                 menu.findItem(R.id.action_add).setVisible(false);
+                menu.findItem(R.id.action_add_deck_override).setVisible(false);
+            } else {
+                JSONObject template = getCurrentTemplate();
+                @StringRes int overrideStringRes = template.has("did") && !template.isNull("did") ?
+                        R.string.card_template_editor_deck_override_on :
+                        R.string.card_template_editor_deck_override_off;
+
+                menu.findItem(R.id.action_add_deck_override).setTitle(overrideStringRes);
             }
 
             // It is invalid to delete if there is only one card template, remove the option from UI
@@ -407,6 +458,10 @@ public class CardTemplateEditor extends AnkiActivity {
                     confirmDeleteCards(template, tempModel.getModel(), numAffectedCards);
                     return true;
                 }
+                case R.id.action_add_deck_override: {
+                    displayDeckOverrideDialog(col, tempModel);
+                    return true;
+                }
                 case R.id.action_preview: {
                     Timber.i("CardTemplateEditor:: Preview on tab %s", mTemplateEditor.mViewPager.getCurrentItem());
                     // Create intent for the previewer and add some arguments
@@ -451,6 +506,36 @@ public class CardTemplateEditor extends AnkiActivity {
                     launchCardBrowserAppearance(getCurrentTemplate());
                 default:
                     return super.onOptionsItemSelected(item);
+            }
+        }
+
+
+        private void displayDeckOverrideDialog(Collection col, TemporaryModel tempModel) {
+            AnkiActivity activity = (AnkiActivity) requireActivity();
+            if (Models.isCloze(tempModel.getModel())) {
+                UIUtils.showThemedToast(activity, getString(R.string.model_manager_deck_override_cloze_error), true);
+                return;
+            }
+            String name = getCurrentTemplateName(tempModel);
+            String explanation = getString(R.string.deck_override_explanation, name);
+            // Anki Desktop allows Dynamic decks, have reported this as a bug:
+            // https://forums.ankiweb.net/t/minor-bug-deck-override-to-filtered-deck/1493
+            FunctionalInterfaces.Filter<Deck> nonDynamic = (d) -> !Decks.isDynamic(d);
+            List<SelectableDeck> decks = SelectableDeck.fromCollection(col, nonDynamic);
+            String title = getString(R.string.card_template_editor_deck_override);
+            DeckSelectionDialog dialog = DeckSelectionDialog.newInstance(title, explanation, decks);
+            AnkiActivity.showDialogFragment(activity, dialog);
+        }
+
+
+        private String getCurrentTemplateName(TemporaryModel tempModel) {
+            try {
+                int ordinal = mTemplateEditor.mViewPager.getCurrentItem();
+                final JSONObject template = tempModel.getTemplate(ordinal);
+                return template.getString("name");
+            } catch (Exception e) {
+                Timber.w(e, "Failed to get name for template");
+                return "";
             }
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.java
@@ -1,0 +1,374 @@
+/*
+ Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.dialogs;
+
+import android.app.Dialog;
+import android.os.Bundle;
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.view.LayoutInflater;
+import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Filter;
+import android.widget.Filterable;
+import android.widget.TextView;
+
+import com.afollestad.materialdialogs.MaterialDialog;
+import com.ichi2.anki.R;
+import com.ichi2.anki.analytics.AnalyticsDialogFragment;
+import com.ichi2.libanki.Collection;
+import com.ichi2.libanki.Deck;
+import com.ichi2.utils.FunctionalInterfaces;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.widget.SearchView;
+import androidx.appcompat.widget.Toolbar;
+import androidx.recyclerview.widget.DividerItemDecoration;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+public class DeckSelectionDialog extends AnalyticsDialogFragment {
+
+    private MaterialDialog mDialog;
+
+
+    /**
+     * A dialog which handles selecting a deck
+     */
+    @NonNull
+    public static DeckSelectionDialog newInstance(@NonNull String title, @NonNull String summaryMessage, @NonNull List<SelectableDeck> decks) {
+        DeckSelectionDialog f = new DeckSelectionDialog();
+        Bundle args = new Bundle();
+        args.putString("summaryMessage", summaryMessage);
+        args.putString("title", title);
+        args.putParcelableArrayList("deckNames", new ArrayList<>(decks));
+        f.setArguments(args);
+        return f;
+    }
+
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setCancelable(true);
+    }
+
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(@Nullable Bundle savedInstanceState) {
+        View dialogView = LayoutInflater.from(getActivity())
+                .inflate(R.layout.deck_picker_dialog, null, false);
+
+
+        TextView summary = dialogView.findViewById(R.id.deck_picker_dialog_summary);
+
+        Bundle arguments = requireArguments();
+
+        summary.setText(getSummaryMessage(arguments));
+
+        RecyclerView recyclerView = dialogView.findViewById(R.id.deck_picker_dialog_list);
+        recyclerView.requestFocus();
+        recyclerView.setHasFixedSize(true);
+
+        RecyclerView.LayoutManager deckLayoutManager = new LinearLayoutManager(requireActivity());
+        recyclerView.setLayoutManager(deckLayoutManager);
+
+        DividerItemDecoration dividerItemDecoration = new DividerItemDecoration(recyclerView.getContext(), DividerItemDecoration.VERTICAL);
+        recyclerView.addItemDecoration(dividerItemDecoration);
+
+        List<SelectableDeck> decks = getDeckNames(arguments);
+        DecksArrayAdapter adapter = new DecksArrayAdapter(decks);
+        recyclerView.setAdapter(adapter);
+
+        adjustToolbar(dialogView, adapter);
+
+        MaterialDialog.Builder builder = new MaterialDialog.Builder(requireActivity())
+                .neutralText(R.string.dialog_cancel)
+                .negativeText(R.string.restore_default)
+                .customView(dialogView, false)
+                .onNegative((dialog, which) -> onDeckSelected(null))
+                .onNeutral((dialog, which) -> { });
+
+        mDialog = builder.build();
+        return mDialog;
+    }
+
+
+    @NonNull
+    private String getSummaryMessage(Bundle arguments) {
+        return Objects.requireNonNull(arguments.getString("summaryMessage"));
+    }
+
+
+    @NonNull
+    private ArrayList<SelectableDeck> getDeckNames(Bundle arguments) {
+        return Objects.requireNonNull(arguments.getParcelableArrayList("deckNames"));
+    }
+
+
+    @NonNull
+    private String getTitle() {
+        return Objects.requireNonNull(requireArguments().getString("title"));
+    }
+
+
+    private void adjustToolbar(View dialogView, DecksArrayAdapter adapter) {
+        Toolbar mToolbar = dialogView.findViewById(R.id.deck_picker_dialog_toolbar);
+
+        mToolbar.setTitle(getTitle());
+
+        mToolbar.inflateMenu(R.menu.deck_picker_dialog_menu);
+
+        MenuItem searchItem = mToolbar.getMenu().findItem(R.id.deck_picker_dialog_action_filter);
+        SearchView searchView = (SearchView) searchItem.getActionView();
+
+        searchView.setQueryHint(getString(R.string.deck_picker_dialog_filter_decks));
+        searchView.setOnQueryTextListener(new SearchView.OnQueryTextListener() {
+            @Override
+            public boolean onQueryTextSubmit(String query) {
+                searchView.clearFocus();
+                return true;
+            }
+
+            @Override
+            public boolean onQueryTextChange(String newText) {
+                adapter.getFilter().filter(newText);
+                return true;
+            }
+        });
+    }
+
+
+    protected void onDeckSelected(@Nullable SelectableDeck deck) {
+        ((DeckSelectionListener) requireActivity()).onDeckSelected(deck);
+    }
+
+    protected void selectDeckAndClose(@NonNull SelectableDeck deck) {
+        onDeckSelected(deck);
+        mDialog.dismiss();
+    }
+
+    protected void displayErrorAndCancel() {
+        mDialog.dismiss();
+    }
+
+
+    public class DecksArrayAdapter extends RecyclerView.Adapter<DecksArrayAdapter.ViewHolder> implements Filterable {
+        public class ViewHolder extends RecyclerView.ViewHolder {
+            private TextView mDeckTextView;
+            public ViewHolder(@NonNull TextView ctv) {
+                super(ctv);
+                mDeckTextView = ctv;
+                mDeckTextView.setOnClickListener(view -> {
+                    String deckName = ctv.getText().toString();
+                    selectDeckByNameAndClose(deckName);
+                });
+            }
+
+
+            public void setDeck(@NonNull SelectableDeck deck) {
+                mDeckTextView.setText(deck.getName());
+            }
+        }
+
+        private final ArrayList<SelectableDeck> mAllDecksList = new ArrayList<>();
+        private final ArrayList<SelectableDeck> mCurrentlyDisplayedDecks = new ArrayList<>();
+
+        public DecksArrayAdapter(@NonNull List<SelectableDeck> deckNames) {
+            mAllDecksList.addAll(deckNames);
+            mCurrentlyDisplayedDecks.addAll(deckNames);
+            Collections.sort(mCurrentlyDisplayedDecks);
+        }
+
+        protected void selectDeckByNameAndClose(@NonNull String deckName) {
+            for (SelectableDeck d : mAllDecksList) {
+                if (d.getName().equals(deckName)) {
+                    selectDeckAndClose(d);
+                    return;
+                }
+            }
+            displayErrorAndCancel();
+        }
+
+        @NonNull
+        @Override
+        public ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+            View v = LayoutInflater.from(parent.getContext())
+                    .inflate(R.layout.deck_picker_dialog_list_item, parent, false);
+
+            return new ViewHolder(v.findViewById(R.id.deck_picker_dialog_list_item_value));
+        }
+
+        @Override
+        public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
+            SelectableDeck deck = mCurrentlyDisplayedDecks.get(position);
+            holder.setDeck(deck);
+        }
+
+        @Override
+        public int getItemCount() {
+            return mCurrentlyDisplayedDecks.size();
+        }
+
+
+        @NonNull
+        @Override
+        public Filter getFilter() {
+            return new DecksFilter();
+        }
+
+        /* Custom Filter class - as seen in http://stackoverflow.com/a/29792313/1332026 */
+        private class DecksFilter extends Filter {
+            private ArrayList<SelectableDeck> mFilteredDecks;
+            protected DecksFilter() {
+                super();
+                mFilteredDecks = new ArrayList<>();
+            }
+
+            @Override
+            protected FilterResults performFiltering(CharSequence constraint) {
+                mFilteredDecks.clear();
+                ArrayList<SelectableDeck> allDecks = DecksArrayAdapter.this.mAllDecksList;
+                final FilterResults filterResults = new FilterResults();
+                if (constraint.length() == 0) {
+                    mFilteredDecks.addAll(allDecks);
+                } else {
+                    final String filterPattern = constraint.toString().toLowerCase().trim();
+                    for (SelectableDeck deck : allDecks) {
+                        if (deck.getName().toLowerCase().contains(filterPattern)) {
+                            mFilteredDecks.add(deck);
+                        }
+                    }
+                }
+
+                filterResults.values = mFilteredDecks;
+                filterResults.count = mFilteredDecks.size();
+                return filterResults;
+            }
+
+            @Override
+            protected void publishResults(CharSequence charSequence, FilterResults filterResults) {
+                ArrayList<SelectableDeck> currentlyDisplayedDecks = DecksArrayAdapter.this.mCurrentlyDisplayedDecks;
+                currentlyDisplayedDecks.clear();
+                currentlyDisplayedDecks.addAll(mFilteredDecks);
+                Collections.sort(currentlyDisplayedDecks);
+                notifyDataSetChanged();
+            }
+        }
+    }
+
+
+    public static class SelectableDeck implements Comparable<SelectableDeck>, Parcelable {
+        private final long mDeckId;
+        private final String mName;
+
+        @NonNull
+        public static List<SelectableDeck> fromCollection(@NonNull Collection c, @NonNull FunctionalInterfaces.Filter<Deck> filter) {
+            List<Deck> all = c.getDecks().all();
+            List<SelectableDeck> ret = new ArrayList<>();
+            for (Deck d : all) {
+                if (!filter.shouldInclude(d)) {
+                    continue;
+                }
+                ret.add( new SelectableDeck(d));
+            }
+            return ret;
+        }
+
+        @SuppressWarnings("unused")
+        @NonNull
+        public static List<SelectableDeck> fromCollection(@NonNull Collection c) {
+            return fromCollection(c, FunctionalInterfaces.Filters.allowAll());
+        }
+
+
+        public SelectableDeck(long deckId, @NonNull String name) {
+            this.mDeckId = deckId;
+            this.mName = name;
+        }
+
+
+        protected SelectableDeck(@NonNull Deck d) {
+            this(d.getLong("id"), d.getString("name"));
+        }
+
+
+        protected SelectableDeck(@NonNull Parcel in) {
+            mDeckId = in.readLong();
+            mName = in.readString();
+        }
+
+
+        public long getDeckId() {
+            return mDeckId;
+        }
+
+
+        @NonNull
+        public String getName() {
+            return mName;
+        }
+
+
+        @Override
+        public int compareTo(@NonNull SelectableDeck o) {
+            return this.mName.compareTo(o.mName);
+        }
+
+
+        @Override
+        public int describeContents() {
+            return 0;
+        }
+
+
+        @Override
+        public void writeToParcel(@NonNull Parcel dest, int flags) {
+            dest.writeLong(mDeckId);
+            dest.writeString(mName);
+        }
+
+
+
+        @SuppressWarnings("unused")
+        public static final Parcelable.Creator<SelectableDeck> CREATOR = new Parcelable.Creator<SelectableDeck>() {
+            @Override
+            public SelectableDeck createFromParcel(Parcel in) {
+                return new SelectableDeck(in);
+            }
+
+
+            @Override
+            public SelectableDeck[] newArray(int size) {
+                return new SelectableDeck[size];
+            }
+        };
+    }
+
+
+    public interface DeckSelectionListener {
+        void onDeckSelected(@Nullable SelectableDeck deck);
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -1196,6 +1196,10 @@ public class Decks {
         getDeckOrFail(deckId).remove("conf");
     }
 
+    public static boolean isDynamic(Collection col, long deckId) {
+        return Decks.isDynamic(col.getDecks().get(deckId));
+    }
+
     public static boolean isDynamic(Deck deck) {
         return deck.getInt("dyn") != 0;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -1255,4 +1255,8 @@ public class Models {
 		}
 		return (count == 0);
 	}
+
+	public static boolean isCloze(JSONObject model) {
+	    return model.getInt("type") == Consts.MODEL_CLOZE;
+    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/FunctionalInterfaces.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/FunctionalInterfaces.java
@@ -1,6 +1,8 @@
 package com.ichi2.utils;
 
 
+import androidx.annotation.NonNull;
+
 /** TODO: Move this to standard library in API 24 */
 public final class FunctionalInterfaces {
 
@@ -22,5 +24,17 @@ public final class FunctionalInterfaces {
     @FunctionalInterface
     public interface FunctionThrowable<TIn, TOut, TEx extends Throwable> {
         TOut apply(TIn item) throws TEx;
+    }
+
+    @FunctionalInterface
+    public interface Filter<TIn> {
+        boolean shouldInclude(TIn item);
+    }
+
+    public static class Filters {
+        @NonNull
+        public static <T> Filter<T> allowAll() {
+            return (a) -> true;
+        }
     }
 }

--- a/AnkiDroid/src/main/res/layout/deck_picker_dialog.xml
+++ b/AnkiDroid/src/main/res/layout/deck_picker_dialog.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+  This program is free software; you can redistribute it and/or modify it under
+  the terms of the GNU General Public License as published by the Free Software
+  Foundation; either version 3 of the License, or (at your option) any later
+  version.
+
+  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along with
+  this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/deck_picker_dialog_toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:minHeight="?attr/actionBarSize"
+        android:layout_alignParentTop="true"
+        android:theme="@style/ActionBarStyle"
+        android:background="?attr/colorPrimary"
+        app:popupTheme="@style/ActionBar.Popup">
+    </androidx.appcompat.widget.Toolbar>
+
+    <TextView android:id="@+id/deck_picker_dialog_summary"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerHorizontal="true"
+        android:textSize="18sp"
+        android:padding="8dp"
+        android:gravity="center"
+        android:textIsSelectable="false"
+        android:layout_below="@id/deck_picker_dialog_toolbar"/>
+
+    <androidx.recyclerview.widget.RecyclerView android:id="@+id/deck_picker_dialog_list"
+                                               android:scrollbars="vertical"
+                                               android:layout_width="fill_parent"
+                                               android:layout_height="wrap_content"
+                                               android:layout_below="@id/deck_picker_dialog_summary"/>
+</RelativeLayout>

--- a/AnkiDroid/src/main/res/layout/deck_picker_dialog_list_item.xml
+++ b/AnkiDroid/src/main/res/layout/deck_picker_dialog_list_item.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+  This program is free software; you can redistribute it and/or modify it under
+  the terms of the GNU General Public License as published by the Free Software
+  Foundation; either version 3 of the License, or (at your option) any later
+  version.
+
+  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along with
+  this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<!-- An item in a deck selection screen. Partially based off deck_item -->
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/deck_picker_dialog_list_item_value"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:minHeight="?android:attr/listPreferredItemHeight"
+    android:paddingStart="@dimen/deck_picker_left_padding"
+    android:paddingLeft="@dimen/deck_picker_left_padding"
+    android:paddingEnd="8dp"
+    android:paddingRight="8dp"
+    android:gravity="start|center_vertical"
+    android:background="?attr/selectableItemBackground"
+    android:textStyle="bold"
+    android:textSize="20sp"
+    android:textIsSelectable="false"
+    android:focusable="true"
+    android:clickable="true"
+     />

--- a/AnkiDroid/src/main/res/menu/card_template_editor.xml
+++ b/AnkiDroid/src/main/res/menu/card_template_editor.xml
@@ -27,4 +27,9 @@
         android:icon="@drawable/ic_view_list_white_24dp"
         android:title="@string/card_template_editor_menu_card_browser_appearance"
         ankidroid:showAsAction="ifRoom"/>
+    <!-- never show - no icon. Title is dynamic (on/off) -->
+    <item
+        android:id="@+id/action_add_deck_override"
+        android:title="@string/card_template_editor_deck_override"
+        ankidroid:showAsAction="never"/>
 </menu>

--- a/AnkiDroid/src/main/res/menu/deck_picker_dialog_menu.xml
+++ b/AnkiDroid/src/main/res/menu/deck_picker_dialog_menu.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+  This program is free software; you can redistribute it and/or modify it under
+  the terms of the GNU General Public License as published by the Free Software
+  Foundation; either version 3 of the License, or (at your option) any later
+  version.
+
+  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along with
+  this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:ankidroid="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/deck_picker_dialog_action_filter"
+        android:icon="@drawable/ic_search_white_24dp"
+        android:title="@string/deck_picker_dialog_filter_decks"
+        ankidroid:actionViewClass="androidx.appcompat.widget.SearchView"
+        ankidroid:showAsAction="always|collapseActionView"/>
+</menu>

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -172,6 +172,7 @@
     <string name="card_template_editor_styling">Styling</string>
     <string name="card_template_editor_menu_delete">Delete</string>
     <string name="card_template_editor_menu_card_browser_appearance">Card Browser Appearance</string>
+    <string name="card_template_editor_deck_override">Deck Override</string>
     <string name="card_template_editor_cant_delete">At least one card type is required</string>
     <plurals name="card_template_editor_confirm_delete">
         <item quantity="one">Delete the “%2$s” card type, and its %1$d card?</item>

--- a/AnkiDroid/src/main/res/values/17-model-manager.xml
+++ b/AnkiDroid/src/main/res/values/17-model-manager.xml
@@ -73,4 +73,15 @@
     <string name="card_template_browser_appearance_restore_default_dialog">Restore Default Values?</string>
     <string name="card_template_browser_appearance_saving_note">These changes are applied when the card template is saved</string>
 
+    <!-- Deck Override -->
+    <string name="card_template_editor_deck_override_on">Deck Override (on)</string>
+    <string name="card_template_editor_deck_override_off">Deck Override (off)</string>
+    <string name="model_manager_deck_override_added_message">Set ‘%1$s’ default deck to ‘%2$s’</string>
+    <string name="model_manager_deck_override_removed_message">Removed default deck for ‘%s’</string>
+    <string name="model_manager_deck_override_cloze_error">Cannot set Deck Override for Cloze notes</string>
+    <string name="model_manager_deck_override_dynamic_deck_error">Cannot set Deck Override to a filtered deck</string>
+    <string name="deck_override_explanation">Select deck to place new ‘%s’ cards into</string>
+    <string name="deck_picker_dialog_filter_decks">Filter decks</string>
+
+
 </resources>


### PR DESCRIPTION
## Feature Description

This allows a specific Card Type to go to a given deck when a new note is added. This overrides the selected deck in the Note Editor. This feature exists in Anki Desktop.

This involves a basic (non hierarchical) deck selection screen with filtering

This should not work for Cloze cards
This should not allow a dynamic deck as a target

The title is "Deck Override (on/off)" in the Card Template Editor

## Fixes
Fixes #5396

## How Has This Been Tested?

* Tested on my phone
* ⚠️ I'm happy to add unit tests if requested

![image](https://user-images.githubusercontent.com/62114487/88676838-77d83380-d0e4-11ea-9f79-44e00a84c510.png)

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code