### PR TITLE
NF: Mock Task manager

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -124,7 +124,6 @@ import com.ichi2.libanki.Models;
 import com.ichi2.libanki.Utils;
 import com.ichi2.libanki.importer.AnkiPackageImporter;
 import com.ichi2.libanki.sched.AbstractDeckTreeNode;
-import com.ichi2.libanki.sched.DeckTreeNode;
 import com.ichi2.libanki.sync.CustomSyncServerUrlException;
 import com.ichi2.libanki.sync.Syncer;
 import com.ichi2.libanki.utils.TimeUtils;
@@ -145,7 +144,6 @@ import com.ichi2.utils.JSONException;
 
 import java.io.File;
 import java.io.FileOutputStream;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -862,7 +860,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
                 }
             } else if (resultCode == Reviewer.RESULT_ABORT_AND_SYNC) {
                 Timber.i("Obtained Abort and Sync result");
-                CollectionTask.waitForAllToFinish(4);
+                TaskManager.waitForAllToFinish(4);
                 sync();
             }
         } else if (requestCode == REQUEST_PATH_UPDATE) {

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -155,7 +155,6 @@ public class CollectionTask<ProgressListener, ProgressBackground extends Progres
         mTask = task;
         mListener = listener;
         mPreviousTask = previousTask;
-        TaskManager.addTask(this);
     }
 
     @Override

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -116,27 +116,6 @@ public class CollectionTask<ProgressListener, ProgressBackground extends Progres
      */
     private Context mContext;
 
-    /**
-     * Block the current thread until all CollectionTasks have finished.
-     * @param timeoutSeconds timeout in seconds
-     * @return whether all tasks exited successfully
-     */
-    @SuppressWarnings("UnusedReturnValue")
-    public static boolean waitForAllToFinish(Integer timeoutSeconds) {
-        // HACK: This should be better - there is currently a race condition in sLatestInstance, and no means to obtain this information.
-        // This should work in all reasonable cases given how few tasks we have concurrently blocking.
-        boolean result;
-        result = TaskManager.waitToFinish(timeoutSeconds / 4);
-        ThreadUtil.sleep(10);
-        result &= TaskManager.waitToFinish(timeoutSeconds / 4);
-        ThreadUtil.sleep(10);
-        result &= TaskManager.waitToFinish(timeoutSeconds / 4);
-        ThreadUtil.sleep(10);
-        result &= TaskManager.waitToFinish(timeoutSeconds / 4);
-        ThreadUtil.sleep(10);
-        Timber.i("Waited for all tasks to finish");
-        return result;
-    }
 
     /** Cancel the current task.
      * @return whether cancelling did occur.*/

