### PR TITLE
Add sched.getNewCount() for testing

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedTest.java
@@ -201,7 +201,7 @@ public class SchedTest extends RobolectricTest {
         note.setItem("Back", "two");
         col.addNote(note);
         col.reset();
-        // assertEquals(1, col.getSched().newCount); get access of new count
+        assertEquals(1, col.getSched().counts()[0]);
         // fetch it
         Card c = col.getSched().getCard();
         assertNotNull(c);
@@ -258,7 +258,7 @@ public class SchedTest extends RobolectricTest {
         col.getDecks().setConf(col.getDecks().get(deck2), c2);
         col.reset();
         // both confs have defaulted to a limit of 20
-        // assertEquals(20, col.getSched().newCount); TODO: newCount getter
+        assertEquals("both confs have defaulted to a limit of 20", 20, col.getSched().counts()[0]);
         // first card we get comes from parent
         Card c = col.getSched().getCard();
         assertEquals(1, c.getDid());
@@ -267,13 +267,13 @@ public class SchedTest extends RobolectricTest {
         conf1.getJSONObject("new").put("perDay", 10);
         col.getDecks().save(conf1);
         col.reset();
-        //assertEquals(10, col.getSched().newCount);TODO: newCount getter
+        assertEquals(10, col.getSched().counts()[0]);
         // if we limit child to 4, we should get 9
         DeckConfig conf2 = col.getDecks().confForDid(deck2);
         conf2.getJSONObject("new").put("perDay", 4);
         col.getDecks().save(conf2);
         col.reset();
-        //assertEquals(9, col.getSched().newCount);TODO: newCount getter
+        assertEquals(9, col.getSched().counts()[0]);
     }
 
 

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.java
@@ -244,14 +244,14 @@ public class SchedV2Test extends RobolectricTest {
     public void test_new_v2() throws Exception {
         Collection col = getColV2();
         col.reset();
-        // assertEquals(0, col.getSched().newCount);TODO: newCount getter
+        assertEquals(0, col.getSched().counts()[0]);
         // add a note
         Note note = col.newNote();
         note.setItem("Front", "one");
         note.setItem("Back", "two");
         col.addNote(note);
         col.reset();
-        // assertEquals(1, col.getSched().newCount);TODO: newCount getter
+        assertEquals(1, col.getSched().counts()[0]);
         // fetch it
         Card c = col.getSched().getCard();
         assertNotNull(c);
@@ -307,7 +307,7 @@ public class SchedV2Test extends RobolectricTest {
         col.getDecks().setConf(col.getDecks().get(deck2), c2);
         col.reset();
         // both confs have defaulted to a limit of 20
-        // assertEquals(20, col.getSched().newCount);TODO: newCount getter
+        assertEquals(20, col.getSched().counts()[0]);
         // first card we get comes from parent
         Card c = col.getSched().getCard();
         assertEquals(1, c.getDid());
@@ -316,13 +316,13 @@ public class SchedV2Test extends RobolectricTest {
         conf1.getJSONObject("new").put("perDay", 10);
         col.getDecks().save(conf1);
         col.reset();
-        // assertEquals(10, col.getSched().newCount);TODO: newCount getter
+        assertEquals(10, col.getSched().counts()[0]);
         // if we limit child to 4, we should get 9
         DeckConfig conf2 = col.getDecks().confForDid(deck2);
         conf2.getJSONObject("new").put("perDay", 4);
         col.getDecks().save(conf2);
         col.reset();
-        //assertEquals(9, col.getSched().newCount);TODO: newCount getter
+        assertEquals(9, col.getSched().counts()[0]);
     }
 
 


### PR DESCRIPTION
My version of https://github.com/ankidroid/Anki-Android/pull/6934 

I believe and hope that it's considered simpler, since it introduce no new method. deferReset already deal with ressetting before giving numbers (it defer things, but should still be executed when needed)

I can't recall why I left those methods commented. My intuition is that I was not sure that it was okay to call `.counts()` since it may call `reset`. But since in all of those examples, `reset` is actually called by the test, that's allright.