### PR TITLE
Remove color attribute references from drawables

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV16.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV16.java
@@ -69,7 +69,7 @@ public class CompatV16 implements Compat {
         a.getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN, WindowManager.LayoutParams.FLAG_FULLSCREEN);
         final int fullscreenMode = Integer.parseInt(AnkiDroidApp.getSharedPrefs(a).getString("fullscreenMode", "0"));
         if (fullscreenMode >= FULLSCREEN_ALL_GONE) {
-            final LinearLayout answerButtons = a.findViewById(R.id.answer_options_layout);
+            final View answerButtons = a.findViewById(R.id.answer_options_layout);
             answerButtons.setVisibility(View.GONE);
         }
     }

--- a/AnkiDroid/src/main/res/drawable-v21/footer_button_again.xml
+++ b/AnkiDroid/src/main/res/drawable-v21/footer_button_again.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ripple xmlns:android="http://schemas.android.com/apk/res/android"
-    android:color="?answerButtonsHighlightColor">
+    android:color="@color/answer_buttons_highlight_color">
     <item android:id="@android:id/mask">
         <shape android:shape="rectangle" >
             <solid android:color="@color/material_red_700" />

--- a/AnkiDroid/src/main/res/drawable-v21/footer_button_again_dark.xml
+++ b/AnkiDroid/src/main/res/drawable-v21/footer_button_again_dark.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ripple xmlns:android="http://schemas.android.com/apk/res/android"
-    android:color="?answerButtonsHighlightColor">
+    android:color="@color/answer_buttons_highlight_color">
     <item android:id="@android:id/mask">
         <shape android:shape="rectangle" >
             <solid android:color="@color/material_red_800" />

--- a/AnkiDroid/src/main/res/drawable-v21/footer_button_all_black.xml
+++ b/AnkiDroid/src/main/res/drawable-v21/footer_button_all_black.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ripple xmlns:android="http://schemas.android.com/apk/res/android"
-    android:color="?answerButtonsHighlightColor">
+    android:color="@color/answer_buttons_highlight_color">
     <item android:id="@android:id/mask">
         <shape android:shape="rectangle" >
             <solid android:color="#000000" />

--- a/AnkiDroid/src/main/res/drawable-v21/footer_button_all_plain.xml
+++ b/AnkiDroid/src/main/res/drawable-v21/footer_button_all_plain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ripple xmlns:android="http://schemas.android.com/apk/res/android"
-    android:color="?answerButtonsHighlightColor">
+    android:color="@color/answer_buttons_highlight_color">
     <item android:id="@android:id/mask">
         <shape android:shape="rectangle" >
             <solid android:color="#9E9E9E" />

--- a/AnkiDroid/src/main/res/drawable-v21/footer_button_easy.xml
+++ b/AnkiDroid/src/main/res/drawable-v21/footer_button_easy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ripple xmlns:android="http://schemas.android.com/apk/res/android"
-    android:color="?answerButtonsHighlightColor">
+    android:color="@color/answer_buttons_highlight_color">
     <item android:id="@android:id/mask">
         <shape android:shape="rectangle" >
             <solid android:color="@color/material_light_blue_500" />

--- a/AnkiDroid/src/main/res/drawable-v21/footer_button_easy_dark.xml
+++ b/AnkiDroid/src/main/res/drawable-v21/footer_button_easy_dark.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ripple xmlns:android="http://schemas.android.com/apk/res/android"
-    android:color="?answerButtonsHighlightColor">
+    android:color="@color/answer_buttons_highlight_color">
     <item android:id="@android:id/mask">
         <shape android:shape="rectangle" >
             <solid android:color="@color/material_light_blue_800" />

--- a/AnkiDroid/src/main/res/drawable-v21/footer_button_good.xml
+++ b/AnkiDroid/src/main/res/drawable-v21/footer_button_good.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ripple xmlns:android="http://schemas.android.com/apk/res/android"
-    android:color="?answerButtonsHighlightColor">
+    android:color="@color/answer_buttons_highlight_color">
     <item android:id="@android:id/mask">
         <shape android:shape="rectangle" >
             <solid android:color="@color/material_green_500" />

