### PR TITLE
Confirm Navigation while reviewing, when preference set

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -240,6 +240,9 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
     protected boolean mSpeakText;
     protected boolean mDisableClipboard = false;
 
+    // Confirm Navigation JS popup
+    private static boolean mPrefConfirmNav;
+
     protected boolean mOptUseGeneralTimerSettings;
 
     protected boolean mUseTimer;
@@ -1736,6 +1739,8 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         mScrollingButtons = preferences.getBoolean("scrolling_buttons", false);
         mDoubleScrolling = preferences.getBoolean("double_scrolling", false);
         mPrefShowTopbar = preferences.getBoolean("showTopbar", true);
+        //confirm navigation popup in webview
+        mPrefConfirmNav = preferences.getBoolean("jsConfirmNavigation", false);
 
         mGesturesEnabled = AnkiDroidApp.initiateGestures(preferences);
         mLinkOverridesTouchGesture = preferences.getBoolean("linkOverridesTouchGesture", false);
@@ -2694,6 +2699,15 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
             Timber.i("AbstractFlashcardViewer:: onJsAlert: %s", message);
             result.confirm();
             return true;
+        }
+
+        @Override
+        public boolean onJsBeforeUnload (WebView view, String url, String message, JsResult result) {
+            if (mPrefConfirmNav) {
+                result.confirm();
+                return true;
+            }
+            return false;
         }
     }
 

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -319,4 +319,8 @@
     <!-- About AnkiDroid screen -->
     <string name="about_ankidroid_successfully_copied_debug">Copied debug information to clipboard</string>
     <string name="about_ankidroid_error_copy_debug_info">Error copying debug information to clipboard</string>
+
+    <!-- Reviewing - Confirm Navigation -->
+    <string name="pref_js_confirm_nav_summ">Auto confirm navigation while reviewing</string>
+    <string name="pref_js_confirm_nav_title">Confirm Navigation</string>
 </resources>

--- a/AnkiDroid/src/main/res/xml/preferences_advanced.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_advanced.xml
@@ -123,6 +123,11 @@
                 android:title="@string/advanced_statistics_title"/>
             <CheckBoxPreference
                 android:defaultValue="false"
+                android:key="jsConfirmNavigation"
+                android:summary="@string/pref_js_confirm_nav_summ"
+                android:title="@string/pref_js_confirm_nav_title"/>
+            <CheckBoxPreference
+                android:defaultValue="false"
                 android:key="html_javascript_debugging"
                 android:summary="@string/html_javascript_debugging_summ"
                 android:title="@string/html_javascript_debugging"/>


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
While reviewing may be some website opened in <iframe>, but when tapping show answer, that website alert for unsaved data. This can be easily sort out by using 
```
window.onbeforeunload = null;
```
But in some cases it doesn't seem to work. So, this is workaround for that one.

## Fixes
Fixes _Link to the issues._

## Approach
Using ```onJsBeforeUnload()``` in WebChromeClient

## How Has This Been Tested?
Tested on android emulator and real device 
1. Add following to front/back
```<iframe src="somewebsite"></iframe>```

This can be used
- https://www.w3schools.com/tags/tryit.asp?filename=tryhtml5_ev_onbeforeunload

In my case I used localhost on phone with ```test.html``` with custom fields

2. Check preference in Advance setting to ```true/false``` and view the changes inside webview 

Demo
<img src="https://user-images.githubusercontent.com/12841290/89949005-bed43600-dc59-11ea-9c7b-ec7aa4af16fd.gif" height="500">

## Learning (optional, can help others)
- https://developer.android.com/reference/android/webkit/WebChromeClient#onJsBeforeUnload(android.webkit.WebView,%20java.lang.String,%20java.lang.String,%20android.webkit.JsResult)
- https://stackoverflow.com/questions/4802007/window-onbeforeunload-not-working-in-chrome

## Checklist
_Please, go through these checks before submitting the PR._

- [ x ] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [ x ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ x ] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ x ] You have commented your code, particularly in hard-to-understand areas
- [ x ] You have performed a self-review of your own code
