### PR TITLE
More prominent reviewer buttons feedback

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -51,8 +51,6 @@ import androidx.core.net.ConnectivityManagerCompat;
 import androidx.core.view.GestureDetectorCompat;
 import androidx.appcompat.app.ActionBar;
 import android.text.SpannableString;
-import android.text.Spanned;
-import android.text.SpannedString;
 import android.text.TextUtils;
 import android.text.style.UnderlineSpan;
 import android.util.TypedValue;
@@ -218,6 +216,8 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
 
     private boolean isInFullscreen;
 
+    protected boolean mDisableAnimations = false;
+
     /**
      * Broadcast that informs us when the sd card is about to be unmounted
      */
@@ -237,6 +237,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
     private boolean mDoubleScrolling;
     private boolean mScrollingButtons;
     private boolean mGesturesEnabled;
+    private boolean mSafeDisplay;
     // Android WebView
     protected boolean mSpeakText;
     protected boolean mDisableClipboard = false;
@@ -254,6 +255,9 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
     protected int mOptWaitQuestionSecond;
 
     protected boolean mUseInputTag;
+
+    // Default short animation duration, provided by Android framework
+    private int mShortAnimDuration;
 
     // Preferences from the collection
     private boolean mShowNextReviewTime;
@@ -295,6 +299,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
     protected TextView mEase3;
     protected TextView mEase4;
     protected LinearLayout mFlipCardLayout;
+    protected LinearLayout mEaseButtonsLayout;
     protected LinearLayout mEase1Layout;
     protected LinearLayout mEase2Layout;
     protected LinearLayout mEase3Layout;
@@ -879,6 +884,8 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
 
         View mainView = findViewById(android.R.id.content);
         initNavigationDrawer(mainView);
