### PR TITLE
Indicator for unsynced local changes

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -924,7 +924,8 @@ public class DeckPicker extends NavigationDrawerActivity implements
         super.onStop();
         if (colIsOpen()) {
             WidgetStatus.update(this);
-            UIUtils.saveCollectionInBackground();
+            // Ignore the modification - a change in deck shouldn't trigger the icon for "pending changes".
+            UIUtils.saveCollectionInBackground(true);
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -49,6 +49,7 @@ import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 import androidx.annotation.VisibleForTesting;
 import androidx.core.app.ActivityCompat;
+import androidx.core.content.ContextCompat;
 import androidx.core.content.FileProvider;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentTransaction;
@@ -112,8 +113,10 @@ import com.ichi2.libanki.utils.SystemTime;
 import com.ichi2.libanki.utils.Time;
 import com.ichi2.libanki.utils.TimeUtils;
 import com.ichi2.themes.StyledProgressDialog;
+import com.ichi2.ui.BadgeDrawableBuilder;
 import com.ichi2.utils.ImportUtils;
 import com.ichi2.utils.Permissions;
+import com.ichi2.utils.SyncStatus;
 import com.ichi2.utils.VersionUtils;
 import com.ichi2.widget.WidgetStatus;
 
@@ -616,7 +619,53 @@ public class DeckPicker extends NavigationDrawerActivity implements
         menu.findItem(R.id.action_check_database).setEnabled(sdCardAvailable);
         menu.findItem(R.id.action_check_media).setEnabled(sdCardAvailable);
         menu.findItem(R.id.action_empty_cards).setEnabled(sdCardAvailable);
+
+        // I haven't had an exception here, but it feels this may be flaky
+        try {
+            displaySyncBadge(menu);
+        } catch (Exception e) {
+            Timber.w(e, "Error Displaying Sync Badge");
+        }
+
+
         return super.onCreateOptionsMenu(menu);
+    }
+
+
+    private void displaySyncBadge(Menu menu) {
+        MenuItem syncMenu = menu.findItem(R.id.action_sync);
+        SyncStatus syncStatus = SyncStatus.getSyncStatus(this::getCol);
+        switch (syncStatus) {
+            case NO_CHANGES:
+            case INCONCLUSIVE:
+                BadgeDrawableBuilder.removeBadge(syncMenu);
+                syncMenu.setTitle(R.string.sync_menu_title);
+                break;
+            case HAS_CHANGES:
+                // Light orange icon
+                new BadgeDrawableBuilder(getResources())
+                        .withColor(ContextCompat.getColor(this, R.color.badge_warning))
+                        .replaceBadge(syncMenu);
+                syncMenu.setTitle(R.string.sync_menu_title);
+                break;
+            case NO_ACCOUNT:
+            case FULL_SYNC:
+                if (syncStatus == SyncStatus.NO_ACCOUNT) {
+                    syncMenu.setTitle(R.string.sync_menu_title_no_account);
+                } else if (syncStatus == SyncStatus.FULL_SYNC) {
+                    syncMenu.setTitle(R.string.sync_menu_title_full_sync);
+                }
+                // Orange-red icon with exclamation mark
+                new BadgeDrawableBuilder(getResources())
+                        .withText('!')
+                        .withColor(ContextCompat.getColor(this, R.color.badge_error))
+                        .replaceBadge(syncMenu);
+                break;
+            default:
+                Timber.w("Unhandled sync status: %s", syncStatus);
+                syncMenu.setTitle(R.string.sync_title);
+                break;
+        }
     }
 
 
@@ -840,6 +889,8 @@ public class DeckPicker extends NavigationDrawerActivity implements
         /** Complete task and enqueue fetching nonessential data for
          * startup. */
         CollectionTask.launchCollectionTask(LOAD_COLLECTION_COMPLETE);
+        // Update sync status (if we've come back from a screen)
+        supportInvalidateOptionsMenu();
     }
 
 
@@ -1788,6 +1839,10 @@ public class DeckPicker extends NavigationDrawerActivity implements
                     Timber.i("Regular sync completed successfully");
                     showSyncLogMessage(R.string.sync_database_acknowledge, syncMessage);
                 }
