### PR TITLE
NF: Check whether a card is mapped to nothing

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -865,7 +865,7 @@ public class NoteEditor extends AnkiActivity {
             final Model oldModel = (mCurrentEditedCard == null) ? null : mCurrentEditedCard.model();
             if (!newModel.equals(oldModel)) {
                 mReloadRequired = true;
-                if (mModelChangeCardMap.size() < mEditorNote.numberOfCards() || mModelChangeCardMap.containsKey(null)) {
+                if (mModelChangeCardMap.size() < mEditorNote.numberOfCards() || mModelChangeCardMap.containsValue(null)) {
                     // If cards will be lost via the new mapping then show a confirmation dialog before proceeding with the change
                     ConfirmationDialog dialog = new ConfirmationDialog ();
                     dialog.setArgs(res.getString(R.string.confirm_map_cards_to_nothing));


### PR DESCRIPTION
The test `mModelChangeCardMap.containsKey(null)` can't succeed since null is never added to this map as a key.

However, it's added as a value, and that's probably what was supposed to be tested in
a4ecc3bc646a0e386ce017cc165c922e718442ec. This means that the warning will be shown if some card is mapped to nothing.

Note that containsValue is slower than containsKey. Howevre, since it loops over the number of cards, that's acceptable.

Note also that this test is currently useless. Indeed, the map contains the value null iff it contains the value null at
creation. This occurs iff the image has less element than the source. I.e. iff mModelChangeCardMap.size() <
mEditorNote.numberOfCards()

This still seems a relevant correction in case one day the map may be changed.

Or we can just delete the test and wait until the problem exists to solve it


Ideally, I'd ask Tim what was his initial purpose. However, I would not expect him to recall a single line of code wrote 6 years ago more than us, so no need to take of his time here