### PR TITLE
Allow the user to disable the Sync Status Badge

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -631,6 +631,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
         MenuItem syncMenu = menu.findItem(R.id.action_sync);
         SyncStatus syncStatus = SyncStatus.getSyncStatus(this::getCol);
         switch (syncStatus) {
+            case BADGE_DISABLED:
             case NO_CHANGES:
             case INCONCLUSIVE:
                 BadgeDrawableBuilder.removeBadge(syncMenu);

--- a/AnkiDroid/src/main/java/com/ichi2/utils/SyncStatus.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/SyncStatus.java
@@ -29,7 +29,8 @@ public enum SyncStatus {
     NO_ACCOUNT,
     NO_CHANGES,
     HAS_CHANGES,
-    FULL_SYNC;
+    FULL_SYNC,
+    BADGE_DISABLED;
 
     private static boolean sPauseCheckingDatabase = false;
     private static boolean sMarkedInMemory = false;
@@ -50,6 +51,10 @@ public enum SyncStatus {
 
     @NonNull
     public static SyncStatus getSyncStatus(@NonNull Collection col) {
+        if (isDisabled()) {
+            return SyncStatus.BADGE_DISABLED;
+        }
+
         if (!isLoggedIn()) {
             return SyncStatus.NO_ACCOUNT;
         }
@@ -63,6 +68,12 @@ public enum SyncStatus {
         } else {
             return SyncStatus.NO_CHANGES;
         }
+    }
+
+
+    private static boolean isDisabled() {
+        SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance());
+        return !preferences.getBoolean("showSyncStatusBadge", true);
     }
 
 

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -105,6 +105,8 @@
     <string name="automatic_sync_choice">Automatic synchronization</string>
     <string name="automatic_sync_choice_summ">Sync automatically on app start/exit if the last sync was more than 10
         minutes ago.</string>
+    <string name="sync_status_badge">Display synchronization status</string>
+    <string name="sync_status_badge_summ">Change the sync icon when changes can be uploaded</string>
     <string name="day_theme">Day theme</string>
     <string name="night_theme">Night theme</string>
     <string name="default_font">Default font</string>

--- a/AnkiDroid/src/main/res/xml/preferences_general.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_general.xml
@@ -44,6 +44,11 @@
             android:key="automaticSyncMode"
             android:summary="@string/automatic_sync_choice_summ"
             android:title="@string/automatic_sync_choice" />
+        <CheckBoxPreference
+            android:defaultValue="true"
+            android:key="showSyncStatusBadge"
+            android:summary="@string/sync_status_badge_summ"
+            android:title="@string/sync_status_badge" />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/pref_cat_general">
         <ListPreference


### PR DESCRIPTION
## Purpose / Description
User requested that the badge should be disabled

## Fixes
Fixes #6856

## Approach
Via a preference - default to true


## How Has This Been Tested?

On my phone - disabled and enabled as expected

## Learning (optional, can help others)
YAGNI isn't always right

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
