### PR TITLE
Pre compute the next card's question

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -547,6 +547,8 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
                 cardChanged = true;  // Keep track of that so we can run a bit of new-card code
             }
             mCurrentCard = value.getCard();
+            CollectionTask.launchCollectionTask(PRELOAD_NEXT_CARD); // Tasks should always be launched from GUI. So in
+                                                                    // listener and not in background
             if (mCurrentCard == null) {
                 // If the card is null means that there are no more cards scheduled for review.
                 mNoMoreCards = true;

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -123,6 +123,7 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
         FIND_EMPTY_CARDS,
         CHECK_CARD_SELECTION,
         LOAD_COLLECTION_COMPLETE,
+        PRELOAD_NEXT_CARD
     }
 
     /**
@@ -446,6 +447,10 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
 
             case LOAD_COLLECTION_COMPLETE:
                 doInBackgroundLoadCollectionComplete();
+                break;
+
+            case PRELOAD_NEXT_CARD:
+                doInBackgroundPreloadNextCard();
                 break;
 
             default:
@@ -1873,6 +1878,14 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
         }
 
         return new TaskData(new Object[] { hasUnsuspended, hasUnmarked});
+    }
+
+    public void doInBackgroundPreloadNextCard() {
+        try {
+            getCol().getSched().preloadNextCard();
+        } catch (RuntimeException e) {
+            Timber.e(e, "doInBackgroundPreloadNextCard - RuntimeException on preloading card");
+        }
     }
 
     public void doInBackgroundLoadCollectionComplete() {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
@@ -40,6 +40,9 @@ public abstract class AbstractSched {
      */
     public abstract void reset();
 
+    /** Ensure that the question on the potential next card can be accessed quickly.
+     */
+    public abstract void preloadNextCard();
     public abstract void resetCounts();
     public abstract void resetQueues();
     /** Ensures that reset is executed before the next card is selected */

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -299,6 +299,35 @@ public class Sched extends SchedV2 {
     }
 
 
+    protected List<? extends Card.Cache>[] _fillNextCard() {
+        // learning card due?
+        if (_fillLrn()) {
+            return new List[]{mLrnQueue};
+        }
+        // new first, or time for one?
+        if (_timeForNewCard()) {
+            if (_fillNew()) {
+                return new List[]{mLrnQueue, mNewQueue};
+            }
+        }
+        // Card due for review?
+        if (_fillRev()) {
+            return new List[]{mLrnQueue, mRevQueue};
+        }
+        // day learning card due?
+        if (_fillLrnDay()) {
+            return new List[]{mLrnQueue, mLrnDayQueue};
+        }
+        // New cards left?
+        if (_fillNew()) {
+            return new List[]{mLrnQueue, mNewQueue};
+        }
+        // collapse or finish
+        if (_preloadLrnCard(true)) {
+            return new List[]{mLrnQueue};
+        }
+        return new List[]{};
+    }
     /**
      * New cards **************************************************************** *******************************
      */

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -413,10 +413,8 @@ public class Sched extends SchedV2 {
                 cutoff += mCol.getConf().getInt("collapseTime");
             }
             if (mLrnQueue.getFirst().getDue() < cutoff) {
-                long id = mLrnQueue.remove().getId();
-                Card card = mCol.getCard(id);
+                return mLrnQueue.remove().getCard();
                 // mLrnCount -= card.getLeft() / 1000; See decrementCount()
-                return card;
             }
         }
         return null;
