### PR TITLE
Second column of browser repaired

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -588,6 +588,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
                     AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance().getBaseContext()).edit()
                             .putInt("cardBrowserColumn2", mColumn2Index).commit();
                     Column[] fromMap = mCardsAdapter.getFromMapping();
+                    fromMap[1] = COLUMN2_KEYS[mColumn2Index];
                     mCardsAdapter.setFromMapping(fromMap);
                 }
             }


### PR DESCRIPTION
In 8f3628f0fda73538b3a8e8739411d34b07239716 I removed one line by accident. The conditional was always false, the line
before was good. I add back this line.

Because of this, the browser had to be closed and reopen to work