### PR TITLE
NF: remove Spannable from a string where it is never used

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -346,7 +346,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
     private int mGestureVolumeUp;
     private int mGestureVolumeDown;
 
-    private Spanned mCardContent;
+    private String mCardContent;
     private String mBaseUrl;
 
     private int mFadeDuration = 300;
@@ -2204,15 +2204,15 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
 
 
         content = CardAppearance.convertSmpToHtmlEntity(content);
-        mCardContent = new SpannedString(mCardTemplate.replace("::content::", content)
-                .replace("::style::", style).replace("::class::", cardClass));
+        mCardContent = mCardTemplate.replace("::content::", content)
+                .replace("::style::", style).replace("::class::", cardClass);
         Timber.d("base url = %s", mBaseUrl);
 
         if (AnkiDroidApp.getSharedPrefs(this).getBoolean("html_javascript_debugging", false)) {
             try {
                 try (FileOutputStream f = new FileOutputStream(new File(CollectionHelper.getCurrentAnkiDroidDirectory(this),
                         "card.html"))) {
-                    f.write(mCardContent.toString().getBytes());
+                    f.write(mCardContent.getBytes());
                 }
             } catch (IOException e) {
                 Timber.d(e, "failed to save card");
@@ -2344,7 +2344,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
             Timber.w("fillFlashCard() called with no card content");
             return;
         }
-        final String cardContent = mCardContent.toString();
+        final String cardContent = mCardContent;
         processCardAction(cardWebView -> loadContentIntoCard(cardWebView, cardContent));
         mGestureDetectorImpl.onFillFlashcard();
         if (mShowTimer && mCardTimer.getVisibility() == View.INVISIBLE) {


### PR DESCRIPTION
My goal is to preload card as much as possible. This mean pre rendering html before actually needing to show it, in particular mathjax and loading media. This also mean that I need to deal with sound outside of the AbstractFlashCard Viewer. I believe that doing simple cleaning is a good first step to attain this goal easily.

My point is that I'm not just doing refactoring for the sake of cleaning. I am doing it because I've got a goal in mind and that I expect that this will help reach it.

In this case, the cleaning is simply avoiding a constructor / toString when it is never useful