### PR TITLE
Javascript API: Add ankiIsActiveNetworkMetered

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -33,6 +33,7 @@ import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.graphics.Color;
+import android.net.ConnectivityManager;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
@@ -46,6 +47,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import androidx.core.content.ContextCompat;
+import androidx.core.net.ConnectivityManagerCompat;
 import androidx.core.view.GestureDetectorCompat;
 import androidx.appcompat.app.ActionBar;
 import android.text.SpannableString;
@@ -3591,6 +3593,22 @@ see card.js for available functions
         @JavascriptInterface
         public boolean ankiIsInNightMode() {
             return isInNightMode();
+        }
+
+        @JavascriptInterface
+        public boolean ankiIsActiveNetworkMetered() {
+            try {
+                ConnectivityManager cm = (ConnectivityManager) AnkiDroidApp.getInstance().getApplicationContext()
+                        .getSystemService(Context.CONNECTIVITY_SERVICE);
+                if (cm == null) {
+                    Timber.w("ConnectivityManager not found - assuming metered connection");
+                    return true;
+                }
+                return ConnectivityManagerCompat.isActiveNetworkMetered(cm);
+            } catch (Exception e) {
+                Timber.w(e, "Exception obtaining metered connection - assuming metered connection");
+                return true;
+            }
         }
     }
 }


### PR DESCRIPTION
## Purpose / Description
Allows for deck developers to stop loading heavy assets such as videos on LTE


## Fixes
Fixes #6783

## Approach
Add relevant JS API

## How Has This Been Tested?

* Tested on my mobile - returns false when I'm on WiFi
  * Using https://github.com/ankidroid/Anki-Android/wiki/Development-Guide#html-javascript-inspection
  * `AnkiDroidJS.ankiIsActiveNetworkMetered() //false;`
* 🛑 Could a reviewer please test this on LTE. I'm paying £0.20/MB, and can't realistically use 4G (probably a good use-case for this API, but it'll cost me quite a lot of money to test this).
  

## Learning (optional, can help others)
* JS API opens exciting possibilities
* https://developer.android.com/reference/android/net/ConnectivityManagerCompat#isActiveNetworkMetered() - doesn't say much
* https://stackoverflow.com/a/23879816
* https://developer.android.com/reference/androidx/core/net/ConnectivityManagerCompat#isActiveNetworkMetered(android.net.ConnectivityManager) - actually does exactly the same on API 16+.

This returns true for mobile data, can be true for WiFi as well if it's detected to be metered

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code