--- a/AnkiDroid/src/main/res/drawable-v21/footer_button_good_dark.xml
+++ b/AnkiDroid/src/main/res/drawable-v21/footer_button_good_dark.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ripple xmlns:android="http://schemas.android.com/apk/res/android"
-    android:color="?answerButtonsHighlightColor">
+    android:color="@color/answer_buttons_highlight_color">
     <item android:id="@android:id/mask">
         <shape android:shape="rectangle" >
             <solid android:color="@color/material_green_800" />

--- a/AnkiDroid/src/main/res/drawable-v21/footer_button_hard.xml
+++ b/AnkiDroid/src/main/res/drawable-v21/footer_button_hard.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ripple xmlns:android="http://schemas.android.com/apk/res/android"
-    android:color="?answerButtonsHighlightColor">
+    android:color="@color/answer_buttons_highlight_color">
     <item android:id="@android:id/mask">
         <shape android:shape="rectangle" >
             <solid android:color="@color/material_blue_grey_700" />

--- a/AnkiDroid/src/main/res/drawable-v21/footer_button_hard_dark.xml
+++ b/AnkiDroid/src/main/res/drawable-v21/footer_button_hard_dark.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ripple xmlns:android="http://schemas.android.com/apk/res/android"
-    android:color="?answerButtonsHighlightColor">
+    android:color="@color/answer_buttons_highlight_color">
     <item android:id="@android:id/mask">
         <shape android:shape="rectangle" >
             <solid android:color="@color/material_blue_grey_800" />

--- a/AnkiDroid/src/main/res/drawable-v21/item_background_light_selectable.xml
+++ b/AnkiDroid/src/main/res/drawable-v21/item_background_light_selectable.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ripple xmlns:android="http://schemas.android.com/apk/res/android"
-    android:color="?attr/answerButtonsHighlightColor">
+    android:color="@color/answer_buttons_highlight_color">
     <item android:id="@android:id/mask">
         <color android:color="@android:color/white" />
     </item>

--- a/AnkiDroid/src/main/res/drawable-v21/item_background_light_selectable_borderless.xml
+++ b/AnkiDroid/src/main/res/drawable-v21/item_background_light_selectable_borderless.xml
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ripple xmlns:android="http://schemas.android.com/apk/res/android"
-    android:color="?attr/answerButtonsHighlightColor" />
+    android:color="@color/answer_buttons_highlight_color" />

--- a/AnkiDroid/src/main/res/drawable/item_background_light_selectable.xml
+++ b/AnkiDroid/src/main/res/drawable/item_background_light_selectable.xml
@@ -3,10 +3,10 @@
     <item android:state_window_focused="false" android:drawable="@android:color/transparent" />
 
     <!-- Even though these two point to the same resource, have two states so the drawable will invalidate itself when coming out of pressed state. -->
-    <item android:state_focused="true"  android:state_enabled="false" android:state_pressed="true" android:drawable="?attr/answerButtonsHighlightColor" />
-    <item android:state_focused="true"  android:state_enabled="false"                              android:drawable="?attr/answerButtonsHighlightColor" />
-    <item android:state_focused="true"                                android:state_pressed="true" android:drawable="?attr/answerButtonsHighlightColor" />
-    <item android:state_focused="false"                               android:state_pressed="true" android:drawable="?attr/answerButtonsHighlightColor" />
-    <item android:state_focused="true"                                                             android:drawable="?attr/answerButtonsHighlightColor" />
+    <item android:state_focused="true"  android:state_enabled="false" android:state_pressed="true" android:drawable="@color/answer_buttons_highlight_color" />
+    <item android:state_focused="true"  android:state_enabled="false"                              android:drawable="@color/answer_buttons_highlight_color" />
+    <item android:state_focused="true"                                android:state_pressed="true" android:drawable="@color/answer_buttons_highlight_color" />
+    <item android:state_focused="false"                               android:state_pressed="true" android:drawable="@color/answer_buttons_highlight_color" />
+    <item android:state_focused="true"                                                             android:drawable="@color/answer_buttons_highlight_color" />
     <item android:drawable="@android:color/transparent" />
 </selector>

