### PR TITLE
#6424 - warning dialog for duplicates

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.java
@@ -125,13 +125,6 @@ public class FieldEditText extends AppCompatEditText {
         setImeHintLocales(new LocaleList(locale));
     }
 
-    /**
-     * Modify the style of this view to represent a duplicate field.
-     */
-    public void setDupeStyle() {
-        setBackgroundColor(Themes.getColorFromAttr(getContext(), R.attr.duplicateColor));
-    }
-
 
     /**
      * Restore the default style of this view.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1509,9 +1509,6 @@ public class NoteEditor extends AnkiActivity {
         if (customTypeface != null) {
             editText.setTypeface(customTypeface);
         }
-
-        // Listen for changes in the first field so we can re-check duplicate status.
-        editText.addTextChangedListener(new EditFieldTextWatcher(index));
         editText.setEnabled(enabled);
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -61,6 +61,7 @@ import com.afollestad.materialdialogs.MaterialDialog;
 import com.ichi2.anim.ActivityTransitionAnimation;
 import com.ichi2.anki.dialogs.ConfirmationDialog;
 import com.ichi2.anki.dialogs.DiscardChangesDialog;
+import com.ichi2.anki.dialogs.DuplicateFrontCardDialog;
 import com.ichi2.anki.dialogs.LocaleSelectionDialog;
 import com.ichi2.anki.dialogs.TagsDialog;
 import com.ichi2.anki.exception.ConfirmModSchemaException;
@@ -1010,7 +1011,7 @@ public class NoteEditor extends AnkiActivity {
 
             case R.id.action_save:
                 Timber.i("NoteEditor:: Save note button pressed");
-                saveNote();
+                saveNoteWithDuplicateCheck();
                 return true;
 
             case R.id.action_add_note_from_note_editor:
@@ -1070,6 +1071,18 @@ public class NoteEditor extends AnkiActivity {
         noteEditorBundle.putBundle("editFields", getFieldsAsBundle(true));
         previewer.putExtra("noteEditorBundle", noteEditorBundle);
         startActivityForResultWithoutAnimation(previewer, REQUEST_PREVIEW);
+    }
+
+
+    private void saveNoteWithDuplicateCheck() {
+        updateField(mEditFields.get(0));
+        if(mEditorNote.dupeOrEmpty() == Note.DupeOrEmpty.DUPE) {
+               DuplicateFrontCardDialog
+                    .getDefault(this)
+                    .onPositive((dialog, which) -> saveNote())
+                    .show();
+        }
+        else { saveNote(); }
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1560,25 +1560,6 @@ public class NoteEditor extends AnkiActivity {
     }
 
 
-    private void setDuplicateFieldStyles() {
-        FieldEditText field = mEditFields.get(0);
-        // Keep copy of current internal value for this field.
-        String oldValue = mEditorNote.getFields()[0];
-        // Update the field in the Note so we can run a dupe check on it.
-        updateField(field);
-        // 1 is empty, 2 is dupe, null is neither.
-        Note.DupeOrEmpty dupeCode = mEditorNote.dupeOrEmpty();
-        // Change bottom line color of text field
-        if (dupeCode != null && dupeCode == Note.DupeOrEmpty.DUPE) {
-            field.setDupeStyle();
-        } else {
-            field.setDefaultStyle();
-        }
-        // Put back the old value so we don't interfere with modification detection
-        mEditorNote.values()[0] = oldValue;
-    }
-
-
     private String getFieldsText() {
         String[] fields = new String[mEditFields.size()];
         for (int i = 0; i < mEditFields.size(); i++) {
@@ -1841,7 +1822,6 @@ public class NoteEditor extends AnkiActivity {
                 }
                 setNote();
                 resetEditFields(oldValues);
-                setDuplicateFieldStyles();
             }
         }
 
@@ -2096,9 +2076,6 @@ public class NoteEditor extends AnkiActivity {
         @Override
         public void afterTextChanged(Editable arg0) {
             mFieldEdited = true;
-            if (mIndex == 0) {
-                setDuplicateFieldStyles();
-            }
         }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DuplicateFrontCardDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DuplicateFrontCardDialog.java
@@ -1,0 +1,15 @@
+package com.ichi2.anki.dialogs;
+
+import android.content.Context;
+
+import com.afollestad.materialdialogs.MaterialDialog;
+import com.ichi2.anki.R;
+
+public class DuplicateFrontCardDialog {
+    public static MaterialDialog.Builder getDefault(Context context) {
+        return new MaterialDialog.Builder(context)
+                .content(R.string.note_editor_dialog_duplicate)
+                .positiveText(R.string.dialog_positive_add)
+                .negativeText(R.string.dialog_cancel);
+    }
+}

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -113,6 +113,7 @@
     <string name="reordering_cards">Reordering cards…</string>
     <string name="field_remapping">%1$s (from “%2$s”)</string>
     <string name="confirm_map_cards_to_nothing">Any cards mapped to nothing will be deleted. If a note has no remaining cards, it will be lost. Are you sure you want to continue?</string>
+    <string name="note_editor_dialog_duplicate">The front card with such content already exists. Do you want to add a duplicate?</string>
 
     <plurals name="timebox_reached">
         <item quantity="one">%1$d card studied in %2$s</item>

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -110,6 +110,7 @@
     <string name="dialog_cancel">Cancel</string>
     <string name="dialog_ok">OK</string>
     <string name="dialog_no">No</string>
+    <string name="dialog_positive_add">Add</string>
     <string name="dialog_continue">Continue</string>
     <string name="dialog_positive_create">Create</string>
     <string name="dialog_positive_delete">Delete</string>


### PR DESCRIPTION
## Purpose / Description
I've created a warning dialog to prevent adding unwanted note with duplicated front card. The past way to warn a user was using red backlight of the first field in the NoteEditor (without any messages). It was unintuitive for users.

## Fixes
Fixes [#6424](https://github.com/ankidroid/Anki-Android/issues/6424)

## Approach
My solution uses the past code to check if a front card is duplicated and displays the warning dialog. I removed the code which backlighted duplicate front cards fields while typing.

## How Has This Been Tested?
on emulator with API 29:
- manually
- automatic tests from NoteEditorTest.java passed