### PR TITLE
Undo message correctly states what is going to be undone

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -76,6 +76,7 @@ import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Consts;
 import com.ichi2.libanki.Decks;
+import com.ichi2.libanki.Undoable;
 import com.ichi2.libanki.Utils;
 import com.ichi2.libanki.Deck;
 import com.ichi2.themes.Themes;
@@ -142,6 +143,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
     private MultiColumnListAdapter mCardsAdapter;
     private String mSearchTerms;
     private String mRestrictOnDeck;
+    @Nullable
+    private Undoable mUndoable;
 
     private MenuItem mSearchItem;
     private MenuItem mSaveSearchItem;
@@ -784,8 +787,11 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
         if (mActionBarMenu != null && mActionBarMenu.findItem(R.id.action_undo) != null) {
             MenuItem undo =  mActionBarMenu.findItem(R.id.action_undo);
-            undo.setVisible(getCol().undoAvailable());
-            undo.setTitle(getResources().getString(R.string.studyoptions_congrats_undo, getCol().undoName(getResources())));
+            mUndoable = getCol().lastUndo();
+            undo.setVisible(mUndoable != null);
+            if (mUndoable != null) {
+                undo.setTitle(getResources().getString(R.string.studyoptions_congrats_undo, mUndoable.getName(getResources())));
+            }
         }
 
         // Maybe we were called from ACTION_PROCESS_TEXT.
@@ -1034,8 +1040,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
             }
 
             case R.id.action_undo:
-                if (getCol().undoAvailable()) {
-                    CollectionTask.launchCollectionTask(UNDO, mUndoHandler);
+                if (mUndoable != null && !mUndoable.isStarted()) {
+                    CollectionTask.launchCollectionTask(UNDO_NAMED, mUndoHandler, new TaskData(mUndoable));
                 }
                 return true;
             case R.id.action_select_none:

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1461,7 +1461,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
             mUndoSnackbar = UIUtils.showSnackbar(CardBrowser.this, String.format(getString(R.string.changed_deck_message), deckName), SNACKBAR_DURATION, R.string.undo, new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
-                    CollectionTask.launchCollectionTask(UNDO, mUndoHandler);
+                    CollectionTask.launchCollectionTask(UNDO_NAMED, mUndoHandler, new TaskData(result.getUndoable()));
                 }
             }, mCardsListView, null);
         }
