### PR TITLE
Note Editor: Improve Cloze handling (Ctrl+Shift+C shortcut & crash fix)

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -644,12 +644,33 @@ public class NoteEditor extends AnkiActivity {
                     showTagsDialog();
                 }
                 break;
+            case KeyEvent.KEYCODE_C: {
+                if (event.isCtrlPressed() && event.isShiftPressed()) {
+                    insertCloze();
+                    // Anki Desktop warns, but still inserts the cloze
+                    if (!isClozeType()) {
+                        UIUtils.showSimpleSnackbar(this, R.string.note_editor_insert_cloze_no_cloze_note_type, false);
+                    }
+
+                }
+            }
             default:
                 break;
         }
 
         return super.onKeyUp(keyCode, event);
     }
+
+
+    private void insertCloze() {
+        View v = getCurrentFocus();
+        if (!(v instanceof FieldEditText)) {
+            return;
+        }
+        FieldEditText editText = (FieldEditText) v;
+        convertSelectedTextToCloze(editText);
+    }
+
 
     private void fetchIntentInformation(Intent intent) {
         Bundle extras = intent.getExtras();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1853,15 +1853,20 @@ public class NoteEditor extends AnkiActivity {
         // get the current text and selection locations
         int selectionStart = textBox.getSelectionStart();
         int selectionEnd = textBox.getSelectionEnd();
+
+        // #6762 values are reversed if using a keyboard and pressing Ctrl+Shift+LeftArrow
+        int start = Math.min(selectionStart, selectionEnd);
+        int end = Math.max(selectionStart, selectionEnd);
+
         String text = "";
         if (textBox.getText() != null) {
             text = textBox.getText().toString();
         }
 
         // Split the text in the places where the cloze deletion will be inserted
-        String beforeText = text.substring(0, selectionStart);
-        String selectedText = text.substring(selectionStart, selectionEnd);
-        String afterText = text.substring(selectionEnd);
+        String beforeText = text.substring(0, start);
+        String selectedText = text.substring(start, end);
+        String afterText = text.substring(end);
         int nextClozeIndex = getNextClozeIndex();
 
         // Format the cloze deletion open bracket
@@ -1870,7 +1875,7 @@ public class NoteEditor extends AnkiActivity {
         // Update text field with updated text and selection
         textBox.setText(String.format("%s%s%s}}%s", beforeText, clozeOpenBracket, selectedText, afterText));
         int clozeOpenSize = clozeOpenBracket.length();
-        textBox.setSelection(selectionStart+clozeOpenSize, selectionEnd+clozeOpenSize);
+        textBox.setSelection(start + clozeOpenSize, end + clozeOpenSize);
     }
 
 

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -101,6 +101,7 @@
     <string name="note_editor_no_first_field">The first field is empty</string>
     <string name="note_editor_no_cloze_delations">This note type must contain cloze deletions</string>
     <string name="note_editor_no_cards_created_all_fields">The current note type did not produce any cards.\nPlease choose another note type, or click ‘Cards’ and add a field substitution</string>
+    <string name="note_editor_insert_cloze_no_cloze_note_type">Cloze deletions will only work on a Cloze note type</string>
     <string name="saving_facts">Saving note</string>
     <string name="saving_model">Saving note type</string>
     <string name="add">Add</string>


### PR DESCRIPTION
## Purpose / Description

* Clozes crashed if selecting from right to left then inserting
* Clozes could not be added by Ctrl+Shift+C like they could on PC

## Fixes
* Fixes #6762 
* Fixes #6014 

## Approach
For the bug: enforce start <= end
Added the keyboard shortcut

## How Has This Been Tested?

Tested on my phone with bluetooth keyboard attached

## Learning 

You can't test most Ctrl+Shift commands on an emulator: https://issuetracker.google.com/issues/37142228

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code