### PR TITLE
Time is long

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
@@ -1174,7 +1174,7 @@ public class CardContentProvider extends ContentProvider {
             try {
                 if (cardToAnswer != null) {
                     if(timeTaken != -1){
-                        cardToAnswer.setTimerStarted(col.getTime().now()-timeTaken/1000);
+                        cardToAnswer.setTimerStarted(col.getTime().intTime()-timeTaken/1000);
                     }
                     sched.answerCard(cardToAnswer, ease);
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.java
@@ -345,6 +345,7 @@ public class Card implements Cloneable {
      * Time taken to answer card, in integer MS.
      */
     public int timeTaken() {
+        // Indeed an int. Difference between two big numbers is still small.
         int total = (int) ((getCol().getTime().now() - mTimerStarted) * 1000);
         return Math.min(total, timeLimit());
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.java
@@ -76,10 +76,10 @@ public class Card implements Cloneable {
     public static final int TYPE_REV = 2;
 
     private Collection mCol;
-    private double mTimerStarted;
+    private long mTimerStarted;
 
     // Not in LibAnki. Record time spent reviewing in order to restore when resuming.
-    private double mElapsedTime;
+    private long mElapsedTime;
 
     // BEGIN SQL table entries
     private long mId;
@@ -121,7 +121,7 @@ public class Card implements Cloneable {
 
     public Card(Collection col, Long id) {
         mCol = col;
-        mTimerStarted = Double.NaN;
+        mTimerStarted = 0L;
         mQA = null;
         mNote = null;
         if (id != null) {
@@ -328,7 +328,7 @@ public class Card implements Cloneable {
 
 
     public void startTimer() {
-        mTimerStarted = getCol().getTime().now();
+        mTimerStarted = getCol().getTime().intTime();
     }
 
 
@@ -346,7 +346,7 @@ public class Card implements Cloneable {
      */
     public int timeTaken() {
         // Indeed an int. Difference between two big numbers is still small.
-        int total = (int) ((getCol().getTime().now() - mTimerStarted) * 1000);
+        int total = (int) ((getCol().getTime().intTime() - mTimerStarted) * 1000);
         return Math.min(total, timeLimit());
     }
 
@@ -389,7 +389,7 @@ public class Card implements Cloneable {
      * method when the session resumes to start counting review time again.
      */
     public void stopTimer() {
-        mElapsedTime = getCol().getTime().now() - mTimerStarted;
+        mElapsedTime = getCol().getTime().intTime() - mTimerStarted;
     }
 
 
@@ -402,10 +402,10 @@ public class Card implements Cloneable {
      * or the result of timeTaken() will be wrong.
      */
     public void resumeTimer() {
-        mTimerStarted = getCol().getTime().now() - mElapsedTime;
+        mTimerStarted = getCol().getTime().intTime() - mElapsedTime;
     }
 
-    public void setTimerStarted(double timeStarted){ mTimerStarted = timeStarted; }
+    public void setTimerStarted(long timeStarted){ mTimerStarted = timeStarted; }
 
     public long getId() {
         return mId;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -104,7 +104,7 @@ public class Collection<T extends Time> {
 
     private AbstractSched mSched;
 
-    private double mStartTime;
+    private long mStartTime;
     private int mStartReps;
 
     // BEGIN: SQL table columns
@@ -1267,7 +1267,7 @@ public class Collection<T extends Time> {
 
 
     public void startTimebox() {
-        mStartTime = getTime().now();
+        mStartTime = getTime().intTime();
         mStartReps = mSched.getReps();
     }
 
@@ -1278,7 +1278,7 @@ public class Collection<T extends Time> {
             // timeboxing disabled
             return null;
         }
-        double elapsed = getTime().now() - mStartTime;
+        long elapsed = getTime().intTime() - mStartTime;
         if (elapsed > mConf.getLong("timeLim")) {
             return new Long[] { mConf.getLong("timeLim"), (long) (mSched.getReps() - mStartReps) };
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -446,7 +446,7 @@ public class Sched extends SchedV2 {
                 // not collapsed; add some randomness
                 delay *= Utils.randomFloatInRange(1f, 1.25f);
             }
-            card.setDue((int) (getTime().now() + delay));
+            card.setDue(getTime().intTime() + delay);
 
             // due today?
             if (card.getDue() < mDayCutoff) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -382,7 +382,7 @@ public class Sched extends SchedV2 {
     @Override
     protected Card _getLrnCard(boolean collapse) {
         if (_fillLrn()) {
-            double cutoff = getTime().now();
+            long cutoff = getTime().intTime();
             if (collapse) {
                 cutoff += mCol.getConf().getInt("collapseTime");
             }
@@ -442,7 +442,7 @@ public class Sched extends SchedV2 {
                 }
             }
             int delay = _delayForGrade(conf, card.getLeft());
-            if (card.getDue() < getTime().now()) {
+            if (card.getDue() < getTime().intTime()) {
                 // not collapsed; add some randomness
                 delay *= Utils.randomFloatInRange(1f, 1.25f);
             }
@@ -778,7 +778,7 @@ public class Sched extends SchedV2 {
             card.setODue(card.getDue());
         }
         delay = _delayForGrade(conf, 0);
-        card.setDue((long) (delay + getTime().now()));
+        card.setDue(delay + getTime().intTime());
         card.setLeft(_startingLeft(card));
         // queue 1
         if (card.getDue() < mDayCutoff) {
@@ -1099,7 +1099,7 @@ public class Sched extends SchedV2 {
     protected void _updateCutoff() {
         Integer oldToday = mToday;
         // days since col created
-        mToday = (int) ((getTime().now() - mCol.getCrt()) / SECONDS_PER_DAY);
+        mToday = (int) ((getTime().intTime() - mCol.getCrt()) / SECONDS_PER_DAY);
         // end of day cutoff
         mDayCutoff = mCol.getCrt() + ((mToday + 1) * SECONDS_PER_DAY);
         if (oldToday != mToday) {
@@ -1236,7 +1236,7 @@ public class Sched extends SchedV2 {
         remFromDyn(cids);
         removeLrn(cids);
         mCol.getDb().execute("update cards set " + queueIsBuriedSnippet() + ",mod=?,usn=? where id in " + Utils.ids2str(cids),
-                getTime().now(), mCol.usn());
+                getTime().intTime(), mCol.usn());
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -1041,7 +1041,7 @@ public class SchedV2 extends AbstractSched {
     protected Card _getLrnCard(boolean collapse) {
         _maybeResetLrn(collapse && mLrnCount == 0);
         if (_fillLrn()) {
-            double cutoff = getTime().now();
+            long cutoff = getTime().intTime();
             if (collapse) {
                 cutoff += mCol.getConf().getInt("collapseTime");
             }
@@ -1057,7 +1057,7 @@ public class SchedV2 extends AbstractSched {
     protected boolean _preloadLrnCard(boolean collapse) {
         _maybeResetLrn(collapse && mLrnCount == 0);
         if (_fillLrn()) {
-            double cutoff = getTime().now();
+            long cutoff = getTime().intTime();
             if (collapse) {
                 cutoff += mCol.getConf().getInt("collapseTime");
             }
@@ -1397,7 +1397,7 @@ public class SchedV2 extends AbstractSched {
     protected void log(long id, int usn, @Consts.BUTTON_TYPE int ease, int ivl, int lastIvl, int factor, int timeTaken, @Consts.REVLOG_TYPE int type) {
         try {
             mCol.getDb().execute("INSERT INTO revlog VALUES (?,?,?,?,?,?,?,?,?)",
-                    getTime().now() * 1000, id, usn, ease, ivl, lastIvl, factor, timeTaken, type);
+                    getTime().intTime() * 1000, id, usn, ease, ivl, lastIvl, factor, timeTaken, type);
         } catch (SQLiteConstraintException e) {
             try {
                 Thread.sleep(10);
@@ -2198,7 +2198,7 @@ public class SchedV2 extends AbstractSched {
 
     public void _checkDay() {
         // check if the day has rolled over
-        if (getTime().now() > mDayCutoff) {
+        if (getTime().intTime() > mDayCutoff) {
             reset();
         }
     }
@@ -2463,7 +2463,7 @@ public class SchedV2 extends AbstractSched {
         int queue = manual ? Consts.QUEUE_TYPE_MANUALLY_BURIED : Consts.QUEUE_TYPE_SIBLING_BURIED;
         mCol.log(cids);
         mCol.getDb().execute("update cards set queue=?,mod=?,usn=? where id in " + Utils.ids2str(cids),
-                queue, getTime().now(), mCol.usn());
+                queue, getTime().intTime(), mCol.usn());
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/stats/AdvancedStatistics.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/stats/AdvancedStatistics.java
@@ -318,7 +318,7 @@ public class AdvancedStatistics {
 
         EaseClassifier classifier = new EaseClassifier(mCol.getTime(), mCol.getDb().getDatabase());
         ReviewSimulator reviewSimulator = new ReviewSimulator(mCol.getDb().getDatabase(), classifier, end, chunk);
-        TodayStats todayStats = new TodayStats(mCol.getDb().getDatabase(), Settings.getDayStartCutoff((int) mCol.getCrt()));
+        TodayStats todayStats = new TodayStats(mCol.getDb().getDatabase(), Settings.getDayStartCutoff(mCol.getCrt()));
 
         long t0 = mCol.getTime().intTimeMS();
         SimulationResult simulationResult = reviewSimulator.simNreviews(Settings.getToday((int)mCol.getCrt()), mCol.getDecks(), dids, todayStats);
@@ -1082,7 +1082,7 @@ public class AdvancedStatistics {
          * @param collectionCreatedTime The difference, measured in seconds, between midnight, January 1, 1970 UTC and the time at which the collection was created.
          * @return Today in days counted from the time at which the collection was created
          */
-        public int getToday(int collectionCreatedTime) {
+        public int getToday(long collectionCreatedTime) {
             Timber.d("Collection creation timestamp: " + collectionCreatedTime);
 
             long currentTime = mCol.getTime().intTime();
@@ -1095,7 +1095,7 @@ public class AdvancedStatistics {
          * @param collectionCreatedTime The difference, measured in seconds, between midnight, January 1, 1970 UTC and the time at which the collection was created.
          * @return The beginning of today in milliseconds counted from the time at which the collection was created
          */
-        public long getDayStartCutoff (int collectionCreatedTime) {
+        public long getDayStartCutoff (long collectionCreatedTime) {
             long today = getToday(collectionCreatedTime);
             return (collectionCreatedTime + (today * SECONDS_PER_DAY)) * 1000;
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/utils/SystemTime.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/utils/SystemTime.java
@@ -24,36 +24,7 @@ import java.util.GregorianCalendar;
 
 public class SystemTime extends Time {
     @Override
-    public Date getCurrentDate() {
-        return new Date();
-    }
-
-    @Override
-    /**The time in integer seconds. */
-    public long intTime() {
-        return System.currentTimeMillis() / 1000;
-    }
-
-    /**The time in integer seconds. */
-    public double now() {
-        return (System.currentTimeMillis() / 1000.0);
-    }
-
     public long intTimeMS() {
         return System.currentTimeMillis();
     }
-
-    @Override
-    public Calendar calendar() {
-        Calendar cal = Calendar.getInstance();
-        return cal;
-    }
-
-    @Override
-    public GregorianCalendar gregorianCalendar() {
-        GregorianCalendar cal = new GregorianCalendar();
-        return cal;
-    }
-
-
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/utils/Time.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/utils/Time.java
@@ -24,20 +24,32 @@ import java.util.GregorianCalendar;
 
 /** Allows injection of time dependencies */
 public abstract class Time {
-    public abstract Date getCurrentDate();
+
+    /** Date of this time */
+    public Date getCurrentDate() {
+        return new Date(intTimeMS());
+    }
+
     /**The time in integer seconds. */
-    public abstract long intTime();
-    /**The time in integer seconds. */
-    public abstract double now();
+    public long intTime() {
+        return intTimeMS() / 1000L;
+    };
+
+    /**The time in milisecond. */
+    public double now() {
+        return (double) intTimeMS();
+    }
 
     public abstract long intTimeMS();
 
+    /** Calendar for this date */
     public Calendar calendar() {
         Calendar cal = Calendar.getInstance();
         cal.setTime(getCurrentDate());
         return cal;
     }
 
+    /** Gregorian calendar for this date */
     public GregorianCalendar gregorianCalendar() {
         GregorianCalendar cal = new GregorianCalendar();
         cal.setTime(getCurrentDate());
@@ -55,7 +67,6 @@ public abstract class Time {
         return t;
     }
 
-
     /** Return the first safe ID to use. */
     public long maxID(DB db) {
         long now = intTimeMS();
@@ -63,5 +74,4 @@ public abstract class Time {
         now = Math.max(now, db.queryLongScalar("SELECT MAX(id) FROM notes"));
         return now + 1;
     }
-
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/utils/Time.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/utils/Time.java
@@ -35,11 +35,6 @@ public abstract class Time {
         return intTimeMS() / 1000L;
     };
 
-    /**The time in milisecond. */
-    public double now() {
-        return (double) intTimeMS();
-    }
-
     public abstract long intTimeMS();
 
     /** Calendar for this date */

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedTest.java
@@ -323,13 +323,13 @@ public class SchedTest extends RobolectricTest {
         assertEquals(3, c.getLeft() % 1000);
         assertEquals(3, c.getLeft() / 1000);
         // it should be due in 30 seconds
-        long t = Math.round(c.getDue() - col.getTime().now());
+        long t = Math.round(c.getDue() - col.getTime().intTime());
         assertThat(t, is(greaterThanOrEqualTo(25L)));
         assertThat(t, is(lessThanOrEqualTo(40L)));
         // pass it once
         col.getSched().answerCard(c, 2);
         // it should be due in 3 minutes
-        assertEquals(Math.round(c.getDue() - col.getTime().now()), 179, 1);
+        assertEquals(Math.round(c.getDue() - col.getTime().intTime()), 179, 1);
         assertEquals(2, c.getLeft() % 1000);
         assertEquals(2, c.getLeft() / 1000);
         // check log is accurate
@@ -341,7 +341,7 @@ public class SchedTest extends RobolectricTest {
         // pass again
         col.getSched().answerCard(c, 2);
         // it should be due in 10 minutes
-        assertEquals(c.getDue() - col.getTime().now(), 599, 1);
+        assertEquals(c.getDue() - col.getTime().intTime(), 599, 1);
         assertEquals(1, c.getLeft() % 1000);
         assertEquals(1, c.getLeft() / 1000);
         // the next pass should graduate the card

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.java
@@ -359,15 +359,15 @@ public class SchedV2Test extends RobolectricTest {
         assertEquals(3, c.getLeft() % 1000);
         assertEquals(3, c.getLeft() / 1000);
         // it should be due in 30 seconds
-        long t = Math.round(c.getDue() - col.getTime().now());
+        long t = Math.round(c.getDue() - col.getTime().intTime());
         assertThat(t, is(greaterThanOrEqualTo(25L)));
         assertThat(t, is(lessThanOrEqualTo(40L)));
         // pass it once
         col.getSched().answerCard(c, 3);
         // it should be due in 3 minutes
-        double dueIn = c.getDue() - col.getTime().now();
-        assertThat(dueIn, is(greaterThanOrEqualTo(178.d)));
-        assertThat(dueIn, is(lessThanOrEqualTo(180 * 1.25)));
+        long dueIn = c.getDue() - col.getTime().intTime();
+        assertThat(dueIn, is(greaterThanOrEqualTo(178L)));
+        assertThat(dueIn, is(lessThanOrEqualTo((long)(180 * 1.25))));
         assertEquals(2, c.getLeft() % 1000);
         assertEquals(2, c.getLeft() / 1000);
         // check log is accurate
@@ -379,9 +379,9 @@ public class SchedV2Test extends RobolectricTest {
         // pass again
         col.getSched().answerCard(c, 3);
         // it should be due in 10 minutes
-        dueIn = c.getDue() - col.getTime().now();
-        assertThat(dueIn, is(greaterThanOrEqualTo(599.d)));
-        assertThat(dueIn, is(lessThanOrEqualTo(600 * 1.25)));
+        dueIn = c.getDue() - col.getTime().intTime();
+        assertThat(dueIn, is(greaterThanOrEqualTo(599L)));
+        assertThat(dueIn, is(lessThanOrEqualTo((long)(600 * 1.25))));
         assertEquals(1, c.getLeft() % 1000);
         assertEquals(1, c.getLeft() / 1000);
         // the next pass should graduate the card
@@ -1614,10 +1614,10 @@ public class SchedV2Test extends RobolectricTest {
         Card c = col.getSched().getCard();
         col.getSched().answerCard(c, 2);
         // should be due in ~ 5.5 mins
-        double expected = col.getTime().now() + 5.5 * 60;
+        long expected = col.getTime().intTime() + (int)(5.5 * 60);
         long due = c.getDue();
-        assertThat(expected - 10, is(lessThan((double)due)));
-        assertThat((double)due, is(lessThanOrEqualTo(expected * 1.25)));
+        assertThat(expected - 10, is(lessThan(due)));
+        assertThat(due, is(lessThanOrEqualTo((long)(expected * 1.25))));
 
         long ivl = col.getDb().queryLongScalar("select ivl from revlog");
         assertEquals((long) (-5.5 * 60), ivl);

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/MockTime.java
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/MockTime.java
@@ -18,10 +18,6 @@ package com.ichi2.testutils;
 
 import com.ichi2.libanki.utils.Time;
 
-import java.util.Calendar;
-import java.util.Date;
-import java.util.GregorianCalendar;
-
 public class MockTime extends Time {
 
     /** Number of miliseconds between each call. */
@@ -40,37 +36,9 @@ public class MockTime extends Time {
         this.mStep = step;
     }
 
-
-    /** Date of this clock */
-    @Override
-    public Date getCurrentDate() {
-        return new Date(getCurrentTime());
-    }
-
-    /**These need confirmation */
-
-    /** Time in second since epoch.  */
-    @Override
-    public long intTime() {
-        return (long) now();
-    }
-
     /** Time in milisecond since epoch. */
     @Override
     public long intTimeMS() {
-        return getCurrentTime();
-    }
-
-
-    /** Time in second since epoch.  */
-    @Override
-    public double now() {
-        return (double) getCurrentTime() / 1000.0d;
-    }
-
-
-    /** Time in second since epoch. This is where step is added. */
-    private long getCurrentTime() {
         long mTime = this.mTime;
         this.mTime += mStep;
         return mTime;


### PR DESCRIPTION
This does a lot of related work together.

`now()` does not exists upstream. I remove it and replace it by `intTime`. I checked each line, there is not a single time where I see a reason to use a float. No multiplication that create number big enough that long can't represent them. And we would not want to add float in the database. Furthermore, in multiple case, we cast a number to (int). 

Crt is a time stamp, number of seconds since epoch. Should not be cast to an int (even if, with 32 bits, we should still be safe)

setDue was getting an int instead of a long in `_answerLrnCard`. On the one hand, it seems suspicious because it's the right function to consider to search for a bug related to reviewing a card in learning. On the other hand, for 32 bit ints, this should not actually have been a problem. This part of the code is here since 8 years, so I don't expect that if it was the cause of the bug, that it was discovered only recently and by multiple people simultaneously.
