### PR TITLE
Fixes 6770

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -662,7 +662,14 @@ public class Sched extends SchedV2 {
         return _deckNewLimit(did, d -> _deckRevLimitSingle(d));
     }
 
-
+    /**
+     * Maximal number of rev card still to see today in deck d. It's computed as:
+     * the number of rev card to see by day according
+     * minus the number of rev cards seen today in deck d or a descendant
+     * plus the number of extra cards to see today in deck d, a parent or a descendant.
+     *
+     * Limits of its ancestors are not applied.  Current card is treated the same way as other cards.
+     * */
     @Override
     protected int _deckRevLimitSingle(Deck d) {
         if (d.getInt("dyn") != 0) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -671,9 +671,8 @@ public class Sched extends SchedV2 {
         long did = d.getLong("id");
         DeckConfig c = mCol.getDecks().confForDid(did);
         int lim = Math.max(0, c.getJSONObject("rev").getInt("perDay") - d.getJSONArray("revToday").getInt(1));
-        if (currentCardIsInQueueWithDeck(Consts.QUEUE_TYPE_REV, did)) {
-            lim--;
-        }
+        // The counts shown in the reviewer does not consider the current card. E.g. if it indicates 6 rev card, it means, 6 rev card including current card will be seen today.
+        // So currentCard does not have to be taken into consideration in this method
         return lim;
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -822,8 +822,15 @@ public class SchedV2 extends AbstractSched {
     }
 
 
-    /* Limit for deck without parent limits. */
-    public int _deckNewLimitSingle(Deck g) {
+    /**
+     * Maximal number of new card still to see today in deck g. It's computed as:
+     * the number of new card to see by day according to the deck optinos
+     * minus the number of new cards seen today in deck d or a descendant
+     * plus the number of extra new cards to see today in deck d, a parent or a descendant.
+     *
+     * Limits of its ancestors are not applied, current card is not treated differently.
+     * */
+    public int _deckNewLimitSingle(@NonNull Deck g) {
         if (g.getInt("dyn") != 0) {
             return mDynReportLimit;
         }
@@ -1308,17 +1315,40 @@ public class SchedV2 extends AbstractSched {
      * Reviews ****************************************************************** *****************************
      */
 
+    /**
+     * Maximal number of rev card still to see today in current deck. It's computed as:
+     * the number of rev card to see by day according to the deck optinos
+     * minus the number of rev cards seen today in this deck or a descendant
+     * plus the number of extra cards to see today in this deck, a parent or a descendant.
+     *
+     * Respects the limits of its ancestor. Current card is treated the same way as other cards.
+     * */
     private int _currentRevLimit() {
         Deck d = mCol.getDecks().get(mCol.getDecks().selected(), false);
         return _deckRevLimitSingle(d);
     }
 
-
+    /**
+     * Maximal number of rev card still to see today in deck d. It's computed as:
+     * the number of rev card to see by day according to the deck optinos
+     * minus the number of rev cards seen today in deck d or a descendant
+     * plus the number of extra cards to see today in deck d, a parent or a descendant.
+     *
+     * Respects the limits of its ancestor
+     * */
     protected int _deckRevLimitSingle(Deck d) {
         return _deckRevLimitSingle(d, null);
     }
 
 
+    /**
+     * Maximal number of rev card still to see today in deck d. It's computed as:
+     * the number of rev card to see by day according to the deck optinos
+     * minus the number of rev cards seen today in deck d or a descendant
+     * plus the number of extra cards to see today in deck d, a parent or a descendant.
+     *
+     * Respects the limits of its ancestor, either given as parentLimit, or through direct computation.
+     * */
     private int _deckRevLimitSingle(Deck d, Integer parentLimit) {
         // invalid deck selected?
         if (d == null) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -830,9 +830,8 @@ public class SchedV2 extends AbstractSched {
         long did = g.getLong("id");
         DeckConfig c = mCol.getDecks().confForDid(did);
         int lim = Math.max(0, c.getJSONObject("new").getInt("perDay") - g.getJSONArray("newToday").getInt(1));
-        if (currentCardIsInQueueWithDeck(Consts.QUEUE_TYPE_NEW, did)) {
-            lim--;
-        }
+        // The counts shown in the reviewer does not consider the current card. E.g. if it indicates 6 new card, it means, 6 new card including current card will be seen today.
+        // So currentCard does not have to be taken into consideration in this method
         return lim;
     }
 
@@ -1331,9 +1330,8 @@ public class SchedV2 extends AbstractSched {
         long did = d.getLong("id");
         DeckConfig c = mCol.getDecks().confForDid(did);
         int lim = Math.max(0, c.getJSONObject("rev").getInt("perDay") - d.getJSONArray("revToday").getInt(1));
-        if (currentCardIsInQueueWithDeck(Consts.QUEUE_TYPE_REV, did)) {
-            lim --;
-        }
+        // The counts shown in the reviewer does not consider the current card. E.g. if it indicates 6 rev card, it means, 6 rev card including current card will be seen today.
+        // So currentCard does not have to be taken into consideration in this method
 
         if (parentLimit != null) {
             return Math.min(parentLimit, lim);

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/AbstractSchedTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/AbstractSchedTest.java
@@ -21,7 +21,12 @@ import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.async.CollectionTask;
 import com.ichi2.async.TaskData;
 import com.ichi2.libanki.Card;
+import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Consts;
+import com.ichi2.libanki.Deck;
+import com.ichi2.libanki.DeckConfig;
+import com.ichi2.libanki.Note;
+import com.ichi2.utils.JSONArray;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -37,6 +42,7 @@ import static com.ichi2.async.CollectionTask.TASK_TYPE.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertTrue;
 
 // Note: These tests can't be run individually but can from the class-level
 // gradlew AnkiDroid:testDebug --tests "com.ichi2.libanki.sched.AbstractSchedTest.*"
@@ -84,5 +90,52 @@ public class AbstractSchedTest extends RobolectricTest {
         int[] countsAfterUndo = sched.counts();
 
         assertThat("Counts after an undo should be the same as before an undo", countsAfterUndo, is(countsBeforeUndo));
+    }
+
+    @Test
+    public void ensureUndoCorrectCounts() {
+        Collection col = getCol();
+        AbstractSched sched = col.getSched();
+        Deck deck = col.getDecks().get(1);
+        DeckConfig dconf = col.getDecks().getConf(1);
+        dconf.getJSONObject("new").put("perDay", 10);
+        JSONArray newCount = deck.getJSONArray("newToday");
+        for (int i = 0; i < 20; i++) {
+            Note note = col.newNote();
+            note.setField(0, "a");
+            col.addNote(note);
+        }
+        sched.reset();
+        assertThat(col.cardCount(), is(20));
+        assertThat(sched.counts()[0], is(10));
+        Card card = sched.getCard();
+        assertThat(sched.counts()[0], is(9));
+        assertThat(sched.counts(card)[0], is(10));
+        sched.answerCard(card, 3);
+        sched.getCard();
+        final boolean[] executed = {false};
+        CollectionTask.launchCollectionTask(UNDO,
+                new CollectionTask.TaskListener() {
+                    Card card;
+                    @Override
+                    public void onPreExecute() {
+
+                    }
+
+                    @Override
+                    public void onProgressUpdate(TaskData data) {
+                        card = data.getCard();
+                    }
+
+
+                    @Override
+                    public void onPostExecute(TaskData result) {
+                        assertThat(sched.counts()[0], is(9));
+                        assertThat(sched.counts(card)[0], is(10));
+                        executed[0] = true;
+                    }
+                });
+        waitForAsyncTasksToComplete();
+        assertTrue(executed[0]);
     }
 }


### PR DESCRIPTION
## Pull Request template

## Fixes
#6770 

## Approach

I added a comment explaining what exactly `count()` is doing. I.e. Returning the number of cards to see today in each category, not counting the card sent to the reviewer.  This means that, by considering `mCurrentCard` I was over correcting because the counter already considered current card. I thus removed this over correction and added explanations about what exactly counts are and what they means in a normal use of the scheduler.

## How Has This Been Tested?

Trying to reproduce #6770 and also trying to to undo reviews/burying when the number of cards is limited by the set of cards and not by the deck's limit.

## Learning (optional, can help others)

`counts` and various counts make really no sens; but I was supposed to know it already.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