+
+        mShortAnimDuration = getResources().getInteger(android.R.integer.config_shortAnimTime);
     }
 
     protected int getContentViewAttr(int fullscreenMode) {
@@ -1434,34 +1441,28 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         mGestureDetectorImpl = mLinkOverridesTouchGesture ? new LinkDetectingGestureDetector() : new MyGestureDetector();
         gestureDetector = new GestureDetectorCompat(this, mGestureDetectorImpl);
 
-        mEase1 = (TextView) findViewById(R.id.ease1);
-        mEase1.setTypeface(TypefaceHelper.get(this, "Roboto-Medium"));
-        mEase1Layout = (LinearLayout) findViewById(R.id.flashcard_layout_ease1);
+        mEaseButtonsLayout = findViewById(R.id.ease_buttons);
+
+        mEase1 = findViewById(R.id.ease1);
+        mEase1Layout = findViewById(R.id.flashcard_layout_ease1);
         mEase1Layout.setOnClickListener(mSelectEaseHandler);
 
-        mEase2 = (TextView) findViewById(R.id.ease2);
-        mEase2.setTypeface(TypefaceHelper.get(this, "Roboto-Medium"));
-        mEase2Layout = (LinearLayout) findViewById(R.id.flashcard_layout_ease2);
+        mEase2 = findViewById(R.id.ease2);
+        mEase2Layout = findViewById(R.id.flashcard_layout_ease2);
         mEase2Layout.setOnClickListener(mSelectEaseHandler);
 
-        mEase3 = (TextView) findViewById(R.id.ease3);
-        mEase3.setTypeface(TypefaceHelper.get(this, "Roboto-Medium"));
-        mEase3Layout = (LinearLayout) findViewById(R.id.flashcard_layout_ease3);
+        mEase3 = findViewById(R.id.ease3);
+        mEase3Layout = findViewById(R.id.flashcard_layout_ease3);
         mEase3Layout.setOnClickListener(mSelectEaseHandler);
 
-        mEase4 = (TextView) findViewById(R.id.ease4);
-        mEase4.setTypeface(TypefaceHelper.get(this, "Roboto-Medium"));
-        mEase4Layout = (LinearLayout) findViewById(R.id.flashcard_layout_ease4);
+        mEase4 = findViewById(R.id.ease4);
+        mEase4Layout = findViewById(R.id.flashcard_layout_ease4);
         mEase4Layout.setOnClickListener(mSelectEaseHandler);
 
-        mNext1 = (TextView) findViewById(R.id.nextTime1);
-        mNext2 = (TextView) findViewById(R.id.nextTime2);
-        mNext3 = (TextView) findViewById(R.id.nextTime3);
-        mNext4 = (TextView) findViewById(R.id.nextTime4);
-        mNext1.setTypeface(TypefaceHelper.get(this, "Roboto-Regular"));
-        mNext2.setTypeface(TypefaceHelper.get(this, "Roboto-Regular"));
-        mNext3.setTypeface(TypefaceHelper.get(this, "Roboto-Regular"));
-        mNext4.setTypeface(TypefaceHelper.get(this, "Roboto-Regular"));
+        mNext1 = findViewById(R.id.nextTime1);
+        mNext2 = findViewById(R.id.nextTime2);
+        mNext3 = findViewById(R.id.nextTime3);
+        mNext4 = findViewById(R.id.nextTime4);
 
         if (!mShowNextReviewTime) {
             mNext1.setVisibility(View.GONE);
@@ -1641,21 +1642,43 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
     }
 
     protected void displayAnswerBottomBar() {
-        // hide flipcard button
-        mFlipCardLayout.setVisibility(View.GONE);
+        mEaseButtonsLayout.setVisibility(View.VISIBLE);
+
+        Runnable after = () -> mFlipCardLayout.setVisibility(View.GONE);
+
+        // hide "Show Answer" button
+        if (mSafeDisplay || mDisableAnimations) {
+            after.run();
+        } else {
+            mEaseButtonsLayout.setAlpha(0);
+            mEaseButtonsLayout.animate().alpha(1).setDuration(mShortAnimDuration).withEndAction(after);
+        }
     }
 
 
     protected void hideEaseButtons() {
-        mEase1Layout.setVisibility(View.GONE);
-        mEase2Layout.setVisibility(View.GONE);
-        mEase3Layout.setVisibility(View.GONE);
-        mEase4Layout.setVisibility(View.GONE);
+        Runnable after = () -> {
+            mEaseButtonsLayout.setVisibility(View.GONE);
+            mEase1Layout.setVisibility(View.GONE);
+            mEase2Layout.setVisibility(View.GONE);
+            mEase3Layout.setVisibility(View.GONE);
+            mEase4Layout.setVisibility(View.GONE);
+            mNext1.setText("");
+            mNext2.setText("");
+            mNext3.setText("");
+            mNext4.setText("");
+        };
+
+        boolean easeButtonsVisible = mEaseButtonsLayout.getVisibility() == View.VISIBLE;
         mFlipCardLayout.setVisibility(View.VISIBLE);
-        mNext1.setText("");
-        mNext2.setText("");
-        mNext3.setText("");
-        mNext4.setText("");
+
+        if (mSafeDisplay || mDisableAnimations || !easeButtonsVisible) {
+            after.run();
+        } else {
+            mEaseButtonsLayout.setAlpha(1);
+            mEaseButtonsLayout.animate().alpha(0).setDuration(mShortAnimDuration).withEndAction(after);
+        }
+
         focusAnswerCompletionField();
     }
 
@@ -1740,6 +1763,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         mScrollingButtons = preferences.getBoolean("scrolling_buttons", false);
         mDoubleScrolling = preferences.getBoolean("double_scrolling", false);
         mPrefShowTopbar = preferences.getBoolean("showTopbar", true);
+        mSafeDisplay = preferences.getBoolean("safeDisplay", false);
 
         mGesturesEnabled = AnkiDroidApp.initiateGestures(preferences);
         mLinkOverridesTouchGesture = preferences.getBoolean("linkOverridesTouchGesture", false);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.java
@@ -41,6 +41,8 @@ public class Previewer extends AbstractFlashcardViewer {
         Timber.d("onCreate()");
         super.onCreate(savedInstanceState);
 
+        mDisableAnimations = true;
+
         mCardList = getIntent().getLongArrayExtra("cardList");
         mIndex = getIntent().getIntExtra("index", -1);
 
@@ -162,6 +164,7 @@ public class Previewer extends AbstractFlashcardViewer {
         }
 
         mFlipCardLayout.setVisibility(View.GONE);
+        mEaseButtonsLayout.setVisibility(View.VISIBLE);
         mEase1Layout.setVisibility(View.VISIBLE);
         mEase2Layout.setVisibility(View.VISIBLE);
         mEase3Layout.setVisibility(View.GONE);

--- a/AnkiDroid/src/main/res/drawable-v21/footer_button_again.xml
+++ b/AnkiDroid/src/main/res/drawable-v21/footer_button_again.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="?answerButtonsHighlightColor">
+    <item android:id="@android:id/mask">
+        <shape android:shape="rectangle" >
+            <solid android:color="@color/material_red_700" />
+        </shape>
+    </item>
+    <item
+        android:id="@android:id/background"
+        android:drawable="@color/material_red_700" />
+</ripple>

--- a/AnkiDroid/src/main/res/drawable-v21/footer_button_again_dark.xml
+++ b/AnkiDroid/src/main/res/drawable-v21/footer_button_again_dark.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="?answerButtonsHighlightColor">
+    <item android:id="@android:id/mask">
+        <shape android:shape="rectangle" >
+            <solid android:color="@color/material_red_800" />
+        </shape>
+    </item>
+    <item
+        android:id="@android:id/background"
+        android:drawable="@color/material_red_800" />
+</ripple>

--- a/AnkiDroid/src/main/res/drawable-v21/footer_button_all_black.xml
+++ b/AnkiDroid/src/main/res/drawable-v21/footer_button_all_black.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="?answerButtonsHighlightColor">
+    <item android:id="@android:id/mask">
+        <shape android:shape="rectangle" >
+            <solid android:color="#000000" />
+        </shape>
+    </item>
+    <item android:id="@android:id/background">
+        <shape android:shape="rectangle" >
+            <solid android:color="#000000" />
+            <stroke android:width=".2dp" android:color="#505050"/>
+        </shape>
+    </item>
+</ripple>

--- a/AnkiDroid/src/main/res/drawable-v21/footer_button_all_plain.xml
+++ b/AnkiDroid/src/main/res/drawable-v21/footer_button_all_plain.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="?answerButtonsHighlightColor">
+    <item android:id="@android:id/mask">
+        <shape android:shape="rectangle" >
+            <solid android:color="#9E9E9E" />
+        </shape>
+    </item>
+    <item android:id="@android:id/background">
+        <shape android:shape="rectangle" >
+            <solid android:color="#9E9E9E" />
+            <stroke android:width=".2dp" android:color="#F5F5F5"/>
+        </shape>
+    </item>
+</ripple>

--- a/AnkiDroid/src/main/res/drawable-v21/footer_button_easy.xml
+++ b/AnkiDroid/src/main/res/drawable-v21/footer_button_easy.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="?answerButtonsHighlightColor">
+    <item android:id="@android:id/mask">
+        <shape android:shape="rectangle" >
+            <solid android:color="@color/material_light_blue_500" />
+        </shape>
+    </item>
+    <item
+        android:id="@android:id/background"
+        android:drawable="@color/material_light_blue_500" />
+</ripple>

--- a/AnkiDroid/src/main/res/drawable-v21/footer_button_easy_dark.xml
+++ b/AnkiDroid/src/main/res/drawable-v21/footer_button_easy_dark.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="?answerButtonsHighlightColor">
+    <item android:id="@android:id/mask">
+        <shape android:shape="rectangle" >
+            <solid android:color="@color/material_light_blue_800" />
+        </shape>
+    </item>
+    <item
+        android:id="@android:id/background"
+        android:drawable="@color/material_light_blue_800" />
+</ripple>

--- a/AnkiDroid/src/main/res/drawable-v21/footer_button_good.xml
+++ b/AnkiDroid/src/main/res/drawable-v21/footer_button_good.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="?answerButtonsHighlightColor">
+    <item android:id="@android:id/mask">
+        <shape android:shape="rectangle" >
+            <solid android:color="@color/material_green_500" />
+        </shape>
+    </item>
+    <item
+        android:id="@android:id/background"
+        android:drawable="@color/material_green_500" />
+</ripple>

--- a/AnkiDroid/src/main/res/drawable-v21/footer_button_good_dark.xml
+++ b/AnkiDroid/src/main/res/drawable-v21/footer_button_good_dark.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="?answerButtonsHighlightColor">
+    <item android:id="@android:id/mask">
+        <shape android:shape="rectangle" >
+            <solid android:color="@color/material_green_800" />
+        </shape>
+    </item>
+    <item
+        android:id="@android:id/background"
+        android:drawable="@color/material_green_800" />
+</ripple>

--- a/AnkiDroid/src/main/res/drawable-v21/footer_button_hard.xml
+++ b/AnkiDroid/src/main/res/drawable-v21/footer_button_hard.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="?answerButtonsHighlightColor">
+    <item android:id="@android:id/mask">
+        <shape android:shape="rectangle" >
+            <solid android:color="@color/material_blue_grey_700" />
+        </shape>
+    </item>
+    <item
+        android:id="@android:id/background"
+        android:drawable="@color/material_blue_grey_700" />
+</ripple>

--- a/AnkiDroid/src/main/res/drawable-v21/footer_button_hard_dark.xml
+++ b/AnkiDroid/src/main/res/drawable-v21/footer_button_hard_dark.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+    android:color="?answerButtonsHighlightColor">
+    <item android:id="@android:id/mask">
+        <shape android:shape="rectangle" >
+            <solid android:color="@color/material_blue_grey_800" />
+        </shape>
+    </item>
+    <item
+        android:id="@android:id/background"
+        android:drawable="@color/material_blue_grey_800" />
+</ripple>

--- a/AnkiDroid/src/main/res/drawable/footer_button_again.xml
+++ b/AnkiDroid/src/main/res/drawable/footer_button_again.xml
@@ -4,7 +4,7 @@
     <selector>
         <item android:state_pressed="true">
             <shape android:shape="rectangle" >
-                <solid android:color="@color/material_red_800" />
+                <solid android:color="@color/material_red_500" />
             </shape>
         </item>
         <item android:state_focused="true">

--- a/AnkiDroid/src/main/res/drawable/footer_button_again_dark.xml
+++ b/AnkiDroid/src/main/res/drawable/footer_button_again_dark.xml
@@ -4,7 +4,7 @@
     <selector>
         <item android:state_pressed="true">
             <shape android:shape="rectangle" >
-                <solid android:color="@color/material_red_700" />
+                <solid android:color="@color/material_red_500" />
             </shape>
         </item>
         <item android:state_focused="true">

--- a/AnkiDroid/src/main/res/drawable/footer_button_all_black.xml
+++ b/AnkiDroid/src/main/res/drawable/footer_button_all_black.xml
@@ -4,7 +4,7 @@
     <selector>
         <item android:state_pressed="true">
             <shape android:shape="rectangle" >
-                <solid android:color="#202020" />
+                <solid android:color="#444444" />
             </shape>
         </item>
         <item android:state_focused="true">

--- a/AnkiDroid/src/main/res/drawable/footer_button_all_plain.xml
+++ b/AnkiDroid/src/main/res/drawable/footer_button_all_plain.xml
@@ -4,7 +4,7 @@
     <selector>
         <item android:state_pressed="true">
             <shape android:shape="rectangle" >
-                <solid android:color="#c89e9e9e" />
+                <solid android:color="#666666" />
             </shape>
         </item>
         <item android:state_focused="true">

--- a/AnkiDroid/src/main/res/drawable/footer_button_easy.xml
+++ b/AnkiDroid/src/main/res/drawable/footer_button_easy.xml
@@ -4,7 +4,7 @@
         <selector>
             <item android:state_pressed="true">
                 <shape android:shape="rectangle" >
-                    <solid android:color="@color/material_light_blue_600" />
+                    <solid android:color="@color/material_light_blue_200" />
                 </shape>
             </item>
             <item android:state_focused="true">

--- a/AnkiDroid/src/main/res/drawable/footer_button_easy_dark.xml
+++ b/AnkiDroid/src/main/res/drawable/footer_button_easy_dark.xml
@@ -4,7 +4,7 @@
         <selector>
             <item android:state_pressed="true">
                 <shape android:shape="rectangle" >
-                    <solid android:color="@color/material_light_blue_700" />
+                    <solid android:color="@color/material_light_blue_400" />
                 </shape>
             </item>
             <item android:state_focused="true">

--- a/AnkiDroid/src/main/res/drawable/footer_button_good.xml
+++ b/AnkiDroid/src/main/res/drawable/footer_button_good.xml
@@ -4,7 +4,7 @@
     <selector>
         <item android:state_pressed="true">
             <shape android:shape="rectangle" >
-                <solid android:color="@color/material_green_600" />
+                <solid android:color="@color/material_green_200" />
             </shape>
         </item>
         <item android:state_focused="true">

--- a/AnkiDroid/src/main/res/drawable/footer_button_good_dark.xml
+++ b/AnkiDroid/src/main/res/drawable/footer_button_good_dark.xml
@@ -4,7 +4,7 @@
     <selector>
         <item android:state_pressed="true">
             <shape android:shape="rectangle" >
-                <solid android:color="@color/material_green_700" />
+                <solid android:color="@color/material_green_400" />
             </shape>
         </item>
         <item android:state_focused="true">

--- a/AnkiDroid/src/main/res/drawable/footer_button_hard.xml
+++ b/AnkiDroid/src/main/res/drawable/footer_button_hard.xml
@@ -4,7 +4,7 @@
         <selector>
             <item android:state_pressed="true">
                 <shape android:shape="rectangle" >
-                    <solid android:color="@color/material_blue_grey_800" />
+                    <solid android:color="@color/material_blue_grey_200" />
                 </shape>
             </item>
             <item android:state_focused="true">

--- a/AnkiDroid/src/main/res/drawable/footer_button_hard_dark.xml
+++ b/AnkiDroid/src/main/res/drawable/footer_button_hard_dark.xml
@@ -4,7 +4,7 @@
         <selector>
             <item android:state_pressed="true">
                 <shape android:shape="rectangle" >
-                    <solid android:color="@color/material_blue_grey_700" />
+                    <solid android:color="@color/material_blue_grey_500" />
                 </shape>
             </item>
             <item android:state_focused="true">

--- a/AnkiDroid/src/main/res/layout/reviewer_answer_buttons.xml
+++ b/AnkiDroid/src/main/res/layout/reviewer_answer_buttons.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
-    android:id="@+id/bottom_area_layout"
+<LinearLayout android:id="@+id/bottom_area_layout"
     android:layout_width="fill_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
-    xmlns:android="http://schemas.android.com/apk/res/android">
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <!-- "Type in the answer" bar -->
     <EditText
@@ -19,7 +19,7 @@
          original AOSP soft keyboard, so don't.
     -->
 
-    <LinearLayout
+    <FrameLayout
         android:id="@+id/answer_options_layout"
         android:layout_width="fill_parent"
         android:layout_height="fill_parent">
@@ -28,8 +28,8 @@
             android:id="@+id/flashcard_layout_flip"
             android:layout_width="fill_parent"
             android:layout_height="@dimen/touch_target"
-            android:layout_weight="1"
-            android:orientation="vertical" >
+            android:orientation="vertical"
+            tools:visibility="gone">
 
             <Button
                 style="@style/FooterButtonLayout"
@@ -43,83 +43,92 @@
         </LinearLayout>
 
         <LinearLayout
-            style="@style/FooterButtonLayout"
-            android:background="?attr/againButtonRef"
-            android:id="@+id/flashcard_layout_ease1"
-            android:layout_width="0dip"
-            android:layout_height="@dimen/touch_target"
-            android:layout_weight="1"
-            android:orientation="vertical"
-            android:visibility="gone" >
+            android:id="@+id/ease_buttons"
+            android:layout_width="fill_parent"
+            android:layout_height="fill_parent"
+            android:orientation="horizontal"
+            android:visibility="gone"
+            tools:visibility="visible">
 
-            <TextView
-                android:id="@+id/nextTime1"
-                style="@style/AgainButtonTimeStyle" />
+            <LinearLayout
+                style="@style/FooterButtonLayout"
+                android:background="?attr/againButtonRef"
+                android:id="@+id/flashcard_layout_ease1"
+                android:layout_width="0dip"
+                android:layout_height="@dimen/touch_target"
+                android:layout_weight="1"
+                android:orientation="vertical">
 
-            <TextView
-                android:id="@+id/ease1"
-                android:text="@string/ease_button_again"
-                style="@style/AgainButtonEaseStyle"/>
+                <TextView
+                    android:id="@+id/nextTime1"
+                    style="@style/AgainButtonTimeStyle"
+                    tools:text="&lt; 10 min" />
+
+                <TextView
+                    android:id="@+id/ease1"
+                    android:text="@string/ease_button_again"
+                    style="@style/AgainButtonEaseStyle"/>
+            </LinearLayout>
+
+            <LinearLayout
+                style="@style/FooterButtonLayout"
+                android:background="?attr/hardButtonRef"
+                android:id="@+id/flashcard_layout_ease2"
+                android:layout_width="0dip"
+                android:layout_height="@dimen/touch_target"
+                android:layout_weight="1"
+                android:orientation="vertical">
+
+                <TextView
+                    android:id="@+id/nextTime2"
+                    style="@style/HardButtonTimeStyle"
+                    tools:text="2 d" />
+
+                <TextView
+                    android:id="@+id/ease2"
+                    android:text="@string/ease_button_hard"
+                    style="@style/HardButtonEaseStyle" />
+            </LinearLayout>
+
+            <LinearLayout
+                style="@style/FooterButtonLayout"
+                android:background="?attr/goodButtonRef"
+                android:id="@+id/flashcard_layout_ease3"
+                android:layout_width="0dip"
+                android:layout_height="@dimen/touch_target"
+                android:layout_weight="1"
+                android:orientation="vertical">
+
+                <TextView
+                    android:id="@+id/nextTime3"
+                    style="@style/GoodButtonTimeStyle"
+                    tools:text="3 d" />
+
+                <TextView
+                    android:id="@+id/ease3"
+                    android:text="@string/ease_button_good"
+                    style="@style/GoodButtonEaseStyle"/>
+            </LinearLayout>
+
+            <LinearLayout
+                style="@style/FooterButtonLayout"
+                android:background="?attr/easyButtonRef"
+                android:id="@+id/flashcard_layout_ease4"
+                android:layout_width="0dip"
+                android:layout_height="@dimen/touch_target"
+                android:layout_weight="1"
+                android:orientation="vertical">
+
+                <TextView
+                    android:id="@+id/nextTime4"
+                    style="@style/EasyButtonTimeStyle"
+                    tools:text="4 d" />
+
+                <TextView
+                    android:id="@+id/ease4"
+                    android:text="@string/ease_button_easy"
+                    style="@style/EasyButtonEaseStyle" />
+            </LinearLayout>
         </LinearLayout>
-
-        <LinearLayout
-            style="@style/FooterButtonLayout"
-            android:background="?attr/hardButtonRef"
-            android:id="@+id/flashcard_layout_ease2"
-            android:layout_width="0dip"
-            android:layout_height="@dimen/touch_target"
-            android:layout_weight="1"
-            android:orientation="vertical"
-            android:visibility="gone" >
-
-            <TextView
-                android:id="@+id/nextTime2"
-                style="@style/HardButtonTimeStyle" />
-
-            <TextView
-                android:id="@+id/ease2"
-                android:text="@string/ease_button_hard"
-                style="@style/HardButtonEaseStyle" />
-        </LinearLayout>
-
-        <LinearLayout
-            style="@style/FooterButtonLayout"
-            android:background="?attr/goodButtonRef"
-            android:id="@+id/flashcard_layout_ease3"
-            android:layout_width="0dip"
-            android:layout_height="@dimen/touch_target"
-            android:layout_weight="1"
-            android:orientation="vertical"
-            android:visibility="gone" >
-
-            <TextView
-                android:id="@+id/nextTime3"
-                style="@style/GoodButtonTimeStyle" />
-
-            <TextView
-                android:id="@+id/ease3"
-                android:text="@string/ease_button_good"
-                style="@style/GoodButtonEaseStyle"/>
-        </LinearLayout>
-
-        <LinearLayout
-            style="@style/FooterButtonLayout"
-            android:background="?attr/easyButtonRef"
-            android:id="@+id/flashcard_layout_ease4"
-            android:layout_width="0dip"
-            android:layout_height="@dimen/touch_target"
-            android:layout_weight="1"
-            android:orientation="vertical"
-            android:visibility="gone" >
-
-            <TextView
-                android:id="@+id/nextTime4"
-                style="@style/EasyButtonTimeStyle" />
-
-            <TextView
-                android:id="@+id/ease4"
-                android:text="@string/ease_button_easy"
-                style="@style/EasyButtonEaseStyle" />
-        </LinearLayout>
-    </LinearLayout>
+    </FrameLayout>
 </LinearLayout>

--- a/AnkiDroid/src/main/res/values-v21/styles.xml
+++ b/AnkiDroid/src/main/res/values-v21/styles.xml
@@ -24,7 +24,7 @@
         <item name="android:fontFamily">@string/font_fontFamily_medium</item>
     </style>
 
-    <style name="FooterButtonEaseText" parent="FooterButtonNextTime">
+    <style name="FooterButtonEaseText" parent="FooterButtonEaseTextBase">
         <item name="android:fontFamily">@string/font_fontFamily_medium</item>
     </style>
 </resources>

--- a/AnkiDroid/src/main/res/values/attrs.xml
+++ b/AnkiDroid/src/main/res/values/attrs.xml
@@ -60,6 +60,7 @@
     <attr name="hardButtonTextColor" format="color"/>
     <attr name="goodButtonTextColor" format="color"/>
     <attr name="easyButtonTextColor" format="color"/>
+    <attr name="answerButtonsHighlightColor" format="color"/>
     <!-- Card Browser Colors -->
     <attr name="cardBrowserDivider" format="color"/>
     <!-- Stats colors -->

--- a/AnkiDroid/src/main/res/values/fonts.xml
+++ b/AnkiDroid/src/main/res/values/fonts.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="font_fontFamily_medium">sans-serif</string>
+    <string name="font_fontFamily_medium">sans-serif-medium</string>
 </resources>

--- a/AnkiDroid/src/main/res/values/styles.xml
+++ b/AnkiDroid/src/main/res/values/styles.xml
@@ -44,6 +44,7 @@
         <item name="android:singleLine">true</item>
     </style>
     <style name="FooterButtonLayout" parent="FooterButtonLayoutBase"/>
+
     <style name="FooterButtonNextTime">
         <item name="android:layout_width">fill_parent</item>
         <item name="android:layout_height">wrap_content</item>
@@ -51,13 +52,15 @@
         <item name="android:ellipsize">marquee</item>
         <item name="android:gravity">bottom|center_horizontal</item>
         <item name="android:singleLine">true</item>
-        <item name="android:textSize">12.5sp</item>
+        <item name="android:textSize">12sp</item>
     </style>
-    <style name="FooterButtonEaseText" parent="FooterButtonNextTime">
+
+    <style name="FooterButtonEaseTextBase" parent="FooterButtonNextTime">
         <item name="android:textSize">14sp</item>
         <item name="android:textAllCaps">true</item>
         <item name="android:typeface">sans</item>
     </style>
+    <style name="FooterButtonEaseText" parent="FooterButtonEaseTextBase" />
 
     <!-- Styles for each of the 4 answer buttons -->
     <!-- Ease text -->

--- a/AnkiDroid/src/main/res/values/theme_dark.xml
+++ b/AnkiDroid/src/main/res/values/theme_dark.xml
@@ -59,6 +59,7 @@
         <item name="hardButtonRef">@drawable/footer_button_hard_dark</item>
         <item name="goodButtonRef">@drawable/footer_button_good_dark</item>
         <item name="easyButtonRef">@drawable/footer_button_easy_dark</item>
+        <item name="answerButtonsHighlightColor">#66FFFFFF</item>
         <!-- Card Browser Colors -->
         <item name="cardBrowserDivider">@color/white</item>
         <!-- Stats colors -->

--- a/AnkiDroid/src/main/res/values/theme_light.xml
+++ b/AnkiDroid/src/main/res/values/theme_light.xml
@@ -67,6 +67,7 @@ APIs. It's visible when there aren't enough decks to fill the screen.
         <item name="hardButtonTextColor">@color/white</item>
         <item name="goodButtonTextColor">@color/white</item>
         <item name="easyButtonTextColor">@color/white</item>
+        <item name="answerButtonsHighlightColor">#88FFFFFF</item>
         <!-- Reviewer button drawables -->
         <item name="againButtonRef">@drawable/footer_button_again</item>
         <item name="hardButtonRef">@drawable/footer_button_hard</item>


### PR DESCRIPTION
## Purpose / Description
This pull request increases visibility of reviewer answer buttons feedback (Show Answer and Again/Hard/Good/Easy).

## Fixes
Fixes #3645 

## Approach
This pull request adds Material Design ripples with lighter highlight color on API >= 21 and increases contrast between normal and pressed states on API < 21. It also introduces fade transition between "Show Answer" button and ease buttons so that ripple effect stays longer and effectively becomes much more useful. It also follows `safeDisplay` preference and protected `mDisableAnimations` variable (the last one is used in Previewer.java to disable animations, because logic is different there and it can bug out. And there are no answer buttons so it's useless anyway)

## How Has This Been Tested?

Here are the screen caps (can be played in the browser):

API 28: [light theme](https://share.dmca.gripe/Z3LVbZ8fL7IAKcsV.webm), [black theme](https://share.dmca.gripe/DhfdFzXgE1hRjnKV.webm), [previewer](https://share.dmca.gripe/PznO53UTVpGZkft4.webm)
API 16: [dark theme](https://share.dmca.gripe/yQMzyZU3YkIGocGp.webm)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
