### PR TITLE
Fix: Use positional format strings

### DIFF
--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -309,7 +309,7 @@
     </plurals>
 
     <!-- JS api -->
-    <string name="api_version_developer_contact">This card uses unsupported AnkiDroid features. Contact developer %s, or view the wiki. %s</string>
+    <string name="api_version_developer_contact">This card uses unsupported AnkiDroid features. Contact developer %1$s, or view the wiki. %2$s</string>
     <string name="invalid_json_data">Card provided invalid data. %s</string>
     <string name="valid_js_api_version">Invalid AnkiDroid JS API version. Contact developer %s, or view wiki</string>
     <string name="update_js_api_version">AnkiDroid JS API update available. Contact developer %s, or view wiki</string>


### PR DESCRIPTION
Caught the warning while looking at build logs.

> /home/travis/build/ankidroid/Anki-Android/AnkiDroid/build/intermediates/incremental/mergeReleaseResources/merged.dir/values-af/values-af.xml:375: warn: multiple substitutions specified in non-positional format; did you mean to add the formatted="false" attribute?.

After a quick google, I can't determine how to turn this into an error. It's a C++ check, rather than a regular lint check. Maybe we can fail if warnings are returned from compileLint?

https://cs.android.com/search?q=%20%22multiple%20substitutions%20specified%20in%20non-positional%20format%22&sq=&ss=android

Fixes #6868 