### PR TITLE
Sync Status: Remove badge when no changes

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -1718,6 +1718,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
                         // then show not logged in dialog
                         showSyncErrorDialog(SyncErrorDialog.DIALOG_USER_NOT_LOGGED_IN_SYNC);
                     } else if ("noChanges".equals(resultType)) {
+                        SyncStatus.markSyncCompleted();
                         // show no changes message, use false flag so we don't show "sync error" as the Dialog title
                         showSyncLogMessage(R.string.sync_no_changes_message, "");
                     } else if ("clockOff".equals(resultType)) {


### PR DESCRIPTION
It seems there's currently a state inconsistency which sets the badge even if there's no changes. This lets us revert to a good state

So: if no changes - remove the badge

Related: #3524


## How Has This Been Tested?

⚠️ Couldn't reproduce the conditions to test this.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code