### PR TITLE
onTrimMemory call super

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1203,6 +1203,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
     // We spawn CollectionTasks that may create memory pressure, this transmits it so polling isCancelled sees the pressure
     @Override
     public void onTrimMemory(int pressureLevel) {
+        super.onTrimMemory(pressureLevel);
         CollectionTask.cancelCurrentlyExecutingTask();
     }
 


### PR DESCRIPTION
According to documentation " If you override this method you must call through to the superclass implementation."
https://developer.android.com/reference/android/app/Application#onTrimMemory(int)

I'm still on current version of ankidroid to see whether I can reproduce a bug, so I've not yet tested it.