### PR TITLE
NF: add a class CardCache

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -492,6 +492,10 @@ public class Collection {
         return new Card(this, id);
     }
 
+    public Card.Cache getCardCache(long id) {
+        return new Card.Cache(this, id);
+    }
+
 
     public Note getNote(long id) {
         return new Note(this, id);


### PR DESCRIPTION
I realized the Card Cache from https://github.com/ankidroid/Anki-Android/pull/6372 can be useful for other purpose too. So I extracted its core in a distinct PR and put the Cache in Card.java. Currently this is NF because this class is not used. I would still like that you confirm that it's a nice way to save card without loading them until needed, but still loading only once. I expect that it will save loading time from database. 
There is a cost however, because if the card is loaded in advance and the card content changed, the new question/answer may or may not be already computed. So it should not be used in every circonstances