### PR TITLE
Don't offer to type answer if there is no front

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1954,19 +1954,17 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         setInterface();
 
         String displayString = displayString(reload);
-        if (!mCurrentCard.isEmpty()) {
+        if (!mCurrentCard.isEmpty() && typeAnswer()) {
             // Show text entry based on if the user wants to write the answer
-            if (typeAnswer()) {
-                mAnswerField.setVisibility(View.VISIBLE);
-            } else {
-                mAnswerField.setVisibility(View.GONE);
-            }
-
-            //if (mSpeakText) {
-            // ReadText.setLanguageInformation(Model.getModel(DeckManager.getMainDeck(),
-            // mCurrentCard.getCardModelId(), false).getId(), mCurrentCard.getCardModelId());
-            //}
+            mAnswerField.setVisibility(View.VISIBLE);
+        } else {
+            mAnswerField.setVisibility(View.GONE);
         }
+
+        //if (mSpeakText) {
+        // ReadText.setLanguageInformation(Model.getModel(DeckManager.getMainDeck(),
+        // mCurrentCard.getCardModelId(), false).getId(), mCurrentCard.getCardModelId());
+        //}
 
         updateCard(displayString);
         hideEaseButtons();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1931,30 +1931,36 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         jsApiInit();
     }
 
-    protected void displayCardQuestion(boolean reload) {
-        Timber.d("displayCardQuestion()");
-        sDisplayAnswer = false;
-        this.mMissingImageHandler.onCardSideChange();
-
-        setInterface();
-
-        String displayString = "";
+    /** String, as it will be displayed in the web viewer. Sound/video removed, image escaped...
+     Or warning if required*/
+    private String displayString(boolean reload) {
         if (mCurrentCard.isEmpty()) {
-            displayString = getResources().getString(R.string.empty_card_warning);
+            return getResources().getString(R.string.empty_card_warning);
         } else {
             String question = mCurrentCard.q(reload);
             question = getCol().getMedia().escapeImages(question);
             question = typeAnsQuestionFilter(question);
 
             Timber.v("question: '%s'", question);
+
+            return CardAppearance.enrichWithQADiv(question, false);
+        }
+    }
+
+    protected void displayCardQuestion(boolean reload) {
+        Timber.d("displayCardQuestion()");
+        sDisplayAnswer = false;
+
+        setInterface();
+
+        String displayString = displayString(reload);
+        if (!mCurrentCard.isEmpty()) {
             // Show text entry based on if the user wants to write the answer
             if (typeAnswer()) {
                 mAnswerField.setVisibility(View.VISIBLE);
             } else {
                 mAnswerField.setVisibility(View.GONE);
             }
-
-            displayString = CardAppearance.enrichWithQADiv(question, false);
 
             //if (mSpeakText) {
             // ReadText.setLanguageInformation(Model.getModel(DeckManager.getMainDeck(),

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1938,12 +1938,11 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
 
         setInterface();
 
-        String question;
         String displayString = "";
         if (mCurrentCard.isEmpty()) {
             displayString = getResources().getString(R.string.empty_card_warning);
         } else {
-            question = mCurrentCard.q(reload);
+            String question = mCurrentCard.q(reload);
             question = getCol().getMedia().escapeImages(question);
             question = typeAnsQuestionFilter(question);
 


### PR DESCRIPTION
My goal is to preload card as much as possible. This mean pre rendering html before actually needing to show it, in particular mathjax and loading media. This also mean that I need to deal with sound outside of the AbstractFlashCard Viewer. I believe that doing simple cleaning is a good first step to attain this goal easily. 

My point is that I'm not just doing refactoring for the sake of cleaning. I am doing it because I've got a goal in mind and that I expect that this will help reach it.

In this case, what I want is to get the display string without having to directly show it.

As a side note, it ensures that if the card is empty, set answer field is set to Gone