### PR TITLE
NF: simplifying getCol

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
@@ -103,8 +103,13 @@ public class CollectionHelper {
      * @return instance of the Collection
      */
     public synchronized Collection getCol(Context context) {
+        if (colIsOpen()) {
+            return mCollection;
+        }
         return getCol(context, new SystemTime());
     }
+
+    @VisibleForTesting
     public synchronized Collection getCol(Context context, @NonNull Time time) {
         // Open collection
         if (!colIsOpen()) {


### PR DESCRIPTION
Each time getCol is called, a new SystemTime is created and immediately deleted. That's not a real trouble, but still kind create useless object. 

This way, `getCol(Context, T)` will be called only when we actually need to add a Time object, when we don't expect the collection to exists.

This should also simplifies https://github.com/ankidroid/Anki-Android/pull/7005 . 