### PR TITLE
Cancel multi-card dismiss on memory pressure

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1186,7 +1186,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
     // We spawn CollectionTasks that may create memory pressure, this transmits it so polling isCancelled sees the pressure
     @Override
     public void onTrimMemory(int pressureLevel) {
-        CollectionTask.cancelCurrentlyExecutingTask();
+        CollectionTask.cancelAllTasks(DISMISS_MULTI);
     }
 
     private long getReviewerCardId() {


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

Cancel the correct tasks in the event of memory pressure

This is an extension of the original implementation of undo on
multi-card dismiss where memory pressure was handled by stopping the
save of undo information

## Fixes
Fixes #6633 

## Approach

As the CollectionTask infrastructure was groomed and cancel API semantics
were altered, it seemed like a defect that a simple cancel was called, as
it may not cancel the correct thing. This now attempts to cancel the actually
correct tasks


## How Has This Been Tested?

None

## Learning (optional, can help others)

None

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
