### PR TITLE
Add option for "Anki Card" in system context menu

### DIFF
--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -266,6 +266,18 @@
             android:exported="false"
             android:configChanges="locale"
             />
+
+        <activity-alias
+            android:name="com.ichi2.anki.AnkiCardContextMenuAction"
+            android:label="@string/context_menu_anki_card_label"
+            android:enabled="false"
+            android:targetActivity=".NoteEditor">
+            <intent-filter>
+                <action android:name="android.intent.action.PROCESS_TEXT" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/plain" />
+            </intent-filter>
+        </activity-alias>
         <activity
             android:name="com.ichi2.anki.NoteEditor"
             android:label="@string/fact_adder_intent_title"

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -39,6 +39,7 @@ import android.view.ViewConfiguration;
 import android.webkit.CookieManager;
 
 import com.ichi2.anki.analytics.AnkiDroidCrashReportDialog;
+import com.ichi2.anki.contextmenu.AnkiCardContextMenu;
 import com.ichi2.anki.contextmenu.CardBrowserContextMenu;
 import com.ichi2.anki.exception.ManuallyReportedException;
 import com.ichi2.anki.exception.StorageAccessException;
@@ -265,6 +266,7 @@ public class AnkiDroidApp extends MultiDexApplication {
         }
 
         CardBrowserContextMenu.ensureConsistentStateWithSharedPreferences(this);
+        AnkiCardContextMenu.ensureConsistentStateWithSharedPreferences(this);
         NotificationChannels.setup(getApplicationContext());
 
         // Configure WebView to allow file scheme pages to access cookies.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -106,6 +106,9 @@ import java.util.Map.Entry;
 
 import timber.log.Timber;
 import static com.ichi2.async.CollectionTask.TASK_TYPE.*;