@@ -1584,7 +1584,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
             mUndoSnackbar = UIUtils.showSnackbar(CardBrowser.this, getString(R.string.deleted_message), SNACKBAR_DURATION, R.string.undo, new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
-                    CollectionTask.launchCollectionTask(UNDO, mUndoHandler);
+                    CollectionTask.launchCollectionTask(UNDO_NAMED, mUndoHandler, new TaskData(result.getUndoable()));
                 }
             }, mCardsListView, null);
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -1276,7 +1276,6 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
     private void undo() {
         Timber.i("undo()");
-        final boolean isReview = undoReviewString.equals(mUndoable.Name(getResources()));
         TaskListener listener = new TaskListener() {
             @Override
             public void onCancelled() {
@@ -1292,7 +1291,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
             public void onPostExecute(TaskData result) {
                 hideProgressBar();
                 Timber.i("Undo completed");
-                if (isReview) {
+                if (mUndoable.isReview()) {
                     Timber.i("Review undone - opening reviewer.");
                     openReviewer();
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -107,6 +107,7 @@ import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Decks;
 import com.ichi2.libanki.Model;
 import com.ichi2.libanki.Models;
+import com.ichi2.libanki.Undoable;
 import com.ichi2.libanki.Utils;
 import com.ichi2.libanki.importer.AnkiPackageImporter;
 import com.ichi2.libanki.sched.DeckDueTreeNode;
@@ -182,6 +183,9 @@ public class DeckPicker extends NavigationDrawerActivity implements
     private SwipeRefreshLayout mPullToSyncWrapper;
 
     private TextView mReviewSummaryTextView;
+
+    @Nullable
+    private Undoable mUndoable;
 
     private BroadcastReceiver mUnmountReceiver = null;
 
@@ -594,12 +598,13 @@ public class DeckPicker extends NavigationDrawerActivity implements
             return false;
         }
         // Show / hide undo
-        if (mFragmented || !getCol().undoAvailable()) {
+        mUndoable = getCol().lastUndo();
+        if (mFragmented || mUndoable == null) {
             menu.findItem(R.id.action_undo).setVisible(false);
         } else {
             Resources res = getResources();
             menu.findItem(R.id.action_undo).setVisible(true);
-            String undo = res.getString(R.string.studyoptions_congrats_undo, getCol().undoName(res));
+            String undo = res.getString(R.string.studyoptions_congrats_undo, mUndoable.getName(res));
             menu.findItem(R.id.action_undo).setTitle(undo);
         }
         return super.onPrepareOptionsMenu(menu);
@@ -1271,8 +1276,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
     private void undo() {
         Timber.i("undo()");
-        String undoReviewString = getResources().getString(R.string.undo_action_review);
-        final boolean isReview = undoReviewString.equals(getCol().undoName(getResources()));
+        final boolean isReview = undoReviewString.equals(mUndoable.Name(getResources()));
         TaskListener listener = new TaskListener() {
             @Override
             public void onCancelled() {
@@ -1294,7 +1298,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
                 }
             }
         };
-        CollectionTask.launchCollectionTask(UNDO, listener);
+        CollectionTask.launchCollectionTask(UNDO_NAMED, listener, new TaskData(mUndoable));
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
@@ -45,6 +45,7 @@ import com.ichi2.compat.CompatHelper;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Consts;
 import com.ichi2.libanki.Decks;
+import com.ichi2.libanki.Undoable;
 import com.ichi2.libanki.Utils;
 import com.ichi2.libanki.Deck;
 import com.ichi2.themes.StyledProgressDialog;
@@ -108,6 +109,9 @@ public class StudyOptionsFragment extends Fragment implements Toolbar.OnMenuItem
     private Thread mFullNewCountThread = null;
 
     private StudyOptionsListener mListener;
+
+    @Nullable
+    private Undoable mUndoable;
 
     /**
      * Callbacks for UI events
@@ -295,7 +299,7 @@ public class StudyOptionsFragment extends Fragment implements Toolbar.OnMenuItem
         switch (item.getItemId()) {
             case R.id.action_undo:
                 Timber.i("StudyOptionsFragment:: Undo button pressed");
-                getCol().undo();
+                mUndoable.undo(getCol());
                 openReviewer();
                 return true;
             case R.id.action_deck_options:
@@ -381,12 +385,13 @@ public class StudyOptionsFragment extends Fragment implements Toolbar.OnMenuItem
             // Switch on or off unbury depending on if there are cards to unbury
             menu.findItem(R.id.action_unbury).setVisible(getCol().getSched().haveBuried());
             // Switch on or off undo depending on whether undo is available
-            if (!getCol().undoAvailable()) {
+            mUndoable = getCol().lastUndo();
+            if (mUndoable == null) {
                 menu.findItem(R.id.action_undo).setVisible(false);
             } else {
                 menu.findItem(R.id.action_undo).setVisible(true);
                 Resources res = AnkiDroidApp.getAppResources();
-                menu.findItem(R.id.action_undo).setTitle(res.getString(R.string.studyoptions_congrats_undo, getCol().undoName(res)));
+                menu.findItem(R.id.action_undo).setTitle(res.getString(R.string.studyoptions_congrats_undo, mUndoable.getName(res)));
             }
             // Set the back button listener
             if (!mFragmented) {

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -636,7 +636,7 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
         }
 
 
-        public long undo(Collection col) {
+        protected long actualUndo(Collection col) {
             Timber.i("UNDO: Suspend Card %d", suspendedCard.getId());
             suspendedCard.flush(false);
             return suspendedCard.getId();
@@ -658,7 +658,7 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
         }
 
 
-        public long undo(Collection col) {
+        protected long actualUndo(Collection col) {
             Timber.i("Undo: Delete note");
             ArrayList<Long> ids = new ArrayList<>();
             note.flush(note.getMod(), false);
@@ -763,7 +763,7 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
         }
 
 
-        public long undo(Collection col) {
+        protected long actualUndo(Collection col) {
             Timber.i("Undo: Suspend multiple cards");
             List<Long> toSuspendIds = new ArrayList<>();
             List<Long> toUnsuspendIds = new ArrayList<>();
@@ -807,7 +807,7 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
         }
 
 
-        public long undo(Collection col) {
+        protected long actualUndo(Collection col) {
             Timber.i("Undo: Delete notes");
             // undo all of these at once instead of one-by-one
             ArrayList<Long> ids = new ArrayList<>();
@@ -838,7 +838,7 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
         }
 
 
-        public long undo(Collection col) {
+        protected long actualUndo(Collection col) {
             Timber.i("Undo: Change Decks");
             // move cards to original deck
             for (int i = 0; i < cards.length; i++) {
@@ -866,7 +866,7 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
         }
 
 
-        public long undo(Collection col) {
+        protected long actualUndo(Collection col) {
             Timber.i("Undo: Mark notes");
             CardUtils.markAll(originalMarked, true);
             CardUtils.markAll(originalUnmarked, false);
@@ -885,7 +885,7 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
         }
 
 
-        public long undo(Collection col) {
+        protected long actualUndo(Collection col) {
             Timber.i("Undoing action of type %s on %d cards", getDismissType(), cards_copied.length);
             for (int i = 0; i < cards_copied.length; i++) {
                 Card card = cards_copied[i];
@@ -1138,6 +1138,8 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
                 } else if (cid == MULTI_CARD) {
                     /* multi-card action undone, no action to take here */
                     Timber.d("Multi-select undo succeeded");
+                } else if (cid == NOT_UNDONE) {
+                    Timber.d("Undoing already processing");
                 } else {
                     // cid is actually a card id.
                     // a review was undone,

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -1102,7 +1102,7 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
         }
         // pass cards back so more actions can be performed by the caller
         // (querying the cards again is unnecessarily expensive)
-        return new TaskData(true, cards);
+        return new TaskData(true, cards, undoable);
     }
 
     private Card[] deepCopyCardArray(Card[] originals) throws CancellationException {

--- a/AnkiDroid/src/main/java/com/ichi2/async/TaskData.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/TaskData.java
@@ -6,6 +6,7 @@ import android.content.Context;
 import com.ichi2.anki.CardBrowser;
 import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Note;
+import com.ichi2.libanki.Undoable;
 
 import java.util.List;
 import java.util.Map;
@@ -22,6 +23,7 @@ public class TaskData {
     private Context mContext;
     private int mType;
     private Object[] mObjects;
+    private Undoable mUndoable;
 
 
     public TaskData(Object[] obj) {
@@ -38,6 +40,10 @@ public class TaskData {
     public TaskData(Object[] obj, boolean bool) {
         mObjects = obj;
         mBool = bool;
+    }
+
+    public TaskData(Undoable undoable) {
+        mUndoable = undoable;
     }
 
 
@@ -217,5 +223,10 @@ public class TaskData {
         }
 
         return clazz.isAssignableFrom(val.getClass());
+    }
+
+
+    public Undoable getUndoable() {
+        return mUndoable;
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/async/TaskData.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/TaskData.java
@@ -93,6 +93,12 @@ public class TaskData {
         mBool = bool;
     }
 
+    public TaskData(boolean bool, Object[] obj, Undoable undoable) {
+        mBool = bool;
+        mObjects = obj;
+        mUndoable = undoable;
+    }
+
     public TaskData(boolean bool, Object[] obj) {
         mBool = bool;
         mObjects = obj;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -64,6 +64,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.regex.Pattern;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import androidx.sqlite.db.SupportSQLiteDatabase;
@@ -1271,10 +1272,10 @@ public class Collection {
         }
         return null;
     }
-    public String undoName(Resources res) {
-        DismissType type = undoType();
-        if (type != null) {
-            return res.getString(type.undoNameId);
+    public @NonNull String undoName(Resources res) {
+        Undoable undoable = lastUndo();
+        if (undoable != null) {
+            return undoable.getName(res);
         }
         return "";
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1254,10 +1254,11 @@ public class Collection {
     }
 
     public @Nullable Undoable lastUndo() {
-        if (mUndo.isEmpty()) {
+        LinkedList<Undoable> undoables = mUndo; // Copied for synchronization
+        if (undoables.isEmpty()) {
            return null;
         }
-        return mUndo.getLast();
+        return undoables.getLast();
     }
 
 
@@ -1292,11 +1293,13 @@ public class Collection {
         return NO_REVIEW;
     }
 
+    /* Undos may get cleared during execution of markUndo. In this case the action can't be undone*/
     public void markUndo(Undoable undo) {
         Timber.d("markUndo() of type %s", undo.getDismissType());
-        mUndo.add(undo);
-        while (mUndo.size() > UNDO_SIZE_MAX) {
-            mUndo.removeFirst();
+        LinkedList<Undoable> undos = mUndo; // Copied for synchronization
+        undos.add(undo);
+        while (undos.size() > UNDO_SIZE_MAX) {
+            undos.removeFirst();
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1332,6 +1332,11 @@ public class Collection {
                 col.getSched().undoReview(clonedCard, wasLeech);
                 return clonedCard.getId();
             }
+
+            @Override
+            public boolean isReview() {
+                return true;
+            }
         };
         markUndo(undoableReview);
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1299,7 +1299,7 @@ public class Collection {
 
     public boolean undoAvailable() {
         Timber.d("undoAvailable() undo size: %s", mUndo.size());
-        return mUndo.size() > 0;
+        return !mUndo.isEmpty();
     }
 
     public long undo() {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1291,7 +1291,7 @@ public class Collection {
         if (lastUndo != null ) {
             return lastUndo.undo(this);
         }
-        return NO_REVIEW;
+        return Undoable.NOT_UNDONE;
     }
 
     /* Undos may get cleared during execution of markUndo. In this case the action can't be undone*/
@@ -1308,7 +1308,7 @@ public class Collection {
         boolean wasLeech = card.note().hasTag("leech");
         Card clonedCard = card.clone();
         Undoable undoableReview = new Undoable(REVIEW) {
-            public long undo(Collection col) {
+            protected long actualUndo(Collection col) {
                 col.getSched().undoReview(clonedCard, wasLeech);
                 return clonedCard.getId();
             }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Undoable.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Undoable.java
@@ -8,6 +8,7 @@ import com.ichi2.libanki.Collection.DismissType;
 import java.util.ArrayList;
 import java.util.List;
 
+import androidx.annotation.NonNull;
 import timber.log.Timber;
 
 import static com.ichi2.libanki.Collection.DismissType.*;
@@ -51,5 +52,9 @@ public abstract class Undoable {
                 return cid;
             }
         };
+    }
+
+    public @NonNull String getName(Resources res) {
+        return res.getString(mDt.undoNameId);
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Undoable.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Undoable.java
@@ -74,4 +74,9 @@ public abstract class Undoable {
     public @NonNull String getName(Resources res) {
         return res.getString(mDt.undoNameId);
     }
+
+    /** Whether this Undoable undo a review. Reviews need special care when undone*/
+    public boolean isReview() {
+        return false;
+    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Undoable.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Undoable.java
@@ -16,7 +16,9 @@ import static com.ichi2.libanki.Collection.DismissType.*;
 public abstract class Undoable {
     private final DismissType mDt;
     public static final long MULTI_CARD = -1L;
+    public static final long NOT_UNDONE = -2L;
     public static final long NO_REVIEW = 0L;
+    private Boolean mStarted = false;
 
     /**
      * For all descendants, we assume that a card/note/object passed as argument is never going to be changed again.
@@ -33,18 +35,33 @@ public abstract class Undoable {
         return mDt;
     }
 
+
     /**
      * Return MULTI_CARD when no other action is needed, e.g. for multi card action
      * Return NO_REVIEW when we just need to reset the collection
+     * Return NOT_UNDONE if the undo was already started and so is not executed here
      * Returned positive integers are card id. Those ids is the card that was discarded and that may be sent back to the reviewer.*/
-    public abstract long undo(Collection col);
+    public long undo(Collection col){
+        synchronized (mStarted) {
+            if (mStarted) {
+                return NOT_UNDONE;
+            }
+            mStarted = true;
+        }
+        return actualUndo(col);
+    }
+    /**Actually undo. It assumes the action was not already undone. Return same as undo, but can't return NOT_UNDONE */
+    protected abstract long actualUndo(Collection col);
 
+    public boolean isStarted() {
+        return mStarted;
+    }
     public static Undoable revertToProvidedState (DismissType dt, Card card){
         Note note = card.note();
         List<Card> cards = note.cards();
         long cid = card.getId();
         return new Undoable(dt) {
-            public long undo(Collection col) {
+            protected long actualUndo(Collection col) {
                 Timber.i("Undo: %s", dt);
                 for (Card cc : cards) {
                     cc.flush(false);


### PR DESCRIPTION
David made a pretty good remark regarding a PR I made: https://github.com/ankidroid/Anki-Android/pull/6863#discussion_r467661553 

And he was extremely right. Actually nothing is safe regarding the queue of undoables. Background tasks can add things any time. The queue could theoretically be emptied (seems hard to do in practice). 

Each time `undo` was called, it was undoing the last element from the queue. Which could seems to be a good idea except that this element may not exists. Or it may have changed, and so the actual undone action would differ from the one you expected to undo. This would be extremely nonsensical in card browser where it asks you whether you want to undelete a bunch a note and you risk to undo something else by accident if you wait long enough.

I'm going to test this on my phone. 

I must state I'm quite happy to have added Undoable. If data were still an array of object, I fear it would have been harder to follow through the logic of this correction

