### PR TITLE
Note Editor: Don't convert newlines on "Add" 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -231,6 +231,8 @@ public class NoteEditor extends AnkiActivity {
                 mChanged = true;
                 mSourceText = null;
                 Note oldNote = mEditorNote.clone();
+                // The saved values may have changes (newline -> <br>) use UI values instead.
+                String[] currentStrings = getCurrentFieldStrings();
                 setNote();
                 // Respect "Remember last input when adding" field option.
                 JSONArray flds;
@@ -238,7 +240,7 @@ public class NoteEditor extends AnkiActivity {
                 if (oldNote != null) {
                     for (int fldIdx = 0; fldIdx < flds.length(); fldIdx++) {
                         if (flds.getJSONObject(fldIdx).getBoolean("sticky")) {
-                            mEditFields.get(fldIdx).setText(oldNote.getFields()[fldIdx]);
+                            mEditFields.get(fldIdx).setText(currentStrings[fldIdx]);
                         }
                     }
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1233,7 +1233,8 @@ public class NoteEditor extends AnkiActivity {
     }
 
 
-    private String[] getCurrentFieldStrings() {
+    @VisibleForTesting
+    String[] getCurrentFieldStrings() {
         if (mEditFields == null) {
             return new String[0];
         }
@@ -1445,27 +1446,7 @@ public class NoteEditor extends AnkiActivity {
         }
 
         // Listen for changes in the first field so we can re-check duplicate status.
-        editText.addTextChangedListener(new TextWatcher() {
-            @Override
-            public void afterTextChanged(Editable arg0) {
-                mFieldEdited = true;
-                if (index == 0) {
-                    setDuplicateFieldStyles();
-                }
-            }
-
-
-            @Override
-            public void beforeTextChanged(CharSequence arg0, int arg1, int arg2, int arg3) {
-                // do nothing
-            }
-
-
-            @Override
-            public void onTextChanged(CharSequence arg0, int arg1, int arg2, int arg3) {
-                // do nothing
-            }
-        });
+        editText.addTextChangedListener(new EditFieldTextWatcher(index));
         editText.setEnabled(enabled);
     }
 
@@ -1937,7 +1918,9 @@ public class NoteEditor extends AnkiActivity {
 
     @VisibleForTesting
     void setFieldValueFromUi(int i, String newText) {
-        mEditFields.get(i).setText(newText);
+        FieldEditText editText = mEditFields.get(i);
+        editText.setText(newText);
+        new EditFieldTextWatcher(i).afterTextChanged(editText.getText());
     }
 
 
@@ -1945,5 +1928,36 @@ public class NoteEditor extends AnkiActivity {
     @VisibleForTesting
     long getDeckId() {
         return mCurrentDid;
+    }
+
+
+    private class EditFieldTextWatcher implements TextWatcher {
+        private final int mIndex;
+
+
+        public EditFieldTextWatcher(int index) {
+
+            this.mIndex = index;
+        }
+
+        @Override
+        public void afterTextChanged(Editable arg0) {
+            mFieldEdited = true;
+            if (mIndex == 0) {
+                setDuplicateFieldStyles();
+            }
+        }
+
+
+        @Override
+        public void beforeTextChanged(CharSequence arg0, int arg1, int arg2, int arg3) {
+            // do nothing
+        }
+
+
+        @Override
+        public void onTextChanged(CharSequence arg0, int arg1, int arg2, int arg3) {
+            // do nothing
+        }
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.java
@@ -235,7 +235,6 @@ public class NoteEditorTest extends RobolectricTest {
 
 
     @Test
-    @Ignore("6795")
     public void stickyFieldsAreUnchangedAfterAdd() {
         // #6795 - newlines were converted to <br>
         Model basic = makeNoteForType(NoteType.BASIC);


### PR DESCRIPTION
## Purpose / Description
Sticky fields converted newline -> `<br>` after clicking Add. We don't want this while adding cards

## Fixes
Fixes #6795 

## Approach
Use the UI values rather than the note values

## How Has This Been Tested?

On my phone, and via unit test

## Learning
Still harder to test automatically then manually

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code