### PR TITLE
Regression test for #6966

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
@@ -320,4 +320,8 @@ public abstract class AbstractSched {
     public abstract void discardCurrentCard();
 
     public abstract Collection getCol();
+
+    /** The button to press to enter "good" on a new card. */
+    @VisibleForTesting
+    public abstract  @Consts.BUTTON_TYPE int getGoodNewButton();
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -1415,4 +1415,11 @@ public class Sched extends SchedV2 {
             break;
         }
     }
+
+    /** The button to press on a new card to answer "good".*/
+    @Override
+    @VisibleForTesting
+    public @Consts.BUTTON_TYPE int getGoodNewButton() {
+        return 2;
+    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -3119,4 +3119,11 @@ public class SchedV2 extends AbstractSched {
     public Collection getCol() {
         return mCol;
     }
+
+    @Override
+    @VisibleForTesting
+    public @Consts.BUTTON_TYPE int getGoodNewButton() {
+        return 3;
+    }
+
 }


### PR DESCRIPTION
The bug was caused by d694006 .

Essentially, the bug is due to the fact that I called reset while there is a card in the reviewer, without actually
taking the card in the reviewer into account. Which is something I corrected later thanks to considering mHaveCounts and
mHaveQueue separately.

This would explain #6898 and #6768

The idea here is that:

* the learn queue gets emptied during reset
* when the card is answered, it is added in the learn queue. But since the queue was empty and not yet refilled, it is
added in a dirty queue. Normally, it's not a problem when the queue is dirty and empty, because _fillLrn will simply
fill the queue again. However, as soon as there is an element in the queue, it is assumed that it is not dirty. This is
corrected thanks to mHaveQueue which simply state whether the queue is dirty or not.
* Since the queue contains a single element and is assumed (incorrectly) not to be dirty, all other cards in learning
never enter the queue, so they are reviewed at the end of the review session
* If there are only cards in learning, the single card in the queue is the only one being reviewed, until it goes to the
Rev queue, at which point fillLrn is allowed to fill the queue again.
* I believe that the more general problem here is that, while I did realize I corrected plenty of bugs on 2.1.13 alpha, I
didn't realize that some of those bugs where in stable. Mostly because I have no idea when the stable branch was cut and
that my mental model of the code uses the code in alpha.
