### PR TITLE
Preserve launcher animation by not animating IntentHandler finish

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.java
@@ -144,7 +144,7 @@ public class IntentHandler extends Activity {
         reloadIntent.addCategory(Intent.CATEGORY_LAUNCHER);
         reloadIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
         startActivityIfNeeded(reloadIntent, 0);
-        AnkiActivity.finishActivityWithFade(this);
+        finish();
     }
 
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

Fixes #5143 by letting IntentHandler just finish, if it specifies an animation
it actually clobbers whatever system launcher animation is specified.

Piexel Launcher seems to override the override but Nova Launcher respects it,
meaning you don't get the Nova Launcher animation you configure

## How Has This Been Tested?

I used an API29 Google Play version emulator so I could install Nova, then I alternated launching the app with Google Pixel launcher (always does the zoom-type launch) and Nova (started as described in the linked issue, but now will do whatever animation you configure Nova to launch)

## Learning (optional, can help others)

AnkiDroid has a surprising amount of Activity transition animation infrastructure, and we should probably use it more, in a consistent way, to signal to the user where they are (like, always slide in from right when going more detailed, always slide out to right when going less detailed)

But! You do still want to call Activity.finish() so user can't go back: https://stackoverflow.com/a/43363868/9910298

Sometimes it takes

1.  an hour of learning, and
1.  10 minutes of tests, in order to realize you just need to
1.  delete one line of code.
1. Then 5 minutes of review to realize
1. You actually just want a plain Activity.finish() not a fancy one

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
