### PR TITLE
Card Template Preview: Preview Edited Note

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.java
@@ -43,6 +43,7 @@ public class CardTemplatePreviewer extends AbstractFlashcardViewer {
     private String mEditedModelFileName = null;
     private Model mEditedModel = null;
     private int mOrdinal;
+    @Nullable
     private long[] mCardList;
     private Bundle mNoteEditorBundle = null;
 
@@ -166,7 +167,7 @@ public class CardTemplatePreviewer extends AbstractFlashcardViewer {
             closeCardTemplatePreviewer();
             return;
         }
-        if (mCurrentCard == null) {
+        if (mCardList != null && mOrdinal >= 0 && mOrdinal < mCardList.length) {
             mCurrentCard = new PreviewerCard(col, mCardList[mOrdinal]);
         }
 


### PR DESCRIPTION
## Purpose / Description
The Card Template Previewer showed Front/Back rather than the currently edited note.

## Fixes
Fixes ???

## Approach
This shows the edited note instead of "Front/Back"

BUT: This does not pass through the current values of the field and instead
returns the database values

Slight improvement, but we're not there yet

## How Has This Been Tested?

Tested:
* No Note - Front/Back
* Edit Note - Note
* Add Note - Front/Back

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code