### PR TITLE
Fix time rounding errors

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
@@ -150,9 +150,9 @@ public class Utils {
         } else if (Math.abs(time_s) < TIME_HOUR) {
             return res.getString(R.string.time_quantity_minutes, (int) Math.round(time_s/TIME_MINUTE));
         } else if (Math.abs(time_s) < TIME_DAY) {
-            return res.getString(R.string.time_quantity_hours_minutes, (int) Math.round(time_s/TIME_HOUR), (int) Math.round((time_s % TIME_HOUR) / TIME_MINUTE));
+            return res.getString(R.string.time_quantity_hours_minutes, (int) Math.floor(time_s/TIME_HOUR), (int) Math.round((time_s % TIME_HOUR) / TIME_MINUTE));
         } else if (Math.abs(time_s) < TIME_MONTH) {
-            return res.getString(R.string.time_quantity_days_hours, (int) Math.round(time_s/TIME_DAY), (int) Math.round((time_s % TIME_DAY) / TIME_HOUR));
+            return res.getString(R.string.time_quantity_days_hours, (int) Math.floor(time_s/TIME_DAY), (int) Math.round((time_s % TIME_DAY) / TIME_HOUR));
         } else if (Math.abs(time_s) < TIME_YEAR) {
             return res.getString(R.string.time_quantity_months, time_s/TIME_MONTH);
         } else {

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/UtilsIntegrationTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/UtilsIntegrationTest.java
@@ -1,0 +1,63 @@
+package com.ichi2.libanki;
+
+import com.ichi2.anki.RobolectricTest;
+import com.ichi2.testutils.NullApplication;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.annotation.Config;
+
+import androidx.annotation.CheckResult;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@RunWith(AndroidJUnit4.class)
+@Config(application = NullApplication.class, qualifiers = "en")
+public class UtilsIntegrationTest extends RobolectricTest {
+
+    @Test
+    public void deckPickerTimeOneAndHalfHours() {
+        int oneAndAHalfHours = 60 * 90;
+
+        String actual = deckPickerTime(oneAndAHalfHours);
+
+        assertThat(actual, is("1 h 30 m"));
+    }
+
+    @Test
+    public void deckPickerTimeOneHour() {
+        int oneAndAHalfHours = 60 * 60;
+
+        String actual = deckPickerTime(oneAndAHalfHours);
+
+        assertThat(actual, is("1 h 0 m"));
+    }
+
+    @Test
+    public void deckPickerTime60Seconds() {
+        int oneAndAHalfHours = 60;
+
+        String actual = deckPickerTime(oneAndAHalfHours);
+
+        assertThat(actual, is("1 min"));
+    }
+
+    @Test
+    public void deckPickerTimeOneAndAHalfDays() {
+        int oneAndAHalfHours = 60 * 60 * 36;
+
+        String actual = deckPickerTime(oneAndAHalfHours);
+
+        assertThat(actual, is("1 d 12 h"));
+    }
+
+
+    @NotNull
+    @CheckResult
+    private String deckPickerTime(long time) {
+        return Utils.timeQuantityTopDeckPicker(this.getTargetContext(), time);
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/NullApplication.java
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/NullApplication.java
@@ -1,0 +1,7 @@
+package com.ichi2.testutils;
+
+import android.app.Application;
+
+/** Used when an application class is not required for a test to run */
+public class NullApplication extends Application {
+}


### PR DESCRIPTION
## Purpose / Description
1h30 currently renders as 2h30

## Fixes
Fixes  #6894

## Approach
Use math.floor instead of math.round

## How Has This Been Tested?

Unit Tested

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code