+import static com.ichi2.compat.Compat.ACTION_PROCESS_TEXT;
+import static com.ichi2.compat.Compat.EXTRA_PROCESS_TEXT;
+
 import com.ichi2.async.TaskData;
 
 /**
@@ -364,7 +367,7 @@ public class NoteEditor extends AnkiActivity {
             mCaller = intent.getIntExtra(EXTRA_CALLER, CALLER_NOCALLER);
             if (mCaller == CALLER_NOCALLER) {
                 String action = intent.getAction();
-                if ((ACTION_CREATE_FLASHCARD.equals(action) || ACTION_CREATE_FLASHCARD_SEND.equals(action))) {
+                if ((ACTION_CREATE_FLASHCARD.equals(action) || ACTION_CREATE_FLASHCARD_SEND.equals(action) || ACTION_PROCESS_TEXT.equals(action))) {
                     mCaller = CALLER_CARDEDITOR_INTENT_ADD;
                 }
             }
@@ -687,10 +690,16 @@ public class NoteEditor extends AnkiActivity {
         if (extras == null) {
             return;
         }
-        if (ACTION_CREATE_FLASHCARD.equals(intent.getAction())) {
+        mSourceText = new String[2];
+
+        if (ACTION_PROCESS_TEXT.equals(intent.getAction())) {
+            String stringExtra = intent.getStringExtra(EXTRA_PROCESS_TEXT);
+            Timber.d("Obtained %s from intent: %s", stringExtra, EXTRA_PROCESS_TEXT);
+            mSourceText[0] = stringExtra != null ? stringExtra : "";
+            mSourceText[1] = "";
+        } else if (ACTION_CREATE_FLASHCARD.equals(intent.getAction())) {
             // mSourceLanguage = extras.getString(SOURCE_LANGUAGE);
             // mTargetLanguage = extras.getString(TARGET_LANGUAGE);
-            mSourceText = new String[2];
             mSourceText[0] = extras.getString(SOURCE_TEXT);
             mSourceText[1] = extras.getString(TARGET_TEXT);
         } else {
@@ -714,7 +723,6 @@ public class NoteEditor extends AnkiActivity {
             }
             Pair<String, String> messages = new Pair<>(first, second);
 
-            mSourceText = new String[2];
             mSourceText[0] = messages.first;
             mSourceText[1] = messages.second;
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -51,6 +51,7 @@ import android.widget.Toast;
 
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.ichi2.anim.ActivityTransitionAnimation;
+import com.ichi2.anki.contextmenu.AnkiCardContextMenu;
 import com.ichi2.anki.contextmenu.CardBrowserContextMenu;
 import com.ichi2.anki.debug.DatabaseLock;
 import com.ichi2.anki.exception.ConfirmModSchemaException;
@@ -61,7 +62,6 @@ import com.ichi2.anki.web.CustomSyncServer;
 import com.ichi2.compat.CompatHelper;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Utils;
-import com.ichi2.libanki.hooks.ChessFilter;
 import com.ichi2.preferences.NumberRangePreference;
 import com.ichi2.themes.Themes;
 import com.ichi2.ui.AppCompatPreferenceActivity;
@@ -91,6 +91,7 @@ import java.util.Set;
 import java.util.TreeMap;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.StringRes;
 import androidx.annotation.VisibleForTesting;
 import timber.log.Timber;
 
@@ -321,12 +322,8 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                     startActivity(i);
                     return true;
                 });
-                // FIXME: The menu is named in the system language (as it's defined in the manifest which may be
-                //  different than the app language
-                CheckBoxPreference cardBrowserContextMenuPreference = (CheckBoxPreference) screen.findPreference(CardBrowserContextMenu.CARD_BROWSER_CONTEXT_MENU_PREF_KEY);
-                String menuName = getString(R.string.card_browser_context_menu);
-                cardBrowserContextMenuPreference.setTitle(getString(R.string.card_browser_enable_external_context_menu, menuName));
-                cardBrowserContextMenuPreference.setSummary(getString(R.string.card_browser_enable_external_context_menu_summary, menuName));
+                setupContextMenuPreference(screen, CardBrowserContextMenu.CARD_BROWSER_CONTEXT_MENU_PREF_KEY, R.string.card_browser_context_menu);
+                setupContextMenuPreference(screen, AnkiCardContextMenu.ANKI_CARD_CONTEXT_MENU_PREF_KEY, R.string.context_menu_anki_card_label);
 
                 // Make it possible to test crash reporting, but only for DEBUG builds
                 if (BuildConfig.DEBUG && !ActivityManager.isUserAMonkey()) {
@@ -422,6 +419,18 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                 break;
         }
     }
+
+
+    private void setupContextMenuPreference(PreferenceScreen screen, String key, @StringRes int contextMenuName) {
+        // FIXME: The menu is named in the system language (as it's defined in the manifest which may be
+        //  different than the app language
+        CheckBoxPreference cardBrowserContextMenuPreference = (CheckBoxPreference) screen.findPreference(key);
+        String menuName = getString(contextMenuName);
+        // Note: The below format strings are generic, not card browser specific despite the name
+        cardBrowserContextMenuPreference.setTitle(getString(R.string.card_browser_enable_external_context_menu, menuName));
+        cardBrowserContextMenuPreference.setSummary(getString(R.string.card_browser_enable_external_context_menu_summary, menuName));
+    }
+
 
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
@@ -739,6 +748,10 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                 }
                 case CardBrowserContextMenu.CARD_BROWSER_CONTEXT_MENU_PREF_KEY:
                     CardBrowserContextMenu.ensureConsistentStateWithSharedPreferences(this);
+                    break;
+                case AnkiCardContextMenu.ANKI_CARD_CONTEXT_MENU_PREF_KEY:
+                    AnkiCardContextMenu.ensureConsistentStateWithSharedPreferences(this);
+                    break;
             }
             // Update the summary text to reflect new value
             updateSummary(pref);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/contextmenu/AnkiCardContextMenu.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/contextmenu/AnkiCardContextMenu.java
@@ -1,0 +1,54 @@
+/*
+ Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.contextmenu;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+
+public class AnkiCardContextMenu extends SystemContextMenu {
+
+
+    public static final String ANKI_CARD_CONTEXT_MENU_PREF_KEY = "anki_card_enable_external_context_menu";
+
+
+    @SuppressWarnings("WeakerAccess")
+    public AnkiCardContextMenu(@NonNull Context context) {
+        super(context);
+    }
+
+    public static void ensureConsistentStateWithSharedPreferences(@NonNull Context context) {
+        new AnkiCardContextMenu(context).ensureConsistentStateWithSharedPreferences();
+    }
+
+    @NonNull
+    @Override
+    protected String getActivityName() {
+        return "com.ichi2.anki.AnkiCardContextMenuAction";
+    }
+
+    @Override
+    protected boolean getDefaultEnabledStatus() {
+        return false;
+    }
+
+    @NonNull
+    @Override
+    protected String getPreferenceKey() {
+        return ANKI_CARD_CONTEXT_MENU_PREF_KEY;
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/contextmenu/CardBrowserContextMenu.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/contextmenu/CardBrowserContextMenu.java
@@ -16,82 +16,38 @@
 
 package com.ichi2.anki.contextmenu;
 
-import android.content.ComponentName;
 import android.content.Context;
-import android.content.pm.PackageManager;
 
-import com.ichi2.anki.AnkiDroidApp;
-
-import androidx.annotation.CheckResult;
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import timber.log.Timber;
 
-import static android.content.pm.PackageManager.*;
+public class CardBrowserContextMenu extends SystemContextMenu {
 
-public class CardBrowserContextMenu {
-
-    @NonNull
-    private final Context mContext;
-    private static final boolean DEFAULT_ENABLED_STATUS = true;
     public static final String CARD_BROWSER_CONTEXT_MENU_PREF_KEY = "card_browser_enable_external_context_menu";
-    /** We define an activity alias so we can disable the context menu without disabling the activity */
-    private static final String ACTIVITY_ALIAS_NAME = "com.ichi2.anki.CardBrowserContextMenuAction";
+
 
     @SuppressWarnings("WeakerAccess")
     public CardBrowserContextMenu(@NonNull Context context) {
-        this.mContext = context;
+        super(context);
     }
 
     public static void ensureConsistentStateWithSharedPreferences(@NonNull Context context) {
         new CardBrowserContextMenu(context).ensureConsistentStateWithSharedPreferences();
     }
 
