### PR TITLE
Split big screen when starting

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -455,11 +455,6 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
         mReviewSummaryTextView = (TextView) findViewById(R.id.today_stats_text_view);
 
-        // Hide the fragment until the counts have been loaded so that the Toolbar fills the whole screen on tablets
-        if (mFragmented) {
-            mStudyoptionsFrame.setVisibility(View.GONE);
-        }
-
         Timber.i("colOpen: %b", colOpen);
         if (colOpen) {
             // Show any necessary dialogs (e.g. changelog, special messages, etc)


### PR DESCRIPTION
This solves https://github.com/ankidroid/Anki-Android/issues/6670
I've just tested on my table, there is nothing ugly occurring when the screen loading. AnkiDroid image still takes the
whole screen. Then instead of having one white page with a loading symbol, there are two of thems. Which means that the
toolbar buttons does not move anymore. So when I press on sync, I know that the button won't be replaced by another
button such as "empty filtered deck" in the next second.

![2020-08-03-131712_1280x800_scrot](https://user-images.githubusercontent.com/357361/89177408-b6119f00-d58b-11ea-8130-24d08f60b79c.png)
