### PR TITLE
Correct 6970

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1635,6 +1635,12 @@ public class CardBrowser extends NavigationDrawerActivity implements
         }
 
         @Override
+        public void actualOnPreExecute(@NonNull CardBrowser browser) {
+            super.actualOnPreExecute(browser);
+            browser.invalidate();
+        }
+
+        @Override
         public void actualOnProgressUpdate(@NonNull CardBrowser browser, TaskData value) {
             Card[] cards = (Card[]) value.getObjArray();
             //we don't need to reorder cards here as we've already deselected all notes,
@@ -1654,6 +1660,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
                     CollectionTask.launchCollectionTask(UNDO, browser.mUndoHandler);
                 }
             }, browser.mCardsListView, null);
+            browser.searchCards();
         }
     };
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -696,8 +696,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
     protected void onStop() {
         Timber.d("onStop()");
         // cancel rendering the question and answer, which has shared access to mCards
-        CollectionTask.cancelAllTasks(SEARCH_CARDS);
-        CollectionTask.cancelAllTasks(RENDER_BROWSER_QA);
+        invalidate();
         super.onStop();
         if (!isFinishing()) {
             WidgetStatus.update(this);
@@ -1259,10 +1258,16 @@ public class CardBrowser extends NavigationDrawerActivity implements
         searchCards();
     }
 
-    private void searchCards() {
-        // cancel the previous search & render tasks if still running
+    private void invalidate() {
         CollectionTask.cancelAllTasks(SEARCH_CARDS);
         CollectionTask.cancelAllTasks(RENDER_BROWSER_QA);
+        mCards.clear();
+        mCheckedCards.clear();
+    }
+
+    private void searchCards() {
+        // cancel the previous search & render tasks if still running
+        invalidate();
         String searchText;
         if (mSearchTerms == null) {
             mSearchTerms = "";


### PR DESCRIPTION
## Pull Request template

## Fixes
Fixes #6970

## Approach

When a card was deleted, it was removed from the list of card. Its siblings was not. To reproduce, it suffices to try to delete a card without selecting one of its sibling.

I follow Mike idea in https://github.com/ankidroid/Anki-Android/pull/6611#issuecomment-653815157 to simply invalidate in case of danger.


## How Has This Been Tested?

Trying to reproduce the bug by deleting a single card of a note with multiple cards

## Learning (optional, can help others)

You know what. Tests of the UI would be nice.
