### PR TITLE
Time box

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -55,6 +55,7 @@ import android.text.Spanned;
 import android.text.SpannedString;
 import android.text.TextUtils;
 import android.text.style.UnderlineSpan;
+import android.util.Pair;
 import android.util.TypedValue;
 import android.view.GestureDetector.SimpleOnGestureListener;
 import android.view.KeyEvent;
@@ -628,12 +629,12 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
                 mSched.incrReps();
             }
 
-            Long[] elapsed = getCol().timeboxReached();
+            Pair<Integer, Integer> elapsed = getCol().timeboxReached();
             if (elapsed != null) {
                 // AnkiDroid is always counting one rep ahead, so we decrement it before displaying
                 // it to the user.
-                int nCards = elapsed[1].intValue() - 1;
-                int nMins = elapsed[0].intValue() / 60;
+                int nCards = elapsed.second.intValue() - 1;
+                int nMins = elapsed.first.intValue() / 60;
                 String mins = res.getQuantityString(R.plurals.in_minutes, nMins, nMins);
                 String timeboxMessage = res.getQuantityString(R.plurals.timebox_reached, nCards, nCards, mins);
                 UIUtils.showThemedToast(AbstractFlashcardViewer.this, timeboxMessage, true);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -674,6 +674,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         return new NextCardHandler() {
             @Override
             public void onPreExecute() {
+                super.onPreExecute();
                 blockControls(quick);
             }
         };

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -592,7 +592,9 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
 
 
         @Override
-        public void onPreExecute() { /* do nothing */}
+        public void onPreExecute() {
+            dealWithTimeBox();
+        }
 
 
         @Override
@@ -622,22 +624,13 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
                 AbstractFlashcardViewer.this.unblockControls();
                 AbstractFlashcardViewer.this.displayCardQuestion();
             }
-
-            // Since reps are incremented on fetch of next card, we will miss counting the
-            // last rep since there isn't a next card. We manually account for it here.
-            if (mNoMoreCards) {
-                mSched.incrReps();
-            }
-            dealWithTimeBox();
         }
 
         private void dealWithTimeBox() {
             Resources res = getResources();
             Pair<Integer, Integer> elapsed = getCol().timeboxReached();
             if (elapsed != null) {
-                // AnkiDroid is always counting one rep ahead, so we decrement it before displaying
-                // it to the user.
-                int nCards = elapsed.second.intValue() - 1;
+                int nCards = elapsed.second.intValue();
                 int nMins = elapsed.first.intValue() / 60;
                 String mins = res.getQuantityString(R.plurals.in_minutes, nMins, nMins);
                 String timeboxMessage = res.getQuantityString(R.plurals.timebox_reached, nCards, nCards, mins);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -628,7 +628,11 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
             if (mNoMoreCards) {
                 mSched.incrReps();
             }
+            dealWithTimeBox();
+        }
 
+        private void dealWithTimeBox() {
+            Resources res = getResources();
             Pair<Integer, Integer> elapsed = getCol().timeboxReached();
             if (elapsed != null) {
                 // AnkiDroid is always counting one rep ahead, so we decrement it before displaying

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -2472,7 +2472,6 @@ public class DeckPicker extends NavigationDrawerActivity implements
     private void openReviewer() {
         Intent reviewer = new Intent(this, Reviewer.class);
         startActivityForResultWithAnimation(reviewer, REQUEST_REVIEW, ActivityTransitionAnimation.LEFT);
-        getCol().startTimebox();
     }
 
     @Override

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -234,6 +234,7 @@ public class Reviewer extends AbstractFlashcardViewer {
         }
 
         col.getSched().deferReset();     // Reset schedule in case card was previously loaded
+        getCol().startTimebox();
         CollectionTask.launchCollectionTask(ANSWER_CARD, mAnswerCardHandler(false),
                 new TaskData(null, 0));
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
@@ -243,7 +243,6 @@ public class StudyOptionsFragment extends Fragment implements Toolbar.OnMenuItem
             getActivity().finish();
         }
         animateLeft();
-        getCol().startTimebox();
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
@@ -501,7 +501,6 @@ public class CustomStudyDialog extends AnalyticsDialogFragment {
         AnkiActivity activity = getAnkiActivity();
         if (jumpToReviewer) {
             activity.startActivityForResultWithoutAnimation(new Intent(activity, Reviewer.class), AnkiActivity.REQUEST_REVIEW);
-            CollectionHelper.getInstance().getCol(activity).startTimebox();
         } else {
             ((CustomStudyListener) activity).onExtendStudyLimits();
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1224,14 +1224,14 @@ public class Collection {
 
 
     /* Return (elapsedTime, reps) if timebox reached, or null. */
-    public Long[] timeboxReached() {
+    public Pair<Integer, Integer> timeboxReached() {
         if (mConf.getLong("timeLim") == 0) {
             // timeboxing disabled
             return null;
         }
         double elapsed = Utils.now() - mStartTime;
         if (elapsed > mConf.getLong("timeLim")) {
-            return new Long[] { mConf.getLong("timeLim"), (long) (mSched.getReps() - mStartReps) };
+            return new Pair<Integer, Integer> (mConf.getInt("timeLim"), mSched.getReps() - mStartReps);
         }
         return null;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
@@ -199,8 +199,8 @@ public abstract class AbstractSched {
     public abstract void setToday(int today);
     public abstract long getDayCutoff();
 
-    public abstract void incrReps();
-    public abstract void decrReps();
+    protected abstract void incrReps();
+    protected abstract void decrReps();
     /** Number of repetitions today*/
     public abstract int getReps();
     /** Number of cards in the current decks, its descendants and ancestors. */

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -2798,12 +2798,12 @@ public class SchedV2 extends AbstractSched {
         return mReps;
     }
 
-    public void incrReps() {
+    protected void incrReps() {
         mReps++;
     }
 
 
-    public void decrReps() {
+    protected void decrReps() {
         mReps--;
     }
 


### PR DESCRIPTION
## Pull Request template

## Fixes
https://github.com/ankidroid/Anki-Android/issues/6853

## Approach
The timebox is consistently used BEFORE getting the next card, so that counting is consistent and there is no more need for special case.

## How Has This Been Tested?

Try to reproduce bugs as shown previously. On second timebox it'll show the correct number of cards

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
