### PR TITLE
NF: uses enum for Sound side

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -149,6 +149,7 @@ import static com.ichi2.anki.cardviewer.ViewerCommand.*;
 import static com.ichi2.anki.reviewer.CardMarker.*;
 import static com.ichi2.async.CollectionTask.TASK_TYPE.*;
 import com.ichi2.async.TaskData;
+import static com.ichi2.libanki.Sound.SoundSide;
 
 import com.github.zafarkhaja.semver.Version;
 
@@ -354,6 +355,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
 
     private Sound mSoundPlayer = new Sound();
 
+    /** Time taken o play all medias in mSoundPlayer */
     private long mUseTimerDynamicMS;
 
     /** File of the temporary mic record **/
@@ -1249,7 +1251,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
 
 
     protected void generateQuestionSoundList() {
-        mSoundPlayer.addSounds(mBaseUrl, mCurrentCard.qSimple(), Sound.SOUNDS_QUESTION);
+        mSoundPlayer.addSounds(mBaseUrl, mCurrentCard.qSimple(), SoundSide.QUESTION);
     }
 
 
@@ -1905,12 +1907,12 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
             if(!mUseTimer) {
                 return;
             }
-            if (ReadText.getmQuestionAnswer() == Sound.SOUNDS_QUESTION) {
+            if (ReadText.getmQuestionAnswer() == SoundSide.QUESTION) {
                 long delay = mWaitAnswerSecond * 1000;
                 if (delay > 0) {
                     mTimeoutHandler.postDelayed(mShowAnswerTask, delay);
                 }
-            } else if (ReadText.getmQuestionAnswer() == Sound.SOUNDS_ANSWER) {
+            } else if (ReadText.getmQuestionAnswer() == SoundSide.ANSWER) {
                 long delay = mWaitQuestionSecond * 1000;
                 if (delay > 0) {
                     mTimeoutHandler.postDelayed(mShowQuestionTask, delay);
@@ -2146,7 +2148,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         // additionally, this condition reduces computation time
         if (!mAnswerSoundsAdded) {
             String answerSoundSource = removeFrontSideAudio(answer);
-            mSoundPlayer.addSounds(mBaseUrl, answerSoundSource, Sound.SOUNDS_ANSWER);
+            mSoundPlayer.addSounds(mBaseUrl, answerSoundSource, SoundSide.ANSWER);
             mAnswerSoundsAdded = true;
         }
     }
@@ -2173,7 +2175,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
             // leaving the card (such as when edited)
             mSoundPlayer.resetSounds();
             mAnswerSoundsAdded = false;
-            mSoundPlayer.addSounds(mBaseUrl, newContent, Sound.SOUNDS_QUESTION);
+            mSoundPlayer.addSounds(mBaseUrl, newContent, SoundSide.QUESTION);
             if (mUseTimer && !mAnswerSoundsAdded && getConfigForCurrentCard().optBoolean("autoplay", false)) {
                 addAnswerSounds(mCurrentCard.a());
             }
@@ -2240,27 +2242,27 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
             if (!useTTS) { // Text to speech not in effect here
                 if (doAudioReplay && replayQuestion && sDisplayAnswer) {
                     // only when all of the above are true will question be played with answer, to match desktop
-                    mSoundPlayer.playSounds(Sound.SOUNDS_QUESTION_AND_ANSWER);
+                    mSoundPlayer.playSounds(SoundSide.QUESTION_AND_ANSWER);
                 } else if (sDisplayAnswer) {
-                    mSoundPlayer.playSounds(Sound.SOUNDS_ANSWER);
+                    mSoundPlayer.playSounds(SoundSide.ANSWER);
                     if (mUseTimer) {
-                        mUseTimerDynamicMS = mSoundPlayer.getSoundsLength(Sound.SOUNDS_ANSWER);
+                        mUseTimerDynamicMS = mSoundPlayer.getSoundsLength(SoundSide.ANSWER);
                     }
                 } else { // question is displayed
-                    mSoundPlayer.playSounds(Sound.SOUNDS_QUESTION);
+                    mSoundPlayer.playSounds(SoundSide.QUESTION);
                     // If the user wants to show the answer automatically
                     if (mUseTimer) {
-                        mUseTimerDynamicMS = mSoundPlayer.getSoundsLength(Sound.SOUNDS_QUESTION_AND_ANSWER);
+                        mUseTimerDynamicMS = mSoundPlayer.getSoundsLength(SoundSide.QUESTION_AND_ANSWER);
                     }
                 }
             } else { // Text to speech is in effect here
                 // If the question is displayed or if the question should be replayed, read the question
                 if (mTtsInitialized) {
                     if (!sDisplayAnswer || doAudioReplay && replayQuestion) {
-                        readCardText(mCurrentCard, Sound.SOUNDS_QUESTION);
+                        readCardText(mCurrentCard, SoundSide.QUESTION);
                     }
                     if (sDisplayAnswer) {
-                        readCardText(mCurrentCard, Sound.SOUNDS_ANSWER);
+                        readCardText(mCurrentCard, SoundSide.ANSWER);
                     }
                 } else {
                     mReplayOnTtsInit = true;
@@ -2275,11 +2277,11 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
      * @param card     The card to play TTS for
      * @param cardSide The side of the current card to play TTS for
      */
-    private void readCardText(final Card card, final int cardSide) {
+    private void readCardText(final Card card, final SoundSide cardSide) {
         final String cardSideContent;
-        if (Sound.SOUNDS_QUESTION == cardSide) {
+        if (SoundSide.QUESTION == cardSide) {
             cardSideContent = card.q(true);
-        } else if (Sound.SOUNDS_ANSWER == cardSide) {
+        } else if (SoundSide.ANSWER == cardSide) {
             cardSideContent = card.getPureAnswer();
         } else {
             Timber.w("Unrecognised cardSide");
@@ -2296,10 +2298,10 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         if (mTtsInitialized) {
             if (!sDisplayAnswer) {
                 ReadText.selectTts(getTextForTts(mCurrentCard.q(true)), getDeckIdForCard(mCurrentCard), mCurrentCard.getOrd(),
-                        Sound.SOUNDS_QUESTION);
+                        SoundSide.QUESTION);
             } else {
                 ReadText.selectTts(getTextForTts(mCurrentCard.getPureAnswer()), getDeckIdForCard(mCurrentCard),
-                        mCurrentCard.getOrd(), Sound.SOUNDS_ANSWER);
+                        mCurrentCard.getOrd(), SoundSide.ANSWER);
             }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/MetaDB.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MetaDB.java
@@ -7,6 +7,8 @@ import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteException;
 import android.util.Pair;
 
+import com.ichi2.libanki.Sound;
+
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -210,7 +212,7 @@ public class MetaDB {
      *            {@link #LANGUAGES_QA_ANSWER}, or {@link #LANGUAGES_QA_UNDEFINED}
      * @param language the language to associate, as a two-characters, lowercase string
      */
-    public static void storeLanguage(Context context, long did, int ord, int qa, String language) {
+    public static void storeLanguage(Context context, long did, int ord, Sound.SoundSide qa, String language) {
         openDBIfClosed(context);
         try {
             mMetaDb.execSQL("INSERT INTO languages (did, ord, qa, language) " + " VALUES (?, ?, ?, ?);", new Object[] {
@@ -228,7 +230,7 @@ public class MetaDB {
      *            {@link #LANGUAGES_QA_ANSWER}, or {@link #LANGUAGES_QA_UNDEFINED}
      * @param language the language to associate, as a two-characters, lowercase string
      */
-    public static void updateLanguage(Context context, long did, int ord, int qa, String language) {
+    public static void updateLanguage(Context context, long did, int ord, Sound.SoundSide qa, String language) {
         openDBIfClosed(context);
         try {
             mMetaDb.execSQL("UPDATE languages SET language = ? WHERE did = ? AND ord = ? AND qa = ?;", new Object[] {
@@ -247,7 +249,7 @@ public class MetaDB {
      *            {@link #LANGUAGES_QA_ANSWER}, or {@link #LANGUAGES_QA_UNDEFINED} return the language associate with
      *            the type, as a two-characters, lowercase string, or the empty string if no association is defined
      */
-    public static String getLanguage(Context context, long did, int ord, int qa) {
+    public static String getLanguage(Context context, long did, int ord, Sound.SoundSide qa) {
         openDBIfClosed(context);
         String language = "";
         Cursor cur = null;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.java
@@ -31,6 +31,7 @@ import com.afollestad.materialdialogs.MaterialDialog;
 import com.google.android.material.snackbar.Snackbar;
 import com.ichi2.compat.Compat;
 import com.ichi2.compat.CompatHelper;
+import com.ichi2.libanki.Sound;
 
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
@@ -48,13 +49,13 @@ public class ReadText {
     private static WeakReference<Context> mReviewer;
     private static long mDid;
     private static int mOrd;
-    private static int mQuestionAnswer;
+    private static Sound.SoundSide mQuestionAnswer;
     public static final String NO_TTS = "0";
     public static ArrayList<String[]> sTextQueue = new ArrayList<>();
     private static Compat compat = CompatHelper.getCompat();
     private static Object mTtsParams = compat.initTtsParams();
 
-    public static int getmQuestionAnswer() {
+    public static Sound.SoundSide getmQuestionAnswer() {
         return mQuestionAnswer;
     }
 
@@ -76,7 +77,7 @@ public class ReadText {
     }
 
 
-    public static String getLanguage(long did, int ord, int qa) {
+    public static String getLanguage(long did, int ord, Sound.SoundSide qa) {
         return MetaDB.getLanguage(mReviewer.get(), did, ord, qa);
     }
 
@@ -89,7 +90,7 @@ public class ReadText {
      * @param ord  The card template ordinal
      * @param qa   The card question or card answer
      */
-    public static void selectTts(String text, long did, int ord, int qa) {
+    public static void selectTts(String text, long did, int ord, Sound.SoundSide qa) {
         //TODO: Consolidate with ReadText.readCardSide
         mTextToSpeak = text;
         mQuestionAnswer = qa;
@@ -158,14 +159,14 @@ public class ReadText {
     /**
      * Read a card side using a TTS service.
      *
-     * @param cardSide         Card side to be read; Sound.SOUNDS_QUESTION or Sound.SOUNDS_ANSWER.
+     * @param cardSide         Card side to be read; SoundSide.SOUNDS_QUESTION or SoundSide.SOUNDS_ANSWER.
      * @param cardSideContents Contents of the card side to be read, in HTML format. If it contains
      *                         any &lt;tts service="android"&gt; elements, only their contents is
      *                         read; otherwise, all text is read. See TtsParser for more details.
      * @param did              Index of the deck containing the card.
      * @param ord              The card template ordinal.
      */
-    public static void readCardSide(int cardSide, String cardSideContents, long did, int ord, String clozeReplacement) {
+    public static void readCardSide(Sound.SoundSide cardSide, String cardSideContents, long did, int ord, String clozeReplacement) {
         boolean isFirstText = true;
         for (TtsParser.LocalisedText textToRead : TtsParser.getTextsToRead(cardSideContents, clozeReplacement)) {
             if (!textToRead.getText().isEmpty()) {
@@ -194,7 +195,7 @@ public class ReadText {
      *
      * @param queueMode TextToSpeech.QUEUE_ADD or TextToSpeech.QUEUE_FLUSH.
      */
-    private static void textToSpeech(String text, long did, int ord, int qa, String localeCode,
+    private static void textToSpeech(String text, long did, int ord, Sound.SoundSide qa, String localeCode,
                                      int queueMode) {
         mTextToSpeak = text;
         mQuestionAnswer = qa;

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReadTextTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReadTextTest.java
@@ -24,6 +24,7 @@ import androidx.annotation.CheckResult;
 import androidx.annotation.NonNull;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
+import static com.ichi2.libanki.Sound.SoundSide.QUESTION;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
@@ -72,7 +73,7 @@ public class ReadTextTest extends RobolectricTest{
 
     @CheckResult
     private String getValueFromReadSide(@NonNull String content) {
-        ReadText.readCardSide(0, content, 1, 1, "blank");
+        ReadText.readCardSide(QUESTION, content, 1, 1, "blank");
         return ReadText.getTextToSpeak();
     }
 }


### PR DESCRIPTION
My goal is to preload card as much as possible. This mean pre rendering html before actually needing to show it, in particular mathjax and loading media. This also mean that I need to deal with sound outside of the AbstractFlashCard Viewer. I believe that doing simple cleaning is a good first step to attain this goal easily. 

My point is that I'm not just doing refactoring for the sake of cleaning. I am doing it because I've got a goal in mind and that I expect that this will help reach it.

In this case, the cleaning is simply replacing int by an enum since there are only three valid values and that the value is never saved anywhere else, it is entirely NF