--- a/AnkiDroid/src/main/java/com/ichi2/async/SingleTaskManager.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/SingleTaskManager.java
@@ -1,0 +1,166 @@
+package com.ichi2.async;
+
+import android.os.AsyncTask;
+
+import com.ichi2.utils.ThreadUtil;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import timber.log.Timber;
+
+public class SingleTaskManager extends TaskManager {
+
+    /**
+     * Tasks which are running or waiting to run.
+     * */
+    private final List<CollectionTask> mTasks = Collections.synchronizedList(new LinkedList<>());
+
+    private void addTasks(CollectionTask task) {
+        mTasks.add(task);
+    }
+
+    @Override
+    protected boolean removeTaskConcrete(CollectionTask task) {
+        return mTasks.remove(task);
+    }
+
+    /**
+     * The most recently started {@link CollectionTask} instance.
+     */
+    private CollectionTask mLatestInstance;
+
+    protected void setLatestInstanceConcrete(CollectionTask task) {
+        mLatestInstance = task;
+    }
+
+
+
+
+    /**
+     * Starts a new {@link CollectionTask}, with no listener
+     * <p>
+     * Tasks will be executed serially, in the order in which they are started.
+     * <p>
+     * This method must be called on the main thread.
+     *
+     * @param task the task to execute
+     * @return the newly created task
+     */
+    @Override
+    public <ProgressBackground, ResultBackground> CollectionTask<ProgressBackground, ProgressBackground, ResultBackground, ResultBackground> launchCollectionTaskConcrete(CollectionTask.Task<ProgressBackground, ResultBackground> task) {
+        return launchCollectionTask(task, null);
+    }
+
+
+
+    /**
+     * Starts a new {@link CollectionTask}, with a listener provided for callbacks during execution
+     * <p>
+     * Tasks will be executed serially, in the order in which they are started.
+     * <p>
+     * This method must be called on the main thread.
+     *
+     * @param task the task to execute
+     * @param listener to the status and result of the task, may be null
+     * @return the newly created task
+     */
+    public <ProgressListener, ProgressBackground extends ProgressListener, ResultListener, ResultBackground extends ResultListener> CollectionTask<ProgressListener, ProgressBackground, ResultListener, ResultBackground>
+    launchCollectionTaskConcrete(@NonNull CollectionTask.Task<ProgressBackground, ResultBackground> task,
+                         @Nullable TaskListener<ProgressListener, ResultListener> listener) {
+        // Start new task
+        CollectionTask<ProgressListener, ProgressBackground, ResultListener, ResultBackground> newTask = new CollectionTask<>(task, listener, mLatestInstance);
+        addTasks(newTask);
+        newTask.execute();
+        return newTask;
+    }
+
+
+    /**
+     * Block the current thread until the currently running CollectionTask instance (if any) has finished.
+     */
+    public void waitToFinishConcrete() {
+        waitToFinish(null);
+    }
+
+    /**
+     * Block the current thread until the currently running CollectionTask instance (if any) has finished.
+     * @param timeoutSeconds timeout in seconds
+     * @return whether or not the previous task was successful or not
+     */
+    @Override
+    public boolean waitToFinishConcrete(Integer timeoutSeconds) {
+        try {
+            if ((mLatestInstance != null) && (mLatestInstance.getStatus() != AsyncTask.Status.FINISHED)) {
+                Timber.d("CollectionTask: waiting for task %s to finish...", mLatestInstance.getTask().getClass());
+                if (timeoutSeconds != null) {
+                    mLatestInstance.get(timeoutSeconds, TimeUnit.SECONDS);
+                } else {
+                    mLatestInstance.get();
+                }
+
+            }
+            return true;
+        } catch (Exception e) {
+            Timber.e(e, "Exception waiting for task to finish");
+            return false;
+        }
+    }
+
+
+    /** Cancel the current task only if it's of type taskType */
+    @Override
+    public void cancelCurrentlyExecutingTaskConcrete() {
+        CollectionTask latestInstance = mLatestInstance;
+        if (latestInstance != null) {
+            if (latestInstance.safeCancel()) {
+                Timber.i("Cancelled task %s", latestInstance.getTask().getClass());
+            }
+        }
+    }
+
+    /** Cancel all tasks of type taskType*/
+    public void cancelAllTasksConcrete(Class taskType) {
+        int count = 0;
+        // safeCancel modifies mTasks, so iterate over a concrete copy
+        for (CollectionTask task: new ArrayList<>(mTasks)) {
+            if (task.getTask().getClass() != taskType) {
+                continue;
+            }
+            if (task.safeCancel()) {
+                count++;
+            }
+        }
+        if (count > 0) {
+            Timber.i("Cancelled %d instances of task %s", count, taskType);
+        }
+    }
+
+    /**
+     * Block the current thread until all CollectionTasks have finished.
+     * @param timeoutSeconds timeout in seconds
+     * @return whether all tasks exited successfully
+     */
+    @SuppressWarnings("UnusedReturnValue")
+    @Override
+    public boolean waitForAllToFinishConcrete(Integer timeoutSeconds) {
+        // HACK: This should be better - there is currently a race condition in sLatestInstance, and no means to obtain this information.
+        // This should work in all reasonable cases given how few tasks we have concurrently blocking.
+        boolean result;
+        result = waitToFinish(timeoutSeconds / 4);
+        ThreadUtil.sleep(10);
+        result &= waitToFinish(timeoutSeconds / 4);
+        ThreadUtil.sleep(10);
+        result &= waitToFinish(timeoutSeconds / 4);
+        ThreadUtil.sleep(10);
+        result &= waitToFinish(timeoutSeconds / 4);
+        ThreadUtil.sleep(10);
+        Timber.i("Waited for all tasks to finish");
+        return result;
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/async/TaskManager.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/TaskManager.java
@@ -74,6 +74,7 @@ public class TaskManager {
         @Nullable TaskListener<ProgressListener, ResultListener> listener) {
         // Start new task
         CollectionTask<ProgressListener, ProgressBackground, ResultListener, ResultBackground> newTask = new CollectionTask<>(task, listener, sLatestInstance);
+        addTask(newTask);
         newTask.execute();
         return newTask;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/async/TaskManager.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/TaskManager.java
@@ -3,6 +3,8 @@ package com.ichi2.async;
 import android.content.res.Resources;
 import android.os.AsyncTask;
 
+import com.ichi2.utils.ThreadUtil;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -138,6 +140,29 @@ public class TaskManager {
 
     public static ProgressCallback progressCallback(CollectionTask task, Resources res) {
         return new ProgressCallback(task, res);
+    }
+
+
+    /**
+     * Block the current thread until all CollectionTasks have finished.
+     * @param timeoutSeconds timeout in seconds
+     * @return whether all tasks exited successfully
+     */
+    @SuppressWarnings("UnusedReturnValue")
+    public static boolean waitForAllToFinish(Integer timeoutSeconds) {
+        // HACK: This should be better - there is currently a race condition in sLatestInstance, and no means to obtain this information.
+        // This should work in all reasonable cases given how few tasks we have concurrently blocking.
+        boolean result;
+        result = waitToFinish(timeoutSeconds / 4);
+        ThreadUtil.sleep(10);
+        result &= waitToFinish(timeoutSeconds / 4);
+        ThreadUtil.sleep(10);
+        result &= waitToFinish(timeoutSeconds / 4);
+        ThreadUtil.sleep(10);
+        result &= waitToFinish(timeoutSeconds / 4);
+        ThreadUtil.sleep(10);
+        Timber.i("Waited for all tasks to finish");
+        return result;
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -99,7 +99,7 @@ import static com.ichi2.libanki.Consts.DECK_DYN;
 @SuppressWarnings({"PMD.ExcessiveClassLength", "PMD.AvoidThrowingRawExceptionTypes","PMD.AvoidReassigningParameters",
         "PMD.NPathComplexity","PMD.MethodNamingConventions","PMD.AvoidBranchingStatementAsLastInLoop",
         "PMD.SwitchStmtsShouldHaveDefault","PMD.CollapsibleIfStatements","PMD.EmptyIfStmt","PMD.ExcessiveMethodLength"})
-public class Collection {
+public class Collection implements CollectionGetter {
 
     private final Context mContext;
 
@@ -2287,5 +2287,14 @@ public class Collection {
     @NonNull
     public Time getTime() {
         return mTime;
+    }
+
+
+    /**
+     * Allows a collection to be used as a CollectionGetter
+     * @return Itself.
+     */
+    public Collection getCol() {
+        return this;
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/CollectionGetter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/CollectionGetter.java
@@ -1,0 +1,5 @@
+package com.ichi2.libanki;
+
+public interface CollectionGetter {
+    Collection getCol();
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
@@ -31,6 +31,7 @@ import com.ichi2.async.TaskManager;
 import com.ichi2.compat.customtabs.CustomTabActivityHelper;
 import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
+import com.ichi2.libanki.CollectionGetter;
 import com.ichi2.libanki.Consts;
 import com.ichi2.libanki.DB;
 import com.ichi2.libanki.Model;
@@ -77,7 +78,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.robolectric.Shadows.shadowOf;
 
-public class RobolectricTest {
+public class RobolectricTest implements CollectionGetter {
+
+    private static boolean mBackground = true;
 
     private final ArrayList<ActivityController<?>> controllersForCleanup = new ArrayList<>();
 
@@ -243,7 +246,7 @@ public class RobolectricTest {
     /** A collection. Created one second ago, not near cutoff time.
     * Each time time is checked, it advance by 10 ms. Not enough to create any change visible to user, but ensure
      * we don't get two equal time.*/
-    protected Collection getCol() {
+    public Collection getCol() {
         MockTime time = new MockTime(2020, 7, 7, 7, 0, 0, 0, 10);
         return CollectionHelper.getInstance().getCol(getTargetContext(), time);
     }

--- a/AnkiDroid/src/test/java/com/ichi2/async/ForegroundTaskManager.java
+++ b/AnkiDroid/src/test/java/com/ichi2/async/ForegroundTaskManager.java
@@ -1,0 +1,69 @@
+package com.ichi2.async;
+
+import com.ichi2.libanki.CollectionGetter;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+public class ForegroundTaskManager extends TaskManager {
+    private final CollectionGetter mColGetter;
+
+
+    public ForegroundTaskManager(CollectionGetter colGetter) {
+        mColGetter = colGetter;
+    }
+
+
+    @Override
+    protected boolean removeTask(CollectionTask task) {
+        return true;
+    }
+
+
+    @Override
+    protected void setLatestInstance(CollectionTask task) {
+    }
+
+
+    @Override
+    public <ProgressListener, ProgressBackground extends ProgressListener, ResultListener, ResultBackground extends ResultListener> CollectionTask<ProgressListener, ProgressBackground, ResultListener, ResultBackground> launchCollectionTask(
+            @NonNull CollectionTask.Task<ProgressBackground, ResultBackground> task,
+            @Nullable TaskListener<ProgressListener, ResultListener> listener) {
+        CollectionTask<ProgressListener, ProgressBackground, ResultListener, ResultBackground>  ct =
+                new CollectionTask<>(task, listener, null);
+        ct.execute();
+        try {
+            ct.wait();
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        return ct;
+    }
+
+
+    @Override
+    public void waitToFinish() {
+    }
+
+
+    @Override
+    public boolean waitToFinish(Integer timeoutSeconds) {
+        return true;
+    }
+
+
+    @Override
+    public void cancelCurrentlyExecutingTask() {
+    }
+
+
+    @Override
+    public void cancelAllTasks(Class taskType) {
+    }
+
+
+    @Override
+    public boolean waitForAllToFinish(Integer timeoutSeconds) {
+        return true;
+    }
+}


### PR DESCRIPTION
Currently, the biggest problem to generate test are that some code is executed in background. Either I wait until the end of the background task, which is not easy to do, or I the test in OnPostExecute. In this case, I need to actually check whether onPostExecute is executed which lead back to first problem.

Worse, as show https://github.com/ankidroid/Anki-Android/pull/6978 there is difference in background task between machines.
The trouble, according to me, is that those are not difference I actually want to consider in tests. In the example linked above, it just means on some machine the counts will takes more time to be updated than on some other machines. That's not actually a problem as long as counts gets updated.

The trouble is that if I want to do test without task actually in background, currently, I need to run copy the background code in the test. This makes code complex, and potentially it does not even follow evolution of the task.


I thought that the solution should be:
* Uses a task manager. It contains what was static in CollectionTask
* Mock the task manager, with a method executing all tasks immediately. This way, this part of the test becomes deterministic. 
* Use the mock in the tests.

A single error remains, `checkDatabaseWithLockedCollectionReturnsLocked`. I'd love your help @david-allison-1 debugging this one. I don't know what this is supposed to test, so no way of knowing how to correct.
I tried to simply do  `getCol().getTaskManager().launchCollection(CHECK_DATABASE)` but this method never ends, so that's not the correct answer