### PR TITLE
Regression 6898 2

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.java
@@ -212,6 +212,47 @@ public class ReviewerTest extends RobolectricTest {
         assertCurrentOrdIsNot(reviewer, 3); // Anki Desktop shows "1"
     }
 
+    @Test
+    public synchronized void testLrnQueueAfterUndo() throws ConfirmModSchemaException, InterruptedException {
+        Collection col = getCol();
+        JSONObject nw = col.getDecks().confForDid(1).getJSONObject("new");
+        MockTime time = (MockTime) col.getTime();
+        nw.put("delays", new JSONArray(new int[] {1, 10, 60, 120}));
+
+        Card cards[] = new Card[4];
+        cards[0] = addRevNoteUsingBasicModelDueToday("1", "bar").firstCard();
+        cards[1] = addNoteUsingBasicModel("2", "bar").firstCard();
+        cards[2] = addNoteUsingBasicModel("3", "bar").firstCard();
+
+        waitForAsyncTasksToComplete();
+
+        Reviewer reviewer = startReviewer();
+
+        waitForAsyncTasksToComplete();
+
+
+        equalFirstField(cards[0], reviewer.mCurrentCard);
+        reviewer.answerCard(Consts.BUTTON_ONE);
+        waitForAsyncTasksToComplete();
+
+        equalFirstField(cards[1], reviewer.mCurrentCard);
+        reviewer.answerCard(Consts.BUTTON_ONE);
+        waitForAsyncTasksToComplete();
+
+        undo(reviewer);
+        waitForAsyncTasksToComplete();
+
+        equalFirstField(cards[1], reviewer.mCurrentCard);
+        reviewer.answerCard(getCol().getSched().getGoodNewButton());
+        waitForAsyncTasksToComplete();
+
+        equalFirstField(cards[2], reviewer.mCurrentCard);
+        time.addM(2);
+        reviewer.answerCard(getCol().getSched().getGoodNewButton());
+        advanceRobolectricLooperWithSleep();
+        equalFirstField(cards[0], reviewer.mCurrentCard); // This failed in #6898 because this card was not in the queue
+    }
+
 
     private void assertCurrentOrdIsNot(Reviewer r, int i) {
         waitForAsyncTasksToComplete();

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.java
@@ -213,7 +213,7 @@ public class ReviewerTest extends RobolectricTest {
     }
 
     @Test
-    public synchronized void testLrnQueueAfterUndo() throws ConfirmModSchemaException, InterruptedException {
+    public void testLrnQueueAfterUndo() throws ConfirmModSchemaException, InterruptedException {
         Collection col = getCol();
         JSONObject nw = col.getDecks().confForDid(1).getJSONObject("new");
         MockTime time = (MockTime) col.getTime();
@@ -416,4 +416,3 @@ public class ReviewerTest extends RobolectricTest {
     }
 
 }
-

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
@@ -27,7 +27,9 @@ import com.ichi2.async.CollectionTask;
 import com.ichi2.async.TaskData;
 import com.ichi2.async.TaskListener;
 import com.ichi2.compat.customtabs.CustomTabActivityHelper;
+import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
+import com.ichi2.libanki.Consts;
 import com.ichi2.libanki.DB;
 import com.ichi2.libanki.Model;
 import com.ichi2.libanki.Models;
@@ -62,6 +64,7 @@ import timber.log.Timber;
 
 import static android.os.Looper.getMainLooper;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.robolectric.Shadows.shadowOf;
 
 public class RobolectricTest {
@@ -406,5 +409,9 @@ public class RobolectricTest {
     public void assumeTrue(String message, boolean b) {
         this.advanceRobolectricLooperWithSleep();
         Assume.assumeTrue(message, b);
+    }
+
+    public void equalFirstField(Card expected, Card obtained) {
+        assertThat(obtained.note().getFields()[0], is(expected.note().getFields()[0]));
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
@@ -242,6 +242,15 @@ public class RobolectricTest {
         return addNoteUsingModelName("Basic", front, back);
     }
 
+    protected Note addRevNoteUsingBasicModelDueToday(String front, String back) {
+        Note note = addNoteUsingBasicModel(front, back);
+        Card card = note.firstCard();
+        card.setQueue(Consts.QUEUE_TYPE_REV);
+        card.setType(Consts.CARD_TYPE_REV);
+        card.setDue(getCol().getSched().getToday());
+        return note;
+    }
+
     protected Note addNoteUsingBasicAndReversedModel(String front, String back) {
         return addNoteUsingModelName("Basic (and reversed card)", front, back);
     }


### PR DESCRIPTION
When doing undo and then reviewing again, the lrn queue was emptied and elements were not added back until the queue was empty (i.e. all elements added in the queue after undo left the queue)

This means that if we add card 1 to learning queue and then undo later, card 1 won't be seen again until the end of the review. This test show it's corrected.

