### PR TITLE
Bug: Undo and card in learning.

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.java
@@ -793,7 +793,7 @@ public class ContentProviderTest extends InstrumentedTest {
 
         Card nextCard = null;
         for(int i = 0; i < 10; i++) {//minimizing fails, when sched.reset() randomly chooses between multiple cards
-            sched.reset();
+            col.reset();
             nextCard = sched.getCard();
             if(nextCard.note().getId() == noteID && nextCard.getOrd() == cardOrd)break;
         }
@@ -829,7 +829,7 @@ public class ContentProviderTest extends InstrumentedTest {
             col.getDecks().select(deckToTest);
             Card nextCard = null;
             for(int i = 0; i < 10; i++) {//minimizing fails, when sched.reset() randomly chooses between multiple cards
-                sched.reset();
+                col.reset();
                 nextCard = sched.getCard();
                 if(nextCard.note().getId() == noteID && nextCard.getOrd() == cardOrd)break;
             }
@@ -861,7 +861,7 @@ public class ContentProviderTest extends InstrumentedTest {
     private Card getFirstCardFromScheduler(Collection col) {
         long deckId = mTestDeckIds.get(0);
         col.getDecks().select(deckId);
-        col.getSched().reset();
+        col.reset();
         return col.getSched().getCard();
     }
     /**
@@ -891,7 +891,7 @@ public class ContentProviderTest extends InstrumentedTest {
         int updateCount = cr.update(reviewInfoUri, values, null, null);
         assertEquals("Check if update returns 1", 1, updateCount);
         try { Thread.currentThread().wait(500); } catch (Exception e) {/* do nothing */}
-        col.getSched().reset();
+        col.reset();
         Card newCard = col.getSched().getCard();
         if(newCard != null){
             if(newCard.note().getId() == card.note().getId() && newCard.getOrd() == card.getOrd()){
@@ -994,7 +994,7 @@ public class ContentProviderTest extends InstrumentedTest {
         // --------------------------------------
 
         col.getSched().unsuspendCards(new long[]{cardId});
-        col.getSched().reset();
+        col.reset();
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -1167,7 +1167,6 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
             newCard.startTimer();
             col.reset();
             sched.deferReset(newCard);
-            sched.setCurrentCard(newCard);
         }
         return newCard;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
@@ -44,7 +44,6 @@ public abstract class AbstractSched {
      */
     public abstract void preloadNextCard();
     public abstract void resetCounts();
-    public abstract void resetQueues();
     /** Ensures that reset is executed before the next card is selected */
     public abstract void deferReset();
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
@@ -37,7 +37,7 @@ public abstract class AbstractSched {
      * The collection saves some numbers such as counts, queues of cards to review, queues of decks potentially having some cards.
      * Reset all of this and compute from scratch. This occurs because anything else than the sequence of getCard/answerCard did occur.
      */
-    public abstract void reset();
+    protected abstract void reset();
 
     public abstract void _updateCutoff();
     /** Ensure that the question on the potential next card can be accessed quickly.

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -207,7 +207,7 @@ public class SchedV2 extends AbstractSched {
         deferReset(null);
     }
 
-    public void reset() {
+    protected void reset() {
         _updateCutoff();
         resetCounts(false);
         resetQueues(false);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -3126,7 +3126,7 @@ public class SchedV2 extends AbstractSched {
         mNewQueue.remove(card.getId());
     }
 
-    protected boolean currentCardIsInQueueWithDeck(int queue, long did) {
+    protected boolean currentCardIsInQueueWithDeck(@Consts.CARD_QUEUE int queue, long did) {
         // mCurrentCard may be set to null when the reviewer gets closed. So we copy it to be sure to avoid NullPointerException
         Card currentCard = mCurrentCard;
         List<Long> currentCardParentsDid = mCurrentCardParentsDid;

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/DecksTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/DecksTest.java
@@ -100,7 +100,7 @@ public class DecksTest extends RobolectricTest {
         assertEqualsArrayList(new Long[] {parentId}, col.getDecks().active());
         // let's create a child
         long childId = col.getDecks().id("new deck::child");
-        col.getSched().reset();
+        col.reset();
         // it should have been added to the active list
         assertEquals(parentId, col.getDecks().selected());
         assertEqualsArrayList(new Long[] {parentId, childId}, col.getDecks().active());

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/AbstractSchedTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/AbstractSchedTest.java
@@ -125,30 +125,10 @@ public class AbstractSchedTest extends RobolectricTest {
         assertThat(sched.counts(card)[0], is(10));
         sched.answerCard(card, 3);
         sched.getCard();
-        final boolean[] executed = {false};
-        CollectionTask.launchCollectionTask(UNDO,
-                new TaskListener() {
-                    Card card;
-                    @Override
-                    public void onPreExecute() {
-
-                    }
-
-                    @Override
-                    public void onProgressUpdate(TaskData data) {
-                        card = data.getCard();
-                    }
-
-
-                    @Override
-                    public void onPostExecute(TaskData result) {
-                        assertThat(sched.newCount(), is(9));
-                        assertThat(sched.counts(card)[0], is(10));
-                        executed[0] = true;
-                    }
-                });
-        waitForAsyncTasksToComplete();
-        assertTrue(executed[0]);
+        nonTaskUndo(col);
+        card.load();
+        assertThat(sched.newCount(), is(9));
+        assertThat(sched.counts(card)[0], is(10));
     }
 
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/AbstractSchedTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/AbstractSchedTest.java
@@ -126,7 +126,7 @@ public class AbstractSchedTest extends RobolectricTest {
         Card card = sched.getCard();
         assertThat(sched.newCount(), is(9));
         assertThat(sched.counts(card)[0], is(10));
-        sched.answerCard(card, 3);
+        sched.answerCard(card, sched.getGoodNewButton());
         sched.getCard();
         nonTaskUndo(col);
         card.load();

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/AbstractSchedTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/AbstractSchedTest.java
@@ -86,8 +86,9 @@ public class AbstractSchedTest extends RobolectricTest {
         // #6587
         addNoteUsingBasicModel("Hello", "World");
 
-        AbstractSched sched = getCol().getSched();
-        sched.reset();
+        Collection col = getCol();
+        AbstractSched sched = col.getSched();
+        col.reset();
 
         Card cardBeforeUndo = sched.getCard();
         int[] countsBeforeUndo = sched.counts();
@@ -117,7 +118,7 @@ public class AbstractSchedTest extends RobolectricTest {
             note.setField(0, "a");
             col.addNote(note);
         }
-        sched.reset();
+        col.reset();
         assertThat(col.cardCount(), is(20));
         assertThat(sched.newCount(), is(10));
         Card card = sched.getCard();
@@ -173,7 +174,7 @@ public class AbstractSchedTest extends RobolectricTest {
             Note note  = addNoteUsingBasicAndReversedModel("front", "back");
             notes[i] = note;
         }
-        sched.reset();
+        col.reset();
 
         for (int i = 0; i < nbNote; i++) {
             Card card = sched.getCard();
@@ -225,7 +226,8 @@ public class AbstractSchedTest extends RobolectricTest {
         }
 
         public void test() {
-            Models models = getCol().getModels();
+            Collection col = getCol();
+            Models models = col.getModels();
 
             DeckConfig dconf = decks.getConf(1);
             dconf.getJSONObject("new").put("perDay", 0);
@@ -248,7 +250,7 @@ public class AbstractSchedTest extends RobolectricTest {
             increaseAndAssertNewCountsIs("Adding a review in D add it in its parents too", dId, 5, 5, 3, 4);
 
             decks.select(cId);
-            sched.reset();
+            col.reset();
             for (int i = 0; i < 3; i++) {
                 Card card = sched.getCard();
                 sched.answerCard(card, sched.answerButtons(card));

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/AbstractSchedTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/AbstractSchedTest.java
@@ -46,6 +46,7 @@ import timber.log.Timber;
 
 import static com.ichi2.anki.AbstractFlashcardViewer.EASE_3;
 import static com.ichi2.async.CollectionTask.TASK_TYPE.*;
+import static com.ichi2.async.CollectionTask.nonTaskUndo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedTest.java
@@ -49,6 +49,7 @@ import static com.ichi2.libanki.Consts.CARD_TYPE_LRN;
 import static com.ichi2.libanki.Consts.CARD_TYPE_NEW;
 import static com.ichi2.libanki.Consts.CARD_TYPE_RELEARNING;
 import static com.ichi2.libanki.Consts.CARD_TYPE_REV;
+import static com.ichi2.libanki.Consts.QUEUE_TYPE_DAY_LEARN_RELEARN;
 import static com.ichi2.libanki.Consts.QUEUE_TYPE_LRN;
 import static com.ichi2.libanki.Consts.QUEUE_TYPE_NEW;
 import static com.ichi2.libanki.Consts.QUEUE_TYPE_REV;
@@ -435,7 +436,7 @@ public class SchedTest extends RobolectricTest {
         // answering it will place it in queue 3
         col.getSched().answerCard(c, 2);
         assertEquals(col.getSched().getToday() + 1, c.getDue());
-        assertEquals(CARD_TYPE_RELEARNING, c.getQueue());
+        assertEquals(QUEUE_TYPE_DAY_LEARN_RELEARN, c.getQueue());
         assertNull(col.getSched().getCard());
         // for testing, move it back a day
         c.setDue(c.getDue() - 1);

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedTest.java
@@ -146,7 +146,7 @@ public class SchedTest extends RobolectricTest {
 
     private Card getCardInDefaultDeck(Sched s) {
         selectDefaultDeck();
-        s.reset();
+        s.deferReset();
         return s.getCard();
     }
 
@@ -418,7 +418,7 @@ public class SchedTest extends RobolectricTest {
         Note note = col.newNote();
         note.setItem("Front", "one");
         col.addNote(note);
-        col.getSched().reset();
+        col.reset();
         Card c = col.getSched().getCard();
         DeckConfig conf = col.getSched()._cardConf(c);
         conf.getJSONObject("new").put("delays", new JSONArray(new double[] {1, 10, 1440, 2880}));

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.java
@@ -497,7 +497,7 @@ public class SchedV2Test extends RobolectricTest {
         Note note = col.newNote();
         note.setItem("Front", "one");
         col.addNote(note);
-        col.getSched().reset();
+        col.reset();
         Card c = col.getSched().getCard();
         DeckConfig conf = col.getSched()._cardConf(c);
         conf.getJSONObject("new").put("delays", new JSONArray(new double[] {1, 10, 1440, 2880}));
@@ -682,7 +682,7 @@ public class SchedV2Test extends RobolectricTest {
 
         // .counts() should match
         col.getDecks().select(child.getLong("id"));
-        col.getSched().reset();
+        col.reset();
         assertArrayEquals(new int[] {0, 0, 5}, col.getSched().counts());
 
         // answering a card in the child should decrement parent count
@@ -1555,7 +1555,7 @@ public class SchedV2Test extends RobolectricTest {
         DeckConfig conf = col.getSched()._cardConf(c);
         conf.getJSONObject("lapse").put("mult", 0.5);
         col.getDecks().save(conf);
-        col.getSched().reset();
+        col.reset();
         c = col.getSched().getCard();
         col.getSched().answerCard(c, 1);
         c.load();


### PR DESCRIPTION
There are multiple things here.

I split undo in two, so that I get access to the actual background part without creating a background task nad having to deal with UI part. This is useful to entirely tests undo, since there are some parts of undo not done in col.undo.

Then, I add a test that bugs and should not bug. Thanks to David for explaining how to create it. Because of it, a card undone which becomes a learning card is not added to the learning queue. The problem is that `mCardNotToFetch` was not set to null even when it is not relevant anymore.

This was relevant for prefetching a card. Except that I forgot to tell the `preLoadCard` method to reset counts and queues if required, which made the method useless after a reset. (Actually, in the first version, preLoadCard was calling `getCard` so this would have been totally useless. But I did change for a version dealing with a queue of card and forgot to update this part...)

For safety, I also ensured that `getCard` set the two variables to null. This should be NF for reviewer. Maybe not NF for the content provider.

I should note it's not related to 2.12.1 bugs since those were introduce in alphas.


