### PR TITLE
Add Test: Ensure layouts can be used on all APIs

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/LayoutValidationTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/LayoutValidationTest.java
@@ -1,0 +1,113 @@
+package com.ichi2.anki.tests;
+
+import android.content.Context;
+import android.os.Handler;
+import android.os.Looper;
+import android.view.LayoutInflater;
+import android.view.ViewGroup;
+import android.widget.LinearLayout;
+
+import com.ichi2.anki.R;
+import com.ichi2.themes.Themes;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import androidx.test.platform.app.InstrumentationRegistry;
+
+@RunWith(Parameterized.class)
+public class LayoutValidationTest {
+
+    @Parameterized.Parameter
+    public int mResourceId;
+
+    @Parameterized.Parameter(1)
+    public String mName;
+
+    @Parameterized.Parameters(name = "{1}")
+    public static java.util.Collection<Object[]> initParameters() throws IllegalAccessException, InvocationTargetException, InstantiationException {
+        Constructor<?> ctor = com.ichi2.anki.R.layout.class.getDeclaredConstructors()[0];
+        ctor.setAccessible(true); // Required for at least API 16, maybe later.
+        Object layout = ctor.newInstance();
+
+        // There are hidden public fields: abc_list_menu_item_layout for example
+        HashSet<String> nonAnkiFieldNames = new HashSet<>();
+        nonAnkiFieldNames.addAll(getFieldNames(androidx.appcompat.resources.R.layout.class));
+        nonAnkiFieldNames.addAll(getFieldNames(com.google.android.material.R.layout.class));
+        nonAnkiFieldNames.addAll(getFieldNames(com.afollestad.materialdialogs.R.layout.class));
+
+
+        List<Object[]> layouts = new ArrayList<>();
+        for (Field f : R.layout.class.getFields()) {
+            if (nonAnkiFieldNames.contains(f.getName())) {
+                continue;
+            }
+            layouts.add(new Object[] {f.getInt(layout), f.getName() });
+        }
+
+        return layouts;
+    }
+
+    @Test
+    public void ensureLayout() throws Exception {
+        // This should be fine to run on a device - but WebViews may be instantiated.
+
+        Context targetContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        Themes.setTheme(targetContext);
+        LayoutInflater li = LayoutInflater.from(targetContext);
+        ViewGroup root = new LinearLayout(targetContext);
+
+        ensureNoCrashOnUiThread(() -> li.inflate(mResourceId, root, true));
+    }
+
+    /** Crashing on the UI thread takes down the process */
+    private void ensureNoCrashOnUiThread(Runnable runnable) throws Exception {
+        AtomicReference<Exception> failed = new AtomicReference<>();
+        AtomicBoolean hasRun = new AtomicBoolean(false);
+        runOnUiThread(() -> {
+            try {
+                runnable.run();
+            } catch (Exception e) {
+                failed.set(e);
+            } finally {
+                hasRun.set(true);
+            }
+        });
+
+        //noinspection StatementWithEmptyBody
+        while (!hasRun.get()) {
+            // spin
+        }
+
+        if (failed.get() != null) {
+            throw failed.get();
+        }
+    }
+
+
+    @NotNull
+    private static <T> HashSet<String> getFieldNames(Class<T> clazz) {
+        Field[] badFields = clazz.getFields();
+        HashSet<String> badFieldNames = new HashSet<>();
+        for (Field f : badFields) {
+            badFieldNames.add(f.getName());
+        }
+        return badFieldNames;
+    }
+
+
+    private void runOnUiThread(Runnable runnable) {
+        new Handler(Looper.getMainLooper()).post(runnable);
+    }
+}


### PR DESCRIPTION
## Purpose / Description
We had a problem with layouts not working on API 16, this instantiates all layouts on all API levels

## Fixes
Related: #6991 

## Approach
Load all fields from `R.layout`, and see if they can be inflated

## How Has This Been Tested?

API 16 and 30 emulators - likely needs a rebase to master to pass, but will be interesting to get an initial failure

## Learning
* `R.layout` has hidden members, which are public, but hidden by the IDE
* You can't assign `R.layout` to a variable
* Some layouts need to be loaded on the UI thread

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code