### PR TITLE
Reviewer: undo gets faster (performance)

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
@@ -288,14 +288,25 @@ public class StudyOptionsFragment extends Fragment implements Toolbar.OnMenuItem
         parent.addView(newView);
     }
 
+    private TaskListener undoListener = new TaskListener() {
+        @Override
+        public void onPreExecute() {
+
+        }
+
+
+        @Override
+        public void onPostExecute(TaskData result) {
+            openReviewer();
+        }
+    };
 
     @Override
     public boolean onMenuItemClick(MenuItem item) {
         switch (item.getItemId()) {
             case R.id.action_undo:
                 Timber.i("StudyOptionsFragment:: Undo button pressed");
-                getCol().undo();
-                openReviewer();
+                CollectionTask.launchCollectionTask(UNDO, undoListener);
                 return true;
             case R.id.action_deck_options:
                 Timber.i("StudyOptionsFragment:: Deck options button pressed");

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -915,7 +915,9 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
                 Card card = cards_copied[i];
                 card.flush(false);
             }
-            return NO_REVIEW;
+            col.reset();
+            Timber.d("Single card non-review change undo succeeded");
+            return col.getSched().getCard().getId();
         }
     }
 
@@ -1149,13 +1151,7 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
         AbstractSched sched = col.getSched();
         Card newCard = null;
         long cid = col.undo();
-        if (cid == NO_REVIEW) {
-            // /* card schedule change undone, reset and get
-            // new card */
-            Timber.d("Single card non-review change undo succeeded");
-            col.reset();
-            newCard = sched.getCard();
-        } else if (cid == MULTI_CARD) {
+        if (cid == MULTI_CARD) {
             /* multi-card action undone, no action to take here */
             Timber.d("Multi-select undo succeeded");
         } else {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1322,7 +1322,7 @@ public class Collection<T extends Time> {
         return mUndo.size() > 0;
     }
 
-    public long undo() {
+    public @Nullable Card undo() {
         Undoable lastUndo = mUndo.removeLast();
         Timber.d("undo() of type %s", lastUndo.getDismissType());
         return lastUndo.undo(this);
@@ -1340,9 +1340,9 @@ public class Collection<T extends Time> {
         boolean wasLeech = card.note().hasTag("leech");
         Card clonedCard = card.clone();
         Undoable undoableReview = new Undoable(REVIEW) {
-            public long undo(Collection col) {
+            public @Nullable Card undo(@NonNull Collection col) {
                 col.getSched().undoReview(clonedCard, wasLeech);
-                return clonedCard.getId();
+                return clonedCard;
             }
         };
         markUndo(undoableReview);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Undoable.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Undoable.java
@@ -15,7 +15,6 @@ import static com.ichi2.libanki.Collection.DismissType.*;
 public abstract class Undoable {
     private final DismissType mDt;
     public static final long MULTI_CARD = -1L;
-    public static final long NO_REVIEW = 0L;
 
     /**
      * For all descendants, we assume that a card/note/object passed as argument is never going to be changed again.

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Undoable.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Undoable.java
@@ -8,13 +8,14 @@ import com.ichi2.libanki.Collection.DismissType;
 import java.util.ArrayList;
 import java.util.List;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import timber.log.Timber;
 
 import static com.ichi2.libanki.Collection.DismissType.*;
 
 public abstract class Undoable {
     private final DismissType mDt;
-    public static final long MULTI_CARD = -1L;
 
     /**
      * For all descendants, we assume that a card/note/object passed as argument is never going to be changed again.
@@ -35,19 +36,19 @@ public abstract class Undoable {
      * Return MULTI_CARD when no other action is needed, e.g. for multi card action
      * Return NO_REVIEW when we just need to reset the collection
      * Returned positive integers are card id. Those ids is the card that was discarded and that may be sent back to the reviewer.*/
-    public abstract long undo(Collection col);
+    public abstract @Nullable Card undo(@NonNull Collection col);
 
     public static Undoable revertToProvidedState (DismissType dt, Card card){
         Note note = card.note();
         List<Card> cards = note.cards();
-        long cid = card.getId();
         return new Undoable(dt) {
-            public long undo(Collection col) {
+            public @Nullable
+            Card undo(@NonNull Collection col) {
                 Timber.i("Undo: %s", dt);
                 for (Card cc : cards) {
                     cc.flush(false);
                 }
-                return cid;
+                return card;
             }
         };
     }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

Undo is slow. One of the reason is that it gets the card from the database. This is actually useless, we usually could as easily save the card than the ID. This lead to saving 20 card object instead of 20 long, this is not a huge cost in term of memory. 

Sending the card directly to the reviewer ensure that it can be displayed almost immediately. It removes one of the last slow operation I had on my phone. (There remains bury/suspend... but I've no idea how to improve this more at this time)

## How Has This Been Tested?

On my phone, doing undo and ensuring that it appears almost without delay.

## Learning (optional, can help others)

When you spent dozen of hours working on background tasks and then some on the Undoable, and then on the list of undo, you can still miss this obvious optimization... and I don't know why it took me so much time to see it !

I may be wrong, but I suspect that if I didn't introduce this Undoable class, I would not have understood what is going on as well, and I may be would not have seen this optimization. But maybe I'm just trying to justify doing so much refactoring


Todo: in study option fragment: open reviewer and call undo from the reviewer, so that it actually gets the card undone instead of calling `sched.getCard()`

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
