### PR TITLE
Add sched.getNewCount() for testing

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
@@ -253,6 +253,9 @@ public abstract class AbstractSched {
     @NonNull
     public abstract Time getTime();
 
+    @VisibleForTesting
+    public abstract int getNewCount();
+
 
     public interface LimitMethod {
         int operation(Deck g);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -142,6 +142,10 @@ public class SchedV2 extends AbstractSched {
     // Not in libAnki.
     protected final Time mTime;
 
+    // For testing
+    private boolean mPendingReset;
+
+
     /**
      * card types: 0=new, 1=lrn, 2=rev, 3=relrn
      * queue types: 0=new, 1=(re)lrn, 2=rev, 3=day (re)lrn,
@@ -208,6 +212,7 @@ public class SchedV2 extends AbstractSched {
 
     /** Ensures that reset is executed before the next card is selected */
     public void deferReset(Card undidCard){
+        mPendingReset = true;
         mHaveQueues = false;
         mHaveCounts = false;
         mCardToDecrement = undidCard;
@@ -222,6 +227,7 @@ public class SchedV2 extends AbstractSched {
         _updateCutoff();
         resetCounts(false);
         resetQueues(false);
+        mPendingReset = false;
     }
 
     @Override
@@ -3093,6 +3099,17 @@ public class SchedV2 extends AbstractSched {
     @Override
     public Time getTime() {
         return mTime;
+    }
+
+
+    @VisibleForTesting
+    @Override
+    public int getNewCount() {
+        // Emulate past Anki Dekstop behaviour - we'd now call reset() on getCard()
+        if (mPendingReset) {
+            reset();
+        }
+        return mNewCount;
     }
 
 

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedTest.java
@@ -201,7 +201,7 @@ public class SchedTest extends RobolectricTest {
         note.setItem("Back", "two");
         col.addNote(note);
         col.reset();
-        // assertEquals(1, col.getSched().newCount); get access of new count
+        assertEquals(1, col.getSched().getNewCount());
         // fetch it
         Card c = col.getSched().getCard();
         assertNotNull(c);
@@ -257,8 +257,7 @@ public class SchedTest extends RobolectricTest {
         long c2 = col.getDecks().confId("new conf");
         col.getDecks().setConf(col.getDecks().get(deck2), c2);
         col.reset();
-        // both confs have defaulted to a limit of 20
-        // assertEquals(20, col.getSched().newCount); TODO: newCount getter
+        assertEquals("both confs have defaulted to a limit of 20", 20, col.getSched().getNewCount());
         // first card we get comes from parent
         Card c = col.getSched().getCard();
         assertEquals(1, c.getDid());
@@ -267,13 +266,13 @@ public class SchedTest extends RobolectricTest {
         conf1.getJSONObject("new").put("perDay", 10);
         col.getDecks().save(conf1);
         col.reset();
-        //assertEquals(10, col.getSched().newCount);TODO: newCount getter
+        assertEquals(10, col.getSched().getNewCount());
         // if we limit child to 4, we should get 9
         DeckConfig conf2 = col.getDecks().confForDid(deck2);
         conf2.getJSONObject("new").put("perDay", 4);
         col.getDecks().save(conf2);
         col.reset();
-        //assertEquals(9, col.getSched().newCount);TODO: newCount getter
+        assertEquals(9, col.getSched().getNewCount());
     }
 
 

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.java
@@ -244,14 +244,14 @@ public class SchedV2Test extends RobolectricTest {
     public void test_new_v2() throws Exception {
         Collection col = getColV2();
         col.reset();
-        // assertEquals(0, col.getSched().newCount);TODO: newCount getter
+        assertEquals(0, col.getSched().getNewCount());
         // add a note
         Note note = col.newNote();
         note.setItem("Front", "one");
         note.setItem("Back", "two");
         col.addNote(note);
         col.reset();
-        // assertEquals(1, col.getSched().newCount);TODO: newCount getter
+        assertEquals(1, col.getSched().getNewCount());
         // fetch it
         Card c = col.getSched().getCard();
         assertNotNull(c);
@@ -307,7 +307,7 @@ public class SchedV2Test extends RobolectricTest {
         col.getDecks().setConf(col.getDecks().get(deck2), c2);
         col.reset();
         // both confs have defaulted to a limit of 20
-        // assertEquals(20, col.getSched().newCount);TODO: newCount getter
+        assertEquals(20, col.getSched().getNewCount());
         // first card we get comes from parent
         Card c = col.getSched().getCard();
         assertEquals(1, c.getDid());
@@ -316,13 +316,13 @@ public class SchedV2Test extends RobolectricTest {
         conf1.getJSONObject("new").put("perDay", 10);
         col.getDecks().save(conf1);
         col.reset();
-        // assertEquals(10, col.getSched().newCount);TODO: newCount getter
+        assertEquals(10, col.getSched().getNewCount());
         // if we limit child to 4, we should get 9
         DeckConfig conf2 = col.getDecks().confForDid(deck2);
         conf2.getJSONObject("new").put("perDay", 4);
         col.getDecks().save(conf2);
         col.reset();
-        //assertEquals(9, col.getSched().newCount);TODO: newCount getter
+        assertEquals(9, col.getSched().getNewCount());
     }
 
 


### PR DESCRIPTION
## Purpose / Description
Tests had todos - this allows us to green up more ported Anki Desktop tests and check off some tests as fully ported

For discussion: Is this the best way to go about it? We're testing internal state, which has changed, but I still feel there's value as the outcomes will be the same.

## Fixes
Improves #6751

## Approach
Implement the methods

## How Has This Been Tested?
It's pretty 100% test-only


## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code