### PR TITLE
Fix ConcurrentModificationException: task cancel

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -135,7 +135,7 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
     /**
      * Tasks which are running or waiting to run.
      * */
-    private static List<CollectionTask> sTasks = Collections.synchronizedList(new LinkedList<>());
+    private static final List<CollectionTask> sTasks = Collections.synchronizedList(new LinkedList<>());
 
 
     /**
@@ -247,7 +247,7 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
                 return cancel(true);
             }
         } catch (Exception e) {
-            // Potentially catching SecurityEcexption, from
+            // Potentially catching SecurityException, from
             // Thread.interrupt from FutureTask.cancel from
             // AsyncTask.cancel
             Timber.w(e, "Exception cancelling task");
@@ -275,14 +275,13 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
     /** Cancel all tasks of type taskType*/
     public static void cancelAllTasks(TASK_TYPE taskType) {
         int count = 0;
-        synchronized (sTasks) {
-            for (CollectionTask task: sTasks) {
-                if (task.mType != taskType) {
-                    continue;
-                }
-                if (task.safeCancel()) {
-                    count ++;
-                }
+        // safeCancel modifies sTasks, so iterate over a concrete copy
+        for (CollectionTask task: new ArrayList<>(sTasks)) {
+            if (task.mType != taskType) {
+                continue;
+            }
+            if (task.safeCancel()) {
+                count++;
             }
         }
         if (count > 0) {


### PR DESCRIPTION
## Purpose / Description
`ConcurrentModificationException` occurred when cancelling all tasks. Heaviest crash of the 2.13.x alpha series

## Fixes
Fixes #6653

## Approach
`sTasks` was modified in the iteration, which shouldn't occur.

We didn't need a synchronized block as it's a concurrent structure.

## How Has This Been Tested?

⚠️  Only conceptually - doesn't crash on my device, but I can't guarantee I triggered the issue

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code