### PR TITLE
NF: Sched now

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
@@ -32,6 +32,8 @@ public abstract class AbstractSched {
      * Pop the next card from the queue. null if finished.
      */
     protected Collection mCol;
+
+    protected abstract double now();
     public abstract Card getCard();
     public abstract void reset();
     /** Ensures that reset is executed before the next card is selected */

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -92,6 +92,9 @@ public class Sched extends SchedV2 {
         super(col);
     }
 
+    protected double now() {
+        return Utils.now();
+    }
 
     @Override
     public void answerCard(Card card, @Consts.BUTTON_TYPE int ease) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -1383,7 +1383,7 @@ public class Sched extends SchedV2 {
         remFromDyn(cids);
         removeLrn(cids);
         mCol.getDb().execute("update cards set " + queueIsBuriedSnippet() + ",mod=?,usn=? where id in " + Utils.ids2str(cids),
-                Utils.now(), mCol.usn());
+                now(), mCol.usn());
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -604,7 +604,7 @@ public class Sched extends SchedV2 {
     private void log(long id, int usn, @Consts.BUTTON_TYPE int ease, int ivl, int lastIvl, int factor, int timeTaken, @Consts.REVLOG_TYPE int type) {
         try {
             mCol.getDb().execute("INSERT INTO revlog VALUES (?,?,?,?,?,?,?,?,?)",
-                    Utils.now() * 1000, id, usn, ease, ivl, lastIvl, factor, timeTaken, type);
+                    now() * 1000, id, usn, ease, ivl, lastIvl, factor, timeTaken, type);
         } catch (SQLiteConstraintException e) {
             try {
                 Thread.sleep(10);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -408,7 +408,7 @@ public class Sched extends SchedV2 {
     @Override
     protected Card _getLrnCard(boolean collapse) {
         if (_fillLrn()) {
-            double cutoff = Utils.now();
+            double cutoff = now();
             if (collapse) {
                 cutoff += mCol.getConf().getInt("collapseTime");
             }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -184,6 +184,9 @@ public class SchedV2 extends AbstractSched {
         _updateCutoff();
     }
 
+    protected double now() {
+        return mTime.now();
+    }
 
     /**
      * Pop the next card from the queue. null if finished.

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -2295,7 +2295,7 @@ public class SchedV2 extends AbstractSched {
         int queue = manual ? Consts.QUEUE_TYPE_MANUALLY_BURIED : Consts.QUEUE_TYPE_SIBLING_BURIED;
         mCol.log(cids);
         mCol.getDb().execute("update cards set queue=?,mod=?,usn=? where id in " + Utils.ids2str(cids),
-                queue, mTime.now(), mCol.usn());
+                queue, now(), mCol.usn());
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -939,7 +939,7 @@ public class SchedV2 extends AbstractSched {
     protected Card _getLrnCard(boolean collapse) {
         _maybeResetLrn(collapse && mLrnCount == 0);
         if (_fillLrn()) {
-            double cutoff = mTime.now();
+            double cutoff = now();
             if (collapse) {
                 cutoff += mCol.getConf().getInt("collapseTime");
             }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -1278,7 +1278,7 @@ public class SchedV2 extends AbstractSched {
     private void log(long id, int usn, @Consts.BUTTON_TYPE int ease, int ivl, int lastIvl, int factor, int timeTaken, @Consts.REVLOG_TYPE int type) {
         try {
             mCol.getDb().execute("INSERT INTO revlog VALUES (?,?,?,?,?,?,?,?,?)",
-                    mTime.now() * 1000, id, usn, ease, ivl, lastIvl, factor, timeTaken, type);
+                    now() * 1000, id, usn, ease, ivl, lastIvl, factor, timeTaken, type);
         } catch (SQLiteConstraintException e) {
             try {
                 Thread.sleep(10);


### PR DESCRIPTION
This is part of https://github.com/ankidroid/Anki-Android/pull/6780 

I factorize the method now, to uses Utils in sched v1 and mTime in Sched V2.

In one cases, v1 scheduler uses mTime instead of Utils, because the sched V2 method is not overridden. I don't expect it to be done on purpose, but since this is a NF PR I won't correct it.

The goal is to allow methods to have similar code, and eventually to factorize them