### PR TITLE
Fixes #6903

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
@@ -297,4 +297,6 @@ public abstract class AbstractSched {
     /** Notifies the scheduler that there is no more current card. This is the case when a card is answered, when the
      * scheduler is reset... */
     public abstract void discardCurrentCard();
+
+    public abstract Collection getCol();
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/CardQueue.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/CardQueue.java
@@ -1,0 +1,71 @@
+package com.ichi2.libanki.sched;
+
+import com.ichi2.libanki.Card;
+import com.ichi2.libanki.Collection;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.NoSuchElementException;
+import java.util.Random;
+
+abstract class CardQueue<T extends Card.Cache> {
+    // We need to store mSched and not queue, because during initialization of sched, when CardQueues are initialized
+    // sched.getCol is null.
+    private final AbstractSched mSched;
+    private final LinkedList<T> mQueue = new LinkedList<>();
+
+
+    public CardQueue(AbstractSched sched) {
+        mSched = sched;
+    }
+
+
+    public void loadFirstCard() {
+        if (!mQueue.isEmpty()) {
+            // No nead to reload. If the card was changed, reset would have been called and emptied the queue
+            mQueue.get(0).loadQA(false, false);
+        }
+    }
+
+    public Card removeFirstCard() throws NoSuchElementException {
+        return mQueue.remove().getCard();
+    }
+
+    public boolean remove(long cid) {
+        // CardCache and LrnCache with the same id will be considered as equal so it's a valid implementation.
+        return mQueue.remove(new Card.Cache(getCol(), cid));
+    }
+
+    public void add(T elt) {
+        mQueue.add(elt);
+    }
+
+    public void clear() {
+        mQueue.clear();
+    }
+
+    public boolean isEmpty() {
+        return mQueue.isEmpty();
+    }
+
+    public int size() {
+        return mQueue.size();
+    }
+
+    protected LinkedList<T> getQueue() {
+        return mQueue;
+    }
+
+    public void shuffle(Random r) {
+        Collections.shuffle(mQueue, r);
+    }
+
+    public Iterator<T> listIterator() {
+        return mQueue.listIterator();
+    }
+
+    protected Collection getCol() {
+        return mSched.getCol();
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/LrnCard.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/LrnCard.java
@@ -1,0 +1,21 @@
+package com.ichi2.libanki.sched;
+
+import com.ichi2.libanki.Card;
+import com.ichi2.libanki.Collection;
+
+class LrnCard extends Card.Cache implements Comparable<LrnCard> {
+    private final long mDue;
+    public LrnCard(Collection col, long due, long cid) {
+        super(col, cid);
+        mDue = due;
+    }
+
+    public long getDue () {
+        return mDue;
+    }
+
+    @Override
+    public int compareTo(LrnCard o) {
+        return Long.compare(mDue, o.mDue);
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/LrnCardQueue.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/LrnCardQueue.java
@@ -1,0 +1,27 @@
+package com.ichi2.libanki.sched;
+
+import com.ichi2.libanki.Collection;
+
+import java.util.Collections;
+
+class LrnCardQueue extends CardQueue<LrnCard> {
+    public LrnCardQueue(AbstractSched sched) {
+        super(sched);
+    }
+
+    public void add(long due, long cid) {
+        add(new LrnCard(getCol(), due, cid));
+    }
+
+    public void add(int pos, LrnCard card) {
+        getQueue().add(pos, card);
+    }
+
+    public void sort() {
+        Collections.sort(getQueue());
+    }
+
+    public long getFirstDue() {
+        return getQueue().getFirst().getDue();
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -381,7 +381,7 @@ public class Sched extends SchedV2 {
                 mLrnQueue.add(cur.getLong(0), cur.getLong(1));
             }
             // as it arrives sorted by did first, we need to sort it
-            Collections.sort(mLrnQueue);
+            mLrnQueue.sort();
             return !mLrnQueue.isEmpty();
         } finally {
             if (cur != null && !cur.isClosed()) {
@@ -398,7 +398,7 @@ public class Sched extends SchedV2 {
             if (collapse) {
                 cutoff += mCol.getConf().getInt("collapseTime");
             }
-            if (mLrnQueue.getFirst().getDue() < cutoff) {
+            if (mLrnQueue.getFirstDue() < cutoff) {
                 return mLrnQueue.removeFirstCard();
                 // mLrnCount -= card.getLeft() / 1000; See decrementCount()
             }
@@ -468,7 +468,7 @@ public class Sched extends SchedV2 {
                 // it twice in a row
                 card.setQueue(Consts.QUEUE_TYPE_LRN);
                 if (!mLrnQueue.isEmpty() && mRevCount == 0 && mNewCount == 0) {
-                    long smallestDue = mLrnQueue.getFirst().getDue();
+                    long smallestDue = mLrnQueue.getFirstDue();
                     card.setDue(Math.max(card.getDue(), smallestDue + 1));
                 }
                 _sortIntoLrn(card.getDue(), card.getId());
@@ -725,7 +725,7 @@ public class Sched extends SchedV2 {
                     } else {
                         Random r = new Random();
                         r.setSeed(mToday);
-                        Collections.shuffle(mRevQueue, r);
+                        mRevQueue.shuffle(r);
                     }
                     // is the current did empty?
                     if (mRevQueue.size() < lim) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -19,16 +19,10 @@
 package com.ichi2.libanki.sched;
 
 import android.app.Activity;
-import android.content.Context;
 import android.database.Cursor;
 import android.database.SQLException;
-import android.database.sqlite.SQLiteConstraintException;
-import android.graphics.Typeface;
-import android.text.SpannableStringBuilder;
 import android.text.TextUtils;
-import android.text.style.StyleSpan;
 
-import com.ichi2.anki.R;
 import com.ichi2.async.CollectionTask;
 import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
@@ -46,11 +40,8 @@ import com.ichi2.utils.JSONException;
 import com.ichi2.utils.JSONObject;
 
 
-import java.lang.ref.WeakReference;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -2599,7 +2599,7 @@ public class SchedV2 extends AbstractSched {
             while (cur.moveToNext()) {
                 long cid = cur.getLong(0);
                 int queue = cur.getInt(1);
-                List<Card.Cache> queue_object;
+                SimpleCardQueue queue_object;
                 if (queue == Consts.QUEUE_TYPE_REV) {
                     queue_object = mRevQueue;
                     if (buryRev) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -146,7 +146,8 @@ public class SchedV2 extends AbstractSched {
         }
     }
 
-    protected class SimpleCardQueue extends CardQueue<Card.Cache> {
+    @VisibleForTesting
+    class SimpleCardQueue extends CardQueue<Card.Cache> {
         public void add(long id) {
             add(new Card.Cache(mCol, id));
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SimpleCardQueue.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SimpleCardQueue.java
@@ -1,0 +1,17 @@
+package com.ichi2.libanki.sched;
+
+import com.ichi2.libanki.Card;
+import com.ichi2.libanki.Collection;
+
+import androidx.annotation.VisibleForTesting;
+
+@VisibleForTesting
+class SimpleCardQueue extends CardQueue<Card.Cache> {
+    public SimpleCardQueue(AbstractSched sched) {
+        super(sched);
+    }
+
+    public void add(long id) {
+        add(new Card.Cache(getCol(), id));
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
@@ -202,6 +202,10 @@ public class RobolectricTest {
         return addNoteUsingModelName("Basic", front, back);
     }
 
+    protected Note addNoteUsingBasicAndReversedModel(String front, String back) {
+        return addNoteUsingModelName("Basic (and reversed card)", front, back);
+    }
+
     protected Note addNoteUsingModelName(String name, String... fields) {
         Model model = getCol().getModels().byName(name);
         //PERF: if we modify newNote(), we can return the card and return a Pair<Note, Card> here.

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/AbstractSchedTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/AbstractSchedTest.java
@@ -152,7 +152,7 @@ public class AbstractSchedTest extends RobolectricTest {
     public void testCardQueue() {
         Collection col = getCol();
         SchedV2 sched = (SchedV2) col.getSched();
-        SchedV2.SimpleCardQueue queue = sched.new SimpleCardQueue();
+        SimpleCardQueue queue = new SimpleCardQueue(sched);
         assertThat(queue.size(), is(0));
         final int nbCard = 6;
         long[] cids = new long[nbCard];

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/AbstractSchedTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/AbstractSchedTest.java
@@ -163,17 +163,17 @@ public class AbstractSchedTest extends RobolectricTest {
             cids[i] = cid;
             queue.add(cid);
         }
-        assertThat(queue, hasSize(nbCard));
+        assertThat(queue.size(), is(nbCard));
         assertEquals(cids[0], queue.removeFirstCard().getId());
-        assertThat(queue, hasSize(nbCard - 1));
+        assertThat(queue.size(), is(nbCard - 1));
         queue.remove(cids[1]);
-        assertThat(queue, hasSize(nbCard - 2));
+        assertThat(queue.size(), is(nbCard - 2));
         queue.remove(cids[3]);
-        assertThat(queue, hasSize(nbCard - 3));
+        assertThat(queue.size(), is(nbCard - 3));
         assertEquals(cids[2], queue.removeFirstCard().getId());
-        assertThat(queue, hasSize(nbCard - 4));
+        assertThat(queue.size(), is(nbCard - 4));
         assertEquals(cids[4], queue.removeFirstCard().getId());
-        assertThat(queue, hasSize(nbCard - 5));
+        assertThat(queue.size(), is(nbCard - 5));
     }
 
     @Test


### PR DESCRIPTION
Fixes #6903

Seems that in this case, the overriding of `remove` was not detected, because for a `List<>`; it thought I used
`remove(Object)` instead of the expected `remove(long)`

The second interesting thing here is that the class CardQueue was added last minute, and not tested in my merge branch
as the remaining of the PR.