### PR TITLE
NF: Listeners do not leak contexts

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -305,22 +305,29 @@ public class CardBrowser extends NavigationDrawerActivity implements
         }
     }
 
-    private TaskListener mRescheduleCardHandler = new TaskListener() {
+    private RescheduleCardHandler rescheduleCardHandler() {
+        new RescheduleCardHandler(this);
+    }
+    private static class RescheduleCardHandler extends TaskListenerWithContext<CardBrowser>{
+        public RescheduleCardHandler (CardBrowser browser) {
+            super(browser);
+        }
+
         @Override
-        public void onPreExecute() {
+        public void actualOnPreExecute(@NonNull CardBrowser browser) {
             Timber.d("CardBrowser::RescheduleCardHandler() onPreExecute");
         }
 
 
         @Override
-        public void onPostExecute(TaskData result) {
+        public void actualOnPostExecute(@NonNull CardBrowser browser, TaskData result) {
             Timber.d("CardBrowser::RescheduleCardHandler() onPostExecute");
-            mReloadRequired = true;
+            browser.mReloadRequired = true;
             int cardCount = result.getObjArray().length;
-            UIUtils.showThemedToast(CardBrowser.this,
-                    getResources().getQuantityString(R.plurals.reschedule_cards_dialog_acknowledge, cardCount, cardCount), true);
+            UIUtils.showThemedToast(browser,
+                    browser.getResources().getQuantityString(R.plurals.reschedule_cards_dialog_acknowledge, cardCount, cardCount), true);
         }
-    };
+    }
 
     private CardBrowserMySearchesDialog.MySearchesDialogListener mMySearchesDialogListener =
             new CardBrowserMySearchesDialog.MySearchesDialogListener() {
@@ -1100,7 +1107,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 long[] selectedCardIds = getSelectedCardIds();
                 FunctionalInterfaces.Consumer<Integer> consumer = newDays ->
                     CollectionTask.launchCollectionTask(DISMISS_MULTI,
-                        mRescheduleCardHandler,
+                        rescheduleCardHandler(),
                         new TaskData(new Object[]{selectedCardIds, Collection.DismissType.RESCHEDULE_CARDS, newDays}));
 
                 RescheduleDialog rescheduleDialog;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -281,22 +281,29 @@ public class CardBrowser extends NavigationDrawerActivity implements
         }
     }
 
-    private TaskListener mResetProgressCardHandler = new TaskListener() {
+    private ResetProgressCardHandler resetProgressCardHandler() {
+        return new ResetProgressCardHandler(this);
+    }
+    private static class ResetProgressCardHandler extends TaskListenerWithContext<CardBrowser>{
+        public ResetProgressCardHandler(CardBrowser browser) {
+            super(browser);
+        }
+
         @Override
-        public void onPreExecute() {
+        public void actualOnPreExecute(@NonNull CardBrowser browser) {
             Timber.d("CardBrowser::ResetProgressCardHandler() onPreExecute");
         }
 
 
         @Override
-        public void onPostExecute(TaskData result) {
+        public void actualOnPostExecute(@NonNull CardBrowser browser, TaskData result) {
             Timber.d("CardBrowser::ResetProgressCardHandler() onPostExecute");
-            mReloadRequired = true;
+            browser.mReloadRequired = true;
             int cardCount = result.getObjArray().length;
-            UIUtils.showThemedToast(CardBrowser.this,
-                    getResources().getQuantityString(R.plurals.reset_cards_dialog_acknowledge, cardCount, cardCount), true);
+            UIUtils.showThemedToast(browser,
+                    browser.getResources().getQuantityString(R.plurals.reset_cards_dialog_acknowledge, cardCount, cardCount), true);
         }
-    };
+    }
 
     private TaskListener mRescheduleCardHandler = new TaskListener() {
         @Override
@@ -1080,7 +1087,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 dialog.setArgs(title, message);
                 Runnable confirm = () -> {
                     Timber.i("CardBrowser:: ResetProgress button pressed");
-                    CollectionTask.launchCollectionTask(DISMISS_MULTI, mResetProgressCardHandler,
+                    CollectionTask.launchCollectionTask(DISMISS_MULTI, resetProgressCardHandler(),
                             new TaskData(new Object[]{getSelectedCardIds(), Collection.DismissType.RESET_CARDS}));
                 };
                 dialog.setConfirm(confirm);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1759,21 +1759,27 @@ public class CardBrowser extends NavigationDrawerActivity implements
             boolean hasUnsuspended = (boolean) resultArr[0];
             boolean hasUnmarked = (boolean) resultArr[1];
 
+            int title;
+            int icon;
             if (hasUnsuspended) {
-                mActionBarMenu.findItem(R.id.action_suspend_card).setTitle(getString(R.string.card_browser_suspend_card));
-                mActionBarMenu.findItem(R.id.action_suspend_card).setIcon(R.drawable.ic_action_suspend);
+                title = R.string.card_browser_suspend_card;
+                icon = R.drawable.ic_action_suspend;
             } else {
-                mActionBarMenu.findItem(R.id.action_suspend_card).setTitle(getString(R.string.card_browser_unsuspend_card));
-                mActionBarMenu.findItem(R.id.action_suspend_card).setIcon(R.drawable.ic_action_unsuspend);
+                title = R.string.card_browser_unsuspend_card;
+                icon = R.drawable.ic_action_unsuspend;
             }
+            mActionBarMenu.findItem(R.id.action_suspend_card).setTitle(getString(title));
+            mActionBarMenu.findItem(R.id.action_suspend_card).setIcon(icon);
 
             if (hasUnmarked) {
-                mActionBarMenu.findItem(R.id.action_mark_card).setTitle(getString(R.string.card_browser_mark_card));
-                mActionBarMenu.findItem(R.id.action_mark_card).setIcon(R.drawable.ic_star_outline_white_24dp);
+                title = R.string.card_browser_mark_card;
+                icon = R.drawable.ic_star_outline_white_24dp;
             } else {
-                mActionBarMenu.findItem(R.id.action_mark_card).setTitle(getString(R.string.card_browser_unmark_card));
-                mActionBarMenu.findItem(R.id.action_mark_card).setIcon(R.drawable.ic_star_white_24dp);
+                title = R.string.card_browser_unmark_card;
+                icon = R.drawable.ic_star_white_24dp;
             }
+            mActionBarMenu.findItem(R.id.action_mark_card).setTitle(getString(title));
+            mActionBarMenu.findItem(R.id.action_mark_card).setIcon(icon);
         }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1768,8 +1768,9 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 title = R.string.card_browser_unsuspend_card;
                 icon = R.drawable.ic_action_unsuspend;
             }
-            mActionBarMenu.findItem(R.id.action_suspend_card).setTitle(getString(title));
-            mActionBarMenu.findItem(R.id.action_suspend_card).setIcon(icon);
+            MenuItem suspend_item = mActionBarMenu.findItem(R.id.action_suspend_card);
+            suspend_item.setTitle(getString(title));
+            suspend_item.setIcon(icon);
 
             if (hasUnmarked) {
                 title = R.string.card_browser_mark_card;
@@ -1778,8 +1779,9 @@ public class CardBrowser extends NavigationDrawerActivity implements
                 title = R.string.card_browser_unmark_card;
                 icon = R.drawable.ic_star_white_24dp;
             }
-            mActionBarMenu.findItem(R.id.action_mark_card).setTitle(getString(title));
-            mActionBarMenu.findItem(R.id.action_mark_card).setIcon(icon);
+            MenuItem mark_item = mActionBarMenu.findItem(R.id.action_mark_card);
+            mark_item.setTitle(getString(title));
+            mark_item.setIcon(icon);
         }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -1489,30 +1489,38 @@ public class DeckPicker extends NavigationDrawerActivity implements
     }
 
 
+    private final MediaCheckListener mediaCheckListener() {
+        return new MediaCheckListener(this);
+    }
+    private static class MediaCheckListener extends TaskListenerWithContext<DeckPicker>{
+        public MediaCheckListener (DeckPicker deckPicker) {
+            super(deckPicker);
+        }
+
+        @Override
+        public void actualOnPreExecute(@NonNull DeckPicker deckPicker) {
+            deckPicker.mProgressDialog = StyledProgressDialog.show(deckPicker, "",
+                    deckPicker.getResources().getString(R.string.check_media_message), false);
+        }
+
+
+        @Override
+        public void actualOnPostExecute(@NonNull DeckPicker deckPicker, TaskData result) {
+            if (deckPicker.mProgressDialog != null && deckPicker.mProgressDialog.isShowing()) {
+                deckPicker.mProgressDialog.dismiss();
+            }
+            if (result != null && result.getBoolean()) {
+                @SuppressWarnings("unchecked")
+                List<List<String>> checkList = (List<List<String>>) result.getObjArray()[0];
+                deckPicker.showMediaCheckDialog(MediaCheckDialog.DIALOG_MEDIA_CHECK_RESULTS, checkList);
+            } else {
+                deckPicker.showSimpleMessageDialog(deckPicker.getResources().getString(R.string.check_media_failed));
+            }
+        }
+    }
     @Override
     public void mediaCheck() {
-        TaskListener listener = new TaskListener() {
-            @Override
-            public void onPreExecute() {
-                mProgressDialog = StyledProgressDialog.show(DeckPicker.this, "",
-                        getResources().getString(R.string.check_media_message), false);
-            }
-
-
-            @Override
-            public void onPostExecute(TaskData result) {
-                if (mProgressDialog != null && mProgressDialog.isShowing()) {
-                    mProgressDialog.dismiss();
-                }
-                if (result != null && result.getBoolean()) {
-                    @SuppressWarnings("unchecked")
-                    List<List<String>> checkList = (List<List<String>>) result.getObjArray()[0];
-                    showMediaCheckDialog(MediaCheckDialog.DIALOG_MEDIA_CHECK_RESULTS, checkList);
-                } else {
-                    showSimpleMessageDialog(getResources().getString(R.string.check_media_failed));
-                }
-            }
-        };
+        TaskListener listener = mediaCheckListener();
         CollectionTask.launchCollectionTask(CHECK_MEDIA, listener);
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -2471,31 +2471,37 @@ public class DeckPicker extends NavigationDrawerActivity implements
     /**
      * Show progress bars and rebuild deck list on completion
      */
-    private TaskListener mSimpleProgressListener = new TaskListener() {
+    private final SimpleProgressListener simpleProgressListener() {
+        return new SimpleProgressListener(this);
+    }
+    private static class SimpleProgressListener extends TaskListenerWithContext<DeckPicker>{
+        public SimpleProgressListener (DeckPicker deckPicker) {
+            super(deckPicker);
+        }
 
         @Override
-        public void onPreExecute() {
-            showProgressBar();
+        public void actualOnPreExecute(@NonNull DeckPicker deckPicker) {
+            deckPicker.showProgressBar();
         }
 
 
         @Override
-        public void onPostExecute(TaskData result) {
-            updateDeckList();
-            if (mFragmented) {
-                loadStudyOptionsFragment(false);
+        public void actualOnPostExecute(@NonNull DeckPicker deckPicker, TaskData result) {
+            deckPicker.updateDeckList();
+            if (deckPicker.mFragmented) {
+                deckPicker.loadStudyOptionsFragment(false);
             }
         }
     };
 
     public void rebuildFiltered() {
         getCol().getDecks().select(mContextMenuDid);
-        CollectionTask.launchCollectionTask(REBUILD_CRAM, mSimpleProgressListener);
+        CollectionTask.launchCollectionTask(REBUILD_CRAM, simpleProgressListener());
     }
 
     public void emptyFiltered() {
         getCol().getDecks().select(mContextMenuDid);
-        CollectionTask.launchCollectionTask(EMPTY_CRAM, mSimpleProgressListener);
+        CollectionTask.launchCollectionTask(EMPTY_CRAM, simpleProgressListener());
     }
 
     @Override

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -358,37 +358,43 @@ public class DeckPicker extends NavigationDrawerActivity implements
         }
     }
 
-    private TaskListener mExportListener = new TaskListener() {
+    private ExportListener exportListener() {
+        return new ExportListener(this);
+    }
+    private static class ExportListener extends TaskListenerWithContext<DeckPicker>{
+        public ExportListener(DeckPicker deckPicker) {
+            super(deckPicker);
+        }
 
         @Override
-        public void onPreExecute() {
-            mProgressDialog = StyledProgressDialog.show(DeckPicker.this, "",
-                    getResources().getString(R.string.export_in_progress), false);
+        public void actualOnPreExecute(@NonNull DeckPicker deckPicker) {
+            deckPicker.mProgressDialog = StyledProgressDialog.show(deckPicker, "",
+                    deckPicker.getResources().getString(R.string.export_in_progress), false);
         }
 
 
         @Override
-        public void onPostExecute(TaskData result) {
-            if (mProgressDialog != null && mProgressDialog.isShowing()) {
-                mProgressDialog.dismiss();
+        public void actualOnPostExecute(@NonNull DeckPicker deckPicker, TaskData result) {
+            if (deckPicker.mProgressDialog != null && deckPicker.mProgressDialog.isShowing()) {
+                deckPicker.mProgressDialog.dismiss();
             }
 
             // If boolean and string are both set, we are signalling an error message
             // instead of a successful result.
             if (result.getBoolean() && result.getString() != null) {
                 Timber.w("Export Failed: %s", result.getString());
-                showSimpleMessageDialog(result.getString());
+                deckPicker.showSimpleMessageDialog(result.getString());
             } else {
                 Timber.i("Export successful");
                 String exportPath = result.getString();
                 if (exportPath != null) {
-                    showAsyncDialogFragment(DeckPickerExportCompleteDialog.newInstance(exportPath));
+                    deckPicker.showAsyncDialogFragment(DeckPickerExportCompleteDialog.newInstance(exportPath));
                 } else {
-                    UIUtils.showThemedToast(DeckPicker.this, getResources().getString(R.string.export_unsuccessful), true);
+                    UIUtils.showThemedToast(deckPicker, deckPicker.getResources().getString(R.string.export_unsuccessful), true);
                 }
             }
         }
-    };
+    }
 
 
     // ----------------------------------------------------------------------------
@@ -1999,7 +2005,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
         inputArgs[2] = did;
         inputArgs[3] = includeSched;
         inputArgs[4] = includeMedia;
-        CollectionTask.launchCollectionTask(EXPORT_APKG, mExportListener, new TaskData(inputArgs));
+        CollectionTask.launchCollectionTask(EXPORT_APKG, exportListener(), new TaskData(inputArgs));
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -278,40 +278,45 @@ public class DeckPicker extends NavigationDrawerActivity implements
         }
     };
 
-    private TaskListener mImportAddListener = new TaskListener() {
+        private final ImportAddListener mImportAddListener = new ImportAddListener(this);
+    private static class ImportAddListener extends TaskListenerWithContext<DeckPicker> {
+        public ImportAddListener(DeckPicker deckPicker) {
+            super(deckPicker);
+        }
+
         @Override
-        public void onPostExecute(TaskData result) {
-            if (mProgressDialog != null && mProgressDialog.isShowing()) {
-                mProgressDialog.dismiss();
+        public void actualOnPostExecute(@NonNull DeckPicker deckPicker, TaskData result) {
+            if (deckPicker.mProgressDialog != null && deckPicker.mProgressDialog.isShowing()) {
+                deckPicker.mProgressDialog.dismiss();
             }
             // If boolean and string are both set, we are signalling an error message
             // instead of a successful result.
             if (result.getBoolean() && result.getString() != null) {
                 Timber.w("Import: Add Failed: %s", result.getString());
-                showSimpleMessageDialog(result.getString());
+                deckPicker.showSimpleMessageDialog(result.getString());
             } else {
                 Timber.i("Import: Add succeeded");
                 AnkiPackageImporter imp = (AnkiPackageImporter) result.getObjArray()[0];
-                showSimpleMessageDialog(TextUtils.join("\n", imp.getLog()));
-                updateDeckList();
+                deckPicker.showSimpleMessageDialog(TextUtils.join("\n", imp.getLog()));
+                deckPicker.updateDeckList();
             }
         }
 
 
         @Override
-        public void onPreExecute() {
-            if (mProgressDialog == null || !mProgressDialog.isShowing()) {
-                mProgressDialog = StyledProgressDialog.show(DeckPicker.this,
-                        getResources().getString(R.string.import_title), null, false);
+        public void actualOnPreExecute(@NonNull DeckPicker deckPicker) {
+            if (deckPicker.mProgressDialog == null || !deckPicker.mProgressDialog.isShowing()) {
+                deckPicker.mProgressDialog = StyledProgressDialog.show(deckPicker,
+                        deckPicker.getResources().getString(R.string.import_title), null, false);
             }
         }
 
 
         @Override
-        public void onProgressUpdate(TaskData value) {
-            mProgressDialog.setContent(value.getString());
+        public void actualOnProgressUpdate(@NonNull DeckPicker deckPicker, TaskData value) {
+            deckPicker.mProgressDialog.setContent(value.getString());
         }
-    };
+    }
 
     private final ImportReplaceListener importReplaceListener() {
         return new ImportReplaceListener(this);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -313,38 +313,45 @@ public class DeckPicker extends NavigationDrawerActivity implements
         }
     };
 
-    private TaskListener mImportReplaceListener = new TaskListener() {
+    private final ImportReplaceListener importReplaceListener() {
+        return new ImportReplaceListener(this);
+    }
+    private static class ImportReplaceListener extends TaskListenerWithContext<DeckPicker>{
+        public ImportReplaceListener(DeckPicker deckPicker) {
+            super(deckPicker);
+        }
+
         @SuppressWarnings("unchecked")
         @Override
-        public void onPostExecute(TaskData result) {
+        public void actualOnPostExecute(@NonNull DeckPicker deckPicker, TaskData result) {
             Timber.i("Import: Replace Task Completed");
-            if (mProgressDialog != null && mProgressDialog.isShowing()) {
-                mProgressDialog.dismiss();
+            if (deckPicker.mProgressDialog != null && deckPicker.mProgressDialog.isShowing()) {
+                deckPicker.mProgressDialog.dismiss();
             }
-            Resources res = getResources();
+            Resources res = deckPicker.getResources();
             if (result != null && result.getBoolean()) {
-                updateDeckList();
+                deckPicker.updateDeckList();
             } else {
-                showSimpleMessageDialog(res.getString(R.string.import_log_no_apkg), true);
+                deckPicker.showSimpleMessageDialog(res.getString(R.string.import_log_no_apkg), true);
             }
         }
 
 
         @Override
-        public void onPreExecute() {
-            if (mProgressDialog == null || !mProgressDialog.isShowing()) {
-                mProgressDialog = StyledProgressDialog.show(DeckPicker.this,
-                        getResources().getString(R.string.import_title),
-                        getResources().getString(R.string.import_replacing), false);
+        public void actualOnPreExecute(@NonNull DeckPicker deckPicker) {
+            if (deckPicker.mProgressDialog == null || !deckPicker.mProgressDialog.isShowing()) {
+                deckPicker.mProgressDialog = StyledProgressDialog.show(deckPicker,
+                        deckPicker.getResources().getString(R.string.import_title),
+                        deckPicker.getResources().getString(R.string.import_replacing), false);
             }
         }
 
 
         @Override
-        public void onProgressUpdate(TaskData value) {
-            mProgressDialog.setContent(value.getString());
+        public void actualOnProgressUpdate(@NonNull DeckPicker deckPicker, TaskData value) {
+            deckPicker.mProgressDialog.setContent(value.getString());
         }
-    };
+    }
 
     private TaskListener mExportListener = new TaskListener() {
 
@@ -1955,7 +1962,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
     // Callback to import a file -- replacing the existing collection
     @Override
     public void importReplace(String importPath) {
-        CollectionTask.launchCollectionTask(IMPORT_REPLACE, mImportReplaceListener, new TaskData(importPath));
+        CollectionTask.launchCollectionTask(IMPORT_REPLACE, importReplaceListener(), new TaskData(importPath));
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -1429,29 +1429,36 @@ public class DeckPicker extends NavigationDrawerActivity implements
     }
 
 
+    private RepairCollectionTask repairCollectionTask() {
+        return new RepairCollectionTask(this);
+    }
+    private static class RepairCollectionTask extends TaskListenerWithContext<DeckPicker>{
+        public RepairCollectionTask(DeckPicker deckPicker) {
+            super(deckPicker);
+        }
+
+        @Override
+        public void actualOnPreExecute(@NonNull DeckPicker deckPicker) {
+            deckPicker.mProgressDialog = StyledProgressDialog.show(deckPicker, "",
+                    deckPicker.getResources().getString(R.string.backup_repair_deck_progress), false);
+        }
+
+
+        @Override
+        public void actualOnPostExecute(@NonNull DeckPicker deckPicker, TaskData result) {
+            if (deckPicker.mProgressDialog != null && deckPicker.mProgressDialog.isShowing()) {
+                deckPicker.mProgressDialog.dismiss();
+            }
+            if (result == null || !result.getBoolean()) {
+                UIUtils.showThemedToast(deckPicker, deckPicker.getResources().getString(R.string.deck_repair_error), true);
+                deckPicker.showCollectionErrorDialog();
+            }
+        }
+    }
     // Callback method to handle repairing deck
     public void repairCollection() {
         Timber.i("Repairing the Collection");
-        TaskListener listener= new TaskListener() {
-
-            @Override
-            public void onPreExecute() {
-                mProgressDialog = StyledProgressDialog.show(DeckPicker.this, "",
-                        getResources().getString(R.string.backup_repair_deck_progress), false);
-            }
-
-
-            @Override
-            public void onPostExecute(TaskData result) {
-                if (mProgressDialog != null && mProgressDialog.isShowing()) {
-                    mProgressDialog.dismiss();
-                }
-                if (result == null || !result.getBoolean()) {
-                    UIUtils.showThemedToast(DeckPicker.this, getResources().getString(R.string.deck_repair_error), true);
-                    showCollectionErrorDialog();
-                }
-            }
-        };
+        TaskListener listener= repairCollectionTask();
         CollectionTask.launchCollectionTask(REPAIR_COLLECTION, listener);
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.java
@@ -44,6 +44,7 @@ import com.ichi2.anki.dialogs.ModelBrowserContextMenu;
 import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.async.CollectionTask;
 import com.ichi2.async.TaskListener;
+import com.ichi2.async.TaskListenerWithContext;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Model;
 import com.ichi2.libanki.StdModels;
@@ -95,28 +96,34 @@ public class ModelBrowser extends AnkiActivity {
      * Displays the loading bar when loading the mModels and displaying them
      * loading bar is necessary because card count per model is not cached *
      */
-    private TaskListener mLoadingModelsHandler = new TaskListener() {
-        @Override
-        public void onCancelled() {
-            hideProgressBar();
+    private LoadingModelsHandler loadingModelsHandler() {
+        return new LoadingModelsHandler(this);
+    }
+    private static class LoadingModelsHandler extends TaskListenerWithContext<ModelBrowser> {
+        public LoadingModelsHandler(ModelBrowser browser) {
+            super(browser);
         }
 
         @Override
-        public void onPreExecute() {
-            showProgressBar();
+        public void actualOnCancelled(@NonNull ModelBrowser browser) {
+            browser.hideProgressBar();
         }
 
         @Override
-        public void onPostExecute(TaskData result) {
+        public void actualOnPreExecute(@NonNull ModelBrowser browser) {
+            browser.showProgressBar();
+        }
 
+        @Override
+        public void actualOnPostExecute(@NonNull ModelBrowser browser, TaskData result) {
             if (!result.getBoolean()) {
                 throw new RuntimeException();
             }
-            hideProgressBar();
-            mModels = (ArrayList<Model>) result.getObjArray()[0];
-            mCardCounts = (ArrayList<Integer>) result.getObjArray()[1];
+            browser.hideProgressBar();
+            browser.mModels = (ArrayList<Model>) result.getObjArray()[0];
+            browser.mCardCounts = (ArrayList<Integer>) result.getObjArray()[1];
 
-            fillModelList();
+            browser.fillModelList();
         }
     };
 
@@ -227,7 +234,7 @@ public class ModelBrowser extends AnkiActivity {
     public void onCollectionLoaded(Collection col) {
         super.onCollectionLoaded(col);
         this.col = col;
-        CollectionTask.launchCollectionTask(COUNT_MODELS, mLoadingModelsHandler);
+        CollectionTask.launchCollectionTask(COUNT_MODELS, loadingModelsHandler());
     }
 
 
@@ -506,7 +513,7 @@ public class ModelBrowser extends AnkiActivity {
      * Reloads everything
      */
     private void fullRefresh() {
-        CollectionTask.launchCollectionTask(COUNT_MODELS, mLoadingModelsHandler);
+        CollectionTask.launchCollectionTask(COUNT_MODELS, loadingModelsHandler());
     }
 
     /*
@@ -614,7 +621,7 @@ public class ModelBrowser extends AnkiActivity {
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
         if (requestCode == REQUEST_TEMPLATE_EDIT) {
-            CollectionTask.launchCollectionTask(COUNT_MODELS, mLoadingModelsHandler);
+            CollectionTask.launchCollectionTask(COUNT_MODELS, loadingModelsHandler());
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.java
@@ -131,20 +131,26 @@ public class ModelBrowser extends AnkiActivity {
      * Displays loading bar when deleting a model loading bar is needed
      * because deleting a model also deletes all of the associated cards/notes *
      */
-    private TaskListener mDeleteModelHandler = new TaskListener() {
-
-        @Override
-        public void onPreExecute() {
-            showProgressBar();
+    private DeleteModelHandler deleteModelHandler() {
+        return new DeleteModelHandler(this);
+    }
+    private static class DeleteModelHandler extends TaskListenerWithContext<ModelBrowser>{
+        public DeleteModelHandler(ModelBrowser browser) {
+            super(browser);
         }
 
         @Override
-        public void onPostExecute(TaskData result) {
+        public void actualOnPreExecute(@NonNull ModelBrowser browser) {
+            browser.showProgressBar();
+        }
+
+        @Override
+        public void actualOnPostExecute(@NonNull ModelBrowser browser, TaskData result) {
             if (!result.getBoolean()) {
                 throw new RuntimeException();
             }
-            hideProgressBar();
-            refreshList();
+            browser.hideProgressBar();
+            browser.refreshList();
         }
     };
 
@@ -520,7 +526,7 @@ public class ModelBrowser extends AnkiActivity {
      * Deletes the currently selected model
      */
     private void deleteModel() throws ConfirmModSchemaException {
-        CollectionTask.launchCollectionTask(DELETE_MODEL, mDeleteModelHandler,
+        CollectionTask.launchCollectionTask(DELETE_MODEL, deleteModelHandler(),
                 new TaskData(mCurrentID));
         mModels.remove(mModelListPosition);
         mModelIds.remove(mModelListPosition);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
@@ -45,6 +45,7 @@ import com.ichi2.anki.UIUtils;
 import com.ichi2.anki.analytics.AnalyticsDialogFragment;
 import com.ichi2.async.CollectionTask;
 import com.ichi2.async.TaskListener;
+import com.ichi2.async.TaskListenerWithContext;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Consts;
 
@@ -480,18 +481,7 @@ public class CustomStudyDialog extends AnalyticsDialogFragment {
         dyn.put("resched", resched);
         // Rebuild the filtered deck
         Timber.i("Rebuilding Custom Study Deck");
-        TaskListener listener = new TaskListener() {
-            @Override
-            public void onPreExecute() {
-                activity.showProgressBar();
-            }
-
-            @Override
-            public void onPostExecute(TaskData result) {
-                activity.hideProgressBar();
-                ((CustomStudyListener) activity).onCreateCustomStudySession();
-            }
-        };
+        TaskListener listener = createCustomStudySessionListener();
         CollectionTask.launchCollectionTask(REBUILD_CRAM, listener);
 
         // Hide the dialogs
@@ -511,5 +501,28 @@ public class CustomStudyDialog extends AnalyticsDialogFragment {
 
     protected AnkiActivity getAnkiActivity() {
         return (AnkiActivity) getActivity();
+    }
+
+
+    private CreateCustomStudySessionListener createCustomStudySessionListener(){
+        return new CreateCustomStudySessionListener(getAnkiActivity());
+    }
+    private static class CreateCustomStudySessionListener extends TaskListenerWithContext<AnkiActivity> {
+        public CreateCustomStudySessionListener(AnkiActivity activity) {
+            super(activity);
+        }
+
+
+        @Override
+        public void actualOnPreExecute(@NonNull AnkiActivity activity) {
+            activity.showProgressBar();
+        }
+
+
+        @Override
+        public void actualOnPostExecute(@NonNull AnkiActivity activity, TaskData result) {
+            activity.hideProgressBar();
+            ((CustomStudyListener) activity).onCreateCustomStudySession();
+        }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/async/TaskListenerWithContext.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/TaskListenerWithContext.java
@@ -1,0 +1,75 @@
+package com.ichi2.async;
+
+import java.lang.ref.WeakReference;
+
+import androidx.annotation.NonNull;
+
+/** Similar to task listener, but if the context disappear, no action are executed.
+ * We ensure that the context can't disappear during the execution of the methods. */
+public abstract class TaskListenerWithContext<CTX> extends TaskListener {
+    private WeakReference<CTX> mContext;
+    protected TaskListenerWithContext(CTX context) {
+        mContext = new WeakReference<>(context);
+    }
+
+
+    final public void onPreExecute() {
+        CTX context = mContext.get();
+        if (context != null) {
+            actualOnPreExecute(context);
+        }
+    };
+
+
+    final public void onProgressUpdate(TaskData value) {
+        CTX context = mContext.get();
+        if (context != null) {
+            actualOnProgressUpdate(context, value);
+        }
+    }
+
+
+    /**
+     * Invoked when the background task publishes an update.
+     * <p>
+     * The semantics of the update data depends on the task itself.
+     * Assumes context exists.
+     */
+    public void actualOnProgressUpdate(@NonNull CTX context, TaskData value) {
+        // most implementations do nothing with this, provide them a default implementation
+    }
+
+
+    /** Invoked before the task is started. Assumes context exists. */
+    public abstract void actualOnPreExecute(@NonNull CTX context);
+
+
+    final public void onPostExecute(TaskData result) {
+        CTX context = mContext.get();
+        if (context != null) {
+            actualOnPostExecute(context, result);
+        }
+    }
+
+
+    /**
+     * Invoked after the task has completed.
+     * <p>
+     * The semantics of the result depends on the task itself.
+     */
+    public abstract void actualOnPostExecute(@NonNull CTX context, TaskData result);
+
+
+    public void onCancelled() {
+        CTX context = mContext.get();
+        if (context != null) {
+            actualOnCancelled(context);
+        }
+    }
+
+
+    /** Assumes context exists. */
+    public void actualOnCancelled(@NonNull CTX context) {
+        // most implementations do nothing with this, provide them a default implementation
+    }
+}


### PR DESCRIPTION
David did mention in another PR that some background tasks were leaking activities. My first reaction was "and so ? All tasks listener leaks activities, and they have the same life duration"... 
Then I realized that actually this was probably a problem. Not a big problem as I've never heard of it creating any bug, but still, that's a useless risk.
So I transformed each anonymous listener into a static class. Since the listener still needs to have access to the UI in order to change it, I kept the access to the UI, however, I only use a weak reference. This way, if the activity can be freed, it will be freed.

That is, currently, if we start a background task and ends it, we are still updating the UI, even if the UI is not displayed anymore. With this change, the background task still occurs, but the UI is ignored 

There are case where the UI action is "add an undo button", and we are not going to add it anymore. However, this is not actually new, because currently, if the screen is changed/closed, then the "undo" button is theoretically added to the UI, but not actually seen by the user.

This means I'm convinced by this question of leaks, and I'll change https://github.com/ankidroid/Anki-Android/pull/6758 to use static inner class instead of anonymous class.
What is going to be a lot of work for me later is to merge with https://github.com/ankidroid/Anki-Android/pull/6758, because I foresee that those two PR will conflict as two of my PRs have never conflicted before. 