--- a/AnkiDroid/src/main/res/drawable/item_background_light_selectable_borderless.xml
+++ b/AnkiDroid/src/main/res/drawable/item_background_light_selectable_borderless.xml
@@ -3,10 +3,10 @@
     <item android:state_window_focused="false" android:drawable="@android:color/transparent" />
 
     <!-- Even though these two point to the same resource, have two states so the drawable will invalidate itself when coming out of pressed state. -->
-    <item android:state_focused="true"  android:state_enabled="false" android:state_pressed="true" android:drawable="?attr/answerButtonsHighlightColor" />
-    <item android:state_focused="true"  android:state_enabled="false"                              android:drawable="?attr/answerButtonsHighlightColor" />
-    <item android:state_focused="true"                                android:state_pressed="true" android:drawable="?attr/answerButtonsHighlightColor" />
-    <item android:state_focused="false"                               android:state_pressed="true" android:drawable="?attr/answerButtonsHighlightColor" />
-    <item android:state_focused="true"                                                             android:drawable="?attr/answerButtonsHighlightColor" />
+    <item android:state_focused="true"  android:state_enabled="false" android:state_pressed="true" android:drawable="@color/answer_buttons_highlight_color" />
+    <item android:state_focused="true"  android:state_enabled="false"                              android:drawable="@color/answer_buttons_highlight_color" />
+    <item android:state_focused="true"                                android:state_pressed="true" android:drawable="@color/answer_buttons_highlight_color" />
+    <item android:state_focused="false"                               android:state_pressed="true" android:drawable="@color/answer_buttons_highlight_color" />
+    <item android:state_focused="true"                                                             android:drawable="@color/answer_buttons_highlight_color" />
     <item android:drawable="@android:color/transparent" />
 </selector>

--- a/AnkiDroid/src/main/res/values/attrs.xml
+++ b/AnkiDroid/src/main/res/values/attrs.xml
@@ -66,7 +66,6 @@
     <attr name="hardButtonTextColor" format="color"/>
     <attr name="goodButtonTextColor" format="color"/>
     <attr name="easyButtonTextColor" format="color"/>
-    <attr name="answerButtonsHighlightColor" format="color"/>
     <!-- Card Browser Colors -->
     <attr name="cardBrowserDivider" format="color"/>
     <!-- Stats colors -->

--- a/AnkiDroid/src/main/res/values/colors.xml
+++ b/AnkiDroid/src/main/res/values/colors.xml
@@ -31,6 +31,8 @@
     <color name="white">#ffffff</color>
     <color name="black">#000000</color>
 
+    <color name="answer_buttons_highlight_color">#66FFFFFF</color>
+
 
     <!-- Material Design: http://www.google.com/design/spec/style/color.html#color-color-palette -->
     <!-- Can eventually be shortened once settled on a color scheme -->

--- a/AnkiDroid/src/main/res/values/theme_dark.xml
+++ b/AnkiDroid/src/main/res/values/theme_dark.xml
@@ -65,7 +65,6 @@
         <item name="hardButtonRef">@drawable/footer_button_hard_dark</item>
         <item name="goodButtonRef">@drawable/footer_button_good_dark</item>
         <item name="easyButtonRef">@drawable/footer_button_easy_dark</item>
-        <item name="answerButtonsHighlightColor">#66FFFFFF</item>
         <!-- Card Browser Colors -->
         <item name="cardBrowserDivider">@color/white</item>
         <!-- Stats colors -->

--- a/AnkiDroid/src/main/res/values/theme_light.xml
+++ b/AnkiDroid/src/main/res/values/theme_light.xml
@@ -73,7 +73,6 @@ APIs. It's visible when there aren't enough decks to fill the screen.
         <item name="hardButtonTextColor">@color/white</item>
         <item name="goodButtonTextColor">@color/white</item>
         <item name="easyButtonTextColor">@color/white</item>
-        <item name="answerButtonsHighlightColor">#AAFFFFFF</item>
         <!-- Reviewer button drawables -->
         <item name="againButtonRef">@drawable/footer_button_again</item>
         <item name="hardButtonRef">@drawable/footer_button_hard</item>


### PR DESCRIPTION
## Purpose / Description
Remove color attribute references from drawables to fix the crash on API < 21

## Fixes
Fixes #6984 

## How Has This Been Tested?

Tested in API 16 and 29 emulators

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
