### PR TITLE
revlog entry should not be deleted when undoing preview card

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1280,8 +1280,11 @@ public class Collection {
      * Undo ********************************************************************* **************************
      */
 
-    /**
-     * [type, undoName, data] type 1 = review; type 2 =
+    /* Note from upstream:
+     * this data structure is a mess, and will be updated soon
+     * in the review case, [1, "Review", [firstReviewedCard, secondReviewedCard, ...], wasLeech]
+     * in the checkpoint case, [2, "action name"]
+     * wasLeech should have been recorded for each card, not globally
      */
     public void clearUndo() {
         mUndo = new LinkedList<>();


### PR DESCRIPTION
The plan is to add a revlog entry when previewing in the future; this
is just a temporary fix.

NF: Porting https://github.com/ankitects/anki/commit/d266f9a80a289012e46051af023008e8ab9dc7bb

Fixes #6916