+                // Mark sync as completed - then refresh the sync icon
+                SyncStatus.markSyncCompleted();
+                supportInvalidateOptionsMenu();
+
                 updateDeckList();
                 WidgetStatus.update(DeckPicker.this);
                 if (mFragmented) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/UIUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/UIUtils.java
@@ -117,6 +117,10 @@ public class UIUtils {
 
 
     public static void saveCollectionInBackground() {
+        saveCollectionInBackground(false);
+    }
+
+    public static void saveCollectionInBackground(boolean syncIgnoresDatabaseModification) {
         if (CollectionHelper.getInstance().colIsOpen()) {
             CollectionTask.TaskListener listener = new CollectionTask.TaskListener() {
                 @Override
@@ -130,7 +134,7 @@ public class UIUtils {
                     Timber.d("saveCollectionInBackground: finished");
                 }
             };
-            CollectionTask.launchCollectionTask(SAVE_COLLECTION, listener);
+            CollectionTask.launchCollectionTask(SAVE_COLLECTION, listener, new TaskData(syncIgnoresDatabaseModification));
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -53,6 +53,7 @@ import com.ichi2.libanki.importer.AnkiPackageImporter;
 import com.ichi2.utils.JSONArray;
 import com.ichi2.utils.JSONException;
 import com.ichi2.utils.JSONObject;
+import com.ichi2.utils.SyncStatus;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -347,7 +348,7 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
                 return doInBackgroundLoadDeckCounts();
 
             case SAVE_COLLECTION:
-                doInBackgroundSaveCollection();
+                doInBackgroundSaveCollection(param);
                 break;
 
             case ANSWER_CARD:
@@ -651,12 +652,17 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
     }
 
 
-    private void doInBackgroundSaveCollection() {
+    private void doInBackgroundSaveCollection(TaskData param) {
         Timber.d("doInBackgroundSaveCollection");
         Collection col = getCol();
         if (col != null) {
             try {
-                col.save();
+                // param: syncIgnoresDatabaseModification
+                if (param.getBoolean()) {
+                    SyncStatus.ignoreDatabaseModification(() -> col.save());
+                } else {
+                    col.save();
+                }
             } catch (RuntimeException e) {
                 Timber.e(e, "Error on saving deck in background");
             }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DB.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DB.java
@@ -29,6 +29,7 @@ import android.widget.Toast;
 import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.CollectionHelper;
 import com.ichi2.anki.dialogs.DatabaseErrorDialog;
+import com.ichi2.utils.DatabaseChangeDecorator;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
@@ -68,7 +69,7 @@ public class DB {
                 .callback(getDBCallback())
                 .build();
         SupportSQLiteOpenHelper helper = getSqliteOpenHelperFactory().create(configuration);
-        mDatabase = helper.getWritableDatabase();
+        mDatabase = new DatabaseChangeDecorator(helper.getWritableDatabase());
         mDatabase.disableWriteAheadLogging();
         mDatabase.query("PRAGMA synchronous = 2", null);
         mMod = false;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -32,6 +32,7 @@ import com.ichi2.libanki.exception.NoSuchDeckException;
 import com.ichi2.utils.DeckComparator;
 import com.ichi2.utils.JSONArray;
 import com.ichi2.utils.JSONObject;
+import com.ichi2.utils.SyncStatus;
 
 import java.text.Normalizer;
 import java.util.ArrayList;
@@ -857,7 +858,7 @@ public class Decks {
     private void _recoverOrphans() {
         Long[] dids = allIds();
         boolean mod = mCol.getDb().getMod();
-        mCol.getDb().execute("update cards set did = 1 where did not in " + Utils.ids2str(dids));
+        SyncStatus.ignoreDatabaseModification(() -> mCol.getDb().execute("update cards set did = 1 where did not in " + Utils.ids2str(dids)));
         mCol.getDb().setMod(mod);
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/ui/BadgeDrawable.java
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/BadgeDrawable.java
@@ -1,0 +1,92 @@
+/*
+ Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.ui;
+
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Paint;
+import android.graphics.Typeface;
+import android.graphics.drawable.Drawable;
+import android.graphics.drawable.DrawableWrapper;
+import android.os.Build;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
+
+@RequiresApi(api = Build.VERSION_CODES.M)
+public class BadgeDrawable extends DrawableWrapper {
+
+    private final Paint mPaint;
+
+    private Drawable mBadge;
+    private String mText;
+    private float mTextX;
+    private float mTextY;
+
+
+    /**
+     * Creates a new wrapper around the specified drawable.
+     *
+     * @param dr the drawable to wrap
+     */
+    public BadgeDrawable(@Nullable Drawable dr) {
+        super(dr);
+        mPaint = new Paint();
+        mPaint.setTypeface(Typeface.DEFAULT_BOLD);
+        mPaint.setTextAlign(Paint.Align.CENTER);
+        mPaint.setColor(Color.WHITE);
+    }
+
+    public void setBadgeDrawable(@NonNull Drawable view) {
+        mBadge = view;
+
+        // This goes out of bounds - it seems to be fine
+        int mSize = (int) (getIntrinsicWidth() * 0.70);
+
+        mPaint.setTextSize((float) (mSize * 0.8));
+
+        int left = (int) (getIntrinsicWidth() * 0.55);
+        int bottom = (int) (getIntrinsicHeight() * 0.45);
+
+        int right = left + mSize;
+        int top = bottom - mSize;
+        mBadge.setBounds(left, top, right, bottom);
+
+        float vcenter = (top + bottom) / 2.0f;
+
+        mTextX = (left + right) / 2.0f;
+        mTextY = vcenter - (mPaint.descent() + mPaint.ascent()) / 2;
+
+    }
+
+    public void setText(char c) {
+        this.mText = new String(new char[] {c});
+    }
+
+    @Override
+    public void draw(@NonNull Canvas canvas) {
+        super.draw(canvas);
+        if (mBadge != null) {
+            mBadge.draw(canvas);
+
+            if (mText != null) {
+                canvas.drawText(mText, mTextX, mTextY, mPaint);
+            }
+        }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/ui/BadgeDrawableBuilder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/BadgeDrawableBuilder.java
@@ -1,0 +1,100 @@
+/*
+ Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.ui;
+
+import android.content.res.Resources;
+import android.graphics.drawable.Drawable;
+import android.os.Build;
+import android.view.MenuItem;
+
+import com.ichi2.anki.R;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.graphics.drawable.DrawableCompat;
+import androidx.vectordrawable.graphics.drawable.VectorDrawableCompat;
+import timber.log.Timber;
+
+public class BadgeDrawableBuilder {
+    private final Resources mResources;
+    private char mChar;
+    private Integer mColor;
+
+
+    public BadgeDrawableBuilder(@NonNull Resources resources) {
+        mResources = resources;
+    }
+
+
+    public static void removeBadge(MenuItem menuItem) {
+        if (android.os.Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            return;
+        }
+
+        Drawable icon = menuItem.getIcon();
+        if (icon instanceof BadgeDrawable) {
+            BadgeDrawable bd = (BadgeDrawable) icon;
+            menuItem.setIcon(bd.getCurrent());
+            Timber.d("Badge removed");
+        }
+    }
+
+
+    @NonNull
+    public BadgeDrawableBuilder withText(char c) {
+        this.mChar = c;
+        return this;
+    }
+
+
+    @NonNull
+    public BadgeDrawableBuilder withColor(@Nullable Integer color) {
+        this.mColor = color;
+        return this;
+    }
+
+
+    public void replaceBadge(@NonNull MenuItem menuItem) {
+        if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.M) {
+            return;
+        }
+
+        Timber.d("Adding badge");
+
+        Drawable originalIcon = menuItem.getIcon();
+        if (originalIcon instanceof BadgeDrawable) {
+            BadgeDrawable bd = (BadgeDrawable) originalIcon;
+            originalIcon = bd.getCurrent();
+        }
+
+        BadgeDrawable badge = new BadgeDrawable(originalIcon);
+        if (mChar != '\0') {
+            badge.setText(mChar);
+        }
+        if (mColor != null) {
+            Drawable badgeDrawable = VectorDrawableCompat.create(mResources, R.drawable.badge_drawable, null);
+            if (badgeDrawable == null) {
+                Timber.w("Unable to find badge_drawable - not drawing badge");
+                return;
+            }
+            Drawable mutableDrawable = badgeDrawable.mutate();
+            DrawableCompat.setTint(mutableDrawable, mColor);
+            badge.setBadgeDrawable(mutableDrawable);
+            menuItem.setIcon(badge);
+        }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/utils/DatabaseChangeDecorator.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/DatabaseChangeDecorator.java
@@ -1,0 +1,280 @@
+/*
+ Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.utils;
+
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.database.SQLException;
+import android.database.sqlite.SQLiteTransactionListener;
+import android.os.CancellationSignal;
+import android.util.Pair;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Locale;
+
+import androidx.sqlite.db.SupportSQLiteDatabase;
+import androidx.sqlite.db.SupportSQLiteQuery;
+import androidx.sqlite.db.SupportSQLiteStatement;
+
+/** Detects any database modifications and notifies the sync status of the application */
+public class DatabaseChangeDecorator implements SupportSQLiteDatabase {
+
+    private static final String[] MOD_SQLS = new String[] { "insert", "update", "delete" };
+
+    private final SupportSQLiteDatabase wrapped;
+
+
+    public DatabaseChangeDecorator(SupportSQLiteDatabase wrapped) {
+        this.wrapped = wrapped;
+    }
+
+    private void markDataAsChanged() {
+        SyncStatus.markDataAsChanged();
+    }
+
+    private boolean needsComplexCheck() {
+        // if we're marked in memory, we can assume no changes - this class only sets the mark.
+        return !SyncStatus.hasBeenMarkedAsChangedInMemory();
+    }
+
+    private void checkForChanges(String sql) {
+        if (!needsComplexCheck()) {
+            return;
+        }
+        String lower = sql.toLowerCase();
+        String upper = sql.toUpperCase();
+        for (String modString : MOD_SQLS) {
+            if (startsWithIgnoreCase(lower, upper, modString)) {
+                markDataAsChanged();
+                break;
+            }
+        }
+    }
+
+
+    private boolean startsWithIgnoreCase(String lowerHaystack, String upperHaystack, String needle) {
+        // Needs to do both according to https://stackoverflow.com/a/38947571
+        return lowerHaystack.startsWith(needle) || upperHaystack.startsWith(needle.toUpperCase());
+    }
+
+
+    public SupportSQLiteStatement compileStatement(String sql) {
+        SupportSQLiteStatement supportSQLiteStatement = wrapped.compileStatement(sql);
+        checkForChanges(sql); //technically a little hasty - as the statement hasn't been executed.
+        return supportSQLiteStatement;
+    }
+
+
+    public void beginTransaction() {
+        wrapped.beginTransaction();
+    }
+
+
+    public void beginTransactionNonExclusive() {
+        wrapped.beginTransactionNonExclusive();
+    }
+
+
+    public void beginTransactionWithListener(SQLiteTransactionListener transactionListener) {
+        wrapped.beginTransactionWithListener(transactionListener);
+    }
+
+
+    public void beginTransactionWithListenerNonExclusive(SQLiteTransactionListener transactionListener) {
+        wrapped.beginTransactionWithListenerNonExclusive(transactionListener);
+    }
+
+
+    public void endTransaction() {
+        wrapped.endTransaction();
+    }
+
+
+    public void setTransactionSuccessful() {
+        wrapped.setTransactionSuccessful();
+    }
+
+
+    public boolean inTransaction() {
+        return wrapped.inTransaction();
+    }
+
+
+    public boolean isDbLockedByCurrentThread() {
+        return wrapped.isDbLockedByCurrentThread();
+    }
+
+
+    public boolean yieldIfContendedSafely() {
+        return wrapped.yieldIfContendedSafely();
+    }
+
+
+    public boolean yieldIfContendedSafely(long sleepAfterYieldDelay) {
+        return wrapped.yieldIfContendedSafely(sleepAfterYieldDelay);
+    }
+
+
+    public int getVersion() {
+        return wrapped.getVersion();
+    }
+
+
+    public void setVersion(int version) {
+        wrapped.setVersion(version);
+    }
+
+
+    public long getMaximumSize() {
+        return wrapped.getMaximumSize();
+    }
+
+
+    public long setMaximumSize(long numBytes) {
+        return wrapped.setMaximumSize(numBytes);
+    }
+
+
+    public long getPageSize() {
+        return wrapped.getPageSize();
+    }
+
+
+    public void setPageSize(long numBytes) {
+        wrapped.setPageSize(numBytes);
+    }
+
+
+    public Cursor query(String query) {
+        return wrapped.query(query);
+    }
+
+
+    public Cursor query(String query, Object[] bindArgs) {
+        return wrapped.query(query, bindArgs);
+    }
+
+
+    public Cursor query(SupportSQLiteQuery query) {
+        return wrapped.query(query);
+    }
+
+
+    public Cursor query(SupportSQLiteQuery query, CancellationSignal cancellationSignal) {
+        return wrapped.query(query, cancellationSignal);
+    }
+
+
+    public long insert(String table, int conflictAlgorithm, ContentValues values) throws SQLException {
+        long insert = wrapped.insert(table, conflictAlgorithm, values);
+        markDataAsChanged();
+        return insert;
+    }
+
+
+    public int delete(String table, String whereClause, Object[] whereArgs) {
+        int delete = wrapped.delete(table, whereClause, whereArgs);
+        markDataAsChanged();
+        return delete;
+    }
+
+
+    public int update(String table, int conflictAlgorithm, ContentValues values, String whereClause, Object[] whereArgs) {
+        int update = wrapped.update(table, conflictAlgorithm, values, whereClause, whereArgs);
+        markDataAsChanged();
+        return update;
+    }
+
+
+    public void execSQL(String sql) throws SQLException {
+        wrapped.execSQL(sql);
+        checkForChanges(sql);
+    }
+
+
+    public void execSQL(String sql, Object[] bindArgs) throws SQLException {
+        wrapped.execSQL(sql, bindArgs);
+        checkForChanges(sql);
+    }
+
+
+    public boolean isReadOnly() {
+        return wrapped.isReadOnly();
+    }
+
+
+    public boolean isOpen() {
+        return wrapped.isOpen();
+    }
+
+
+    public boolean needUpgrade(int newVersion) {
+        return wrapped.needUpgrade(newVersion);
+    }
+
+
+    public String getPath() {
+        return wrapped.getPath();
+    }
+
+
+    public void setLocale(Locale locale) {
+        wrapped.setLocale(locale);
+    }
+
+
+    public void setMaxSqlCacheSize(int cacheSize) {
+        wrapped.setMaxSqlCacheSize(cacheSize);
+    }
+
+
+    public void setForeignKeyConstraintsEnabled(boolean enable) {
+        wrapped.setForeignKeyConstraintsEnabled(enable);
+    }
+
+
+    public boolean enableWriteAheadLogging() {
+        return wrapped.enableWriteAheadLogging();
+    }
+
+
+    public void disableWriteAheadLogging() {
+        wrapped.disableWriteAheadLogging();
+    }
+
+
+    public boolean isWriteAheadLoggingEnabled() {
+        return wrapped.isWriteAheadLoggingEnabled();
+    }
+
+
+    public List<Pair<String, String>> getAttachedDbs() {
+        return wrapped.getAttachedDbs();
+    }
+
+
+    public boolean isDatabaseIntegrityOk() {
+        return wrapped.isDatabaseIntegrityOk();
+    }
+
+
+    public void close() throws IOException {
+        wrapped.close();
+    }
+}
+

--- a/AnkiDroid/src/main/java/com/ichi2/utils/SyncStatus.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/SyncStatus.java
@@ -1,0 +1,90 @@
+/*
+ Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.utils;
+
+import android.content.SharedPreferences;
+
+import com.ichi2.anki.AnkiDroidApp;
+import com.ichi2.libanki.Collection;
+import com.ichi2.utils.FunctionalInterfaces.Supplier;
+
+import androidx.annotation.NonNull;
+
+public enum SyncStatus {
+    INCONCLUSIVE,
+    NO_ACCOUNT,
+    NO_CHANGES,
+    HAS_CHANGES,
+    FULL_SYNC;
+
+
+    @NonNull
+    public static SyncStatus getSyncStatus(@NonNull Supplier<Collection> getCol) {
+        Collection col;
+        try {
+            col = getCol.get();
+        } catch (Exception e) {
+            return SyncStatus.INCONCLUSIVE;
+        }
+
+        return getSyncStatus(col);
+    }
+
+
+    @NonNull
+    public static SyncStatus getSyncStatus(@NonNull Collection col) {
+        if (!isLoggedIn()) {
+            return SyncStatus.NO_ACCOUNT;
+        }
+
+        if (col.schemaChanged()) {
+            return SyncStatus.FULL_SYNC;
+        }
+
+        if (dataChanged()) {
+            return SyncStatus.HAS_CHANGES;
+        } else {
+            return SyncStatus.NO_CHANGES;
+        }
+    }
+
+
+    private static boolean isLoggedIn() {
+        SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance());
+        String hkey = preferences.getString("hkey", "");
+        return hkey != null && hkey.length() != 0;
+    }
+
+
+
+    /** Whether data has been changed - to be converted to Rust */
+    public static boolean dataChanged() {
+        return AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance()).getBoolean("changesSinceLastSync", false);
+    }
+
+
+    /** To be converted to Rust */
+    public static void markDataAsChanged() {
+        AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance()).edit().putBoolean("changesSinceLastSync", true).apply();
+    }
+
+
+    /** To be converted to Rust */
+    public static void markSyncCompleted() {
+        AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance()).edit().putBoolean("changesSinceLastSync", false).apply();
+    }
+}

--- a/AnkiDroid/src/main/res/drawable/badge_drawable.xml
+++ b/AnkiDroid/src/main/res/drawable/badge_drawable.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <stroke android:color="@android:color/transparent"
+        android:width="1dp"/>
+    <solid android:color="#F45000"/>
+    <size
+        android:width="11dp"
+        android:height="11dp"/>
+</shape>

--- a/AnkiDroid/src/main/res/menu/deck_picker.xml
+++ b/AnkiDroid/src/main/res/menu/deck_picker.xml
@@ -4,7 +4,7 @@
     <item
         android:id="@+id/action_sync"
         android:icon="@drawable/ic_sync_white_24dp"
-        android:title="@string/sync_title"
+        android:title="@string/sync_menu_title"
         ankidroid:showAsAction="always"/>
     <item
         android:id="@+id/action_undo"

--- a/AnkiDroid/src/main/res/values/04-network.xml
+++ b/AnkiDroid/src/main/res/values/04-network.xml
@@ -112,4 +112,8 @@
     <string name="sync_error_501_upgrade_required">Please upgrade to the latest version of AnkiDroid</string>
     <string name="sync_error_502_maintenance">AnkiWeb is under maintenance. Please try again in a few minutes.</string>
     <string name="sync_error_504_gateway_timeout">504 gateway timeout error received.</string>
+    <!-- Deck Picker Sync Icon -->
+    <string name="sync_menu_title">Sync</string>
+    <string name="sync_menu_title_full_sync">Sync (full)</string>
+    <string name="sync_menu_title_no_account">Sync (log in)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values/colors.xml
+++ b/AnkiDroid/src/main/res/values/colors.xml
@@ -103,4 +103,7 @@
     <color name="flag_orange">#FF9800</color>
     <color name="flag_green">#00ff00</color>
     <color name="flag_blue">#0000ff</color>
+
+    <color name="badge_error">#f45000</color>
+    <color name="badge_warning">#ffa500</color>
 </resources>


### PR DESCRIPTION
## Purpose / Description
Users currently do not know if they have pending changes. We add a badge to fix this.

API 23+ due to DrawableWrapper

## Fixes
Fixes #3524

## Approach
* Add a badge to the sync icon
  * If the user does not have an account (clicking sync takes them to logon).
  * If the changes require a full sync
  * If the changes require a regular sync

* On each database query, check if the query starts with "

This badge is not set when changing decks - as it would be more annoying than helpful (even though changing decks is internally a change when syncing).

## How Has This Been Tested?
On my phone - Statistics and Browse do not trigger the icon, reviewing and adding notes do.

![image](https://user-images.githubusercontent.com/62114487/89234241-72e31a80-d5e3-11ea-81b7-b3187d8765ae.png)
![image](https://user-images.githubusercontent.com/62114487/89234245-75de0b00-d5e3-11ea-958c-409e6d2c672c.png)


## Learning
* Not listing false starts  - see the issue
* Android Drawables need a `.setBounds()` call if they're not
* `setBounds()` can be negative and still work
* UI is hard
* https://developer.android.com/reference/android/graphics/drawable/DrawableWrapper is API23+
* https://stackoverflow.com/questions/13057782/dynamic-drawable-icon-for-actionbar-menu-item-android-actionbarsherlock/13058113#13058113

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code