### PR TITLE
NF: mocked time accessible from collection

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
@@ -28,6 +28,7 @@ import androidx.annotation.Nullable;
 import com.ichi2.anki.exception.StorageAccessException;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Storage;
+import com.ichi2.libanki.utils.Time;
 import com.ichi2.preferences.PreferenceExtensions;
 import com.ichi2.utils.FileUtil;
 
@@ -101,6 +102,9 @@ public class CollectionHelper {
      * @return instance of the Collection
      */
     public synchronized Collection getCol(Context context) {
+        return getCol(context, null);
+    }
+    public synchronized Collection getCol(Context context, Time time) {
         // Open collection
         if (!colIsOpen()) {
             String path = getCollectionPath(context);
@@ -114,7 +118,7 @@ public class CollectionHelper {
             }
             // Open the database
             Timber.i("Begin openCollection: %s", path);
-            mCollection = Storage.Collection(context, path, false, true);
+            mCollection = Storage.Collection(context, path, false, true, time);
             Timber.i("End openCollection: %s", path);
         }
         return mCollection;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Storage.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Storage.java
@@ -21,6 +21,7 @@ import android.content.Context;
 
 import com.ichi2.anki.exception.ConfirmModSchemaException;
 
+import com.ichi2.libanki.utils.Time;
 import com.ichi2.utils.JSONArray;
 import com.ichi2.utils.JSONException;
 import com.ichi2.utils.JSONObject;
@@ -43,6 +44,9 @@ public class Storage {
 
 
     public static Collection Collection(Context context, String path, boolean server, boolean log) {
+        return Collection(context, path, server, log, null);
+    }
+    public static Collection Collection(Context context, String path, boolean server, boolean log, Time time) {
         assert path.endsWith(".anki2");
         File dbFile = new File(path);
         boolean create = !dbFile.exists();
@@ -58,7 +62,7 @@ public class Storage {
             }
             db.execute("PRAGMA temp_store = memory");
             // add db to col and do any remaining upgrades
-            Collection col = new Collection(context, db, path, server, log);
+            Collection col = new Collection(context, db, path, server, log, time);
             if (ver < Consts.SCHEMA_VERSION) {
                 _upgrade(col, ver);
             } else if (ver > Consts.SCHEMA_VERSION) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
@@ -14,7 +14,6 @@ import com.ichi2.libanki.Consts;
 import com.ichi2.libanki.Deck;
 import com.ichi2.libanki.DeckConfig;
 import com.ichi2.libanki.Collection;
-import com.ichi2.libanki.utils.Time;
 
 import java.lang.ref.WeakReference;
 import java.util.List;
@@ -274,13 +273,6 @@ public abstract class AbstractSched {
      * @param wasLeech Whether the card was a leech before the review was made (if false, remove the leech tag)
      * */
     public abstract void undoReview(@NonNull Card card, boolean wasLeech);
-
-
-    /**
-     * @return The current time dependency that the scheduler is using (used for Unit Testing).
-     */
-    @NonNull
-    public abstract Time getTime();
 
 
     public interface LimitMethod {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -84,11 +84,6 @@ public class Sched extends SchedV2 {
         super(col);
     }
 
-    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    public Sched(@NonNull Collection col, @NonNull Time time) {
-        super(col, time);
-    }
-
     @Override
     public void answerCard(Card card, @Consts.BUTTON_TYPE int ease) {
         mCol.log();

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -140,9 +140,6 @@ public class SchedV2 extends AbstractSched {
      * current card nor a sibling.
      */
 
-    // Not in libAnki.
-    protected final Time mTime;
-
     /**
      * card types: 0=new, 1=lrn, 2=rev, 3=relrn
      * queue types: 0=new, 1=(re)lrn, 2=rev, 3=day (re)lrn,
@@ -152,17 +149,8 @@ public class SchedV2 extends AbstractSched {
      * odue/odid store original due/did when cards moved to filtered deck
      *
      */
-
     public SchedV2(Collection col) {
-        this(col, new SystemTime());
-    }
-
-    /** we need a constructor as the constructor performs work
-     * involving the dependency, so we can't use setter injection */
-    @VisibleForTesting
-    public SchedV2(Collection col, Time time) {
         super();
-        this.mTime = time;
         mCol = col;
         mQueueLimit = 50;
         mReportLimit = 99999;
@@ -3090,9 +3078,8 @@ public class SchedV2 extends AbstractSched {
 
 
     @NonNull
-    @Override
     public Time getTime() {
-        return mTime;
+        return mCol.getTime();
     }
 
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
@@ -36,6 +36,7 @@ import com.ichi2.libanki.Note;
 import com.ichi2.libanki.sched.AbstractSched;
 import com.ichi2.libanki.sched.Sched;
 import com.ichi2.libanki.sched.SchedV2;
+import com.ichi2.testutils.MockTime;
 import com.ichi2.utils.JSONException;
 import com.ichi2.utils.JSONObject;
 
@@ -168,7 +169,10 @@ public class RobolectricTest {
 
 
     protected Collection getCol() {
-        return CollectionHelper.getInstance().getCol(getTargetContext());
+        // 2020/08/07, 07:00:00. Normally not near day cutoff.
+        MockTime time = new MockTime(1596783600000L, 10);
+        Collection col = CollectionHelper.getInstance().getCol(getTargetContext(), time);
+        return col;
     }
 
     /** Call this method in your test if you to test behavior with a null collection */

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.java
@@ -144,7 +144,7 @@ public class SchedV2Test extends RobolectricTest {
         c.setDid(dynId);
         c.flush();
 
-        SchedV2 v2 = new SchedV2(getCol(), new MockTime(1587928085001L));
+        SchedV2 v2 = new SchedV2(getCol());
 
         Card schedCard = v2.getCard();
         assertThat(schedCard, Matchers.notNullValue());
@@ -206,14 +206,8 @@ public class SchedV2Test extends RobolectricTest {
 
     public Collection getColV2() throws Exception {
         Collection col = getCol();
-        changeSchedulerVer(col, 2);
+        col.changeSchedulerVer(2);
         return col;
-    }
-
-    private void changeSchedulerVer(Collection col, int ver) throws ConfirmModSchemaException {
-        col.changeSchedulerVer(ver);
-        col.setCrt(1596540138L);
-        col.replaceSchedulerForTests(mTime);
     }
 
     private double now() {
@@ -1514,7 +1508,7 @@ public class SchedV2Test extends RobolectricTest {
     @Test
     public void test_moveVersions() throws Exception {
         Collection col = getColV2();
-        changeSchedulerVer(col, 1);
+        col.changeSchedulerVer( 1);
 
         Note n = col.newNote();
         n.setItem("Front", "one");
@@ -1526,7 +1520,7 @@ public class SchedV2Test extends RobolectricTest {
         col.getSched().answerCard(c, 1);
 
         // the move to v2 should reset it to new
-        changeSchedulerVer(col, 2);
+        col.changeSchedulerVer( 2);
         c.load();
         assertEquals(QUEUE_TYPE_NEW, c.getQueue());
         assertEquals(CARD_TYPE_NEW, c.getType());
@@ -1540,7 +1534,7 @@ public class SchedV2Test extends RobolectricTest {
         assertEquals(QUEUE_TYPE_MANUALLY_BURIED, c.getQueue());
 
         // revert to version 1
-        changeSchedulerVer(col, 1);
+        col.changeSchedulerVer(1);
 
         // card should have moved queues
         c.load();
@@ -1553,7 +1547,7 @@ public class SchedV2Test extends RobolectricTest {
         assertEquals(QUEUE_TYPE_NEW, c.getType());
 
         // make sure relearning cards transition correctly to v1
-        changeSchedulerVer(col, 2);
+        col.changeSchedulerVer(2);
         // card with 100 day interval, answering again
         col.getSched().reschedCards(new long[] {c.getId()}, 100, 100);
         c.load();
@@ -1566,7 +1560,7 @@ public class SchedV2Test extends RobolectricTest {
         c = col.getSched().getCard();
         col.getSched().answerCard(c, 1);
         // due should be correctly set when removed from learning early
-        changeSchedulerVer(col, 1);
+        col.changeSchedulerVer( 1);
         c.load();
         assertEquals(50, c.getDue());
     }


### PR DESCRIPTION
This is a part of #6942 which ensures that time is saved in collection. This way, in the big commit/future commit, mocked time can be accessed everywhere, such as to create ids.