### PR TITLE
Allow import of SchedV1 collection.anki21 files

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.java
@@ -401,10 +401,6 @@ public final class AnkiPackageExporter extends AnkiExporter {
         // export into the anki2 file
         String colfile = path.replace(".apkg", ".anki2");
 
-        if (_v2sched) {
-            throw new ImportExportException(context.getString(R.string.export_v2_forbidden));
-        }
-
         super.exportInto(colfile, context);
         z.write(colfile, CollectionHelper.COLLECTION_FILENAME);
         // and media

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/AnkiPackageImporter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/AnkiPackageImporter.java
@@ -85,8 +85,13 @@ public class AnkiPackageImporter extends Anki2Importer {
                     mLog.add(getRes().getString(R.string.import_log_insufficient_space, uncompressedSize, availableSpace));
                     return;
                 }
-
-                Utils.unzipFiles(mZip, tempDir.getAbsolutePath(), new String[]{colname, "media"}, null);
+                // The filename that we extract should be collection.anki2
+                // Importing collection.anki21 fails due to some media regexes expecting collection.anki2.
+                // We follow how Anki does it and fix the problem here.
+                HashMap<String, String> mediaToFileNameMap = new HashMap<>();
+                mediaToFileNameMap.put(colname, CollectionHelper.COLLECTION_FILENAME);
+                Utils.unzipFiles(mZip, tempDir.getAbsolutePath(), new String[]{colname, "media"}, mediaToFileNameMap);
+                colname = CollectionHelper.COLLECTION_FILENAME;
             } catch (IOException e) {
                 Timber.e(e, "Failed to unzip apkg.");
                 AnkiDroidApp.sendExceptionReport(e, "AnkiPackageImporter::run() - unzip");

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -254,7 +254,6 @@
     <string name="import_needs_v2">V2 scheduler must be enabled to import this file.</string>
     <string name="import_cannot_with_v2">V2 scheduler can not import V1 decks with scheduling included.</string>
     <string name="export_v2_dummy_note">This file requires a newer version of Anki.</string>
-    <string name="export_v2_forbidden">Please switch to the V1 scheduler before exporting a single deck with scheduling information.</string>
     <!-- Placed in a snackbar with a long URL. Limit the length and move the URL to the start of the string -->
     <string name="activity_start_failed_load_url">Loading \'%s\' failed.</string>
     <string name="activity_start_failed">The system does not have an app installed that can perform this action.</string>


### PR DESCRIPTION
## Purpose / Description

Copies the following changes to allow imports of a apkg containing a collection.anki21 file without crashing when importing media
----

ankitects/anki@9d6523e
ankitects/anki@b9280ca

----

## Fixes
Fixes #6764

## How Has This Been Tested?

* A few import regression tests on my device. The test deck provided by the affected user now imports with no error
* ⚠️ I feel this needs better testing still, it's a fairly involved change, and I'm not the most familiar with the code
* Exporting the single deck now works


## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code