### PR TITLE
Adding a new card reload reviewer

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -164,6 +164,7 @@ public class NoteEditor extends AnkiActivity {
     public static final int REQUEST_TEMPLATE_EDIT = 3;
     public static final int REQUEST_PREVIEW = 4;
 
+    /** Whether any change are saved. E.g. multimedia, new card added, field changed and saved.*/
     private boolean mChanged = false;
     private boolean mTagsEdited = false;
     private boolean mFieldEdited = false;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -841,6 +841,7 @@ public class NoteEditor extends AnkiActivity {
             getCol().getModels().current().put("tags", ja);
             getCol().getModels().setChanged();
             CollectionTask.launchCollectionTask(ADD_NOTE, mSaveNoteHandler, new TaskData(mEditorNote));
+            mReloadRequired = true;
         } else {
             // Check whether note type has been changed
             final Model newModel = getCurrentlySelectedModel();


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

## Fixes
Fixes #6887

## Approach
If a card is added, it states to reload the reviewer

## How Has This Been Tested?

trying steps as in https://github.com/ankidroid/Anki-Android/issues/6887#issuecomment-672990200

## Learning (optional, can help others)

There still is a problem if editing a card lead to generating new cards. I don't see where the edited card is flushed, so I don't know where to check whether the edition generates new card. I'd need help to solve this similar bug


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
