### PR TITLE
Convert Schedulers to use time dependency: mTime

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
@@ -187,6 +187,13 @@ public abstract class AbstractSched {
     public abstract int[] recalculateCounts();
     public abstract void setReportLimit(int reportLimit);
 
+    /**
+     * Reverts answering a card.
+     * 
+     * @param card The data of the card before the review was made
+     * @param wasLeech Whether the card was a leech before the review was made (if false, remove the leech tag)
+     * */
+    public abstract void undoReview(@NonNull Card card, boolean wasLeech);
 
     /**
      * Holds the data for a single node (row) in the deck due tree (the user-visible list

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -151,7 +151,7 @@ public class SchedV2 extends AbstractSched {
      */
 
     // Not in libAnki.
-    private final Time mTime;
+    protected final Time mTime;
 
     /**
      * card types: 0=new, 1=lrn, 2=rev, 3=relrn
@@ -2881,7 +2881,7 @@ public class SchedV2 extends AbstractSched {
         mCol.getDb().execute("DELETE FROM revlog WHERE id = " + last);
         // restore any siblings
         mCol.getDb().execute("update cards set queue=type,mod=?,usn=? where queue=" + Consts.QUEUE_TYPE_SIBLING_BURIED + " and nid=?",
-                new Object[] {Utils.intTime(), mCol.usn(), oldCardData.getNid()});
+                new Object[] {mTime.intTime(), mCol.usn(), oldCardData.getNid()});
         // and finally, update daily count
         @Consts.CARD_QUEUE int n = oldCardData.getQueue() == Consts.QUEUE_TYPE_DAY_LEARN_RELEARN ? Consts.QUEUE_TYPE_LRN : oldCardData.getQueue();
         String type = (new String[]{"new", "lrn", "rev"})[n];

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -2866,6 +2866,30 @@ public class SchedV2 extends AbstractSched {
         this.mReportLimit = reportLimit;
     }
 
+    @Override
+    public void undoReview(@NonNull Card oldCardData, boolean wasLeech) {
+        // remove leech tag if it didn't have it before
+        if (!wasLeech && oldCardData.note().hasTag("leech")) {
+            oldCardData.note().delTag("leech");
+            oldCardData.note().flush();
+        }
+        Timber.i("Undo Review of card %d, leech: %b", oldCardData.getId(), wasLeech);
+        // write old data
+        oldCardData.flush(false);
+        // and delete revlog entry
+        long last = mCol.getDb().queryLongScalar("SELECT id FROM revlog WHERE cid = ? ORDER BY id DESC LIMIT 1", new Object[] {oldCardData.getId()});
+        mCol.getDb().execute("DELETE FROM revlog WHERE id = " + last);
+        // restore any siblings
+        mCol.getDb().execute("update cards set queue=type,mod=?,usn=? where queue=" + Consts.QUEUE_TYPE_SIBLING_BURIED + " and nid=?",
+                new Object[] {Utils.intTime(), mCol.usn(), oldCardData.getNid()});
+        // and finally, update daily count
+        @Consts.CARD_QUEUE int n = oldCardData.getQueue() == Consts.QUEUE_TYPE_DAY_LEARN_RELEARN ? Consts.QUEUE_TYPE_LRN : oldCardData.getQueue();
+        String type = (new String[]{"new", "lrn", "rev"})[n];
+        _updateStats(oldCardData, type, -1);
+        setReps(getReps() - 1);
+    }
+
+
     /** End #5666 */
     public void discardCurrentCard() {
         mCurrentCard = null;


### PR DESCRIPTION
## Purpose / Description
Allows for repeatable tests without the risk of crossing the new day threshold

No impact intended for users

Intended for #6794

## Approach
* Extract `undoReview`
* Indirect all IO (current time) to `mTime`, which can be mocked

## How Has This Been Tested?

None - CI should perform the automated tests

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code