### PR TITLE
BUGFIX: Correctly persist TTS data (Fixes #6919)

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/MetaDB.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MetaDB.java
@@ -215,29 +215,17 @@ public class MetaDB {
     public static void storeLanguage(Context context, long did, int ord, Sound.SoundSide qa, String language) {
         openDBIfClosed(context);
         try {
-            mMetaDb.execSQL("INSERT INTO languages (did, ord, qa, language) " + " VALUES (?, ?, ?, ?);", new Object[] {
-                    did, ord, qa.getInt(), language });
-            Timber.v("Store language for deck %d", did);
+            if ("".equals(getLanguage(context, did, ord, qa))) {
+                mMetaDb.execSQL("INSERT INTO languages (did, ord, qa, language) " + " VALUES (?, ?, ?, ?);", new Object[] {
+                        did, ord, qa.getInt(), language });
+                Timber.v("Store language for deck %d", did);
+            } else {
+                mMetaDb.execSQL("UPDATE languages SET language = ? WHERE did = ? AND ord = ? AND qa = ?;", new Object[] {
+                        language, did, ord, qa.getInt()});
+                Timber.v("Update language for deck %d", did);
+            }
         } catch (Exception e) {
             Timber.e(e,"Error storing language in MetaDB ");
-        }
-    }
-
-    /**
-     * Associates a language to a deck, model, and card model for a given type.
-     *
-     * @param qa the part of the card for which to store the association, {@link #LANGUAGES_QA_QUESTION},
-     *            {@link #LANGUAGES_QA_ANSWER}, or {@link #LANGUAGES_QA_UNDEFINED}
-     * @param language the language to associate, as a two-characters, lowercase string
-     */
-    public static void updateLanguage(Context context, long did, int ord, Sound.SoundSide qa, String language) {
-        openDBIfClosed(context);
-        try {
-            mMetaDb.execSQL("UPDATE languages SET language = ? WHERE did = ? AND ord = ? AND qa = ?;", new Object[] {
-                    language, did, ord, qa.getInt()});
-            Timber.v("Update language for deck %d", did);
-        } catch (Exception e) {
-            Timber.e(e,"Error updating language in MetaDB ");
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/MetaDB.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MetaDB.java
@@ -216,7 +216,7 @@ public class MetaDB {
         openDBIfClosed(context);
         try {
             mMetaDb.execSQL("INSERT INTO languages (did, ord, qa, language) " + " VALUES (?, ?, ?, ?);", new Object[] {
-                    did, ord, qa, language });
+                    did, ord, qa.getInt(), language });
             Timber.v("Store language for deck %d", did);
         } catch (Exception e) {
             Timber.e(e,"Error storing language in MetaDB ");
@@ -234,7 +234,7 @@ public class MetaDB {
         openDBIfClosed(context);
         try {
             mMetaDb.execSQL("UPDATE languages SET language = ? WHERE did = ? AND ord = ? AND qa = ?;", new Object[] {
-                    language, did, ord, qa});
+                    language, did, ord, qa.getInt()});
             Timber.v("Update language for deck %d", did);
         } catch (Exception e) {
             Timber.e(e,"Error updating language in MetaDB ");
@@ -254,9 +254,8 @@ public class MetaDB {
         String language = "";
         Cursor cur = null;
         try {
-            String query = "SELECT language FROM languages " + "WHERE did = " + did + " AND ord = " + ord
-                    + " AND qa = " + qa + " " + "LIMIT 1";
-            cur = mMetaDb.rawQuery(query, null);
+            String query = "SELECT language FROM languages WHERE did = ? AND ord = ? AND qa = ? LIMIT 1";
+            cur = mMetaDb.rawQuery(query, new String[] {Long.toString(did), Integer.toString(ord), Integer.toString(qa.getInt())});
             Timber.v("getLanguage: %s", query);
             if (cur.moveToNext()) {
                 language = cur.getString(0);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.java
@@ -131,13 +131,7 @@ public class ReadText {
                             if (!locale.equals(NO_TTS)) {
                                 speak(mTextToSpeak, locale, TextToSpeech.QUEUE_FLUSH);
                             }
-                            String language = getLanguage(mDid, mOrd, mQuestionAnswer);
-                            if ("".equals(language)) { // No language stored
-                                MetaDB.storeLanguage(mReviewer.get(), mDid, mOrd, mQuestionAnswer, locale);
-                            } else {
-                                MetaDB.updateLanguage(mReviewer.get(), mDid, mOrd, mQuestionAnswer, locale);
-                            }
-
+                            MetaDB.storeLanguage(mReviewer.get(), mDid, mOrd, mQuestionAnswer, locale);
                         }
                     });
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.java
@@ -90,9 +90,17 @@ public class Sound {
      * Subset Flags: Flags that indicate the subset of sounds to involve
      */
     public enum SoundSide {
-        QUESTION,
-        ANSWER,
-        QUESTION_AND_ANSWER
+        QUESTION(0),
+        ANSWER(1),
+        QUESTION_AND_ANSWER(2);
+
+        private final int mInt;
+        SoundSide(int i) {
+            mInt = i;
+        }
+        public int getInt() {
+            return mInt;
+        };
     };
 
     /**

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReadTextTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReadTextTest.java
@@ -85,9 +85,8 @@ public class ReadTextTest extends RobolectricTest{
         MetaDB.storeLanguage(getTargetContext(), 1, 1, QUESTION, "French");
         assertThat(MetaDB.getLanguage(getTargetContext(), 1, 1, QUESTION), is("French"));
         MetaDB.storeLanguage(getTargetContext(), 1, 1, QUESTION, "German");
-        // store does not update an already existing language
-        assertThat(MetaDB.getLanguage(getTargetContext(), 1, 1, QUESTION), is("French"));
-        MetaDB.updateLanguage(getTargetContext(), 1, 1, QUESTION, "Deutsch");
-        assertThat(MetaDB.getLanguage(getTargetContext(), 1, 1, QUESTION), is("Deutsch"));
+        assertThat(MetaDB.getLanguage(getTargetContext(), 1, 1, QUESTION), is("German"));
+        MetaDB.storeLanguage(getTargetContext(), 2, 1, QUESTION, "English");
+        assertThat(MetaDB.getLanguage(getTargetContext(), 2, 1, QUESTION), is("English"));
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReadTextTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReadTextTest.java
@@ -16,6 +16,8 @@
 
 package com.ichi2.anki;
 
+import com.ichi2.libanki.Sound;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -75,5 +77,17 @@ public class ReadTextTest extends RobolectricTest{
     private String getValueFromReadSide(@NonNull String content) {
         ReadText.readCardSide(QUESTION, content, 1, 1, "blank");
         return ReadText.getTextToSpeak();
+    }
+
+    @Test
+    public void SaveValue() {
+        assertThat(MetaDB.getLanguage(getTargetContext(), 1, 1, QUESTION), is(""));
+        MetaDB.storeLanguage(getTargetContext(), 1, 1, QUESTION, "French");
+        assertThat(MetaDB.getLanguage(getTargetContext(), 1, 1, QUESTION), is("French"));
+        MetaDB.storeLanguage(getTargetContext(), 1, 1, QUESTION, "German");
+        // store does not update an already existing language
+        assertThat(MetaDB.getLanguage(getTargetContext(), 1, 1, QUESTION), is("French"));
+        MetaDB.updateLanguage(getTargetContext(), 1, 1, QUESTION, "Deutsch");
+        assertThat(MetaDB.getLanguage(getTargetContext(), 1, 1, QUESTION), is("Deutsch"));
     }
 }


### PR DESCRIPTION
I missed that the SoundSides were saved in database. I only checked when the variables where created and didn't think
that they may only be used to create query.

I'm still surprised that this break anything. I would have expect that, at worst, it would reset all TTS saving (which
would already be a problem in itself), since the same QA representation value would be saved each time the database is
queried (and sql would have no problem saving anything in any column of a database)

----
Fixes #6919 