-    @CheckResult
-    @Nullable
-    private Boolean getSystemMenuStatus() {
-        try {
-            return getPackageManager().getComponentEnabledSetting(getComponentName()) == COMPONENT_ENABLED_STATE_ENABLED;
-        } catch (Exception e) {
-            Timber.w(e, "Failed to read context menu status setting");
-            return null;
-        }
+    @NonNull
+    @Override
+    protected String getActivityName() {
+        return "com.ichi2.anki.CardBrowserContextMenuAction";
     }
 
-    @SuppressWarnings("WeakerAccess")
-    public void setSystemMenuEnabled(boolean enabled) {
-        try {
-            int enabledState = enabled ? COMPONENT_ENABLED_STATE_ENABLED : COMPONENT_ENABLED_STATE_DISABLED;
-            getPackageManager().setComponentEnabledSetting(getComponentName(), enabledState, DONT_KILL_APP);
-        } catch (Exception e) {
-            Timber.w(e, "Failed to set Context Menu state");
-        }
+    @Override
+    protected boolean getDefaultEnabledStatus() {
+        return true;
     }
 
-
-    private PackageManager getPackageManager() {
-        return mContext.getPackageManager();
-    }
-
-
-    //this can throw if context.getPackageName() throws
-    @CheckResult
-    private ComponentName getComponentName() {
-        return new ComponentName(mContext, ACTIVITY_ALIAS_NAME);
-    }
-
-
-    private boolean getPreferenceStatus() {
-        return AnkiDroidApp.getSharedPrefs(mContext).getBoolean(CARD_BROWSER_CONTEXT_MENU_PREF_KEY, DEFAULT_ENABLED_STATUS);
-    }
-
-    @SuppressWarnings("WeakerAccess")
-    public void ensureConsistentStateWithSharedPreferences() {
-        boolean preferenceStatus = getPreferenceStatus();
-        Boolean actualStatus = getSystemMenuStatus();
-        if (actualStatus == null || actualStatus != preferenceStatus) {
-            Timber.d("Modifying Context Menu Status: Preference was %b", preferenceStatus);
-            setSystemMenuEnabled(preferenceStatus);
-        }
+    @NonNull
+    @Override
+    protected String getPreferenceKey() {
+        return CARD_BROWSER_CONTEXT_MENU_PREF_KEY;
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/contextmenu/SystemContextMenu.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/contextmenu/SystemContextMenu.java
@@ -1,0 +1,95 @@
+/*
+ Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.contextmenu;
+
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.pm.PackageManager;
+
+import com.ichi2.anki.AnkiDroidApp;
+
+import androidx.annotation.CheckResult;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import timber.log.Timber;
+
+import static android.content.pm.PackageManager.COMPONENT_ENABLED_STATE_DISABLED;
+import static android.content.pm.PackageManager.COMPONENT_ENABLED_STATE_ENABLED;
+import static android.content.pm.PackageManager.DONT_KILL_APP;
+
+public abstract class SystemContextMenu {
+
+    protected abstract boolean getDefaultEnabledStatus();
+    @NonNull
+    protected abstract String getPreferenceKey();
+    /** We use an activity alias as the name so we can disable the context menu without disabling the activity */
+    @NonNull
+    protected abstract String getActivityName();
+
+    @NonNull
+    private final Context mContext;
+
+    public SystemContextMenu(@NonNull Context context) {
+        mContext = context;
+    }
+
+    @SuppressWarnings("WeakerAccess")
+    public void setSystemMenuEnabled(boolean enabled) {
+        try {
+            int enabledState = enabled ? COMPONENT_ENABLED_STATE_ENABLED : COMPONENT_ENABLED_STATE_DISABLED;
+            getPackageManager().setComponentEnabledSetting(getComponentName(), enabledState, DONT_KILL_APP);
+        } catch (Exception e) {
+            Timber.w(e, "Failed to set Context Menu state");
+        }
+    }
+
+    @SuppressWarnings("WeakerAccess")
+    public void ensureConsistentStateWithSharedPreferences() {
+        boolean preferenceStatus = getPreferenceStatus();
+        Boolean actualStatus = getSystemMenuStatus();
+        if (actualStatus == null || actualStatus != preferenceStatus) {
+            Timber.d("Modifying Context Menu Status: Preference was %b", preferenceStatus);
+            setSystemMenuEnabled(preferenceStatus);
+        }
+    }
+
+    protected boolean getPreferenceStatus() {
+        return AnkiDroidApp.getSharedPrefs(mContext).getBoolean(getPreferenceKey(), getDefaultEnabledStatus());
+    }
+
+
+    @CheckResult
+    @Nullable
+    private Boolean getSystemMenuStatus() {
+        try {
+            return getPackageManager().getComponentEnabledSetting(getComponentName()) == COMPONENT_ENABLED_STATE_ENABLED;
+        } catch (Exception e) {
+            Timber.w(e, "Failed to read context menu status setting");
+            return null;
+        }
+    }
+
+    private PackageManager getPackageManager() {
+        return mContext.getPackageManager();
+    }
+
+    //this can throw if context.getPackageName() throws
+    @CheckResult
+    private ComponentName getComponentName() {
+        return new ComponentName(mContext, getActivityName());
+    }
+}

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -189,6 +189,10 @@
     <!-- Permissions -->
     <string name="read_write_permission_label">Read and write to the AnkiDroid database</string>
     <string name="read_write_permission_description">access existing notes, cards, note types, and decks, as well as create new ones</string>
+
+    <!-- Context Menu -->
     <string name="card_browser_label">Card Browser</string>
     <string name="card_browser_context_menu">Card Browser</string>
+
+    <string name="context_menu_anki_card_label">Anki Card</string>
 </resources>

--- a/AnkiDroid/src/main/res/xml/preferences_advanced.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_advanced.xml
@@ -132,6 +132,10 @@
                 android:id="@+id/card_browser_external_context_menu"
                 android:defaultValue="true"
                 android:key="card_browser_enable_external_context_menu"/>
+            <CheckBoxPreference
+                android:id="@+id/anki_card_external_context_menu"
+                android:defaultValue="false"
+                android:key="anki_card_enable_external_context_menu"/>
         </PreferenceCategory>
 
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.java
@@ -44,6 +44,7 @@ import androidx.appcompat.view.menu.ActionMenuItemView;
 import androidx.test.core.app.ActivityScenario;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
+import static com.ichi2.compat.Compat.EXTRA_PROCESS_TEXT;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
@@ -261,6 +262,14 @@ public class NoteEditorTest extends RobolectricTest {
 
         List<String> actual = Arrays.asList(editor.getCurrentFieldStrings());
         assertThat("newlines should be preserved, second field should be blanked", actual, contains(newFirstField, ""));
+    }
+
+    @Test
+    public void processTextIntentShouldCopyFirstField() {
+        Intent i = new Intent(Intent.ACTION_PROCESS_TEXT);
+        i.putExtra(EXTRA_PROCESS_TEXT, "hello\nworld");
+        NoteEditor editor = startActivityNormallyOpenCollectionWithIntent(NoteEditor.class, i);
+        assertThat(Arrays.asList(editor.getCurrentFieldStrings()), contains("hello\nworld", ""));
     }
 
     private Intent getCopyNoteIntent(NoteEditor editor) {


### PR DESCRIPTION
## Purpose / Description
User request - feature I've been wanting an excuse to add for a while.

To be honest, I think this would be more useful than the "Card Browser", and would consider swapping them, so this is enabled, and card browser is disabled by default. Neither may also be a better option - I assume the 'Card Browser' may be a reason for some installs.

We might also want to consider changing the ordering so Anki Card comes first? Probably just done via ordering of items in the manifest.


## Fixes
Fixes #6817 

## Approach
Add a context menu - disabled by default

## How Has This Been Tested?

Unit tested, and tested via the icon from Google Keep.
Returns to Google Keep after save is pressed

![image](https://user-images.githubusercontent.com/62114487/89390406-918a0400-d6fe-11ea-90dc-521396f27fae.png)

## Learning
* So much code for such a relatively simple thing


## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code