### PR TITLE
NF: Add test for card generation

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/libanki/CardTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/CardTest.java
@@ -1,16 +1,21 @@
 package com.ichi2.libanki;
 
 import com.ichi2.anki.RobolectricTest;
+import com.ichi2.anki.exception.ConfirmModSchemaException;
+import com.ichi2.utils.JSONArray;
 import com.ichi2.utils.JSONObject;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
+import static org.hamcrest.Matchers.hasItemInArray;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 
 @RunWith(AndroidJUnit4.class)
@@ -114,4 +119,121 @@ public class CardTest extends RobolectricTest {
         note.flush();
         assertEquals(newId, note.cards().get(3).getDid());
     }
+
+    @Test
+    public void test_gen_or() throws ConfirmModSchemaException {
+        Collection col = getCol();
+        Models models = col.getModels();
+        Model model = models.byName("Basic");
+        JSONArray flds = model.getJSONArray("flds");
+        models.renameField(model, flds.getJSONObject(0), "A");
+        models.renameField(model, flds.getJSONObject(1), "B");
+        JSONObject fld2 = models.newField("C");
+        fld2.put("ord", null);
+        models.addField(model, fld2);
+
+        JSONArray tmpls = model.getJSONArray("tmpls");
+        tmpls.getJSONObject(0).put("qfmt", "{{A}}{{B}}{{C}}");
+        // ensure first card is always generated,
+        // because at last one card is generated
+        JSONObject tmpl = models.newTemplate("AND_OR");
+        tmpl.put("qfmt", "        {{A}}    {{#B}}        {{#C}}            {{B}}        {{/C}}    {{/B}}");
+        models.addTemplate(model, tmpl);
+
+        models.save(model);
+        models.setCurrent(model);
+
+        Note note = col.newNote();
+        note.setItem("A", "foo");
+        col.addNote(note);
+        assertNoteOrdinalAre(note, new Integer[]{0, 1});
+
+        note = col.newNote();
+        note.setItem("B", "foo");
+        note.setItem("C", "foo");
+        col.addNote(note);
+        assertNoteOrdinalAre(note, new Integer[]{0, 1});
+
+        note = col.newNote();
+        note.setItem("B", "foo");
+        col.addNote(note);
+        assertNoteOrdinalAre(note, new Integer[]{0});
+
+        note = col.newNote();
+        note.setItem("C", "foo");
+        col.addNote(note);
+        assertNoteOrdinalAre(note, new Integer[]{0});
+
+        note = col.newNote();
+        note.setItem("A", "foo");
+        note.setItem("B", "foo");
+        note.setItem("C", "foo");
+        col.addNote(note);
+        assertNoteOrdinalAre(note, new Integer[]{0, 1});
+
+        note = col.newNote();
+        col.addNote(note);
+        assertNoteOrdinalAre(note, new Integer[]{0});
+        // First card is generated if no other card
+    }
+
+    @Test
+    public void test_gen_not() throws ConfirmModSchemaException {
+        Collection col = getCol();
+        Models models = col.getModels();
+        Model model = models.byName("Basic");
+        JSONArray flds = model.getJSONArray("flds");
+        JSONArray tmpls = model.getJSONArray("tmpls");
+
+        models.renameField(model, flds.getJSONObject(0), "First");
+        models.renameField(model, flds.getJSONObject(1), "Front");
+        JSONObject fld2 = models.newField("AddIfEmpty");
+        fld2.put("name", "AddIfEmpty");
+        models.addField(model, fld2);
+
+        // ensure first card is always generated,
+        // because at last one card is generated
+        tmpls.getJSONObject(0).put("qfmt", "{{AddIfEmpty}}{{Front}}{{First}}");
+        JSONObject tmpl = models.newTemplate("NOT");
+        tmpl.put("qfmt", "    {{^AddIfEmpty}}        {{Front}}    {{/AddIfEmpty}}    ");
+
+        models.addTemplate(model, tmpl);
+
+        models.save(model);
+        models.setCurrent(model);
+
+        Note note = col.newNote();
+        note.setItem("First", "foo");
+        note.setItem("AddIfEmpty", "foo");
+        note.setItem("Front", "foo");
+        col.addNote(note);
+        assertNoteOrdinalAre(note, new Integer[]{0});
+
+        note = col.newNote();
+        note.setItem("First", "foo");
+        note.setItem("AddIfEmpty", "foo");
+        col.addNote(note);
+        assertNoteOrdinalAre(note, new Integer[]{0});
+
+        note = col.newNote();
+        note.setItem("First", "foo"); // ensure first note generated
+        col.addNote(note);
+        assertNoteOrdinalAre(note, new Integer[]{0});
+
+        note = col.newNote();
+        note.setItem("First", "foo");
+        note.setItem("Front", "foo");
+        col.addNote(note);
+        assertNoteOrdinalAre(note, new Integer[]{0, 1});
+    }
+
+    private void  assertNoteOrdinalAre(Note note, Integer[] ords) {
+        ArrayList<Card> cards = note.cards();
+        assumeThat(cards.size(), is(ords.length));
+        for (Card card: cards) {
+            Integer ord = card.getOrd();
+            assumeThat(ords, hasItemInArray(ord));
+        }
+    }
+    
 }


### PR DESCRIPTION
I'm adding tests related to change in anki 2.1.28. This port succesfull test I created in https://github.com/ankitects/anki/pull/733

It's only "assume" because I've not yet ported those change. I don't speak rust well enough to know how it is implemented and whether Damien found an easier way to code it than just checking manually whether a field value is used in the process.