### PR TITLE
BUGFIX: Filtered deck early due calculation

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -1809,9 +1809,9 @@ public class SchedV2 extends AbstractSched {
             // of the normal factor
             minNewIvl = factor / 2;
         } else if (ease == 3) {
-            factor = card.getFactor() / 1000;
+            factor = card.getFactor() / 1000.0;
         } else { // ease == 4
-            factor = card.getFactor() / 1000;
+            factor = card.getFactor() / 1000.0;
             double ease4 = conf.getDouble("ease4");
             // 1.3 -> 1.15
             easyBonus = ease4 - (ease4 - 1)/2;

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.java
@@ -988,8 +988,8 @@ public class SchedV2Test extends RobolectricTest {
         assertEquals(4, col.getSched().answerButtons(c));
         assertEquals(600, col.getSched().nextIvl(c, 1));
         assertEquals(Math.round(75 * 1.2) * 86400, col.getSched().nextIvl(c, 2));
-        assumeThat("Investigate this difference", col.getSched().nextIvl(c, 3), is(((long)(75 * 2.5)) * 86400));
-        assumeThat("Investigate this difference", col.getSched().nextIvl(c, 4), is(Math.round(75 * 2.5 * 1.15)));
+        assertThat(col.getSched().nextIvl(c, 3), is((long)(75 * 2.5) * 86400));
+        assertThat(col.getSched().nextIvl(c, 4), is((long)(75 * 2.5 * 1.15) * 86400));
 
         // answer 'good'
         col.getSched().answerCard(c, 3);


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
A user noted that there was a discrepancy between Anki Desktop and AnkiDroid filtered deck calculations.

## Fixes
Fixes #6899

## Approach
Use double division rather than int division

## How Has This Been Tested?

Via pre-existing unit tests

## Learning
We need to go through the test failures and determine the issues involved.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code