### PR TITLE
Colin p hill templates

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/template/Template.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/template/Template.java
@@ -160,33 +160,16 @@ public class Template {
     }
 
     /**
-     * Expands all tags, iteratively until all tags (even tags that are replaced by tags) are resolved.
-     */
-    private @NonNull String render_tags(@NonNull String template, @NonNull Map<String, String> context) {
-        /* Apply render_some_tags to the tags, until
-           render_some_tags states that it does not find tags to replace anymore
-           anymore. Return the last template state */
-        String previous_template = null;
-        while (template != null) {
-            previous_template = template;
-            template = render_some_tags(template, context);
-        }
-        return previous_template;
-    }
-
-    /**
      * Replaces all the tags in a template in a single pass for the values in the given context map.
      */
-    private @Nullable String render_some_tags(@NonNull String template, @NonNull Map<String, String> context) {
+    private @NonNull String render_tags(@NonNull String template, @NonNull Map<String, String> context) {
         String ALT_HANDLEBAR_DIRECTIVE = "{{=<% %>=}}";
         if (template.contains(ALT_HANDLEBAR_DIRECTIVE)) {
             template = template.replace(ALT_HANDLEBAR_DIRECTIVE, "").replace("<%", "{{").replace("%>", "}}");
         }
         StringBuffer sb = new StringBuffer();
         Matcher match = sTag_re.matcher(template);
-        boolean found = false;
         while (match.find()) {
-            found = true;
             String tag_type = match.group(1);
             String tag_name = match.group(2).trim();
             String replacement;
@@ -200,9 +183,6 @@ public class Template {
                 return "{{invalid template}}";
             }
             match.appendReplacement(sb, Matcher.quoteReplacement(replacement));
-        }
-        if (!found) {
-            return null;
         }
         match.appendTail(sb);
         return sb.toString();

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/template/TemplateTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/template/TemplateTest.java
@@ -42,7 +42,7 @@ public class TemplateTest extends RobolectricTest {
 
         String rendered = t.render();
 
-        assertThat(rendered, is("AA[[type:Back]]"));
+        assertThat(rendered, is("AA{{type:Back}}"));
     }
 
     @Test


### PR DESCRIPTION
This is a rewrite of https://github.com/ankidroid/Anki-Android/pull/6851 which correct the code and a test.
The result of the test is the same as upstream (I just tested)

Fixes #6295

@mikehardy, I think you mentioned keeping a special case; maybe if a field A has {{type:B}} or {{B}} then B gets reinterpreted as another field if it actually exists and is ignored otherwise. We are not going in this direction. That's fine by me, but there is at least one user for which this change of behavior will be a problem