### PR TITLE
CardViewer - Key Input - Highlight Pressed Answer

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1554,8 +1554,9 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
             displayCardAnswer();
             return;
         }
-        answerCard(cardOrdinal);
+        performClickWithVisualFeedback(cardOrdinal);
     }
+
 
     private boolean webViewRendererLastCrashedOnCard(long cardId) {
         return lastCrashingCardId != null && lastCrashingCardId == cardId;
@@ -2619,8 +2620,33 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         if (!sDisplayAnswer) {
             return false;
         }
-        answerCard(ease);
+        performClickWithVisualFeedback(ease);
         return true;
+    }
+
+
+    protected void performClickWithVisualFeedback(int ease) {
+        // Delay could potentially be lower - testing with 20 left a visible "click"
+        switch (ease) {
+            case EASE_1:
+                performClickWithVisualFeedback(mEase1Layout);
+                break;
+            case EASE_2:
+                performClickWithVisualFeedback(mEase2Layout);
+                break;
+            case EASE_3:
+                performClickWithVisualFeedback(mEase3Layout);
+                break;
+            case EASE_4:
+                performClickWithVisualFeedback(mEase4Layout);
+                break;
+        }
+    }
+
+
+    private void performClickWithVisualFeedback(LinearLayout easeLayout) {
+        easeLayout.requestFocus();
+        easeLayout.postDelayed(easeLayout::performClick, 20);
     }
 
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerKeyboardInputTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerKeyboardInputTest.java
@@ -486,5 +486,10 @@ public class ReviewerKeyboardInputTest {
         public boolean hasBeenAnswered() {
             return mAnswered != null;
         }
+
+        @Override
+        protected void performClickWithVisualFeedback(int ease) {
+            answerCard(ease);
+        }
     }
 }


### PR DESCRIPTION
## Purpose / Description

Previously we were unfocusing the currently focused answer, we still do this but with a barely visible pause to indicate the correct answer.

## Fixes
Fixes #5683

## Approach
Add a 20ms delay - enough for visual feedback, but not enough to slow reviews

## How Has This Been Tested?

On my phone with a bluetooth keyboard

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code