### PR TITLE
NoteEditor: On Add - Keep Keyboard Open

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -47,6 +47,7 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.WindowManager;
+import android.view.inputmethod.InputMethodManager;
 import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemSelectedListener;
 import android.widget.ArrayAdapter;
@@ -257,7 +258,13 @@ public class NoteEditor extends AnkiActivity {
                 mIntent = new Intent();
                 mIntent.putExtra(EXTRA_ID, getIntent().getStringExtra(EXTRA_ID));
             } else if (!mEditFields.isEmpty()) {
-                mEditFields.getFirst().requestFocus();
+                FieldEditText firstEditField = mEditFields.getFirst();
+                // Required on my Android 9 Phone to show keyboard: https://stackoverflow.com/a/7784904
+                firstEditField.postDelayed(() -> {
+                    firstEditField.requestFocus();
+                    InputMethodManager imm = (InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE);
+                    imm.showSoftInput(firstEditField, InputMethodManager.SHOW_IMPLICIT);
+                }, 200);
             }
             if (!mCloseAfter && (mProgressDialog != null) && mProgressDialog.isShowing()) {
                 try {


### PR DESCRIPTION
## Purpose / Description
Improves the user experience of adding more than one note

## Fixes
Fixes #4788

## Approach
Show the keyboard when save is pressed if the user is adding multiple notes

## How Has This Been Tested?
On my phone, works as expected

Tested on my bluetooth keyboard - the on-screen keyboard is immediately shown when focusing a field, so keeping it open did not seem problematic

## Learning (optional, can help others)
* https://stackoverflow.com/a/7784904 . The accepted solution did not work

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code