### PR TITLE
Added toast on debug info copy

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Info.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Info.java
@@ -184,6 +184,9 @@ public class Info extends AnkiActivity {
         android.content.ClipboardManager clipboardManager = (android.content.ClipboardManager)getSystemService(Context.CLIPBOARD_SERVICE);
         if (clipboardManager != null) {
             clipboardManager.setPrimaryClip(ClipData.newPlainText(this.getTitle(), debugInfo));
+            UIUtils.showThemedToast(this, getString(R.string.about_ankidroid_successfully_copied_debug), true);
+        } else {
+            UIUtils.showThemedToast(this, getString(R.string.about_ankidroid_error_copy_debug_info), false);
         }
         return debugInfo;
     }

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -315,4 +315,8 @@
     <string name="update_js_api_version">AnkiDroid JS API update available. Contact developer %s, or view wiki</string>
     <string name="reviewer_invalid_api_version_visit_documentation">View</string>
     <string name="anki_js_error_code">(Error Code: %d)</string>
+
+    <!-- About AnkiDroid screen -->
+    <string name="about_ankidroid_successfully_copied_debug">Copied debug information to clipboard</string>
+    <string name="about_ankidroid_error_copy_debug_info">Error copying debug information to clipboard</string>
 </resources>


### PR DESCRIPTION
## Purpose / Description
I once had a user ask what to do once they clicked the button, I remembered this when accessing the screen, I hope this will mean it won't happen again

## Approach
Add toast to both success and failure case.

I don't expect the failure case to happen

## How Has This Been Tested?
On my device

## Learning 
Make everything as obvious as possible

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
