### PR TITLE
Note Editor Preview: Fix Crash

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -393,7 +393,13 @@ public class NoteEditor extends AnkiActivity {
     }
 
     @Override
-    protected void onSaveInstanceState(Bundle savedInstanceState) {
+    protected void onSaveInstanceState(@NonNull Bundle savedInstanceState) {
+        addInstanceStateToBundle(savedInstanceState);
+        super.onSaveInstanceState(savedInstanceState);
+    }
+
+
+    private void addInstanceStateToBundle(@NonNull Bundle savedInstanceState) {
         Timber.i("Saving instance");
         savedInstanceState.putInt("caller", mCaller);
         savedInstanceState.putBoolean("addNote", mAddNote);
@@ -405,7 +411,6 @@ public class NoteEditor extends AnkiActivity {
         }
         savedInstanceState.putStringArrayList("tags", mSelectedTags);
         savedInstanceState.putBundle("editFields", getFieldsAsBundle(false));
-        super.onSaveInstanceState(savedInstanceState);
     }
 
 
@@ -1000,17 +1005,7 @@ public class NoteEditor extends AnkiActivity {
 
             case R.id.action_preview:
                 Timber.i("NoteEditor:: Preview button pressed");
-                Intent previewer = new Intent(NoteEditor.this, CardTemplatePreviewer.class);
-
-                previewer.putExtra("ordinal", 0);
-                previewer.putExtra(TemporaryModel.INTENT_MODEL_FILENAME, TemporaryModel.saveTempModel(this, mEditorNote.model()));
-
-                // Send the previewer all our current editing information
-                Bundle noteEditorBundle = new Bundle();
-                onSaveInstanceState(noteEditorBundle);
-                noteEditorBundle.putBundle("editFields", getFieldsAsBundle(true));
-                previewer.putExtra("noteEditorBundle", noteEditorBundle);
-                startActivityForResultWithoutAnimation(previewer, REQUEST_PREVIEW);
+                performPreview();
                 return true;
 
             case R.id.action_save:
@@ -1061,6 +1056,22 @@ public class NoteEditor extends AnkiActivity {
     // ----------------------------------------------------------------------------
     // CUSTOM METHODS
     // ----------------------------------------------------------------------------
+
+    @VisibleForTesting
+    void performPreview() {
+        Intent previewer = new Intent(NoteEditor.this, CardTemplatePreviewer.class);
+
+        previewer.putExtra("ordinal", 0);
+        previewer.putExtra(TemporaryModel.INTENT_MODEL_FILENAME, TemporaryModel.saveTempModel(this, mEditorNote.model()));
+
+        // Send the previewer all our current editing information
+        Bundle noteEditorBundle = new Bundle();
+        addInstanceStateToBundle(noteEditorBundle);
+        noteEditorBundle.putBundle("editFields", getFieldsAsBundle(true));
+        previewer.putExtra("noteEditorBundle", noteEditorBundle);
+        startActivityForResultWithoutAnimation(previewer, REQUEST_PREVIEW);
+    }
+
 
     /**
      * finish when sd card is ejected

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.java
@@ -27,7 +27,6 @@ import com.ichi2.anki.multimediacard.fields.IField;
 import com.ichi2.libanki.Consts;
 import com.ichi2.libanki.Model;
 import com.ichi2.libanki.Note;
-import com.ichi2.utils.JSONObject;
 
 import org.junit.Ignore;
 import org.junit.Test;
@@ -45,6 +44,7 @@ import androidx.test.core.app.ActivityScenario;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import static com.ichi2.compat.Compat.EXTRA_PROCESS_TEXT;
+import static com.ichi2.testutils.AnkiAssert.assertDoesNotThrow;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
@@ -270,6 +270,13 @@ public class NoteEditorTest extends RobolectricTest {
         i.putExtra(EXTRA_PROCESS_TEXT, "hello\nworld");
         NoteEditor editor = startActivityNormallyOpenCollectionWithIntent(NoteEditor.class, i);
         assertThat(Arrays.asList(editor.getCurrentFieldStrings()), contains("hello\nworld", ""));
+    }
+
+    @Test
+    public void previewWorksWithNoError() {
+        // #6923 regression test - Low value - Could not make this fail as onSaveInstanceState did not crash under Robolectric.
+        NoteEditor editor = getNoteEditorAddingNote(FromScreen.DECK_LIST, NoteEditor.class);
+        assertDoesNotThrow(editor::performPreview);
     }
 
     private Intent getCopyNoteIntent(NoteEditor editor) {


### PR DESCRIPTION
## Purpose / Description
`super.onSaveInstanceState` was called too early which caused a crash from `dismissAllDialogFragments` when called from `onPause`

## Fixes
Fixes #6923

## Approach
* Extract `performPreview` to allow testing
* Extract the method to add to bundle without calling `super.onSaveInstanceState`

## How Has This Been Tested?

Tested on my phone, no longer crashes

## Learning (optional, can help others)
I'll prioritise getting the monkey set up for 2.14, this would have caught it before release. Unit Tests weren't helpful in this situation as Robolectric did not mirror real life.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code