@@ -751,7 +749,7 @@ public class Sched extends SchedV2 {
                                             + " AND " + idName + " != ? LIMIT ?",
                                     new Object[]{did, mToday, id, lim});
                     while (cur.moveToNext()) {
-                        mRevQueue.add(cur.getLong(0));
+                        mRevQueue.add(mCol.getCardCache(cur.getLong(0)));
                     }
                 } finally {
                     if (cur != null && !cur.isClosed()) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -299,34 +299,34 @@ public class Sched extends SchedV2 {
     }
 
 
-    protected List<? extends Card.Cache>[] _fillNextCard() {
+    protected CardQueue<? extends Card.Cache>[] _fillNextCard() {
         // learning card due?
         if (_fillLrn()) {
-            return new List[]{mLrnQueue};
+            return new CardQueue[]{mLrnQueue};
         }
         // new first, or time for one?
         if (_timeForNewCard()) {
             if (_fillNew()) {
-                return new List[]{mLrnQueue, mNewQueue};
+                return new CardQueue[]{mLrnQueue, mNewQueue};
             }
         }
         // Card due for review?
         if (_fillRev()) {
-            return new List[]{mLrnQueue, mRevQueue};
+            return new CardQueue[]{mLrnQueue, mRevQueue};
         }
         // day learning card due?
         if (_fillLrnDay()) {
-            return new List[]{mLrnQueue, mLrnDayQueue};
+            return new CardQueue[]{mLrnQueue, mLrnDayQueue};
         }
         // New cards left?
         if (_fillNew()) {
-            return new List[]{mLrnQueue, mNewQueue};
+            return new CardQueue[]{mLrnQueue, mNewQueue};
         }
         // collapse or finish
         if (_preloadLrnCard(true)) {
-            return new List[]{mLrnQueue};
+            return new CardQueue[]{mLrnQueue};
         }
-        return new List[]{};
+        return new CardQueue[]{};
     }
     /**
      * New cards **************************************************************** *******************************
@@ -415,7 +415,7 @@ public class Sched extends SchedV2 {
                            "SELECT due, id FROM cards WHERE did IN " + _deckLimit() + " AND queue = " + Consts.QUEUE_TYPE_LRN + " AND due < ? AND id != ? LIMIT ?",
                            new Object[]{mDayCutoff, currentCardId(), mReportLimit});
             while (cur.moveToNext()) {
-                mLrnQueue.add(new LrnCard(cur.getLong(0), cur.getLong(1) ));
+                mLrnQueue.add(cur.getLong(0), cur.getLong(1));
             }
             // as it arrives sorted by did first, we need to sort it
             Collections.sort(mLrnQueue);
@@ -442,7 +442,7 @@ public class Sched extends SchedV2 {
                 cutoff += mCol.getConf().getInt("collapseTime");
             }
             if (mLrnQueue.getFirst().getDue() < cutoff) {
-                return mLrnQueue.remove().getCard();
+                return mLrnQueue.removeFirstCard();
                 // mLrnCount -= card.getLeft() / 1000; See decrementCount()
             }
         }
@@ -778,7 +778,7 @@ public class Sched extends SchedV2 {
                                             + " AND " + idName + " != ? LIMIT ?",
                                     new Object[]{did, mToday, id, lim});
                     while (cur.moveToNext()) {
-                        mRevQueue.add(mCol.getCardCache(cur.getLong(0)));
+                        mRevQueue.add(cur.getLong(0));
                     }
                 } finally {
                     if (cur != null && !cur.isClosed()) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -105,19 +105,16 @@ public class SchedV2 extends AbstractSched {
     private double[] mEtaCache = new double[] { -1, -1, -1, -1, -1, -1 };
 
     // Queues
-    protected final LinkedList<Long> mNewQueue = new LinkedList<>();
-    protected class LrnCard implements Comparable<LrnCard> {
-        private final long mCid;
+    protected final LinkedList<Card.Cache> mNewQueue = new LinkedList<>();
+    protected class LrnCard extends Card.Cache implements Comparable<LrnCard> {
         private final long mDue;
         public LrnCard(long due, long cid) {
-            mCid = cid;
+            super(mCol, cid);
             mDue = due;
         }
+
         public long getDue () {
             return mDue;
-        }
-        public long getId() {
-            return mCid;
         }
 
         @Override
@@ -126,8 +123,8 @@ public class SchedV2 extends AbstractSched {
         }
     }
     protected final LinkedList<LrnCard> mLrnQueue = new LinkedList<>();
-    protected final LinkedList<Long> mLrnDayQueue = new LinkedList<>();
-    protected final LinkedList<Long> mRevQueue = new LinkedList<>();
+    protected final LinkedList<Card.Cache> mLrnDayQueue = new LinkedList<>();
+    protected final LinkedList<Card.Cache> mRevQueue = new LinkedList<>();
 
     private LinkedList<Long> mNewDids = new LinkedList<>();
     protected LinkedList<Long> mLrnDids = new LinkedList<>();
@@ -776,7 +773,7 @@ public class SchedV2 extends AbstractSched {
                     long id = (allowSibling) ? currentCardId(): currentCardNid();
                     cur = mCol.getDb().query("SELECT id FROM cards WHERE did = ? AND queue = " + Consts.QUEUE_TYPE_NEW + " AND " + idName + "!= ? ORDER BY due, ord LIMIT ?", did, id, lim);
                     while (cur.moveToNext()) {
-                        mNewQueue.add(cur.getLong(0));
+                        mNewQueue.add(mCol.getCardCache(cur.getLong(0)));
                     }
                 } finally {
                     if (cur != null && !cur.isClosed()) {
@@ -804,7 +801,7 @@ public class SchedV2 extends AbstractSched {
     protected Card _getNewCard() {
         if (_fillNew()) {
             // mNewCount -= 1; see decrementCounts()
-            return mCol.getCard(mNewQueue.remove());
+            return mNewQueue.remove().getCard();
         }
         return null;
     }
@@ -1014,10 +1011,8 @@ public class SchedV2 extends AbstractSched {
                 cutoff += mCol.getConf().getInt("collapseTime");
             }
             if (mLrnQueue.getFirst().getDue() < cutoff) {
-                long id = mLrnQueue.remove().getId();
-                Card card = mCol.getCard(id);
+                return mLrnQueue.remove().getCard();
                 // mLrnCount -= 1; see decrementCounts()
-                return card;
             }
         }
         return null;
@@ -1052,7 +1047,7 @@ public class SchedV2 extends AbstractSched {
                                 "SELECT id FROM cards WHERE did = ? AND queue = " + Consts.QUEUE_TYPE_DAY_LEARN_RELEARN + " AND due <= ? and id != ? LIMIT ?",
                                 did, mToday, currentCardId(), mQueueLimit);
                 while (cur.moveToNext()) {
-                    mLrnDayQueue.add(cur.getLong(0));
+                    mLrnDayQueue.add(mCol.getCardCache(cur.getLong(0)));
                 }
             } finally {
                 if (cur != null && !cur.isClosed()) {
@@ -1080,7 +1075,7 @@ public class SchedV2 extends AbstractSched {
     protected Card _getLrnDayCard() {
         if (_fillLrnDay()) {
             // mLrnCount -= 1; see decrementCounts()
-            return mCol.getCard(mLrnDayQueue.remove());
+            return mLrnDayQueue.remove().getCard();
         }
         return null;
     }
@@ -1520,7 +1515,7 @@ public class SchedV2 extends AbstractSched {
                                + " ORDER BY due, random()  LIMIT ?",
                                mToday, id, lim);
                 while (cur.moveToNext()) {
-                    mRevQueue.add(cur.getLong(0));
+                    mRevQueue.add(mCol.getCardCache(cur.getLong(0)));
                 }
             } finally {
                 if (cur != null && !cur.isClosed()) {
@@ -1546,7 +1541,7 @@ public class SchedV2 extends AbstractSched {
     protected Card _getRevCard() {
         if (_fillRev()) {
             // mRevCount -= 1; see decrementCounts()
-            return mCol.getCard(mRevQueue.remove());
+            return mRevQueue.remove().getCard();
         } else {
             return null;
         }
@@ -2500,7 +2495,7 @@ public class SchedV2 extends AbstractSched {
             while (cur.moveToNext()) {
                 long cid = cur.getLong(0);
                 int queue = cur.getInt(1);
-                List<Long> queue_object;
+                List<Card.Cache> queue_object;
                 if (queue == Consts.QUEUE_TYPE_REV) {
                     queue_object = mRevQueue;
                     if (buryRev) {


### PR DESCRIPTION
This is a new version of https://github.com/ankidroid/Anki-Android/pull/6026 

I believe the code is quite simpler. Instead of having a list of ID, I have a list of CardCache. That is, essentially, it's an ID, with potentially one more data, the card loaded and even the question preloaded. Thanks to this, I can preload the card content without needing to actually change anything about the content of the queue.

I actually usually preload two cards, because I do not know in advance whether the next card will be a card in learning or not. 

This also means that if for some unknown reason I got the next card wrong, the worst that will occur is that the next card will need to be loaded before being displayed instead of being preloaded.  I don't expect to get the next card wrong, but at this point I'm not as confident as I used to be. Thanks to David for noticing in the last version of the code that I was preloading the next card as if it were a card that we must review now, ignoring that in the future, a card in learning may become due.

The next task would be to figure out how to preload the medias, and maybe even create partially the HTML document to load MathJax in it if required. 

