### PR TITLE
Fix representation of months to match Anki Desktop

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
@@ -87,14 +87,13 @@ public class Utils {
     private static final long TIME_HOUR_LONG = 60 * TIME_MINUTE_LONG;
     private static final long TIME_DAY_LONG = 24 * TIME_HOUR_LONG;
     // These are doubles on purpose because we want a rounded, not integer result later.
+    // Use values from Anki Desktop:
+    // https://github.com/ankitects/anki/blob/05cc47a5d3d48851267cda47f62af79f468eb028/rslib/src/sched/timespan.rs#L83
     private static final double TIME_MINUTE = 60.0;  // seconds
-    private static final double TIME_HOUR = 60 * TIME_MINUTE;
-    private static final double TIME_DAY = 24 * TIME_HOUR;
-    // How long is a year? This is a tropical year, according to NIST.
-    // http://www.physics.nist.gov/Pubs/SP811/appenB9.html
-    private static final double TIME_YEAR = 31556930.0;  // seconds
-    // Pretty much everybody agrees that one year is twelve months
-    private static final double TIME_MONTH = TIME_YEAR / 12.0;
+    private static final double TIME_HOUR = 60.0 * TIME_MINUTE;
+    private static final double TIME_DAY = 24.0 * TIME_HOUR;
+    private static final double TIME_MONTH = 30.0 * TIME_DAY;
+    private static final double TIME_YEAR = 12.0 * TIME_MONTH;
 
 
     // List of all extensions we accept as font files.

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/UtilsIntegrationTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/UtilsIntegrationTest.java
@@ -55,6 +55,20 @@ public class UtilsIntegrationTest extends RobolectricTest {
     }
 
 
+    @Test
+    @Config(qualifiers = "en")
+    public void timeQuantityMonths() {
+        // Anki Desktop 2.1.30: '\u206810.8\u2069 months'
+        assertThat(timeQuantityNextInterval(28080000), is("10.8 mo"));
+    }
+
+
+    @NotNull
+    private String timeQuantityNextInterval(@SuppressWarnings("SameParameterValue") int time_s) {
+        return Utils.timeQuantityNextIvl(getTargetContext(), time_s);
+    }
+
+
     @NotNull
     @CheckResult
     private String deckPickerTime(long time) {

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedTest.java
@@ -701,10 +701,8 @@ public class SchedTest extends RobolectricTest {
         assertEquals(21600000, col.getSched().nextIvl(c, 3));
         // (* 100 2.5 1.3 86400)28080000.0
         assertEquals(28080000, col.getSched().nextIvl(c, 4));
-        // TODO: upstream is 10.8, try to understand the difference
 
-        assumeThat(without_unicode_isolation(col.getSched().nextIvlStr(getTargetContext(), c, 4)), either(is("10.7 mo")).or(is("10.8 mo")));
-        assumeTrue("Investigate this difference: Anki displays 10.8, we display 10.7", false);
+        assertThat(without_unicode_isolation(col.getSched().nextIvlStr(getTargetContext(), c, 4)), is("10.8 mo"));
     }
 
 

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.java
@@ -856,9 +856,8 @@ public class SchedV2Test extends RobolectricTest {
         assertEquals(21600000, col.getSched().nextIvl(c, 3));
         // (* 100 2.5 1.3 86400)28080000.0
         assertEquals(28080000, col.getSched().nextIvl(c, 4));
-        // TODO: upstream is 10.8, try to understand the differencek
-        assumeThat(without_unicode_isolation(col.getSched().nextIvlStr(getTargetContext(), c, 4)), either(is("10.7 mo")).or(is("10.8 mo")));
-        assumeTrue("Investigate this difference: Anki displays 10.8, we display 10.7", false);
+
+        assertThat(without_unicode_isolation(col.getSched().nextIvlStr(getTargetContext(), c, 4)), is("10.8 mo"));
     }
 
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
We want more passing tests. This helps

## Fixes
Fixes two of the many checkboxes on #6751

## Approach
Fix values to match Rust: https://github.com/ankitects/anki/blob/05cc47a5d3d48851267cda47f62af79f468eb028/rslib/src/sched/timespan.rs#L83

## How Has This Been Tested?

Unit test now passes

## Learning (optional, can help others)
1 month is 30 days. Who woulda thunk it.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code