### PR TITLE
Travis CI API27 disable / Robolectric jar pre download w/retry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ env:
    - API=24 LOCALE="zh_CN"
    - API=25 LOCALE="es_ES"
    #- API=26 # Fails with unrecognized tests? orchestrator change or something?
-   - API=27 LOCALE="fr_FR"
+   #- API=27 LOCALE="fr_FR" # API27 has become very flaky recently, disabling 2020/08/20
    - API=28 # API28 does not handle locale changes for some reason, so it is our default locale test
    - API=29 LOCALE="pt_BR"
    - API=30 EMU_FLAVOR=google_apis LOCALE="de_DE" # This will be API30 when released, until now it is R, with intermittent failure

--- a/.travis.yml
+++ b/.travis.yml
@@ -140,6 +140,7 @@ install:
 
 script:
   - travis_retry ./gradlew :AnkiDroid:compileReleaseJavaWithJavac compileLint # warm gradle w/travis_retry to handle network blips
+  - if [ "$UNIT_TEST" = "TRUE" ]; then travis_retry ./gradlew robolectricSdkDownload; fi # pre-download robolectric jars w/travis_retry to handle network blips
   - if [ "$UNIT_TEST" = "TRUE" ]; then ./gradlew jacocoUnitTestReport; fi
   - if [ "$LINT" != "FALSE" ]; then ./gradlew lint$LINT; fi
   - if [ "$API" != "NONE" ]; then ./gradlew jacocoAndroidTestReport; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,7 @@ before_install:
   # Set up JDK 8 for Android SDK - Java is universally needed: codacy, unit tests, emulators
   - travis_retry git clone --depth 1 $GRAVIS_REPO $GRAVIS
   - export TARGET_JDK="${JDK}"
-  - JDK="1.8"
+  - JDK="adopt@1.8"
   - source $GRAVIS/install-jdk
 
   # Set up Android SDK - this is needed everywhere but coverage finalization, so toggle on that
@@ -135,7 +135,7 @@ install:
   - if [ "$LOCALE" != "NONE" ]; then adb shell am broadcast -a com.android.intent.action.SET_LOCALE --es com.android.intent.extra.LOCALE "$LOCALE" com.android.customlocale2; fi
 
   # Switch back to our target JDK version to build and run tests
-  - JDK="${TARGET_JDK}"
+  - JDK="adopt@${TARGET_JDK}"
   - source $GRAVIS/install-jdk
 
 script:

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -200,6 +200,7 @@ tasks.withType(JavaCompile) {
     options.incremental = true
 }
 
+apply from: "./robolectricDownloader.gradle"
 apply from: "./jacoco.gradle"
 apply from: "../lint.gradle"
 

--- a/AnkiDroid/robolectricDownloader.gradle
+++ b/AnkiDroid/robolectricDownloader.gradle
@@ -1,0 +1,74 @@
+/**
+ * Downloads all android-all dependencies and copies them to the mavenLocal() repository
+ *
+ * Once applied to your gradle project, can be executed with ./gradlew robolectricSdkDownload
+ */
+
+import java.nio.file.Files
+
+// The general idea of this was borrowed from https://gist.github.com/xian/05c4f27da6d4156b9827842217c2cd5c
+// I then modified it heavily to allow easier addition of new SDK versions
+// The full implementation is from https://gist.github.com/simtel12/13ff3e57c37e78e468502b51ebb0f4f2
+
+// List from: https://github.com/robolectric/robolectric/blob/master/robolectric/src/main/java/org/robolectric/internal/SdkConfig.java
+// This list will need to be updated for new Android SDK versions that come out.
+// Only the versions currently used in AnkiDroid Robolectric tests are active, the rest are commented out
+def robolectricAndroidSdkVersions = [
+        [androidVersion: "4.1.2_r1", frameworkSdkBuildVersion: "r1"],
+        [androidVersion: "4.2.2_r1.2", frameworkSdkBuildVersion: "r1"],
+//        [androidVersion: "4.3_r2", frameworkSdkBuildVersion: "r1"],
+//        [androidVersion: "4.4_r1", frameworkSdkBuildVersion: "r2"],
+//        [androidVersion: "5.0.2_r3", frameworkSdkBuildVersion: "r0"],
+//        [androidVersion: "5.1.1_r9", frameworkSdkBuildVersion: "r2"],
+//        [androidVersion: "6.0.1_r3", frameworkSdkBuildVersion: "r1"],
+        [androidVersion: "7.0.0_r1", frameworkSdkBuildVersion: "r1"],
+//        [androidVersion: "7.1.0_r7", frameworkSdkBuildVersion: "r1"],
+        [androidVersion: "8.0.0_r4", frameworkSdkBuildVersion: "r1"],
+//        [androidVersion: "8.1.0", frameworkSdkBuildVersion: "4611349"],
+        [androidVersion: "9", frameworkSdkBuildVersion: "4913185-2"],
+]
+
+// Base, public task - will be displayed in ./gradlew robolectricDownloader:tasks
+task robolectricSdkDownload {
+    group = "Dependencies"
+    description = "Downloads all robolectric SDK dependencies into mavenLocal, for use with offline robolectric"
+}
+
+// Generate the configuration and actual copy tasks.
+robolectricAndroidSdkVersions.forEach { robolectricSdkVersion ->
+    def version = "${robolectricSdkVersion['androidVersion']}-robolectric-${robolectricSdkVersion['frameworkSdkBuildVersion']}"
+
+    // Creating a configuration with a dependency allows Gradle to manage the actual resolution of
+    // the jar file
+    def sdkConfig = configurations.create(version)
+    dependencies.add(version, "org.robolectric:android-all:${version}")
+
+    def mavenLocalFile = new File(this.repositories.mavenLocal().url)
+    def mavenRobolectric = new File(mavenLocalFile, "org/robolectric/android-all/${version}")
+    // Copying all files downloaded for the created configuration into maven local.
+    task "robolectricSdkDownload-${version}"(type: Copy) {
+        from sdkConfig
+        into mavenRobolectric
+
+        doLast {
+            ArtifactResolutionResult result = dependencies.createArtifactResolutionQuery()
+                .forModule("org.robolectric", "android-all", version)
+                .withArtifacts(MavenModule, MavenPomArtifact)
+                .execute()
+
+            for(component in result.resolvedComponents) {
+                def componentId = component.id
+
+                if(componentId instanceof ModuleComponentIdentifier) {
+                    File pomFile = component.getArtifacts(MavenPomArtifact)[0].file
+                    File dest = new File(mavenRobolectric, pomFile.name)
+                    if (!dest.exists()) {
+                        Files.copy(pomFile.toPath(), dest.toPath())
+                    }
+                }
+            }
+        }
+    }
+    robolectricSdkDownload.dependsOn "robolectricSdkDownload-${version}"
+}
+


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

The periodic CI-deflake PR

The API27 flakiness is semi-new and not expected. Has caused lots of false negatives in the last few days though.

The robolectric jar thing doesn't happen often but has happened since we started using robolectric, and just had some sort of network flare up this morning which reminded me about it

## Fixes


## Approach
Disables API27, so that won't be a problem.
Stole a robolectric SDK jar pre-downloader from a gist, it just stuffs them in the expected place if they were downloaded to begin with so should be pretty transparent except now it is a separate step so we may use travis_retry with it

## How Has This Been Tested?

Local testing during development, and now in Travis - the whole thing is tests...

## Learning (optional, can help others)
There is a robolectric gradle task in development which may supercede this when I researched best practices, but it's been in development for years so I didn't want to wait



## Checklist
_Please, go through these checks before submitting the PR._

- [ ] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
