### PR TITLE
Use new ACRA APIs to clear AcraLimiter

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -61,6 +61,7 @@ import org.acra.annotation.AcraLimiter;
 import org.acra.annotation.AcraToast;
 import org.acra.config.CoreConfigurationBuilder;
 import org.acra.config.DialogConfigurationBuilder;
+import org.acra.config.LimiterData;
 import org.acra.config.ToastConfigurationBuilder;
 import org.acra.sender.HttpSender;
 
@@ -376,11 +377,14 @@ public class AnkiDroidApp extends MultiDexApplication {
     /**
      * If you want to make sure that the next exception of any time is posted, you need to clear limiter data
      *
-     * ACRA 5.3.x does this automatically on version upgrade (https://github.com/ACRA/acra/pull/696), until then they blessed deleting file
      * @param context the context leading to the directory with ACRA limiter data
      */
     public static void deleteACRALimiterData(Context context) {
-        context.getFileStreamPath("ACRA-limiter.json").delete();
+        try {
+            new LimiterData().store(context);
+        } catch (Exception e) {
+            Timber.w(e, "Unable to clear ACRA limiter data");
+        }
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -1086,9 +1086,6 @@ public class DeckPicker extends NavigationDrawerActivity implements
             }
             preferences.edit().putLong(UPGRADE_VERSION_KEY, current).apply();
 
-            // New version, clear out old exception report limits
-            AnkiDroidApp.deleteACRALimiterData(this);
-
             // Delete the media database made by any version before 2.3 beta due to upgrade errors.
             // It is rebuilt on the next sync or media check
             if (previous < 20300200) {


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

We were manually clearing the limiter on new versions or
when user toggled crash report preferences, but upstream added
the necessary APIs to do so, port to those

## Fixes
Fixes #4968

## Approach

Propose a change to upstream when you find yourself poking a hole in an abstraction, then port to the APIs upstream when implemented

## How Has This Been Tested?

I wrote an instrumented test that verified the behavior long ago, and it still does -> yay automated testing

## Learning (optional, can help others)

I don't believe I learned a thing here currently. In the original upstream PR I learned how receptive most projects are to good ideas, which was formative in how I participate in the development of my dependency network

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
