### PR TITLE
Adding comment to each string ressources (Improving translation process)

### DIFF
--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -345,7 +345,7 @@
         <!-- "Add Note" widget -->
         <receiver
             android:name="com.ichi2.widget.AddNoteWidget"
-            android:label="@string/widget_add_note">
+            android:label="@string/menu_add_note">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
             </intent-filter>

--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -231,7 +231,7 @@
             />
         <activity
             android:name="com.ichi2.anki.MyAccount"
-            android:label="@string/menu_my_account"
+            android:label="@string/button_sync"
             android:exported="false"
             android:configChanges="keyboardHidden|orientation|locale|screenSize"
             />

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -489,7 +489,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
         // Setup the FloatingActionButtons, should work everywhere with min API >= 15
         mActionsMenu = findViewById(R.id.add_content_menu);
-        mActionsMenu.findViewById(R.id.fab_expand_menu_button).setContentDescription(getString(R.string.menu_add));
+        mActionsMenu.findViewById(R.id.fab_expand_menu_button).setContentDescription(getString(R.string.menu_add_note));
         configureFloatingActionsMenu();
 
         mReviewSummaryTextView = (TextView) findViewById(R.id.today_stats_text_view);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -2219,7 +2219,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
             // If the deck is empty and has no children then show a message saying it's empty
             final Uri helpUrl = Uri.parse(getResources().getString(R.string.link_manual_getting_started));
             mayOpenUrl(helpUrl);
-            UIUtils.showSnackbar(this, R.string.empty_deck, false, R.string.help,
+            UIUtils.showSnackbar(this, R.string.studyoptions_empty, false, R.string.help,
                     v -> openHelpUrl(helpUrl), findViewById(R.id.root_layout), mSnackbarShowHideCallback);
             if (mFragmented) {
                 openStudyOptions(false);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -586,7 +586,7 @@ public class NoteEditor extends AnkiActivity {
 
         if (mAddNote) {
             mNoteTypeSpinner.setOnItemSelectedListener(new SetNoteTypeListener());
-            setTitle(R.string.cardeditor_title_add_note);
+            setTitle(R.string.menu_add_note);
             // set information transferred by intent
             String contents = null;
             String[] tags = intent.getStringArrayExtra(EXTRA_TAGS);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.java
@@ -84,7 +84,7 @@ public class DeckPickerContextMenu extends AnalyticsDialogFragment {
         keyValueMap.put(CONTEXT_MENU_DELETE_DECK, res.getString(R.string.contextmenu_deckpicker_delete_deck));
         keyValueMap.put(CONTEXT_MENU_EXPORT_DECK, res.getString(R.string.export_deck));
         keyValueMap.put(CONTEXT_MENU_UNBURY, res.getString(R.string.unbury));
-        keyValueMap.put(CONTEXT_MENU_CUSTOM_STUDY_REBUILD, res.getString(R.string.rebuild_cram_label));
+        keyValueMap.put(CONTEXT_MENU_CUSTOM_STUDY_REBUILD, res.getString(R.string.rebuild_cram_deck));
         keyValueMap.put(CONTEXT_MENU_CUSTOM_STUDY_EMPTY, res.getString(R.string.empty_cram_label));
         keyValueMap.put(CONTEXT_MENU_CREATE_SUBDECK, res.getString(R.string.create_subdeck));
         return keyValueMap;

--- a/AnkiDroid/src/main/res/layout/floating_add_button.xml
+++ b/AnkiDroid/src/main/res/layout/floating_add_button.xml
@@ -38,10 +38,10 @@
             android:id="@+id/add_note_action"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:contentDescription="@string/menu_add"
+            android:contentDescription="@string/menu_add_note"
             fab:fab_colorNormal="?attr/fab_normal"
             fab:fab_icon="@drawable/ic_add_white_24dp"
-            fab:fab_title="@string/menu_add"
+            fab:fab_title="@string/menu_add_note"
             fab:fab_size="mini"
             fab:fab_colorPressed="?attr/fab_pressed"/>
     </com.getbase.floatingactionbutton.FloatingActionsMenu>

--- a/AnkiDroid/src/main/res/menu/card_browser.xml
+++ b/AnkiDroid/src/main/res/menu/card_browser.xml
@@ -40,7 +40,7 @@
 
     <item
         android:id="@+id/action_preview"
-        android:title="@string/card_editor_preview_card"/>
+        android:title="@string/preview_title"/>
 
     <item
         android:id="@+id/action_select_all"

--- a/AnkiDroid/src/main/res/menu/card_browser.xml
+++ b/AnkiDroid/src/main/res/menu/card_browser.xml
@@ -4,7 +4,7 @@
     <item
         android:id="@+id/action_add_note_from_card_browser"
         android:icon="@drawable/ic_add_white_24dp"
-        android:title="@string/note_editor_add_note"
+        android:title="@string/menu_add_note"
         ankidroid:showAsAction="ifRoom"/>
     <item
         android:id="@+id/action_search"

--- a/AnkiDroid/src/main/res/menu/card_browser_multiselect.xml
+++ b/AnkiDroid/src/main/res/menu/card_browser_multiselect.xml
@@ -72,7 +72,7 @@
 
     <item
         android:id="@+id/action_preview"
-        android:title="@string/card_editor_preview_card"/>
+        android:title="@string/preview_title"/>
 
     <item
         ankidroid:showAsAction="ifRoom"

--- a/AnkiDroid/src/main/res/menu/card_template_editor.xml
+++ b/AnkiDroid/src/main/res/menu/card_template_editor.xml
@@ -15,8 +15,8 @@
     <item
         android:id="@+id/action_add"
         android:icon="@drawable/ic_menu_add"
-        android:title="@string/menu_add"
-        ankidroid:showAsAction="never"/>
+        android:title="@string/menu_add_note"
+        ankidroid:showAsAction="never" />
     <item
         android:id="@+id/action_delete"
         android:icon="@drawable/ic_action_cancel"

--- a/AnkiDroid/src/main/res/menu/card_template_editor.xml
+++ b/AnkiDroid/src/main/res/menu/card_template_editor.xml
@@ -3,7 +3,7 @@
     <item
         android:id="@+id/action_preview"
         android:icon="@drawable/ic_remove_red_eye_white_24dp"
-        android:title="@string/card_editor_preview_card"
+        android:title="@string/preview_title"
         ankidroid:showAsAction="ifRoom"
         android:visible="true"/>
     <item

--- a/AnkiDroid/src/main/res/menu/model_browser.xml
+++ b/AnkiDroid/src/main/res/menu/model_browser.xml
@@ -3,7 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
         android:id="@+id/action_add_new_note_type"
-        android:title="@string/model_editor_action_add_model"
+        android:title="@string/model_browser_add"
         android:icon="@drawable/ic_add_white_24dp"
         app:showAsAction="always"/>
 </menu>

--- a/AnkiDroid/src/main/res/menu/note_editor.xml
+++ b/AnkiDroid/src/main/res/menu/note_editor.xml
@@ -9,7 +9,7 @@
     <item
         android:id="@+id/action_preview"
         android:icon="@drawable/ic_remove_red_eye_white_24dp"
-        android:title="@string/card_editor_preview_card"
+        android:title="@string/preview_title"
         ankidroid:showAsAction="ifRoom"
         android:visible="true"/>
     <item

--- a/AnkiDroid/src/main/res/menu/note_editor.xml
+++ b/AnkiDroid/src/main/res/menu/note_editor.xml
@@ -14,7 +14,7 @@
         android:visible="true"/>
     <item
         android:id="@+id/action_add_note_from_note_editor"
-        android:title="@string/note_editor_add_note"
+        android:title="@string/menu_add_note"
         android:visible="false"/>
     <item
         android:id="@+id/action_copy_note"

--- a/AnkiDroid/src/main/res/menu/reviewer.xml
+++ b/AnkiDroid/src/main/res/menu/reviewer.xml
@@ -84,7 +84,7 @@
         ankidroid:showAsAction="ifRoom"/>
     <item
         android:id="@+id/action_toggle_mic_tool_bar"
-        android:title="@string/toggle_mic_tool_bar"
+        android:title="@string/menu_toggle_mic_tool_bar"
         android:icon="@drawable/ic_action_mic"
         ankidroid:showAsAction="never"/>
     <item

--- a/AnkiDroid/src/main/res/menu/study_options_fragment.xml
+++ b/AnkiDroid/src/main/res/menu/study_options_fragment.xml
@@ -8,7 +8,7 @@
         ankidroid:showAsAction="always"/>
     <item
         android:id="@+id/action_rebuild"
-        android:title="@string/rebuild_cram_label"
+        android:title="@string/rebuild_cram_deck"
         android:visibility = "gone"
         android:icon="@drawable/ic_refresh_white_24dp"
         ankidroid:showAsAction="ifRoom"/>

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -329,11 +329,6 @@
       Delete note
     </string>
     <string
-        name="menu_flag"
-        >
-      Flag
-    </string>
-    <string
         name="menu_flag_card"
         >
       Flag card

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -284,11 +284,6 @@
       Rename deck
     </string>
     <string
-        name="menu_add"
-        >
-      Add
-    </string>
-    <string
         name="menu_add_note"
         >
       Add note

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -17,112 +17,277 @@
 ~
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
---><resources>
-    <!-- Navigation drawer items-->
-    <string name="decks">Decks</string>
-    <string name="card_browser">Card browser</string>
-    <string name="statistics">Statistics</string>
-    <string name="settings">Settings</string>
-    <string name="help">Help</string>
-    <string name="send_feedback">Send feedback</string>
+-->
+<resources>
+  <!-- Navigation drawer items-->
+  <string name="decks">
+    Decks
+  </string>
+  <string name="card_browser">
+    Card browser
+  </string>
+  <string name="statistics">
+    Statistics
+  </string>
+  <string name="settings">
+    Settings
+  </string>
+  <string name="help">
+    Help
+  </string>
+  <string name="send_feedback">
+    Send feedback
+  </string>
 
-    <string name="studyoptions_title">Deck overview</string>
-    <string name="studyoptions_due_today">Due today:</string>
-    <string name="studyoptions_new_total">Total new cards:</string>
-    <string name="studyoptions_total_cards">Total cards:</string>
-    <string name="studyoptions_eta">Estimated time (min):</string>
-    <string name="studyoptions_start">Study</string>
+  <string name="studyoptions_title">
+    Deck overview
+  </string>
+  <string name="studyoptions_due_today">
+    Due today:
+  </string>
+  <string name="studyoptions_new_total">
+    Total new cards:
+  </string>
+  <string name="studyoptions_total_cards">
+    Total cards:
+  </string>
+  <string name="studyoptions_eta">
+    Estimated time (min):
+  </string>
+  <string name="studyoptions_start">
+    Study
+  </string>
 
-    <!-- DeckPicker.java -->
-    <string name="expand">Expand</string>
-    <string name="collapse">Collapse</string>
-    <string name="study_more">Study more</string>
-    <plurals name="deckpicker_title">
-        <item quantity="one">%1$d card due (%2$s)</item>
-        <item quantity="other">%1$d cards due (%2$s)</item>
+  <!-- DeckPicker.java -->
+  <string name="expand">
+    Expand
+  </string>
+  <string name="collapse">
+    Collapse
+  </string>
+  <string name="study_more">
+    Study more
+  </string>
+  <plurals name="deckpicker_title">
+    <item quantity="one">
+      %1$d card due (%2$s)
+    </item>
+    <item quantity="other">
+      %1$d cards due (%2$s)
+    </item>
     </plurals>
     <plurals name="reviewer_window_title">
-        <item quantity="one">%d minute left</item>
-        <item quantity="other">%d minutes left</item>
+      <item quantity="one">
+        %d minute left
+      </item>
+      <item quantity="other">
+        %d minutes left
+      </item>
     </plurals>
     <plurals name="reviewer_window_title_hours">
-        <item quantity="one">%d hour %d left</item>
-        <item quantity="other">%d hours %d left</item>
+      <item quantity="one">
+        %d hour %d left
+      </item>
+      <item quantity="other">
+        %d hours %d left
+      </item>
     </plurals>
     <plurals name="reviewer_window_title_days">
-        <item quantity="one">%d day %d left</item>
-        <item quantity="other">%d days %d left</item>
+      <item quantity="one">
+        %d day %d left
+      </item>
+      <item quantity="other">
+        %d days %d left
+      </item>
     </plurals>
-    <string name="no_cards_placeholder_title">Collection is empty</string>
-    <string name="no_cards_placeholder_description">Start adding cards\nusing the + icon.</string>
+    <string name="no_cards_placeholder_title">
+      Collection is empty
+    </string>
+    <string name="no_cards_placeholder_description">
+      Start adding cards\nusing the + icon.
+    </string>
 
     <!-- The deck picker via AnkiStatsTaskHandler.java -->
     <plurals name="studied_cards_today">
-        <item quantity="one">Studied %1$d card in %2$s today</item>
-        <item quantity="other">Studied %1$d cards in %2$s today</item>
+      <item quantity="one">
+        Studied %1$d card in %2$s today
+      </item>
+      <item quantity="other">
+        Studied %1$d cards in %2$s today
+      </item>
     </plurals>
 
 
     <!-- flashcard_portrait.xml -->
-    <string name="type_answer_hint">Type answer</string>
-    <string name="show_answer">Show answer</string>
-    <string name="hide_answer">Hide answer</string>
-    <string name="ease_button_again">Again</string>
-    <string name="ease_button_hard">Hard</string>
-    <string name="ease_button_good">Good</string>
-    <string name="ease_button_easy">Easy</string>
-    <string name="studyoptions_congrats_undo">Undo %s</string>
-    <string name="menu_import">Import</string>
-    <string name="undo">Undo</string>
-    <string name="undo_action_review">last review</string>
-    <string name="undo_action_bury_card">bury card</string>
-    <string name="undo_action_bury_note">bury note</string>
-    <string name="undo_action_suspend_card">suspend card</string>
-    <string name="undo_action_suspend_note">suspend note</string>
-    <string name="undo_action_delete">delete note</string>
-    <string name="undo_action_delete_multi">delete notes</string>
-    <string name="undo_action_change_deck_multi">change decks</string>
-    <string name="undo_action_reschedule_card">reschedule</string>
-    <string name="undo_action_reset_card">reset progress</string>
-    <string name="undo_action_reposition_card">reposition</string>
-    <string name="move_all_to_deck">Move all to deck</string>
-    <string name="unbury">Unbury</string>
-    <string name="rename_deck">Rename deck</string>
-    <string name="menu_add">Add</string>
-    <string name="menu_add_note">Add note</string>
-    <string name="menu_my_account">Sync account</string>
-    <string name="menu_dismiss_note">Hide / delete</string>
-    <string name="menu_bury_card">Bury card</string>
-    <string name="menu_bury_note">Bury note</string>
-    <string name="menu_suspend_card">Suspend card</string>
-    <string name="menu_suspend_note">Suspend note</string>
-    <string name="menu_bury">Bury</string>
-    <string name="menu_suspend">Suspend</string>
-    <string name="menu_delete_note">Delete note</string>
-    <string name="menu_flag">Flag</string>
-    <string name="menu_flag_card">Flag card</string>
-    <string name="menu_flag_card_zero">No flag</string>
-    <string name="menu_flag_card_one">Red flag</string>
-    <string name="menu_flag_card_two">Orange flag</string>
-    <string name="menu_flag_card_three">Green flag</string>
-    <string name="menu_flag_card_four">Blue flag</string>
-    <string name="menu_edit_tags">Edit tags</string>
-    <string name="delete_note_message">Really delete this note and all its cards?\n%s</string>
-    <string name="menu_select">Select text</string>
-    <string name="menu_search">Lookup in %1$s</string>
-    <string name="menu_mark_note">Mark note</string>
-    <string name="menu_unmark_note">Unmark note</string>
-    <string name="menu_toggle_mic_tool_bar">Check pronunciation</string>
-    <string name="new_deck">Create deck</string>
-    <string name="create">Create</string>
-    <string name="new_dynamic_deck">Create filtered deck</string>
-    <string name="night_mode">Night mode</string>
-    <string name="directory_inaccessible">AnkiDroid directory is inaccessible</string>
+    <string name="type_answer_hint">
+      Type answer
+    </string>
+    <string name="show_answer">
+      Show answer
+    </string>
+    <string name="hide_answer">
+      Hide answer
+    </string>
+    <string name="ease_button_again">
+      Again
+    </string>
+    <string name="ease_button_hard">
+      Hard
+    </string>
+    <string name="ease_button_good">
+      Good
+    </string>
+    <string name="ease_button_easy">
+      Easy
+    </string>
+    <string name="studyoptions_congrats_undo">
+      Undo %s
+    </string>
+    <string name="menu_import">
+      Import
+    </string>
+    <string name="undo">
+      Undo
+    </string>
+    <string name="undo_action_review">
+      last review
+    </string>
+    <string name="undo_action_bury_card">
+      bury card
+    </string>
+    <string name="undo_action_bury_note">
+      bury note
+    </string>
+    <string name="undo_action_suspend_card">
+      suspend card
+    </string>
+    <string name="undo_action_suspend_note">
+      suspend note
+    </string>
+    <string name="undo_action_delete">
+      delete note
+    </string>
+    <string name="undo_action_delete_multi">
+      delete notes
+    </string>
+    <string name="undo_action_change_deck_multi">
+      change decks
+    </string>
+    <string name="undo_action_reschedule_card">
+      reschedule
+    </string>
+    <string name="undo_action_reset_card">
+      reset progress
+    </string>
+    <string name="undo_action_reposition_card">
+      reposition
+    </string>
+    <string name="move_all_to_deck">
+      Move all to deck
+    </string>
+    <string name="unbury">
+      Unbury
+    </string>
+    <string name="rename_deck">
+      Rename deck
+    </string>
+    <string name="menu_add">
+      Add
+    </string>
+    <string name="menu_add_note">
+      Add note
+    </string>
+    <string name="menu_my_account">
+      Sync account
+    </string>
+    <string name="menu_dismiss_note">
+      Hide / delete
+    </string>
+    <string name="menu_bury_card">
+      Bury card
+    </string>
+    <string name="menu_bury_note">
+      Bury note
+    </string>
+    <string name="menu_suspend_card">
+      Suspend card
+    </string>
+    <string name="menu_suspend_note">
+      Suspend note
+    </string>
+    <string name="menu_bury">
+      Bury
+    </string>
+    <string name="menu_suspend">
+      Suspend
+    </string>
+    <string name="menu_delete_note">
+      Delete note
+    </string>
+    <string name="menu_flag">
+      Flag
+    </string>
+    <string name="menu_flag_card">
+      Flag card
+    </string>
+    <string name="menu_flag_card_zero">
+      No flag
+    </string>
+    <string name="menu_flag_card_one">
+      Red flag
+    </string>
+    <string name="menu_flag_card_two">
+      Orange flag
+    </string>
+    <string name="menu_flag_card_three">
+      Green flag
+    </string>
+    <string name="menu_flag_card_four">
+      Blue flag
+    </string>
+    <string name="menu_edit_tags">
+      Edit tags
+    </string>
+    <string name="delete_note_message">
+      Really delete this note and all its cards?\n%s
+    </string>
+    <string name="menu_select">
+      Select text
+    </string>
+    <string name="menu_search">
+      Lookup in %1$s
+    </string>
+    <string name="menu_mark_note">
+      Mark note
+    </string>
+    <string name="menu_unmark_note">
+      Unmark note
+    </string>
+    <string name="menu_toggle_mic_tool_bar">
+      Check pronunciation
+    </string>
+    <string name="new_deck">
+      Create deck
+    </string>
+    <string name="create">
+      Create
+    </string>
+    <string name="new_dynamic_deck">
+      Create filtered deck
+    </string>
+    <string name="night_mode">
+      Night mode
+    </string>
+    <string name="directory_inaccessible">
+      AnkiDroid directory is inaccessible
+    </string>
     <!--This is shown when AnkiDroid starts up with no storage permissions.
     The user is taken to the "App Info" screen, and needs to click "Permissions" and
     grant AnkiDroid the 'Storage' permission. This needs to be a fairly generic message as implementations
     of the permissions/app info screen will differ between devices. -->
-    <string name="startup_no_storage_permission">Please grant AnkiDroid the ‘Storage’ permission to continue</string>
+    <string name="startup_no_storage_permission">
+      Please grant AnkiDroid the ‘Storage’ permission to continue
+    </string>
     <!--
         The time_quantities are units of time. They are used without
         plurals or dots.
@@ -130,72 +295,185 @@
         not be translated, at least not for languages using the Latin
         alphabet.
     -->
-    <string name="time_quantity_seconds">%d s</string>
-    <string name="time_quantity_minutes">%d min</string>
-    <string name="time_quantity_hours_minutes">%1$d h %2$d m</string>
-    <string name="time_quantity_hours">%d h</string>
-    <string name="time_quantity_days">%d d</string>
-    <string name="time_quantity_days_hours">%1$d d %2$d h</string>
-    <string name="time_quantity_months">%.1f mo</string>
-    <string name="time_quantity_years">%.1f yr</string><!-- or "%.1f a" -->
-    <string name="rebuild_cram_deck">Rebuilding cram deck…</string>
-    <string name="rebuild_cram_label">Rebuild</string>
-    <string name="empty_cram_label">Empty</string>
-    <string name="create_subdeck">Create subdeck</string>
-    <string name="empty_cram_deck">Emptying cram deck…</string>
-    <string name="custom_study_deck_name">Custom study session</string>
-    <string name="custom_study_deck_exists">Rename the existing custom study deck first</string>
-    <string name="empty_deck">This deck is empty</string>
-    <string name="invalid_deck_name">Invalid deck name</string>
-    <string name="studyoptions_empty">This deck is empty. Press the + button to add new content.</string>
-    <string name="studyoptions_limit_reached">Daily study limit reached</string>
-    <string name="studyoptions_empty_schedule">No cards scheduled to study</string>
-    <string name="studyoptions_congrats_finished">Congratulations! You have finished for now.</string>
-    <string name="studyoptions_congrats_more_rev">Today’s limit has been reached, but there are still cards to review. You can increase the limit in the options.</string>
-    <string name="studyoptions_congrats_more_new">Today’s limit has been reached. There are more new cards available; you can increase the limit in the options, but this will increase your short-term review workload.</string>
-    <string name="studyoptions_congrats_custom">To study outside of the normal schedule, touch the “Custom study” button</string>
-    <string name="studyoptions_no_cards_due">No cards are due yet</string>
+    <string name="time_quantity_seconds">
+      %d s
+    </string>
+    <string name="time_quantity_minutes">
+      %d min
+    </string>
+    <string name="time_quantity_hours_minutes">
+      %1$d h %2$d m
+    </string>
+    <string name="time_quantity_hours">
+      %d h
+    </string>
+    <string name="time_quantity_days">
+      %d d
+    </string>
+    <string name="time_quantity_days_hours">
+      %1$d d %2$d h
+    </string>
+    <string name="time_quantity_months">
+      %.1f mo
+    </string>
+    <string name="time_quantity_years">
+      %.1f yr
+    </string><!-- or "%.1f a" -->
+    <string name="rebuild_cram_deck">
+      Rebuilding cram deck…
+    </string>
+    <string name="rebuild_cram_label">
+      Rebuild
+    </string>
+    <string name="empty_cram_label">
+      Empty
+    </string>
+    <string name="create_subdeck">
+      Create subdeck
+    </string>
+    <string name="empty_cram_deck">
+      Emptying cram deck…
+    </string>
+    <string name="custom_study_deck_name">
+      Custom study session
+    </string>
+    <string name="custom_study_deck_exists">
+      Rename the existing custom study deck first
+    </string>
+    <string name="empty_deck">
+      This deck is empty
+    </string>
+    <string name="invalid_deck_name">
+      Invalid deck name
+    </string>
+    <string name="studyoptions_empty">
+      This deck is empty. Press the + button to add new content.
+    </string>
+    <string name="studyoptions_limit_reached">
+      Daily study limit reached
+    </string>
+    <string name="studyoptions_empty_schedule">
+      No cards scheduled to study
+    </string>
+    <string name="studyoptions_congrats_finished">
+      Congratulations! You have finished for now.
+    </string>
+    <string name="studyoptions_congrats_more_rev">
+      Today’s limit has been reached, but there are still cards to review. You can increase the limit in the options.
+    </string>
+    <string name="studyoptions_congrats_more_new">
+    Today’s limit has been reached. There are more new cards available; you can increase the limit in the options, but
+    this will increase your short-term review workload.
+    </string>
+    <string name="studyoptions_congrats_custom">
+      To study outside of the normal schedule, touch the “Custom study” button
+    </string>
+    <string name="studyoptions_no_cards_due">
+      No cards are due yet
+    </string>
 
-    <string name="sd_card_not_mounted">Device storage not mounted</string>
-    <string name="empty_cloze_warning">Edit this note and add some cloze deletions. (%1$s)</string>
-    <string name="button_sync">Sync</string>
-    <string name="cancel_sync_confirm">Do you want to cancel the sync?</string>
-    <string name="continue_sync">Continue sync</string>
-    <string name="sync_cancelled">Sync cancelled</string>
-    <string name="sync_cancel_message">Cancelling…\nThis may take some time.</string>
-    <string name="export">Export</string>
-    <string name="export_collection">Export collection</string>
-    <string name="export_deck">Export deck</string>
-    <string name="nothing">Nothing</string>
+    <string name="sd_card_not_mounted">
+      Device storage not mounted
+    </string>
+    <string name="empty_cloze_warning">
+      Edit this note and add some cloze deletions. (%1$s)
+    </string>
+    <string name="button_sync">
+      Sync
+    </string>
+    <string name="cancel_sync_confirm">
+      Do you want to cancel the sync?
+    </string>
+    <string name="continue_sync">
+      Continue sync
+    </string>
+    <string name="sync_cancelled">
+      Sync cancelled
+    </string>
+    <string name="sync_cancel_message">
+      Cancelling…\nThis may take some time.
+    </string>
+    <string name="export">
+      Export
+    </string>
+    <string name="export_collection">
+      Export collection
+    </string>
+    <string name="export_deck">
+      Export deck
+    </string>
+    <string name="nothing">
+      Nothing
+    </string>
 
     <!-- Card template editor -->
-    <string name="title_activity_template_editor">Card types</string>
-    <string name="card_template_editor_front">Front template</string>
-    <string name="card_template_editor_back">Back template</string>
-    <string name="card_template_editor_styling">Styling</string>
-    <string name="card_template_editor_menu_delete">Delete</string>
-    <string name="card_template_editor_menu_card_browser_appearance">Card Browser Appearance</string>
-    <string name="card_template_editor_deck_override">Deck Override</string>
-    <string name="card_template_editor_cant_delete">At least one card type is required</string>
+    <string name="title_activity_template_editor">
+      Card types
+    </string>
+    <string name="card_template_editor_front">
+      Front template
+    </string>
+    <string name="card_template_editor_back">
+      Back template
+    </string>
+    <string name="card_template_editor_styling">
+      Styling
+    </string>
+    <string name="card_template_editor_menu_delete">
+      Delete
+    </string>
+    <string name="card_template_editor_menu_card_browser_appearance">
+      Card Browser Appearance
+    </string>
+    <string name="card_template_editor_deck_override">
+      Deck Override
+    </string>
+    <string name="card_template_editor_cant_delete">
+      At least one card type is required
+    </string>
     <plurals name="card_template_editor_confirm_delete">
-        <item quantity="one">Delete the “%2$s” card type, and its %1$d card?</item>
-        <item quantity="other">Delete the “%2$s” card type, and its %1$d cards?</item>
+      <item quantity="one">
+        Delete the “%2$s” card type, and its %1$d card?
+      </item>
+      <item quantity="other">
+        Delete the “%2$s” card type, and its %1$d cards?
+      </item>
     </plurals>
-    <string name="invalid_template">A card could not be generated</string>
-    <string name="card_template_editor_would_delete_note">Removing this card type would cause one or more notes to be deleted. Please create and save a new card type first.</string>
-    <string name="card_template_editor_save_error">Unable to save card template changes: %s</string>
-    <string name="template_for_current_card_deleted">The card type for the current card was deleted.</string>
+    <string name="invalid_template">
+      A card could not be generated
+    </string>
+    <string name="card_template_editor_would_delete_note">
+      Removing this card type would cause one or more notes to be deleted. Please create and save a new card type first.
+    </string>
+    <string name="card_template_editor_save_error">
+      Unable to save card template changes: %s
+    </string>
+    <string name="template_for_current_card_deleted">
+      The card type for the current card was deleted.
+    </string>
 
     <!-- Card Browser Appearance -->
-    <string name="card_template_browser_appearance_title">Browser appearance</string>
+    <string name="card_template_browser_appearance_title">
+      Browser appearance
+    </string>
 
     <!-- Permissions -->
-    <string name="read_write_permission_label">Read and write to the AnkiDroid database</string>
-    <string name="read_write_permission_description">access existing notes, cards, note types, and decks, as well as create new ones</string>
+    <string name="read_write_permission_label">
+      Read and write to the AnkiDroid database
+    </string>
+    <string name="read_write_permission_description">
+      access existing notes, cards, note types, and decks, as well as create new ones
+    </string>
 
     <!-- Context Menu -->
-    <string name="card_browser_label">Card Browser</string>
-    <string name="card_browser_context_menu">Card Browser</string>
+    <string name="card_browser_label">
+      Card Browser
+    </string>
+    <string name="card_browser_context_menu">
+      Card Browser
+    </string>
 
-    <string name="context_menu_anki_card_label">Anki Card</string>
+    <string name="context_menu_anki_card_label">
+      Anki Card
+    </string>
 </resources>

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -477,7 +477,7 @@
     <string
         name="rebuild_cram_deck"
         >
-      Rebuilding cram deck…
+      Rebuilding cram deck
     </string>
     <string
         name="rebuild_cram_label"
@@ -497,7 +497,7 @@
     <string
         name="empty_cram_deck"
         >
-      Emptying cram deck…
+      Emptying cram deck
     </string>
     <string
         name="custom_study_deck_name"

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -289,11 +289,6 @@
       Add note
     </string>
     <string
-        name="menu_my_account"
-        >
-      Sync account
-    </string>
-    <string
         name="menu_dismiss_note"
         >
       Hide / delete

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -505,11 +505,6 @@
       Rename the existing custom study deck first
     </string>
     <string
-        name="empty_deck"
-        >
-      This deck is empty
-    </string>
-    <string
         name="invalid_deck_name"
         >
       Invalid deck name

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -22,62 +22,74 @@
   <!-- Navigation drawer items-->
   <string
       name="decks"
+      comment="A list of cards. What the user select to choose what to review."
       >
     Decks
   </string>
   <string
       name="card_browser"
+      comment="The screen in which you can search for cards, select some and edit them."
       >
     Card browser
   </string>
   <string
       name="statistics"
+      comment="The screen where you can see aggregated informations about your review history."
       >
     Statistics
   </string>
   <string
       name="settings"
+      comment="The screen where the user can change global parameter ."
       >
     Settings
   </string>
   <string
       name="help"
+      comment="A button to get some information. Either global help for AnkiDroid or help for a specific context."
       >
     Help
   </string>
   <string
       name="send_feedback"
+      comment="The screen allowing user to send feedbacks to the AnkiDroid team."
       >
     Send feedback
   </string>
 
   <string
       name="studyoptions_title"
+      comment="Title of the page showing information about current deck."
       >
     Deck overview
   </string>
   <string
       name="studyoptions_due_today"
+      comment="Label in deck overview for the number of cards that are going to be due today."
       >
     Due today:
   </string>
   <string
       name="studyoptions_new_total"
+      comment="Label in deck overview for the number of new cards (for today or later) in selected deck."
       >
     Total new cards:
   </string>
   <string
       name="studyoptions_total_cards"
+      comment="Label in deck overview for the total number of cards in the selected deck."
       >
     Total cards:
   </string>
   <string
       name="studyoptions_eta"
+      comment="Label in the deck overview for the estimated time the user will spend reviewing this deck."
       >
     Estimated time (min):
   </string>
   <string
       name="studyoptions_start"
+      comment="Label of the button to move from overview and start studying."
       >
     Study
   </string>
@@ -85,21 +97,25 @@
   <!-- DeckPicker.java -->
   <string
       name="expand"
+      comment="Description of the action done in the deck picker, i.e. expanding subdecks of a deck. Used for accessibility."
       >
     Expand
   </string>
   <string
       name="collapse"
+      comment="Description of the action done in the deck picker, i.e. collapsing subdecks of a deck. Used for accessibility."
       >
     Collapse
   </string>
   <string
       name="study_more"
+      comment="Link to invite users to increase the number of card they'll study today in a deck."
       >
     Study more
   </string>
   <plurals
       name="deckpicker_title"
+      comment="Message under AnkiDroid in the main screen."
       >
     <item quantity="one">
       %1$d card due (%2$s)
@@ -110,6 +126,7 @@
     </plurals>
     <plurals
         name="reviewer_window_title"
+        comment="Shown in reviewer to indicates how much time is expected to be spent in it, in minutes (at most 59)."
         >
       <item quantity="one">
         %d minute left
@@ -120,6 +137,7 @@
     </plurals>
     <plurals
         name="reviewer_window_title_hours"
+        comment="Shown in reviewer to indicates how much time is expected to be spent in it, in hours (at most 23) and minutes."
         >
       <item quantity="one">
         %d hour %d left
@@ -130,6 +148,7 @@
     </plurals>
     <plurals
         name="reviewer_window_title_days"
+        comment="Shown in reviewer to indicates how much time is expected to be spent in it, in days and hours."
         >
       <item quantity="one">
         %d day %d left
@@ -140,11 +159,13 @@
     </plurals>
     <string
         name="no_cards_placeholder_title"
+        comment="Message displayed on start, before the user adds they first cards or decks, to explain why they can't start reviewing yet."
         >
       Collection is empty
     </string>
     <string
         name="no_cards_placeholder_description"
+        comment="Message displayed on start, to explain to the user how to start creating cards to learn."
         >
       Start adding cards\nusing the + icon.
     </string>
@@ -152,6 +173,7 @@
     <!-- The deck picker via AnkiStatsTaskHandler.java -->
     <plurals
         name="studied_cards_today"
+        comment="Message in deck picker telling the user how much time was spent and how much card reviewed today."
         >
       <item quantity="one">
         Studied %1$d card in %2$s today
@@ -165,236 +187,283 @@
     <!-- flashcard_portrait.xml -->
     <string
         name="type_answer_hint"
+        comment="In the reviewer, for cards where you should type the answer. This is the text displayed in the field while it's empty, to indicate the field purpose."
         >
       Type answer
     </string>
     <string
         name="show_answer"
+        comment="In the reviewer, on question side. Label of the button which should be pressed to show the answer."
         >
       Show answer
     </string>
     <string
         name="hide_answer"
+        comment="In previewer, inverse of 'show_answer'; goes back to question side of the card."
         >
       Hide answer
     </string>
     <string
         name="ease_button_again"
+        comment="In the reviewer, on the answer side. Label of the left-most button."
         >
       Again
     </string>
     <string
         name="ease_button_hard"
+        comment="In the reviewer, on the answer side. Label of the second button in most case."
         >
       Hard
     </string>
     <string
         name="ease_button_good"
+        comment="In the reviewer, on the answer side. Label of the default button."
         >
       Good
     </string>
     <string
         name="ease_button_easy"
+        comment="In the reviewer, on the answer side. Label of the right-most button."
         >
       Easy
     </string>
     <string
         name="studyoptions_congrats_undo"
+        comment="Label of button inviting to undo, and explaining what will be undone."
         >
       Undo %s
     </string>
     <string
         name="menu_import"
+        comment="Label of the 'import' menu entry in deck picker."
         >
       Import
     </string>
     <string
         name="undo"
+        comment="Label of the 'undo' button in card browser, reviewer and study option."
         >
       Undo
     </string>
     <string
         name="undo_action_review"
+        comment="Label indicating that, if you press undo, it'll undo the last review."
         >
       last review
     </string>
     <string
         name="undo_action_bury_card"
+        comment="Label indicating that, if you press undo, it'll undo burying a card."
         >
       bury card
     </string>
     <string
         name="undo_action_bury_note"
+        comment="Label indicating that, if you press undo, it'll undo the burying a note."
         >
       bury note
     </string>
     <string
         name="undo_action_suspend_card"
+        comment="Label indicating that, if you press undo, it'll undo the suspension of a card."
         >
       suspend card
     </string>
     <string
         name="undo_action_suspend_note"
+        comment="Label indicating that, if you press undo, it'll undo the suspension of a note."
         >
       suspend note
     </string>
     <string
         name="undo_action_delete"
+        comment="Label indicating that, if you press undo, it'll undo the deletion of a note."
         >
       delete note
     </string>
     <string
         name="undo_action_delete_multi"
+        comment="Label indicating that, if you press undo, it'll undo the deletion of notes."
         >
       delete notes
     </string>
     <string
         name="undo_action_change_deck_multi"
+        comment="Label indicating that, if you press undo, it'll undo changing decks of cards."
         >
       change decks
     </string>
     <string
         name="undo_action_reschedule_card"
+        comment="Label indicating that, if you press undo, it'll undo the rescheduling of card(s)."
         >
       reschedule
     </string>
     <string
         name="undo_action_reset_card"
+        comment="Label indicating that, if you press undo, it'll undo resetting the progress of card(s)."
         >
       reset progress
     </string>
     <string
         name="undo_action_reposition_card"
+        comment="Label indicating that, if you press undo, it'll undo the repositioning card(s)."
         >
       reposition
     </string>
     <string
         name="move_all_to_deck"
+        comment="Label indicating that, if you press undo, it'll undo the move of cards."
         >
       Move all to deck
     </string>
     <string
         name="unbury"
+        comment="Label of the menu item which unbury the cards of a deck."
         >
       Unbury
     </string>
     <string
         name="rename_deck"
+        comment="Label of the menu item which rename a deck.."
         >
       Rename deck
     </string>
     <string
         name="menu_add_note"
+        comment="Label of the menu item to add notes from the reviewer. Same effect as menu_add but displayed in the reviewer."
         >
       Add note
     </string>
     <string
         name="menu_dismiss_note"
+        comment="In reviewer's option, label of the part of the menu dealing with all options removing a card from reviewer today. I.e. suspend, bury and delete."
         >
       Hide / delete
     </string>
     <string
         name="menu_bury_card"
+        comment="Label of the reviewer's menu entry to bury current card."
         >
       Bury card
     </string>
     <string
         name="menu_bury_note"
+        comment="Label of the reviewer's menu entry to bury the note of current card."
         >
       Bury note
     </string>
     <string
         name="menu_suspend_card"
+        comment="Label of the reviewer's menu entry to suspend current card."
         >
       Suspend card
     </string>
     <string
         name="menu_suspend_note"
+        comment="Label of the reviewer's menu entry to suspend current note."
         >
       Suspend note
     </string>
     <string
         name="menu_bury"
+        comment="Label of the reviewer's menu entry to bury. It'll ask whether to bury card or note if it's relevant. Also the label in the preference regarding the bury button."
         >
       Bury
     </string>
     <string
         name="menu_suspend"
+        comment="Label of the reviewer's menu entry to bury. It'll ask whether to suspend card or note if it's relevant. Also the label in the preference regarding the suspend button."
         >
       Suspend
     </string>
     <string
         name="menu_delete_note"
+        comment="Label of the reviewer's menu entry to delete the note. Also the label in the preference regarding the delete button."
         >
       Delete note
     </string>
     <string
         name="menu_flag_card"
+        comment="Label of the reviewer/card browser's menu entry to select which flag to add to a card. Also the label of the preference entry related to this menu entry."
         >
       Flag card
     </string>
     <string
         name="menu_flag_card_zero"
+        comment="Label of the reviewer/card browser's menu entry to remove the card(s)'s flag."
         >
       No flag
     </string>
     <string
         name="menu_flag_card_one"
+        comment="Label of the reviewer/card browser's menu entry to add the red flag to the current/selected card(s)."
         >
       Red flag
     </string>
     <string
         name="menu_flag_card_two"
+        comment="Label of the reviewer/card browser's menu entry to add the orange flag to the current/selected card(s)."
         >
       Orange flag
     </string>
     <string
         name="menu_flag_card_three"
+        comment="Label of the reviewer/card browser's menu entry to add the green flag to the current/selected card(s)."
         >
       Green flag
     </string>
     <string
         name="menu_flag_card_four"
+        comment="Label of the reviewer/card browser's menu entry to add the blue flag to the current/selected card(s)."
         >
       Blue flag
     </string>
     <string
         name="menu_edit_tags"
+        comment="Label of the menu item (and its preference entry) which open the window with a list of tag, allowing you to add/remove already existing tag to the note."
         >
       Edit tags
     </string>
     <string
         name="delete_note_message"
+        comment="The message shown to the user when they click on the delete note button."
         >
       Really delete this note and all its cards?\n%s
     </string>
     <string
         name="menu_select"
+        comment="TODO: what is it ?."
         >
       Select text
     </string>
     <string
         name="menu_search"
+        comment="TODO: Not used yet ?."
         >
       Lookup in %1$s
     </string>
     <string
         name="menu_mark_note"
+        comment="Label of the menu item (and its preference entry) which mark the current note (i.e. add the yellow star)."
         >
       Mark note
     </string>
     <string
         name="menu_unmark_note"
+        comment="Label of the menu item (and its preference entry) which unmark the current note (i.e. remove the yellow star)."
         >
       Unmark note
     </string>
     <string
         name="menu_toggle_mic_tool_bar"
+        comment="Label of the menu item (and its preference entry) which add a recorder/player, to let user hear themselves pronunce something. Represented as a mic."
         >
       Check pronunciation
     </string>
     <string
         name="new_deck"
+        comment="Title of the window inviting to create a deck, and label of the button to open this window."
         >
       Create deck
     </string>
@@ -405,34 +474,31 @@
     </string>
     <string
         name="new_dynamic_deck"
+        comment="Label of the menu item in deck picker inviting to create a filtered deck."
         >
       Create filtered deck
     </string>
     <string
         name="night_mode"
+        comment="Label near the switch between night and day mode."
         >
       Night mode
     </string>
     <string
         name="directory_inaccessible"
+        comment="An error message explaining that the directory can't be accessed."
         >
       AnkiDroid directory is inaccessible
     </string>
-    <!--This is shown when AnkiDroid starts up with no storage permissions.
-    The user is taken to the "App Info" screen, and needs to click "Permissions" and
-    grant AnkiDroid the 'Storage' permission. This needs to be a fairly generic message as implementations
-    of the permissions/app info screen will differ between devices. -->
+    <!-- -->
     <string
         name="startup_no_storage_permission"
+        comment="This is shown when AnkiDroid starts up with no storage permissions. The user is taken to the &quot;App Info&quot; screen, and needs to click &quot;Permissions&quot; and grant AnkiDroid the 'Storage' permission. This needs to be a fairly generic message as implementations of the permissions/app info screen will differ between devices."
         >
       Please grant AnkiDroid the ‘Storage’ permission to continue
     </string>
     <!--
-        The time_quantities are units of time. They are used without
-        plurals or dots.
-        s, min, h, d, are standard (ISO 31-1) units and should usually
-        not be translated, at least not for languages using the Latin
-        alphabet.
+        The time_quantities are units of time. They are used without plurals or dots.<br/>s, min, h, d, are standard (ISO 31-1) units and should usually not be translated, at least not for languages using the Latin  alphabet.
     -->
     <string
         name="time_quantity_seconds"
@@ -476,133 +542,159 @@
     </string><!-- or "%.1f a" -->
     <string
         name="rebuild_cram_deck"
+        comment="Label of meny entry offering to rebuild a cram deck."
         >
+
       Rebuilding cram deck
     </string>
     <string
         name="empty_cram_label"
+        comment="Label of the menu item inviting to empty the cram deck."
         >
       Empty
     </string>
     <string
         name="create_subdeck"
+        comment="Title of the window offering the user to create a subdeck of the deck they selected. label of the menu item opening this window."
         >
       Create subdeck
     </string>
     <string
         name="empty_cram_deck"
+        comment="Message explaining to the user that the cram deck is getting emptied."
         >
       Emptying cram deck
     </string>
     <string
         name="custom_study_deck_name"
+        comment="Default name of a custom study deck."
         >
       Custom study session
     </string>
     <string
         name="custom_study_deck_exists"
+        comment="The user just tried to create a custom study deck. However a deck with the default name of custom study deck exists. This message explain this existing deck should be renamed before the user can create a new custom study deck."
         >
       Rename the existing custom study deck first
     </string>
     <string
         name="invalid_deck_name"
+        comment="Warns user they entered a deck name which is not valid. Currently, that only means that it contains only whitespace, tab and other invisible characters."
         >
       Invalid deck name
     </string>
     <string
         name="studyoptions_empty"
+        comment="Message shown to the user when the select a deck to review and this deck is empty."
         >
       This deck is empty. Press the + button to add new content.
     </string>
     <string
         name="studyoptions_limit_reached"
+        comment="Message shown when the user select a deck, no card can be seen now because of daily limit, however there remain new cards or card due today in the deck."
         >
       Daily study limit reached
     </string>
     <string
         name="studyoptions_empty_schedule"
+        comment="Message shown when a user select a deck, and there is no new card nor any card in learning, or review card due today."
         >
       No cards scheduled to study
     </string>
     <string
         name="studyoptions_congrats_finished"
+        comment="Message shown to user when the reviewer closed because there is no more card to see."
         >
       Congratulations! You have finished for now.
     </string>
     <string
         name="studyoptions_congrats_more_rev"
+        comment="Message shown to the user when there are card to review in the selected deck, due today, but can't be seen because of the daily limit."
         >
       Today’s limit has been reached, but there are still cards to review. You can increase the limit in the options.
     </string>
     <string
         name="studyoptions_congrats_more_new"
+        comment="Message shown to the user when there are new card(s) in the selected deck that can't be seen because of the daily limit."
         >
-    Today’s limit has been reached. There are more new cards available; you can increase the limit in the options, but
-    this will increase your short-term review workload.
+      Today’s limit has been reached. There are more new cards available; you can increase the limit in the options, but this will increase your short-term review workload.
     </string>
     <string
         name="studyoptions_congrats_custom"
+        comment="Message explaining that more cards can be reviewed by creating a custom study session."
         >
       To study outside of the normal schedule, touch the “Custom study” button
     </string>
     <string
         name="studyoptions_no_cards_due"
+        comment="Message shown to the user when there are cards in learning due later, that can't be shown yet."
         >
       No cards are due yet
     </string>
 
     <string
         name="sd_card_not_mounted"
+        comment="Message shown to user when the card on which data is supposed to be saved can't be accessed."
         >
       Device storage not mounted
     </string>
     <string
         name="empty_cloze_warning"
+        comment="Message shown on the question side telling when the note type is cloze, but there are no cloze deletion in the cloze field."
         >
       Edit this note and add some cloze deletions. (%1$s)
     </string>
     <string
         name="button_sync"
+        comment="Label of the sync button (for accessibility) and of the sync android activity (A theoretical button on android which would start a sync)."
         >
       Sync
     </string>
     <string
         name="cancel_sync_confirm"
+        comment="Message shown when the user press on cancel during sync."
         >
       Do you want to cancel the sync?
     </string>
     <string
         name="continue_sync"
+        comment="In the box asking the user whether they want to cancel sync, this is the label of the button which state that sync is not cancelled."
         >
       Continue sync
     </string>
     <string
         name="sync_cancelled"
+        comment="Message confirming to user that the sync was correctly cancelled as they requested."
         >
       Sync cancelled
     </string>
     <string
         name="sync_cancel_message"
+        comment="Message shown to user when they requested cancellation of sync, stating that this is ongoing."
         >
       Cancelling…\nThis may take some time.
     </string>
     <string
         name="export"
+        comment="Title of the export dialog. That is, the dialog that the user create by selecting Export deck or by selecting from the deck picker menu."
         >
       Export
     </string>
     <string
         name="export_collection"
+        comment="Label of the deckpicker's menu item. When clicked, it allows user to export their whole collection."
         >
       Export collection
     </string>
     <string
         name="export_deck"
+        comment="Label of the menu item, obtained when pressing a deck, allowing to export this deck."
         >
       Export deck
     </string>
     <string
         name="nothing"
+        comment="When a user want to change the type of a note, they are asked for each field/card type to which field/card they want to send it. This is the label of the option which states that the field/card should be deleted."
         >
       Nothing
     </string>
@@ -610,46 +702,55 @@
     <!-- Card template editor -->
     <string
         name="title_activity_template_editor"
+        comment="Title of the window in which the user can edit the card types."
         >
       Card types
     </string>
     <string
         name="card_template_editor_front"
+        comment="In the Card Type window: label explaining that the text field below contains the template of the front of this card type."
         >
       Front template
     </string>
     <string
         name="card_template_editor_back"
+        comment="In the Card Type window: label explaining that the text field below contains the template of the back of this card type."
         >
       Back template
     </string>
     <string
         name="card_template_editor_styling"
+        comment="In the Card Type window: label explaining that the text field below contains the css of this card type."
         >
       Styling
     </string>
     <string
         name="card_template_editor_menu_delete"
+        comment="Label of the menu item in card template editor which allow to delete the card type."
         >
       Delete
     </string>
     <string
         name="card_template_editor_menu_card_browser_appearance"
+        comment="The label of the menu item in card template editor which allow to change the apparence of the card in the card browser."
         >
       Card Browser Appearance
     </string>
     <string
         name="card_template_editor_deck_override"
+        comment="The label of the menu item, in card template editor, which allow to set the deck in which the card of this card type goes when they are created. This override the current deck selection when creating cards."
         >
       Deck Override
     </string>
     <string
         name="card_template_editor_cant_delete"
+        comment="Message shown to the user when they try to delete the last card type of a note type."
         >
       At least one card type is required
     </string>
     <plurals
         name="card_template_editor_confirm_delete"
+        comment="Ask the user to confirm they want to delete a card type, giving them the card type name and the number of existing card of this type."
         >
       <item quantity="one">
         Delete the “%2$s” card type, and its %1$d card?
@@ -660,21 +761,25 @@
     </plurals>
     <string
         name="invalid_template"
+        comment="In the previewer of card template, warn the user that the generation did not occurs."
         >
       A card could not be generated
     </string>
     <string
         name="card_template_editor_would_delete_note"
+        comment="In the card template editor, after the user requested to delete a card type, tells them this can't be done because otherwise a note would have no card left."
         >
       Removing this card type would cause one or more notes to be deleted. Please create and save a new card type first.
     </string>
     <string
         name="card_template_editor_save_error"
+        comment="In the card template editor, warn the user their change were not saved because of the reason in the parameter."
         >
       Unable to save card template changes: %s
     </string>
     <string
         name="template_for_current_card_deleted"
+        comment="If the user opened a card to edit, then edited the note type by deleting the card type of the current card, then the editor mus close. This warn the user that the editor is closing because they are looking at a card whose type does not exists anymore."
         >
       The card type for the current card was deleted.
     </string>
@@ -689,11 +794,13 @@
     <!-- Permissions -->
     <string
         name="read_write_permission_label"
+        comment="If an external app asks to interact with Ankidroid and require to change the collection, then this is the short description that the user will see to explain what authorization they are granting to the other app."
         >
       Read and write to the AnkiDroid database
     </string>
     <string
         name="read_write_permission_description"
+        comment="If an external app asks to interact with Ankidroid and require to change the collection, then this is the long description that the user will see to explain what authorization they are granting to the other app."
         >
       access existing notes, cards, note types, and decks, as well as create new ones
     </string>
@@ -701,17 +808,20 @@
     <!-- Context Menu -->
     <string
         name="card_browser_label"
+        comment="If the user add a button on android which opens directly the card browser, then this is the string labelling the button."
         >
       Card Browser
     </string>
     <string
         name="card_browser_context_menu"
+        comment="Label of the menu item proposing to open to open the card browser when some text is selected. TODO: check."
         >
       Card Browser
     </string>
 
     <string
         name="context_menu_anki_card_label"
+        comment="TODO: what does it label ?."
         >
       Anki Card
     </string>

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -20,55 +20,87 @@
 -->
 <resources>
   <!-- Navigation drawer items-->
-  <string name="decks">
+  <string
+      name="decks"
+      >
     Decks
   </string>
-  <string name="card_browser">
+  <string
+      name="card_browser"
+      >
     Card browser
   </string>
-  <string name="statistics">
+  <string
+      name="statistics"
+      >
     Statistics
   </string>
-  <string name="settings">
+  <string
+      name="settings"
+      >
     Settings
   </string>
-  <string name="help">
+  <string
+      name="help"
+      >
     Help
   </string>
-  <string name="send_feedback">
+  <string
+      name="send_feedback"
+      >
     Send feedback
   </string>
 
-  <string name="studyoptions_title">
+  <string
+      name="studyoptions_title"
+      >
     Deck overview
   </string>
-  <string name="studyoptions_due_today">
+  <string
+      name="studyoptions_due_today"
+      >
     Due today:
   </string>
-  <string name="studyoptions_new_total">
+  <string
+      name="studyoptions_new_total"
+      >
     Total new cards:
   </string>
-  <string name="studyoptions_total_cards">
+  <string
+      name="studyoptions_total_cards"
+      >
     Total cards:
   </string>
-  <string name="studyoptions_eta">
+  <string
+      name="studyoptions_eta"
+      >
     Estimated time (min):
   </string>
-  <string name="studyoptions_start">
+  <string
+      name="studyoptions_start"
+      >
     Study
   </string>
 
   <!-- DeckPicker.java -->
-  <string name="expand">
+  <string
+      name="expand"
+      >
     Expand
   </string>
-  <string name="collapse">
+  <string
+      name="collapse"
+      >
     Collapse
   </string>
-  <string name="study_more">
+  <string
+      name="study_more"
+      >
     Study more
   </string>
-  <plurals name="deckpicker_title">
+  <plurals
+      name="deckpicker_title"
+      >
     <item quantity="one">
       %1$d card due (%2$s)
     </item>
@@ -76,7 +108,9 @@
       %1$d cards due (%2$s)
     </item>
     </plurals>
-    <plurals name="reviewer_window_title">
+    <plurals
+        name="reviewer_window_title"
+        >
       <item quantity="one">
         %d minute left
       </item>
@@ -84,7 +118,9 @@
         %d minutes left
       </item>
     </plurals>
-    <plurals name="reviewer_window_title_hours">
+    <plurals
+        name="reviewer_window_title_hours"
+        >
       <item quantity="one">
         %d hour %d left
       </item>
@@ -92,7 +128,9 @@
         %d hours %d left
       </item>
     </plurals>
-    <plurals name="reviewer_window_title_days">
+    <plurals
+        name="reviewer_window_title_days"
+        >
       <item quantity="one">
         %d day %d left
       </item>
@@ -100,15 +138,21 @@
         %d days %d left
       </item>
     </plurals>
-    <string name="no_cards_placeholder_title">
+    <string
+        name="no_cards_placeholder_title"
+        >
       Collection is empty
     </string>
-    <string name="no_cards_placeholder_description">
+    <string
+        name="no_cards_placeholder_description"
+        >
       Start adding cards\nusing the + icon.
     </string>
 
     <!-- The deck picker via AnkiStatsTaskHandler.java -->
-    <plurals name="studied_cards_today">
+    <plurals
+        name="studied_cards_today"
+        >
       <item quantity="one">
         Studied %1$d card in %2$s today
       </item>
@@ -119,173 +163,283 @@
 
 
     <!-- flashcard_portrait.xml -->
-    <string name="type_answer_hint">
+    <string
+        name="type_answer_hint"
+        >
       Type answer
     </string>
-    <string name="show_answer">
+    <string
+        name="show_answer"
+        >
       Show answer
     </string>
-    <string name="hide_answer">
+    <string
+        name="hide_answer"
+        >
       Hide answer
     </string>
-    <string name="ease_button_again">
+    <string
+        name="ease_button_again"
+        >
       Again
     </string>
-    <string name="ease_button_hard">
+    <string
+        name="ease_button_hard"
+        >
       Hard
     </string>
-    <string name="ease_button_good">
+    <string
+        name="ease_button_good"
+        >
       Good
     </string>
-    <string name="ease_button_easy">
+    <string
+        name="ease_button_easy"
+        >
       Easy
     </string>
-    <string name="studyoptions_congrats_undo">
+    <string
+        name="studyoptions_congrats_undo"
+        >
       Undo %s
     </string>
-    <string name="menu_import">
+    <string
+        name="menu_import"
+        >
       Import
     </string>
-    <string name="undo">
+    <string
+        name="undo"
+        >
       Undo
     </string>
-    <string name="undo_action_review">
+    <string
+        name="undo_action_review"
+        >
       last review
     </string>
-    <string name="undo_action_bury_card">
+    <string
+        name="undo_action_bury_card"
+        >
       bury card
     </string>
-    <string name="undo_action_bury_note">
+    <string
+        name="undo_action_bury_note"
+        >
       bury note
     </string>
-    <string name="undo_action_suspend_card">
+    <string
+        name="undo_action_suspend_card"
+        >
       suspend card
     </string>
-    <string name="undo_action_suspend_note">
+    <string
+        name="undo_action_suspend_note"
+        >
       suspend note
     </string>
-    <string name="undo_action_delete">
+    <string
+        name="undo_action_delete"
+        >
       delete note
     </string>
-    <string name="undo_action_delete_multi">
+    <string
+        name="undo_action_delete_multi"
+        >
       delete notes
     </string>
-    <string name="undo_action_change_deck_multi">
+    <string
+        name="undo_action_change_deck_multi"
+        >
       change decks
     </string>
-    <string name="undo_action_reschedule_card">
+    <string
+        name="undo_action_reschedule_card"
+        >
       reschedule
     </string>
-    <string name="undo_action_reset_card">
+    <string
+        name="undo_action_reset_card"
+        >
       reset progress
     </string>
-    <string name="undo_action_reposition_card">
+    <string
+        name="undo_action_reposition_card"
+        >
       reposition
     </string>
-    <string name="move_all_to_deck">
+    <string
+        name="move_all_to_deck"
+        >
       Move all to deck
     </string>
-    <string name="unbury">
+    <string
+        name="unbury"
+        >
       Unbury
     </string>
-    <string name="rename_deck">
+    <string
+        name="rename_deck"
+        >
       Rename deck
     </string>
-    <string name="menu_add">
+    <string
+        name="menu_add"
+        >
       Add
     </string>
-    <string name="menu_add_note">
+    <string
+        name="menu_add_note"
+        >
       Add note
     </string>
-    <string name="menu_my_account">
+    <string
+        name="menu_my_account"
+        >
       Sync account
     </string>
-    <string name="menu_dismiss_note">
+    <string
+        name="menu_dismiss_note"
+        >
       Hide / delete
     </string>
-    <string name="menu_bury_card">
+    <string
+        name="menu_bury_card"
+        >
       Bury card
     </string>
-    <string name="menu_bury_note">
+    <string
+        name="menu_bury_note"
+        >
       Bury note
     </string>
-    <string name="menu_suspend_card">
+    <string
+        name="menu_suspend_card"
+        >
       Suspend card
     </string>
-    <string name="menu_suspend_note">
+    <string
+        name="menu_suspend_note"
+        >
       Suspend note
     </string>
-    <string name="menu_bury">
+    <string
+        name="menu_bury"
+        >
       Bury
     </string>
-    <string name="menu_suspend">
+    <string
+        name="menu_suspend"
+        >
       Suspend
     </string>
-    <string name="menu_delete_note">
+    <string
+        name="menu_delete_note"
+        >
       Delete note
     </string>
-    <string name="menu_flag">
+    <string
+        name="menu_flag"
+        >
       Flag
     </string>
-    <string name="menu_flag_card">
+    <string
+        name="menu_flag_card"
+        >
       Flag card
     </string>
-    <string name="menu_flag_card_zero">
+    <string
+        name="menu_flag_card_zero"
+        >
       No flag
     </string>
-    <string name="menu_flag_card_one">
+    <string
+        name="menu_flag_card_one"
+        >
       Red flag
     </string>
-    <string name="menu_flag_card_two">
+    <string
+        name="menu_flag_card_two"
+        >
       Orange flag
     </string>
-    <string name="menu_flag_card_three">
+    <string
+        name="menu_flag_card_three"
+        >
       Green flag
     </string>
-    <string name="menu_flag_card_four">
+    <string
+        name="menu_flag_card_four"
+        >
       Blue flag
     </string>
-    <string name="menu_edit_tags">
+    <string
+        name="menu_edit_tags"
+        >
       Edit tags
     </string>
-    <string name="delete_note_message">
+    <string
+        name="delete_note_message"
+        >
       Really delete this note and all its cards?\n%s
     </string>
-    <string name="menu_select">
+    <string
+        name="menu_select"
+        >
       Select text
     </string>
-    <string name="menu_search">
+    <string
+        name="menu_search"
+        >
       Lookup in %1$s
     </string>
-    <string name="menu_mark_note">
+    <string
+        name="menu_mark_note"
+        >
       Mark note
     </string>
-    <string name="menu_unmark_note">
+    <string
+        name="menu_unmark_note"
+        >
       Unmark note
     </string>
-    <string name="menu_toggle_mic_tool_bar">
+    <string
+        name="menu_toggle_mic_tool_bar"
+        >
       Check pronunciation
     </string>
-    <string name="new_deck">
+    <string
+        name="new_deck"
+        >
       Create deck
     </string>
-    <string name="create">
+    <string
+        name="create"
+        >
       Create
     </string>
-    <string name="new_dynamic_deck">
+    <string
+        name="new_dynamic_deck"
+        >
       Create filtered deck
     </string>
-    <string name="night_mode">
+    <string
+        name="night_mode"
+        >
       Night mode
     </string>
-    <string name="directory_inaccessible">
+    <string
+        name="directory_inaccessible"
+        >
       AnkiDroid directory is inaccessible
     </string>
     <!--This is shown when AnkiDroid starts up with no storage permissions.
     The user is taken to the "App Info" screen, and needs to click "Permissions" and
     grant AnkiDroid the 'Storage' permission. This needs to be a fairly generic message as implementations
     of the permissions/app info screen will differ between devices. -->
-    <string name="startup_no_storage_permission">
+    <string
+        name="startup_no_storage_permission"
+        >
       Please grant AnkiDroid the ‘Storage’ permission to continue
     </string>
     <!--
@@ -295,143 +449,233 @@
         not be translated, at least not for languages using the Latin
         alphabet.
     -->
-    <string name="time_quantity_seconds">
+    <string
+        name="time_quantity_seconds"
+        >
       %d s
     </string>
-    <string name="time_quantity_minutes">
+    <string
+        name="time_quantity_minutes"
+        >
       %d min
     </string>
-    <string name="time_quantity_hours_minutes">
+    <string
+        name="time_quantity_hours_minutes"
+        >
       %1$d h %2$d m
     </string>
-    <string name="time_quantity_hours">
+    <string
+        name="time_quantity_hours"
+        >
       %d h
     </string>
-    <string name="time_quantity_days">
+    <string
+        name="time_quantity_days"
+        >
       %d d
     </string>
-    <string name="time_quantity_days_hours">
+    <string
+        name="time_quantity_days_hours"
+        >
       %1$d d %2$d h
     </string>
-    <string name="time_quantity_months">
+    <string
+        name="time_quantity_months"
+        >
       %.1f mo
     </string>
-    <string name="time_quantity_years">
+    <string
+        name="time_quantity_years"
+        >
       %.1f yr
     </string><!-- or "%.1f a" -->
-    <string name="rebuild_cram_deck">
+    <string
+        name="rebuild_cram_deck"
+        >
       Rebuilding cram deck…
     </string>
-    <string name="rebuild_cram_label">
+    <string
+        name="rebuild_cram_label"
+        >
       Rebuild
     </string>
-    <string name="empty_cram_label">
+    <string
+        name="empty_cram_label"
+        >
       Empty
     </string>
-    <string name="create_subdeck">
+    <string
+        name="create_subdeck"
+        >
       Create subdeck
     </string>
-    <string name="empty_cram_deck">
+    <string
+        name="empty_cram_deck"
+        >
       Emptying cram deck…
     </string>
-    <string name="custom_study_deck_name">
+    <string
+        name="custom_study_deck_name"
+        >
       Custom study session
     </string>
-    <string name="custom_study_deck_exists">
+    <string
+        name="custom_study_deck_exists"
+        >
       Rename the existing custom study deck first
     </string>
-    <string name="empty_deck">
+    <string
+        name="empty_deck"
+        >
       This deck is empty
     </string>
-    <string name="invalid_deck_name">
+    <string
+        name="invalid_deck_name"
+        >
       Invalid deck name
     </string>
-    <string name="studyoptions_empty">
+    <string
+        name="studyoptions_empty"
+        >
       This deck is empty. Press the + button to add new content.
     </string>
-    <string name="studyoptions_limit_reached">
+    <string
+        name="studyoptions_limit_reached"
+        >
       Daily study limit reached
     </string>
-    <string name="studyoptions_empty_schedule">
+    <string
+        name="studyoptions_empty_schedule"
+        >
       No cards scheduled to study
     </string>
-    <string name="studyoptions_congrats_finished">
+    <string
+        name="studyoptions_congrats_finished"
+        >
       Congratulations! You have finished for now.
     </string>
-    <string name="studyoptions_congrats_more_rev">
+    <string
+        name="studyoptions_congrats_more_rev"
+        >
       Today’s limit has been reached, but there are still cards to review. You can increase the limit in the options.
     </string>
-    <string name="studyoptions_congrats_more_new">
+    <string
+        name="studyoptions_congrats_more_new"
+        >
     Today’s limit has been reached. There are more new cards available; you can increase the limit in the options, but
     this will increase your short-term review workload.
     </string>
-    <string name="studyoptions_congrats_custom">
+    <string
+        name="studyoptions_congrats_custom"
+        >
       To study outside of the normal schedule, touch the “Custom study” button
     </string>
-    <string name="studyoptions_no_cards_due">
+    <string
+        name="studyoptions_no_cards_due"
+        >
       No cards are due yet
     </string>
 
-    <string name="sd_card_not_mounted">
+    <string
+        name="sd_card_not_mounted"
+        >
       Device storage not mounted
     </string>
-    <string name="empty_cloze_warning">
+    <string
+        name="empty_cloze_warning"
+        >
       Edit this note and add some cloze deletions. (%1$s)
     </string>
-    <string name="button_sync">
+    <string
+        name="button_sync"
+        >
       Sync
     </string>
-    <string name="cancel_sync_confirm">
+    <string
+        name="cancel_sync_confirm"
+        >
       Do you want to cancel the sync?
     </string>
-    <string name="continue_sync">
+    <string
+        name="continue_sync"
+        >
       Continue sync
     </string>
-    <string name="sync_cancelled">
+    <string
+        name="sync_cancelled"
+        >
       Sync cancelled
     </string>
-    <string name="sync_cancel_message">
+    <string
+        name="sync_cancel_message"
+        >
       Cancelling…\nThis may take some time.
     </string>
-    <string name="export">
+    <string
+        name="export"
+        >
       Export
     </string>
-    <string name="export_collection">
+    <string
+        name="export_collection"
+        >
       Export collection
     </string>
-    <string name="export_deck">
+    <string
+        name="export_deck"
+        >
       Export deck
     </string>
-    <string name="nothing">
+    <string
+        name="nothing"
+        >
       Nothing
     </string>
 
     <!-- Card template editor -->
-    <string name="title_activity_template_editor">
+    <string
+        name="title_activity_template_editor"
+        >
       Card types
     </string>
-    <string name="card_template_editor_front">
+    <string
+        name="card_template_editor_front"
+        >
       Front template
     </string>
-    <string name="card_template_editor_back">
+    <string
+        name="card_template_editor_back"
+        >
       Back template
     </string>
-    <string name="card_template_editor_styling">
+    <string
+        name="card_template_editor_styling"
+        >
       Styling
     </string>
-    <string name="card_template_editor_menu_delete">
+    <string
+        name="card_template_editor_menu_delete"
+        >
       Delete
     </string>
-    <string name="card_template_editor_menu_card_browser_appearance">
+    <string
+        name="card_template_editor_menu_card_browser_appearance"
+        >
       Card Browser Appearance
     </string>
-    <string name="card_template_editor_deck_override">
+    <string
+        name="card_template_editor_deck_override"
+        >
       Deck Override
     </string>
-    <string name="card_template_editor_cant_delete">
+    <string
+        name="card_template_editor_cant_delete"
+        >
       At least one card type is required
     </string>
-    <plurals name="card_template_editor_confirm_delete">
+    <plurals
+        name="card_template_editor_confirm_delete"
+        >
       <item quantity="one">
         Delete the “%2$s” card type, and its %1$d card?
       </item>
@@ -439,41 +683,61 @@
         Delete the “%2$s” card type, and its %1$d cards?
       </item>
     </plurals>
-    <string name="invalid_template">
+    <string
+        name="invalid_template"
+        >
       A card could not be generated
     </string>
-    <string name="card_template_editor_would_delete_note">
+    <string
+        name="card_template_editor_would_delete_note"
+        >
       Removing this card type would cause one or more notes to be deleted. Please create and save a new card type first.
     </string>
-    <string name="card_template_editor_save_error">
+    <string
+        name="card_template_editor_save_error"
+        >
       Unable to save card template changes: %s
     </string>
-    <string name="template_for_current_card_deleted">
+    <string
+        name="template_for_current_card_deleted"
+        >
       The card type for the current card was deleted.
     </string>
 
     <!-- Card Browser Appearance -->
-    <string name="card_template_browser_appearance_title">
+    <string
+        name="card_template_browser_appearance_title"
+        >
       Browser appearance
     </string>
 
     <!-- Permissions -->
-    <string name="read_write_permission_label">
+    <string
+        name="read_write_permission_label"
+        >
       Read and write to the AnkiDroid database
     </string>
-    <string name="read_write_permission_description">
+    <string
+        name="read_write_permission_description"
+        >
       access existing notes, cards, note types, and decks, as well as create new ones
     </string>
 
     <!-- Context Menu -->
-    <string name="card_browser_label">
+    <string
+        name="card_browser_label"
+        >
       Card Browser
     </string>
-    <string name="card_browser_context_menu">
+    <string
+        name="card_browser_context_menu"
+        >
       Card Browser
     </string>
 
-    <string name="context_menu_anki_card_label">
+    <string
+        name="context_menu_anki_card_label"
+        >
       Anki Card
     </string>
 </resources>

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -480,11 +480,6 @@
       Rebuilding cram deck
     </string>
     <string
-        name="rebuild_cram_label"
-        >
-      Rebuild
-    </string>
-    <string
         name="empty_cram_label"
         >
       Empty

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -146,11 +146,6 @@
     Replay audio
   </string>
   <string
-      name="toggle_mic_tool_bar"
-      >
-    Check Pronunciation
-  </string>
-  <string
       name="leech_suspend_notification"
       >
     Card marked as leech and suspended

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -20,122 +20,196 @@
 -->
 <resources>
   <!-- How to format a percentage shown in the summary field of a preference -->
-  <string name="preference_summary_percentage">
+  <string
+      name="preference_summary_percentage"
+      >
     XXX%
   </string>
 
   <!-- Navigation drawer strings -->
-  <string name="drawer_open">
+  <string
+      name="drawer_open"
+      >
     Open drawer
   </string>
-  <string name="drawer_close">
+  <string
+      name="drawer_close"
+      >
     Close drawer
   </string>
 
-  <string name="CardEditorLaterMessage">
+  <string
+      name="CardEditorLaterMessage"
+      >
     Saved information for later
   </string>
-  <string name="CardEditorCardDeck">
+  <string
+      name="CardEditorCardDeck"
+      >
     Card deck:
   </string>
-  <string name="CardEditorNoteDeck">
+  <string
+      name="CardEditorNoteDeck"
+      >
     Deck:
   </string>
-  <string name="CardEditorModel">
+  <string
+      name="CardEditorModel"
+      >
     Type:
   </string>
-  <string name="CardEditorTags">
+  <string
+      name="CardEditorTags"
+      >
     Tags: %1$s
   </string>
-  <string name="CardEditorCards">
+  <string
+      name="CardEditorCards"
+      >
     Cards: %1$s
   </string>
-  <string name="tag_name">
+  <string
+      name="tag_name"
+      >
     Tag name
   </string>
-  <string name="add_new_filter_tags">
+  <string
+      name="add_new_filter_tags"
+      >
     Add/filter tags
   </string>
-  <string name="add_tag">
+  <string
+      name="add_tag"
+      >
     Add tag
   </string>
-  <string name="check_all_tags">
+  <string
+      name="check_all_tags"
+      >
     Check/uncheck all tags
   </string>
-  <string name="filter_tags">
+  <string
+      name="filter_tags"
+      >
     Filter tags
   </string>
-  <string name="no_tags">
+  <string
+      name="no_tags"
+      >
     You haven’t added any tags yet
   </string>
-  <string name="sdcard_missing_message">
+  <string
+      name="sdcard_missing_message"
+      >
     Switch off USB storage to access your decks
   </string>
-  <string name="updated_version">
+  <string
+      name="updated_version"
+      >
     Updated to version %s
   </string>
 
   <!-- Reviewer.java -->
-  <string name="save_whiteboard">
+  <string
+      name="save_whiteboard"
+      >
     Save whiteboard
   </string>
-  <string name="enable_whiteboard">
+  <string
+      name="enable_whiteboard"
+      >
     Enable whiteboard
   </string>
-  <string name="disable_whiteboard">
+  <string
+      name="disable_whiteboard"
+      >
     Disable whiteboard
   </string>
-  <string name="show_whiteboard">
+  <string
+      name="show_whiteboard"
+      >
     Show whiteboard
   </string>
-  <string name="hide_whiteboard">
+  <string
+      name="hide_whiteboard"
+      >
     Hide whiteboard
   </string>
-  <string name="clear_whiteboard">
+  <string
+      name="clear_whiteboard"
+      >
     Clear whiteboard
   </string>
-  <string name="replay_audio">
+  <string
+      name="replay_audio"
+      >
     Replay audio
   </string>
-  <string name="toggle_mic_tool_bar">
+  <string
+      name="toggle_mic_tool_bar"
+      >
     Check Pronunciation
   </string>
-  <string name="leech_suspend_notification">
+  <string
+      name="leech_suspend_notification"
+      >
     Card marked as leech and suspended
   </string>
-  <string name="leech_notification">
+  <string
+      name="leech_notification"
+      >
     Card marked as leech
   </string>
-  <string name="corrupt_font">
+  <string
+      name="corrupt_font"
+      >
     Corrupt font file %s
   </string>
-  <string name="webview_crash_unknown">
+  <string
+      name="webview_crash_unknown"
+      >
     Unknown error
   </string>
-  <string name="webview_crash_unknwon_detailed">
+  <string
+      name="webview_crash_unknwon_detailed"
+      >
     This was caused by an internal error in the WebView
   </string>
-  <string name="webview_crash_oom">
+  <string
+      name="webview_crash_oom"
+      >
     Out of Memory
   </string>
-  <string name="webview_crash_oom_details">
+  <string
+      name="webview_crash_oom_details"
+      >
     The WebView was terminated by the system. This typically happens when the application runs out of memory, often due to large fonts or media.
   </string>
-  <string name="webview_crash_nonfatal">
+  <string
+      name="webview_crash_nonfatal"
+      >
     WebView renderer crashed. Cause: %s
   </string>
-  <string name="webview_crash_fatal">
+  <string
+      name="webview_crash_fatal"
+      >
     Fatal Error: WebView renderer crashed. Cause: %s
   </string>
-  <string name="webview_crash_loop_dialog_title">
+  <string
+      name="webview_crash_loop_dialog_title"
+      >
     System WebView Rendering Failure
   </string>
-  <string name="webview_crash_loop_dialog_content">
+  <string
+      name="webview_crash_loop_dialog_content"
+      >
     System WebView failed to render card \'%1$s\'.\n %2$s
   </string>
 
   <!-- Browser -->
-  <string-array name="browser_column1_headings">
+  <string-array
+      name="browser_column1_headings"
+      >
     <item>
       Question
     </item>
@@ -143,7 +217,9 @@
       Sort field
     </item>
   </string-array>
-  <string-array name="browser_column2_headings">
+  <string-array
+      name="browser_column2_headings"
+      >
     <item>
       Answer
     </item>
@@ -189,88 +265,142 @@
   </string-array>
 
   <!-- Custom study options -->
-  <string name="custom_study_increase_new_limit">
+  <string
+      name="custom_study_increase_new_limit"
+      >
     Modify today’s new card limit
   </string>
-  <string name="custom_study_increase_review_limit">
+  <string
+      name="custom_study_increase_review_limit"
+      >
     Modify today’s review card limit
   </string>
-  <string name="custom_study_review_forgotten">
+  <string
+      name="custom_study_review_forgotten"
+      >
     Review forgotten cards
   </string>
-  <string name="custom_study_review_ahead">
+  <string
+      name="custom_study_review_ahead"
+      >
     Review ahead
   </string>
-  <string name="custom_study_random_selection">
+  <string
+      name="custom_study_random_selection"
+      >
     Study a random selection of cards
   </string>
-  <string name="custom_study_preview_new">
+  <string
+      name="custom_study_preview_new"
+      >
     Preview new cards
   </string>
-  <string name="custom_study_limit_tags">
+  <string
+      name="custom_study_limit_tags"
+      >
     Limit to particular tags
   </string>
 
   <!-- Card editor -->
-  <string name="cardeditor_title_add_note">
+  <string
+      name="cardeditor_title_add_note"
+      >
     Add note
   </string>
-  <string name="cardeditor_title_edit_card">
+  <string
+      name="cardeditor_title_edit_card"
+      >
     Edit note
   </string>
-  <string name="discard_unsaved_changes">
+  <string
+      name="discard_unsaved_changes"
+      >
     Close and lose current input?
   </string>
-  <string name="note_editor_no_cards_created">
+  <string
+      name="note_editor_no_cards_created"
+      >
     No cards created. Please fill in more fields
   </string>
-  <string name="note_editor_no_first_field">
+  <string
+      name="note_editor_no_first_field"
+      >
     The first field is empty
   </string>
-  <string name="note_editor_no_cloze_delations">
+  <string
+      name="note_editor_no_cloze_delations"
+      >
     This note type must contain cloze deletions
   </string>
-  <string name="note_editor_set_field_language">
+  <string
+      name="note_editor_set_field_language"
+      >
     Set field language
   </string>
-  <string name="note_editor_no_cards_created_all_fields">
+  <string
+      name="note_editor_no_cards_created_all_fields"
+      >
     The current note type did not produce any cards.\nPlease choose another note type, or click ‘Cards’ and add a field substitution
   </string>
-  <string name="note_editor_insert_cloze_no_cloze_note_type">
+  <string
+      name="note_editor_insert_cloze_no_cloze_note_type"
+      >
     Cloze deletions will only work on a Cloze note type
   </string>
-  <string name="saving_facts">
+  <string
+      name="saving_facts"
+      >
     Saving note
   </string>
-  <string name="saving_model">
+  <string
+      name="saving_model"
+      >
     Saving note type
   </string>
-  <string name="add">
+  <string
+      name="add"
+      >
     Add
   </string>
-  <string name="save">
+  <string
+      name="save"
+      >
     Save
   </string>
-  <string name="close">
+  <string
+      name="close"
+      >
     Close
   </string>
-  <string name="select">
+  <string
+      name="select"
+      >
     Select
   </string>
-  <string name="saving_changes">
+  <string
+      name="saving_changes"
+      >
     Saving changes…
   </string>
-  <string name="reordering_cards">
+  <string
+      name="reordering_cards"
+      >
     Reordering cards…
   </string>
-  <string name="field_remapping">
+  <string
+      name="field_remapping"
+      >
     %1$s (from “%2$s”)
   </string>
-  <string name="confirm_map_cards_to_nothing">
+  <string
+      name="confirm_map_cards_to_nothing"
+      >
     Any cards mapped to nothing will be deleted. If a note has no remaining cards, it will be lost. Are you sure you want to continue?
   </string>
 
-  <plurals name="timebox_reached">
+  <plurals
+      name="timebox_reached"
+      >
     <item quantity="one">
       %1$d card studied in %2$s
     </item>
@@ -279,7 +409,9 @@
     </item>
   </plurals>
   <!-- minutes used in '[studied in] x minutes' context, causing inflexion in some languages -->
-  <plurals name="in_minutes">
+  <plurals
+      name="in_minutes"
+      >
     <item quantity="one">
       %1$d minute
     </item>
@@ -288,44 +420,70 @@
     </item>
   </plurals>
 
-  <string name="studyoptions_welcome_title">
+  <string
+      name="studyoptions_welcome_title"
+      >
     Welcome to AnkiDroid
   </string>
-  <string name="fact_adder_intent_title">
+  <string
+      name="fact_adder_intent_title"
+      >
     AnkiDroid card
   </string>
-  <string name="note_editor_add_note">
+  <string
+      name="note_editor_add_note"
+      >
     Add note
   </string>
-  <string name="note_editor_copy_note">
+  <string
+      name="note_editor_copy_note"
+      >
     Copy note
   </string>
-  <string name="card_editor_copy_card">
+  <string
+      name="card_editor_copy_card"
+      >
     Copy card
   </string>
-  <string name="card_editor_reposition_card">
+  <string
+      name="card_editor_reposition_card"
+      >
     Reposition
   </string>
-  <string name="card_editor_reset_card">
+  <string
+      name="card_editor_reset_card"
+      >
     Reset progress
   </string>
-  <string name="card_editor_reschedule_card">
+  <string
+      name="card_editor_reschedule_card"
+      >
     Reschedule
   </string>
-  <string name="card_editor_preview_card">
+  <string
+      name="card_editor_preview_card"
+      >
     Preview
   </string>
-  <string name="error_insufficient_memory">
+  <string
+      name="error_insufficient_memory"
+      >
     Operation not possible due to insufficient memory on your device
   </string>
-  <string name="rename">
+  <string
+      name="rename"
+      >
     Rename
   </string>
-  <string name="default_conf_delete_error">
+  <string
+      name="default_conf_delete_error"
+      >
     The default options group can’t be removed
   </string>
 
-  <plurals name="factadder_cards_added">
+  <plurals
+      name="factadder_cards_added"
+      >
     <item quantity="one">
       %d card added
     </item>
@@ -334,140 +492,230 @@
     </item>
   </plurals>
 
-  <string name="help_title">
+  <string
+      name="help_title"
+      >
     Help
   </string>
-  <string name="check_db">
+  <string
+      name="check_db"
+      >
     Check database
   </string>
-  <string name="check_media">
+  <string
+      name="check_media"
+      >
     Check media
   </string>
-  <string name="empty_cards">
+  <string
+      name="empty_cards"
+      >
     Empty cards
   </string>
-  <string name="check_db_message">
+  <string
+      name="check_db_message"
+      >
     Checking database…
   </string>
-  <string name="empty_card_warning">
+  <string
+      name="empty_card_warning"
+      >
     This card is empty. Use the “Empty cards” option from the menu on the deck list screen.
   </string>
-  <string name="unknown_type_field_warning">
+  <string
+      name="unknown_type_field_warning"
+      >
     Type answer: unknown field %s
   </string>
-  <string name="delete_deck">
+  <string
+      name="delete_deck"
+      >
     Deleting deck…
   </string>
 
-  <string name="show_hint">
+  <string
+      name="show_hint"
+      >
     Show %s
   </string>
-  <string name="info_rate">
+  <string
+      name="info_rate"
+      >
     Rate AnkiDroid
   </string>
-  <string name="col_load_failed">
+  <string
+      name="col_load_failed"
+      >
     Collection loading failed.\nPress back to close AnkiDroid.
   </string>
-  <string name="import_title">
+  <string
+      name="import_title"
+      >
     Importing
   </string>
-  <string name="import_select_title">
+  <string
+      name="import_select_title"
+      >
     Choose a file to import
   </string>
-  <string name="import_message_add">
+  <string
+      name="import_message_add"
+      >
     Add
   </string>
-  <string name="import_message_replace_confirm">
+  <string
+      name="import_message_replace_confirm"
+      >
     This will delete your existing collection and replace it with the data of file %s
   </string>
-  <string name="import_message_add_confirm">
+  <string
+      name="import_message_add_confirm"
+      >
     Add “%s” to collection? This may take a long time
   </string>
-  <string name="import_log_no_apkg">
+  <string
+      name="import_log_no_apkg"
+      >
     This isn’t a valid Anki package file
   </string>
-  <string name="import_log_failed_unzip">
+  <string
+      name="import_log_failed_unzip"
+      >
     Failed to unzip apkg: %s
   </string>
-  <string name="import_log_failed_copy_to">
+  <string
+      name="import_log_failed_copy_to"
+      >
     Failed to copy apkg to %s
   </string>
-  <string name="import_log_failed_validate">
+  <string
+      name="import_log_failed_validate"
+      >
     apkg failed validation
   </string>
-  <string name="import_log_insufficient_space">
+  <string
+      name="import_log_insufficient_space"
+      >
     There is not enough space to unzip the package. Needed %1$d, available %2$d
   </string>
-  <string name="import_log_file_cache_cleared">
+  <string
+      name="import_log_file_cache_cleared"
+      >
     Error importing file, likely a cache clear during processing.\nPlease try again
   </string>
-  <string name="import_succeeded_but_check_database">
+  <string
+      name="import_succeeded_but_check_database"
+      >
     Data import succeeded but post-import cleanup failed. Run check database later. Root cause: %s
   </string>
-  <string name="import_error_unhandled_request">
+  <string
+      name="import_error_unhandled_request"
+      >
     Unable to process import request
   </string>
-  <string name="import_error_exception">
+  <string
+      name="import_error_exception"
+      >
     Failed to import package\n\n%s
   </string>
-  <string name="import_error_not_apkg_extension">
+  <string
+      name="import_error_not_apkg_extension"
+      >
     Filename “%s” doesn’t have .apkg or .colpkg extension
   </string>
-  <string name="import_error_load_imported_database">
+  <string
+      name="import_error_load_imported_database"
+      >
     Anki Database (.anki2) replacements are not yet supported. Please see the manual for replacement instructions.
   </string>
-  <string name="import_error_content_provider">
+  <string
+      name="import_error_content_provider"
+      >
     The selected file couldn’t be imported automatically by AnkiDroid. Please see the user manual for how to manually import anki files: \n%s
   </string>
-  <string name="import_error_copy_file_to_cache">
+  <string
+      name="import_error_copy_file_to_cache"
+      >
     copyFileToCache() failed (possibly out of storage space)
   </string>
-  <string name="import_replacing">
+  <string
+      name="import_replacing"
+      >
     Replacing collection…
   </string>
-  <string name="import_interrupted">
+  <string
+      name="import_interrupted"
+      >
     Import interrupted
   </string>
-  <string name="export_include_schedule">
+  <string
+      name="export_include_schedule"
+      >
     Include scheduling
   </string>
-  <string name="export_include_media">
+  <string
+      name="export_include_media"
+      >
     Include media
   </string>
-  <string name="confirm_apkg_export">
+  <string
+      name="confirm_apkg_export"
+      >
     Export collection as Anki package?
   </string>
-  <string name="confirm_apkg_export_deck">
+  <string
+      name="confirm_apkg_export_deck"
+      >
     Export “%s” as apkg file?
   </string>
-  <string name="export_in_progress">
+  <string
+      name="export_in_progress"
+      >
     Exporting Anki package file…
   </string>
-  <string name="export_successful_title">
+  <string
+      name="export_successful_title"
+      >
     Send Anki package?
   </string>
-  <string name="export_send_button">
+  <string
+      name="export_send_button"
+      >
     Send
   </string>
-  <string name="export_save_button">
+  <string
+      name="export_save_button"
+      >
     Save to file
   </string>
-  <string name="export_send_no_handlers">
+  <string
+      name="export_send_no_handlers"
+      >
     No applications available to handle apkg. Saving...
   </string>
-  <string name="export_save_apkg_successful">
+  <string
+      name="export_save_apkg_successful"
+      >
     Successfully saved Anki package
   </string>
-  <string name="export_save_apkg_unsuccessful">
+  <string
+      name="export_save_apkg_unsuccessful"
+      >
     Save Anki package failed
   </string>
-  <string name="export_successful">
+  <string
+      name="export_successful"
+      >
     File “%s” was exported. Do you want to send it with another app?
   </string>
-  <string name="export_email_subject">
+  <string
+      name="export_email_subject"
+      >
     AnkiDroid exported flashcards: %s
   </string>
-  <string name="export_email_text">
+  <string
+      name="export_email_text"
+      >
     <![CDATA[
              Hi!
              <br/><br/>
@@ -475,56 +723,90 @@
              Try to open it using one of the available <a href="http://ankisrs.net/#download">Anki distributions</a> and enjoy easy and efficient learning!
     ]]>
   </string>
-  <string name="export_unsuccessful">
+  <string
+      name="export_unsuccessful"
+      >
     Error exporting apkg file
   </string>
-  <string name="import_hint">
+  <string
+      name="import_hint"
+      >
     Place the apkg file in directory “%s” and touch “OK” to import cards
   </string>
-  <string name="upgrade_import_no_file_found">
+  <string
+      name="upgrade_import_no_file_found"
+      >
     No importable %1$s file found
   </string>
-  <string name="study_options">
+  <string
+      name="study_options"
+      >
     Options
   </string>
-  <string name="select_tts">
+  <string
+      name="select_tts"
+      >
     Set TTS language
   </string>
-  <string name="custom_study">
+  <string
+      name="custom_study"
+      >
     Custom study
   </string>
-  <string name="more_options">
+  <string
+      name="more_options"
+      >
     More
   </string>
-  <string name="dyn_deck_desc">
+  <string
+      name="dyn_deck_desc"
+      >
     This is a special deck for studying outside of the normal schedule. Cards will be automatically returned to their original decks after you review them. Deleting this deck from the deck list will return all remaining cards to their original deck.
   </string>
-  <string name="steps_error">
+  <string
+      name="steps_error"
+      >
     Steps must be numbers greater than 0
   </string>
-  <string name="steps_min_error">
+  <string
+      name="steps_min_error"
+      >
     At least one step is required
   </string>
-  <string name="sched_end">
+  <string
+      name="sched_end"
+      >
     (end)
   </string>
-  <string name="sched_unbury_action">
+  <string
+      name="sched_unbury_action"
+      >
     To see them now touch the “Unbury” item in the menu
   </string>
-  <string name="sched_has_buried">
+  <string
+      name="sched_has_buried"
+      >
     Some related or buried cards were delayed until tomorrow
   </string>
-  <string name="tag_editor_add_feedback">
+  <string
+      name="tag_editor_add_feedback"
+      >
     Touch “%2$s” to confirm adding “%1$s”
   </string>
-  <string name="tag_editor_add_feedback_existing">
+  <string
+      name="tag_editor_add_feedback_existing"
+      >
     Existing tag “%1$s” selected
   </string>
-  <string name="lookup_hint">
+  <string
+      name="lookup_hint"
+      >
     After copying the text, tap anywhere on the flashcard to show the search icon
   </string>
   <!-- Time spans -->
-  <plurals name="time_span_seconds">
+  <plurals
+      name="time_span_seconds"
+      >
     <item quantity="one">
       %s second
     </item>
@@ -532,7 +814,9 @@
       %s seconds
     </item>
   </plurals>
-  <plurals name="time_span_minutes">
+  <plurals
+      name="time_span_minutes"
+      >
     <item quantity="one">
       %s minute
     </item>
@@ -540,7 +824,9 @@
       %s minutes
     </item>
   </plurals>
-  <plurals name="time_span_hours">
+  <plurals
+      name="time_span_hours"
+      >
     <item quantity="one">
       %s hour
     </item>
@@ -548,7 +834,9 @@
       %s hours
     </item>
   </plurals>
-  <plurals name="time_span_days">
+  <plurals
+      name="time_span_days"
+      >
     <item quantity="one">
       %s day
     </item>
@@ -556,7 +844,9 @@
       %s days
     </item>
   </plurals>
-  <plurals name="time_span_months">
+  <plurals
+      name="time_span_months"
+      >
     <item quantity="one">
       %s month
     </item>
@@ -564,7 +854,9 @@
       %s months
     </item>
   </plurals>
-  <plurals name="time_span_years">
+  <plurals
+      name="time_span_years"
+      >
     <item quantity="one">
       %s year
     </item>
@@ -575,24 +867,36 @@
   <!-- The reason for making a simple “< x” translatable are RTL
        languages which apparently use the other symbol to mean less
        than. -->
-  <string name="less_than_time">
+  <string
+      name="less_than_time"
+      >
     &lt; %s
   </string>
 
-  <string name="decks_rename_exists">
+  <string
+      name="decks_rename_exists"
+      >
     That deck already exists
   </string>
-  <string name="decks_rename_filtered_nosubdecks">
+  <string
+      name="decks_rename_filtered_nosubdecks"
+      >
     A filtered deck cannot have subdecks
   </string>
-  <string name="filtered_deck_name">
+  <string
+      name="filtered_deck_name"
+      >
     Filtered Deck
   </string>
 
-  <string name="reminder_title">
+  <string
+      name="reminder_title"
+      >
     Do not forget to study today!
   </string>
-  <plurals name="reminder_text">
+  <plurals
+      name="reminder_text"
+      >
     <item quantity="one">
       %2$d card to review in %1$s
     </item>
@@ -601,104 +905,162 @@
     </item>
   </plurals>
   <!-- Currently only used if exporting APKG fails -->
-  <string name="apk_share_error">
+  <string
+      name="apk_share_error"
+      >
     Error sharing apkg file
   </string>
   <!-- Import and export v2 feedback -->
-  <string name="import_needs_v2">
+  <string
+      name="import_needs_v2"
+      >
     V2 scheduler must be enabled to import this file.
   </string>
-  <string name="import_cannot_with_v2">
+  <string
+      name="import_cannot_with_v2"
+      >
     V2 scheduler can not import V1 decks with scheduling included.
   </string>
-  <string name="export_v2_dummy_note">
+  <string
+      name="export_v2_dummy_note"
+      >
     This file requires a newer version of Anki.
   </string>
   <!-- Placed in a snackbar with a long URL. Limit the length and move the URL to the start of the string -->
-  <string name="activity_start_failed_load_url">
+  <string
+      name="activity_start_failed_load_url"
+      >
     Loading \'%s\' failed.
   </string>
-  <string name="activity_start_failed">
+  <string
+      name="activity_start_failed"
+      >
     The system does not have an app installed that can perform this action.
   </string>
-  <string name="multimedia_editor_image_compression_failed">
+  <string
+      name="multimedia_editor_image_compression_failed"
+      >
     <![CDATA[Camera images may be large. You may wish to compress & resize images in the media directory]]>
   </string>
-  <string name="no_browser_notification">
+  <string
+      name="no_browser_notification"
+      >
     No browser found，please visit web page by pc or mobile:
   </string>
-  <string name="no_outgoing_link_in_cardbrowser">
+  <string
+      name="no_outgoing_link_in_cardbrowser"
+      >
     External page link in card is not supported.
   </string>
   <!-- The name of the deck which corrupt cards will be moved to -->
-  <string name="check_integrity_recovered_deck_name">
+  <string
+      name="check_integrity_recovered_deck_name"
+      >
     Recovered Cards
   </string>
   <!-- Deckpicker Background -->
-  <string name="background_image_title">
+  <string
+      name="background_image_title"
+      >
     Background
   </string>
-  <string name="choose_an_image">
+  <string
+      name="choose_an_image"
+      >
     Choose an Image
   </string>
   <!-- Card Template Browser Appearance -->
-  <string name="restore_default">
+  <string
+      name="restore_default"
+      >
     Restore Default
   </string>
-  <string name="reviewer_tts_cloze_spoken_replacement">
+  <string
+      name="reviewer_tts_cloze_spoken_replacement"
+      >
     Blank
   </string>
   <!-- in options menu & Navigation Drawer -->
-  <string name="ankidroid_turn_on_fullscreen_nav_drawer">
+  <string
+      name="ankidroid_turn_on_fullscreen_nav_drawer"
+      >
     Please turn on fullscreen to use Show Navigation Drawer using JavaScript.
   </string>
-  <string name="ankidroid_turn_on_fullscreen_options_menu">
+  <string
+      name="ankidroid_turn_on_fullscreen_options_menu"
+      >
     Please turn on fullscreen to use Show Options Menu using JavaScript.
   </string>
   <!-- Whiteboard save image message in Reviewer -->
-  <string name="white_board_image_save_failed">
+  <string
+      name="white_board_image_save_failed"
+      >
     Failed to save whiteboard image. %s
   </string>
-  <string name="white_board_image_saved">
+  <string
+      name="white_board_image_saved"
+      >
     Whiteboard image saved to %s
   </string>
 
-  <string name="title_whiteboard_pen_color">
+  <string
+      name="title_whiteboard_pen_color"
+      >
     Whiteboard pen color
   </string>
 
 
   <!-- CSV/Note Import -->
-  <string name="note_importer_empty_cards_found">
+  <string
+      name="note_importer_empty_cards_found"
+      >
     <![CDATA[Empty cards found. Please run Tools>Empty Cards.]]>
   </string>
 
-  <string name="note_importer_error_empty_first_field">
+  <string
+      name="note_importer_error_empty_first_field"
+      >
     Empty first field: %s
   </string>
-  <string name="note_importer_error_first_field_matched">
+  <string
+      name="note_importer_error_first_field_matched"
+      >
     First field matched: %s
   </string>
-  <string name="note_importer_error_added_duplicate_first_field">
+  <string
+      name="note_importer_error_added_duplicate_first_field"
+      >
     Added duplicate with first field: %s
   </string>
-  <string name="note_importer_error_appeared_twice">
+  <string
+      name="note_importer_error_appeared_twice"
+      >
     Appeared twice in file: %s
   </string>
-  <string name="note_importer_error_empty_notes">
+  <string
+      name="note_importer_error_empty_notes"
+      >
     One or more notes were not imported, because they didn\'t generate any cards. This can happen when you have empty fields or when you have not mapped the content in the text file to the correct fields
   </string>
-  <string name="csv_importer_error_invalid_field_count">
+  <string
+      name="csv_importer_error_invalid_field_count"
+      >
     ‘%1$s’ had %2$d fields, expected %3$d
   </string>
-  <string name="csv_importer_error_exception">
+  <string
+      name="csv_importer_error_exception"
+      >
     Aborted: %s
   </string>
-  <string name="user_is_a_robot">
+  <string
+      name="user_is_a_robot"
+      >
     Detected automated test. If you are a human, contact AnkiDroid support
   </string>
 
-  <plurals name="note_importer_notes_added">
+  <plurals
+      name="note_importer_notes_added"
+      >
     <item quantity="one">
       %d note added
     </item>
@@ -707,7 +1069,9 @@
     </item>
   </plurals>
 
-  <plurals name="note_importer_notes_updated">
+  <plurals
+      name="note_importer_notes_updated"
+      >
     <item quantity="one">
       %d note updated
     </item>
@@ -716,7 +1080,9 @@
     </item>
   </plurals>
 
-  <plurals name="note_importer_notes_unchanged">
+  <plurals
+      name="note_importer_notes_unchanged"
+      >
     <item quantity="one">
       %d note unchanged
     </item>
@@ -726,30 +1092,46 @@
   </plurals>
 
   <!-- JS api -->
-  <string name="api_version_developer_contact">
+  <string
+      name="api_version_developer_contact"
+      >
     This card uses unsupported AnkiDroid features. Contact developer %1$s, or view the wiki. %2$s
   </string>
-  <string name="invalid_json_data">
+  <string
+      name="invalid_json_data"
+      >
     Card provided invalid data. %s
   </string>
-  <string name="valid_js_api_version">
+  <string
+      name="valid_js_api_version"
+      >
     Invalid AnkiDroid JS API version. Contact developer %s, or view wiki
   </string>
-  <string name="update_js_api_version">
+  <string
+      name="update_js_api_version"
+      >
     AnkiDroid JS API update available. Contact developer %s, or view wiki
   </string>
-  <string name="reviewer_invalid_api_version_visit_documentation">
+  <string
+      name="reviewer_invalid_api_version_visit_documentation"
+      >
     View
   </string>
-  <string name="anki_js_error_code">
+  <string
+      name="anki_js_error_code"
+      >
     (Error Code: %d)
   </string>
 
   <!-- About AnkiDroid screen -->
-  <string name="about_ankidroid_successfully_copied_debug">
+  <string
+      name="about_ankidroid_successfully_copied_debug"
+      >
     Copied debug information to clipboard
   </string>
-  <string name="about_ankidroid_error_copy_debug_info">
+  <string
+      name="about_ankidroid_error_copy_debug_info"
+      >
     Error copying debug information to clipboard
   </string>
 </resources>

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -19,305 +19,737 @@
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <resources>
-    <!-- How to format a percentage shown in the summary field of a preference -->
-    <string name="preference_summary_percentage">XXX%</string>
+  <!-- How to format a percentage shown in the summary field of a preference -->
+  <string name="preference_summary_percentage">
+    XXX%
+  </string>
 
-    <!-- Navigation drawer strings -->
-    <string name="drawer_open">Open drawer</string>
-    <string name="drawer_close">Close drawer</string>
+  <!-- Navigation drawer strings -->
+  <string name="drawer_open">
+    Open drawer
+  </string>
+  <string name="drawer_close">
+    Close drawer
+  </string>
 
-    <string name="CardEditorLaterMessage">Saved information for later</string>
-    <string name="CardEditorCardDeck">Card deck:</string>
-    <string name="CardEditorNoteDeck">Deck:</string>
-    <string name="CardEditorModel">Type:</string>
-    <string name="CardEditorTags">Tags: %1$s</string>
-    <string name="CardEditorCards">Cards: %1$s</string>
-    <string name="tag_name">Tag name</string>
-    <string name="add_new_filter_tags">Add/filter tags</string>
-    <string name="add_tag">Add tag</string>
-    <string name="check_all_tags">Check/uncheck all tags</string>
-    <string name="filter_tags">Filter tags</string>
-    <string name="no_tags">You haven’t added any tags yet</string>
-    <string name="sdcard_missing_message">Switch off USB storage to access your decks</string>
-    <string name="updated_version">Updated to version %s</string>
+  <string name="CardEditorLaterMessage">
+    Saved information for later
+  </string>
+  <string name="CardEditorCardDeck">
+    Card deck:
+  </string>
+  <string name="CardEditorNoteDeck">
+    Deck:
+  </string>
+  <string name="CardEditorModel">
+    Type:
+  </string>
+  <string name="CardEditorTags">
+    Tags: %1$s
+  </string>
+  <string name="CardEditorCards">
+    Cards: %1$s
+  </string>
+  <string name="tag_name">
+    Tag name
+  </string>
+  <string name="add_new_filter_tags">
+    Add/filter tags
+  </string>
+  <string name="add_tag">
+    Add tag
+  </string>
+  <string name="check_all_tags">
+    Check/uncheck all tags
+  </string>
+  <string name="filter_tags">
+    Filter tags
+  </string>
+  <string name="no_tags">
+    You haven’t added any tags yet
+  </string>
+  <string name="sdcard_missing_message">
+    Switch off USB storage to access your decks
+  </string>
+  <string name="updated_version">
+    Updated to version %s
+  </string>
 
-    <!-- Reviewer.java -->
-    <string name="save_whiteboard">Save whiteboard</string>
-    <string name="enable_whiteboard">Enable whiteboard</string>
-    <string name="disable_whiteboard">Disable whiteboard</string>
-    <string name="show_whiteboard">Show whiteboard</string>
-    <string name="hide_whiteboard">Hide whiteboard</string>
-    <string name="clear_whiteboard">Clear whiteboard</string>
-    <string name="replay_audio">Replay audio</string>
-    <string name="toggle_mic_tool_bar">Check Pronunciation</string>
-    <string name="leech_suspend_notification">Card marked as leech and suspended</string>
-    <string name="leech_notification">Card marked as leech</string>
-    <string name="corrupt_font">Corrupt font file %s</string>
-    <string name="webview_crash_unknown">Unknown error</string>
-    <string name="webview_crash_unknwon_detailed">This was caused by an internal error in the WebView</string>
-    <string name="webview_crash_oom">Out of Memory</string>
-    <string name="webview_crash_oom_details">The WebView was terminated by the system. This typically happens when the application runs out of memory, often due to large fonts or media.</string>
-    <string name="webview_crash_nonfatal">WebView renderer crashed. Cause: %s</string>
-    <string name="webview_crash_fatal">Fatal Error: WebView renderer crashed. Cause: %s</string>
-    <string name="webview_crash_loop_dialog_title">System WebView Rendering Failure</string>
-    <string name="webview_crash_loop_dialog_content">System WebView failed to render card \'%1$s\'.\n %2$s</string>
+  <!-- Reviewer.java -->
+  <string name="save_whiteboard">
+    Save whiteboard
+  </string>
+  <string name="enable_whiteboard">
+    Enable whiteboard
+  </string>
+  <string name="disable_whiteboard">
+    Disable whiteboard
+  </string>
+  <string name="show_whiteboard">
+    Show whiteboard
+  </string>
+  <string name="hide_whiteboard">
+    Hide whiteboard
+  </string>
+  <string name="clear_whiteboard">
+    Clear whiteboard
+  </string>
+  <string name="replay_audio">
+    Replay audio
+  </string>
+  <string name="toggle_mic_tool_bar">
+    Check Pronunciation
+  </string>
+  <string name="leech_suspend_notification">
+    Card marked as leech and suspended
+  </string>
+  <string name="leech_notification">
+    Card marked as leech
+  </string>
+  <string name="corrupt_font">
+    Corrupt font file %s
+  </string>
+  <string name="webview_crash_unknown">
+    Unknown error
+  </string>
+  <string name="webview_crash_unknwon_detailed">
+    This was caused by an internal error in the WebView
+  </string>
+  <string name="webview_crash_oom">
+    Out of Memory
+  </string>
+  <string name="webview_crash_oom_details">
+    The WebView was terminated by the system. This typically happens when the application runs out of memory, often due to large fonts or media.
+  </string>
+  <string name="webview_crash_nonfatal">
+    WebView renderer crashed. Cause: %s
+  </string>
+  <string name="webview_crash_fatal">
+    Fatal Error: WebView renderer crashed. Cause: %s
+  </string>
+  <string name="webview_crash_loop_dialog_title">
+    System WebView Rendering Failure
+  </string>
+  <string name="webview_crash_loop_dialog_content">
+    System WebView failed to render card \'%1$s\'.\n %2$s
+  </string>
 
-    <!-- Browser -->
-    <string-array name="browser_column1_headings">
-        <item>Question</item>
-        <item>Sort field</item>
-    </string-array>
-    <string-array name="browser_column2_headings">
-        <item>Answer</item>
-        <item>Card</item>
-        <item>Deck</item>
-        <item>Note</item>
-        <item>Question</item>
-        <item>Tags</item>
-        <item>Lapses</item>
-        <item>Reviews</item>
-        <item>Interval</item>
-        <item>Ease</item>
-        <item>Due</item>
-        <item>Card Modified</item>
-        <item>Created</item>
-        <item>Note Modified</item>
-    </string-array>
+  <!-- Browser -->
+  <string-array name="browser_column1_headings">
+    <item>
+      Question
+    </item>
+    <item>
+      Sort field
+    </item>
+  </string-array>
+  <string-array name="browser_column2_headings">
+    <item>
+      Answer
+    </item>
+    <item>
+      Card
+    </item>
+    <item>
+      Deck
+    </item>
+    <item>
+      Note
+    </item>
+    <item>
+      Question
+    </item>
+    <item>
+      Tags
+    </item>
+    <item>
+      Lapses
+    </item>
+    <item>
+      Reviews
+    </item>
+    <item>
+      Interval
+    </item>
+    <item>
+      Ease
+    </item>
+    <item>
+      Due
+    </item>
+    <item>
+      Card Modified
+    </item>
+    <item>
+      Created
+    </item>
+    <item>
+      Note Modified
+    </item>
+  </string-array>
 
-    <!-- Custom study options -->
-    <string name="custom_study_increase_new_limit">Modify today’s new card limit</string>
-    <string name="custom_study_increase_review_limit">Modify today’s review card limit</string>
-    <string name="custom_study_review_forgotten">Review forgotten cards</string>
-    <string name="custom_study_review_ahead">Review ahead</string>
-    <string name="custom_study_random_selection">Study a random selection of cards</string>
-    <string name="custom_study_preview_new">Preview new cards</string>
-    <string name="custom_study_limit_tags">Limit to particular tags</string>
+  <!-- Custom study options -->
+  <string name="custom_study_increase_new_limit">
+    Modify today’s new card limit
+  </string>
+  <string name="custom_study_increase_review_limit">
+    Modify today’s review card limit
+  </string>
+  <string name="custom_study_review_forgotten">
+    Review forgotten cards
+  </string>
+  <string name="custom_study_review_ahead">
+    Review ahead
+  </string>
+  <string name="custom_study_random_selection">
+    Study a random selection of cards
+  </string>
+  <string name="custom_study_preview_new">
+    Preview new cards
+  </string>
+  <string name="custom_study_limit_tags">
+    Limit to particular tags
+  </string>
 
-    <!-- Card editor -->
-    <string name="cardeditor_title_add_note">Add note</string>
-    <string name="cardeditor_title_edit_card">Edit note</string>
-    <string name="discard_unsaved_changes">Close and lose current input?</string>
-    <string name="note_editor_no_cards_created">No cards created. Please fill in more fields</string>
-    <string name="note_editor_no_first_field">The first field is empty</string>
-    <string name="note_editor_no_cloze_delations">This note type must contain cloze deletions</string>
-    <string name="note_editor_set_field_language">Set field language</string>
-    <string name="note_editor_no_cards_created_all_fields">The current note type did not produce any cards.\nPlease choose another note type, or click ‘Cards’ and add a field substitution</string>
-    <string name="note_editor_insert_cloze_no_cloze_note_type">Cloze deletions will only work on a Cloze note type</string>
-    <string name="saving_facts">Saving note</string>
-    <string name="saving_model">Saving note type</string>
-    <string name="add">Add</string>
-    <string name="save">Save</string>
-    <string name="close">Close</string>
-    <string name="select">Select</string>
-    <string name="saving_changes">Saving changes…</string>
-    <string name="reordering_cards">Reordering cards…</string>
-    <string name="field_remapping">%1$s (from “%2$s”)</string>
-    <string name="confirm_map_cards_to_nothing">Any cards mapped to nothing will be deleted. If a note has no remaining cards, it will be lost. Are you sure you want to continue?</string>
+  <!-- Card editor -->
+  <string name="cardeditor_title_add_note">
+    Add note
+  </string>
+  <string name="cardeditor_title_edit_card">
+    Edit note
+  </string>
+  <string name="discard_unsaved_changes">
+    Close and lose current input?
+  </string>
+  <string name="note_editor_no_cards_created">
+    No cards created. Please fill in more fields
+  </string>
+  <string name="note_editor_no_first_field">
+    The first field is empty
+  </string>
+  <string name="note_editor_no_cloze_delations">
+    This note type must contain cloze deletions
+  </string>
+  <string name="note_editor_set_field_language">
+    Set field language
+  </string>
+  <string name="note_editor_no_cards_created_all_fields">
+    The current note type did not produce any cards.\nPlease choose another note type, or click ‘Cards’ and add a field substitution
+  </string>
+  <string name="note_editor_insert_cloze_no_cloze_note_type">
+    Cloze deletions will only work on a Cloze note type
+  </string>
+  <string name="saving_facts">
+    Saving note
+  </string>
+  <string name="saving_model">
+    Saving note type
+  </string>
+  <string name="add">
+    Add
+  </string>
+  <string name="save">
+    Save
+  </string>
+  <string name="close">
+    Close
+  </string>
+  <string name="select">
+    Select
+  </string>
+  <string name="saving_changes">
+    Saving changes…
+  </string>
+  <string name="reordering_cards">
+    Reordering cards…
+  </string>
+  <string name="field_remapping">
+    %1$s (from “%2$s”)
+  </string>
+  <string name="confirm_map_cards_to_nothing">
+    Any cards mapped to nothing will be deleted. If a note has no remaining cards, it will be lost. Are you sure you want to continue?
+  </string>
 
-    <plurals name="timebox_reached">
-        <item quantity="one">%1$d card studied in %2$s</item>
-        <item quantity="other">%1$d cards studied in %2$s</item>
-    </plurals>
-    <!-- minutes used in '[studied in] x minutes' context, causing inflexion in some languages -->
-    <plurals name="in_minutes">
-        <item quantity="one">%1$d minute</item>
-        <item quantity="other">%1$d minutes</item>
-    </plurals>
+  <plurals name="timebox_reached">
+    <item quantity="one">
+      %1$d card studied in %2$s
+    </item>
+    <item quantity="other">
+      %1$d cards studied in %2$s
+    </item>
+  </plurals>
+  <!-- minutes used in '[studied in] x minutes' context, causing inflexion in some languages -->
+  <plurals name="in_minutes">
+    <item quantity="one">
+      %1$d minute
+    </item>
+    <item quantity="other">
+      %1$d minutes
+    </item>
+  </plurals>
 
-    <string name="studyoptions_welcome_title">Welcome to AnkiDroid</string>
-    <string name="fact_adder_intent_title">AnkiDroid card</string>
-    <string name="note_editor_add_note">Add note</string>
-    <string name="note_editor_copy_note">Copy note</string>
-    <string name="card_editor_copy_card">Copy card</string>
-    <string name="card_editor_reposition_card">Reposition</string>
-    <string name="card_editor_reset_card">Reset progress</string>
-    <string name="card_editor_reschedule_card">Reschedule</string>
-    <string name="card_editor_preview_card">Preview</string>
-    <string name="error_insufficient_memory">Operation not possible due to insufficient memory on your device</string>
-    <string name="rename">Rename</string>
-    <string name="default_conf_delete_error">The default options group can’t be removed</string>
+  <string name="studyoptions_welcome_title">
+    Welcome to AnkiDroid
+  </string>
+  <string name="fact_adder_intent_title">
+    AnkiDroid card
+  </string>
+  <string name="note_editor_add_note">
+    Add note
+  </string>
+  <string name="note_editor_copy_note">
+    Copy note
+  </string>
+  <string name="card_editor_copy_card">
+    Copy card
+  </string>
+  <string name="card_editor_reposition_card">
+    Reposition
+  </string>
+  <string name="card_editor_reset_card">
+    Reset progress
+  </string>
+  <string name="card_editor_reschedule_card">
+    Reschedule
+  </string>
+  <string name="card_editor_preview_card">
+    Preview
+  </string>
+  <string name="error_insufficient_memory">
+    Operation not possible due to insufficient memory on your device
+  </string>
+  <string name="rename">
+    Rename
+  </string>
+  <string name="default_conf_delete_error">
+    The default options group can’t be removed
+  </string>
 
-    <plurals name="factadder_cards_added">
-        <item quantity="one">%d card added</item>
-        <item quantity="other">%d cards added</item>
-    </plurals>
+  <plurals name="factadder_cards_added">
+    <item quantity="one">
+      %d card added
+    </item>
+    <item quantity="other">
+      %d cards added
+    </item>
+  </plurals>
 
-    <string name="help_title">Help</string>
-    <string name="check_db">Check database</string>
-    <string name="check_media">Check media</string>
-    <string name="empty_cards">Empty cards</string>
-    <string name="check_db_message">Checking database…</string>
-    <string name="empty_card_warning">This card is empty. Use the “Empty cards” option from the menu on the deck list screen.</string>
-    <string name="unknown_type_field_warning">Type answer: unknown field %s</string>
-    <string name="delete_deck">Deleting deck…</string>
+  <string name="help_title">
+    Help
+  </string>
+  <string name="check_db">
+    Check database
+  </string>
+  <string name="check_media">
+    Check media
+  </string>
+  <string name="empty_cards">
+    Empty cards
+  </string>
+  <string name="check_db_message">
+    Checking database…
+  </string>
+  <string name="empty_card_warning">
+    This card is empty. Use the “Empty cards” option from the menu on the deck list screen.
+  </string>
+  <string name="unknown_type_field_warning">
+    Type answer: unknown field %s
+  </string>
+  <string name="delete_deck">
+    Deleting deck…
+  </string>
 
-    <string name="show_hint">Show %s</string>
-    <string name="info_rate">Rate AnkiDroid</string>
-    <string name="col_load_failed">Collection loading failed.\nPress back to close AnkiDroid.</string>
-    <string name="import_title">Importing</string>
-    <string name="import_select_title">Choose a file to import</string>
-    <string name="import_message_add">Add</string>
-    <string name="import_message_replace_confirm">This will delete your existing collection and replace it with the data of file %s</string>
-    <string name="import_message_add_confirm">Add “%s” to collection? This may take a long time</string>
-    <string name="import_log_no_apkg">This isn’t a valid Anki package file</string>
-    <string name="import_log_failed_unzip">Failed to unzip apkg: %s</string>
-    <string name="import_log_failed_copy_to">Failed to copy apkg to %s</string>
-    <string name="import_log_failed_validate">apkg failed validation</string>
-    <string name="import_log_insufficient_space">There is not enough space to unzip the package. Needed %1$d, available %2$d</string>
-    <string name="import_log_file_cache_cleared">Error importing file, likely a cache clear during processing.\nPlease try again</string>
-    <string name="import_succeeded_but_check_database">Data import succeeded but post-import cleanup failed. Run check database later. Root cause: %s</string>
-    <string name="import_error_unhandled_request">Unable to process import request</string>
-    <string name="import_error_exception">Failed to import package\n\n%s</string>
-    <string name="import_error_not_apkg_extension">Filename “%s” doesn’t have .apkg or .colpkg extension</string>
-    <string name="import_error_load_imported_database">Anki Database (.anki2) replacements are not yet supported. Please see the manual for replacement instructions.</string>
-    <string name="import_error_content_provider">The selected file couldn’t be imported automatically by AnkiDroid. Please see the user manual for how to manually import anki files: \n%s</string>
-    <string name="import_error_copy_file_to_cache">copyFileToCache() failed (possibly out of storage space)</string>
-    <string name="import_replacing">Replacing collection…</string>
-    <string name="import_interrupted">Import interrupted</string>
-    <string name="export_include_schedule">Include scheduling</string>
-    <string name="export_include_media">Include media</string>
-    <string name="confirm_apkg_export">Export collection as Anki package?</string>
-    <string name="confirm_apkg_export_deck">Export “%s” as apkg file?</string>
-    <string name="export_in_progress">Exporting Anki package file…</string>
-    <string name="export_successful_title">Send Anki package?</string>
-    <string name="export_send_button">Send</string>
-    <string name="export_save_button">Save to file</string>
-    <string name="export_send_no_handlers">No applications available to handle apkg. Saving...</string>
-    <string name="export_save_apkg_successful">Successfully saved Anki package</string>
-    <string name="export_save_apkg_unsuccessful">Save Anki package failed</string>
-    <string name="export_successful">File “%s” was exported. Do you want to send it with another app?</string>
-    <string name="export_email_subject">AnkiDroid exported flashcards: %s</string>
-    <string name="export_email_text">
-        <![CDATA[
-        Hi!
-        <br/><br/>
-        This is an Anki flashcards deck send from <a href="https://ankidroid.org/docs/manual.html">AnkiDroid</a>.
-        Try to open it using one of the available <a href="http://ankisrs.net/#download">Anki distributions</a> and enjoy easy and efficient learning!
-        ]]>
-    </string>
-    <string name="export_unsuccessful">Error exporting apkg file</string>
-    <string name="import_hint">Place the apkg file in directory “%s” and touch “OK” to import cards</string>
-    <string name="upgrade_import_no_file_found">No importable %1$s file found</string>
-    <string name="study_options">Options</string>
-    <string name="select_tts">Set TTS language</string>
-    <string name="custom_study">Custom study</string>
-    <string name="more_options">More</string>
-    <string name="dyn_deck_desc">This is a special deck for studying outside of the normal schedule. Cards will be automatically returned to their original decks after you review them. Deleting this deck from the deck list will return all remaining cards to their original deck.</string>
-    <string name="steps_error">Steps must be numbers greater than 0</string>
-    <string name="steps_min_error">At least one step is required</string>
-    <string name="sched_end">(end)</string>
-    <string name="sched_unbury_action">To see them now touch the “Unbury” item in the menu</string>
-    <string name="sched_has_buried">Some related or buried cards were delayed until tomorrow</string>
-    <string name="tag_editor_add_feedback">Touch “%2$s” to confirm adding “%1$s”</string>
-    <string name="tag_editor_add_feedback_existing">Existing tag “%1$s” selected</string>
-    <string name="lookup_hint">After copying the text, tap anywhere on the flashcard to show the search icon</string>
-    <!-- Time spans -->
-    <plurals name="time_span_seconds">
-        <item quantity="one">%s second</item>
-        <item quantity="other">%s seconds</item>
-    </plurals>
-    <plurals name="time_span_minutes">
-        <item quantity="one">%s minute</item>
-        <item quantity="other">%s minutes</item>
-    </plurals>
-    <plurals name="time_span_hours">
-        <item quantity="one">%s hour</item>
-        <item quantity="other">%s hours</item>
-    </plurals>
-    <plurals name="time_span_days">
-        <item quantity="one">%s day</item>
-        <item quantity="other">%s days</item>
-    </plurals>
-    <plurals name="time_span_months">
-        <item quantity="one">%s month</item>
-        <item quantity="other">%s months</item>
-    </plurals>
-    <plurals name="time_span_years">
-        <item quantity="one">%s year</item>
-        <item quantity="other">%s years</item>
-    </plurals>
-    <!-- The reason for making a simple “< x” translatable are RTL
-         languages which apparently use the other symbol to mean less
-         than. -->
-    <string name="less_than_time">&lt; %s</string>
+  <string name="show_hint">
+    Show %s
+  </string>
+  <string name="info_rate">
+    Rate AnkiDroid
+  </string>
+  <string name="col_load_failed">
+    Collection loading failed.\nPress back to close AnkiDroid.
+  </string>
+  <string name="import_title">
+    Importing
+  </string>
+  <string name="import_select_title">
+    Choose a file to import
+  </string>
+  <string name="import_message_add">
+    Add
+  </string>
+  <string name="import_message_replace_confirm">
+    This will delete your existing collection and replace it with the data of file %s
+  </string>
+  <string name="import_message_add_confirm">
+    Add “%s” to collection? This may take a long time
+  </string>
+  <string name="import_log_no_apkg">
+    This isn’t a valid Anki package file
+  </string>
+  <string name="import_log_failed_unzip">
+    Failed to unzip apkg: %s
+  </string>
+  <string name="import_log_failed_copy_to">
+    Failed to copy apkg to %s
+  </string>
+  <string name="import_log_failed_validate">
+    apkg failed validation
+  </string>
+  <string name="import_log_insufficient_space">
+    There is not enough space to unzip the package. Needed %1$d, available %2$d
+  </string>
+  <string name="import_log_file_cache_cleared">
+    Error importing file, likely a cache clear during processing.\nPlease try again
+  </string>
+  <string name="import_succeeded_but_check_database">
+    Data import succeeded but post-import cleanup failed. Run check database later. Root cause: %s
+  </string>
+  <string name="import_error_unhandled_request">
+    Unable to process import request
+  </string>
+  <string name="import_error_exception">
+    Failed to import package\n\n%s
+  </string>
+  <string name="import_error_not_apkg_extension">
+    Filename “%s” doesn’t have .apkg or .colpkg extension
+  </string>
+  <string name="import_error_load_imported_database">
+    Anki Database (.anki2) replacements are not yet supported. Please see the manual for replacement instructions.
+  </string>
+  <string name="import_error_content_provider">
+    The selected file couldn’t be imported automatically by AnkiDroid. Please see the user manual for how to manually import anki files: \n%s
+  </string>
+  <string name="import_error_copy_file_to_cache">
+    copyFileToCache() failed (possibly out of storage space)
+  </string>
+  <string name="import_replacing">
+    Replacing collection…
+  </string>
+  <string name="import_interrupted">
+    Import interrupted
+  </string>
+  <string name="export_include_schedule">
+    Include scheduling
+  </string>
+  <string name="export_include_media">
+    Include media
+  </string>
+  <string name="confirm_apkg_export">
+    Export collection as Anki package?
+  </string>
+  <string name="confirm_apkg_export_deck">
+    Export “%s” as apkg file?
+  </string>
+  <string name="export_in_progress">
+    Exporting Anki package file…
+  </string>
+  <string name="export_successful_title">
+    Send Anki package?
+  </string>
+  <string name="export_send_button">
+    Send
+  </string>
+  <string name="export_save_button">
+    Save to file
+  </string>
+  <string name="export_send_no_handlers">
+    No applications available to handle apkg. Saving...
+  </string>
+  <string name="export_save_apkg_successful">
+    Successfully saved Anki package
+  </string>
+  <string name="export_save_apkg_unsuccessful">
+    Save Anki package failed
+  </string>
+  <string name="export_successful">
+    File “%s” was exported. Do you want to send it with another app?
+  </string>
+  <string name="export_email_subject">
+    AnkiDroid exported flashcards: %s
+  </string>
+  <string name="export_email_text">
+    <![CDATA[
+             Hi!
+             <br/><br/>
+             This is an Anki flashcards deck send from <a href="https://ankidroid.org/docs/manual.html">AnkiDroid</a>.
+             Try to open it using one of the available <a href="http://ankisrs.net/#download">Anki distributions</a> and enjoy easy and efficient learning!
+    ]]>
+  </string>
+  <string name="export_unsuccessful">
+    Error exporting apkg file
+  </string>
+  <string name="import_hint">
+    Place the apkg file in directory “%s” and touch “OK” to import cards
+  </string>
+  <string name="upgrade_import_no_file_found">
+    No importable %1$s file found
+  </string>
+  <string name="study_options">
+    Options
+  </string>
+  <string name="select_tts">
+    Set TTS language
+  </string>
+  <string name="custom_study">
+    Custom study
+  </string>
+  <string name="more_options">
+    More
+  </string>
+  <string name="dyn_deck_desc">
+    This is a special deck for studying outside of the normal schedule. Cards will be automatically returned to their original decks after you review them. Deleting this deck from the deck list will return all remaining cards to their original deck.
+  </string>
+  <string name="steps_error">
+    Steps must be numbers greater than 0
+  </string>
+  <string name="steps_min_error">
+    At least one step is required
+  </string>
+  <string name="sched_end">
+    (end)
+  </string>
+  <string name="sched_unbury_action">
+    To see them now touch the “Unbury” item in the menu
+  </string>
+  <string name="sched_has_buried">
+    Some related or buried cards were delayed until tomorrow
+  </string>
+  <string name="tag_editor_add_feedback">
+    Touch “%2$s” to confirm adding “%1$s”
+  </string>
+  <string name="tag_editor_add_feedback_existing">
+    Existing tag “%1$s” selected
+  </string>
+  <string name="lookup_hint">
+    After copying the text, tap anywhere on the flashcard to show the search icon
+  </string>
+  <!-- Time spans -->
+  <plurals name="time_span_seconds">
+    <item quantity="one">
+      %s second
+    </item>
+    <item quantity="other">
+      %s seconds
+    </item>
+  </plurals>
+  <plurals name="time_span_minutes">
+    <item quantity="one">
+      %s minute
+    </item>
+    <item quantity="other">
+      %s minutes
+    </item>
+  </plurals>
+  <plurals name="time_span_hours">
+    <item quantity="one">
+      %s hour
+    </item>
+    <item quantity="other">
+      %s hours
+    </item>
+  </plurals>
+  <plurals name="time_span_days">
+    <item quantity="one">
+      %s day
+    </item>
+    <item quantity="other">
+      %s days
+    </item>
+  </plurals>
+  <plurals name="time_span_months">
+    <item quantity="one">
+      %s month
+    </item>
+    <item quantity="other">
+      %s months
+    </item>
+  </plurals>
+  <plurals name="time_span_years">
+    <item quantity="one">
+      %s year
+    </item>
+    <item quantity="other">
+      %s years
+    </item>
+  </plurals>
+  <!-- The reason for making a simple “< x” translatable are RTL
+       languages which apparently use the other symbol to mean less
+       than. -->
+  <string name="less_than_time">
+    &lt; %s
+  </string>
 
-    <string name="decks_rename_exists">That deck already exists</string>
-    <string name="decks_rename_filtered_nosubdecks">A filtered deck cannot have subdecks</string>
-    <string name="filtered_deck_name">Filtered Deck</string>
+  <string name="decks_rename_exists">
+    That deck already exists
+  </string>
+  <string name="decks_rename_filtered_nosubdecks">
+    A filtered deck cannot have subdecks
+  </string>
+  <string name="filtered_deck_name">
+    Filtered Deck
+  </string>
 
-    <string name="reminder_title">Do not forget to study today!</string>
-    <plurals name="reminder_text">
-        <item quantity="one">%2$d card to review in %1$s</item>
-        <item quantity="other">%2$d cards to review in %1$s</item>
-    </plurals>
-    <!-- Currently only used if exporting APKG fails -->
-    <string name="apk_share_error">Error sharing apkg file</string>
-    <!-- Import and export v2 feedback -->
-    <string name="import_needs_v2">V2 scheduler must be enabled to import this file.</string>
-    <string name="import_cannot_with_v2">V2 scheduler can not import V1 decks with scheduling included.</string>
-    <string name="export_v2_dummy_note">This file requires a newer version of Anki.</string>
-    <!-- Placed in a snackbar with a long URL. Limit the length and move the URL to the start of the string -->
-    <string name="activity_start_failed_load_url">Loading \'%s\' failed.</string>
-    <string name="activity_start_failed">The system does not have an app installed that can perform this action.</string>
-    <string name="multimedia_editor_image_compression_failed"><![CDATA[Camera images may be large. You may wish to compress & resize images in the media directory]]></string>
-    <string name="no_browser_notification">No browser found，please visit web page by pc or mobile: </string>
-    <string name="no_outgoing_link_in_cardbrowser">External page link in card is not supported.</string>
-    <!-- The name of the deck which corrupt cards will be moved to -->
-    <string name="check_integrity_recovered_deck_name">Recovered Cards</string>
-    <!-- Deckpicker Background -->
-    <string name="background_image_title">Background</string>
-    <string name="choose_an_image">Choose an Image</string>
-    <!-- Card Template Browser Appearance -->
-    <string name="restore_default">Restore Default</string>
+  <string name="reminder_title">
+    Do not forget to study today!
+  </string>
+  <plurals name="reminder_text">
+    <item quantity="one">
+      %2$d card to review in %1$s
+    </item>
+    <item quantity="other">
+      %2$d cards to review in %1$s
+    </item>
+  </plurals>
+  <!-- Currently only used if exporting APKG fails -->
+  <string name="apk_share_error">
+    Error sharing apkg file
+  </string>
+  <!-- Import and export v2 feedback -->
+  <string name="import_needs_v2">
+    V2 scheduler must be enabled to import this file.
+  </string>
+  <string name="import_cannot_with_v2">
+    V2 scheduler can not import V1 decks with scheduling included.
+  </string>
+  <string name="export_v2_dummy_note">
+    This file requires a newer version of Anki.
+  </string>
+  <!-- Placed in a snackbar with a long URL. Limit the length and move the URL to the start of the string -->
+  <string name="activity_start_failed_load_url">
+    Loading \'%s\' failed.
+  </string>
+  <string name="activity_start_failed">
+    The system does not have an app installed that can perform this action.
+  </string>
+  <string name="multimedia_editor_image_compression_failed">
+    <![CDATA[Camera images may be large. You may wish to compress & resize images in the media directory]]>
+  </string>
+  <string name="no_browser_notification">
+    No browser found，please visit web page by pc or mobile:
+  </string>
+  <string name="no_outgoing_link_in_cardbrowser">
+    External page link in card is not supported.
+  </string>
+  <!-- The name of the deck which corrupt cards will be moved to -->
+  <string name="check_integrity_recovered_deck_name">
+    Recovered Cards
+  </string>
+  <!-- Deckpicker Background -->
+  <string name="background_image_title">
+    Background
+  </string>
+  <string name="choose_an_image">
+    Choose an Image
+  </string>
+  <!-- Card Template Browser Appearance -->
+  <string name="restore_default">
+    Restore Default
+  </string>
+  <string name="reviewer_tts_cloze_spoken_replacement">
+    Blank
+  </string>
+  <!-- in options menu & Navigation Drawer -->
+  <string name="ankidroid_turn_on_fullscreen_nav_drawer">
+    Please turn on fullscreen to use Show Navigation Drawer using JavaScript.
+  </string>
+  <string name="ankidroid_turn_on_fullscreen_options_menu">
+    Please turn on fullscreen to use Show Options Menu using JavaScript.
+  </string>
+  <!-- Whiteboard save image message in Reviewer -->
+  <string name="white_board_image_save_failed">
+    Failed to save whiteboard image. %s
+  </string>
+  <string name="white_board_image_saved">
+    Whiteboard image saved to %s
+  </string>
 
-    <string name="reviewer_tts_cloze_spoken_replacement">Blank</string>
-
-    <!-- in options menu & Navigation Drawer -->
-    <string name="ankidroid_turn_on_fullscreen_nav_drawer">Please turn on fullscreen to use Show Navigation Drawer using JavaScript.</string>
-    <string name="ankidroid_turn_on_fullscreen_options_menu">Please turn on fullscreen to use Show Options Menu using JavaScript.</string>
-    <!-- Whiteboard save image message in Reviewer -->
-    <string name="white_board_image_save_failed">Failed to save whiteboard image. %s</string>
-    <string name="white_board_image_saved">Whiteboard image saved to %s</string>
-
-    <string name="title_whiteboard_pen_color">Whiteboard pen color</string>
+  <string name="title_whiteboard_pen_color">
+    Whiteboard pen color
+  </string>
 
 
-    <!-- CSV/Note Import -->
-    <string name="note_importer_empty_cards_found"><![CDATA[Empty cards found. Please run Tools>Empty Cards.]]></string>
+  <!-- CSV/Note Import -->
+  <string name="note_importer_empty_cards_found">
+    <![CDATA[Empty cards found. Please run Tools>Empty Cards.]]>
+  </string>
 
-    <string name="note_importer_error_empty_first_field">Empty first field: %s</string>
-    <string name="note_importer_error_first_field_matched">First field matched: %s</string>
-    <string name="note_importer_error_added_duplicate_first_field">Added duplicate with first field: %s</string>
-    <string name="note_importer_error_appeared_twice">Appeared twice in file: %s</string>
-    <string name="note_importer_error_empty_notes">One or more notes were not imported, because they didn\'t generate any cards. This can happen when you have empty fields or when you have not mapped the content in the text file to the correct fields</string>
-    <string name="csv_importer_error_invalid_field_count">‘%1$s’ had %2$d fields, expected %3$d</string>
-    <string name="csv_importer_error_exception">Aborted: %s</string>
-    <string name="user_is_a_robot">Detected automated test. If you are a human, contact AnkiDroid support</string>
+  <string name="note_importer_error_empty_first_field">
+    Empty first field: %s
+  </string>
+  <string name="note_importer_error_first_field_matched">
+    First field matched: %s
+  </string>
+  <string name="note_importer_error_added_duplicate_first_field">
+    Added duplicate with first field: %s
+  </string>
+  <string name="note_importer_error_appeared_twice">
+    Appeared twice in file: %s
+  </string>
+  <string name="note_importer_error_empty_notes">
+    One or more notes were not imported, because they didn\'t generate any cards. This can happen when you have empty fields or when you have not mapped the content in the text file to the correct fields
+  </string>
+  <string name="csv_importer_error_invalid_field_count">
+    ‘%1$s’ had %2$d fields, expected %3$d
+  </string>
+  <string name="csv_importer_error_exception">
+    Aborted: %s
+  </string>
+  <string name="user_is_a_robot">
+    Detected automated test. If you are a human, contact AnkiDroid support
+  </string>
 
-    <plurals name="note_importer_notes_added">
-        <item quantity="one">%d note added</item>
-        <item quantity="other">%d notes added</item>
-    </plurals>
+  <plurals name="note_importer_notes_added">
+    <item quantity="one">
+      %d note added
+    </item>
+    <item quantity="other">
+      %d notes added
+    </item>
+  </plurals>
 
-    <plurals name="note_importer_notes_updated">
-        <item quantity="one">%d note updated</item>
-        <item quantity="other">%d notes updated</item>
-    </plurals>
+  <plurals name="note_importer_notes_updated">
+    <item quantity="one">
+      %d note updated
+    </item>
+    <item quantity="other">
+      %d notes updated
+    </item>
+  </plurals>
 
-    <plurals name="note_importer_notes_unchanged">
-        <item quantity="one">%d note unchanged</item>
-        <item quantity="other">%d notes unchanged</item>
-    </plurals>
+  <plurals name="note_importer_notes_unchanged">
+    <item quantity="one">
+      %d note unchanged
+    </item>
+    <item quantity="other">
+      %d notes unchanged
+    </item>
+  </plurals>
 
-    <!-- JS api -->
-    <string name="api_version_developer_contact">This card uses unsupported AnkiDroid features. Contact developer %1$s, or view the wiki. %2$s</string>
-    <string name="invalid_json_data">Card provided invalid data. %s</string>
-    <string name="valid_js_api_version">Invalid AnkiDroid JS API version. Contact developer %s, or view wiki</string>
-    <string name="update_js_api_version">AnkiDroid JS API update available. Contact developer %s, or view wiki</string>
-    <string name="reviewer_invalid_api_version_visit_documentation">View</string>
-    <string name="anki_js_error_code">(Error Code: %d)</string>
+  <!-- JS api -->
+  <string name="api_version_developer_contact">
+    This card uses unsupported AnkiDroid features. Contact developer %1$s, or view the wiki. %2$s
+  </string>
+  <string name="invalid_json_data">
+    Card provided invalid data. %s
+  </string>
+  <string name="valid_js_api_version">
+    Invalid AnkiDroid JS API version. Contact developer %s, or view wiki
+  </string>
+  <string name="update_js_api_version">
+    AnkiDroid JS API update available. Contact developer %s, or view wiki
+  </string>
+  <string name="reviewer_invalid_api_version_visit_documentation">
+    View
+  </string>
+  <string name="anki_js_error_code">
+    (Error Code: %d)
+  </string>
 
-    <!-- About AnkiDroid screen -->
-    <string name="about_ankidroid_successfully_copied_debug">Copied debug information to clipboard</string>
-    <string name="about_ankidroid_error_copy_debug_info">Error copying debug information to clipboard</string>
+  <!-- About AnkiDroid screen -->
+  <string name="about_ankidroid_successfully_copied_debug">
+    Copied debug information to clipboard
+  </string>
+  <string name="about_ankidroid_error_copy_debug_info">
+    Error copying debug information to clipboard
+  </string>
 </resources>

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -22,6 +22,7 @@
   <!-- How to format a percentage shown in the summary field of a preference -->
   <string
       name="preference_summary_percentage"
+      comment="XXX is a number. The translation should state how to present a percentage and contains XXX in place of the number."
       >
     XXX%
   </string>
@@ -29,61 +30,73 @@
   <!-- Navigation drawer strings -->
   <string
       name="CardEditorCardDeck"
+      comment="When the note is edited for an already existing card, this label the deck of this card. This indicates in particular that changing the deck will only affect this card and not the remaining of the note."
       >
     Card deck:
   </string>
   <string
       name="CardEditorNoteDeck"
+      comment="When adding a card, this label the choice of deck. It indicates that all cards of the note created will go to this deck (except if deck override is used)."
       >
     Deck:
   </string>
   <string
       name="CardEditorModel"
+      comment="In the card editor, labels showing where to choose the note type."
       >
     Type:
   </string>
   <string
       name="CardEditorTags"
+      comment="Label on the left of the list of tags, on the bottom of the card editor."
       >
     Tags: %1$s
   </string>
   <string
       name="CardEditorCards"
+      comment="In the bottom of the card editor, the list of card type of the current card."
       >
     Cards: %1$s
   </string>
   <string
       name="tag_name"
+      comment="The hint shown in the field of the add tag window, when there is no tag, to indicate to the user what they are expected to type."
       >
     Tag name
   </string>
   <string
       name="add_new_filter_tags"
+      comment="The hint, shown in the search bar of the tag list window, when nothing is searched yet, to indicate to the user what is this field purpose."
       >
     Add/filter tags
   </string>
   <string
       name="add_tag"
+      comment="Title of the window inviting the user to type a tag to add to their note."
       >
     Add tag
   </string>
   <string
       name="check_all_tags"
+      comment="Title of the 'select all' button in the window containing the tag list. Shown when the button is pressed, not normally seen."
       >
     Check/uncheck all tags
   </string>
   <string
       name="filter_tags"
+      comment="It is: -The hint of the field in which to search for some tag. -The label of the button allowing to search tags and make the search field appear."
       >
     Filter tags
   </string>
   <string
       name="no_tags"
+      comment="The string in the tag list which indicates that there is not a single task in the collection."
       >
     You haven’t added any tags yet
   </string>
   <string
       name="updated_version"
+      comment="Message telling the version of AnkiDroid has been updated.."
       >
     Updated to version %s
   </string>
@@ -91,91 +104,109 @@
   <!-- Reviewer.java -->
   <string
       name="save_whiteboard"
+      comment="Label of the menu item used to save the whiteboard. Also the label in the preference of the menu item allowing to change the saving preference of the whiteboard."
       >
     Save whiteboard
   </string>
   <string
       name="enable_whiteboard"
+      comment="Label of menu item used to enable the whiteboard. Label of the icon allowing to enable the whiteboard. Also the label of the preference related to enabling whiteboard."
       >
     Enable whiteboard
   </string>
   <string
       name="disable_whiteboard"
+      comment="Label of the icon which allows to disable the whiteboard."
       >
     Disable whiteboard
   </string>
   <string
       name="show_whiteboard"
+      comment="Label of the icon which allow to show the whiteboard."
       >
     Show whiteboard
   </string>
   <string
       name="hide_whiteboard"
+      comment="Label of the menu item and of the icon to hide the whiteboard. Also the label of the preference entry dealing with this icon."
       >
     Hide whiteboard
   </string>
   <string
       name="clear_whiteboard"
+      comment="Label of the menu item to clear the whiteboard and label of the related preference entry."
       >
     Clear whiteboard
   </string>
   <string
       name="replay_audio"
+      comment="Label of the menu item to replay the audio, and label of the related preference entry."
       >
     Replay audio
   </string>
   <string
       name="leech_suspend_notification"
+      comment="Notification shown to the user when they press again and the card is now considered as a leech and suspended."
       >
     Card marked as leech and suspended
   </string>
   <string
       name="leech_notification"
+      comment="Notification shown to the user when they press again and the card is now considered as a leech (but not suspended)."
       >
     Card marked as leech
   </string>
   <string
       name="corrupt_font"
+      comment="Message shown to the user when the font was not correctly created."
       >
     Corrupt font file %s
   </string>
   <string
       name="webview_crash_unknown"
+      comment="Message warning the user that the webview (tool to display the card content as a web page) crashed for unknown reason. This is a part of longer message."
       >
     Unknown error
   </string>
   <string
       name="webview_crash_unknwon_detailed"
+      comment="Message inside a material dialog explaining that an error was caused by webview for unknown reason."
       >
     This was caused by an internal error in the WebView
   </string>
   <string
       name="webview_crash_oom"
+      comment="Message warning the user that the webview (tool to display the card content as a web page) crashed because the system didn't have any memory available. It's part of a longer message."
       >
     Out of Memory
   </string>
   <string
       name="webview_crash_oom_details"
+      comment="Message inside a material dialog explaining that an error was caused by webview because of lack of memory."
       >
     The WebView was terminated by the system. This typically happens when the application runs out of memory, often due to large fonts or media.
   </string>
   <string
       name="webview_crash_nonfatal"
+      comment="Message telling the user the webview crashed and why it did (or that we don't know why)."
       >
     WebView renderer crashed. Cause: %s
   </string>
   <string
       name="webview_crash_fatal"
+      comment="Message telling the user the webview crashed and why it did (or that we don't know why) and that we can't recover."
       >
     Fatal Error: WebView renderer crashed. Cause: %s
   </string>
   <string
       name="webview_crash_loop_dialog_title"
+      comment="Title of the dialog box explaining that the webview failed."
       >
     System WebView Rendering Failure
   </string>
   <string
       name="webview_crash_loop_dialog_content"
+      comment="Message of the dialog explaining webview failed to render, with card number and explanation."
       >
     System WebView failed to render card \'%1$s\'.\n %2$s
   </string>
@@ -185,10 +216,12 @@
       name="browser_column1_headings"
       >
     <item
+        comment="In card browser, label showing that the first column shows the start of the question side of the card."
         >
       Question
     </item>
     <item
+        comment="In card browser, label showing that the first column shows the content of the field used for sorting."
         >
       Sort field
     </item>
@@ -197,58 +230,72 @@
       name="browser_column2_headings"
       >
     <item
+        comment="In card browser, label showing that the second column shows the start of the answer side (with question trimmed potentially)."
         >
       Answer
     </item>
     <item
+        comment="In card browser, label showing that the second column shows the name of the card type."
         >
       Card
     </item>
     <item
+        comment="In card browser, label showing that the second column shows the card's deck."
         >
       Deck
     </item>
     <item
+        comment="In card browser, label showing that the second column shows the note type."
         >
       Note
     </item>
     <item
+        comment="In card browser, label showing that the second column shows the start of the question side of the card."
         >
       Question
     </item>
     <item
+        comment="In card browser, label showing that the second column shows the tags of the note."
         >
       Tags
     </item>
     <item
+        comment="In card browser, label showing that the second column shows the number of lapses."
         >
       Lapses
     </item>
     <item
+        comment="In card browser, label showing that the second column shows the number of time the card was reviewed."
         >
       Reviews
     </item>
     <item
+        comment="In card browser, label showing that the second column shows the interval between the last review and the next one (for card in reviews)."
         >
       Interval
     </item>
     <item
+        comment="In card browser, label showing that the second column shows the &quot;ease factor&quot; of the card."
         >
       Ease
     </item>
     <item
+        comment="In card browser, label showing that the second column shows when the card is due next. Its position in the list of new card or a date."
         >
       Due
     </item>
     <item
+        comment="In card browser, label showing that the second column shows the last time the card was modified."
         >
       Card Modified
     </item>
     <item
+        comment="In card browser, label showing that the second column shows when the card was created."
         >
       Created
     </item>
     <item
+        comment="In card browser, label showing that the second column shows when the note was modified."
         >
       Note Modified
     </item>
@@ -257,36 +304,43 @@
   <!-- Custom study options -->
   <string
       name="custom_study_increase_new_limit"
+      comment="Label of the menu item in custom study to increase the number of new card seen in the selected deck today."
       >
     Modify today’s new card limit
   </string>
   <string
       name="custom_study_increase_review_limit"
+      comment="Label of the menu item in custom study to increase the number of review card seen in the selected deck today."
       >
     Modify today’s review card limit
   </string>
   <string
       name="custom_study_review_forgotten"
+      comment="Label of the menu item in custom study to invite the user to review forgotten cards."
       >
     Review forgotten cards
   </string>
   <string
       name="custom_study_review_ahead"
+      comment="Label of the menu item in custom study to invite the user to review cards that are due in a few days."
       >
     Review ahead
   </string>
   <string
       name="custom_study_random_selection"
+      comment="Label of the menu item in custom study to invite the user to review a random selection of cards."
       >
     Study a random selection of cards
   </string>
   <string
       name="custom_study_preview_new"
+      comment="Label of the menu item in custom study to invite the user to preview new cards."
       >
     Preview new cards
   </string>
   <string
       name="custom_study_limit_tags"
+      comment="Label of the menu item in custom study to invite the user to TODO : what is it ?."
       >
     Limit to particular tags
   </string>
@@ -294,92 +348,111 @@
   <!-- Card editor -->
   <string
       name="cardeditor_title_edit_card"
+      comment="Title of the window used to edit existing cards."
       >
     Edit note
   </string>
   <string
       name="discard_unsaved_changes"
+      comment="Ask user to confirm they want to discard and ignore change they made to a card or a card type."
       >
     Close and lose current input?
   </string>
   <string
       name="note_editor_no_cards_created"
+      comment="Message shown if the user asked to create a note, and this failed but we don't know the reason."
       >
     No cards created. Please fill in more fields
   </string>
   <string
       name="note_editor_no_first_field"
+      comment="Message shown if the user asked to create a note, and this failed because they did not fill the first field."
       >
     The first field is empty
   </string>
   <string
       name="note_editor_no_cloze_delations"
+      comment="Message shown if the user asked to create a note, and this failed because the note type is a cloze type and they did not provide a cloze."
       >
     This note type must contain cloze deletions
   </string>
   <string
       name="note_editor_set_field_language"
+      comment="Label of the item obtained by maintening pression in a field, to invite to set the local language of the field (TODO: what's the purpose)."
       >
     Set field language
   </string>
   <string
       name="note_editor_no_cards_created_all_fields"
+      comment="Message shown if the user asked to create a note, and this failed even if all fields are filled. This show the note type should be corrected or changed."
       >
     The current note type did not produce any cards.\nPlease choose another note type, or click ‘Cards’ and add a field substitution
   </string>
   <string
       name="note_editor_insert_cloze_no_cloze_note_type"
+      comment="Message shown to the user if they entered the shortcut to enter a cloze deletion while to warn them that they are not currently in a cloze type."
       >
     Cloze deletions will only work on a Cloze note type
   </string>
+  <!-- Note used to be called "fact". Old name kept because changing it would require to ask for new translation in all languages -->
   <string
       name="saving_facts"
+      comment="Message shown to the user when they added a new note, to indicate it's currently done."
       >
     Saving note
   </string>
   <string
       name="saving_model"
+      comment="Message shown to the user when they added or changed a note type, to indicate it's currently done."
       >
     Saving note type
   </string>
   <string
       name="save"
+      comment="Label of the tick icon which validate change of card, card template."
       >
     Save
   </string>
   <string
       name="close"
+      comment="Label of buttons inviting teh user to close a window without doing any actual actions."
       >
     Close
   </string>
   <string
       name="select"
+      comment="In custom study, when limiting to tag. This is the button to create the custom study deck using the tags that were selected."
       >
     Select
   </string>
   <string
       name="saving_changes"
+      comment="In the card template editor, message of a dialog displayed while the note type is being saved."
       >
     Saving changes…
   </string>
   <string
       name="reordering_cards"
+      comment="Message shown when some change is done to configurations and the result is processed. TODO: why is it shown even if the change is not related to reordering ?"
       >
     Reordering cards…
   </string>
   <string
       name="field_remapping"
+      comment="When a card is edited and its note type is changed, the label of the %1th field indicates that the original content of this field come from a field called %2."
       >
     %1$s (from “%2$s”)
   </string>
   <string
       name="confirm_map_cards_to_nothing"
+      comment="If a card is edited, its note type changed, and there is a risk that cards are lost, warn the user this risk exists."
       >
     Any cards mapped to nothing will be deleted. If a note has no remaining cards, it will be lost. Are you sure you want to continue?
   </string>
 
   <plurals
       name="timebox_reached"
+      comment="Message telling regularly to the user how many review they made (%1) in the amount of time %2 they specified in the preference.."
       >
     <item quantity="one">
       %1$d card studied in %2$s
@@ -388,9 +461,9 @@
       %1$d cards studied in %2$s
     </item>
   </plurals>
-  <!-- minutes used in '[studied in] x minutes' context, causing inflexion in some languages -->
   <plurals
       name="in_minutes"
+      comment="minutes used in '[studied in] x minutes' context, causing inflexion in some languages."
       >
     <item quantity="one">
       %1$d minute
@@ -402,47 +475,56 @@
 
   <string
       name="fact_adder_intent_title"
+      comment="Label of the button on android which directly open the 'add note' window."
       >
     AnkiDroid card
   </string>
   <string
       name="note_editor_copy_note"
+      comment="When editing an already existing card, label of the button allowing to create a new note copying the current one."
       >
     Copy note
   </string>
   <string
       name="card_editor_reposition_card"
+      comment="Label of the menu item in the card browser to reposition selected cards."
       >
     Reposition
   </string>
   <string
       name="card_editor_reset_card"
+      comment="Label of the menu item in the card browser and reviewer to reset the progress of selected cards. Also the title ."
       >
     Reset progress
   </string>
   <string
       name="card_editor_reschedule_card"
+      comment="Label of the menu item in the card browser/reviweer to reschedule the progress of selected/current cards. Also the label of the menu entry related to this button in the preferences"
       >
     Reschedule
   </string>
   <string
       name="error_insufficient_memory"
+      comment="Error message shown to user when a commit fail due to lack of memory on device (RAM, not storage)."
       >
     Operation not possible due to insufficient memory on your device
   </string>
   <string
       name="rename"
+      comment="Label of the button the user should click when they have entered the new name of a field, deck, note type, to confirm the renaming should occur"
       >
     Rename
   </string>
   <string
       name="default_conf_delete_error"
+      comment="Error message shown to the user if they try to delete the default option, explaining that this is not allowed."
       >
     The default options group can’t be removed
   </string>
 
   <plurals
       name="factadder_cards_added"
+      comment="Toast appearing when a note is added, telling how many cards were generated."
       >
     <item quantity="one">
       %d card added
@@ -453,223 +535,261 @@
   </plurals>
 
   <string
-      name="help_title"
-      >
-    Help
-  </string>
-  <string
       name="check_db"
+      comment="Label of the menu items allowing users to check the database."
       >
     Check database
   </string>
   <string
       name="check_media"
+      comment="Label of the menu items and buttons allowing users to check the media."
       >
     Check media
   </string>
   <string
       name="empty_cards"
+      comment="Label of the menu items allowing users to delete the empty cards."
       >
     Empty cards
   </string>
   <string
       name="check_db_message"
+      comment="Message shown to the user to let them know the app is checking the database."
       >
     Checking database…
   </string>
   <string
       name="empty_card_warning"
+      comment="Message shown in the reviewer when a card is empty to let the user know how to solve this problem."
       >
     This card is empty. Use the “Empty cards” option from the menu on the deck list screen.
   </string>
   <string
       name="unknown_type_field_warning"
+      comment="Message shown to the user in the reviewer to warn them the template of the card tehy are seeing contains a reference to a field which does not appear in the note type."
       >
     Type answer: unknown field %s
   </string>
   <string
       name="delete_deck"
+      comment="Message shown to the user to let them know the app is currently deleting deck."
       >
     Deleting deck…
   </string>
 
   <string
       name="show_hint"
+      comment="Label of the link in the reviewer which, when clicked, lead to showing the content of the field in parameter."
       >
     Show %s
   </string>
   <string
       name="info_rate"
+      comment="Label of the button inviting the user to rate AnkiDroid in the app store."
       >
     Rate AnkiDroid
   </string>
   <string
       name="import_title"
+      comment="Title of various box allowing the user to decide what to import or to let them know import is currently occurring."
       >
     Importing
   </string>
   <string
       name="import_select_title"
+      comment="Title of the dialgo inviting the user to choose a file to import."
       >
     Choose a file to import
   </string>
   <string
       name="import_message_add"
+      comment="Label of the button the user should press to confirm they have chosen the correct file to import."
       >
     Add
   </string>
   <string
       name="import_message_replace_confirm"
+      comment="Message shown to the user when they ask to import a collection, to explain that it will delete and replace current collection and check whether they are okay with it."
       >
     This will delete your existing collection and replace it with the data of file %s
   </string>
   <string
       name="import_message_add_confirm"
+      comment="Message asking the user whether they want to import the file in paramater to the collection and warn them it may takes time."
       >
     Add “%s” to collection? This may take a long time
   </string>
   <string
       name="import_log_no_apkg"
+      comment="Title and mesage of dialog explaining that the import failed because the file does not have the good format."
       >
     This isn’t a valid Anki package file
   </string>
   <string
       name="import_log_failed_unzip"
+      comment="Message shown to the user when the apkg can't be unzipped."
       >
     Failed to unzip apkg: %s
   </string>
   <string
       name="import_log_failed_copy_to"
+      comment="Message added to the list of errors shown to the error if file was not being able to be copied."
       >
     Failed to copy apkg to %s
   </string>
   <string
       name="import_log_failed_validate"
+      comment="Message added to the list of errors shown to the error if during importing, the file was find not to be valid."
       >
     apkg failed validation
   </string>
   <string
       name="import_log_insufficient_space"
+      comment="Message added to the list of errors shown to the error if during importing, there was not enough space to unzip a file."
       >
     There is not enough space to unzip the package. Needed %1$d, available %2$d
   </string>
   <string
       name="import_log_file_cache_cleared"
+      comment="Message added to the list of errors shown to the error if during importing, unzip seemed to succed but the unzipped could not be found."
       >
     Error importing file, likely a cache clear during processing.\nPlease try again
   </string>
   <string
       name="import_succeeded_but_check_database"
+      comment="Message added to the list of errors shown to the error if importing decks lead to errors that required a Check Database."
       >
     Data import succeeded but post-import cleanup failed. Run check database later. Root cause: %s
   </string>
   <string
       name="import_error_unhandled_request"
+      comment="TODO: what does it means."
       >
     Unable to process import request
   </string>
   <string
       name="import_error_exception"
+      comment="Message telling the package was not correctly imported, followed by the logs."
       >
     Failed to import package\n\n%s
   </string>
   <string
       name="import_error_not_apkg_extension"
+      comment="Error message stating a file can't be imported because of improper extension."
       >
     Filename “%s” doesn’t have .apkg or .colpkg extension
   </string>
   <string
       name="import_error_load_imported_database"
+      comment="Error message explaining to the user that they can't import file of format .anki2 in AnkiDroid and they need to read how to do it."
       >
     Anki Database (.anki2) replacements are not yet supported. Please see the manual for replacement instructions.
   </string>
   <string
       name="import_error_content_provider"
+      comment="Error message explaining to the user that they can't import the file of the selected format in AnkiDroid and they need to read how to do it. Giving the url of the manual localized if it exists, english otherwise"
       >
     The selected file couldn’t be imported automatically by AnkiDroid. Please see the user manual for how to manually import anki files: \n%s
   </string>
   <string
       name="import_error_copy_file_to_cache"
+      comment="Error message telling the user there is probably lack of storage, and a message which may help get debugging otherwise."
       >
     copyFileToCache() failed (possibly out of storage space)
   </string>
   <string
       name="import_replacing"
+      comment="Message shown when importing a whole new collection replacing the previous one to tell users to wait."
       >
     Replacing collection…
   </string>
   <string
       name="import_interrupted"
+      comment="Message shown to user if for some reason, importing a deck was interrupted."
       >
     Import interrupted
   </string>
   <string
       name="export_include_schedule"
+      comment="Label of the checkbox in the exporter asking user whether they want to include the scheduling in their export."
       >
     Include scheduling
   </string>
   <string
       name="export_include_media"
+      comment="Label of the checkbox in the exporter asking user whether they want to include medias in their export."
       >
     Include media
   </string>
   <string
       name="confirm_apkg_export"
+      comment="Message in the exporter window to ask to confirm the user want to export."
       >
     Export collection as Anki package?
   </string>
   <string
       name="confirm_apkg_export_deck"
+      comment="Ask the user to confirm they want to export a deck and recall which deck they are exporting."
       >
     Export “%s” as apkg file?
   </string>
   <string
       name="export_in_progress"
+      comment="."
       >
     Exporting Anki package file…
   </string>
   <string
       name="export_successful_title"
+      comment="."
       >
     Send Anki package?
   </string>
   <string
       name="export_send_button"
+      comment="."
       >
     Send
   </string>
   <string
       name="export_save_button"
+      comment="."
       >
     Save to file
   </string>
   <string
       name="export_send_no_handlers"
+      comment="."
       >
     No applications available to handle apkg. Saving...
   </string>
   <string
       name="export_save_apkg_successful"
+      comment="."
       >
     Successfully saved Anki package
   </string>
   <string
       name="export_save_apkg_unsuccessful"
+      comment="."
       >
     Save Anki package failed
   </string>
   <string
       name="export_successful"
+      comment="."
       >
     File “%s” was exported. Do you want to send it with another app?
   </string>
   <string
       name="export_email_subject"
+      comment="."
       >
     AnkiDroid exported flashcards: %s
   </string>
   <string
       name="export_email_text"
+      comment="."
       >
     <![CDATA[
              Hi!
@@ -680,87 +800,104 @@
   </string>
   <string
       name="export_unsuccessful"
+      comment="."
       >
     Error exporting apkg file
   </string>
   <string
       name="import_hint"
+      comment="."
       >
     Place the apkg file in directory “%s” and touch “OK” to import cards
   </string>
   <string
       name="upgrade_import_no_file_found"
+      comment="."
       >
     No importable %1$s file found
   </string>
   <string
       name="study_options"
+      comment="."
       >
     Options
   </string>
   <string
       name="select_tts"
+      comment="."
       >
     Set TTS language
   </string>
   <string
       name="custom_study"
+      comment="."
       >
     Custom study
   </string>
   <string
       name="more_options"
+      comment="."
       >
     More
   </string>
   <string
       name="dyn_deck_desc"
+      comment="."
       >
     This is a special deck for studying outside of the normal schedule. Cards will be automatically returned to their original decks after you review them. Deleting this deck from the deck list will return all remaining cards to their original deck.
   </string>
   <string
       name="steps_error"
+      comment="."
       >
     Steps must be numbers greater than 0
   </string>
   <string
       name="steps_min_error"
+      comment="."
       >
     At least one step is required
   </string>
   <string
       name="sched_end"
+      comment="."
       >
     (end)
   </string>
   <string
       name="sched_unbury_action"
+      comment="."
       >
     To see them now touch the “Unbury” item in the menu
   </string>
   <string
       name="sched_has_buried"
+      comment="."
       >
     Some related or buried cards were delayed until tomorrow
   </string>
   <string
       name="tag_editor_add_feedback"
+      comment="."
       >
     Touch “%2$s” to confirm adding “%1$s”
   </string>
   <string
       name="tag_editor_add_feedback_existing"
+      comment="."
       >
     Existing tag “%1$s” selected
   </string>
   <string
       name="lookup_hint"
+      comment="."
       >
     After copying the text, tap anywhere on the flashcard to show the search icon
   </string>
   <!-- Time spans -->
   <plurals
       name="time_span_seconds"
+      comment="."
       >
     <item quantity="one">
       %s second
@@ -771,6 +908,7 @@
   </plurals>
   <plurals
       name="time_span_minutes"
+      comment="."
       >
     <item quantity="one">
       %s minute
@@ -781,6 +919,7 @@
   </plurals>
   <plurals
       name="time_span_hours"
+      comment="."
       >
     <item quantity="one">
       %s hour
@@ -791,6 +930,7 @@
   </plurals>
   <plurals
       name="time_span_days"
+      comment="."
       >
     <item quantity="one">
       %s day
@@ -801,6 +941,7 @@
   </plurals>
   <plurals
       name="time_span_months"
+      comment="."
       >
     <item quantity="one">
       %s month
@@ -811,6 +952,7 @@
   </plurals>
   <plurals
       name="time_span_years"
+      comment="."
       >
     <item quantity="one">
       %s year
@@ -824,33 +966,39 @@
        than. -->
   <string
       name="less_than_time"
+      comment="."
       >
     &lt; %s
   </string>
 
   <string
       name="decks_rename_exists"
+      comment="."
       >
     That deck already exists
   </string>
   <string
       name="decks_rename_filtered_nosubdecks"
+      comment="."
       >
     A filtered deck cannot have subdecks
   </string>
   <string
       name="filtered_deck_name"
+      comment="."
       >
     Filtered Deck
   </string>
 
   <string
       name="reminder_title"
+      comment="."
       >
     Do not forget to study today!
   </string>
   <plurals
       name="reminder_text"
+      comment="."
       >
     <item quantity="one">
       %2$d card to review in %1$s
@@ -862,104 +1010,123 @@
   <!-- Currently only used if exporting APKG fails -->
   <string
       name="apk_share_error"
+      comment="."
       >
     Error sharing apkg file
   </string>
   <!-- Import and export v2 feedback -->
   <string
       name="import_needs_v2"
+      comment="."
       >
     V2 scheduler must be enabled to import this file.
   </string>
   <string
       name="import_cannot_with_v2"
+      comment="."
       >
     V2 scheduler can not import V1 decks with scheduling included.
   </string>
   <string
       name="export_v2_dummy_note"
+      comment="."
       >
     This file requires a newer version of Anki.
   </string>
   <!-- Placed in a snackbar with a long URL. Limit the length and move the URL to the start of the string -->
   <string
       name="activity_start_failed_load_url"
+      comment="."
       >
     Loading \'%s\' failed.
   </string>
   <string
       name="activity_start_failed"
+      comment="."
       >
     The system does not have an app installed that can perform this action.
   </string>
   <string
       name="multimedia_editor_image_compression_failed"
+      comment="."
       >
     <![CDATA[Camera images may be large. You may wish to compress & resize images in the media directory]]>
   </string>
   <string
       name="no_browser_notification"
+      comment="."
       >
     No browser found，please visit web page by pc or mobile:
   </string>
   <string
       name="no_outgoing_link_in_cardbrowser"
+      comment="."
       >
     External page link in card is not supported.
   </string>
   <!-- The name of the deck which corrupt cards will be moved to -->
   <string
       name="check_integrity_recovered_deck_name"
+      comment="."
       >
     Recovered Cards
   </string>
   <!-- Deckpicker Background -->
   <string
       name="background_image_title"
+      comment="."
       >
     Background
   </string>
   <string
       name="choose_an_image"
+      comment="."
       >
     Choose an Image
   </string>
   <!-- Card Template Browser Appearance -->
   <string
       name="restore_default"
+      comment="."
       >
     Restore Default
   </string>
   <string
       name="reviewer_tts_cloze_spoken_replacement"
+      comment="."
       >
     Blank
   </string>
   <!-- in options menu & Navigation Drawer -->
   <string
       name="ankidroid_turn_on_fullscreen_nav_drawer"
+      comment="."
       >
     Please turn on fullscreen to use Show Navigation Drawer using JavaScript.
   </string>
   <string
       name="ankidroid_turn_on_fullscreen_options_menu"
+      comment="."
       >
     Please turn on fullscreen to use Show Options Menu using JavaScript.
   </string>
   <!-- Whiteboard save image message in Reviewer -->
   <string
       name="white_board_image_save_failed"
+      comment="."
       >
     Failed to save whiteboard image. %s
   </string>
   <string
       name="white_board_image_saved"
+      comment="."
       >
     Whiteboard image saved to %s
   </string>
 
   <string
       name="title_whiteboard_pen_color"
+      comment="."
       >
     Whiteboard pen color
   </string>
@@ -968,53 +1135,63 @@
   <!-- CSV/Note Import -->
   <string
       name="note_importer_empty_cards_found"
+      comment="."
       >
     <![CDATA[Empty cards found. Please run Tools>Empty Cards.]]>
   </string>
 
   <string
       name="note_importer_error_empty_first_field"
+      comment="."
       >
     Empty first field: %s
   </string>
   <string
       name="note_importer_error_first_field_matched"
+      comment="."
       >
     First field matched: %s
   </string>
   <string
       name="note_importer_error_added_duplicate_first_field"
+      comment="."
       >
     Added duplicate with first field: %s
   </string>
   <string
       name="note_importer_error_appeared_twice"
+      comment="."
       >
     Appeared twice in file: %s
   </string>
   <string
       name="note_importer_error_empty_notes"
+      comment="."
       >
     One or more notes were not imported, because they didn\'t generate any cards. This can happen when you have empty fields or when you have not mapped the content in the text file to the correct fields
   </string>
   <string
       name="csv_importer_error_invalid_field_count"
+      comment="."
       >
     ‘%1$s’ had %2$d fields, expected %3$d
   </string>
   <string
       name="csv_importer_error_exception"
+      comment="."
       >
     Aborted: %s
   </string>
   <string
       name="user_is_a_robot"
+      comment="."
       >
     Detected automated test. If you are a human, contact AnkiDroid support
   </string>
 
   <plurals
       name="note_importer_notes_added"
+      comment="."
       >
     <item quantity="one">
       %d note added
@@ -1026,6 +1203,7 @@
 
   <plurals
       name="note_importer_notes_updated"
+      comment="."
       >
     <item quantity="one">
       %d note updated
@@ -1037,6 +1215,7 @@
 
   <plurals
       name="note_importer_notes_unchanged"
+      comment="."
       >
     <item quantity="one">
       %d note unchanged
@@ -1049,31 +1228,37 @@
   <!-- JS api -->
   <string
       name="api_version_developer_contact"
+      comment="."
       >
     This card uses unsupported AnkiDroid features. Contact developer %1$s, or view the wiki. %2$s
   </string>
   <string
       name="invalid_json_data"
+      comment="."
       >
     Card provided invalid data. %s
   </string>
   <string
       name="valid_js_api_version"
+      comment="."
       >
     Invalid AnkiDroid JS API version. Contact developer %s, or view wiki
   </string>
   <string
       name="update_js_api_version"
+      comment="."
       >
     AnkiDroid JS API update available. Contact developer %s, or view wiki
   </string>
   <string
       name="reviewer_invalid_api_version_visit_documentation"
+      comment="."
       >
     View
   </string>
   <string
       name="anki_js_error_code"
+      comment="."
       >
     (Error Code: %d)
   </string>
@@ -1081,11 +1266,13 @@
   <!-- About AnkiDroid screen -->
   <string
       name="about_ankidroid_successfully_copied_debug"
+      comment="."
       >
     Copied debug information to clipboard
   </string>
   <string
       name="about_ankidroid_error_copy_debug_info"
+      comment="."
       >
     Error copying debug information to clipboard
   </string>

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -210,56 +210,72 @@
   <string-array
       name="browser_column1_headings"
       >
-    <item>
+    <item
+        >
       Question
     </item>
-    <item>
+    <item
+        >
       Sort field
     </item>
   </string-array>
   <string-array
       name="browser_column2_headings"
       >
-    <item>
+    <item
+        >
       Answer
     </item>
-    <item>
+    <item
+        >
       Card
     </item>
-    <item>
+    <item
+        >
       Deck
     </item>
-    <item>
+    <item
+        >
       Note
     </item>
-    <item>
+    <item
+        >
       Question
     </item>
-    <item>
+    <item
+        >
       Tags
     </item>
-    <item>
+    <item
+        >
       Lapses
     </item>
-    <item>
+    <item
+        >
       Reviews
     </item>
-    <item>
+    <item
+        >
       Interval
     </item>
-    <item>
+    <item
+        >
       Ease
     </item>
-    <item>
+    <item
+        >
       Due
     </item>
-    <item>
+    <item
+        >
       Card Modified
     </item>
-    <item>
+    <item
+        >
       Created
     </item>
-    <item>
+    <item
+        >
       Note Modified
     </item>
   </string-array>

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -462,11 +462,6 @@
     Reschedule
   </string>
   <string
-      name="card_editor_preview_card"
-      >
-    Preview
-  </string>
-  <string
       name="error_insufficient_memory"
       >
     Operation not possible due to insufficient memory on your device

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -319,11 +319,6 @@
 
   <!-- Card editor -->
   <string
-      name="cardeditor_title_add_note"
-      >
-    Add note
-  </string>
-  <string
       name="cardeditor_title_edit_card"
       >
     Edit note

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -442,11 +442,6 @@
     AnkiDroid card
   </string>
   <string
-      name="note_editor_add_note"
-      >
-    Add note
-  </string>
-  <string
       name="note_editor_copy_note"
       >
     Copy note

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -28,22 +28,6 @@
 
   <!-- Navigation drawer strings -->
   <string
-      name="drawer_open"
-      >
-    Open drawer
-  </string>
-  <string
-      name="drawer_close"
-      >
-    Close drawer
-  </string>
-
-  <string
-      name="CardEditorLaterMessage"
-      >
-    Saved information for later
-  </string>
-  <string
       name="CardEditorCardDeck"
       >
     Card deck:
@@ -97,11 +81,6 @@
       name="no_tags"
       >
     You haven’t added any tags yet
-  </string>
-  <string
-      name="sdcard_missing_message"
-      >
-    Switch off USB storage to access your decks
   </string>
   <string
       name="updated_version"
@@ -364,11 +343,6 @@
     Saving note type
   </string>
   <string
-      name="add"
-      >
-    Add
-  </string>
-  <string
       name="save"
       >
     Save
@@ -427,11 +401,6 @@
   </plurals>
 
   <string
-      name="studyoptions_welcome_title"
-      >
-    Welcome to AnkiDroid
-  </string>
-  <string
       name="fact_adder_intent_title"
       >
     AnkiDroid card
@@ -440,11 +409,6 @@
       name="note_editor_copy_note"
       >
     Copy note
-  </string>
-  <string
-      name="card_editor_copy_card"
-      >
-    Copy card
   </string>
   <string
       name="card_editor_reposition_card"
@@ -538,11 +502,6 @@
       name="info_rate"
       >
     Rate AnkiDroid
-  </string>
-  <string
-      name="col_load_failed"
-      >
-    Collection loading failed.\nPress back to close AnkiDroid.
   </string>
   <string
       name="import_title"

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -21,41 +21,49 @@
 <resources>
   <string
       name="check_db_title"
+      comment="Title of the dialog offering the user to check the database and warinngi it may take time."
       >
     Check database?
   </string>
   <string
       name="check_db_warning"
+      comment="Message shown to user who want to check the databas, warning them it may be long."
       >
     This may take a long time
   </string>
   <string
       name="check_db_acknowledge"
+      comment="Message shown at the end of the database check to explain it is done."
       >
     Database checked
   </string>
   <string
       name="check_db_acknowledge_shrunk"
+      comment="Message shown at the end of the database check to explain it is done and telling them how much space they saved."
       >
     Database checked and optimized.\nShrunk by %d MB.
   </string>
   <string
       name="contextmenu_deckpicker_delete_deck"
+      comment="Label of the menu item, in the deck picker, offering to delete the selected deck."
       >
     Delete deck
   </string>
   <string
       name="delete_deck_default_deck"
+      comment="Message telling the user that we can't grant their request to a deck, because it's the default deck and this deck can not be deleted."
       >
     The default deck can’t be deleted
   </string>
   <string
       name="delete_deck_title"
+      comment="Title of the message box asking the user to confirm whether they want to delete a deck as they required."
       >
     Delete deck?
   </string>
   <plurals
       name="delete_deck_message"
+      comment="Content of the message box asking the user to confirm that they want to delete a deck."
       >
     <item quantity="one">
       Delete all cards in %1$s? It contains %2$d card.
@@ -66,45 +74,55 @@
   </plurals>
   <string
       name="delete_cram_deck_message"
+      comment="Message shown to user who are asking to delete a cram deck, this explain what occurs to this deck's card.."
       >
     Send all cards in %s back to their original decks?
   </string>
   <string
       name="no_tts_available_message"
+      comment="Warning shown to user that we didn't find any teext-to speech language available to offer them."
       >
     No text-to-speech language available
   </string>
   <string
       name="initializing_tts"
+      comment="Message shown to the user to explain that we intend to use TTS. This may take time, so it shows it has not been forgotten, just that it needs to load."
       >
     Initializing TTS…
   </string>
   <string
       name="tts_no_tts"
+      comment="When the user is asked to choose a TTS language, this is an extra option not to activate TTS in this case."
       >
     Don’t speak
   </string>
 
   <string-array
       name="about_content"
+      comment="Message shown in the Preferences>Advanced>About Ankidroid screen. This is the screen where the user can obtain debug info."
       >
     <item
+        comment="."
         >
       <![CDATA[<h2>%1$s:<br/>Flashcards for Android</h2>AnkiDroid is a flashcard application which is fully compatible with the desktop software <a href=\"%2$s\">Anki</a>. You can create, download and learn material on both AnkiDroid or Anki Desktop, and synchronize them easily with AnkiWeb.]]>
     </item>
     <item
+        comment="."
         >
       <![CDATA[To help us make AnkiDroid better, please report bugs to <a href=\"%1$s\">the issue tracker</a>; new feature ideas are very welcome too. Find answers on <a href=\"%2$s\">the wiki</a> or start a discussion on <a href=\"%3$s\">the forum</a>.]]>
     </item>
     <item
+        comment="."
         >
       <![CDATA[AnkiDroid is <a href=\"%1$s\">open source software<a/>, so everyone is encouraged to <a href=\"%2$s\">become a contributor</a> :-)]]>
     </item>
     <item
+        comment="."
         >
       <![CDATA[Non-developers can also help. For instance, you can <a href=\"%1$s\">help translate</a> AnkiDroid, update the wiki, provide screenshots, or blog about AnkiDroid.]]>
     </item>
     <item
+        comment="."
         >
       <![CDATA[AnkiDroid is released under the <a href=\"%1$s\">GNU-GPL v3 license</a> and the source code is available <a href=\"%2$s\">on GitHub</a>.]]>
     </item>
@@ -112,27 +130,32 @@
 
   <string
       name="preview_title"
+      comment="Title of the Previewer windows. Label of the android activity which opens the previewer directly."
       >
     Preview
   </string>
   <string
       name="reposition_card_dialog_title"
+      comment="Title of the dialog in the card browser offering to reposition card.."
       >
     Reposition new card
   </string>
   <string
       name="reposition_card_dialog_message"
+      comment="In the reposition card dialog, in the card browser, label of the field to enter the start of the reposition.."
       >
     Start position:
   </string>
   <string
       name="reposition_card_not_new_error"
+      comment="Error message shown to the user when they try to reposition a card which is not new."
       >
     Only new cards can be repositioned
   </string>
 
   <plurals
       name="reposition_card_dialog_acknowledge"
+      comment="Message shown to the user after they repositioned card.."
       >
     <item quantity="one">
       %d card repositioned
@@ -143,16 +166,19 @@
   </plurals>
   <string
       name="reset_card_dialog_title"
+      comment="Title of the dialog box offering to reset the progress of card."
       >
     Reset card progress
   </string>
   <string
       name="reset_card_dialog_message"
+      comment="Message in the dialog box explaining to the user what will occur if they reset the cards."
       >
     This card will be placed at the end of the new card queue
   </string>
   <plurals
       name="reset_cards_dialog_acknowledge"
+      comment="Message shown to the user after they reset cards, recapping what occurred."
       >
     <item quantity="one">
       %d card reset
@@ -165,11 +191,13 @@
   <!-- Reschedule Card Dialog -->
   <string
       name="reschedule_card_dialog_title"
+      comment="Title of the Reschedule card dialog."
       >
     Reschedule card
   </string>
   <plurals
       name="reschedule_cards_dialog_title"
+      comment="Message shown to the user in the reschedule card dialogs."
       >
     <item quantity="one">
       Reschedule card
@@ -180,6 +208,7 @@
   </plurals>
   <plurals
       name="reschedule_card_dialog_interval"
+      comment="TODO: where is it used ?."
       >
     <item quantity="one">
       Current interval: %d day
@@ -190,11 +219,13 @@
   </plurals>
   <string
       name="reschedule_card_dialog_message"
+      comment="In the Reschedule card dialog, this is the background text explaining to the user what mean the field they should fill."
       >
     Reschedule for review in x days
   </string>
   <plurals
       name="reschedule_cards_dialog_acknowledge"
+      comment="Mesasage shown after rescheduling, recapping what occured."
       >
     <item quantity="one">
       %d card rescheduled
@@ -205,226 +236,269 @@
   </plurals>
   <string
       name="reschedule_card_dialog_new_card_warning"
+      comment="Warning shown to the user when they selected a new card and want to reschedule it, which is not the normal way things should occur."
       >
-  A new card is being rescheduled. Rescheduling also turns new cards into review cards. Use the ‘reposition card’ option
-  to change a new card\'s position within the new queue
+  A new card is being rescheduled. Rescheduling also turns new cards into review cards. Use the ‘reposition card’ option to change a new card\'s position within the new queue
   </string>
   <string
       name="reschedule_card_dialog_warning_ease_reset"
+      comment="In the rescheduling box, message explaining what means the action they are about to do."
       >
     Rescheduling also resets how the scheduler treats the card in the future (ease will be set to %d%%)
   </string>
 
   <string
       name="firefox_workaround_launched_reviewer_opening_deck"
+      comment="Message explaining the user how to import a deck they downloaded from firefox, as it's not straightforward."
       >
     Select the deck in your file manager or visit the about:downloads page to import it
   </string>
   <string
       name="answering_error_title"
+      comment="Title of the message box and notification box explaining that there was some database related error (and that we don't have more informations)."
       >
     Database error
   </string>
   <string
       name="answering_error_message"
+      comment="In the database error message box, message explaining what may have occured."
       >
     Writing to the collection failed. The database could be corrupt or there may not to be enough empty space on disk.\n\nIf this happens more often, try checking the database, repairing the collection or restoring it from a backup. Touch “options” for that.\n\Or it could be an AnkiDroid bug as well; please report the error so that we can check this.
   </string>
   <string
       name="answering_error_report"
+      comment="Background default text to show the user they should type a report about the current error in this field."
       >
     Report error
   </string>
   <string
       name="repair_deck_dialog"
+      comment="In case of error, if the user selected &quot;repair the database&quot;, it'll ask the user to confirm their choice."
       >
     Do you really want to try to repair the database?\n\nBefore starting the attempt, a copy will be created in subfolder “%s”.
   </string>
   <string
       name="intent_aedict_empty"
+      comment="TODO: explain what it means. Need to know aedict probably."
       >
     Category “default” is empty
   </string>
   <string
       name="intent_aedict_category"
+      comment="TODO: explain what it means. Need to know aedict probably."
       >
     To add cards to AnkiDroid remove all Notepad categories or add one named “default”
   </string>
   <string
       name="custom_study_new_total_new"
+      comment="In custom study, show the number of new cards in the deck. That's the maximal number number of new card that can be added to see today."
       >
     New cards in deck: %d
   </string>
   <string
       name="custom_study_rev_total_rev"
+      comment="In custom study, show the number of review cards due today in the deck. That's the maximal number number of review card that can be added to see today."
       >
     Reviews due in deck: %d
   </string>
   <string
       name="custom_study_new_extend"
+      comment="."
       >
     Increase/decrease (“-3”) today’s new card limit by
   </string>
   <string
       name="custom_study_rev_extend"
+      comment="."
       >
     Increase/decrease (“-3”) today’s review limit by
   </string>
   <string
       name="custom_study_forgotten"
+      comment="."
       >
     Review cards forgotten in last x days:
   </string>
   <string
       name="custom_study_ahead"
+      comment="."
       >
     Review ahead by x days:
   </string>
   <string
       name="custom_study_random"
+      comment="."
       >
     Select x cards randomly from the deck:
   </string>
   <string
       name="custom_study_preview"
+      comment="."
       >
     Preview new cards added in the last x days:
   </string>
   <string
       name="custom_study_rebuild_deck_corrupt"
+      comment="."
       >
     Could not rebuild custom study deck
   </string>
 
   <string
       name="rebuild_custom_study_deck"
+      comment="."
       >
     Rebuilding custom study deck…
   </string>
   <string
       name="importing_collection"
+      comment="."
       >
     Importing collection…
   </string>
   <string
       name="import_media_count"
+      comment="."
       >
     Importing media files %1$d%%…
   </string>
   <string
       name="import_progress"
+      comment="."
       >
     • Importing notes: %1$d%%\n• Importing cards: %2$d%%\n• Post-processing: %3$d%%
   </string>
   <string
       name="import_update_details"
+      comment="."
       >
     Updated %1$d of %2$d existing notes.
   </string>
   <string
       name="import_update_ignored"
+      comment="."
       >
     Some updates were ignored because note type has changed
   </string>
   <string
       name="import_complete_count"
+      comment="."
       >
     Cards imported: %d
   </string>
   <string
       name="sd_card_full_title"
+      comment="."
       >
     SD card full
   </string>
   <string
       name="sd_card_almost_full_title"
+      comment="."
       >
     SD card almost full
   </string>
   <string
       name="restore_backup_title"
+      comment="."
       >
     Restore backup?
   </string>
   <string
       name="restore_backup"
+      comment="."
       >
     Your collection will be replaced with an older copy. Any unsaved progress will be lost.
   </string>
 
   <string
       name="dialog_cancel"
+      comment="."
       >
     Cancel
   </string>
   <string
       name="dialog_ok"
+      comment="."
       >
     OK
   </string>
   <string
       name="dialog_no"
+      comment="."
       >
     No
   </string>
   <string
       name="dialog_continue"
+      comment="."
       >
     Continue
   </string>
   <string
       name="dialog_positive_create"
+      comment="."
       >
     Create
   </string>
   <string
       name="dialog_positive_delete"
+      comment="."
       >
     Delete
   </string>
   <string
       name="dialog_positive_disable"
+      comment="."
       >
     Disable
   </string>
   <string
       name="dialog_positive_overwrite"
+      comment="."
       >
     Overwrite
   </string>
   <string
       name="dialog_positive_remove"
+      comment="."
       >
     Remove
   </string>
   <string
       name="dialog_positive_repair"
+      comment="."
       >
     Repair
   </string>
   <string
       name="dialog_positive_replace"
+      comment="."
       >
     Replace
   </string>
   <string
       name="dialog_positive_restore"
+      comment="."
       >
     Restore
   </string>
   <string
       name="dialog_positive_set"
+      comment="."
       >
     Set
   </string>
 
   <string
       name="lookup_button_content"
+      comment="."
       >
     Look up
   </string>
   <string
       name="dialog_collection_path_not_dir"
+      comment="."
       >
     The path specified wasn’t a valid directory
   </string>
@@ -432,61 +506,73 @@
   <!-- Media checking -->
   <string
       name="check_media_title"
+      comment="."
       >
     Check media?
   </string>
   <string
       name="check_media_warning"
+      comment="."
       >
     This may take a long time with large media collections
   </string>
   <string
       name="check_media_message"
+      comment="."
       >
     Checking media…
   </string>
   <string
       name="check_media_acknowledge"
+      comment="."
       >
     Media checked
   </string>
   <string
       name="check_media_failed"
+      comment="."
       >
     Media check failed
   </string>
   <string
       name="check_media_invalid"
+      comment="."
       >
     Files with invalid encoding: %d
   </string>
   <string
       name="check_media_unused"
+      comment="."
       >
     Files in media folder but not used by any cards: %d
   </string>
   <string
       name="check_media_nohave"
+      comment="."
       >
     Files used on cards but not in media folder: %d
   </string>
   <string
       name="check_media_no_unused_missing"
+      comment="."
       >
     No unused or missing files found
   </string>
   <string
       name="check_media_db_updated"
+      comment="."
       >
     Media database rebuilt
   </string>
   <string
       name="check_media_delete_unused"
+      comment="."
       >
     Delete unused
   </string>
   <string
       name="check_media_deleted"
+      comment="."
       >
     Files deleted: %d
   </string>
@@ -494,16 +580,19 @@
   <!-- Tags Dialog Options -->
   <string
       name="tags_dialog_option_all_cards"
+      comment="."
       >
     All cards
   </string>
   <string
       name="tags_dialog_option_new_cards"
+      comment="."
       >
     New
   </string>
   <string
       name="tags_dialog_option_due_cards"
+      comment="."
       >
     Due
   </string>
@@ -511,21 +600,25 @@
   <!-- Empty cards -->
   <string
       name="emtpy_cards_finding"
+      comment="."
       >
     Finding empty cards…
   </string>
   <string
       name="empty_cards_none"
+      comment="."
       >
     No empty cards
   </string>
   <string
       name="empty_cards_count"
+      comment="."
       >
     Cards to delete: %d
   </string>
   <string
       name="empty_cards_deleted"
+      comment="."
       >
     Cards deleted: %d
   </string>
@@ -533,16 +626,19 @@
   <!-- Multimedia - Edit Field Activity -->
   <string
       name="multimedia_editor_audio_permission_refused"
+      comment="."
       >
     Could not obtain microphone permission.
   </string>
   <string
       name="multimedia_editor_camera_permission_refused"
+      comment="."
       >
     Could not obtain camera permission. Functionality has been disabled.
   </string>
   <string
       name="multimedia_editor_failed"
+      comment="."
       >
     Failed to open Multimedia Editor
   </string>
@@ -550,6 +646,7 @@
   <!-- Multimedia - Audio View -->
   <string
       name="multimedia_editor_audio_permission_denied"
+      comment="."
       >
     Audio recording permission denied
   </string>
@@ -557,16 +654,19 @@
   <!-- Initial collection load -->
   <string
       name="collection_load_welcome_request_permissions_title"
+      comment="."
       >
     Welcome to AnkiDroid!
   </string>
   <string
       name="collection_load_welcome_request_permissions_details"
+      comment="."
       >
     AnkiDroid requires storage permission, which we use exclusively to store your AnkiDroid collection, flashcard media and backups. Our code is open-source, written by volunteers, and trusted by millions.\n\nIf you have any questions, please access our in-app manual or visit our support forums.\n\nThank you for trying AnkiDroid!\n—AnkiDroid Development Team
   </string>
   <string
       name="mutimedia_editor_assertion_failed"
+      comment="."
       >
     Unknown error occurred displaying Advanced Editor
   </string>
@@ -574,42 +674,50 @@
   <!-- Database Integrity Check -->
   <string
       name="integrity_check_startup_title"
+      comment="."
       >
     AnkiDroid Upgraded
   </string>
   <string
       name="integrity_check_startup_content"
+      comment="."
       >
     AnkiDroid has been upgraded. This upgrade includes fixes for possible database problems, and we advise you to run check database now.
   </string>
   <string
       name="integrity_check_positive"
+      comment="."
       >
     Check Database
   </string>
   <string
       name="integrity_check_continue_anyway"
+      comment="."
       >
     Continue Anyway
   </string>
   <string
       name="integrity_check_insufficient_space"
+      comment="."
       >
     Check Database uses a large amount of temporary storage.\n\nIt is strongly recommended that you have at least %s free space on your device before continuing.
   </string>
   <string
       name="integrity_check_insufficient_space_extra_content"
+      comment="."
       >
     \n\nYou currently have %s free.
   </string>
   <string
       name="integrity_check_fixed_no_home_deck"
+      comment="."
       >
     %d cards with incorrect home decks were recovered. Please see the manual for more information.
   </string>
 
   <string
       name="video_creation_error"
+      comment="."
       >
     Could not play video
   </string>
@@ -617,12 +725,14 @@
   <!-- Card Browser -->
   <string
       name="card_browser_deck_change_error"
+      comment="."
       >
     Could not change deck
   </string>
   <!-- AbstractFlashCardViewer -->
   <string
       name="card_viewer_url_decode_error"
+      comment="."
       >
     Error decoding data from card
   </string>
@@ -630,6 +740,7 @@
   <!-- Deck Options -->
   <string
       name="deck_options_corrupt"
+      comment="."
       >
     Failed to process deck options: %s
   </string>
@@ -637,11 +748,13 @@
   <!-- Database Errors-->
   <string
       name="database_locked_title"
+      comment="."
       >
     Database Locked
   </string>
   <string
       name="database_locked_summary"
+      comment="."
       >
     The AnkiDroid database is in use by another application. Please close the other application then reopen AnkiDroid.
   </string>
@@ -649,41 +762,49 @@
   <!-- Deck Picker Background-->
   <string
       name="background_image_applied"
+      comment="."
       >
     Background image applied
   </string>
   <string
       name="background_image_removed"
+      comment="."
       >
     Background image removed
   </string>
   <string
       name="no_image_selected"
+      comment="."
       >
     No image selected
   </string>
   <string
       name="error_selecting_image"
+      comment="."
       >
     Error selecting image. Please see manual. %s
   </string>
   <string
       name="error_deleting_image"
+      comment="."
       >
     Error deleting image
   </string>
   <string
       name="failed_to_apply_background_image"
+      comment="."
       >
     Failed to apply background image %s
   </string>
   <string
       name="background_image_too_large"
+      comment="."
       >
     Deck Picker background too large
   </string>
   <string
       name="image_max_size_allowed"
+      comment="."
       >
     Maximum image size %d MB allowed
   </string>
@@ -692,6 +813,7 @@
   <!-- Also used by Card Browser, not renaming to save translators effort -->
   <string
       name="intent_handler_failed_no_storage_permission"
+      comment="."
       >
     Missing required storage permission. Please grant storage permission then retry your action.
   </string>
@@ -699,6 +821,7 @@
   <!-- Browser Appearance -->
   <string
       name="card_template_editor_card_browser_appearance_failed"
+      comment="."
       >
     Could not load Card Browser Appearance
   </string>
@@ -706,11 +829,13 @@
   <!-- Boot Service -->
   <string
       name="boot_service_failed_to_schedule_notifications"
+      comment="."
       >
     Failed to schedule reminders
   </string>
   <string
       name="boot_service_too_many_notifications"
+      comment="."
       >
     Too many reminders scheduled. Some will not appear
   </string>
@@ -718,11 +843,13 @@
   <!-- Locale Selection Dialog -->
   <string
       name="locale_selection_dialog_title"
+      comment="."
       >
     Keyboard Hint Selection
   </string>
   <string
       name="locale_selection_dialog_summary"
+      comment="."
       >
     Some multilingual keyboards, such as GBoard support changing language when editing text\n\nPlease request the “setImeHintLocales” feature from your keyboard manufacturer if your keyboard does not change language.
   </string>
@@ -731,6 +858,7 @@
   <!--Sync-->
   <plurals
       name="sync_automatic_sync_needs_more_time"
+      comment="."
       >
     <item quantity="one">
       An automatic sync may be triggered in %d second

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -88,19 +88,24 @@
   <string-array
       name="about_content"
       >
-    <item>
+    <item
+        >
       <![CDATA[<h2>%1$s:<br/>Flashcards for Android</h2>AnkiDroid is a flashcard application which is fully compatible with the desktop software <a href=\"%2$s\">Anki</a>. You can create, download and learn material on both AnkiDroid or Anki Desktop, and synchronize them easily with AnkiWeb.]]>
     </item>
-    <item>
+    <item
+        >
       <![CDATA[To help us make AnkiDroid better, please report bugs to <a href=\"%1$s\">the issue tracker</a>; new feature ideas are very welcome too. Find answers on <a href=\"%2$s\">the wiki</a> or start a discussion on <a href=\"%3$s\">the forum</a>.]]>
     </item>
-    <item>
+    <item
+        >
       <![CDATA[AnkiDroid is <a href=\"%1$s\">open source software<a/>, so everyone is encouraged to <a href=\"%2$s\">become a contributor</a> :-)]]>
     </item>
-    <item>
+    <item
+        >
       <![CDATA[Non-developers can also help. For instance, you can <a href=\"%1$s\">help translate</a> AnkiDroid, update the wiki, provide screenshots, or blog about AnkiDroid.]]>
     </item>
-    <item>
+    <item
+        >
       <![CDATA[AnkiDroid is released under the <a href=\"%1$s\">GNU-GPL v3 license</a> and the source code is available <a href=\"%2$s\">on GitHub</a>.]]>
     </item>
   </string-array>

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -241,16 +241,6 @@
     Do you really want to try to repair the database?\n\nBefore starting the attempt, a copy will be created in subfolder “%s”.
   </string>
   <string
-      name="intent_add_saved_information"
-      >
-    Saved data
-  </string>
-  <string
-      name="intent_add_clear_all"
-      >
-    Clear all
-  </string>
-  <string
       name="intent_aedict_empty"
       >
     Category “default” is empty

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -17,204 +17,480 @@
 ~
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
---><resources>
-    <string name="check_db_title">Check database?</string>
-    <string name="check_db_warning">This may take a long time</string>
-    <string name="check_db_acknowledge">Database checked</string>
-    <string name="check_db_acknowledge_shrunk">Database checked and optimized.\nShrunk by %d MB.</string>
-    <string name="contextmenu_deckpicker_delete_deck">Delete deck</string>
-    <string name="delete_deck_default_deck">The default deck can’t be deleted</string>
-    <string name="delete_deck_title">Delete deck?</string>
-    <plurals name="delete_deck_message">
-        <item quantity="one">Delete all cards in %1$s? It contains %2$d card.</item>
-        <item quantity="other">Delete all cards in %1$s? It contains %2$d cards.</item>
-    </plurals>
-    <string name="delete_cram_deck_message">Send all cards in %s back to their original decks?</string>
-    <string name="no_tts_available_message">No text-to-speech language available</string>
-    <string name="initializing_tts">Initializing TTS…</string>
-    <string name="tts_no_tts">Don’t speak</string>
+-->
+<resources>
+  <string name="check_db_title">
+    Check database?
+  </string>
+  <string name="check_db_warning">
+    This may take a long time
+  </string>
+  <string name="check_db_acknowledge">
+    Database checked
+  </string>
+  <string name="check_db_acknowledge_shrunk">
+    Database checked and optimized.\nShrunk by %d MB.
+  </string>
+  <string name="contextmenu_deckpicker_delete_deck">
+    Delete deck
+  </string>
+  <string name="delete_deck_default_deck">
+    The default deck can’t be deleted
+  </string>
+  <string name="delete_deck_title">
+    Delete deck?
+  </string>
+  <plurals name="delete_deck_message">
+    <item quantity="one">
+      Delete all cards in %1$s? It contains %2$d card.
+    </item>
+    <item quantity="other">
+      Delete all cards in %1$s? It contains %2$d cards.
+    </item>
+  </plurals>
+  <string name="delete_cram_deck_message">
+    Send all cards in %s back to their original decks?
+  </string>
+  <string name="no_tts_available_message">
+    No text-to-speech language available
+  </string>
+  <string name="initializing_tts">
+    Initializing TTS…
+  </string>
+  <string name="tts_no_tts">
+    Don’t speak
+  </string>
 
-    <string-array name="about_content">
-        <item><![CDATA[<h2>%1$s:<br/>Flashcards for Android</h2>AnkiDroid is a flashcard application which is fully compatible with the desktop software <a href=\"%2$s\">Anki</a>. You can create, download and learn material on both AnkiDroid or Anki Desktop, and synchronize them easily with AnkiWeb.]]></item>
-        <item><![CDATA[To help us make AnkiDroid better, please report bugs to <a href=\"%1$s\">the issue tracker</a>; new feature ideas are very welcome too. Find answers on <a href=\"%2$s\">the wiki</a> or start a discussion on <a href=\"%3$s\">the forum</a>.]]></item>
-        <item><![CDATA[AnkiDroid is <a href=\"%1$s\">open source software<a/>, so everyone is encouraged to <a href=\"%2$s\">become a contributor</a> :-)]]></item>
-        <item><![CDATA[Non-developers can also help. For instance, you can <a href=\"%1$s\">help translate</a> AnkiDroid, update the wiki, provide screenshots, or blog about AnkiDroid.]]></item>
-        <item><![CDATA[AnkiDroid is released under the <a href=\"%1$s\">GNU-GPL v3 license</a> and the source code is available <a href=\"%2$s\">on GitHub</a>.]]></item>
-    </string-array>
+  <string-array name="about_content">
+    <item>
+      <![CDATA[<h2>%1$s:<br/>Flashcards for Android</h2>AnkiDroid is a flashcard application which is fully compatible with the desktop software <a href=\"%2$s\">Anki</a>. You can create, download and learn material on both AnkiDroid or Anki Desktop, and synchronize them easily with AnkiWeb.]]>
+    </item>
+    <item>
+      <![CDATA[To help us make AnkiDroid better, please report bugs to <a href=\"%1$s\">the issue tracker</a>; new feature ideas are very welcome too. Find answers on <a href=\"%2$s\">the wiki</a> or start a discussion on <a href=\"%3$s\">the forum</a>.]]>
+    </item>
+    <item>
+      <![CDATA[AnkiDroid is <a href=\"%1$s\">open source software<a/>, so everyone is encouraged to <a href=\"%2$s\">become a contributor</a> :-)]]>
+    </item>
+    <item>
+      <![CDATA[Non-developers can also help. For instance, you can <a href=\"%1$s\">help translate</a> AnkiDroid, update the wiki, provide screenshots, or blog about AnkiDroid.]]>
+    </item>
+    <item>
+      <![CDATA[AnkiDroid is released under the <a href=\"%1$s\">GNU-GPL v3 license</a> and the source code is available <a href=\"%2$s\">on GitHub</a>.]]>
+    </item>
+  </string-array>
 
-    <string name="preview_title">Preview</string>
-    <string name="reposition_card_dialog_title">Reposition new card</string>
-    <string name="reposition_card_dialog_message">Start position:</string>
-    <string name="reposition_card_not_new_error">Only new cards can be repositioned</string>
+  <string name="preview_title">
+    Preview
+  </string>
+  <string name="reposition_card_dialog_title">
+    Reposition new card
+  </string>
+  <string name="reposition_card_dialog_message">
+    Start position:
+  </string>
+  <string name="reposition_card_not_new_error">
+    Only new cards can be repositioned
+  </string>
 
-    <plurals name="reposition_card_dialog_acknowledge">
-        <item quantity="one">%d card repositioned</item>
-        <item quantity="other">%d cards repositioned</item>
-    </plurals>
-    <string name="reset_card_dialog_title">Reset card progress</string>
-    <string name="reset_card_dialog_message">This card will be placed at the end of the new card queue</string>
-    <plurals name="reset_cards_dialog_acknowledge">
-        <item quantity="one">%d card reset</item>
-        <item quantity="other">%d cards reset</item>
-    </plurals>
+  <plurals name="reposition_card_dialog_acknowledge">
+    <item quantity="one">
+      %d card repositioned
+    </item>
+    <item quantity="other">
+      %d cards repositioned
+    </item>
+  </plurals>
+  <string name="reset_card_dialog_title">
+    Reset card progress
+  </string>
+  <string name="reset_card_dialog_message">
+    This card will be placed at the end of the new card queue
+  </string>
+  <plurals name="reset_cards_dialog_acknowledge">
+    <item quantity="one">
+      %d card reset
+    </item>
+    <item quantity="other">
+      %d cards reset
+    </item>
+  </plurals>
 
-    <!-- Reschedule Card Dialog -->
-    <string name="reschedule_card_dialog_title">Reschedule card</string>
-    <plurals name="reschedule_cards_dialog_title">
-        <item quantity="one">Reschedule card</item>
-        <item quantity="other">Reschedule cards</item>
-    </plurals>
-    <plurals name="reschedule_card_dialog_interval">
-        <item quantity="one">Current interval: %d day</item>
-        <item quantity="other">Current interval: %d days</item>
-    </plurals>
-    <string name="reschedule_card_dialog_message">Reschedule for review in x days</string>
-    <plurals name="reschedule_cards_dialog_acknowledge">
-        <item quantity="one">%d card rescheduled</item>
-        <item quantity="other">%d cards rescheduled</item>
-    </plurals>
-    <string name="reschedule_card_dialog_new_card_warning">A new card is being rescheduled. Rescheduling also turns new cards into review cards. Use the ‘reposition card’ option to change a new card\'s position within the new queue</string>
-    <string name="reschedule_card_dialog_warning_ease_reset">Rescheduling also resets how the scheduler treats the card in the future (ease will be set to %d%%)</string>
+  <!-- Reschedule Card Dialog -->
+  <string name="reschedule_card_dialog_title">
+    Reschedule card
+  </string>
+  <plurals name="reschedule_cards_dialog_title">
+    <item quantity="one">
+      Reschedule card
+    </item>
+    <item quantity="other">
+      Reschedule cards
+    </item>
+  </plurals>
+  <plurals name="reschedule_card_dialog_interval">
+    <item quantity="one">
+      Current interval: %d day
+    </item>
+    <item quantity="other">
+      Current interval: %d days
+    </item>
+  </plurals>
+  <string name="reschedule_card_dialog_message">
+    Reschedule for review in x days
+  </string>
+  <plurals name="reschedule_cards_dialog_acknowledge">
+    <item quantity="one">
+      %d card rescheduled
+    </item>
+    <item quantity="other">
+      %d cards rescheduled
+    </item>
+  </plurals>
+  <string name="reschedule_card_dialog_new_card_warning">
+  A new card is being rescheduled. Rescheduling also turns new cards into review cards. Use the ‘reposition card’ option
+  to change a new card\'s position within the new queue
+  </string>
+  <string name="reschedule_card_dialog_warning_ease_reset">
+    Rescheduling also resets how the scheduler treats the card in the future (ease will be set to %d%%)
+  </string>
 
-    <string name="firefox_workaround_launched_reviewer_opening_deck">Select the deck in your file manager or visit the about:downloads page to import it</string>
-    <string name="answering_error_title">Database error</string>
-    <string name="answering_error_message">Writing to the collection failed. The database could be corrupt or there may not to be enough empty space on disk.\n\nIf this happens more often, try checking the database, repairing the collection or restoring it from a backup. Touch “options” for that.\n\Or it could be an AnkiDroid bug as well; please report the error so that we can check this.</string>
-    <string name="answering_error_report">Report error</string>
-    <string name="repair_deck_dialog">Do you really want to try to repair the database?\n\nBefore starting the attempt, a copy will be created in subfolder “%s”.</string>
-    <string name="intent_add_saved_information">Saved data</string>
-    <string name="intent_add_clear_all">Clear all</string>
-    <string name="intent_aedict_empty">Category “default” is empty</string>
-    <string name="intent_aedict_category">To add cards to AnkiDroid remove all Notepad categories or add one named “default”</string>
-    <string name="custom_study_new_total_new">New cards in deck: %d</string>
-    <string name="custom_study_rev_total_rev">Reviews due in deck: %d</string>
-    <string name="custom_study_new_extend">Increase/decrease (“-3”) today’s new card limit by</string>
-    <string name="custom_study_rev_extend">Increase/decrease (“-3”) today’s review limit by</string>
-    <string name="custom_study_forgotten">Review cards forgotten in last x days:</string>
-    <string name="custom_study_ahead">Review ahead by x days:</string>
-    <string name="custom_study_random">Select x cards randomly from the deck:</string>
-    <string name="custom_study_preview">Preview new cards added in the last x days:</string>
-    <string name="custom_study_rebuild_deck_corrupt">Could not rebuild custom study deck</string>
+  <string name="firefox_workaround_launched_reviewer_opening_deck">
+    Select the deck in your file manager or visit the about:downloads page to import it
+  </string>
+  <string name="answering_error_title">
+    Database error
+  </string>
+  <string name="answering_error_message">
+    Writing to the collection failed. The database could be corrupt or there may not to be enough empty space on disk.\n\nIf this happens more often, try checking the database, repairing the collection or restoring it from a backup. Touch “options” for that.\n\Or it could be an AnkiDroid bug as well; please report the error so that we can check this.
+  </string>
+  <string name="answering_error_report">
+    Report error
+  </string>
+  <string name="repair_deck_dialog">
+    Do you really want to try to repair the database?\n\nBefore starting the attempt, a copy will be created in subfolder “%s”.
+  </string>
+  <string name="intent_add_saved_information">
+    Saved data
+  </string>
+  <string name="intent_add_clear_all">
+    Clear all
+  </string>
+  <string name="intent_aedict_empty">
+    Category “default” is empty
+  </string>
+  <string name="intent_aedict_category">
+    To add cards to AnkiDroid remove all Notepad categories or add one named “default”
+  </string>
+  <string name="custom_study_new_total_new">
+    New cards in deck: %d
+  </string>
+  <string name="custom_study_rev_total_rev">
+    Reviews due in deck: %d
+  </string>
+  <string name="custom_study_new_extend">
+    Increase/decrease (“-3”) today’s new card limit by
+  </string>
+  <string name="custom_study_rev_extend">
+    Increase/decrease (“-3”) today’s review limit by
+  </string>
+  <string name="custom_study_forgotten">
+    Review cards forgotten in last x days:
+  </string>
+  <string name="custom_study_ahead">
+    Review ahead by x days:
+  </string>
+  <string name="custom_study_random">
+    Select x cards randomly from the deck:
+  </string>
+  <string name="custom_study_preview">
+    Preview new cards added in the last x days:
+  </string>
+  <string name="custom_study_rebuild_deck_corrupt">
+    Could not rebuild custom study deck
+  </string>
 
-    <string name="rebuild_custom_study_deck">Rebuilding custom study deck…</string>
-    <string name="importing_collection">Importing collection…</string>
-    <string name="import_media_count">Importing media files %1$d%%…</string>
-    <string name="import_progress">• Importing notes: %1$d%%\n• Importing cards: %2$d%%\n• Post-processing: %3$d%%</string>
-    <string name="import_update_details">Updated %1$d of %2$d existing notes.</string>
-    <string name="import_update_ignored">Some updates were ignored because note type has changed</string>
-    <string name="import_complete_count">Cards imported: %d</string>
-    <string name="sd_card_full_title">SD card full</string>
-    <string name="sd_card_almost_full_title">SD card almost full</string>
-    <string name="restore_backup_title">Restore backup?</string>
-    <string name="restore_backup">Your collection will be replaced with an older copy. Any unsaved progress will be lost.</string>
+  <string name="rebuild_custom_study_deck">
+    Rebuilding custom study deck…
+  </string>
+  <string name="importing_collection">
+    Importing collection…
+  </string>
+  <string name="import_media_count">
+    Importing media files %1$d%%…
+  </string>
+  <string name="import_progress">
+    • Importing notes: %1$d%%\n• Importing cards: %2$d%%\n• Post-processing: %3$d%%
+  </string>
+  <string name="import_update_details">
+    Updated %1$d of %2$d existing notes.
+  </string>
+  <string name="import_update_ignored">
+    Some updates were ignored because note type has changed
+  </string>
+  <string name="import_complete_count">
+    Cards imported: %d
+  </string>
+  <string name="sd_card_full_title">
+    SD card full
+  </string>
+  <string name="sd_card_almost_full_title">
+    SD card almost full
+  </string>
+  <string name="restore_backup_title">
+    Restore backup?
+  </string>
+  <string name="restore_backup">
+    Your collection will be replaced with an older copy. Any unsaved progress will be lost.
+  </string>
 
-    <string name="dialog_cancel">Cancel</string>
-    <string name="dialog_ok">OK</string>
-    <string name="dialog_no">No</string>
-    <string name="dialog_continue">Continue</string>
-    <string name="dialog_positive_create">Create</string>
-    <string name="dialog_positive_delete">Delete</string>
-    <string name="dialog_positive_disable">Disable</string>
-    <string name="dialog_positive_overwrite">Overwrite</string>
-    <string name="dialog_positive_remove">Remove</string>
-    <string name="dialog_positive_repair">Repair</string>
-    <string name="dialog_positive_replace">Replace</string>
-    <string name="dialog_positive_restore">Restore</string>
-    <string name="dialog_positive_set">Set</string>
+  <string name="dialog_cancel">
+    Cancel
+  </string>
+  <string name="dialog_ok">
+    OK
+  </string>
+  <string name="dialog_no">
+    No
+  </string>
+  <string name="dialog_continue">
+    Continue
+  </string>
+  <string name="dialog_positive_create">
+    Create
+  </string>
+  <string name="dialog_positive_delete">
+    Delete
+  </string>
+  <string name="dialog_positive_disable">
+    Disable
+  </string>
+  <string name="dialog_positive_overwrite">
+    Overwrite
+  </string>
+  <string name="dialog_positive_remove">
+    Remove
+  </string>
+  <string name="dialog_positive_repair">
+    Repair
+  </string>
+  <string name="dialog_positive_replace">
+    Replace
+  </string>
+  <string name="dialog_positive_restore">
+    Restore
+  </string>
+  <string name="dialog_positive_set">
+    Set
+  </string>
 
-    <string name="lookup_button_content">Look up</string>
-    <string name="dialog_collection_path_not_dir">The path specified wasn’t a valid directory</string>
+  <string name="lookup_button_content">
+    Look up
+  </string>
+  <string name="dialog_collection_path_not_dir">
+    The path specified wasn’t a valid directory
+  </string>
 
-    <!-- Media checking -->
-    <string name="check_media_title">Check media?</string>
-    <string name="check_media_warning">This may take a long time with large media collections</string>
-    <string name="check_media_message">Checking media…</string>
-    <string name="check_media_acknowledge">Media checked</string>
-    <string name="check_media_failed">Media check failed</string>
-    <string name="check_media_invalid">Files with invalid encoding: %d</string>
-    <string name="check_media_unused">Files in media folder but not used by any cards: %d</string>
-    <string name="check_media_nohave">Files used on cards but not in media folder: %d</string>
-    <string name="check_media_no_unused_missing">No unused or missing files found</string>
-    <string name="check_media_db_updated">Media database rebuilt</string>
-    <string name="check_media_delete_unused">Delete unused</string>
-    <string name="check_media_deleted">Files deleted: %d</string>
+  <!-- Media checking -->
+  <string name="check_media_title">
+    Check media?
+  </string>
+  <string name="check_media_warning">
+    This may take a long time with large media collections
+  </string>
+  <string name="check_media_message">
+    Checking media…
+  </string>
+  <string name="check_media_acknowledge">
+    Media checked
+  </string>
+  <string name="check_media_failed">
+    Media check failed
+  </string>
+  <string name="check_media_invalid">
+    Files with invalid encoding: %d
+  </string>
+  <string name="check_media_unused">
+    Files in media folder but not used by any cards: %d
+  </string>
+  <string name="check_media_nohave">
+    Files used on cards but not in media folder: %d
+  </string>
+  <string name="check_media_no_unused_missing">
+    No unused or missing files found
+  </string>
+  <string name="check_media_db_updated">
+    Media database rebuilt
+  </string>
+  <string name="check_media_delete_unused">
+    Delete unused
+  </string>
+  <string name="check_media_deleted">
+    Files deleted: %d
+  </string>
 
-    <!-- Tags Dialog Options -->
-    <string name="tags_dialog_option_all_cards">All cards</string>
-    <string name="tags_dialog_option_new_cards">New</string>
-    <string name="tags_dialog_option_due_cards">Due</string>
+  <!-- Tags Dialog Options -->
+  <string name="tags_dialog_option_all_cards">
+    All cards
+  </string>
+  <string name="tags_dialog_option_new_cards">
+    New
+  </string>
+  <string name="tags_dialog_option_due_cards">
+    Due
+  </string>
 
-    <!-- Empty cards -->
-    <string name="emtpy_cards_finding">Finding empty cards…</string>
-    <string name="empty_cards_none">No empty cards</string>
-    <string name="empty_cards_count">Cards to delete: %d</string>
-    <string name="empty_cards_deleted">Cards deleted: %d</string>
+  <!-- Empty cards -->
+  <string name="emtpy_cards_finding">
+    Finding empty cards…
+  </string>
+  <string name="empty_cards_none">
+    No empty cards
+  </string>
+  <string name="empty_cards_count">
+    Cards to delete: %d
+  </string>
+  <string name="empty_cards_deleted">
+    Cards deleted: %d
+  </string>
 
-    <!-- Multimedia - Edit Field Activity -->
-    <string name="multimedia_editor_audio_permission_refused">Could not obtain microphone permission.</string>
-    <string name="multimedia_editor_camera_permission_refused">Could not obtain camera permission. Functionality has been disabled.</string>
-    <string name="multimedia_editor_failed">Failed to open Multimedia Editor</string>
+  <!-- Multimedia - Edit Field Activity -->
+  <string name="multimedia_editor_audio_permission_refused">
+    Could not obtain microphone permission.
+  </string>
+  <string name="multimedia_editor_camera_permission_refused">
+    Could not obtain camera permission. Functionality has been disabled.
+  </string>
+  <string name="multimedia_editor_failed">
+    Failed to open Multimedia Editor
+  </string>
 
-    <!-- Multimedia - Audio View -->
-    <string name="multimedia_editor_audio_permission_denied">Audio recording permission denied</string>
+  <!-- Multimedia - Audio View -->
+  <string name="multimedia_editor_audio_permission_denied">
+    Audio recording permission denied
+  </string>
 
-    <!-- Initial collection load -->
-    <string name="collection_load_welcome_request_permissions_title">Welcome to AnkiDroid!</string>
-    <string name="collection_load_welcome_request_permissions_details">AnkiDroid requires storage permission, which we use exclusively to store your AnkiDroid collection, flashcard media and backups. Our code is open-source, written by volunteers, and trusted by millions.\n\nIf you have any questions, please access our in-app manual or visit our support forums.\n\nThank you for trying AnkiDroid!\n—AnkiDroid Development Team</string>
-    <string name="mutimedia_editor_assertion_failed">Unknown error occurred displaying Advanced Editor</string>
+  <!-- Initial collection load -->
+  <string name="collection_load_welcome_request_permissions_title">
+    Welcome to AnkiDroid!
+  </string>
+  <string name="collection_load_welcome_request_permissions_details">
+    AnkiDroid requires storage permission, which we use exclusively to store your AnkiDroid collection, flashcard media and backups. Our code is open-source, written by volunteers, and trusted by millions.\n\nIf you have any questions, please access our in-app manual or visit our support forums.\n\nThank you for trying AnkiDroid!\n—AnkiDroid Development Team
+  </string>
+  <string name="mutimedia_editor_assertion_failed">
+    Unknown error occurred displaying Advanced Editor
+  </string>
 
-    <!-- Database Integrity Check -->
-    <string name="integrity_check_startup_title">AnkiDroid Upgraded</string>
-    <string name="integrity_check_startup_content">AnkiDroid has been upgraded. This upgrade includes fixes for possible database problems, and we advise you to run check database now.</string>
-    <string name="integrity_check_positive">Check Database</string>
-    <string name="integrity_check_continue_anyway">Continue Anyway</string>
-    <string name="integrity_check_insufficient_space">Check Database uses a large amount of temporary storage.\n\nIt is strongly recommended that you have at least %s free space on your device before continuing.</string>>
-    <string name="integrity_check_insufficient_space_extra_content">\n\nYou currently have %s free.</string>
-    <string name="integrity_check_fixed_no_home_deck">%d cards with incorrect home decks were recovered. Please see the manual for more information.</string>
+  <!-- Database Integrity Check -->
+  <string name="integrity_check_startup_title">
+    AnkiDroid Upgraded
+  </string>
+  <string name="integrity_check_startup_content">
+    AnkiDroid has been upgraded. This upgrade includes fixes for possible database problems, and we advise you to run check database now.
+  </string>
+  <string name="integrity_check_positive">
+    Check Database
+  </string>
+  <string name="integrity_check_continue_anyway">
+    Continue Anyway
+  </string>
+  <string name="integrity_check_insufficient_space">
+    Check Database uses a large amount of temporary storage.\n\nIt is strongly recommended that you have at least %s free space on your device before continuing.
+  </string>
+  <string name="integrity_check_insufficient_space_extra_content">
+    \n\nYou currently have %s free.
+  </string>
+  <string name="integrity_check_fixed_no_home_deck">
+    %d cards with incorrect home decks were recovered. Please see the manual for more information.
+  </string>
 
-    <string name="video_creation_error">Could not play video</string>
+  <string name="video_creation_error">
+    Could not play video
+  </string>
 
-    <!-- Card Browser -->
-    <string name="card_browser_deck_change_error">Could not change deck</string>
-    <!-- AbstractFlashCardViewer -->
-    <string name="card_viewer_url_decode_error">Error decoding data from card</string>
+  <!-- Card Browser -->
+  <string name="card_browser_deck_change_error">
+    Could not change deck
+  </string>
+  <!-- AbstractFlashCardViewer -->
+  <string name="card_viewer_url_decode_error">
+    Error decoding data from card
+  </string>
 
-    <!-- Deck Options -->
-    <string name="deck_options_corrupt">Failed to process deck options: %s</string>
+  <!-- Deck Options -->
+  <string name="deck_options_corrupt">
+    Failed to process deck options: %s
+  </string>
 
-    <!-- Database Errors-->
-    <string name="database_locked_title">Database Locked</string>
-    <string name="database_locked_summary">The AnkiDroid database is in use by another application. Please close the other application then reopen AnkiDroid.</string>
+  <!-- Database Errors-->
+  <string name="database_locked_title">
+    Database Locked
+  </string>
+  <string name="database_locked_summary">
+    The AnkiDroid database is in use by another application. Please close the other application then reopen AnkiDroid.
+  </string>
 
-    <!-- Deck Picker Background-->
-    <string name="background_image_applied">Background image applied</string>
-    <string name="background_image_removed">Background image removed</string>
-    <string name="no_image_selected">No image selected</string>
-    <string name="error_selecting_image">Error selecting image. Please see manual. %s</string>
-    <string name="error_deleting_image">Error deleting image</string>
-    <string name="failed_to_apply_background_image">Failed to apply background image %s</string>
-    <string name="background_image_too_large">Deck Picker background too large</string>
-    <string name="image_max_size_allowed">Maximum image size %d MB allowed</string>
-    
-    <!-- Global Intent handler -->
-    <!-- Also used by Card Browser, not renaming to save translators effort -->
-    <string name="intent_handler_failed_no_storage_permission">Missing required storage permission. Please grant storage permission then retry your action.</string>
+  <!-- Deck Picker Background-->
+  <string name="background_image_applied">
+    Background image applied
+  </string>
+  <string name="background_image_removed">
+    Background image removed
+  </string>
+  <string name="no_image_selected">
+    No image selected
+  </string>
+  <string name="error_selecting_image">
+    Error selecting image. Please see manual. %s
+  </string>
+  <string name="error_deleting_image">
+    Error deleting image
+  </string>
+  <string name="failed_to_apply_background_image">
+    Failed to apply background image %s
+  </string>
+  <string name="background_image_too_large">
+    Deck Picker background too large
+  </string>
+  <string name="image_max_size_allowed">
+    Maximum image size %d MB allowed
+  </string>
+  
+  <!-- Global Intent handler -->
+  <!-- Also used by Card Browser, not renaming to save translators effort -->
+  <string name="intent_handler_failed_no_storage_permission">
+    Missing required storage permission. Please grant storage permission then retry your action.
+  </string>
 
-    <!-- Browser Appearance -->
-    <string name="card_template_editor_card_browser_appearance_failed">Could not load Card Browser Appearance</string>
+  <!-- Browser Appearance -->
+  <string name="card_template_editor_card_browser_appearance_failed">
+    Could not load Card Browser Appearance
+  </string>
 
-    <!-- Boot Service -->
-    <string name="boot_service_failed_to_schedule_notifications">Failed to schedule reminders</string>
-    <string name="boot_service_too_many_notifications">Too many reminders scheduled. Some will not appear</string>
+  <!-- Boot Service -->
+  <string name="boot_service_failed_to_schedule_notifications">
+    Failed to schedule reminders
+  </string>
+  <string name="boot_service_too_many_notifications">
+    Too many reminders scheduled. Some will not appear
+  </string>
 
-    <!-- Locale Selection Dialog -->
-    <string name="locale_selection_dialog_title">Keyboard Hint Selection</string>
-    <string name="locale_selection_dialog_summary">Some multilingual keyboards, such as GBoard support changing language when editing text\n\nPlease request the “setImeHintLocales” feature from your keyboard manufacturer if your keyboard does not change language.</string>
+  <!-- Locale Selection Dialog -->
+  <string name="locale_selection_dialog_title">
+    Keyboard Hint Selection
+  </string>
+  <string name="locale_selection_dialog_summary">
+    Some multilingual keyboards, such as GBoard support changing language when editing text\n\nPlease request the “setImeHintLocales” feature from your keyboard manufacturer if your keyboard does not change language.
+  </string>
 
 
-    <!--Sync-->
-    <plurals name="sync_automatic_sync_needs_more_time">
-        <item quantity="one">An automatic sync may be triggered in %d second</item>
-        <item quantity="other">An automatic sync may be triggered in %d seconds</item>
-    </plurals>
+  <!--Sync-->
+  <plurals name="sync_automatic_sync_needs_more_time">
+    <item quantity="one">
+      An automatic sync may be triggered in %d second
+    </item>
+    <item quantity="other">
+      An automatic sync may be triggered in %d seconds
+    </item>
+  </plurals>
 
 </resources>

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -19,28 +19,44 @@
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <resources>
-  <string name="check_db_title">
+  <string
+      name="check_db_title"
+      >
     Check database?
   </string>
-  <string name="check_db_warning">
+  <string
+      name="check_db_warning"
+      >
     This may take a long time
   </string>
-  <string name="check_db_acknowledge">
+  <string
+      name="check_db_acknowledge"
+      >
     Database checked
   </string>
-  <string name="check_db_acknowledge_shrunk">
+  <string
+      name="check_db_acknowledge_shrunk"
+      >
     Database checked and optimized.\nShrunk by %d MB.
   </string>
-  <string name="contextmenu_deckpicker_delete_deck">
+  <string
+      name="contextmenu_deckpicker_delete_deck"
+      >
     Delete deck
   </string>
-  <string name="delete_deck_default_deck">
+  <string
+      name="delete_deck_default_deck"
+      >
     The default deck can’t be deleted
   </string>
-  <string name="delete_deck_title">
+  <string
+      name="delete_deck_title"
+      >
     Delete deck?
   </string>
-  <plurals name="delete_deck_message">
+  <plurals
+      name="delete_deck_message"
+      >
     <item quantity="one">
       Delete all cards in %1$s? It contains %2$d card.
     </item>
@@ -48,20 +64,30 @@
       Delete all cards in %1$s? It contains %2$d cards.
     </item>
   </plurals>
-  <string name="delete_cram_deck_message">
+  <string
+      name="delete_cram_deck_message"
+      >
     Send all cards in %s back to their original decks?
   </string>
-  <string name="no_tts_available_message">
+  <string
+      name="no_tts_available_message"
+      >
     No text-to-speech language available
   </string>
-  <string name="initializing_tts">
+  <string
+      name="initializing_tts"
+      >
     Initializing TTS…
   </string>
-  <string name="tts_no_tts">
+  <string
+      name="tts_no_tts"
+      >
     Don’t speak
   </string>
 
-  <string-array name="about_content">
+  <string-array
+      name="about_content"
+      >
     <item>
       <![CDATA[<h2>%1$s:<br/>Flashcards for Android</h2>AnkiDroid is a flashcard application which is fully compatible with the desktop software <a href=\"%2$s\">Anki</a>. You can create, download and learn material on both AnkiDroid or Anki Desktop, and synchronize them easily with AnkiWeb.]]>
     </item>
@@ -79,20 +105,30 @@
     </item>
   </string-array>
 
-  <string name="preview_title">
+  <string
+      name="preview_title"
+      >
     Preview
   </string>
-  <string name="reposition_card_dialog_title">
+  <string
+      name="reposition_card_dialog_title"
+      >
     Reposition new card
   </string>
-  <string name="reposition_card_dialog_message">
+  <string
+      name="reposition_card_dialog_message"
+      >
     Start position:
   </string>
-  <string name="reposition_card_not_new_error">
+  <string
+      name="reposition_card_not_new_error"
+      >
     Only new cards can be repositioned
   </string>
 
-  <plurals name="reposition_card_dialog_acknowledge">
+  <plurals
+      name="reposition_card_dialog_acknowledge"
+      >
     <item quantity="one">
       %d card repositioned
     </item>
@@ -100,13 +136,19 @@
       %d cards repositioned
     </item>
   </plurals>
-  <string name="reset_card_dialog_title">
+  <string
+      name="reset_card_dialog_title"
+      >
     Reset card progress
   </string>
-  <string name="reset_card_dialog_message">
+  <string
+      name="reset_card_dialog_message"
+      >
     This card will be placed at the end of the new card queue
   </string>
-  <plurals name="reset_cards_dialog_acknowledge">
+  <plurals
+      name="reset_cards_dialog_acknowledge"
+      >
     <item quantity="one">
       %d card reset
     </item>
@@ -116,10 +158,14 @@
   </plurals>
 
   <!-- Reschedule Card Dialog -->
-  <string name="reschedule_card_dialog_title">
+  <string
+      name="reschedule_card_dialog_title"
+      >
     Reschedule card
   </string>
-  <plurals name="reschedule_cards_dialog_title">
+  <plurals
+      name="reschedule_cards_dialog_title"
+      >
     <item quantity="one">
       Reschedule card
     </item>
@@ -127,7 +173,9 @@
       Reschedule cards
     </item>
   </plurals>
-  <plurals name="reschedule_card_dialog_interval">
+  <plurals
+      name="reschedule_card_dialog_interval"
+      >
     <item quantity="one">
       Current interval: %d day
     </item>
@@ -135,10 +183,14 @@
       Current interval: %d days
     </item>
   </plurals>
-  <string name="reschedule_card_dialog_message">
+  <string
+      name="reschedule_card_dialog_message"
+      >
     Reschedule for review in x days
   </string>
-  <plurals name="reschedule_cards_dialog_acknowledge">
+  <plurals
+      name="reschedule_cards_dialog_acknowledge"
+      >
     <item quantity="one">
       %d card rescheduled
     </item>
@@ -146,345 +198,545 @@
       %d cards rescheduled
     </item>
   </plurals>
-  <string name="reschedule_card_dialog_new_card_warning">
+  <string
+      name="reschedule_card_dialog_new_card_warning"
+      >
   A new card is being rescheduled. Rescheduling also turns new cards into review cards. Use the ‘reposition card’ option
   to change a new card\'s position within the new queue
   </string>
-  <string name="reschedule_card_dialog_warning_ease_reset">
+  <string
+      name="reschedule_card_dialog_warning_ease_reset"
+      >
     Rescheduling also resets how the scheduler treats the card in the future (ease will be set to %d%%)
   </string>
 
-  <string name="firefox_workaround_launched_reviewer_opening_deck">
+  <string
+      name="firefox_workaround_launched_reviewer_opening_deck"
+      >
     Select the deck in your file manager or visit the about:downloads page to import it
   </string>
-  <string name="answering_error_title">
+  <string
+      name="answering_error_title"
+      >
     Database error
   </string>
-  <string name="answering_error_message">
+  <string
+      name="answering_error_message"
+      >
     Writing to the collection failed. The database could be corrupt or there may not to be enough empty space on disk.\n\nIf this happens more often, try checking the database, repairing the collection or restoring it from a backup. Touch “options” for that.\n\Or it could be an AnkiDroid bug as well; please report the error so that we can check this.
   </string>
-  <string name="answering_error_report">
+  <string
+      name="answering_error_report"
+      >
     Report error
   </string>
-  <string name="repair_deck_dialog">
+  <string
+      name="repair_deck_dialog"
+      >
     Do you really want to try to repair the database?\n\nBefore starting the attempt, a copy will be created in subfolder “%s”.
   </string>
-  <string name="intent_add_saved_information">
+  <string
+      name="intent_add_saved_information"
+      >
     Saved data
   </string>
-  <string name="intent_add_clear_all">
+  <string
+      name="intent_add_clear_all"
+      >
     Clear all
   </string>
-  <string name="intent_aedict_empty">
+  <string
+      name="intent_aedict_empty"
+      >
     Category “default” is empty
   </string>
-  <string name="intent_aedict_category">
+  <string
+      name="intent_aedict_category"
+      >
     To add cards to AnkiDroid remove all Notepad categories or add one named “default”
   </string>
-  <string name="custom_study_new_total_new">
+  <string
+      name="custom_study_new_total_new"
+      >
     New cards in deck: %d
   </string>
-  <string name="custom_study_rev_total_rev">
+  <string
+      name="custom_study_rev_total_rev"
+      >
     Reviews due in deck: %d
   </string>
-  <string name="custom_study_new_extend">
+  <string
+      name="custom_study_new_extend"
+      >
     Increase/decrease (“-3”) today’s new card limit by
   </string>
-  <string name="custom_study_rev_extend">
+  <string
+      name="custom_study_rev_extend"
+      >
     Increase/decrease (“-3”) today’s review limit by
   </string>
-  <string name="custom_study_forgotten">
+  <string
+      name="custom_study_forgotten"
+      >
     Review cards forgotten in last x days:
   </string>
-  <string name="custom_study_ahead">
+  <string
+      name="custom_study_ahead"
+      >
     Review ahead by x days:
   </string>
-  <string name="custom_study_random">
+  <string
+      name="custom_study_random"
+      >
     Select x cards randomly from the deck:
   </string>
-  <string name="custom_study_preview">
+  <string
+      name="custom_study_preview"
+      >
     Preview new cards added in the last x days:
   </string>
-  <string name="custom_study_rebuild_deck_corrupt">
+  <string
+      name="custom_study_rebuild_deck_corrupt"
+      >
     Could not rebuild custom study deck
   </string>
 
-  <string name="rebuild_custom_study_deck">
+  <string
+      name="rebuild_custom_study_deck"
+      >
     Rebuilding custom study deck…
   </string>
-  <string name="importing_collection">
+  <string
+      name="importing_collection"
+      >
     Importing collection…
   </string>
-  <string name="import_media_count">
+  <string
+      name="import_media_count"
+      >
     Importing media files %1$d%%…
   </string>
-  <string name="import_progress">
+  <string
+      name="import_progress"
+      >
     • Importing notes: %1$d%%\n• Importing cards: %2$d%%\n• Post-processing: %3$d%%
   </string>
-  <string name="import_update_details">
+  <string
+      name="import_update_details"
+      >
     Updated %1$d of %2$d existing notes.
   </string>
-  <string name="import_update_ignored">
+  <string
+      name="import_update_ignored"
+      >
     Some updates were ignored because note type has changed
   </string>
-  <string name="import_complete_count">
+  <string
+      name="import_complete_count"
+      >
     Cards imported: %d
   </string>
-  <string name="sd_card_full_title">
+  <string
+      name="sd_card_full_title"
+      >
     SD card full
   </string>
-  <string name="sd_card_almost_full_title">
+  <string
+      name="sd_card_almost_full_title"
+      >
     SD card almost full
   </string>
-  <string name="restore_backup_title">
+  <string
+      name="restore_backup_title"
+      >
     Restore backup?
   </string>
-  <string name="restore_backup">
+  <string
+      name="restore_backup"
+      >
     Your collection will be replaced with an older copy. Any unsaved progress will be lost.
   </string>
 
-  <string name="dialog_cancel">
+  <string
+      name="dialog_cancel"
+      >
     Cancel
   </string>
-  <string name="dialog_ok">
+  <string
+      name="dialog_ok"
+      >
     OK
   </string>
-  <string name="dialog_no">
+  <string
+      name="dialog_no"
+      >
     No
   </string>
-  <string name="dialog_continue">
+  <string
+      name="dialog_continue"
+      >
     Continue
   </string>
-  <string name="dialog_positive_create">
+  <string
+      name="dialog_positive_create"
+      >
     Create
   </string>
-  <string name="dialog_positive_delete">
+  <string
+      name="dialog_positive_delete"
+      >
     Delete
   </string>
-  <string name="dialog_positive_disable">
+  <string
+      name="dialog_positive_disable"
+      >
     Disable
   </string>
-  <string name="dialog_positive_overwrite">
+  <string
+      name="dialog_positive_overwrite"
+      >
     Overwrite
   </string>
-  <string name="dialog_positive_remove">
+  <string
+      name="dialog_positive_remove"
+      >
     Remove
   </string>
-  <string name="dialog_positive_repair">
+  <string
+      name="dialog_positive_repair"
+      >
     Repair
   </string>
-  <string name="dialog_positive_replace">
+  <string
+      name="dialog_positive_replace"
+      >
     Replace
   </string>
-  <string name="dialog_positive_restore">
+  <string
+      name="dialog_positive_restore"
+      >
     Restore
   </string>
-  <string name="dialog_positive_set">
+  <string
+      name="dialog_positive_set"
+      >
     Set
   </string>
 
-  <string name="lookup_button_content">
+  <string
+      name="lookup_button_content"
+      >
     Look up
   </string>
-  <string name="dialog_collection_path_not_dir">
+  <string
+      name="dialog_collection_path_not_dir"
+      >
     The path specified wasn’t a valid directory
   </string>
 
   <!-- Media checking -->
-  <string name="check_media_title">
+  <string
+      name="check_media_title"
+      >
     Check media?
   </string>
-  <string name="check_media_warning">
+  <string
+      name="check_media_warning"
+      >
     This may take a long time with large media collections
   </string>
-  <string name="check_media_message">
+  <string
+      name="check_media_message"
+      >
     Checking media…
   </string>
-  <string name="check_media_acknowledge">
+  <string
+      name="check_media_acknowledge"
+      >
     Media checked
   </string>
-  <string name="check_media_failed">
+  <string
+      name="check_media_failed"
+      >
     Media check failed
   </string>
-  <string name="check_media_invalid">
+  <string
+      name="check_media_invalid"
+      >
     Files with invalid encoding: %d
   </string>
-  <string name="check_media_unused">
+  <string
+      name="check_media_unused"
+      >
     Files in media folder but not used by any cards: %d
   </string>
-  <string name="check_media_nohave">
+  <string
+      name="check_media_nohave"
+      >
     Files used on cards but not in media folder: %d
   </string>
-  <string name="check_media_no_unused_missing">
+  <string
+      name="check_media_no_unused_missing"
+      >
     No unused or missing files found
   </string>
-  <string name="check_media_db_updated">
+  <string
+      name="check_media_db_updated"
+      >
     Media database rebuilt
   </string>
-  <string name="check_media_delete_unused">
+  <string
+      name="check_media_delete_unused"
+      >
     Delete unused
   </string>
-  <string name="check_media_deleted">
+  <string
+      name="check_media_deleted"
+      >
     Files deleted: %d
   </string>
 
   <!-- Tags Dialog Options -->
-  <string name="tags_dialog_option_all_cards">
+  <string
+      name="tags_dialog_option_all_cards"
+      >
     All cards
   </string>
-  <string name="tags_dialog_option_new_cards">
+  <string
+      name="tags_dialog_option_new_cards"
+      >
     New
   </string>
-  <string name="tags_dialog_option_due_cards">
+  <string
+      name="tags_dialog_option_due_cards"
+      >
     Due
   </string>
 
   <!-- Empty cards -->
-  <string name="emtpy_cards_finding">
+  <string
+      name="emtpy_cards_finding"
+      >
     Finding empty cards…
   </string>
-  <string name="empty_cards_none">
+  <string
+      name="empty_cards_none"
+      >
     No empty cards
   </string>
-  <string name="empty_cards_count">
+  <string
+      name="empty_cards_count"
+      >
     Cards to delete: %d
   </string>
-  <string name="empty_cards_deleted">
+  <string
+      name="empty_cards_deleted"
+      >
     Cards deleted: %d
   </string>
 
   <!-- Multimedia - Edit Field Activity -->
-  <string name="multimedia_editor_audio_permission_refused">
+  <string
+      name="multimedia_editor_audio_permission_refused"
+      >
     Could not obtain microphone permission.
   </string>
-  <string name="multimedia_editor_camera_permission_refused">
+  <string
+      name="multimedia_editor_camera_permission_refused"
+      >
     Could not obtain camera permission. Functionality has been disabled.
   </string>
-  <string name="multimedia_editor_failed">
+  <string
+      name="multimedia_editor_failed"
+      >
     Failed to open Multimedia Editor
   </string>
 
   <!-- Multimedia - Audio View -->
-  <string name="multimedia_editor_audio_permission_denied">
+  <string
+      name="multimedia_editor_audio_permission_denied"
+      >
     Audio recording permission denied
   </string>
 
   <!-- Initial collection load -->
-  <string name="collection_load_welcome_request_permissions_title">
+  <string
+      name="collection_load_welcome_request_permissions_title"
+      >
     Welcome to AnkiDroid!
   </string>
-  <string name="collection_load_welcome_request_permissions_details">
+  <string
+      name="collection_load_welcome_request_permissions_details"
+      >
     AnkiDroid requires storage permission, which we use exclusively to store your AnkiDroid collection, flashcard media and backups. Our code is open-source, written by volunteers, and trusted by millions.\n\nIf you have any questions, please access our in-app manual or visit our support forums.\n\nThank you for trying AnkiDroid!\n—AnkiDroid Development Team
   </string>
-  <string name="mutimedia_editor_assertion_failed">
+  <string
+      name="mutimedia_editor_assertion_failed"
+      >
     Unknown error occurred displaying Advanced Editor
   </string>
 
   <!-- Database Integrity Check -->
-  <string name="integrity_check_startup_title">
+  <string
+      name="integrity_check_startup_title"
+      >
     AnkiDroid Upgraded
   </string>
-  <string name="integrity_check_startup_content">
+  <string
+      name="integrity_check_startup_content"
+      >
     AnkiDroid has been upgraded. This upgrade includes fixes for possible database problems, and we advise you to run check database now.
   </string>
-  <string name="integrity_check_positive">
+  <string
+      name="integrity_check_positive"
+      >
     Check Database
   </string>
-  <string name="integrity_check_continue_anyway">
+  <string
+      name="integrity_check_continue_anyway"
+      >
     Continue Anyway
   </string>
-  <string name="integrity_check_insufficient_space">
+  <string
+      name="integrity_check_insufficient_space"
+      >
     Check Database uses a large amount of temporary storage.\n\nIt is strongly recommended that you have at least %s free space on your device before continuing.
   </string>
-  <string name="integrity_check_insufficient_space_extra_content">
+  <string
+      name="integrity_check_insufficient_space_extra_content"
+      >
     \n\nYou currently have %s free.
   </string>
-  <string name="integrity_check_fixed_no_home_deck">
+  <string
+      name="integrity_check_fixed_no_home_deck"
+      >
     %d cards with incorrect home decks were recovered. Please see the manual for more information.
   </string>
 
-  <string name="video_creation_error">
+  <string
+      name="video_creation_error"
+      >
     Could not play video
   </string>
 
   <!-- Card Browser -->
-  <string name="card_browser_deck_change_error">
+  <string
+      name="card_browser_deck_change_error"
+      >
     Could not change deck
   </string>
   <!-- AbstractFlashCardViewer -->
-  <string name="card_viewer_url_decode_error">
+  <string
+      name="card_viewer_url_decode_error"
+      >
     Error decoding data from card
   </string>
 
   <!-- Deck Options -->
-  <string name="deck_options_corrupt">
+  <string
+      name="deck_options_corrupt"
+      >
     Failed to process deck options: %s
   </string>
 
   <!-- Database Errors-->
-  <string name="database_locked_title">
+  <string
+      name="database_locked_title"
+      >
     Database Locked
   </string>
-  <string name="database_locked_summary">
+  <string
+      name="database_locked_summary"
+      >
     The AnkiDroid database is in use by another application. Please close the other application then reopen AnkiDroid.
   </string>
 
   <!-- Deck Picker Background-->
-  <string name="background_image_applied">
+  <string
+      name="background_image_applied"
+      >
     Background image applied
   </string>
-  <string name="background_image_removed">
+  <string
+      name="background_image_removed"
+      >
     Background image removed
   </string>
-  <string name="no_image_selected">
+  <string
+      name="no_image_selected"
+      >
     No image selected
   </string>
-  <string name="error_selecting_image">
+  <string
+      name="error_selecting_image"
+      >
     Error selecting image. Please see manual. %s
   </string>
-  <string name="error_deleting_image">
+  <string
+      name="error_deleting_image"
+      >
     Error deleting image
   </string>
-  <string name="failed_to_apply_background_image">
+  <string
+      name="failed_to_apply_background_image"
+      >
     Failed to apply background image %s
   </string>
-  <string name="background_image_too_large">
+  <string
+      name="background_image_too_large"
+      >
     Deck Picker background too large
   </string>
-  <string name="image_max_size_allowed">
+  <string
+      name="image_max_size_allowed"
+      >
     Maximum image size %d MB allowed
   </string>
   
   <!-- Global Intent handler -->
   <!-- Also used by Card Browser, not renaming to save translators effort -->
-  <string name="intent_handler_failed_no_storage_permission">
+  <string
+      name="intent_handler_failed_no_storage_permission"
+      >
     Missing required storage permission. Please grant storage permission then retry your action.
   </string>
 
   <!-- Browser Appearance -->
-  <string name="card_template_editor_card_browser_appearance_failed">
+  <string
+      name="card_template_editor_card_browser_appearance_failed"
+      >
     Could not load Card Browser Appearance
   </string>
 
   <!-- Boot Service -->
-  <string name="boot_service_failed_to_schedule_notifications">
+  <string
+      name="boot_service_failed_to_schedule_notifications"
+      >
     Failed to schedule reminders
   </string>
-  <string name="boot_service_too_many_notifications">
+  <string
+      name="boot_service_too_many_notifications"
+      >
     Too many reminders scheduled. Some will not appear
   </string>
 
   <!-- Locale Selection Dialog -->
-  <string name="locale_selection_dialog_title">
+  <string
+      name="locale_selection_dialog_title"
+      >
     Keyboard Hint Selection
   </string>
-  <string name="locale_selection_dialog_summary">
+  <string
+      name="locale_selection_dialog_summary"
+      >
     Some multilingual keyboards, such as GBoard support changing language when editing text\n\nPlease request the “setImeHintLocales” feature from your keyboard manufacturer if your keyboard does not change language.
   </string>
 
 
   <!--Sync-->
-  <plurals name="sync_automatic_sync_needs_more_time">
+  <plurals
+      name="sync_automatic_sync_needs_more_time"
+      >
     <item quantity="one">
       An automatic sync may be triggered in %d second
     </item>

--- a/AnkiDroid/src/main/res/values/04-network.xml
+++ b/AnkiDroid/src/main/res/values/04-network.xml
@@ -18,102 +18,280 @@
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 
---><resources>
+-->
+<resources>
 
-    <string name="youre_offline">You are offline</string>
-    <string name="sync_even_if_offline">Try Anyway</string>
-    <string name="sync_error">Sync error</string>
-    <string name="vague_error">Error</string>
-    <string name="retry">Retry</string>
-    <string name="cancel">Cancel</string>
+  <string name="youre_offline">
+    You are offline
+  </string>
+  <string name="sync_even_if_offline">
+    Try Anyway
+  </string>
+  <string name="sync_error">
+    Sync error
+  </string>
+  <string name="vague_error">
+    Error
+  </string>
+  <string name="retry">
+    Retry
+  </string>
+  <string name="cancel">Cancel</string>
+  <string name="terms_and_conditions">
+    <a href="https://ankiweb.net/account/terms">Terms and conditions</a>
+  </string>
+  <string name="menu_get_shared_decks">
+    Get shared decks
+  </string>
+  <string name="connection_error_message">
+    A network error has occurred
+  </string>
+  <string name="not_logged_in_title">
+    Log in to AnkiWeb
+  </string>
+  <string name="login_create_account_message">
+    You must log in to a third party account to use the cloud sync service. You can create one in the next step.
+  </string>
 
-    <string name="terms_and_conditions"><a href="https://ankiweb.net/account/terms">Terms and conditions</a></string>
-    <string name="menu_get_shared_decks">Get shared decks</string>
-    <string name="connection_error_message">A network error has occurred</string>
-    <string name="not_logged_in_title">Log in to AnkiWeb</string>
-    <string name="login_create_account_message">You must log in to a third party account to use the cloud sync service. You can create one in the next step.</string>
-
-    <!-- MyAccount.java -->
-    <string name="username">Email address</string>
-    <string name="username_repeat">Repeat email address</string>
-    <string name="password">Password</string>
-    <string name="password_repeat">Repeat password</string>
-    <string name="log_in">Log in</string>
-    <string name="sign_up_description">Don’t have an AnkiWeb account? It’s free!</string>
-    <string name="sign_up_not_affiliated">Note: AnkiWeb is not affiliated with AnkiDroid</string>
-    <string name="sign_up">Sign up</string>
-    <string name="logged_as">Logged in as</string>
-    <string name="log_out">Log out</string>
-    <string name="alert_logging_message">Logging in…</string>
-    <string name="invalid_username_password">Invalid email address or password</string>
-    <string name="reset_password">Reset password</string>
-
-    <!-- AndroidManifest.xml -->
-    <string name="downloaddeck_search">Search</string>
-    <string name="preferences_title">Preferences</string>
-    <string name="deckpreferences_title">Options for XXX</string>
-    <string name="sync_conflict_message">You must either upload this collection or download it from Ankiweb, as they can’t be merged. The collection on one side will be overwritten.</string>
-    <string name="sync_conflict_local">Upload</string>
-    <string name="sync_conflict_remote">Download</string>
-    <string name="sync_conflict_remote_confirm">Overwrite your local collection?</string>
-    <string name="sync_conflict_local_confirm">Overwrite your collection on the server?</string>
-    <string name="sync_prepare_syncing">Preparing syncing…</string>
-    <string name="sync_preparing_full_sync_message">Preparing full sync…</string>
-    <string name="sync_uploading_message">Uploading…</string>
-    <string name="sync_downloading_message">Downloading…</string>
-    <string name="sync_title">Synchronization</string>
-    <string name="sync_downloading_media">Downloading media %1$d/%2$d…</string>
-    <string name="sync_log_uploading_message">Full sync from local</string>
-    <string name="sync_log_downloading_message">Full sync from server</string>
-    <string name="sync_log_clocks_unsynchronized">Your clock’s off by %1$d seconds%2$s. Make sure that the date, time, and timezone on your phone are set correctly, then sync again.</string>
-    <string name="sync_log_clocks_unsynchronized_tz">, the time zone’s possibly wrong</string>
-    <string name="sync_log_clocks_unsynchronized_date">, the date’s possibly wrong</string>
-    <string name="sync_conflict_title">Syncing conflict</string>
-    <string name="sync_no_changes_message">No changes found</string>
-    <string name="sync_database_acknowledge">Collection synchronized</string>
-    <string name="sync_log_error_specific">Syncing error, type: %1$s, message: %2$s</string>
-    <string name="sync_corrupt_database">Your database is corrupt. Please fix it before trying again to sync.\n\nSee %s for information about repairing your database.</string>
-    <string name="sync_too_busy">Server busy. Try again later.</string>
-    <string name="sync_remote_db_error">The downloaded database was corrupt. Please try again.</string>
-    <string name="sync_overwrite_error">Your current collection couldn’t be overwritten by the downloaded file</string>
-    <string name="sync_connection_error">Connection timed out. Either your internet connection is experiencing problems, or you have a very large file in your media folder.</string>
-    <string name="sync_write_access_error">The downloaded file couldn’t be saved to the SD card. Either the card is mounted read-only or there isn’t enough space.</string>
-    <string name="sync_deletions_message">Syncing deletions…</string>
-    <string name="sync_small_objects_message">Syncing small objects…</string>
-    <string name="sync_finish_message">Finishing syncing…</string>
-    <string name="sync_log_finish_error">Error while sending finish direction to server</string>
-    <string name="sync_writing_db">Writing changes into database…</string>
-    <string name="sync_download_chunk">Downloading changes…</string>
-    <string name="sync_upload_chunk">Uploading changes…</string>
-    <string name="sync_up_down_size">Up: %1$d KB, down: %2$d KB</string>
-    <string name="sync_generic_error">An error has occurred. Try again later.</string>
-    <string name="sync_check_upload_file">Checking file before upload…</string>
-    <string name="sync_check_download_file">Checking downloaded file…</string>
-    <string name="sync_media_find">Finding changed media…</string>
-    <string name="sync_media_no_changes">No changes to media files</string>
-    <string name="sync_media_success">Media synced</string>
-    <string name="sync_media_changes_count">%d media changes to upload</string>
-    <string name="sync_media_downloaded_count">%d media files downloaded</string>
-    <string name="sync_sanity_failed">After syncing, the collection was in an inconsistent state. To fix this problem, AnkiDroid will force a full sync. Choose which side you would like to keep.</string>
-    <string name="sync_media_sanity_failed">Media sync completed, but the media count doesn’t agree with the server. The next media sync will be full to correct any error.</string>
-    <string name="sync_media_db_error">Media sync failed because current database is corrupt. A media check is recommended.</string>
-    <string name="sync_media_error">Error syncing media data</string>
-    <string name="sync_media_error_check">Error while syncing media. A media check is recommended.</string>
-    <string name="sync_sanity_local">Local</string>
-    <string name="sync_sanity_remote">Remote</string>
-    <string name="force_full_sync_title">Force full sync</string>
-    <string name="force_full_sync_summary">On next sync, force changes in one direction</string>
-    <string name="full_sync_confirmation">The requested change will require a full upload of the database when you next synchronize your collection. If you have reviews or other changes waiting on another device that haven’t been synchronized here yet, they will be lost. Continue?</string>
-    <string name="full_sync_confirmation_upgrade">Due to a bug in the previously installed version of AnkiDroid, it’s recommended to force a full sync.</string>
-    <string name="sync_error_407_proxy_required">Proxy authentication required.</string>
-    <string name="sync_error_409">Only one client can access AnkiWeb at a time. If a previous sync failed, please try again in a few minutes.</string>
-    <string name="sync_error_413_collection_size">Your collection or a media file is too large to sync.</string>
-    <string name="sync_error_500_unknown">AnkiWeb encountered an error. Please try again in a few minutes, and if the problem persists, please file a bug report.</string>
-    <string name="sync_error_501_upgrade_required">Please upgrade to the latest version of AnkiDroid</string>
-    <string name="sync_error_502_maintenance">AnkiWeb is under maintenance. Please try again in a few minutes.</string>
-    <string name="sync_error_504_gateway_timeout">504 gateway timeout error received.</string>
-    <!-- Deck Picker Sync Icon -->
-    <string name="sync_menu_title">Sync</string>
-    <string name="sync_menu_title_full_sync">Sync (full)</string>
-    <string name="sync_menu_title_no_account">Sync (log in)</string>
+  <!-- MyAccount.java -->
+  <string name="username">
+    Email address
+  </string>
+  <string name="username_repeat">
+    Repeat email address
+  </string>
+  <string name="password">
+    Password
+  </string>
+  <string name="password_repeat">
+    Repeat password
+  </string>
+  <string name="log_in">
+    Log in
+  </string>
+  <string name="sign_up_description">
+    Don’t have an AnkiWeb account? It’s free!
+  </string>
+  <string name="sign_up_not_affiliated">
+    Note: AnkiWeb is not affiliated with AnkiDroid
+  </string>
+  <string name="sign_up">
+    Sign up
+  </string>
+  <string name="logged_as">
+    Logged in as
+  </string>
+  <string name="log_out">
+    Log out
+  </string>
+  <string name="alert_logging_message">
+    Logging in…
+  </string>
+  <string name="invalid_username_password">
+    Invalid email address or password
+  </string>
+  <string name="reset_password">
+    Reset password
+  </string>
+  <!-- AndroidManifest.xml -->
+  <string name="downloaddeck_search">
+    Search
+  </string>
+  <string name="preferences_title">
+    Preferences
+  </string>
+  <string name="deckpreferences_title">
+    Options for XXX
+  </string>
+  <string name="sync_conflict_message">
+    You must either upload this collection or download it from Ankiweb, as they can’t be merged. The collection on one
+    side will be overwritten.
+  </string>
+  <string name="sync_conflict_local">
+    Upload
+  </string>
+  <string name="sync_conflict_remote">
+    Download
+  </string>
+  <string name="sync_conflict_remote_confirm">
+    Overwrite your local collection?
+  </string>
+  <string name="sync_conflict_local_confirm">
+    Overwrite your collection on the server?
+  </string>
+  <string name="sync_prepare_syncing">
+    Preparing syncing…
+  </string>
+  <string name="sync_preparing_full_sync_message">
+    Preparing full sync…
+  </string>
+  <string name="sync_uploading_message">
+    Uploading…
+  </string>
+  <string name="sync_downloading_message">
+    Downloading…
+  </string>
+  <string name="sync_title">
+    Synchronization
+  </string>
+  <string name="sync_downloading_media">
+    Downloading media %1$d/%2$d…
+  </string>
+  <string name="sync_log_uploading_message">
+    Full sync from local
+  </string>
+  <string name="sync_log_downloading_message">
+    Full sync from server
+  </string>
+  <string name="sync_log_clocks_unsynchronized">
+    Your clock’s off by %1$d seconds%2$s. Make sure that the date, time, and timezone on your phone are set correctly, then sync again.
+  </string>
+  <string name="sync_log_clocks_unsynchronized_tz">
+    , the time zone’s possibly wrong
+  </string>
+  <string name="sync_log_clocks_unsynchronized_date">
+    , the date’s possibly wrong
+  </string>
+  <string name="sync_conflict_title">
+    Syncing conflict
+  </string>
+  <string name="sync_no_changes_message">
+    No changes found
+  </string>
+  <string name="sync_database_acknowledge">
+    Collection synchronized
+  </string>
+  <string name="sync_log_error_specific">
+    Syncing error, type: %1$s, message: %2$s
+  </string>
+  <string name="sync_corrupt_database">
+    Your database is corrupt. Please fix it before trying again to sync.\n\nSee %s for information about repairing your database.
+  </string>
+  <string name="sync_too_busy">
+    Server busy. Try again later.
+  </string>
+  <string name="sync_remote_db_error">
+    The downloaded database was corrupt. Please try again.
+  </string>
+  <string name="sync_overwrite_error">
+    Your current collection couldn’t be overwritten by the downloaded file
+  </string>
+  <string name="sync_connection_error">
+    Connection timed out. Either your internet connection is experiencing problems, or you have a very large file in your media folder.
+  </string>
+  <string name="sync_write_access_error">
+    The downloaded file couldn’t be saved to the SD card. Either the card is mounted read-only or there isn’t enough space.
+  </string>
+  <string name="sync_deletions_message">
+    Syncing deletions…
+  </string>
+  <string name="sync_small_objects_message">
+    Syncing small objects…
+  </string>
+  <string name="sync_finish_message">
+    Finishing syncing…
+  </string>
+  <string name="sync_log_finish_error">
+    Error while sending finish direction to server
+  </string>
+  <string name="sync_writing_db">
+    Writing changes into database…
+  </string>
+  <string name="sync_download_chunk">
+    Downloading changes…
+  </string>
+  <string name="sync_upload_chunk">
+    Uploading changes…
+  </string>
+  <string name="sync_up_down_size">
+    Up: %1$d KB, down: %2$d KB
+  </string>
+  <string name="sync_generic_error">
+    An error has occurred. Try again later.
+  </string>
+  <string name="sync_check_upload_file">
+    Checking file before upload…
+  </string>
+  <string name="sync_check_download_file">
+    Checking downloaded file…
+  </string>
+  <string name="sync_media_find">
+    Finding changed media…
+  </string>
+  <string name="sync_media_no_changes">
+    No changes to media files
+  </string>
+  <string name="sync_media_success">
+    Media synced
+  </string>
+  <string name="sync_media_changes_count">
+    %d media changes to upload
+  </string>
+  <string name="sync_media_downloaded_count">
+    %d media files downloaded
+  </string>
+  <string name="sync_sanity_failed">
+    After syncing, the collection was in an inconsistent state. To fix this problem, AnkiDroid will force a full sync. Choose which side you would like to keep.
+  </string>
+  <string name="sync_media_sanity_failed">
+    Media sync completed, but the media count doesn’t agree with the server. The next media sync will be full to correct any error.
+  </string>
+  <string name="sync_media_db_error">
+    Media sync failed because current database is corrupt. A media check is recommended.
+  </string>
+  <string name="sync_media_error">
+    Error syncing media data
+  </string>
+  <string name="sync_media_error_check">
+    Error while syncing media. A media check is recommended.
+  </string>
+  <string name="sync_sanity_local">
+    Local
+  </string>
+  <string name="sync_sanity_remote">
+    Remote
+  </string>
+  <string name="force_full_sync_title">
+    Force full sync
+  </string>
+  <string name="force_full_sync_summary">
+    On next sync, force changes in one direction
+  </string>
+  <string name="full_sync_confirmation">
+    The requested change will require a full upload of the database when you next synchronize your collection. If you have reviews or other changes waiting on another device that haven’t been synchronized here yet, they will be lost. Continue?
+  </string>
+  <string name="full_sync_confirmation_upgrade">
+    Due to a bug in the previously installed version of AnkiDroid, it’s recommended to force a full sync.
+  </string>
+  <string name="sync_error_407_proxy_required">
+    Proxy authentication required.
+  </string>
+  <string name="sync_error_409">
+    Only one client can access AnkiWeb at a time. If a previous sync failed, please try again in a few minutes.
+  </string>
+  <string name="sync_error_413_collection_size">
+    Your collection or a media file is too large to sync.
+  </string>
+  <string name="sync_error_500_unknown">
+    AnkiWeb encountered an error. Please try again in a few minutes, and if the problem persists, please file a bug report.
+  </string>
+  <string name="sync_error_501_upgrade_required">
+    Please upgrade to the latest version of AnkiDroid
+  </string>
+  <string name="sync_error_502_maintenance">
+    AnkiWeb is under maintenance. Please try again in a few minutes.
+  </string>
+  <string name="sync_error_504_gateway_timeout">
+    504 gateway timeout error received.
+  </string>
+  <!-- Deck Picker Sync Icon -->
+  <string name="sync_menu_title">
+    Sync
+  </string>
+  <string name="sync_menu_title_full_sync">
+    Sync (full)
+  </string>
+  <string name="sync_menu_title_no_account">
+    Sync (log in)
+  </string>
 </resources>

--- a/AnkiDroid/src/main/res/values/04-network.xml
+++ b/AnkiDroid/src/main/res/values/04-network.xml
@@ -23,54 +23,65 @@
 
   <string
       name="youre_offline"
+      comment="."
       >
     You are offline
   </string>
   <string
       name="sync_even_if_offline"
+      comment="."
       >
     Try Anyway
   </string>
   <string
       name="sync_error"
+      comment="."
       >
     Sync error
   </string>
   <string
       name="vague_error"
+      comment="."
       >
     Error
   </string>
   <string
       name="retry"
+      comment="."
       >
     Retry
   </string>
   <string
       name="cancel"
+      comment="."
       >Cancel</string>
   <string
       name="terms_and_conditions"
+      comment="."
       >
     <a href="https://ankiweb.net/account/terms">Terms and conditions</a>
   </string>
   <string
       name="menu_get_shared_decks"
+      comment="."
       >
     Get shared decks
   </string>
   <string
       name="connection_error_message"
+      comment="."
       >
     A network error has occurred
   </string>
   <string
       name="not_logged_in_title"
+      comment="."
       >
     Log in to AnkiWeb
   </string>
   <string
       name="login_create_account_message"
+      comment="."
       >
     You must log in to a third party account to use the cloud sync service. You can create one in the next step.
   </string>
@@ -78,399 +89,478 @@
   <!-- MyAccount.java -->
   <string
       name="username"
+      comment="."
       >
     Email address
   </string>
   <string
       name="username_repeat"
+      comment="."
       >
     Repeat email address
   </string>
   <string
       name="password"
+      comment="."
       >
     Password
   </string>
   <string
       name="password_repeat"
+      comment="."
       >
     Repeat password
   </string>
   <string
       name="log_in"
+      comment="."
       >
     Log in
   </string>
   <string
       name="sign_up_description"
+      comment="."
       >
     Don’t have an AnkiWeb account? It’s free!
   </string>
   <string
       name="sign_up_not_affiliated"
+      comment="."
       >
     Note: AnkiWeb is not affiliated with AnkiDroid
   </string>
   <string
       name="sign_up"
+      comment="."
       >
     Sign up
   </string>
   <string
       name="logged_as"
+      comment="."
       >
     Logged in as
   </string>
   <string
       name="log_out"
+      comment="."
       >
     Log out
   </string>
   <string
       name="alert_logging_message"
+      comment="."
       >
     Logging in…
   </string>
   <string
       name="invalid_username_password"
+      comment="."
       >
     Invalid email address or password
   </string>
   <string
       name="reset_password"
+      comment="."
       >
     Reset password
   </string>
   <!-- AndroidManifest.xml -->
   <string
       name="downloaddeck_search"
+      comment="."
       >
     Search
   </string>
   <string
       name="preferences_title"
+      comment="."
       >
     Preferences
   </string>
   <string
       name="deckpreferences_title"
+      comment="."
       >
     Options for XXX
   </string>
   <string
       name="sync_conflict_message"
+      comment="."
       >
     You must either upload this collection or download it from Ankiweb, as they can’t be merged. The collection on one
     side will be overwritten.
   </string>
   <string
       name="sync_conflict_local"
+      comment="."
       >
     Upload
   </string>
   <string
       name="sync_conflict_remote"
+      comment="."
       >
     Download
   </string>
   <string
       name="sync_conflict_remote_confirm"
+      comment="."
       >
     Overwrite your local collection?
   </string>
   <string
       name="sync_conflict_local_confirm"
+      comment="."
       >
     Overwrite your collection on the server?
   </string>
   <string
       name="sync_prepare_syncing"
+      comment="."
       >
     Preparing syncing…
   </string>
   <string
       name="sync_preparing_full_sync_message"
+      comment="."
       >
     Preparing full sync…
   </string>
   <string
       name="sync_uploading_message"
+      comment="."
       >
     Uploading…
   </string>
   <string
       name="sync_downloading_message"
+      comment="."
       >
     Downloading…
   </string>
   <string
       name="sync_title"
+      comment="."
       >
     Synchronization
   </string>
   <string
       name="sync_downloading_media"
+      comment="."
       >
     Downloading media %1$d/%2$d…
   </string>
   <string
       name="sync_log_uploading_message"
+      comment="."
       >
     Full sync from local
   </string>
   <string
       name="sync_log_downloading_message"
+      comment="."
       >
     Full sync from server
   </string>
   <string
       name="sync_log_clocks_unsynchronized"
+      comment="."
       >
     Your clock’s off by %1$d seconds%2$s. Make sure that the date, time, and timezone on your phone are set correctly, then sync again.
   </string>
   <string
       name="sync_log_clocks_unsynchronized_tz"
+      comment="."
       >
     , the time zone’s possibly wrong
   </string>
   <string
       name="sync_log_clocks_unsynchronized_date"
+      comment="."
       >
     , the date’s possibly wrong
   </string>
   <string
       name="sync_conflict_title"
+      comment="."
       >
     Syncing conflict
   </string>
   <string
       name="sync_no_changes_message"
+      comment="."
       >
     No changes found
   </string>
   <string
       name="sync_database_acknowledge"
+      comment="."
       >
     Collection synchronized
   </string>
   <string
       name="sync_log_error_specific"
+      comment="."
       >
     Syncing error, type: %1$s, message: %2$s
   </string>
   <string
       name="sync_corrupt_database"
+      comment="."
       >
     Your database is corrupt. Please fix it before trying again to sync.\n\nSee %s for information about repairing your database.
   </string>
   <string
       name="sync_too_busy"
+      comment="."
       >
     Server busy. Try again later.
   </string>
   <string
       name="sync_remote_db_error"
+      comment="."
       >
     The downloaded database was corrupt. Please try again.
   </string>
   <string
       name="sync_overwrite_error"
+      comment="."
       >
     Your current collection couldn’t be overwritten by the downloaded file
   </string>
   <string
       name="sync_connection_error"
+      comment="."
       >
     Connection timed out. Either your internet connection is experiencing problems, or you have a very large file in your media folder.
   </string>
   <string
       name="sync_write_access_error"
+      comment="."
       >
     The downloaded file couldn’t be saved to the SD card. Either the card is mounted read-only or there isn’t enough space.
   </string>
   <string
       name="sync_deletions_message"
+      comment="."
       >
     Syncing deletions…
   </string>
   <string
       name="sync_small_objects_message"
+      comment="."
       >
     Syncing small objects…
   </string>
   <string
       name="sync_finish_message"
+      comment="."
       >
     Finishing syncing…
   </string>
   <string
       name="sync_log_finish_error"
+      comment="."
       >
     Error while sending finish direction to server
   </string>
   <string
       name="sync_writing_db"
+      comment="."
       >
     Writing changes into database…
   </string>
   <string
       name="sync_download_chunk"
+      comment="."
       >
     Downloading changes…
   </string>
   <string
       name="sync_upload_chunk"
+      comment="."
       >
     Uploading changes…
   </string>
   <string
       name="sync_up_down_size"
+      comment="."
       >
     Up: %1$d KB, down: %2$d KB
   </string>
   <string
       name="sync_generic_error"
+      comment="."
       >
     An error has occurred. Try again later.
   </string>
   <string
       name="sync_check_upload_file"
+      comment="."
       >
     Checking file before upload…
   </string>
   <string
       name="sync_check_download_file"
+      comment="."
       >
     Checking downloaded file…
   </string>
   <string
       name="sync_media_find"
+      comment="."
       >
     Finding changed media…
   </string>
   <string
       name="sync_media_no_changes"
+      comment="."
       >
     No changes to media files
   </string>
   <string
       name="sync_media_success"
+      comment="."
       >
     Media synced
   </string>
   <string
       name="sync_media_changes_count"
+      comment="."
       >
     %d media changes to upload
   </string>
   <string
       name="sync_media_downloaded_count"
+      comment="."
       >
     %d media files downloaded
   </string>
   <string
       name="sync_sanity_failed"
+      comment="."
       >
     After syncing, the collection was in an inconsistent state. To fix this problem, AnkiDroid will force a full sync. Choose which side you would like to keep.
   </string>
   <string
       name="sync_media_sanity_failed"
+      comment="."
       >
     Media sync completed, but the media count doesn’t agree with the server. The next media sync will be full to correct any error.
   </string>
   <string
       name="sync_media_db_error"
+      comment="."
       >
     Media sync failed because current database is corrupt. A media check is recommended.
   </string>
   <string
       name="sync_media_error"
+      comment="."
       >
     Error syncing media data
   </string>
   <string
       name="sync_media_error_check"
+      comment="."
       >
     Error while syncing media. A media check is recommended.
   </string>
   <string
       name="sync_sanity_local"
+      comment="."
       >
     Local
   </string>
   <string
       name="sync_sanity_remote"
+      comment="."
       >
     Remote
   </string>
   <string
       name="force_full_sync_title"
+      comment="."
       >
     Force full sync
   </string>
   <string
       name="force_full_sync_summary"
+      comment="."
       >
     On next sync, force changes in one direction
   </string>
   <string
       name="full_sync_confirmation"
+      comment="."
       >
     The requested change will require a full upload of the database when you next synchronize your collection. If you have reviews or other changes waiting on another device that haven’t been synchronized here yet, they will be lost. Continue?
   </string>
   <string
       name="full_sync_confirmation_upgrade"
+      comment="."
       >
     Due to a bug in the previously installed version of AnkiDroid, it’s recommended to force a full sync.
   </string>
   <string
       name="sync_error_407_proxy_required"
+      comment="."
       >
     Proxy authentication required.
   </string>
   <string
       name="sync_error_409"
+      comment="."
       >
     Only one client can access AnkiWeb at a time. If a previous sync failed, please try again in a few minutes.
   </string>
   <string
       name="sync_error_413_collection_size"
+      comment="."
       >
     Your collection or a media file is too large to sync.
   </string>
   <string
       name="sync_error_500_unknown"
+      comment="."
       >
     AnkiWeb encountered an error. Please try again in a few minutes, and if the problem persists, please file a bug report.
   </string>
   <string
       name="sync_error_501_upgrade_required"
+      comment="."
       >
     Please upgrade to the latest version of AnkiDroid
   </string>
   <string
       name="sync_error_502_maintenance"
+      comment="."
       >
     AnkiWeb is under maintenance. Please try again in a few minutes.
   </string>
   <string
       name="sync_error_504_gateway_timeout"
+      comment="."
       >
     504 gateway timeout error received.
   </string>
   <!-- Deck Picker Sync Icon -->
   <string
       name="sync_menu_title"
+      comment="."
       >
     Sync
   </string>
   <string
       name="sync_menu_title_full_sync"
+      comment="."
       >
     Sync (full)
   </string>
   <string
       name="sync_menu_title_no_account"
+      comment="."
       >
     Sync (log in)
   </string>

--- a/AnkiDroid/src/main/res/values/04-network.xml
+++ b/AnkiDroid/src/main/res/values/04-network.xml
@@ -21,277 +21,457 @@
 -->
 <resources>
 
-  <string name="youre_offline">
+  <string
+      name="youre_offline"
+      >
     You are offline
   </string>
-  <string name="sync_even_if_offline">
+  <string
+      name="sync_even_if_offline"
+      >
     Try Anyway
   </string>
-  <string name="sync_error">
+  <string
+      name="sync_error"
+      >
     Sync error
   </string>
-  <string name="vague_error">
+  <string
+      name="vague_error"
+      >
     Error
   </string>
-  <string name="retry">
+  <string
+      name="retry"
+      >
     Retry
   </string>
-  <string name="cancel">Cancel</string>
-  <string name="terms_and_conditions">
+  <string
+      name="cancel"
+      >Cancel</string>
+  <string
+      name="terms_and_conditions"
+      >
     <a href="https://ankiweb.net/account/terms">Terms and conditions</a>
   </string>
-  <string name="menu_get_shared_decks">
+  <string
+      name="menu_get_shared_decks"
+      >
     Get shared decks
   </string>
-  <string name="connection_error_message">
+  <string
+      name="connection_error_message"
+      >
     A network error has occurred
   </string>
-  <string name="not_logged_in_title">
+  <string
+      name="not_logged_in_title"
+      >
     Log in to AnkiWeb
   </string>
-  <string name="login_create_account_message">
+  <string
+      name="login_create_account_message"
+      >
     You must log in to a third party account to use the cloud sync service. You can create one in the next step.
   </string>
 
   <!-- MyAccount.java -->
-  <string name="username">
+  <string
+      name="username"
+      >
     Email address
   </string>
-  <string name="username_repeat">
+  <string
+      name="username_repeat"
+      >
     Repeat email address
   </string>
-  <string name="password">
+  <string
+      name="password"
+      >
     Password
   </string>
-  <string name="password_repeat">
+  <string
+      name="password_repeat"
+      >
     Repeat password
   </string>
-  <string name="log_in">
+  <string
+      name="log_in"
+      >
     Log in
   </string>
-  <string name="sign_up_description">
+  <string
+      name="sign_up_description"
+      >
     Don’t have an AnkiWeb account? It’s free!
   </string>
-  <string name="sign_up_not_affiliated">
+  <string
+      name="sign_up_not_affiliated"
+      >
     Note: AnkiWeb is not affiliated with AnkiDroid
   </string>
-  <string name="sign_up">
+  <string
+      name="sign_up"
+      >
     Sign up
   </string>
-  <string name="logged_as">
+  <string
+      name="logged_as"
+      >
     Logged in as
   </string>
-  <string name="log_out">
+  <string
+      name="log_out"
+      >
     Log out
   </string>
-  <string name="alert_logging_message">
+  <string
+      name="alert_logging_message"
+      >
     Logging in…
   </string>
-  <string name="invalid_username_password">
+  <string
+      name="invalid_username_password"
+      >
     Invalid email address or password
   </string>
-  <string name="reset_password">
+  <string
+      name="reset_password"
+      >
     Reset password
   </string>
   <!-- AndroidManifest.xml -->
-  <string name="downloaddeck_search">
+  <string
+      name="downloaddeck_search"
+      >
     Search
   </string>
-  <string name="preferences_title">
+  <string
+      name="preferences_title"
+      >
     Preferences
   </string>
-  <string name="deckpreferences_title">
+  <string
+      name="deckpreferences_title"
+      >
     Options for XXX
   </string>
-  <string name="sync_conflict_message">
+  <string
+      name="sync_conflict_message"
+      >
     You must either upload this collection or download it from Ankiweb, as they can’t be merged. The collection on one
     side will be overwritten.
   </string>
-  <string name="sync_conflict_local">
+  <string
+      name="sync_conflict_local"
+      >
     Upload
   </string>
-  <string name="sync_conflict_remote">
+  <string
+      name="sync_conflict_remote"
+      >
     Download
   </string>
-  <string name="sync_conflict_remote_confirm">
+  <string
+      name="sync_conflict_remote_confirm"
+      >
     Overwrite your local collection?
   </string>
-  <string name="sync_conflict_local_confirm">
+  <string
+      name="sync_conflict_local_confirm"
+      >
     Overwrite your collection on the server?
   </string>
-  <string name="sync_prepare_syncing">
+  <string
+      name="sync_prepare_syncing"
+      >
     Preparing syncing…
   </string>
-  <string name="sync_preparing_full_sync_message">
+  <string
+      name="sync_preparing_full_sync_message"
+      >
     Preparing full sync…
   </string>
-  <string name="sync_uploading_message">
+  <string
+      name="sync_uploading_message"
+      >
     Uploading…
   </string>
-  <string name="sync_downloading_message">
+  <string
+      name="sync_downloading_message"
+      >
     Downloading…
   </string>
-  <string name="sync_title">
+  <string
+      name="sync_title"
+      >
     Synchronization
   </string>
-  <string name="sync_downloading_media">
+  <string
+      name="sync_downloading_media"
+      >
     Downloading media %1$d/%2$d…
   </string>
-  <string name="sync_log_uploading_message">
+  <string
+      name="sync_log_uploading_message"
+      >
     Full sync from local
   </string>
-  <string name="sync_log_downloading_message">
+  <string
+      name="sync_log_downloading_message"
+      >
     Full sync from server
   </string>
-  <string name="sync_log_clocks_unsynchronized">
+  <string
+      name="sync_log_clocks_unsynchronized"
+      >
     Your clock’s off by %1$d seconds%2$s. Make sure that the date, time, and timezone on your phone are set correctly, then sync again.
   </string>
-  <string name="sync_log_clocks_unsynchronized_tz">
+  <string
+      name="sync_log_clocks_unsynchronized_tz"
+      >
     , the time zone’s possibly wrong
   </string>
-  <string name="sync_log_clocks_unsynchronized_date">
+  <string
+      name="sync_log_clocks_unsynchronized_date"
+      >
     , the date’s possibly wrong
   </string>
-  <string name="sync_conflict_title">
+  <string
+      name="sync_conflict_title"
+      >
     Syncing conflict
   </string>
-  <string name="sync_no_changes_message">
+  <string
+      name="sync_no_changes_message"
+      >
     No changes found
   </string>
-  <string name="sync_database_acknowledge">
+  <string
+      name="sync_database_acknowledge"
+      >
     Collection synchronized
   </string>
-  <string name="sync_log_error_specific">
+  <string
+      name="sync_log_error_specific"
+      >
     Syncing error, type: %1$s, message: %2$s
   </string>
-  <string name="sync_corrupt_database">
+  <string
+      name="sync_corrupt_database"
+      >
     Your database is corrupt. Please fix it before trying again to sync.\n\nSee %s for information about repairing your database.
   </string>
-  <string name="sync_too_busy">
+  <string
+      name="sync_too_busy"
+      >
     Server busy. Try again later.
   </string>
-  <string name="sync_remote_db_error">
+  <string
+      name="sync_remote_db_error"
+      >
     The downloaded database was corrupt. Please try again.
   </string>
-  <string name="sync_overwrite_error">
+  <string
+      name="sync_overwrite_error"
+      >
     Your current collection couldn’t be overwritten by the downloaded file
   </string>
-  <string name="sync_connection_error">
+  <string
+      name="sync_connection_error"
+      >
     Connection timed out. Either your internet connection is experiencing problems, or you have a very large file in your media folder.
   </string>
-  <string name="sync_write_access_error">
+  <string
+      name="sync_write_access_error"
+      >
     The downloaded file couldn’t be saved to the SD card. Either the card is mounted read-only or there isn’t enough space.
   </string>
-  <string name="sync_deletions_message">
+  <string
+      name="sync_deletions_message"
+      >
     Syncing deletions…
   </string>
-  <string name="sync_small_objects_message">
+  <string
+      name="sync_small_objects_message"
+      >
     Syncing small objects…
   </string>
-  <string name="sync_finish_message">
+  <string
+      name="sync_finish_message"
+      >
     Finishing syncing…
   </string>
-  <string name="sync_log_finish_error">
+  <string
+      name="sync_log_finish_error"
+      >
     Error while sending finish direction to server
   </string>
-  <string name="sync_writing_db">
+  <string
+      name="sync_writing_db"
+      >
     Writing changes into database…
   </string>
-  <string name="sync_download_chunk">
+  <string
+      name="sync_download_chunk"
+      >
     Downloading changes…
   </string>
-  <string name="sync_upload_chunk">
+  <string
+      name="sync_upload_chunk"
+      >
     Uploading changes…
   </string>
-  <string name="sync_up_down_size">
+  <string
+      name="sync_up_down_size"
+      >
     Up: %1$d KB, down: %2$d KB
   </string>
-  <string name="sync_generic_error">
+  <string
+      name="sync_generic_error"
+      >
     An error has occurred. Try again later.
   </string>
-  <string name="sync_check_upload_file">
+  <string
+      name="sync_check_upload_file"
+      >
     Checking file before upload…
   </string>
-  <string name="sync_check_download_file">
+  <string
+      name="sync_check_download_file"
+      >
     Checking downloaded file…
   </string>
-  <string name="sync_media_find">
+  <string
+      name="sync_media_find"
+      >
     Finding changed media…
   </string>
-  <string name="sync_media_no_changes">
+  <string
+      name="sync_media_no_changes"
+      >
     No changes to media files
   </string>
-  <string name="sync_media_success">
+  <string
+      name="sync_media_success"
+      >
     Media synced
   </string>
-  <string name="sync_media_changes_count">
+  <string
+      name="sync_media_changes_count"
+      >
     %d media changes to upload
   </string>
-  <string name="sync_media_downloaded_count">
+  <string
+      name="sync_media_downloaded_count"
+      >
     %d media files downloaded
   </string>
-  <string name="sync_sanity_failed">
+  <string
+      name="sync_sanity_failed"
+      >
     After syncing, the collection was in an inconsistent state. To fix this problem, AnkiDroid will force a full sync. Choose which side you would like to keep.
   </string>
-  <string name="sync_media_sanity_failed">
+  <string
+      name="sync_media_sanity_failed"
+      >
     Media sync completed, but the media count doesn’t agree with the server. The next media sync will be full to correct any error.
   </string>
-  <string name="sync_media_db_error">
+  <string
+      name="sync_media_db_error"
+      >
     Media sync failed because current database is corrupt. A media check is recommended.
   </string>
-  <string name="sync_media_error">
+  <string
+      name="sync_media_error"
+      >
     Error syncing media data
   </string>
-  <string name="sync_media_error_check">
+  <string
+      name="sync_media_error_check"
+      >
     Error while syncing media. A media check is recommended.
   </string>
-  <string name="sync_sanity_local">
+  <string
+      name="sync_sanity_local"
+      >
     Local
   </string>
-  <string name="sync_sanity_remote">
+  <string
+      name="sync_sanity_remote"
+      >
     Remote
   </string>
-  <string name="force_full_sync_title">
+  <string
+      name="force_full_sync_title"
+      >
     Force full sync
   </string>
-  <string name="force_full_sync_summary">
+  <string
+      name="force_full_sync_summary"
+      >
     On next sync, force changes in one direction
   </string>
-  <string name="full_sync_confirmation">
+  <string
+      name="full_sync_confirmation"
+      >
     The requested change will require a full upload of the database when you next synchronize your collection. If you have reviews or other changes waiting on another device that haven’t been synchronized here yet, they will be lost. Continue?
   </string>
-  <string name="full_sync_confirmation_upgrade">
+  <string
+      name="full_sync_confirmation_upgrade"
+      >
     Due to a bug in the previously installed version of AnkiDroid, it’s recommended to force a full sync.
   </string>
-  <string name="sync_error_407_proxy_required">
+  <string
+      name="sync_error_407_proxy_required"
+      >
     Proxy authentication required.
   </string>
-  <string name="sync_error_409">
+  <string
+      name="sync_error_409"
+      >
     Only one client can access AnkiWeb at a time. If a previous sync failed, please try again in a few minutes.
   </string>
-  <string name="sync_error_413_collection_size">
+  <string
+      name="sync_error_413_collection_size"
+      >
     Your collection or a media file is too large to sync.
   </string>
-  <string name="sync_error_500_unknown">
+  <string
+      name="sync_error_500_unknown"
+      >
     AnkiWeb encountered an error. Please try again in a few minutes, and if the problem persists, please file a bug report.
   </string>
-  <string name="sync_error_501_upgrade_required">
+  <string
+      name="sync_error_501_upgrade_required"
+      >
     Please upgrade to the latest version of AnkiDroid
   </string>
-  <string name="sync_error_502_maintenance">
+  <string
+      name="sync_error_502_maintenance"
+      >
     AnkiWeb is under maintenance. Please try again in a few minutes.
   </string>
-  <string name="sync_error_504_gateway_timeout">
+  <string
+      name="sync_error_504_gateway_timeout"
+      >
     504 gateway timeout error received.
   </string>
   <!-- Deck Picker Sync Icon -->
-  <string name="sync_menu_title">
+  <string
+      name="sync_menu_title"
+      >
     Sync
   </string>
-  <string name="sync_menu_title_full_sync">
+  <string
+      name="sync_menu_title_full_sync"
+      >
     Sync (full)
   </string>
-  <string name="sync_menu_title_no_account">
+  <string
+      name="sync_menu_title_no_account"
+      >
     Sync (log in)
   </string>
 </resources>

--- a/AnkiDroid/src/main/res/values/05-feedback.xml
+++ b/AnkiDroid/src/main/res/values/05-feedback.xml
@@ -23,54 +23,65 @@
   <!-- Feedback.java -->
   <string
       name="empty_string"
+      comment="."
       />
   <string
       name="error_reporting_choice"
+      comment="."
       >
     Error reporting mode
   </string>
   <string
       name="feedback_disclaimer"
+      comment="."
       >
     Disclaimer: We don’t collect any personal information such as your email address, phone number, or your phone IMEI. We do collect some information about your device such as the manufacturer, model and version of Android, as well as the nature of reported errors themselves and the steps which led up to them occurring.
   </string>
   <string
       name="feedback_title"
+      comment="."
       >
     AnkiDroid Feedback
   </string>
   <string
       name="feedback_default_text"
+      comment="."
       >
     Enter your feedback or information about the nature of any errors you’re reporting.
   </string>
   <string
       name="feedback_auto_toast_text"
+      comment="."
       >
     AnkiDroid has encountered a problem; a report is being sent to the developers…
   </string>
   <string
       name="feedback_manual_toast_text"
+      comment="."
       >
     AnkiDroid has encountered a problem; a report is being generated…
   </string>
   <string
       name="feedback_copy_debug"
+      comment="."
       >
     Copy debug info
   </string>
   <string
       name="feedback_report"
+      comment="."
       >
     Report
   </string>
   <string
       name="feedback_report_automatically"
+      comment="."
       >
     Send error reports automatically
   </string>
   <string
       name="feedback_no_suitable_app_found"
+      comment="."
       >
     No suitable app found
   </string>

--- a/AnkiDroid/src/main/res/values/05-feedback.xml
+++ b/AnkiDroid/src/main/res/values/05-feedback.xml
@@ -20,16 +20,36 @@
 -->
 
 <resources>
-    <!-- Feedback.java -->
-    <string name="empty_string"/>
-    <string name="error_reporting_choice">Error reporting mode</string>
-    <string name="feedback_disclaimer">Disclaimer: We don’t collect any personal information such as your email address, phone number, or your phone IMEI. We do collect some information about your device such as the manufacturer, model and version of Android, as well as the nature of reported errors themselves and the steps which led up to them occurring.</string>
-    <string name="feedback_title">AnkiDroid Feedback</string>
-    <string name="feedback_default_text">Enter your feedback or information about the nature of any errors you’re reporting.</string>
-    <string name="feedback_auto_toast_text">AnkiDroid has encountered a problem; a report is being sent to the developers…</string>
-    <string name="feedback_manual_toast_text">AnkiDroid has encountered a problem; a report is being generated…</string>
-    <string name="feedback_copy_debug">Copy debug info</string>
-    <string name="feedback_report">Report</string>
-    <string name="feedback_report_automatically">Send error reports automatically</string>
-    <string name="feedback_no_suitable_app_found">No suitable app found</string>
+  <!-- Feedback.java -->
+  <string name="empty_string"/>
+  <string name="error_reporting_choice">
+    Error reporting mode
+  </string>
+  <string name="feedback_disclaimer">
+    Disclaimer: We don’t collect any personal information such as your email address, phone number, or your phone IMEI. We do collect some information about your device such as the manufacturer, model and version of Android, as well as the nature of reported errors themselves and the steps which led up to them occurring.
+  </string>
+  <string name="feedback_title">
+    AnkiDroid Feedback
+  </string>
+  <string name="feedback_default_text">
+    Enter your feedback or information about the nature of any errors you’re reporting.
+  </string>
+  <string name="feedback_auto_toast_text">
+    AnkiDroid has encountered a problem; a report is being sent to the developers…
+  </string>
+  <string name="feedback_manual_toast_text">
+    AnkiDroid has encountered a problem; a report is being generated…
+  </string>
+  <string name="feedback_copy_debug">
+    Copy debug info
+  </string>
+  <string name="feedback_report">
+    Report
+  </string>
+  <string name="feedback_report_automatically">
+    Send error reports automatically
+  </string>
+  <string name="feedback_no_suitable_app_found">
+    No suitable app found
+  </string>
 </resources>

--- a/AnkiDroid/src/main/res/values/05-feedback.xml
+++ b/AnkiDroid/src/main/res/values/05-feedback.xml
@@ -21,35 +21,57 @@
 
 <resources>
   <!-- Feedback.java -->
-  <string name="empty_string"/>
-  <string name="error_reporting_choice">
+  <string
+      name="empty_string"
+      />
+  <string
+      name="error_reporting_choice"
+      >
     Error reporting mode
   </string>
-  <string name="feedback_disclaimer">
+  <string
+      name="feedback_disclaimer"
+      >
     Disclaimer: We don’t collect any personal information such as your email address, phone number, or your phone IMEI. We do collect some information about your device such as the manufacturer, model and version of Android, as well as the nature of reported errors themselves and the steps which led up to them occurring.
   </string>
-  <string name="feedback_title">
+  <string
+      name="feedback_title"
+      >
     AnkiDroid Feedback
   </string>
-  <string name="feedback_default_text">
+  <string
+      name="feedback_default_text"
+      >
     Enter your feedback or information about the nature of any errors you’re reporting.
   </string>
-  <string name="feedback_auto_toast_text">
+  <string
+      name="feedback_auto_toast_text"
+      >
     AnkiDroid has encountered a problem; a report is being sent to the developers…
   </string>
-  <string name="feedback_manual_toast_text">
+  <string
+      name="feedback_manual_toast_text"
+      >
     AnkiDroid has encountered a problem; a report is being generated…
   </string>
-  <string name="feedback_copy_debug">
+  <string
+      name="feedback_copy_debug"
+      >
     Copy debug info
   </string>
-  <string name="feedback_report">
+  <string
+      name="feedback_report"
+      >
     Report
   </string>
-  <string name="feedback_report_automatically">
+  <string
+      name="feedback_report_automatically"
+      >
     Send error reports automatically
   </string>
-  <string name="feedback_no_suitable_app_found">
+  <string
+      name="feedback_no_suitable_app_found"
+      >
     No suitable app found
   </string>
 </resources>

--- a/AnkiDroid/src/main/res/values/06-statistics.xml
+++ b/AnkiDroid/src/main/res/values/06-statistics.xml
@@ -351,13 +351,16 @@
   <string-array
       name="due_x_axis_title"
       >
-    <item>
+    <item
+        >
       Days
     </item>
-    <item>
+    <item
+        >
       Weeks
     </item>
-    <item>
+    <item
+        >
       Months
     </item>
   </string-array>
@@ -420,121 +423,156 @@
   <string-array
       name="stats_day_time_strings"
       >
-    <item>
+    <item
+        >
       4AM
     </item>
-    <item>
+    <item
+        >
       10AM
     </item>
-    <item>
+    <item
+        >
       4PM
     </item>
-    <item>
+    <item
+        >
       10PM
     </item>
-    <item>
+    <item
+        >
       3AM
     </item>
   </string-array>
   <string-array
       name="stats_week_days"
       >
-    <item>
+    <item
+        >
       Sun
     </item>
-    <item>
+    <item
+        >
       Mon
     </item>
-    <item>
+    <item
+        >
       Tue
     </item>
-    <item>
+    <item
+        >
       Wed
     </item>
-    <item>
+    <item
+        >
       Thu
     </item>
-    <item>
+    <item
+        >
       Fri
     </item>
-    <item>
+    <item
+        >
       Sat
     </item>
   </string-array>
   <string-array
       name="stats_eases_ticks"
       >
-    <item>
+    <item
+        >
       1
     </item>
-    <item>
+    <item
+        >
       2
     </item>
-    <item>
+    <item
+        >
       3
     </item>
-    <item>
+    <item
+        >
       1
     </item>
-    <item>
+    <item
+        >
       2
     </item>
-    <item>
+    <item
+        >
       3
     </item>
-    <item>
+    <item
+        >
       4
     </item>
-    <item>
+    <item
+        >
       1
     </item>
-    <item>
+    <item
+        >
       2
     </item>
-    <item>
+    <item
+        >
       3
     </item>
-    <item>
+    <item
+        >
       4
     </item>
   </string-array>
   <string-array
       name="stats_eases_ticks_schedv2"
       >
-    <item>
+    <item
+        >
       1
     </item>
-    <item>
+    <item
+        >
       2
     </item>
-    <item>
+    <item
+        >
       3
     </item>
-    <item>
+    <item
+        >
       4
     </item>
-    <item>
+    <item
+        >
       1
     </item>
-    <item>
+    <item
+        >
       2
     </item>
-    <item>
+    <item
+        >
       3
     </item>
-    <item>
+    <item
+        >
       4
     </item>
-    <item>
+    <item
+        >
       1
     </item>
-    <item>
+    <item
+        >
       2
     </item>
-    <item>
+    <item
+        >
       3
     </item>
-    <item>
+    <item
+        >
       4
     </item>
   </string-array>

--- a/AnkiDroid/src/main/res/values/06-statistics.xml
+++ b/AnkiDroid/src/main/res/values/06-statistics.xml
@@ -17,143 +17,374 @@
 ~
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
---><resources>
-    <string name="statistics_young">Young</string>
-    <string name="statistics_mature">Mature</string>
-    <string name="statistics_young_and_learn">Young+Learn</string>
-    <string name="statistics_unlearned">Unseen</string>
-    <string name="statistics_suspended_and_buried">Suspended+Buried</string>
-    <string name="statistics_relearn">Relearn</string>
-    <string name="statistics_learn">Learn</string>
-    <string name="statistics_cram">Cram</string>
-    <string name="stats_cards">Cards</string>
-    <string name="stats_cards_intervals">Cards with given interval</string>
-    <string name="stats_cumulative_cards">Cumulative cards</string>
-    <string name="stats_cumulative_answers">Cumulative answers</string>
-    <string name="stats_cumulative_time_minutes">Cumulative minutes</string>
-    <string name="stats_cumulative_time_hours">Cumulative hours</string>
-    <string name="stats_cumulative">Cumulative</string>
-    <string name="stats_cumulative_percentage">Cumulative percentage</string>
-    <string formatted="false" name="stats_cumulative_correct_percentage">Cumulative correct %</string>
-    <string name="stats_answers">Answers</string>
-    <string name="stats_minutes">Minutes</string>
-    <string name="stats_hours">Hours</string>
-    <string name="stats_percentage">Percentage</string>
-    <string name="stats_period_month">1 month</string>
-    <string name="stats_period_year">1 year</string>
-    <string name="stats_period_lifetime">deck life</string>
-    <string name="stats_deck_collection">collection</string>
-    <string name="stats_time_of_day">Time of day</string>
-    <string name="stats_day_of_week">Day of week</string>
-    <string formatted="false" name="stats_percentage_correct">% correct</string>
-    <string name="stats_reviews">Reviews</string>
-    <string name="stats_answer_type">Answer type</string>
-    <string name="stats_today_again_count">Again count: &lt;b&gt;%d&lt;/b&gt;</string>
-    <string name="stats_today_correct_count">(&lt;b&gt;%.1f%%&lt;/b&gt; correct)</string>
-    <string name="stats_today_type_breakdown">Learn: &lt;b&gt;%1$d&lt;/b&gt;, review: &lt;b&gt;%2$d&lt;/b&gt;, relearn: &lt;b&gt;%3$d&lt;/b&gt;, filtered: &lt;b&gt;%4$d&lt;/b&gt;</string>
-    <string name="stats_today_mature_cards">Correct answers on mature cards: %1$d/%2$d (%3$.1f%%)</string>
-    <string name="stats_today_no_mature_cards">No mature cards were studied today</string>
+-->
+<resources>
+  <string name="statistics_young">
+    Young
+  </string>
+  <string name="statistics_mature">
+    Mature
+  </string>
+  <string name="statistics_young_and_learn">
+    Young+Learn
+  </string>
+  <string name="statistics_unlearned">
+    Unseen
+  </string>
+  <string name="statistics_suspended_and_buried">
+    Suspended+Buried
+  </string>
+  <string name="statistics_relearn">
+    Relearn
+  </string>
+  <string name="statistics_learn">
+    Learn
+  </string>
+  <string name="statistics_cram">
+    Cram
+  </string>
+  <string name="stats_cards">
+    Cards
+  </string>
+  <string name="stats_cards_intervals">
+    Cards with given interval
+  </string>
+  <string name="stats_cumulative_cards">
+    Cumulative cards
+  </string>
+  <string name="stats_cumulative_answers">
+    Cumulative answers
+  </string>
+  <string name="stats_cumulative_time_minutes">
+    Cumulative minutes
+  </string>
+  <string name="stats_cumulative_time_hours">
+    Cumulative hours
+  </string>
+  <string name="stats_cumulative">
+    Cumulative
+  </string>
+  <string name="stats_cumulative_percentage">
+    Cumulative percentage
+  </string>
+  <string formatted="false" name="stats_cumulative_correct_percentage">
+    Cumulative correct %
+  </string>
+  <string name="stats_answers">
+    Answers
+  </string>
+  <string name="stats_minutes">
+    Minutes
+  </string>
+  <string name="stats_hours">
+    Hours
+  </string>
+  <string name="stats_percentage">
+    Percentage
+  </string>
+  <string name="stats_period_month">
+    1 month
+  </string>
+  <string name="stats_period_year">
+    1 year
+  </string>
+  <string name="stats_period_lifetime">
+    deck life
+  </string>
+  <string name="stats_deck_collection">
+    collection
+  </string>
+  <string name="stats_time_of_day">
+    Time of day
+  </string>
+  <string name="stats_day_of_week">
+    Day of week
+  </string>
+  <string formatted="false" name="stats_percentage_correct">
+    % correct
+  </string>
+  <string name="stats_reviews">
+    Reviews
+  </string>
+  <string name="stats_answer_type">
+    Answer type
+  </string>
+  <string name="stats_today_again_count">
+    Again count: &lt;b&gt;%d&lt;/b&gt;
+  </string>
+  <string name="stats_today_correct_count">
+    (&lt;b&gt;%.1f%%&lt;/b&gt; correct)
+  </string>
+  <string name="stats_today_type_breakdown">
+    Learn: &lt;b&gt;%1$d&lt;/b&gt;, review: &lt;b&gt;%2$d&lt;/b&gt;, relearn: &lt;b&gt;%3$d&lt;/b&gt;, filtered: &lt;b&gt;%4$d&lt;/b&gt;
+  </string>
+  <string name="stats_today_mature_cards">
+    Correct answers on mature cards: %1$d/%2$d (%3$.1f%%)
+  </string>
+  <string name="stats_today_no_mature_cards">
+    No mature cards were studied today
+  </string>
 
-    <string name="stats_overview_forecast_total">Total: &lt;b&gt;%1$d&lt;/b&gt; reviews</string>
-    <string name="stats_overview_forecast_average">Average: &lt;b&gt;%1$.1f&lt;/b&gt; reviews/day</string>
-    <string name="stats_overview_forecast_due_tomorrow">Due tomorrow: &lt;b&gt;%1$d&lt;/b&gt;</string>
+  <string name="stats_overview_forecast_total">
+    Total: &lt;b&gt;%1$d&lt;/b&gt; reviews
+  </string>
+  <string name="stats_overview_forecast_average">
+    Average: &lt;b&gt;%1$.1f&lt;/b&gt; reviews/day
+  </string>
+  <string name="stats_overview_forecast_due_tomorrow">
+    Due tomorrow: &lt;b&gt;%1$d&lt;/b&gt;
+  </string>
 
-    <string name="stats_overview_days_studied">Days studied: &lt;b&gt;%1$d%%&lt;/b&gt; (%2$d of %3$d)</string>
-    <string name="stats_overview_total_reviews">Total: &lt;b&gt;%1$d&lt;/b&gt; reviews</string>
-    <string name="stats_overview_reviews_per_day_studydays">Average for days studied: &lt;b&gt;%1$.1f&lt;/b&gt; reviews/day</string>
-    <string name="stats_overview_reviews_per_day_all">If you studied every day: &lt;b&gt;%1$.1f&lt;/b&gt; reviews/day</string>
+  <string name="stats_overview_days_studied">
+    Days studied: &lt;b&gt;%1$d%%&lt;/b&gt; (%2$d of %3$d)
+  </string>
+  <string name="stats_overview_total_reviews">
+    Total: &lt;b&gt;%1$d&lt;/b&gt; reviews
+  </string>
+  <string name="stats_overview_reviews_per_day_studydays">
+    Average for days studied: &lt;b&gt;%1$.1f&lt;/b&gt; reviews/day
+  </string>
+  <string name="stats_overview_reviews_per_day_all">
+    If you studied every day: &lt;b&gt;%1$.1f&lt;/b&gt; reviews/day
+  </string>
 
-    <string name="stats_overview_total_time_in_period">Total: &lt;b&gt;%d&lt;/b&gt; minutes</string>
-    <string name="stats_overview_time_per_day_studydays">Average for days studied: &lt;b&gt;%1$.1f&lt;/b&gt; minutes/day</string>
-    <string name="stats_overview_time_per_day_all">If you studied every day:  &lt;b&gt;%1$.1f&lt;/b&gt; minutes/day</string>
-    <string name="stats_overview_average_answer_time">Average answer time: &lt;b&gt;%1$.1fs&lt;/b&gt; (&lt;b&gt;%2$.2f&lt;/b&gt; cards/minute)</string>
+  <string name="stats_overview_total_time_in_period">
+    Total: &lt;b&gt;%d&lt;/b&gt; minutes
+  </string>
+  <string name="stats_overview_time_per_day_studydays">
+    Average for days studied: &lt;b&gt;%1$.1f&lt;/b&gt; minutes/day
+  </string>
+  <string name="stats_overview_time_per_day_all">
+    If you studied every day:  &lt;b&gt;%1$.1f&lt;/b&gt; minutes/day
+  </string>
+  <string name="stats_overview_average_answer_time">
+    Average answer time: &lt;b&gt;%1$.1fs&lt;/b&gt; (&lt;b&gt;%2$.2f&lt;/b&gt; cards/minute)
+  </string>
 
-    <string name="stats_overview_new_cards_per_day">Average: &lt;b&gt;%1$.1f&lt;/b&gt; cards/day</string>
-    <string name="stats_overview_total_new_cards">Total: &lt;b&gt;%1$d&lt;/b&gt; cards</string>
+  <string name="stats_overview_new_cards_per_day">
+    Average: &lt;b&gt;%1$.1f&lt;/b&gt; cards/day
+  </string>
+  <string name="stats_overview_total_new_cards">
+    Total: &lt;b&gt;%1$d&lt;/b&gt; cards
+  </string>
 
-    <string name="stats_overview_average_interval">"Average interval: "</string>
-    <string name="stats_overview_longest_interval">"Longest interval: "</string>
+  <string name="stats_overview_average_interval">
+    "Average interval: "
+  </string>
+  <string name="stats_overview_longest_interval">
+    "Longest interval: "
+  </string>
 
-    <string name="stats_overview_years">&lt;b&gt;%1$.1f&lt;/b&gt; years</string>
-    <string name="stats_overview_months">&lt;b&gt;%1$.1f&lt;/b&gt; months</string>
-    <string name="stats_overview_days">&lt;b&gt;%1$.1f&lt;/b&gt; days</string>
-    <string name="stats_overview_hours">&lt;b&gt;%1$.1f&lt;/b&gt; hours</string>
+  <string name="stats_overview_years">
+    &lt;b&gt;%1$.1f&lt;/b&gt; years
+  </string>
+  <string name="stats_overview_months">
+    &lt;b&gt;%1$.1f&lt;/b&gt; months
+  </string>
+  <string name="stats_overview_days">
+    &lt;b&gt;%1$.1f&lt;/b&gt; days
+  </string>
+  <string name="stats_overview_hours">
+    &lt;b&gt;%1$.1f&lt;/b&gt; hours
+  </string>
 
-    <string name="stats_overview_answer_buttons_learn">Learning: &lt;b&gt;%1$.2f%%&lt;/b&gt; correct (%2$d of %3$d)</string>
-    <string name="stats_overview_answer_buttons_young">Young: &lt;b&gt;%1$.2f%%&lt;/b&gt; correct (%2$d of %3$d)</string>
-    <string name="stats_overview_answer_buttons_mature">Mature: &lt;b&gt;%1$.2f%%&lt;/b&gt; correct (%2$d of %3$d)</string>
+  <string name="stats_overview_answer_buttons_learn">
+    Learning: &lt;b&gt;%1$.2f%%&lt;/b&gt; correct (%2$d of %3$d)
+  </string>
+  <string name="stats_overview_answer_buttons_young">
+    Young: &lt;b&gt;%1$.2f%%&lt;/b&gt; correct (%2$d of %3$d)
+  </string>
+  <string name="stats_overview_answer_buttons_mature">
+    Mature: &lt;b&gt;%1$.2f%%&lt;/b&gt; correct (%2$d of %3$d)
+  </string>
 
-    <string name="stats_overview_card_types_total_cards">Total cards: &lt;b&gt;%d&lt;/b&gt;</string>
-    <string name="stats_overview_card_types_total_notes">Total notes: &lt;b&gt;%d&lt;/b&gt;</string>
-    <string name="stats_overview_card_types_lowest_ease">Lowest ease: &lt;b&gt;%.0f%%&lt;/b&gt;</string>
-    <string name="stats_overview_card_types_average_ease">Average ease: &lt;b&gt;%.0f%%&lt;/b&gt;</string>
-    <string name="stats_overview_card_types_highest_ease">Highest ease: &lt;b&gt;%.0f%%&lt;/b&gt;</string>
+  <string name="stats_overview_card_types_total_cards">
+    Total cards: &lt;b&gt;%d&lt;/b&gt;
+  </string>
+  <string name="stats_overview_card_types_total_notes">
+    Total notes: &lt;b&gt;%d&lt;/b&gt;
+  </string>
+  <string name="stats_overview_card_types_lowest_ease">
+    Lowest ease: &lt;b&gt;%.0f%%&lt;/b&gt;
+  </string>
+  <string name="stats_overview_card_types_average_ease">
+    Average ease: &lt;b&gt;%.0f%%&lt;/b&gt;
+  </string>
+  <string name="stats_overview_card_types_highest_ease">
+    Highest ease: &lt;b&gt;%.0f%%&lt;/b&gt;
+  </string>
 
-    <string name="deck_summary_all_decks">All decks</string>
-    <string name="stats_select_time_scale">Select timescale</string>
-    <string-array name="due_x_axis_title">
-        <item>Days</item>
-        <item>Weeks</item>
-        <item>Months</item>
-    </string-array>
-    <string name="stats_today">Today</string>
-    <string name="stats_overview">Overview</string>
-    <string name="stats_forecast">Forecast</string>
-    <string name="stats_review_count">Review count</string>
-    <string name="stats_review_time">Review time</string>
-    <string name="stats_added">Added</string>
-    <string name="stats_review_intervals">Intervals</string>
-    <string name="stats_breakdown">Hourly breakdown</string>
-    <string name="stats_weekly_breakdown">Weekly breakdown</string>
-    <string name="stats_answer_buttons">Answer buttons</string>
-    <string name="stats_cards_types">Card types</string>
+  <string name="deck_summary_all_decks">
+    All decks
+  </string>
+  <string name="stats_select_time_scale">
+    Select timescale
+  </string>
+  <string-array name="due_x_axis_title">
+    <item>
+      Days
+    </item>
+    <item>
+      Weeks
+    </item>
+    <item>
+      Months
+    </item>
+  </string-array>
+  <string name="stats_today">
+    Today
+  </string>
+  <string name="stats_overview">
+    Overview
+  </string>
+  <string name="stats_forecast">
+    Forecast
+  </string>
+  <string name="stats_review_count">
+    Review count
+  </string>
+  <string name="stats_review_time">
+    Review time
+  </string>
+  <string name="stats_added">
+    Added
+  </string>
+  <string name="stats_review_intervals">
+    Intervals
+  </string>
+  <string name="stats_breakdown">
+    Hourly breakdown
+  </string>
+  <string name="stats_weekly_breakdown">
+    Weekly breakdown
+  </string>
+  <string name="stats_answer_buttons">
+    Answer buttons
+  </string>
+  <string name="stats_cards_types">
+    Card types
+  </string>
 
-    <string-array name="stats_day_time_strings">
-        <item>4AM</item>
-        <item>10AM</item>
-        <item>4PM</item>
-        <item>10PM</item>
-        <item>3AM</item>
-    </string-array>
-    <string-array name="stats_week_days">
-        <item>Sun</item>
-        <item>Mon</item>
-        <item>Tue</item>
-        <item>Wed</item>
-        <item>Thu</item>
-        <item>Fri</item>
-        <item>Sat</item>
-    </string-array>
-    <string-array name="stats_eases_ticks">
-        <item>1</item>
-        <item>2</item>
-        <item>3</item>
-        <item>1</item>
-        <item>2</item>
-        <item>3</item>
-        <item>4</item>
-        <item>1</item>
-        <item>2</item>
-        <item>3</item>
-        <item>4</item>
-    </string-array>
-    <string-array name="stats_eases_ticks_schedv2">
-        <item>1</item>
-        <item>2</item>
-        <item>3</item>
-        <item>4</item>
-        <item>1</item>
-        <item>2</item>
-        <item>3</item>
-        <item>4</item>
-        <item>1</item>
-        <item>2</item>
-        <item>3</item>
-        <item>4</item>
-    </string-array>
+  <string-array name="stats_day_time_strings">
+    <item>
+      4AM
+    </item>
+    <item>
+      10AM
+    </item>
+    <item>
+      4PM
+    </item>
+    <item>
+      10PM
+    </item>
+    <item>
+      3AM
+    </item>
+  </string-array>
+  <string-array name="stats_week_days">
+    <item>
+      Sun
+    </item>
+    <item>
+      Mon
+    </item>
+    <item>
+      Tue
+    </item>
+    <item>
+      Wed
+    </item>
+    <item>
+      Thu
+    </item>
+    <item>
+      Fri
+    </item>
+    <item>
+      Sat
+    </item>
+  </string-array>
+  <string-array name="stats_eases_ticks">
+    <item>
+      1
+    </item>
+    <item>
+      2
+    </item>
+    <item>
+      3
+    </item>
+    <item>
+      1
+    </item>
+    <item>
+      2
+    </item>
+    <item>
+      3
+    </item>
+    <item>
+      4
+    </item>
+    <item>
+      1
+    </item>
+    <item>
+      2
+    </item>
+    <item>
+      3
+    </item>
+    <item>
+      4
+    </item>
+  </string-array>
+  <string-array name="stats_eases_ticks_schedv2">
+    <item>
+      1
+    </item>
+    <item>
+      2
+    </item>
+    <item>
+      3
+    </item>
+    <item>
+      4
+    </item>
+    <item>
+      1
+    </item>
+    <item>
+      2
+    </item>
+    <item>
+      3
+    </item>
+    <item>
+      4
+    </item>
+    <item>
+      1
+    </item>
+    <item>
+      2
+    </item>
+    <item>
+      3
+    </item>
+    <item>
+      4
+    </item>
+  </string-array>
 
-    <plurals name="stats_today_cards">
-        <item quantity="one">Studied &lt;b&gt;%1$d card&lt;/b&gt; in &lt;b&gt;%2$s&lt;/b&gt; today</item>
-        <item quantity="other">Studied &lt;b&gt;%1$d cards&lt;/b&gt; in &lt;b&gt;%2$s&lt;/b&gt; today</item>
-    </plurals>
+  <plurals name="stats_today_cards">
+    <item quantity="one">
+      Studied &lt;b&gt;%1$d card&lt;/b&gt; in &lt;b&gt;%2$s&lt;/b&gt; today
+    </item>
+    <item quantity="other">
+      Studied &lt;b&gt;%1$d cards&lt;/b&gt; in &lt;b&gt;%2$s&lt;/b&gt; today
+    </item>
+  </plurals>
 </resources>

--- a/AnkiDroid/src/main/res/values/06-statistics.xml
+++ b/AnkiDroid/src/main/res/values/06-statistics.xml
@@ -21,557 +21,675 @@
 <resources>
   <string
       name="statistics_young"
+      comment="."
       >
     Young
   </string>
   <string
       name="statistics_mature"
+      comment="."
       >
     Mature
   </string>
   <string
       name="statistics_young_and_learn"
+      comment="."
       >
     Young+Learn
   </string>
   <string
       name="statistics_unlearned"
+      comment="."
       >
     Unseen
   </string>
   <string
       name="statistics_suspended_and_buried"
+      comment="."
       >
     Suspended+Buried
   </string>
   <string
       name="statistics_relearn"
+      comment="."
       >
     Relearn
   </string>
   <string
       name="statistics_learn"
+      comment="."
       >
     Learn
   </string>
   <string
       name="statistics_cram"
+      comment="."
       >
     Cram
   </string>
   <string
       name="stats_cards"
+      comment="."
       >
     Cards
   </string>
   <string
       name="stats_cards_intervals"
+      comment="."
       >
     Cards with given interval
   </string>
   <string
       name="stats_cumulative_cards"
+      comment="."
       >
     Cumulative cards
   </string>
   <string
       name="stats_cumulative_answers"
+      comment="."
       >
     Cumulative answers
   </string>
   <string
       name="stats_cumulative_time_minutes"
+      comment="."
       >
     Cumulative minutes
   </string>
   <string
       name="stats_cumulative_time_hours"
+      comment="."
       >
     Cumulative hours
   </string>
   <string
       name="stats_cumulative"
+      comment="."
       >
     Cumulative
   </string>
   <string
       name="stats_cumulative_percentage"
+      comment="."
       >
     Cumulative percentage
   </string>
   <string formatted="false"
           name="stats_cumulative_correct_percentage"
+          comment="."
           >
     Cumulative correct %
   </string>
   <string
       name="stats_answers"
+      comment="."
       >
     Answers
   </string>
   <string
       name="stats_minutes"
+      comment="."
       >
     Minutes
   </string>
   <string
       name="stats_hours"
+      comment="."
       >
     Hours
   </string>
   <string
       name="stats_percentage"
+      comment="."
       >
     Percentage
   </string>
   <string
       name="stats_period_month"
+      comment="."
       >
     1 month
   </string>
   <string
       name="stats_period_year"
+      comment="."
       >
     1 year
   </string>
   <string
       name="stats_period_lifetime"
+      comment="."
       >
     deck life
   </string>
   <string
       name="stats_deck_collection"
+      comment="."
       >
     collection
   </string>
   <string
       name="stats_time_of_day"
+      comment="."
       >
     Time of day
   </string>
   <string
       name="stats_day_of_week"
+      comment="."
       >
     Day of week
   </string>
   <string formatted="false"
           name="stats_percentage_correct"
+          comment="."
           >
     % correct
   </string>
   <string
       name="stats_reviews"
+      comment="."
       >
     Reviews
   </string>
   <string
       name="stats_answer_type"
+      comment="."
       >
     Answer type
   </string>
   <string
       name="stats_today_again_count"
+      comment="."
       >
     Again count: &lt;b&gt;%d&lt;/b&gt;
   </string>
   <string
       name="stats_today_correct_count"
+      comment="."
       >
     (&lt;b&gt;%.1f%%&lt;/b&gt; correct)
   </string>
   <string
       name="stats_today_type_breakdown"
+      comment="."
       >
     Learn: &lt;b&gt;%1$d&lt;/b&gt;, review: &lt;b&gt;%2$d&lt;/b&gt;, relearn: &lt;b&gt;%3$d&lt;/b&gt;, filtered: &lt;b&gt;%4$d&lt;/b&gt;
   </string>
   <string
       name="stats_today_mature_cards"
+      comment="."
       >
     Correct answers on mature cards: %1$d/%2$d (%3$.1f%%)
   </string>
   <string
       name="stats_today_no_mature_cards"
+      comment="."
       >
     No mature cards were studied today
   </string>
 
   <string
       name="stats_overview_forecast_total"
+      comment="."
       >
     Total: &lt;b&gt;%1$d&lt;/b&gt; reviews
   </string>
   <string
       name="stats_overview_forecast_average"
+      comment="."
       >
     Average: &lt;b&gt;%1$.1f&lt;/b&gt; reviews/day
   </string>
   <string
       name="stats_overview_forecast_due_tomorrow"
+      comment="."
       >
     Due tomorrow: &lt;b&gt;%1$d&lt;/b&gt;
   </string>
 
   <string
       name="stats_overview_days_studied"
+      comment="."
       >
     Days studied: &lt;b&gt;%1$d%%&lt;/b&gt; (%2$d of %3$d)
   </string>
   <string
       name="stats_overview_total_reviews"
+      comment="."
       >
     Total: &lt;b&gt;%1$d&lt;/b&gt; reviews
   </string>
   <string
       name="stats_overview_reviews_per_day_studydays"
+      comment="."
       >
     Average for days studied: &lt;b&gt;%1$.1f&lt;/b&gt; reviews/day
   </string>
   <string
       name="stats_overview_reviews_per_day_all"
+      comment="."
       >
     If you studied every day: &lt;b&gt;%1$.1f&lt;/b&gt; reviews/day
   </string>
 
   <string
       name="stats_overview_total_time_in_period"
+      comment="."
       >
     Total: &lt;b&gt;%d&lt;/b&gt; minutes
   </string>
   <string
       name="stats_overview_time_per_day_studydays"
+      comment="."
       >
     Average for days studied: &lt;b&gt;%1$.1f&lt;/b&gt; minutes/day
   </string>
   <string
       name="stats_overview_time_per_day_all"
+      comment="."
       >
     If you studied every day:  &lt;b&gt;%1$.1f&lt;/b&gt; minutes/day
   </string>
   <string
       name="stats_overview_average_answer_time"
+      comment="."
       >
     Average answer time: &lt;b&gt;%1$.1fs&lt;/b&gt; (&lt;b&gt;%2$.2f&lt;/b&gt; cards/minute)
   </string>
 
   <string
       name="stats_overview_new_cards_per_day"
+      comment="."
       >
     Average: &lt;b&gt;%1$.1f&lt;/b&gt; cards/day
   </string>
   <string
       name="stats_overview_total_new_cards"
+      comment="."
       >
     Total: &lt;b&gt;%1$d&lt;/b&gt; cards
   </string>
 
   <string
       name="stats_overview_average_interval"
+      comment="."
       >
     "Average interval: "
   </string>
   <string
       name="stats_overview_longest_interval"
+      comment="."
       >
     "Longest interval: "
   </string>
 
   <string
       name="stats_overview_years"
+      comment="."
       >
     &lt;b&gt;%1$.1f&lt;/b&gt; years
   </string>
   <string
       name="stats_overview_months"
+      comment="."
       >
     &lt;b&gt;%1$.1f&lt;/b&gt; months
   </string>
   <string
       name="stats_overview_days"
+      comment="."
       >
     &lt;b&gt;%1$.1f&lt;/b&gt; days
   </string>
   <string
       name="stats_overview_hours"
+      comment="."
       >
     &lt;b&gt;%1$.1f&lt;/b&gt; hours
   </string>
 
   <string
       name="stats_overview_answer_buttons_learn"
+      comment="."
       >
     Learning: &lt;b&gt;%1$.2f%%&lt;/b&gt; correct (%2$d of %3$d)
   </string>
   <string
       name="stats_overview_answer_buttons_young"
+      comment="."
       >
     Young: &lt;b&gt;%1$.2f%%&lt;/b&gt; correct (%2$d of %3$d)
   </string>
   <string
       name="stats_overview_answer_buttons_mature"
+      comment="."
       >
     Mature: &lt;b&gt;%1$.2f%%&lt;/b&gt; correct (%2$d of %3$d)
   </string>
 
   <string
       name="stats_overview_card_types_total_cards"
+      comment="."
       >
     Total cards: &lt;b&gt;%d&lt;/b&gt;
   </string>
   <string
       name="stats_overview_card_types_total_notes"
+      comment="."
       >
     Total notes: &lt;b&gt;%d&lt;/b&gt;
   </string>
   <string
       name="stats_overview_card_types_lowest_ease"
+      comment="."
       >
     Lowest ease: &lt;b&gt;%.0f%%&lt;/b&gt;
   </string>
   <string
       name="stats_overview_card_types_average_ease"
+      comment="."
       >
     Average ease: &lt;b&gt;%.0f%%&lt;/b&gt;
   </string>
   <string
       name="stats_overview_card_types_highest_ease"
+      comment="."
       >
     Highest ease: &lt;b&gt;%.0f%%&lt;/b&gt;
   </string>
 
   <string
       name="deck_summary_all_decks"
+      comment="."
       >
     All decks
   </string>
   <string
       name="stats_select_time_scale"
+      comment="."
       >
     Select timescale
   </string>
   <string-array
       name="due_x_axis_title"
+      comment="."
       >
     <item
+        comment="."
         >
       Days
     </item>
     <item
+        comment="."
         >
       Weeks
     </item>
     <item
+        comment="."
         >
       Months
     </item>
   </string-array>
   <string
       name="stats_today"
+      comment="."
       >
     Today
   </string>
   <string
       name="stats_overview"
+      comment="."
       >
     Overview
   </string>
   <string
       name="stats_forecast"
+      comment="."
       >
     Forecast
   </string>
   <string
       name="stats_review_count"
+      comment="."
       >
     Review count
   </string>
   <string
       name="stats_review_time"
+      comment="."
       >
     Review time
   </string>
   <string
       name="stats_added"
+      comment="."
       >
     Added
   </string>
   <string
       name="stats_review_intervals"
+      comment="."
       >
     Intervals
   </string>
   <string
       name="stats_breakdown"
+      comment="."
       >
     Hourly breakdown
   </string>
   <string
       name="stats_weekly_breakdown"
+      comment="."
       >
     Weekly breakdown
   </string>
   <string
       name="stats_answer_buttons"
+      comment="."
       >
     Answer buttons
   </string>
   <string
       name="stats_cards_types"
+      comment="."
       >
     Card types
   </string>
 
   <string-array
       name="stats_day_time_strings"
+      comment="."
       >
     <item
+        comment="."
         >
       4AM
     </item>
     <item
+        comment="."
         >
       10AM
     </item>
     <item
+        comment="."
         >
       4PM
     </item>
     <item
+        comment="."
         >
       10PM
     </item>
     <item
+        comment="."
         >
       3AM
     </item>
   </string-array>
   <string-array
       name="stats_week_days"
+      comment="."
       >
     <item
+        comment="."
         >
       Sun
     </item>
     <item
+        comment="."
         >
       Mon
     </item>
     <item
+        comment="."
         >
       Tue
     </item>
     <item
+        comment="."
         >
       Wed
     </item>
     <item
+        comment="."
         >
       Thu
     </item>
     <item
+        comment="."
         >
       Fri
     </item>
     <item
+        comment="."
         >
       Sat
     </item>
   </string-array>
   <string-array
       name="stats_eases_ticks"
+      comment="."
       >
     <item
+        comment="."
         >
       1
     </item>
     <item
+        comment="."
         >
       2
     </item>
     <item
+        comment="."
         >
       3
     </item>
     <item
+        comment="."
         >
       1
     </item>
     <item
+        comment="."
         >
       2
     </item>
     <item
+        comment="."
         >
       3
     </item>
     <item
+        comment="."
         >
       4
     </item>
     <item
+        comment="."
         >
       1
     </item>
     <item
+        comment="."
         >
       2
     </item>
     <item
+        comment="."
         >
       3
     </item>
     <item
+        comment="."
         >
       4
     </item>
   </string-array>
   <string-array
       name="stats_eases_ticks_schedv2"
+      comment="."
       >
     <item
+        comment="."
         >
       1
     </item>
     <item
+        comment="."
         >
       2
     </item>
     <item
+        comment="."
         >
       3
     </item>
     <item
+        comment="."
         >
       4
     </item>
     <item
+        comment="."
         >
       1
     </item>
     <item
+        comment="."
         >
       2
     </item>
     <item
+        comment="."
         >
       3
     </item>
     <item
+        comment="."
         >
       4
     </item>
     <item
+        comment="."
         >
       1
     </item>
     <item
+        comment="."
         >
       2
     </item>
     <item
+        comment="."
         >
       3
     </item>
     <item
+        comment="."
         >
       4
     </item>
@@ -579,6 +697,7 @@
 
   <plurals
       name="stats_today_cards"
+      comment="."
       >
     <item quantity="one">
       Studied &lt;b&gt;%1$d card&lt;/b&gt; in &lt;b&gt;%2$s&lt;/b&gt; today

--- a/AnkiDroid/src/main/res/values/06-statistics.xml
+++ b/AnkiDroid/src/main/res/values/06-statistics.xml
@@ -19,208 +19,338 @@
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <resources>
-  <string name="statistics_young">
+  <string
+      name="statistics_young"
+      >
     Young
   </string>
-  <string name="statistics_mature">
+  <string
+      name="statistics_mature"
+      >
     Mature
   </string>
-  <string name="statistics_young_and_learn">
+  <string
+      name="statistics_young_and_learn"
+      >
     Young+Learn
   </string>
-  <string name="statistics_unlearned">
+  <string
+      name="statistics_unlearned"
+      >
     Unseen
   </string>
-  <string name="statistics_suspended_and_buried">
+  <string
+      name="statistics_suspended_and_buried"
+      >
     Suspended+Buried
   </string>
-  <string name="statistics_relearn">
+  <string
+      name="statistics_relearn"
+      >
     Relearn
   </string>
-  <string name="statistics_learn">
+  <string
+      name="statistics_learn"
+      >
     Learn
   </string>
-  <string name="statistics_cram">
+  <string
+      name="statistics_cram"
+      >
     Cram
   </string>
-  <string name="stats_cards">
+  <string
+      name="stats_cards"
+      >
     Cards
   </string>
-  <string name="stats_cards_intervals">
+  <string
+      name="stats_cards_intervals"
+      >
     Cards with given interval
   </string>
-  <string name="stats_cumulative_cards">
+  <string
+      name="stats_cumulative_cards"
+      >
     Cumulative cards
   </string>
-  <string name="stats_cumulative_answers">
+  <string
+      name="stats_cumulative_answers"
+      >
     Cumulative answers
   </string>
-  <string name="stats_cumulative_time_minutes">
+  <string
+      name="stats_cumulative_time_minutes"
+      >
     Cumulative minutes
   </string>
-  <string name="stats_cumulative_time_hours">
+  <string
+      name="stats_cumulative_time_hours"
+      >
     Cumulative hours
   </string>
-  <string name="stats_cumulative">
+  <string
+      name="stats_cumulative"
+      >
     Cumulative
   </string>
-  <string name="stats_cumulative_percentage">
+  <string
+      name="stats_cumulative_percentage"
+      >
     Cumulative percentage
   </string>
-  <string formatted="false" name="stats_cumulative_correct_percentage">
+  <string formatted="false"
+          name="stats_cumulative_correct_percentage"
+          >
     Cumulative correct %
   </string>
-  <string name="stats_answers">
+  <string
+      name="stats_answers"
+      >
     Answers
   </string>
-  <string name="stats_minutes">
+  <string
+      name="stats_minutes"
+      >
     Minutes
   </string>
-  <string name="stats_hours">
+  <string
+      name="stats_hours"
+      >
     Hours
   </string>
-  <string name="stats_percentage">
+  <string
+      name="stats_percentage"
+      >
     Percentage
   </string>
-  <string name="stats_period_month">
+  <string
+      name="stats_period_month"
+      >
     1 month
   </string>
-  <string name="stats_period_year">
+  <string
+      name="stats_period_year"
+      >
     1 year
   </string>
-  <string name="stats_period_lifetime">
+  <string
+      name="stats_period_lifetime"
+      >
     deck life
   </string>
-  <string name="stats_deck_collection">
+  <string
+      name="stats_deck_collection"
+      >
     collection
   </string>
-  <string name="stats_time_of_day">
+  <string
+      name="stats_time_of_day"
+      >
     Time of day
   </string>
-  <string name="stats_day_of_week">
+  <string
+      name="stats_day_of_week"
+      >
     Day of week
   </string>
-  <string formatted="false" name="stats_percentage_correct">
+  <string formatted="false"
+          name="stats_percentage_correct"
+          >
     % correct
   </string>
-  <string name="stats_reviews">
+  <string
+      name="stats_reviews"
+      >
     Reviews
   </string>
-  <string name="stats_answer_type">
+  <string
+      name="stats_answer_type"
+      >
     Answer type
   </string>
-  <string name="stats_today_again_count">
+  <string
+      name="stats_today_again_count"
+      >
     Again count: &lt;b&gt;%d&lt;/b&gt;
   </string>
-  <string name="stats_today_correct_count">
+  <string
+      name="stats_today_correct_count"
+      >
     (&lt;b&gt;%.1f%%&lt;/b&gt; correct)
   </string>
-  <string name="stats_today_type_breakdown">
+  <string
+      name="stats_today_type_breakdown"
+      >
     Learn: &lt;b&gt;%1$d&lt;/b&gt;, review: &lt;b&gt;%2$d&lt;/b&gt;, relearn: &lt;b&gt;%3$d&lt;/b&gt;, filtered: &lt;b&gt;%4$d&lt;/b&gt;
   </string>
-  <string name="stats_today_mature_cards">
+  <string
+      name="stats_today_mature_cards"
+      >
     Correct answers on mature cards: %1$d/%2$d (%3$.1f%%)
   </string>
-  <string name="stats_today_no_mature_cards">
+  <string
+      name="stats_today_no_mature_cards"
+      >
     No mature cards were studied today
   </string>
 
-  <string name="stats_overview_forecast_total">
+  <string
+      name="stats_overview_forecast_total"
+      >
     Total: &lt;b&gt;%1$d&lt;/b&gt; reviews
   </string>
-  <string name="stats_overview_forecast_average">
+  <string
+      name="stats_overview_forecast_average"
+      >
     Average: &lt;b&gt;%1$.1f&lt;/b&gt; reviews/day
   </string>
-  <string name="stats_overview_forecast_due_tomorrow">
+  <string
+      name="stats_overview_forecast_due_tomorrow"
+      >
     Due tomorrow: &lt;b&gt;%1$d&lt;/b&gt;
   </string>
 
-  <string name="stats_overview_days_studied">
+  <string
+      name="stats_overview_days_studied"
+      >
     Days studied: &lt;b&gt;%1$d%%&lt;/b&gt; (%2$d of %3$d)
   </string>
-  <string name="stats_overview_total_reviews">
+  <string
+      name="stats_overview_total_reviews"
+      >
     Total: &lt;b&gt;%1$d&lt;/b&gt; reviews
   </string>
-  <string name="stats_overview_reviews_per_day_studydays">
+  <string
+      name="stats_overview_reviews_per_day_studydays"
+      >
     Average for days studied: &lt;b&gt;%1$.1f&lt;/b&gt; reviews/day
   </string>
-  <string name="stats_overview_reviews_per_day_all">
+  <string
+      name="stats_overview_reviews_per_day_all"
+      >
     If you studied every day: &lt;b&gt;%1$.1f&lt;/b&gt; reviews/day
   </string>
 
-  <string name="stats_overview_total_time_in_period">
+  <string
+      name="stats_overview_total_time_in_period"
+      >
     Total: &lt;b&gt;%d&lt;/b&gt; minutes
   </string>
-  <string name="stats_overview_time_per_day_studydays">
+  <string
+      name="stats_overview_time_per_day_studydays"
+      >
     Average for days studied: &lt;b&gt;%1$.1f&lt;/b&gt; minutes/day
   </string>
-  <string name="stats_overview_time_per_day_all">
+  <string
+      name="stats_overview_time_per_day_all"
+      >
     If you studied every day:  &lt;b&gt;%1$.1f&lt;/b&gt; minutes/day
   </string>
-  <string name="stats_overview_average_answer_time">
+  <string
+      name="stats_overview_average_answer_time"
+      >
     Average answer time: &lt;b&gt;%1$.1fs&lt;/b&gt; (&lt;b&gt;%2$.2f&lt;/b&gt; cards/minute)
   </string>
 
-  <string name="stats_overview_new_cards_per_day">
+  <string
+      name="stats_overview_new_cards_per_day"
+      >
     Average: &lt;b&gt;%1$.1f&lt;/b&gt; cards/day
   </string>
-  <string name="stats_overview_total_new_cards">
+  <string
+      name="stats_overview_total_new_cards"
+      >
     Total: &lt;b&gt;%1$d&lt;/b&gt; cards
   </string>
 
-  <string name="stats_overview_average_interval">
+  <string
+      name="stats_overview_average_interval"
+      >
     "Average interval: "
   </string>
-  <string name="stats_overview_longest_interval">
+  <string
+      name="stats_overview_longest_interval"
+      >
     "Longest interval: "
   </string>
 
-  <string name="stats_overview_years">
+  <string
+      name="stats_overview_years"
+      >
     &lt;b&gt;%1$.1f&lt;/b&gt; years
   </string>
-  <string name="stats_overview_months">
+  <string
+      name="stats_overview_months"
+      >
     &lt;b&gt;%1$.1f&lt;/b&gt; months
   </string>
-  <string name="stats_overview_days">
+  <string
+      name="stats_overview_days"
+      >
     &lt;b&gt;%1$.1f&lt;/b&gt; days
   </string>
-  <string name="stats_overview_hours">
+  <string
+      name="stats_overview_hours"
+      >
     &lt;b&gt;%1$.1f&lt;/b&gt; hours
   </string>
 
-  <string name="stats_overview_answer_buttons_learn">
+  <string
+      name="stats_overview_answer_buttons_learn"
+      >
     Learning: &lt;b&gt;%1$.2f%%&lt;/b&gt; correct (%2$d of %3$d)
   </string>
-  <string name="stats_overview_answer_buttons_young">
+  <string
+      name="stats_overview_answer_buttons_young"
+      >
     Young: &lt;b&gt;%1$.2f%%&lt;/b&gt; correct (%2$d of %3$d)
   </string>
-  <string name="stats_overview_answer_buttons_mature">
+  <string
+      name="stats_overview_answer_buttons_mature"
+      >
     Mature: &lt;b&gt;%1$.2f%%&lt;/b&gt; correct (%2$d of %3$d)
   </string>
 
-  <string name="stats_overview_card_types_total_cards">
+  <string
+      name="stats_overview_card_types_total_cards"
+      >
     Total cards: &lt;b&gt;%d&lt;/b&gt;
   </string>
-  <string name="stats_overview_card_types_total_notes">
+  <string
+      name="stats_overview_card_types_total_notes"
+      >
     Total notes: &lt;b&gt;%d&lt;/b&gt;
   </string>
-  <string name="stats_overview_card_types_lowest_ease">
+  <string
+      name="stats_overview_card_types_lowest_ease"
+      >
     Lowest ease: &lt;b&gt;%.0f%%&lt;/b&gt;
   </string>
-  <string name="stats_overview_card_types_average_ease">
+  <string
+      name="stats_overview_card_types_average_ease"
+      >
     Average ease: &lt;b&gt;%.0f%%&lt;/b&gt;
   </string>
-  <string name="stats_overview_card_types_highest_ease">
+  <string
+      name="stats_overview_card_types_highest_ease"
+      >
     Highest ease: &lt;b&gt;%.0f%%&lt;/b&gt;
   </string>
 
-  <string name="deck_summary_all_decks">
+  <string
+      name="deck_summary_all_decks"
+      >
     All decks
   </string>
-  <string name="stats_select_time_scale">
+  <string
+      name="stats_select_time_scale"
+      >
     Select timescale
   </string>
-  <string-array name="due_x_axis_title">
+  <string-array
+      name="due_x_axis_title"
+      >
     <item>
       Days
     </item>
@@ -231,41 +361,65 @@
       Months
     </item>
   </string-array>
-  <string name="stats_today">
+  <string
+      name="stats_today"
+      >
     Today
   </string>
-  <string name="stats_overview">
+  <string
+      name="stats_overview"
+      >
     Overview
   </string>
-  <string name="stats_forecast">
+  <string
+      name="stats_forecast"
+      >
     Forecast
   </string>
-  <string name="stats_review_count">
+  <string
+      name="stats_review_count"
+      >
     Review count
   </string>
-  <string name="stats_review_time">
+  <string
+      name="stats_review_time"
+      >
     Review time
   </string>
-  <string name="stats_added">
+  <string
+      name="stats_added"
+      >
     Added
   </string>
-  <string name="stats_review_intervals">
+  <string
+      name="stats_review_intervals"
+      >
     Intervals
   </string>
-  <string name="stats_breakdown">
+  <string
+      name="stats_breakdown"
+      >
     Hourly breakdown
   </string>
-  <string name="stats_weekly_breakdown">
+  <string
+      name="stats_weekly_breakdown"
+      >
     Weekly breakdown
   </string>
-  <string name="stats_answer_buttons">
+  <string
+      name="stats_answer_buttons"
+      >
     Answer buttons
   </string>
-  <string name="stats_cards_types">
+  <string
+      name="stats_cards_types"
+      >
     Card types
   </string>
 
-  <string-array name="stats_day_time_strings">
+  <string-array
+      name="stats_day_time_strings"
+      >
     <item>
       4AM
     </item>
@@ -282,7 +436,9 @@
       3AM
     </item>
   </string-array>
-  <string-array name="stats_week_days">
+  <string-array
+      name="stats_week_days"
+      >
     <item>
       Sun
     </item>
@@ -305,7 +461,9 @@
       Sat
     </item>
   </string-array>
-  <string-array name="stats_eases_ticks">
+  <string-array
+      name="stats_eases_ticks"
+      >
     <item>
       1
     </item>
@@ -340,7 +498,9 @@
       4
     </item>
   </string-array>
-  <string-array name="stats_eases_ticks_schedv2">
+  <string-array
+      name="stats_eases_ticks_schedv2"
+      >
     <item>
       1
     </item>
@@ -379,7 +539,9 @@
     </item>
   </string-array>
 
-  <plurals name="stats_today_cards">
+  <plurals
+      name="stats_today_cards"
+      >
     <item quantity="one">
       Studied &lt;b&gt;%1$d card&lt;/b&gt; in &lt;b&gt;%2$s&lt;/b&gt; today
     </item>

--- a/AnkiDroid/src/main/res/values/07-cardbrowser.xml
+++ b/AnkiDroid/src/main/res/values/07-cardbrowser.xml
@@ -23,6 +23,7 @@
   <!-- CardBrowser -->
   <plurals
       name="card_browser_subtitle"
+      comment="."
       >
     <item quantity="one">
       %d card shown
@@ -34,280 +35,338 @@
 
   <string
       name="card_browser_all_decks"
+      comment="."
       >
     All decks
   </string>
   <string
       name="card_browser_delete_card"
+      comment="."
       >
     Delete notes
   </string>
   <string
       name="card_browser_suspend_card"
+      comment="."
       >
     Suspend cards
   </string>
   <string
       name="card_browser_toggle_suspend_card"
+      comment="."
       >
     (un)suspend cards
   </string>
   <string
       name="card_browser_change_deck"
+      comment="."
       >
     Change deck
   </string>
   <string
       name="card_browser_unsuspend_card"
+      comment="."
       >
     Unsuspend cards
   </string>
   <string
       name="card_browser_mark_card"
+      comment="."
       >
     Mark notes
   </string>
   <string
       name="card_browser_flag"
+      comment="."
       >
     Flag
   </string>
   <string
       name="card_browser_toggle_mark_card"
+      comment="."
       >
     (un)mark notes
   </string>
   <string
       name="card_browser_unmark_card"
+      comment="."
       >
     Unmark notes
   </string>
   <string
       name="delete_card_title"
+      comment="."
       >
     Delete note?
   </string>
   <string
       name="delete_cards_title"
+      comment="."
       >
     Delete notes?
   </string>
   <string
       name="delete_card_message"
+      comment="."
       >
     Delete all cards of this note?\nSearch field: %s
   </string>
   <string
       name="delete_card_mult_message"
+      comment="."
       >
     Delete all cards of all selected notes?\n(Not only selected cards)
   </string>
   <string
       name="deleted_message"
+      comment="."
       >
     Notes deleted
   </string>
   <string
       name="changed_deck_message"
+      comment="."
       >
     Moved to %s
   </string>
   <string
       name="card_browser_suspended_cards"
+      comment="."
       >
     (un)suspended cards
   </string>
   <string
       name="card_browser_show_marked"
+      comment="."
       >
     Filter marked
   </string>
   <string
       name="card_browser_show_suspended"
+      comment="."
       >
     Filter suspended
   </string>
   <string
       name="card_browser_search_by_tag"
+      comment="."
       >
     Filter by tag
   </string>
   <string
       name="card_browser_tags_shown"
+      comment="."
       >
     Tags: %1$s
   </string>
   <string
       name="card_browser_list_my_searches"
+      comment="."
       >
     My searches
   </string>
   <string
       name="card_browser_list_my_searches_save"
+      comment="."
       >
     Save search
   </string>
   <string
       name="card_browser_list_my_searches_title"
+      comment="."
       >
     Choose a saved search
   </string>
   <string
       name="card_browser_list_my_searches_new_name"
+      comment="."
       >
     Name for the current search
   </string>
   <string
       name="card_browser_list_my_searches_new_search_error_empty_name"
+      comment="."
       >
     You can’t save a search without a name
   </string>
   <string
       name="card_browser_list_my_searches_new_search_error_dup"
+      comment="."
       >
     Name exists
   </string>
   <string
       name="card_browser_list_my_searches_remove_content"
+      comment="."
       >
     Delete “%1$s”?
   </string>
   <string
       name="card_browser_change_display_order"
+      comment="."
       >
     Change display order
   </string>
   <string
       name="card_browser_change_display_order_title"
+      comment="."
       >
     Choose display order
   </string>
   <string
       name="card_browser_change_display_order_reverse"
+      comment="."
       >
     Select a field twice to reverse
   </string>
   <string
       name="card_details_question"
+      comment="."
       >
     Question
   </string>
   <string
       name="card_details_answer"
+      comment="."
       >
     Answer
   </string>
   <string
       name="card_details_due"
+      comment="."
       >
     Due
   </string>
   <string
       name="card_details_tags"
+      comment="."
       >
     Tags
   </string>
   <string
       name="card_browser_filtering_cards"
+      comment="."
       >
     Filtering cards… \nPress back button to cancel
   </string>
   <string-array
       name="card_browser_order_labels"
+      comment="."
       >
     <item
+        comment="."
         >
       No sorting (faster)
     </item>
     <item
+        comment="."
         >
       By sort field
     </item>
     <item
+        comment="."
         >
       By created time
     </item>
     <item
+        comment="."
         >
       By note modification time
     </item>
     <item
+        comment="."
         >
       By card modification time
     </item>
     <item
+        comment="."
         >
       By due time
     </item>
     <item
+        comment="."
         >
       By interval
     </item>
     <item
+        comment="."
         >
       By ease
     </item>
     <item
+        comment="."
         >
       By reviews
     </item>
     <item
+        comment="."
         >
       By lapses
     </item>
   </string-array>
   <string
       name="card_browser_select_all"
+      comment="."
       >
     Select all
   </string>
   <string
       name="card_browser_select_none"
+      comment="."
       >
     Select none
   </string>
   <string
       name="card_browser_edit_note"
+      comment="."
       >
     Edit note
   </string>
   <string
       name="card_browser_interval_new_card"
+      comment="."
       >
     (new)
   </string>
   <string
       name="card_browser_ease_new_card"
+      comment="."
       >
     (new)
   </string>
   <string
       name="card_browser_due_filtered_card"
+      comment="."
       >
     (filtered)
   </string>
   <string
       name="card_browser_interval_learning_card"
+      comment="."
       >
     (learning)
   </string>
   <string
       name="card_browser_note_editor_error"
+      comment="."
       >
     Error opening Note Editor
   </string>
   <string
       name="card_browser_no_cards_in_deck"
+      comment="."
       >
     No cards found in deck ‘%s’
   </string>
   <string
       name="card_browser_search_all_decks"
+      comment="."
       >
     Search all decks
   </string>
   <string
       name="card_browser_unknown_deck_name"
+      comment="."
       >
     Unknown
   </string>

--- a/AnkiDroid/src/main/res/values/07-cardbrowser.xml
+++ b/AnkiDroid/src/main/res/values/07-cardbrowser.xml
@@ -17,71 +17,190 @@
 ~
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
---><resources>
+-->
+<resources>
 
-    <!-- CardBrowser -->
-    <plurals name="card_browser_subtitle">
-        <item quantity="one">%d card shown</item>
-        <item quantity="other">%d cards shown</item>
-    </plurals>
+  <!-- CardBrowser -->
+  <plurals name="card_browser_subtitle">
+    <item quantity="one">
+      %d card shown
+    </item>
+    <item quantity="other">
+      %d cards shown
+    </item>
+  </plurals>
 
-    <string name="card_browser_all_decks">All decks</string>
-    <string name="card_browser_delete_card">Delete notes</string>
-    <string name="card_browser_suspend_card">Suspend cards</string>
-    <string name="card_browser_toggle_suspend_card">(un)suspend cards</string>
-    <string name="card_browser_change_deck">Change deck</string>
-    <string name="card_browser_unsuspend_card">Unsuspend cards</string>
-    <string name="card_browser_mark_card">Mark notes</string>
-    <string name="card_browser_flag">Flag</string>
-    <string name="card_browser_toggle_mark_card">(un)mark notes</string>
-    <string name="card_browser_unmark_card">Unmark notes</string>
-    <string name="delete_card_title">Delete note?</string>
-    <string name="delete_cards_title">Delete notes?</string>
-    <string name="delete_card_message">Delete all cards of this note?\nSearch field: %s</string>
-    <string name="delete_card_mult_message">Delete all cards of all selected notes?\n(Not only selected cards)</string>
-    <string name="deleted_message">Notes deleted</string>
-    <string name="changed_deck_message">Moved to %s</string>
-    <string name="card_browser_suspended_cards">(un)suspended cards</string>
-    <string name="card_browser_show_marked">Filter marked</string>
-    <string name="card_browser_show_suspended">Filter suspended</string>
-    <string name="card_browser_search_by_tag">Filter by tag</string>
-    <string name="card_browser_tags_shown">Tags: %1$s</string>
-    <string name="card_browser_list_my_searches">My searches</string>
-    <string name="card_browser_list_my_searches_save">Save search</string>
-    <string name="card_browser_list_my_searches_title">Choose a saved search</string>
-    <string name="card_browser_list_my_searches_new_name">Name for the current search</string>
-    <string name="card_browser_list_my_searches_new_search_error_empty_name">You can’t save a search without a name</string>
-    <string name="card_browser_list_my_searches_new_search_error_dup">Name exists</string>
-    <string name="card_browser_list_my_searches_remove_content">Delete “%1$s”?</string>
-    <string name="card_browser_change_display_order">Change display order</string>
-    <string name="card_browser_change_display_order_title">Choose display order</string>
-    <string name="card_browser_change_display_order_reverse">Select a field twice to reverse</string>
-    <string name="card_details_question">Question</string>
-    <string name="card_details_answer">Answer</string>
-    <string name="card_details_due">Due</string>
-    <string name="card_details_tags">Tags</string>
-    <string name="card_browser_filtering_cards">Filtering cards… \nPress back button to cancel</string>
-    <string-array name="card_browser_order_labels">
-        <item>No sorting (faster)</item>
-        <item>By sort field</item>
-        <item>By created time</item>
-        <item>By note modification time</item>
-        <item>By card modification time</item>
-        <item>By due time</item>
-        <item>By interval</item>
-        <item>By ease</item>
-        <item>By reviews</item>
-        <item>By lapses</item>
-    </string-array>
-    <string name="card_browser_select_all">Select all</string>
-    <string name="card_browser_select_none">Select none</string>
-    <string name="card_browser_edit_note">Edit note</string>
-    <string name="card_browser_interval_new_card">(new)</string>
-    <string name="card_browser_ease_new_card">(new)</string>
-    <string name="card_browser_due_filtered_card">(filtered)</string>
-    <string name="card_browser_interval_learning_card">(learning)</string>
-    <string name="card_browser_note_editor_error">Error opening Note Editor</string>
-    <string name="card_browser_no_cards_in_deck">No cards found in deck ‘%s’</string>
-    <string name="card_browser_search_all_decks">Search all decks</string>
-    <string name="card_browser_unknown_deck_name">Unknown</string>
+  <string name="card_browser_all_decks">
+    All decks
+  </string>
+  <string name="card_browser_delete_card">
+    Delete notes
+  </string>
+  <string name="card_browser_suspend_card">
+    Suspend cards
+  </string>
+  <string name="card_browser_toggle_suspend_card">
+    (un)suspend cards
+  </string>
+  <string name="card_browser_change_deck">
+    Change deck
+  </string>
+  <string name="card_browser_unsuspend_card">
+    Unsuspend cards
+  </string>
+  <string name="card_browser_mark_card">
+    Mark notes
+  </string>
+  <string name="card_browser_flag">
+    Flag
+  </string>
+  <string name="card_browser_toggle_mark_card">
+    (un)mark notes
+  </string>
+  <string name="card_browser_unmark_card">
+    Unmark notes
+  </string>
+  <string name="delete_card_title">
+    Delete note?
+  </string>
+  <string name="delete_cards_title">
+    Delete notes?
+  </string>
+  <string name="delete_card_message">
+    Delete all cards of this note?\nSearch field: %s
+  </string>
+  <string name="delete_card_mult_message">
+    Delete all cards of all selected notes?\n(Not only selected cards)
+  </string>
+  <string name="deleted_message">
+    Notes deleted
+  </string>
+  <string name="changed_deck_message">
+    Moved to %s
+  </string>
+  <string name="card_browser_suspended_cards">
+    (un)suspended cards
+  </string>
+  <string name="card_browser_show_marked">
+    Filter marked
+  </string>
+  <string name="card_browser_show_suspended">
+    Filter suspended
+  </string>
+  <string name="card_browser_search_by_tag">
+    Filter by tag
+  </string>
+  <string name="card_browser_tags_shown">
+    Tags: %1$s
+  </string>
+  <string name="card_browser_list_my_searches">
+    My searches
+  </string>
+  <string name="card_browser_list_my_searches_save">
+    Save search
+  </string>
+  <string name="card_browser_list_my_searches_title">
+    Choose a saved search
+  </string>
+  <string name="card_browser_list_my_searches_new_name">
+    Name for the current search
+  </string>
+  <string name="card_browser_list_my_searches_new_search_error_empty_name">
+    You can’t save a search without a name
+  </string>
+  <string name="card_browser_list_my_searches_new_search_error_dup">
+    Name exists
+  </string>
+  <string name="card_browser_list_my_searches_remove_content">
+    Delete “%1$s”?
+  </string>
+  <string name="card_browser_change_display_order">
+    Change display order
+  </string>
+  <string name="card_browser_change_display_order_title">
+    Choose display order
+  </string>
+  <string name="card_browser_change_display_order_reverse">
+    Select a field twice to reverse
+  </string>
+  <string name="card_details_question">
+    Question
+  </string>
+  <string name="card_details_answer">
+    Answer
+  </string>
+  <string name="card_details_due">
+    Due
+  </string>
+  <string name="card_details_tags">
+    Tags
+  </string>
+  <string name="card_browser_filtering_cards">
+    Filtering cards… \nPress back button to cancel
+  </string>
+  <string-array name="card_browser_order_labels">
+    <item>
+      No sorting (faster)
+    </item>
+    <item>
+      By sort field
+    </item>
+    <item>
+      By created time
+    </item>
+    <item>
+      By note modification time
+    </item>
+    <item>
+      By card modification time
+    </item>
+    <item>
+      By due time
+    </item>
+    <item>
+      By interval
+    </item>
+    <item>
+      By ease
+    </item>
+    <item>
+      By reviews
+    </item>
+    <item>
+      By lapses
+    </item>
+  </string-array>
+  <string name="card_browser_select_all">
+    Select all
+  </string>
+  <string name="card_browser_select_none">
+    Select none
+  </string>
+  <string name="card_browser_edit_note">
+    Edit note
+  </string>
+  <string name="card_browser_interval_new_card">
+    (new)
+  </string>
+  <string name="card_browser_ease_new_card">
+    (new)
+  </string>
+  <string name="card_browser_due_filtered_card">
+    (filtered)
+  </string>
+  <string name="card_browser_interval_learning_card">
+    (learning)
+  </string>
+  <string name="card_browser_note_editor_error">
+    Error opening Note Editor
+  </string>
+  <string name="card_browser_no_cards_in_deck">
+    No cards found in deck ‘%s’
+  </string>
+  <string name="card_browser_search_all_decks">
+    Search all decks
+  </string>
+  <string name="card_browser_unknown_deck_name">
+    Unknown
+  </string>
 </resources>

--- a/AnkiDroid/src/main/res/values/07-cardbrowser.xml
+++ b/AnkiDroid/src/main/res/values/07-cardbrowser.xml
@@ -215,34 +215,44 @@
   <string-array
       name="card_browser_order_labels"
       >
-    <item>
+    <item
+        >
       No sorting (faster)
     </item>
-    <item>
+    <item
+        >
       By sort field
     </item>
-    <item>
+    <item
+        >
       By created time
     </item>
-    <item>
+    <item
+        >
       By note modification time
     </item>
-    <item>
+    <item
+        >
       By card modification time
     </item>
-    <item>
+    <item
+        >
       By due time
     </item>
-    <item>
+    <item
+        >
       By interval
     </item>
-    <item>
+    <item
+        >
       By ease
     </item>
-    <item>
+    <item
+        >
       By reviews
     </item>
-    <item>
+    <item
+        >
       By lapses
     </item>
   </string-array>

--- a/AnkiDroid/src/main/res/values/07-cardbrowser.xml
+++ b/AnkiDroid/src/main/res/values/07-cardbrowser.xml
@@ -21,7 +21,9 @@
 <resources>
 
   <!-- CardBrowser -->
-  <plurals name="card_browser_subtitle">
+  <plurals
+      name="card_browser_subtitle"
+      >
     <item quantity="one">
       %d card shown
     </item>
@@ -30,115 +32,189 @@
     </item>
   </plurals>
 
-  <string name="card_browser_all_decks">
+  <string
+      name="card_browser_all_decks"
+      >
     All decks
   </string>
-  <string name="card_browser_delete_card">
+  <string
+      name="card_browser_delete_card"
+      >
     Delete notes
   </string>
-  <string name="card_browser_suspend_card">
+  <string
+      name="card_browser_suspend_card"
+      >
     Suspend cards
   </string>
-  <string name="card_browser_toggle_suspend_card">
+  <string
+      name="card_browser_toggle_suspend_card"
+      >
     (un)suspend cards
   </string>
-  <string name="card_browser_change_deck">
+  <string
+      name="card_browser_change_deck"
+      >
     Change deck
   </string>
-  <string name="card_browser_unsuspend_card">
+  <string
+      name="card_browser_unsuspend_card"
+      >
     Unsuspend cards
   </string>
-  <string name="card_browser_mark_card">
+  <string
+      name="card_browser_mark_card"
+      >
     Mark notes
   </string>
-  <string name="card_browser_flag">
+  <string
+      name="card_browser_flag"
+      >
     Flag
   </string>
-  <string name="card_browser_toggle_mark_card">
+  <string
+      name="card_browser_toggle_mark_card"
+      >
     (un)mark notes
   </string>
-  <string name="card_browser_unmark_card">
+  <string
+      name="card_browser_unmark_card"
+      >
     Unmark notes
   </string>
-  <string name="delete_card_title">
+  <string
+      name="delete_card_title"
+      >
     Delete note?
   </string>
-  <string name="delete_cards_title">
+  <string
+      name="delete_cards_title"
+      >
     Delete notes?
   </string>
-  <string name="delete_card_message">
+  <string
+      name="delete_card_message"
+      >
     Delete all cards of this note?\nSearch field: %s
   </string>
-  <string name="delete_card_mult_message">
+  <string
+      name="delete_card_mult_message"
+      >
     Delete all cards of all selected notes?\n(Not only selected cards)
   </string>
-  <string name="deleted_message">
+  <string
+      name="deleted_message"
+      >
     Notes deleted
   </string>
-  <string name="changed_deck_message">
+  <string
+      name="changed_deck_message"
+      >
     Moved to %s
   </string>
-  <string name="card_browser_suspended_cards">
+  <string
+      name="card_browser_suspended_cards"
+      >
     (un)suspended cards
   </string>
-  <string name="card_browser_show_marked">
+  <string
+      name="card_browser_show_marked"
+      >
     Filter marked
   </string>
-  <string name="card_browser_show_suspended">
+  <string
+      name="card_browser_show_suspended"
+      >
     Filter suspended
   </string>
-  <string name="card_browser_search_by_tag">
+  <string
+      name="card_browser_search_by_tag"
+      >
     Filter by tag
   </string>
-  <string name="card_browser_tags_shown">
+  <string
+      name="card_browser_tags_shown"
+      >
     Tags: %1$s
   </string>
-  <string name="card_browser_list_my_searches">
+  <string
+      name="card_browser_list_my_searches"
+      >
     My searches
   </string>
-  <string name="card_browser_list_my_searches_save">
+  <string
+      name="card_browser_list_my_searches_save"
+      >
     Save search
   </string>
-  <string name="card_browser_list_my_searches_title">
+  <string
+      name="card_browser_list_my_searches_title"
+      >
     Choose a saved search
   </string>
-  <string name="card_browser_list_my_searches_new_name">
+  <string
+      name="card_browser_list_my_searches_new_name"
+      >
     Name for the current search
   </string>
-  <string name="card_browser_list_my_searches_new_search_error_empty_name">
+  <string
+      name="card_browser_list_my_searches_new_search_error_empty_name"
+      >
     You can’t save a search without a name
   </string>
-  <string name="card_browser_list_my_searches_new_search_error_dup">
+  <string
+      name="card_browser_list_my_searches_new_search_error_dup"
+      >
     Name exists
   </string>
-  <string name="card_browser_list_my_searches_remove_content">
+  <string
+      name="card_browser_list_my_searches_remove_content"
+      >
     Delete “%1$s”?
   </string>
-  <string name="card_browser_change_display_order">
+  <string
+      name="card_browser_change_display_order"
+      >
     Change display order
   </string>
-  <string name="card_browser_change_display_order_title">
+  <string
+      name="card_browser_change_display_order_title"
+      >
     Choose display order
   </string>
-  <string name="card_browser_change_display_order_reverse">
+  <string
+      name="card_browser_change_display_order_reverse"
+      >
     Select a field twice to reverse
   </string>
-  <string name="card_details_question">
+  <string
+      name="card_details_question"
+      >
     Question
   </string>
-  <string name="card_details_answer">
+  <string
+      name="card_details_answer"
+      >
     Answer
   </string>
-  <string name="card_details_due">
+  <string
+      name="card_details_due"
+      >
     Due
   </string>
-  <string name="card_details_tags">
+  <string
+      name="card_details_tags"
+      >
     Tags
   </string>
-  <string name="card_browser_filtering_cards">
+  <string
+      name="card_browser_filtering_cards"
+      >
     Filtering cards… \nPress back button to cancel
   </string>
-  <string-array name="card_browser_order_labels">
+  <string-array
+      name="card_browser_order_labels"
+      >
     <item>
       No sorting (faster)
     </item>
@@ -170,37 +246,59 @@
       By lapses
     </item>
   </string-array>
-  <string name="card_browser_select_all">
+  <string
+      name="card_browser_select_all"
+      >
     Select all
   </string>
-  <string name="card_browser_select_none">
+  <string
+      name="card_browser_select_none"
+      >
     Select none
   </string>
-  <string name="card_browser_edit_note">
+  <string
+      name="card_browser_edit_note"
+      >
     Edit note
   </string>
-  <string name="card_browser_interval_new_card">
+  <string
+      name="card_browser_interval_new_card"
+      >
     (new)
   </string>
-  <string name="card_browser_ease_new_card">
+  <string
+      name="card_browser_ease_new_card"
+      >
     (new)
   </string>
-  <string name="card_browser_due_filtered_card">
+  <string
+      name="card_browser_due_filtered_card"
+      >
     (filtered)
   </string>
-  <string name="card_browser_interval_learning_card">
+  <string
+      name="card_browser_interval_learning_card"
+      >
     (learning)
   </string>
-  <string name="card_browser_note_editor_error">
+  <string
+      name="card_browser_note_editor_error"
+      >
     Error opening Note Editor
   </string>
-  <string name="card_browser_no_cards_in_deck">
+  <string
+      name="card_browser_no_cards_in_deck"
+      >
     No cards found in deck ‘%s’
   </string>
-  <string name="card_browser_search_all_decks">
+  <string
+      name="card_browser_search_all_decks"
+      >
     Search all decks
   </string>
-  <string name="card_browser_unknown_deck_name">
+  <string
+      name="card_browser_unknown_deck_name"
+      >
     Unknown
   </string>
 </resources>

--- a/AnkiDroid/src/main/res/values/08-widget.xml
+++ b/AnkiDroid/src/main/res/values/08-widget.xml
@@ -20,10 +20,14 @@
 <resources>
 
   <!-- Widget -->
-  <string name="widget_minimum_cards_due_notification_ticker_title">
+  <string
+      name="widget_minimum_cards_due_notification_ticker_title"
+      >
     Cards due
   </string>
-  <plurals name="widget_minimum_cards_due_notification_ticker_text">
+  <plurals
+      name="widget_minimum_cards_due_notification_ticker_text"
+      >
     <item quantity="one">
       %d AnkiDroid card due
     </item>
@@ -31,14 +35,20 @@
       %d AnkiDroid cards due
     </item>
   </plurals>
-  <string name="widget_no_cards_due">
+  <string
+      name="widget_no_cards_due"
+      >
     No cards due
   </string>
-  <string name="widget_loading">
+  <string
+      name="widget_loading"
+      >
     Widget loading…
   </string>
 
-  <plurals name="widget_cards_in_decks_due">
+  <plurals
+      name="widget_cards_in_decks_due"
+      >
     <item quantity="one">
       %1$d card due in %2$s
     </item>
@@ -46,7 +56,9 @@
       %1$d cards due in %2$s
     </item>
   </plurals>
-  <plurals name="widget_decks">
+  <plurals
+      name="widget_decks"
+      >
     <item quantity="one">
       %1$d deck
     </item>
@@ -55,15 +67,21 @@
     </item>
   </plurals>
 
-  <string name="widget_small">
+  <string
+      name="widget_small"
+      >
     AnkiDroid small
   </string>
 
-  <string name="widget_small_button">
+  <string
+      name="widget_small_button"
+      >
     AnkiDroid
   </string>
 
-  <plurals name="widget_cards_due">
+  <plurals
+      name="widget_cards_due"
+      >
     <item quantity="one">
       %d card due
     </item>
@@ -71,7 +89,9 @@
       %d cards due
     </item>
   </plurals>
-  <plurals name="widget_eta">
+  <plurals
+      name="widget_eta"
+      >
     <item quantity="one">
       %d minute remaining
     </item>
@@ -80,10 +100,14 @@
     </item>
   </plurals>
 
-  <string name="widget_add_note">
+  <string
+      name="widget_add_note"
+      >
     Add note
   </string>
-  <string name="widget_add_note_button">
+  <string
+      name="widget_add_note_button"
+      >
     Add new AnkiDroid note
   </string>
 </resources>

--- a/AnkiDroid/src/main/res/values/08-widget.xml
+++ b/AnkiDroid/src/main/res/values/08-widget.xml
@@ -101,11 +101,6 @@
   </plurals>
 
   <string
-      name="widget_add_note"
-      >
-    Add note
-  </string>
-  <string
       name="widget_add_note_button"
       >
     Add new AnkiDroid note

--- a/AnkiDroid/src/main/res/values/08-widget.xml
+++ b/AnkiDroid/src/main/res/values/08-widget.xml
@@ -19,37 +19,71 @@
 -->
 <resources>
 
-    <!-- Widget -->
-    <string name="widget_minimum_cards_due_notification_ticker_title">Cards due</string>
-    <plurals name="widget_minimum_cards_due_notification_ticker_text">
-        <item quantity="one">%d AnkiDroid card due</item>
-        <item quantity="other">%d AnkiDroid cards due</item>
-    </plurals>
-    <string name="widget_no_cards_due">No cards due</string>
-    <string name="widget_loading">Widget loading…</string>
+  <!-- Widget -->
+  <string name="widget_minimum_cards_due_notification_ticker_title">
+    Cards due
+  </string>
+  <plurals name="widget_minimum_cards_due_notification_ticker_text">
+    <item quantity="one">
+      %d AnkiDroid card due
+    </item>
+    <item quantity="other">
+      %d AnkiDroid cards due
+    </item>
+  </plurals>
+  <string name="widget_no_cards_due">
+    No cards due
+  </string>
+  <string name="widget_loading">
+    Widget loading…
+  </string>
 
-    <plurals name="widget_cards_in_decks_due">
-        <item quantity="one">%1$d card due in %2$s</item>
-        <item quantity="other">%1$d cards due in %2$s</item>
-    </plurals>
-    <plurals name="widget_decks">
-        <item quantity="one">%1$d deck</item>
-        <item quantity="other">%1$d decks</item>
-    </plurals>
+  <plurals name="widget_cards_in_decks_due">
+    <item quantity="one">
+      %1$d card due in %2$s
+    </item>
+    <item quantity="other">
+      %1$d cards due in %2$s
+    </item>
+  </plurals>
+  <plurals name="widget_decks">
+    <item quantity="one">
+      %1$d deck
+    </item>
+    <item quantity="other">
+      %1$d decks
+    </item>
+  </plurals>
 
-    <string name="widget_small">AnkiDroid small</string>
+  <string name="widget_small">
+    AnkiDroid small
+  </string>
 
-    <string name="widget_small_button">AnkiDroid</string>
+  <string name="widget_small_button">
+    AnkiDroid
+  </string>
 
-    <plurals name="widget_cards_due">
-        <item quantity="one">%d card due</item>
-        <item quantity="other">%d cards due</item>
-    </plurals>
-    <plurals name="widget_eta">
-        <item quantity="one">%d minute remaining</item>
-        <item quantity="other">%d minutes remaining</item>
-    </plurals>
+  <plurals name="widget_cards_due">
+    <item quantity="one">
+      %d card due
+    </item>
+    <item quantity="other">
+      %d cards due
+    </item>
+  </plurals>
+  <plurals name="widget_eta">
+    <item quantity="one">
+      %d minute remaining
+    </item>
+    <item quantity="other">
+      %d minutes remaining
+    </item>
+  </plurals>
 
-    <string name="widget_add_note">Add note</string>
-    <string name="widget_add_note_button">Add new AnkiDroid note</string>
+  <string name="widget_add_note">
+    Add note
+  </string>
+  <string name="widget_add_note_button">
+    Add new AnkiDroid note
+  </string>
 </resources>

--- a/AnkiDroid/src/main/res/values/08-widget.xml
+++ b/AnkiDroid/src/main/res/values/08-widget.xml
@@ -22,11 +22,13 @@
   <!-- Widget -->
   <string
       name="widget_minimum_cards_due_notification_ticker_title"
+      comment="."
       >
     Cards due
   </string>
   <plurals
       name="widget_minimum_cards_due_notification_ticker_text"
+      comment="."
       >
     <item quantity="one">
       %d AnkiDroid card due
@@ -37,17 +39,20 @@
   </plurals>
   <string
       name="widget_no_cards_due"
+      comment="."
       >
     No cards due
   </string>
   <string
       name="widget_loading"
+      comment="."
       >
     Widget loading…
   </string>
 
   <plurals
       name="widget_cards_in_decks_due"
+      comment="."
       >
     <item quantity="one">
       %1$d card due in %2$s
@@ -58,6 +63,7 @@
   </plurals>
   <plurals
       name="widget_decks"
+      comment="."
       >
     <item quantity="one">
       %1$d deck
@@ -69,18 +75,21 @@
 
   <string
       name="widget_small"
+      comment="."
       >
     AnkiDroid small
   </string>
 
   <string
       name="widget_small_button"
+      comment="."
       >
     AnkiDroid
   </string>
 
   <plurals
       name="widget_cards_due"
+      comment="."
       >
     <item quantity="one">
       %d card due
@@ -91,6 +100,7 @@
   </plurals>
   <plurals
       name="widget_eta"
+      comment="."
       >
     <item quantity="one">
       %d minute remaining
@@ -102,6 +112,7 @@
 
   <string
       name="widget_add_note_button"
+      comment="."
       >
     Add new AnkiDroid note
   </string>

--- a/AnkiDroid/src/main/res/values/09-backup.xml
+++ b/AnkiDroid/src/main/res/values/09-backup.xml
@@ -22,117 +22,140 @@
 
   <string
       name="backup_deck_no_space_left"
+      comment="."
       >
     Backup not saved. Not enough space left on SD card. Lower the backup depth or remove some other files.
   </string>
   <string
       name="sd_space_warning"
+      comment="."
       >
     Less than %d MB space on your SD card left.\nFree some space to avoid data loss.
   </string>
   <string
       name="backup_delete"
+      comment="."
       >
     Deleting backups…
   </string>
   <string
       name="backup_restore"
+      comment="."
       >
     Restore from backup
   </string>
   <string
       name="backup_new_collection"
+      comment="."
       >
     New collection
   </string>
   <string
       name="backup_del_collection"
+      comment="."
       >
     Delete collection and create new one
   </string>
   <string
       name="backup_del_collection_question"
+      comment="."
       >
     Delete the collection and create a new one? This will drop all your learning progress and delete all cards.
   </string>
   <string
       name="backup_full_sync_from_server"
+      comment="."
       >
     Full sync from server
   </string>
   <string
       name="backup_full_sync_from_server_question"
+      comment="."
       >
     Overwrite your collection with the one from AnkiWeb? This will drop all your learning progress and added information since your last sync.
   </string>
   <string
       name="error_handling_title"
+      comment="."
       >
     Error handling
   </string>
   <string
       name="error_handling_options"
+      comment="."
       >
     Options
   </string>
   <string
       name="backup_retry_opening"
+      comment="."
       >
     Retry opening
   </string>
   <string
       name="backup_error_menu_repair"
+      comment="."
       >
     Repair database
   </string>
   <string
       name="backup_repair_deck"
+      comment="."
       >
     Repair
   </string>
   <!-- Collection used to be called deck. Name is kept for consistency with translation software -->
   <string
       name="backup_repair_deck_progress"
+      comment="."
       >
     Repairing database…
   </string>
   <string
       name="backup_error"
+      comment="."
       >
     Error
   </string>
   <string
       name="backup_invalid_file_error"
+      comment="."
       >
     The selected backup file was invalid
   </string>
   <string
       name="backup_restore_select_title"
+      comment="."
       >
     Select backup to restore
   </string>
   <string
       name="backup_restore_no_backups"
+      comment="."
       >
     No backups available on this device. If you have backups on your desktop computer, copy them manually into your AnkiDroid folder.
   </string>
   <string
       name="open_collection_failed_title"
+      comment="."
       >
     Collection not opened
   </string>
   <string
       name="corrupt_db_message"
+      comment="."
       >
     Your collection has become corrupted.\n\nTouch “options” to restore from a backup, or if that doesn’t work, see the following instructions for manually repairing the database:\n%1$s
   </string>
   <string
       name="access_collection_failed_message"
+      comment="."
       >
     An error occurred while accessing your collection. It may have been caused by a harmless bug, or there may be a problem with it. \n\nTry running check database, or restoring from backup by pressing the “options” button. If you continue to see this message, please file a bug report:\n%1$s
   </string>
   <string
       name="deck_repair_error"
+      comment="."
       >
     Collection couldn’t be repaired
   </string>

--- a/AnkiDroid/src/main/res/values/09-backup.xml
+++ b/AnkiDroid/src/main/res/values/09-backup.xml
@@ -17,31 +17,78 @@
 ~
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
---><resources>
+-->
+<resources>
 
-    <string name="backup_deck_no_space_left">Backup not saved. Not enough space left on SD card. Lower the backup depth or remove some other files.</string>
-    <string name="sd_space_warning">Less than %d MB space on your SD card left.\nFree some space to avoid data loss.</string>
-    <string name="backup_delete">Deleting backups…</string>
-    <string name="backup_restore">Restore from backup</string>
-    <string name="backup_new_collection">New collection</string>
-    <string name="backup_del_collection">Delete collection and create new one</string>
-    <string name="backup_del_collection_question">Delete the collection and create a new one? This will drop all your learning progress and delete all cards.</string>
-    <string name="backup_full_sync_from_server">Full sync from server</string>
-    <string name="backup_full_sync_from_server_question">Overwrite your collection with the one from AnkiWeb? This will drop all your learning progress and added information since your last sync.</string>
-    <string name="error_handling_title">Error handling</string>
-    <string name="error_handling_options">Options</string>
-    <string name="backup_retry_opening">Retry opening</string>
-    <string name="backup_error_menu_repair">Repair database</string>
-    <string name="backup_repair_deck">Repair</string>
-    <!-- Collection used to be called deck. Name is kept for consistency with translation software -->
-    <string name="backup_repair_deck_progress">Repairing database…</string>
-    <string name="backup_error">Error</string>
-    <string name="backup_invalid_file_error">The selected backup file was invalid</string>
-    <string name="backup_restore_select_title">Select backup to restore</string>
-    <string name="backup_restore_no_backups">No backups available on this device. If you have backups on your desktop computer, copy them manually into your AnkiDroid folder.</string>
-    <string name="open_collection_failed_title">Collection not opened</string>
-    <string name="corrupt_db_message">Your collection has become corrupted.\n\nTouch “options” to restore from a backup, or if that doesn’t work, see the following instructions for manually repairing the database:\n%1$s</string>
-    <string name="access_collection_failed_message">An error occurred while accessing your collection. It may have been caused by a harmless bug, or there may be a problem with it. \n\nTry running check database, or restoring from backup by pressing the “options” button. If you continue to see this message, please file a bug report:\n%1$s</string>
-    <string name="deck_repair_error">Collection couldn’t be repaired</string>
+  <string name="backup_deck_no_space_left">
+    Backup not saved. Not enough space left on SD card. Lower the backup depth or remove some other files.
+  </string>
+  <string name="sd_space_warning">
+    Less than %d MB space on your SD card left.\nFree some space to avoid data loss.
+  </string>
+  <string name="backup_delete">
+    Deleting backups…
+  </string>
+  <string name="backup_restore">
+    Restore from backup
+  </string>
+  <string name="backup_new_collection">
+    New collection
+  </string>
+  <string name="backup_del_collection">
+    Delete collection and create new one
+  </string>
+  <string name="backup_del_collection_question">
+    Delete the collection and create a new one? This will drop all your learning progress and delete all cards.
+  </string>
+  <string name="backup_full_sync_from_server">
+    Full sync from server
+  </string>
+  <string name="backup_full_sync_from_server_question">
+    Overwrite your collection with the one from AnkiWeb? This will drop all your learning progress and added information since your last sync.
+  </string>
+  <string name="error_handling_title">
+    Error handling
+  </string>
+  <string name="error_handling_options">
+    Options
+  </string>
+  <string name="backup_retry_opening">
+    Retry opening
+  </string>
+  <string name="backup_error_menu_repair">
+    Repair database
+  </string>
+  <string name="backup_repair_deck">
+    Repair
+  </string>
+  <!-- Collection used to be called deck. Name is kept for consistency with translation software -->
+  <string name="backup_repair_deck_progress">
+    Repairing database…
+  </string>
+  <string name="backup_error">
+    Error
+  </string>
+  <string name="backup_invalid_file_error">
+    The selected backup file was invalid
+  </string>
+  <string name="backup_restore_select_title">
+    Select backup to restore
+  </string>
+  <string name="backup_restore_no_backups">
+    No backups available on this device. If you have backups on your desktop computer, copy them manually into your AnkiDroid folder.
+  </string>
+  <string name="open_collection_failed_title">
+    Collection not opened
+  </string>
+  <string name="corrupt_db_message">
+    Your collection has become corrupted.\n\nTouch “options” to restore from a backup, or if that doesn’t work, see the following instructions for manually repairing the database:\n%1$s
+  </string>
+  <string name="access_collection_failed_message">
+    An error occurred while accessing your collection. It may have been caused by a harmless bug, or there may be a problem with it. \n\nTry running check database, or restoring from backup by pressing the “options” button. If you continue to see this message, please file a bug report:\n%1$s
+  </string>
+  <string name="deck_repair_error">
+    Collection couldn’t be repaired
+  </string>
 
 </resources>

--- a/AnkiDroid/src/main/res/values/09-backup.xml
+++ b/AnkiDroid/src/main/res/values/09-backup.xml
@@ -20,74 +20,120 @@
 -->
 <resources>
 
-  <string name="backup_deck_no_space_left">
+  <string
+      name="backup_deck_no_space_left"
+      >
     Backup not saved. Not enough space left on SD card. Lower the backup depth or remove some other files.
   </string>
-  <string name="sd_space_warning">
+  <string
+      name="sd_space_warning"
+      >
     Less than %d MB space on your SD card left.\nFree some space to avoid data loss.
   </string>
-  <string name="backup_delete">
+  <string
+      name="backup_delete"
+      >
     Deleting backups…
   </string>
-  <string name="backup_restore">
+  <string
+      name="backup_restore"
+      >
     Restore from backup
   </string>
-  <string name="backup_new_collection">
+  <string
+      name="backup_new_collection"
+      >
     New collection
   </string>
-  <string name="backup_del_collection">
+  <string
+      name="backup_del_collection"
+      >
     Delete collection and create new one
   </string>
-  <string name="backup_del_collection_question">
+  <string
+      name="backup_del_collection_question"
+      >
     Delete the collection and create a new one? This will drop all your learning progress and delete all cards.
   </string>
-  <string name="backup_full_sync_from_server">
+  <string
+      name="backup_full_sync_from_server"
+      >
     Full sync from server
   </string>
-  <string name="backup_full_sync_from_server_question">
+  <string
+      name="backup_full_sync_from_server_question"
+      >
     Overwrite your collection with the one from AnkiWeb? This will drop all your learning progress and added information since your last sync.
   </string>
-  <string name="error_handling_title">
+  <string
+      name="error_handling_title"
+      >
     Error handling
   </string>
-  <string name="error_handling_options">
+  <string
+      name="error_handling_options"
+      >
     Options
   </string>
-  <string name="backup_retry_opening">
+  <string
+      name="backup_retry_opening"
+      >
     Retry opening
   </string>
-  <string name="backup_error_menu_repair">
+  <string
+      name="backup_error_menu_repair"
+      >
     Repair database
   </string>
-  <string name="backup_repair_deck">
+  <string
+      name="backup_repair_deck"
+      >
     Repair
   </string>
   <!-- Collection used to be called deck. Name is kept for consistency with translation software -->
-  <string name="backup_repair_deck_progress">
+  <string
+      name="backup_repair_deck_progress"
+      >
     Repairing database…
   </string>
-  <string name="backup_error">
+  <string
+      name="backup_error"
+      >
     Error
   </string>
-  <string name="backup_invalid_file_error">
+  <string
+      name="backup_invalid_file_error"
+      >
     The selected backup file was invalid
   </string>
-  <string name="backup_restore_select_title">
+  <string
+      name="backup_restore_select_title"
+      >
     Select backup to restore
   </string>
-  <string name="backup_restore_no_backups">
+  <string
+      name="backup_restore_no_backups"
+      >
     No backups available on this device. If you have backups on your desktop computer, copy them manually into your AnkiDroid folder.
   </string>
-  <string name="open_collection_failed_title">
+  <string
+      name="open_collection_failed_title"
+      >
     Collection not opened
   </string>
-  <string name="corrupt_db_message">
+  <string
+      name="corrupt_db_message"
+      >
     Your collection has become corrupted.\n\nTouch “options” to restore from a backup, or if that doesn’t work, see the following instructions for manually repairing the database:\n%1$s
   </string>
-  <string name="access_collection_failed_message">
+  <string
+      name="access_collection_failed_message"
+      >
     An error occurred while accessing your collection. It may have been caused by a harmless bug, or there may be a problem with it. \n\nTry running check database, or restoring from backup by pressing the “options” button. If you continue to see this message, please file a bug report:\n%1$s
   </string>
-  <string name="deck_repair_error">
+  <string
+      name="deck_repair_error"
+      >
     Collection couldn’t be repaired
   </string>
 

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -17,255 +17,711 @@
 ~
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
---><resources>
-    <!-- generic strings -->
-    <string name="disabled">Disabled</string>
-    <string name="enabled">Enabled</string>
-    <!-- preferences.xml categories-->
-    <string name="pref_cat_general">AnkiDroid</string>
-    <string name="pref_cat_general_summ">General settings</string>
-    <string name="pref_cat_reviewing">Reviewing</string>
-    <string name="pref_cat_reviewing_summ">Non-deck-specific reviewer settings</string>
-    <string name="pref_cat_reviewer_behaviour">Behavior</string>
-    <string name="pref_cat_flashcard">Display</string>
-    <string name="pref_cat_whiteboard">Whiteboard</string>
-    <string name="pref_cat_automatic_display">Automatic display answer</string>
-    <string name="pref_cat_appearance">Appearance</string>
-    <string name="pref_cat_appearance_summ">Change themes and default font</string>
-    <string name="pref_cat_themes">Themes</string>
-    <string name="pref_cat_fonts">Fonts</string>
-    <string name="pref_cat_gestures">Gestures</string>
-    <string name="pref_cat_gestures_summ">Use taps and swipes instead of buttons</string>
-    <string name="pref_cat_actions">Actions</string>
-    <string name="pref_cat_advanced">Advanced</string>
-    <string name="pref_cat_advanced_summ">Optimization and experimental features</string>
-    <string name="pref_cat_performance">Performance</string>
-    <string name="pref_cat_workarounds">Workarounds</string>
-    <string name="pref_cat_plugins">Plugins</string>
-    <string name="about_title">About AnkiDroid</string>
-    <string name="about_version">Version: </string>
+-->
+<resources>
+  <!-- generic strings -->
+  <string name="disabled">
+    Disabled
+  </string>
+  <string name="enabled">
+    Enabled
+  </string>
+  <!-- preferences.xml categories-->
+  <string name="pref_cat_general">
+    AnkiDroid
+  </string>
+  <string name="pref_cat_general_summ">
+    General settings
+  </string>
+  <string name="pref_cat_reviewing">
+    Reviewing
+  </string>
+  <string name="pref_cat_reviewing_summ">
+    Non-deck-specific reviewer settings
+  </string>
+  <string name="pref_cat_reviewer_behaviour">
+    Behavior
+  </string>
+  <string name="pref_cat_flashcard">
+    Display
+  </string>
+  <string name="pref_cat_whiteboard">
+    Whiteboard
+  </string>
+  <string name="pref_cat_automatic_display">
+    Automatic display answer
+  </string>
+  <string name="pref_cat_appearance">
+    Appearance
+  </string>
+  <string name="pref_cat_appearance_summ">
+    Change themes and default font
+  </string>
+  <string name="pref_cat_themes">
+    Themes
+  </string>
+  <string name="pref_cat_fonts">
+    Fonts
+  </string>
+  <string name="pref_cat_gestures">
+    Gestures
+  </string>
+  <string name="pref_cat_gestures_summ">
+    Use taps and swipes instead of buttons
+  </string>
+  <string name="pref_cat_actions">
+    Actions
+  </string>
+  <string name="pref_cat_advanced">
+    Advanced
+  </string>
+  <string name="pref_cat_advanced_summ">
+    Optimization and experimental features
+  </string>
+  <string name="pref_cat_performance">
+    Performance
+  </string>
+  <string name="pref_cat_workarounds">
+    Workarounds
+  </string>
+  <string name="pref_cat_plugins">
+    Plugins
+  </string>
+  <string name="about_title">
+    About AnkiDroid
+  </string>
+  <string name="about_version">
+    Version:
+  </string>
 
-    <!-- preferences.xml entries-->
-    <string name="whiteboard_stroke_width">Stroke width</string>
-    <string name="whiteboard_black">Black strokes</string>
-    <string name="whiteboard_black_summ">Uses less memory, unless in night mode</string>
-    <string name="use_input_tag">Type answer into the card</string>
-    <string name="use_input_tag_summ">Use a text input box inside the card to type in the answer</string>
-    <string name="dictionary">Lookup dictionary</string>
-    <string name="reset_languages">Reset languages</string>
-    <string name="reset_languages_summ">Reset language assignments (for text to speech and dictionaries) for all decks</string>
-    <string name="reset_languages_question">Reset all language assignments?</string>
-    <string name="reset_confirmation">All states reset</string>
-    <string name="card_zoom">Card zoom</string>
-    <string name="image_zoom">Image zoom</string>
-    <string name="button_size">Answer button size</string>
-    <string name="card_browser_font_size">Card browser font scaling</string>
-    <string name="card_browser_hide_media">Display filenames in card browser</string>
-    <string name="card_browser_hide_media_summary">Display media filenames in the card browser question/answer fields</string>
-    <string name="col_path">AnkiDroid directory</string>
-    <string name="fullscreen_review">Fullscreen mode</string>
-    <string name="full_screen_off">Off</string>
-    <string name="full_screen_system">Hide the system bars</string>
-    <string name="full_screen_complete">Hide the system bars and answer buttons</string>
-    <string name="full_screen_error_gestures">You must enable gestures to hide the answer buttons</string>
-    <string name="answer_buttons_position">Answer buttons position</string>
-    <string-array name="answer_buttons_position_labels">
-        <item>Top</item>
-        <item>Bottom</item>
-    </string-array>
-    <string name="gestures">Enable gestures</string>
-    <string name="gestures_summ">Assign gestures to actions such as answering and editing cards.</string>
-    <string name="gestures_allow_links">Ignore touch gestures on links</string>
-    <string name="gestures_allow_links_summary">Touch gestures will not be processed if a link/hint is pressed.</string>
-    <string name="gestures_swipe_up">Swipe up</string>
-    <string name="gestures_swipe_down">Swipe down</string>
-    <string name="gestures_swipe_left">Swipe left</string>
-    <string name="gestures_swipe_right">Swipe right</string>
-    <string name="gestures_double_tap">Double touch</string>
-    <string name="gestures_tap_top">Touch top</string>
-    <string name="gestures_tap_bottom">Touch bottom</string>
-    <string name="gestures_tap_left">Touch left</string>
-    <string name="gestures_tap_right">Touch right</string>
-    <string name="gestures_volume_up">Volume up</string>
-    <string name="gestures_volume_down">Volume down</string>
-    <string name="more_scrolling_buttons">eReader</string>
-    <string name="more_scrolling_buttons_summ">Also use kanji/katakana, emoji/kao-moji buttons for scrolling</string>
-    <string name="card_browser_enable_external_context_menu">‘%s’ Menu</string>
-    <string name="card_browser_enable_external_context_menu_summary">Enables the ‘%s’ context menu globally</string>
-    <string name="double_scrolling_gap">Double scrolling</string>
-    <string name="double_scrolling_gap_summ">Double the scroll gap with eReader</string>
-    <string name="swipe_sensitivity">Swipe sensitivity</string>
-    <string name="tts">Text to speech</string>
-    <string name="tts_summ">Reads out question and answer if no sound file is included</string>
-    <string name="sync_fetch_missing_media">Fetch media on sync</string>
-    <string name="sync_fetch_missing_media_summ">Automatically fetch missing media when syncing</string>
-    <string name="sync_account">AnkiWeb account</string>
-    <string name="sync_account_summ_logged_out">Not logged in</string>
-    <string name="sync_account_summ_logged_in">%s</string>
-    <string name="automatic_sync_choice">Automatic synchronization</string>
-    <string name="automatic_sync_choice_summ">Sync automatically on app start/exit if the last sync was more than 10
-        minutes ago.</string>
-    <string name="sync_status_badge">Display synchronization status</string>
-    <string name="sync_status_badge_summ">Change the sync icon when changes can be uploaded</string>
-    <string name="day_theme">Day theme</string>
-    <string name="night_theme">Night theme</string>
-    <string name="default_font">Default font</string>
-    <string name="override_font">Default font applicability</string>
-    <string name="language">Language</string>
-    <string name="language_system">System language</string>
-    <string name="notification_pref">Notifications</string>
-    <string name="notification_pref_title">Notify when</string>
-    <string name="never_notify">Never notify</string>
-    <string name="notify_when_pending">Pending messages available</string>
-    <string name="notification_minimum_cards_due">More than %d cards due</string>
-    <string name="notification_minimum_cards_due_vibrate">Vibrate</string>
-    <string name="notification_minimum_cards_due_blink">Blink light</string>
-    <string name="timeout_answer_text">Automatic display answer</string>
-    <string name="timeout_answer_summ">Show answer automatically without user input. Delay includes time for automatically played audio files.</string>
-    <string name="timeout_answer_seconds">Time to show answer</string>
-    <string name="timeout_answer_seconds_summ">XXX s</string>
-    <string name="timeout_question_seconds">Time to show next question</string>
-    <string name="timeout_question_seconds_summ">XXX s</string>
-    <string name="select_locale_title">Select language</string>
-    <string name="safe_display">Safe display mode</string>
-    <string name="safe_display_summ">Disable all animations and use safer method for drawing cards. E-ink devices may require this.</string>
-    <string name="disable_extended_text_ui">Disable Single-Field Edit Mode</string>
-    <!--See: multimedia_editor_popup_cloze. We can't use format strings as this is auto-generated-->
-    <string name="disable_extended_text_ui_summ">Allows \'Cloze Deletion\' context menu when in landscape mode.</string>
-    <string name="vertical_centering">Center align</string>
-    <string name="vertical_centering_summ">Center the content of cards vertically</string>
-    <string name="pref_backup_max">Max number of backups</string>
-    <string name="show_estimates">Show button time</string>
-    <string name="show_estimates_summ">Show next review time on answer buttons</string>
-    <string name="show_top_bar">Show Top Bar</string>
-    <string name="show_top_bar_summ">Show card counts, flag and mark in top bar</string>
-    <string name="show_progress">Show remaining</string>
-    <string name="show_progress_summ">Show remaining card count</string>
-    <string name="show_eta">Show ETA</string>
-    <string name="show_eta_summ">Show remaining time</string>
-    <string name="use_current">Deck for new cards</string>
-    <string name="new_spread">New card position</string>
-    <string name="learn_cutoff">Learn ahead limit</string>
-    <string name="learn_cutoff_summ">XXX min</string>
-    <string name="time_limit">Timebox time limit</string>
-    <string name="time_limit_summ">XXX min</string>
-    <string name="day_offset">Start of next day</string>
-    <string name="day_offset_summ">XXX hours past midnight</string>
-    <string name="sched_ver">Experimental V2 scheduler</string>
-    <string name="sched_ver_summ">Enable the experimental scheduler. Forces changes in one direction on next sync</string>
-    <string name="sched_ver_toggle_title">Confirm</string>
-    <string name="sched_ver_2to1">This will reset any cards in learning, clear filtered decks, and change the scheduler version. Proceed?</string>
-    <string name="sched_ver_1to2">The experimental scheduler could cause incorrect scheduling. Please ensure you have read the documentation first. Proceed?</string>
-    <string name="pref_keep_screen_on">Keep screen on</string>
-    <string name="pref_keep_screen_on_summ">Disable screen timeout</string>
-    <string name="convert_fen_text">Chess notation support</string>
-    <string name="convert_fen_text_summ">Draw chessboard from Forsyth–Edwards Notation. The notation must be enclosed in [fen][/fen] tags.</string>
-    <string name="enable_api_title">Enable AnkiDroid API</string>
-    <string name="enable_api_summary">Let other apps connect to AnkiDroid and read / write data without your intervention</string>
-    <string name="custom_buttons">App bar buttons</string>
-    <string name="custom_buttons_summary">Customize which actions appear in the app bar</string>
-    <string name="custom_buttons_setting_always_show">Always show</string>
-    <string name="custom_buttons_setting_if_room">Show if room</string>
-    <string name="custom_buttons_setting_menu_only">Menu only</string>
-    <string name="reset_custom_buttons">Reset to default</string>
-    <string name="thirdparty_apps_title">Third-party API apps</string>
-    <string name="thirdparty_apps_summary">See a list of applications which make use of the AnkiDroid API such as dictionaries, utilities.</string>
+  <!-- preferences.xml entries-->
+  <string name="whiteboard_stroke_width">
+    Stroke width
+  </string>
+  <string name="whiteboard_black">
+    Black strokes
+  </string>
+  <string name="whiteboard_black_summ">
+    Uses less memory, unless in night mode
+  </string>
+  <string name="use_input_tag">
+    Type answer into the card
+  </string>
+  <string name="use_input_tag_summ">
+    Use a text input box inside the card to type in the answer
+  </string>
+  <string name="dictionary">
+    Lookup dictionary
+  </string>
+  <string name="reset_languages">
+    Reset languages
+  </string>
+  <string name="reset_languages_summ">
+    Reset language assignments (for text to speech and dictionaries) for all decks
+  </string>
+  <string name="reset_languages_question">
+    Reset all language assignments?
+  </string>
+  <string name="reset_confirmation">
+    All states reset
+  </string>
+  <string name="card_zoom">
+    Card zoom
+  </string>
+  <string name="image_zoom">
+    Image zoom
+  </string>
+  <string name="button_size">
+    Answer button size
+  </string>
+  <string name="card_browser_font_size">
+    Card browser font scaling
+  </string>
+  <string name="card_browser_hide_media">
+    Display filenames in card browser
+  </string>
+  <string name="card_browser_hide_media_summary">
+    Display media filenames in the card browser question/answer fields
+  </string>
+  <string name="col_path">
+    AnkiDroid directory
+  </string>
+  <string name="fullscreen_review">
+    Fullscreen mode
+  </string>
+  <string name="full_screen_off">
+    Off
+  </string>
+  <string name="full_screen_system">
+    Hide the system bars
+  </string>
+  <string name="full_screen_complete">
+    Hide the system bars and answer buttons
+  </string>
+  <string name="full_screen_error_gestures">
+    You must enable gestures to hide the answer buttons
+  </string>
+  <string name="answer_buttons_position">
+    Answer buttons position
+  </string>
+  <string-array name="answer_buttons_position_labels">
+    <item>
+      Top
+    </item>
+    <item>
+      Bottom
+    </item>
+  </string-array>
+  <string name="gestures">
+    Enable gestures
+  </string>
+  <string name="gestures_summ">
+    Assign gestures to actions such as answering and editing cards.
+  </string>
+  <string name="gestures_allow_links">
+    Ignore touch gestures on links
+  </string>
+  <string name="gestures_allow_links_summary">
+    Touch gestures will not be processed if a link/hint is pressed.
+  </string>
+  <string name="gestures_swipe_up">
+    Swipe up
+  </string>
+  <string name="gestures_swipe_down">
+    Swipe down
+  </string>
+  <string name="gestures_swipe_left">
+    Swipe left
+  </string>
+  <string name="gestures_swipe_right">
+    Swipe right
+  </string>
+  <string name="gestures_double_tap">
+    Double touch
+  </string>
+  <string name="gestures_tap_top">
+    Touch top
+  </string>
+  <string name="gestures_tap_bottom">
+    Touch bottom
+  </string>
+  <string name="gestures_tap_left">
+    Touch left
+  </string>
+  <string name="gestures_tap_right">
+    Touch right
+  </string>
+  <string name="gestures_volume_up">
+    Volume up
+  </string>
+  <string name="gestures_volume_down">
+    Volume down
+  </string>
+  <string name="more_scrolling_buttons">
+    eReader
+  </string>
+  <string name="more_scrolling_buttons_summ">
+    Also use kanji/katakana, emoji/kao-moji buttons for scrolling
+  </string>
+  <string name="card_browser_enable_external_context_menu">
+    ‘%s’ Menu
+  </string>
+  <string name="card_browser_enable_external_context_menu_summary">
+    Enables the ‘%s’ context menu globally
+  </string>
+  <string name="double_scrolling_gap">
+    Double scrolling
+  </string>
+  <string name="double_scrolling_gap_summ">
+    Double the scroll gap with eReader
+  </string>
+  <string name="swipe_sensitivity">
+    Swipe sensitivity
+  </string>
+  <string name="tts">
+    Text to speech
+  </string>
+  <string name="tts_summ">
+    Reads out question and answer if no sound file is included
+  </string>
+  <string name="sync_fetch_missing_media">
+    Fetch media on sync
+  </string>
+  <string name="sync_fetch_missing_media_summ">
+    Automatically fetch missing media when syncing
+  </string>
+  <string name="sync_account">
+    AnkiWeb account
+  </string>
+  <string name="sync_account_summ_logged_out">
+    Not logged in
+  </string>
+  <string name="sync_account_summ_logged_in">
+    %s
+  </string>
+  <string name="automatic_sync_choice">
+    Automatic synchronization
+  </string>
+  <string name="automatic_sync_choice_summ">
+    Sync automatically on app start/exit if the last sync was more than 10 minutes ago.
+  </string>
+  <string name="sync_status_badge">
+    Display synchronization status
+  </string>
+  <string name="sync_status_badge_summ">
+    Change the sync icon when changes can be uploaded
+  </string>
+  <string name="day_theme">
+    Day theme
+  </string>
+  <string name="night_theme">
+    Night theme
+  </string>
+  <string name="default_font">
+    Default font
+  </string>
+  <string name="override_font">
+    Default font applicability
+  </string>
+  <string name="language">
+    Language
+  </string>
+  <string name="language_system">
+    System language
+  </string>
+  <string name="notification_pref">
+    Notifications
+  </string>
+  <string name="notification_pref_title">
+    Notify when
+  </string>
+  <string name="never_notify">
+    Never notify
+  </string>
+  <string name="notify_when_pending">
+    Pending messages available
+  </string>
+  <string name="notification_minimum_cards_due">
+    More than %d cards due
+  </string>
+  <string name="notification_minimum_cards_due_vibrate">
+    Vibrate
+  </string>
+  <string name="notification_minimum_cards_due_blink">
+    Blink light
+  </string>
+  <string name="timeout_answer_text">
+    Automatic display answer
+  </string>
+  <string name="timeout_answer_summ">
+    Show answer automatically without user input. Delay includes time for automatically played audio files.
+  </string>
+  <string name="timeout_answer_seconds">
+    Time to show answer
+  </string>
+  <string name="timeout_answer_seconds_summ">
+    XXX s
+  </string>
+  <string name="timeout_question_seconds">
+    Time to show next question
+  </string>
+  <string name="timeout_question_seconds_summ">
+    XXX s
+  </string>
+  <string name="select_locale_title">
+    Select language
+  </string>
+  <string name="safe_display">
+    Safe display mode
+  </string>
+  <string name="safe_display_summ">
+    Disable all animations and use safer method for drawing cards. E-ink devices may require this.
+  </string>
+  <string name="disable_extended_text_ui">
+    Disable Single-Field Edit Mode
+  </string>
+  <!--See: multimedia_editor_popup_cloze. We can't use format strings as this is auto-generated-->
+  <string name="disable_extended_text_ui_summ">
+    Allows \'Cloze Deletion\' context menu when in landscape mode.
+  </string>
+  <string name="vertical_centering">
+    Center align
+  </string>
+  <string name="vertical_centering_summ">
+    Center the content of cards vertically
+  </string>
+  <string name="pref_backup_max">
+    Max number of backups
+  </string>
+  <string name="show_estimates">
+    Show button time
+  </string>
+  <string name="show_estimates_summ">
+    Show next review time on answer buttons
+  </string>
+  <string name="show_top_bar">
+    Show Top Bar
+  </string>
+  <string name="show_top_bar_summ">
+    Show card counts, flag and mark in top bar
+  </string>
+  <string name="show_progress">
+    Show remaining
+  </string>
+  <string name="show_progress_summ">
+    Show remaining card count
+  </string>
+  <string name="show_eta">
+    Show ETA
+  </string>
+  <string name="show_eta_summ">
+    Show remaining time
+  </string>
+  <string name="use_current">
+    Deck for new cards
+  </string>
+  <string name="new_spread">
+    New card position
+  </string>
+  <string name="learn_cutoff">
+    Learn ahead limit
+  </string>
+  <string name="learn_cutoff_summ">
+    XXX min
+  </string>
+  <string name="time_limit">
+    Timebox time limit
+  </string>
+  <string name="time_limit_summ">
+    XXX min
+  </string>
+  <string name="day_offset">
+    Start of next day
+  </string>
+  <string name="day_offset_summ">
+    XXX hours past midnight
+  </string>
+  <string name="sched_ver">
+    Experimental V2 scheduler
+  </string>
+  <string name="sched_ver_summ">
+    Enable the experimental scheduler. Forces changes in one direction on next sync
+  </string>
+  <string name="sched_ver_toggle_title">
+    Confirm
+  </string>
+  <string name="sched_ver_2to1">
+    This will reset any cards in learning, clear filtered decks, and change the scheduler version. Proceed?
+  </string>
+  <string name="sched_ver_1to2">
+    The experimental scheduler could cause incorrect scheduling. Please ensure you have read the documentation first. Proceed?
+  </string>
+  <string name="pref_keep_screen_on">
+    Keep screen on
+  </string>
+  <string name="pref_keep_screen_on_summ">
+    Disable screen timeout
+  </string>
+  <string name="convert_fen_text">
+    Chess notation support
+  </string>
+  <string name="convert_fen_text_summ">
+    Draw chessboard from Forsyth–Edwards Notation. The notation must be enclosed in [fen][/fen] tags.
+  </string>
+  <string name="enable_api_title">
+    Enable AnkiDroid API
+  </string>
+  <string name="enable_api_summary">
+    Let other apps connect to AnkiDroid and read / write data without your intervention
+  </string>
+  <string name="custom_buttons">
+    App bar buttons
+  </string>
+  <string name="custom_buttons_summary">
+    Customize which actions appear in the app bar
+  </string>
+  <string name="custom_buttons_setting_always_show">
+    Always show
+  </string>
+  <string name="custom_buttons_setting_if_room">
+    Show if room
+  </string>
+  <string name="custom_buttons_setting_menu_only">
+    Menu only
+  </string>
+  <string name="reset_custom_buttons">
+    Reset to default
+  </string>
+  <string name="thirdparty_apps_title">
+    Third-party API apps
+  </string>
+  <string name="thirdparty_apps_summary">
+    See a list of applications which make use of the AnkiDroid API such as dictionaries, utilities.
+  </string>
+  <string name="html_javascript_debugging">
+    HTML / Javascript Debugging
+  </string>
+  <string name="html_javascript_debugging_summ">
+    Enable remote WebView connections, and save card HTML to AnkiDroid directory
+  </string>
 
-    <string name="html_javascript_debugging">HTML / Javascript Debugging</string>
-    <string name="html_javascript_debugging_summ">Enable remote WebView connections, and save card HTML to AnkiDroid directory</string>
+  <!-- Advanced statistics settings -->
+  <string name="advanced_statistics_title">
+    Advanced statistics
+  </string>
+  <string name="enable_advanced_statistics_title">
+    Enable advanced statistics
+  </string>
+  <string name="enable_advanced_statistics_summ">
+    Display forecast statistics based on a computation or simulation of future reviews (enabled) or on the future reviews already scheduled (disabled).
+  </string>
+  <string name="advanced_forecast_stats_compute_n_days_title">
+    Compute first n days, simulate remainder
+  </string>
+  <string name="advanced_forecast_stats_compute_precision_title">
+    Precision of computation
+  </string>
+  <string name="advanced_forecast_stats_mc_n_iterations_title">
+    Number of iterations of the simulation
+  </string>
+  <!-- Custom sync server settings -->
+  <string name="custom_sync_server_title">
+    Custom sync server
+  </string>
+  <string name="custom_sync_server_enable_title">
+    Use custom sync server
+  </string>
+  <string name="custom_sync_server_enable_summary">
+    If you don\'t want to use the proprietary AnkiWeb service you can specify an alternative server here
+  </string>
+  <string name="custom_sync_server_base_url_title">
+    Sync url
+  </string>
+  <string name="custom_sync_server_base_url_invalid">
+    Sync url invalid
+  </string>
+  <string name="custom_sync_server_media_url_title">
+    Media sync url
+  </string>
+  <string name="custom_sync_server_media_url_invalid">
+    Media sync url invalid
+  </string>
+  <!-- studyoptions -->
+  <string name="deck_conf_group_summ">
+    Changes to deck group options will affect multiple decks. If you wish to change only the current deck, please add a new options group first
+  </string>
+  <string name="studyoptions_limit_select_tags">
+    Select tags
+  </string>
+  <!-- Deck configurations -->
+  <string name="deck_conf_deck_description">
+    Deck description (affects current deck only)
+  </string>
+  <string name="deck_conf_group">
+    Options group
+  </string>
+  <plurals name="deck_conf_group_summ">
+    <item quantity="one">
+      %1$s\n%2$d deck uses this group
+    </item>
+    <item quantity="other">
+      %1$s\n%2$d decks use this group
+    </item>
+  </plurals>
+  <string name="deck_conf_new_cards">
+    New cards
+  </string>
+  <string name="deck_conf_rev_cards">
+    Reviews
+  </string>
+  <string name="deck_conf_lps_cards">
+    Lapses
+  </string>
+  <string name="deck_conf_general">
+    General
+  </string>
+  <string name="deck_conf_reminders">
+    Reminders
+  </string>
+  <string name="deck_conf_steps">
+    Steps (in minutes)
+  </string>
+  <string name="deck_conf_order">
+    Order
+  </string>
+  <string name="deck_conf_new_cards_day">
+    New cards/day
+  </string>
+  <string name="deck_conf_graduating_ivl">
+    Graduating interval
+  </string>
+  <string name="deck_conf_days">
+    XXX day(s)
+  </string>
+  <string name="deck_conf_easy_ivl">
+    Easy interval
+  </string>
+  <string name="deck_conf_start_ease">
+    Starting ease
+  </string>
+  <string name="deck_conf_max_rev">
+    Maximum reviews/day
+  </string>
+  <string name="deck_conf_new_bury">
+    Bury related new cards
+  </string>
+  <string name="deck_conf_new_bury_summ">
+    Related new cards are buried until the next day
+  </string>
+  <string name="deck_conf_rev_bury">
+    Bury related reviews
+  </string>
+  <string name="deck_conf_rev_bury_summ">
+    Related reviews are buried until the next day
+  </string>
+  <string name="deck_conf_use_general_timeout_settings">
+    Use general settings
+  </string>
+  <string name="deck_conf_use_general_timeout_settings_summ">
+    Use general \'Automatic display answer\' settings instead of using the settings for this group.
+  </string>
+  <string name="deck_conf_easy_bonus">
+    Easy bonus
+  </string>
+  <string name="deck_conf_ivl_fct">
+    Interval modifier
+  </string>
+  <string name="deck_conf_max_ivl">
+    Maximum interval
+  </string>
+  <string name="deck_conf_new_lps_ivl">
+    New interval
+  </string>
+  <string name="deck_conf_min_ivl">
+    Minimum interval
+  </string>
+  <string name="deck_conf_leech_thres">
+    Leech threshold
+  </string>
+  <string name="deck_conf_fails">
+    XXX lapse(s)
+  </string>
+  <string name="deck_conf_leech_action">
+    Leech action
+  </string>
+  <string name="deck_conf_max_time">
+    Maximal answer time
+  </string>
+  <string name="deck_conf_seconds">
+    XXX seconds
+  </string>
+  <string name="deck_conf_timer">
+    Show answer timer
+  </string>
+  <string name="deck_conf_autoplay">
+    Automatically play audio
+  </string>
+  <string name="deck_conf_replayq">
+    Replay question
+  </string>
+  <string name="deck_conf_replayq_summ">
+    When answer shown, replay both question and answer audio
+  </string>
+  <string name="deck_conf_manage">
+    Group management
+  </string>
+  <string name="deck_conf_current_group">
+    Current group
+  </string>
+  <string name="deck_conf_rename">
+    Rename
+  </string>
+  <string name="deck_conf_reset">
+    Restore defaults
+  </string>
+  <string name="deck_conf_reset_title">
+    Restore defaults
+  </string>
+  <string name="deck_conf_reset_message">
+    Restore current options group to default values?
+  </string>
+  <string name="deck_conf_add">
+    Add
+  </string>
+  <string name="deck_conf_add_summ">
+    Create a copy of the current options group
+  </string>
+  <string name="deck_conf_remove">
+    Remove
+  </string>
+  <string name="deck_conf_remove_title">
+    Remove
+  </string>
+  <string name="deck_conf_remove_message">
+    Remove current options group?
+  </string>
+  <string name="deck_conf_set_subdecks">
+    Set for all subdecks
+  </string>
+  <plurals name="deck_conf_set_subdecks_summ">
+    <item quantity="one">%s subdeck will use this group</item>
+    <item quantity="other">
+      %s subdecks will use this group
+    </item>
+  </plurals>
+  
 
-    <!-- Advanced statistics settings -->
-    <string name="advanced_statistics_title">Advanced statistics</string>
-    <string name="enable_advanced_statistics_title">Enable advanced statistics</string>
-    <string name="enable_advanced_statistics_summ">Display forecast statistics based on a computation or simulation of future reviews (enabled) or on the future reviews already scheduled (disabled).</string>
-    <string name="advanced_forecast_stats_compute_n_days_title">Compute first n days, simulate remainder</string>
-    <string name="advanced_forecast_stats_compute_precision_title">Precision of computation</string>
-    <string name="advanced_forecast_stats_mc_n_iterations_title">Number of iterations of the simulation</string>
-    <!-- Custom sync server settings -->
-    <string name="custom_sync_server_title">Custom sync server</string>
-    <string name="custom_sync_server_enable_title">Use custom sync server</string>
-    <string name="custom_sync_server_enable_summary">If you don\'t want to use the proprietary AnkiWeb service you can specify an alternative server here</string>
-    <string name="custom_sync_server_base_url_title">Sync url</string>
-    <string name="custom_sync_server_base_url_invalid">Sync url invalid</string>
-    <string name="custom_sync_server_media_url_title">Media sync url</string>
-    <string name="custom_sync_server_media_url_invalid">Media sync url invalid</string>
+  <string name="deck_conf_set_subdecks_title">
+    Set for all subdecks
+  </string>
+  <string name="deck_conf_set_subdecks_message">
+    Set current options group for all of this deck’s subdecks?
+  </string>
+  <string name="pref_browser_editor_font">
+    Browser and editor font
+  </string>
+  <string name="deck_conf_cram_filter">
+    Filter
+  </string>
+  <string name="deck_conf_cram_options">
+    Options
+  </string>
+  <string name="deck_conf_cram_search">
+    Search
+  </string>
+  <string name="deck_conf_cram_limit">
+    Limit to
+  </string>
+  <string name="deck_conf_cram_order">
+    cards selected by
+  </string>
+  <string name="deck_conf_cram_reschedule">
+    Reschedule
+  </string>
+  <string name="deck_conf_cram_reschedule_summ">
+    Reschedule cards based on my answers in this deck
+  </string>
+  <string name="deck_conf_cram_steps">
+    Custom steps (in minutes)
+  </string>
+  <string name="deck_conf_cram_steps_summ">
+    Define custom steps
+  </string>
+  <string name="deck_conf_reminders_enabled">
+    Enable reminder notifications for decks in this deck group
+  </string>
+  <string name="deck_conf_reminders_time">
+    Remind at
+  </string>
 
-    <!-- studyoptions -->
-    <string name="deck_conf_group_summ">Changes to deck group options will affect multiple decks. If you wish to change only the current deck, please add a new options group first</string>
-    <string name="studyoptions_limit_select_tags">Select tags</string>
-    <!-- Deck configurations -->
-    <string name="deck_conf_deck_description">Deck description (affects current deck only)</string>
-    <string name="deck_conf_group">Options group</string>
-    <plurals name="deck_conf_group_summ">
-        <item quantity="one">%1$s\n%2$d deck uses this group</item>
-        <item quantity="other">%1$s\n%2$d decks use this group</item>
-    </plurals>
-    <string name="deck_conf_new_cards">New cards</string>
-    <string name="deck_conf_rev_cards">Reviews</string>
-    <string name="deck_conf_lps_cards">Lapses</string>
-    <string name="deck_conf_general">General</string>
-    <string name="deck_conf_reminders">Reminders</string>
-    <string name="deck_conf_steps">Steps (in minutes)</string>
-    <string name="deck_conf_order">Order</string>
-    <string name="deck_conf_new_cards_day">New cards/day</string>
-    <string name="deck_conf_graduating_ivl">Graduating interval</string>
-    <string name="deck_conf_days">XXX day(s)</string>
-    <string name="deck_conf_easy_ivl">Easy interval</string>
-    <string name="deck_conf_start_ease">Starting ease</string>
-    <string name="deck_conf_max_rev">Maximum reviews/day</string>
-    <string name="deck_conf_new_bury">Bury related new cards</string>
-    <string name="deck_conf_new_bury_summ">Related new cards are buried until the next day</string>
-    <string name="deck_conf_rev_bury">Bury related reviews</string>
-    <string name="deck_conf_rev_bury_summ">Related reviews are buried until the next day</string>
-    <string name="deck_conf_use_general_timeout_settings">Use general settings</string>
-    <string name="deck_conf_use_general_timeout_settings_summ">Use general \'Automatic display answer\' settings instead of using the settings for this group.</string>
-    <string name="deck_conf_easy_bonus">Easy bonus</string>
-    <string name="deck_conf_ivl_fct">Interval modifier</string>
-    <string name="deck_conf_max_ivl">Maximum interval</string>
-    <string name="deck_conf_new_lps_ivl">New interval</string>
-    <string name="deck_conf_min_ivl">Minimum interval</string>
-    <string name="deck_conf_leech_thres">Leech threshold</string>
-    <string name="deck_conf_fails">XXX lapse(s)</string>
-    <string name="deck_conf_leech_action">Leech action</string>
-    <string name="deck_conf_max_time">Maximal answer time</string>
-    <string name="deck_conf_seconds">XXX seconds</string>
-    <string name="deck_conf_timer">Show answer timer</string>
-    <string name="deck_conf_autoplay">Automatically play audio</string>
-    <string name="deck_conf_replayq">Replay question</string>
-    <string name="deck_conf_replayq_summ">When answer shown, replay both question and answer audio</string>
-    <string name="deck_conf_manage">Group management</string>
-    <string name="deck_conf_current_group">Current group</string>
-    <string name="deck_conf_rename">Rename</string>
-    <string name="deck_conf_reset">Restore defaults</string>
-    <string name="deck_conf_reset_title">Restore defaults</string>
-    <string name="deck_conf_reset_message">Restore current options group to default values?</string>
-    <string name="deck_conf_add">Add</string>
-    <string name="deck_conf_add_summ">Create a copy of the current options group</string>
-    <string name="deck_conf_remove">Remove</string>
-    <string name="deck_conf_remove_title">Remove</string>
-    <string name="deck_conf_remove_message">Remove current options group?</string>
-    <string name="deck_conf_set_subdecks">Set for all subdecks</string>
-    <plurals name="deck_conf_set_subdecks_summ">
-        <item quantity="one">%s subdeck will use this group</item>
-        <item quantity="other">%s subdecks will use this group</item>
-    </plurals>
-    <string name="deck_conf_set_subdecks_title">Set for all subdecks</string>
-    <string name="deck_conf_set_subdecks_message">Set current options group for all of this deck’s subdecks?</string>
-    <string name="pref_browser_editor_font">Browser and editor font</string>
-    <string name="deck_conf_cram_filter">Filter</string>
-    <string name="deck_conf_cram_options">Options</string>
-    <string name="deck_conf_cram_search">Search</string>
-    <string name="deck_conf_cram_limit">Limit to</string>
-    <string name="deck_conf_cram_order">cards selected by</string>
-    <string name="deck_conf_cram_reschedule">Reschedule</string>
-    <string name="deck_conf_cram_reschedule_summ">Reschedule cards based on my answers in this deck</string>
-    <string name="deck_conf_cram_steps">Custom steps (in minutes)</string>
-    <string name="deck_conf_cram_steps_summ">Define custom steps</string>
-    <string name="deck_conf_reminders_enabled">Enable reminder notifications for decks in this deck group</string>
-    <string name="deck_conf_reminders_time">Remind at</string>
-
-    <!-- analytics options -->
-    <string name="analytics_dialog_title">Help make AnkiDroid better!</string>
-    <string name="analytics_title">Share feature usage</string>
-    <string name="analytics_summ">You can contribute to AnkiDroid by helping the development team see which features people use</string>
-"</resources>
+  <!-- analytics options -->
+  <string name="analytics_dialog_title">
+    Help make AnkiDroid better!
+  </string>
+  <string name="analytics_title">
+    Share feature usage
+  </string>
+  <string name="analytics_summ">
+    You can contribute to AnkiDroid by helping the development team see which features people use
+  </string>
+</resources>

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -20,151 +20,247 @@
 -->
 <resources>
   <!-- generic strings -->
-  <string name="disabled">
+  <string
+      name="disabled"
+      >
     Disabled
   </string>
-  <string name="enabled">
+  <string
+      name="enabled"
+      >
     Enabled
   </string>
   <!-- preferences.xml categories-->
-  <string name="pref_cat_general">
+  <string
+      name="pref_cat_general"
+      >
     AnkiDroid
   </string>
-  <string name="pref_cat_general_summ">
+  <string
+      name="pref_cat_general_summ"
+      >
     General settings
   </string>
-  <string name="pref_cat_reviewing">
+  <string
+      name="pref_cat_reviewing"
+      >
     Reviewing
   </string>
-  <string name="pref_cat_reviewing_summ">
+  <string
+      name="pref_cat_reviewing_summ"
+      >
     Non-deck-specific reviewer settings
   </string>
-  <string name="pref_cat_reviewer_behaviour">
+  <string
+      name="pref_cat_reviewer_behaviour"
+      >
     Behavior
   </string>
-  <string name="pref_cat_flashcard">
+  <string
+      name="pref_cat_flashcard"
+      >
     Display
   </string>
-  <string name="pref_cat_whiteboard">
+  <string
+      name="pref_cat_whiteboard"
+      >
     Whiteboard
   </string>
-  <string name="pref_cat_automatic_display">
+  <string
+      name="pref_cat_automatic_display"
+      >
     Automatic display answer
   </string>
-  <string name="pref_cat_appearance">
+  <string
+      name="pref_cat_appearance"
+      >
     Appearance
   </string>
-  <string name="pref_cat_appearance_summ">
+  <string
+      name="pref_cat_appearance_summ"
+      >
     Change themes and default font
   </string>
-  <string name="pref_cat_themes">
+  <string
+      name="pref_cat_themes"
+      >
     Themes
   </string>
-  <string name="pref_cat_fonts">
+  <string
+      name="pref_cat_fonts"
+      >
     Fonts
   </string>
-  <string name="pref_cat_gestures">
+  <string
+      name="pref_cat_gestures"
+      >
     Gestures
   </string>
-  <string name="pref_cat_gestures_summ">
+  <string
+      name="pref_cat_gestures_summ"
+      >
     Use taps and swipes instead of buttons
   </string>
-  <string name="pref_cat_actions">
+  <string
+      name="pref_cat_actions"
+      >
     Actions
   </string>
-  <string name="pref_cat_advanced">
+  <string
+      name="pref_cat_advanced"
+      >
     Advanced
   </string>
-  <string name="pref_cat_advanced_summ">
+  <string
+      name="pref_cat_advanced_summ"
+      >
     Optimization and experimental features
   </string>
-  <string name="pref_cat_performance">
+  <string
+      name="pref_cat_performance"
+      >
     Performance
   </string>
-  <string name="pref_cat_workarounds">
+  <string
+      name="pref_cat_workarounds"
+      >
     Workarounds
   </string>
-  <string name="pref_cat_plugins">
+  <string
+      name="pref_cat_plugins"
+      >
     Plugins
   </string>
-  <string name="about_title">
+  <string
+      name="about_title"
+      >
     About AnkiDroid
   </string>
-  <string name="about_version">
+  <string
+      name="about_version"
+      >
     Version:
   </string>
 
   <!-- preferences.xml entries-->
-  <string name="whiteboard_stroke_width">
+  <string
+      name="whiteboard_stroke_width"
+      >
     Stroke width
   </string>
-  <string name="whiteboard_black">
+  <string
+      name="whiteboard_black"
+      >
     Black strokes
   </string>
-  <string name="whiteboard_black_summ">
+  <string
+      name="whiteboard_black_summ"
+      >
     Uses less memory, unless in night mode
   </string>
-  <string name="use_input_tag">
+  <string
+      name="use_input_tag"
+      >
     Type answer into the card
   </string>
-  <string name="use_input_tag_summ">
+  <string
+      name="use_input_tag_summ"
+      >
     Use a text input box inside the card to type in the answer
   </string>
-  <string name="dictionary">
+  <string
+      name="dictionary"
+      >
     Lookup dictionary
   </string>
-  <string name="reset_languages">
+  <string
+      name="reset_languages"
+      >
     Reset languages
   </string>
-  <string name="reset_languages_summ">
+  <string
+      name="reset_languages_summ"
+      >
     Reset language assignments (for text to speech and dictionaries) for all decks
   </string>
-  <string name="reset_languages_question">
+  <string
+      name="reset_languages_question"
+      >
     Reset all language assignments?
   </string>
-  <string name="reset_confirmation">
+  <string
+      name="reset_confirmation"
+      >
     All states reset
   </string>
-  <string name="card_zoom">
+  <string
+      name="card_zoom"
+      >
     Card zoom
   </string>
-  <string name="image_zoom">
+  <string
+      name="image_zoom"
+      >
     Image zoom
   </string>
-  <string name="button_size">
+  <string
+      name="button_size"
+      >
     Answer button size
   </string>
-  <string name="card_browser_font_size">
+  <string
+      name="card_browser_font_size"
+      >
     Card browser font scaling
   </string>
-  <string name="card_browser_hide_media">
+  <string
+      name="card_browser_hide_media"
+      >
     Display filenames in card browser
   </string>
-  <string name="card_browser_hide_media_summary">
+  <string
+      name="card_browser_hide_media_summary"
+      >
     Display media filenames in the card browser question/answer fields
   </string>
-  <string name="col_path">
+  <string
+      name="col_path"
+      >
     AnkiDroid directory
   </string>
-  <string name="fullscreen_review">
+  <string
+      name="fullscreen_review"
+      >
     Fullscreen mode
   </string>
-  <string name="full_screen_off">
+  <string
+      name="full_screen_off"
+      >
     Off
   </string>
-  <string name="full_screen_system">
+  <string
+      name="full_screen_system"
+      >
     Hide the system bars
   </string>
-  <string name="full_screen_complete">
+  <string
+      name="full_screen_complete"
+      >
     Hide the system bars and answer buttons
   </string>
-  <string name="full_screen_error_gestures">
+  <string
+      name="full_screen_error_gestures"
+      >
     You must enable gestures to hide the answer buttons
   </string>
-  <string name="answer_buttons_position">
+  <string
+      name="answer_buttons_position"
+      >
     Answer buttons position
   </string>
-  <string-array name="answer_buttons_position_labels">
+  <string-array
+      name="answer_buttons_position_labels"
+      >
     <item>
       Top
     </item>
@@ -172,355 +268,585 @@
       Bottom
     </item>
   </string-array>
-  <string name="gestures">
+  <string
+      name="gestures"
+      >
     Enable gestures
   </string>
-  <string name="gestures_summ">
+  <string
+      name="gestures_summ"
+      >
     Assign gestures to actions such as answering and editing cards.
   </string>
-  <string name="gestures_allow_links">
+  <string
+      name="gestures_allow_links"
+      >
     Ignore touch gestures on links
   </string>
-  <string name="gestures_allow_links_summary">
+  <string
+      name="gestures_allow_links_summary"
+      >
     Touch gestures will not be processed if a link/hint is pressed.
   </string>
-  <string name="gestures_swipe_up">
+  <string
+      name="gestures_swipe_up"
+      >
     Swipe up
   </string>
-  <string name="gestures_swipe_down">
+  <string
+      name="gestures_swipe_down"
+      >
     Swipe down
   </string>
-  <string name="gestures_swipe_left">
+  <string
+      name="gestures_swipe_left"
+      >
     Swipe left
   </string>
-  <string name="gestures_swipe_right">
+  <string
+      name="gestures_swipe_right"
+      >
     Swipe right
   </string>
-  <string name="gestures_double_tap">
+  <string
+      name="gestures_double_tap"
+      >
     Double touch
   </string>
-  <string name="gestures_tap_top">
+  <string
+      name="gestures_tap_top"
+      >
     Touch top
   </string>
-  <string name="gestures_tap_bottom">
+  <string
+      name="gestures_tap_bottom"
+      >
     Touch bottom
   </string>
-  <string name="gestures_tap_left">
+  <string
+      name="gestures_tap_left"
+      >
     Touch left
   </string>
-  <string name="gestures_tap_right">
+  <string
+      name="gestures_tap_right"
+      >
     Touch right
   </string>
-  <string name="gestures_volume_up">
+  <string
+      name="gestures_volume_up"
+      >
     Volume up
   </string>
-  <string name="gestures_volume_down">
+  <string
+      name="gestures_volume_down"
+      >
     Volume down
   </string>
-  <string name="more_scrolling_buttons">
+  <string
+      name="more_scrolling_buttons"
+      >
     eReader
   </string>
-  <string name="more_scrolling_buttons_summ">
+  <string
+      name="more_scrolling_buttons_summ"
+      >
     Also use kanji/katakana, emoji/kao-moji buttons for scrolling
   </string>
-  <string name="card_browser_enable_external_context_menu">
+  <string
+      name="card_browser_enable_external_context_menu"
+      >
     ‘%s’ Menu
   </string>
-  <string name="card_browser_enable_external_context_menu_summary">
+  <string
+      name="card_browser_enable_external_context_menu_summary"
+      >
     Enables the ‘%s’ context menu globally
   </string>
-  <string name="double_scrolling_gap">
+  <string
+      name="double_scrolling_gap"
+      >
     Double scrolling
   </string>
-  <string name="double_scrolling_gap_summ">
+  <string
+      name="double_scrolling_gap_summ"
+      >
     Double the scroll gap with eReader
   </string>
-  <string name="swipe_sensitivity">
+  <string
+      name="swipe_sensitivity"
+      >
     Swipe sensitivity
   </string>
-  <string name="tts">
+  <string
+      name="tts"
+      >
     Text to speech
   </string>
-  <string name="tts_summ">
+  <string
+      name="tts_summ"
+      >
     Reads out question and answer if no sound file is included
   </string>
-  <string name="sync_fetch_missing_media">
+  <string
+      name="sync_fetch_missing_media"
+      >
     Fetch media on sync
   </string>
-  <string name="sync_fetch_missing_media_summ">
+  <string
+      name="sync_fetch_missing_media_summ"
+      >
     Automatically fetch missing media when syncing
   </string>
-  <string name="sync_account">
+  <string
+      name="sync_account"
+      >
     AnkiWeb account
   </string>
-  <string name="sync_account_summ_logged_out">
+  <string
+      name="sync_account_summ_logged_out"
+      >
     Not logged in
   </string>
-  <string name="sync_account_summ_logged_in">
+  <string
+      name="sync_account_summ_logged_in"
+      >
     %s
   </string>
-  <string name="automatic_sync_choice">
+  <string
+      name="automatic_sync_choice"
+      >
     Automatic synchronization
   </string>
-  <string name="automatic_sync_choice_summ">
+  <string
+      name="automatic_sync_choice_summ"
+      >
     Sync automatically on app start/exit if the last sync was more than 10 minutes ago.
   </string>
-  <string name="sync_status_badge">
+  <string
+      name="sync_status_badge"
+      >
     Display synchronization status
   </string>
-  <string name="sync_status_badge_summ">
+  <string
+      name="sync_status_badge_summ"
+      >
     Change the sync icon when changes can be uploaded
   </string>
-  <string name="day_theme">
+  <string
+      name="day_theme"
+      >
     Day theme
   </string>
-  <string name="night_theme">
+  <string
+      name="night_theme"
+      >
     Night theme
   </string>
-  <string name="default_font">
+  <string
+      name="default_font"
+      >
     Default font
   </string>
-  <string name="override_font">
+  <string
+      name="override_font"
+      >
     Default font applicability
   </string>
-  <string name="language">
+  <string
+      name="language"
+      >
     Language
   </string>
-  <string name="language_system">
+  <string
+      name="language_system"
+      >
     System language
   </string>
-  <string name="notification_pref">
+  <string
+      name="notification_pref"
+      >
     Notifications
   </string>
-  <string name="notification_pref_title">
+  <string
+      name="notification_pref_title"
+      >
     Notify when
   </string>
-  <string name="never_notify">
+  <string
+      name="never_notify"
+      >
     Never notify
   </string>
-  <string name="notify_when_pending">
+  <string
+      name="notify_when_pending"
+      >
     Pending messages available
   </string>
-  <string name="notification_minimum_cards_due">
+  <string
+      name="notification_minimum_cards_due"
+      >
     More than %d cards due
   </string>
-  <string name="notification_minimum_cards_due_vibrate">
+  <string
+      name="notification_minimum_cards_due_vibrate"
+      >
     Vibrate
   </string>
-  <string name="notification_minimum_cards_due_blink">
+  <string
+      name="notification_minimum_cards_due_blink"
+      >
     Blink light
   </string>
-  <string name="timeout_answer_text">
+  <string
+      name="timeout_answer_text"
+      >
     Automatic display answer
   </string>
-  <string name="timeout_answer_summ">
+  <string
+      name="timeout_answer_summ"
+      >
     Show answer automatically without user input. Delay includes time for automatically played audio files.
   </string>
-  <string name="timeout_answer_seconds">
+  <string
+      name="timeout_answer_seconds"
+      >
     Time to show answer
   </string>
-  <string name="timeout_answer_seconds_summ">
+  <string
+      name="timeout_answer_seconds_summ"
+      >
     XXX s
   </string>
-  <string name="timeout_question_seconds">
+  <string
+      name="timeout_question_seconds"
+      >
     Time to show next question
   </string>
-  <string name="timeout_question_seconds_summ">
+  <string
+      name="timeout_question_seconds_summ"
+      >
     XXX s
   </string>
-  <string name="select_locale_title">
+  <string
+      name="select_locale_title"
+      >
     Select language
   </string>
-  <string name="safe_display">
+  <string
+      name="safe_display"
+      >
     Safe display mode
   </string>
-  <string name="safe_display_summ">
+  <string
+      name="safe_display_summ"
+      >
     Disable all animations and use safer method for drawing cards. E-ink devices may require this.
   </string>
-  <string name="disable_extended_text_ui">
+  <string
+      name="disable_extended_text_ui"
+      >
     Disable Single-Field Edit Mode
   </string>
   <!--See: multimedia_editor_popup_cloze. We can't use format strings as this is auto-generated-->
-  <string name="disable_extended_text_ui_summ">
+  <string
+      name="disable_extended_text_ui_summ"
+      >
     Allows \'Cloze Deletion\' context menu when in landscape mode.
   </string>
-  <string name="vertical_centering">
+  <string
+      name="vertical_centering"
+      >
     Center align
   </string>
-  <string name="vertical_centering_summ">
+  <string
+      name="vertical_centering_summ"
+      >
     Center the content of cards vertically
   </string>
-  <string name="pref_backup_max">
+  <string
+      name="pref_backup_max"
+      >
     Max number of backups
   </string>
-  <string name="show_estimates">
+  <string
+      name="show_estimates"
+      >
     Show button time
   </string>
-  <string name="show_estimates_summ">
+  <string
+      name="show_estimates_summ"
+      >
     Show next review time on answer buttons
   </string>
-  <string name="show_top_bar">
+  <string
+      name="show_top_bar"
+      >
     Show Top Bar
   </string>
-  <string name="show_top_bar_summ">
+  <string
+      name="show_top_bar_summ"
+      >
     Show card counts, flag and mark in top bar
   </string>
-  <string name="show_progress">
+  <string
+      name="show_progress"
+      >
     Show remaining
   </string>
-  <string name="show_progress_summ">
+  <string
+      name="show_progress_summ"
+      >
     Show remaining card count
   </string>
-  <string name="show_eta">
+  <string
+      name="show_eta"
+      >
     Show ETA
   </string>
-  <string name="show_eta_summ">
+  <string
+      name="show_eta_summ"
+      >
     Show remaining time
   </string>
-  <string name="use_current">
+  <string
+      name="use_current"
+      >
     Deck for new cards
   </string>
-  <string name="new_spread">
+  <string
+      name="new_spread"
+      >
     New card position
   </string>
-  <string name="learn_cutoff">
+  <string
+      name="learn_cutoff"
+      >
     Learn ahead limit
   </string>
-  <string name="learn_cutoff_summ">
+  <string
+      name="learn_cutoff_summ"
+      >
     XXX min
   </string>
-  <string name="time_limit">
+  <string
+      name="time_limit"
+      >
     Timebox time limit
   </string>
-  <string name="time_limit_summ">
+  <string
+      name="time_limit_summ"
+      >
     XXX min
   </string>
-  <string name="day_offset">
+  <string
+      name="day_offset"
+      >
     Start of next day
   </string>
-  <string name="day_offset_summ">
+  <string
+      name="day_offset_summ"
+      >
     XXX hours past midnight
   </string>
-  <string name="sched_ver">
+  <string
+      name="sched_ver"
+      >
     Experimental V2 scheduler
   </string>
-  <string name="sched_ver_summ">
+  <string
+      name="sched_ver_summ"
+      >
     Enable the experimental scheduler. Forces changes in one direction on next sync
   </string>
-  <string name="sched_ver_toggle_title">
+  <string
+      name="sched_ver_toggle_title"
+      >
     Confirm
   </string>
-  <string name="sched_ver_2to1">
+  <string
+      name="sched_ver_2to1"
+      >
     This will reset any cards in learning, clear filtered decks, and change the scheduler version. Proceed?
   </string>
-  <string name="sched_ver_1to2">
+  <string
+      name="sched_ver_1to2"
+      >
     The experimental scheduler could cause incorrect scheduling. Please ensure you have read the documentation first. Proceed?
   </string>
-  <string name="pref_keep_screen_on">
+  <string
+      name="pref_keep_screen_on"
+      >
     Keep screen on
   </string>
-  <string name="pref_keep_screen_on_summ">
+  <string
+      name="pref_keep_screen_on_summ"
+      >
     Disable screen timeout
   </string>
-  <string name="convert_fen_text">
+  <string
+      name="convert_fen_text"
+      >
     Chess notation support
   </string>
-  <string name="convert_fen_text_summ">
+  <string
+      name="convert_fen_text_summ"
+      >
     Draw chessboard from Forsyth–Edwards Notation. The notation must be enclosed in [fen][/fen] tags.
   </string>
-  <string name="enable_api_title">
+  <string
+      name="enable_api_title"
+      >
     Enable AnkiDroid API
   </string>
-  <string name="enable_api_summary">
+  <string
+      name="enable_api_summary"
+      >
     Let other apps connect to AnkiDroid and read / write data without your intervention
   </string>
-  <string name="custom_buttons">
+  <string
+      name="custom_buttons"
+      >
     App bar buttons
   </string>
-  <string name="custom_buttons_summary">
+  <string
+      name="custom_buttons_summary"
+      >
     Customize which actions appear in the app bar
   </string>
-  <string name="custom_buttons_setting_always_show">
+  <string
+      name="custom_buttons_setting_always_show"
+      >
     Always show
   </string>
-  <string name="custom_buttons_setting_if_room">
+  <string
+      name="custom_buttons_setting_if_room"
+      >
     Show if room
   </string>
-  <string name="custom_buttons_setting_menu_only">
+  <string
+      name="custom_buttons_setting_menu_only"
+      >
     Menu only
   </string>
-  <string name="reset_custom_buttons">
+  <string
+      name="reset_custom_buttons"
+      >
     Reset to default
   </string>
-  <string name="thirdparty_apps_title">
+  <string
+      name="thirdparty_apps_title"
+      >
     Third-party API apps
   </string>
-  <string name="thirdparty_apps_summary">
+  <string
+      name="thirdparty_apps_summary"
+      >
     See a list of applications which make use of the AnkiDroid API such as dictionaries, utilities.
   </string>
-  <string name="html_javascript_debugging">
+  <string
+      name="html_javascript_debugging"
+      >
     HTML / Javascript Debugging
   </string>
-  <string name="html_javascript_debugging_summ">
+  <string
+      name="html_javascript_debugging_summ"
+      >
     Enable remote WebView connections, and save card HTML to AnkiDroid directory
   </string>
 
   <!-- Advanced statistics settings -->
-  <string name="advanced_statistics_title">
+  <string
+      name="advanced_statistics_title"
+      >
     Advanced statistics
   </string>
-  <string name="enable_advanced_statistics_title">
+  <string
+      name="enable_advanced_statistics_title"
+      >
     Enable advanced statistics
   </string>
-  <string name="enable_advanced_statistics_summ">
+  <string
+      name="enable_advanced_statistics_summ"
+      >
     Display forecast statistics based on a computation or simulation of future reviews (enabled) or on the future reviews already scheduled (disabled).
   </string>
-  <string name="advanced_forecast_stats_compute_n_days_title">
+  <string
+      name="advanced_forecast_stats_compute_n_days_title"
+      >
     Compute first n days, simulate remainder
   </string>
-  <string name="advanced_forecast_stats_compute_precision_title">
+  <string
+      name="advanced_forecast_stats_compute_precision_title"
+      >
     Precision of computation
   </string>
-  <string name="advanced_forecast_stats_mc_n_iterations_title">
+  <string
+      name="advanced_forecast_stats_mc_n_iterations_title"
+      >
     Number of iterations of the simulation
   </string>
   <!-- Custom sync server settings -->
-  <string name="custom_sync_server_title">
+  <string
+      name="custom_sync_server_title"
+      >
     Custom sync server
   </string>
-  <string name="custom_sync_server_enable_title">
+  <string
+      name="custom_sync_server_enable_title"
+      >
     Use custom sync server
   </string>
-  <string name="custom_sync_server_enable_summary">
+  <string
+      name="custom_sync_server_enable_summary"
+      >
     If you don\'t want to use the proprietary AnkiWeb service you can specify an alternative server here
   </string>
-  <string name="custom_sync_server_base_url_title">
+  <string
+      name="custom_sync_server_base_url_title"
+      >
     Sync url
   </string>
-  <string name="custom_sync_server_base_url_invalid">
+  <string
+      name="custom_sync_server_base_url_invalid"
+      >
     Sync url invalid
   </string>
-  <string name="custom_sync_server_media_url_title">
+  <string
+      name="custom_sync_server_media_url_title"
+      >
     Media sync url
   </string>
-  <string name="custom_sync_server_media_url_invalid">
+  <string
+      name="custom_sync_server_media_url_invalid"
+      >
     Media sync url invalid
   </string>
   <!-- studyoptions -->
-  <string name="deck_conf_group_summ">
+  <string
+      name="deck_conf_group_summ"
+      >
     Changes to deck group options will affect multiple decks. If you wish to change only the current deck, please add a new options group first
   </string>
-  <string name="studyoptions_limit_select_tags">
+  <string
+      name="studyoptions_limit_select_tags"
+      >
     Select tags
   </string>
   <!-- Deck configurations -->
-  <string name="deck_conf_deck_description">
+  <string
+      name="deck_conf_deck_description"
+      >
     Deck description (affects current deck only)
   </string>
-  <string name="deck_conf_group">
+  <string
+      name="deck_conf_group"
+      >
     Options group
   </string>
-  <plurals name="deck_conf_group_summ">
+  <plurals
+      name="deck_conf_group_summ"
+      >
     <item quantity="one">
       %1$s\n%2$d deck uses this group
     </item>
@@ -528,142 +854,234 @@
       %1$s\n%2$d decks use this group
     </item>
   </plurals>
-  <string name="deck_conf_new_cards">
+  <string
+      name="deck_conf_new_cards"
+      >
     New cards
   </string>
-  <string name="deck_conf_rev_cards">
+  <string
+      name="deck_conf_rev_cards"
+      >
     Reviews
   </string>
-  <string name="deck_conf_lps_cards">
+  <string
+      name="deck_conf_lps_cards"
+      >
     Lapses
   </string>
-  <string name="deck_conf_general">
+  <string
+      name="deck_conf_general"
+      >
     General
   </string>
-  <string name="deck_conf_reminders">
+  <string
+      name="deck_conf_reminders"
+      >
     Reminders
   </string>
-  <string name="deck_conf_steps">
+  <string
+      name="deck_conf_steps"
+      >
     Steps (in minutes)
   </string>
-  <string name="deck_conf_order">
+  <string
+      name="deck_conf_order"
+      >
     Order
   </string>
-  <string name="deck_conf_new_cards_day">
+  <string
+      name="deck_conf_new_cards_day"
+      >
     New cards/day
   </string>
-  <string name="deck_conf_graduating_ivl">
+  <string
+      name="deck_conf_graduating_ivl"
+      >
     Graduating interval
   </string>
-  <string name="deck_conf_days">
+  <string
+      name="deck_conf_days"
+      >
     XXX day(s)
   </string>
-  <string name="deck_conf_easy_ivl">
+  <string
+      name="deck_conf_easy_ivl"
+      >
     Easy interval
   </string>
-  <string name="deck_conf_start_ease">
+  <string
+      name="deck_conf_start_ease"
+      >
     Starting ease
   </string>
-  <string name="deck_conf_max_rev">
+  <string
+      name="deck_conf_max_rev"
+      >
     Maximum reviews/day
   </string>
-  <string name="deck_conf_new_bury">
+  <string
+      name="deck_conf_new_bury"
+      >
     Bury related new cards
   </string>
-  <string name="deck_conf_new_bury_summ">
+  <string
+      name="deck_conf_new_bury_summ"
+      >
     Related new cards are buried until the next day
   </string>
-  <string name="deck_conf_rev_bury">
+  <string
+      name="deck_conf_rev_bury"
+      >
     Bury related reviews
   </string>
-  <string name="deck_conf_rev_bury_summ">
+  <string
+      name="deck_conf_rev_bury_summ"
+      >
     Related reviews are buried until the next day
   </string>
-  <string name="deck_conf_use_general_timeout_settings">
+  <string
+      name="deck_conf_use_general_timeout_settings"
+      >
     Use general settings
   </string>
-  <string name="deck_conf_use_general_timeout_settings_summ">
+  <string
+      name="deck_conf_use_general_timeout_settings_summ"
+      >
     Use general \'Automatic display answer\' settings instead of using the settings for this group.
   </string>
-  <string name="deck_conf_easy_bonus">
+  <string
+      name="deck_conf_easy_bonus"
+      >
     Easy bonus
   </string>
-  <string name="deck_conf_ivl_fct">
+  <string
+      name="deck_conf_ivl_fct"
+      >
     Interval modifier
   </string>
-  <string name="deck_conf_max_ivl">
+  <string
+      name="deck_conf_max_ivl"
+      >
     Maximum interval
   </string>
-  <string name="deck_conf_new_lps_ivl">
+  <string
+      name="deck_conf_new_lps_ivl"
+      >
     New interval
   </string>
-  <string name="deck_conf_min_ivl">
+  <string
+      name="deck_conf_min_ivl"
+      >
     Minimum interval
   </string>
-  <string name="deck_conf_leech_thres">
+  <string
+      name="deck_conf_leech_thres"
+      >
     Leech threshold
   </string>
-  <string name="deck_conf_fails">
+  <string
+      name="deck_conf_fails"
+      >
     XXX lapse(s)
   </string>
-  <string name="deck_conf_leech_action">
+  <string
+      name="deck_conf_leech_action"
+      >
     Leech action
   </string>
-  <string name="deck_conf_max_time">
+  <string
+      name="deck_conf_max_time"
+      >
     Maximal answer time
   </string>
-  <string name="deck_conf_seconds">
+  <string
+      name="deck_conf_seconds"
+      >
     XXX seconds
   </string>
-  <string name="deck_conf_timer">
+  <string
+      name="deck_conf_timer"
+      >
     Show answer timer
   </string>
-  <string name="deck_conf_autoplay">
+  <string
+      name="deck_conf_autoplay"
+      >
     Automatically play audio
   </string>
-  <string name="deck_conf_replayq">
+  <string
+      name="deck_conf_replayq"
+      >
     Replay question
   </string>
-  <string name="deck_conf_replayq_summ">
+  <string
+      name="deck_conf_replayq_summ"
+      >
     When answer shown, replay both question and answer audio
   </string>
-  <string name="deck_conf_manage">
+  <string
+      name="deck_conf_manage"
+      >
     Group management
   </string>
-  <string name="deck_conf_current_group">
+  <string
+      name="deck_conf_current_group"
+      >
     Current group
   </string>
-  <string name="deck_conf_rename">
+  <string
+      name="deck_conf_rename"
+      >
     Rename
   </string>
-  <string name="deck_conf_reset">
+  <string
+      name="deck_conf_reset"
+      >
     Restore defaults
   </string>
-  <string name="deck_conf_reset_title">
+  <string
+      name="deck_conf_reset_title"
+      >
     Restore defaults
   </string>
-  <string name="deck_conf_reset_message">
+  <string
+      name="deck_conf_reset_message"
+      >
     Restore current options group to default values?
   </string>
-  <string name="deck_conf_add">
+  <string
+      name="deck_conf_add"
+      >
     Add
   </string>
-  <string name="deck_conf_add_summ">
+  <string
+      name="deck_conf_add_summ"
+      >
     Create a copy of the current options group
   </string>
-  <string name="deck_conf_remove">
+  <string
+      name="deck_conf_remove"
+      >
     Remove
   </string>
-  <string name="deck_conf_remove_title">
+  <string
+      name="deck_conf_remove_title"
+      >
     Remove
   </string>
-  <string name="deck_conf_remove_message">
+  <string
+      name="deck_conf_remove_message"
+      >
     Remove current options group?
   </string>
-  <string name="deck_conf_set_subdecks">
+  <string
+      name="deck_conf_set_subdecks"
+      >
     Set for all subdecks
   </string>
-  <plurals name="deck_conf_set_subdecks_summ">
+  <plurals
+      name="deck_conf_set_subdecks_summ"
+      >
     <item quantity="one">%s subdeck will use this group</item>
     <item quantity="other">
       %s subdecks will use this group
@@ -671,57 +1089,91 @@
   </plurals>
   
 
-  <string name="deck_conf_set_subdecks_title">
+  <string
+      name="deck_conf_set_subdecks_title"
+      >
     Set for all subdecks
   </string>
-  <string name="deck_conf_set_subdecks_message">
+  <string
+      name="deck_conf_set_subdecks_message"
+      >
     Set current options group for all of this deck’s subdecks?
   </string>
-  <string name="pref_browser_editor_font">
+  <string
+      name="pref_browser_editor_font"
+      >
     Browser and editor font
   </string>
-  <string name="deck_conf_cram_filter">
+  <string
+      name="deck_conf_cram_filter"
+      >
     Filter
   </string>
-  <string name="deck_conf_cram_options">
+  <string
+      name="deck_conf_cram_options"
+      >
     Options
   </string>
-  <string name="deck_conf_cram_search">
+  <string
+      name="deck_conf_cram_search"
+      >
     Search
   </string>
-  <string name="deck_conf_cram_limit">
+  <string
+      name="deck_conf_cram_limit"
+      >
     Limit to
   </string>
-  <string name="deck_conf_cram_order">
+  <string
+      name="deck_conf_cram_order"
+      >
     cards selected by
   </string>
-  <string name="deck_conf_cram_reschedule">
+  <string
+      name="deck_conf_cram_reschedule"
+      >
     Reschedule
   </string>
-  <string name="deck_conf_cram_reschedule_summ">
+  <string
+      name="deck_conf_cram_reschedule_summ"
+      >
     Reschedule cards based on my answers in this deck
   </string>
-  <string name="deck_conf_cram_steps">
+  <string
+      name="deck_conf_cram_steps"
+      >
     Custom steps (in minutes)
   </string>
-  <string name="deck_conf_cram_steps_summ">
+  <string
+      name="deck_conf_cram_steps_summ"
+      >
     Define custom steps
   </string>
-  <string name="deck_conf_reminders_enabled">
+  <string
+      name="deck_conf_reminders_enabled"
+      >
     Enable reminder notifications for decks in this deck group
   </string>
-  <string name="deck_conf_reminders_time">
+  <string
+      name="deck_conf_reminders_time"
+      >
     Remind at
   </string>
 
   <!-- analytics options -->
-  <string name="analytics_dialog_title">
+  <string
+      name="analytics_dialog_title"
+      >
     Help make AnkiDroid better!
   </string>
-  <string name="analytics_title">
+  <string
+      name="analytics_title"
+      >
     Share feature usage
   </string>
-  <string name="analytics_summ">
+  <string
+      name="analytics_summ"
+      >
     You can contribute to AnkiDroid by helping the development team see which features people use
   </string>
 </resources>

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -22,122 +22,146 @@
   <!-- generic strings -->
   <string
       name="disabled"
+      comment="."
       >
     Disabled
   </string>
   <string
       name="enabled"
+      comment="."
       >
     Enabled
   </string>
   <!-- preferences.xml categories-->
   <string
       name="pref_cat_general"
+      comment="."
       >
     AnkiDroid
   </string>
   <string
       name="pref_cat_general_summ"
+      comment="."
       >
     General settings
   </string>
   <string
       name="pref_cat_reviewing"
+      comment="."
       >
     Reviewing
   </string>
   <string
       name="pref_cat_reviewing_summ"
+      comment="."
       >
     Non-deck-specific reviewer settings
   </string>
   <string
       name="pref_cat_reviewer_behaviour"
+      comment="."
       >
     Behavior
   </string>
   <string
       name="pref_cat_flashcard"
+      comment="."
       >
     Display
   </string>
   <string
       name="pref_cat_whiteboard"
+      comment="."
       >
     Whiteboard
   </string>
   <string
       name="pref_cat_automatic_display"
+      comment="."
       >
     Automatic display answer
   </string>
   <string
       name="pref_cat_appearance"
+      comment="."
       >
     Appearance
   </string>
   <string
       name="pref_cat_appearance_summ"
+      comment="."
       >
     Change themes and default font
   </string>
   <string
       name="pref_cat_themes"
+      comment="."
       >
     Themes
   </string>
   <string
       name="pref_cat_fonts"
+      comment="."
       >
     Fonts
   </string>
   <string
       name="pref_cat_gestures"
+      comment="."
       >
     Gestures
   </string>
   <string
       name="pref_cat_gestures_summ"
+      comment="."
       >
     Use taps and swipes instead of buttons
   </string>
   <string
       name="pref_cat_actions"
+      comment="."
       >
     Actions
   </string>
   <string
       name="pref_cat_advanced"
+      comment="."
       >
     Advanced
   </string>
   <string
       name="pref_cat_advanced_summ"
+      comment="."
       >
     Optimization and experimental features
   </string>
   <string
       name="pref_cat_performance"
+      comment="."
       >
     Performance
   </string>
   <string
       name="pref_cat_workarounds"
+      comment="."
       >
     Workarounds
   </string>
   <string
       name="pref_cat_plugins"
+      comment="."
       >
     Plugins
   </string>
   <string
       name="about_title"
+      comment="."
       >
     About AnkiDroid
   </string>
   <string
       name="about_version"
+      comment="."
       >
     Version:
   </string>
@@ -145,614 +169,737 @@
   <!-- preferences.xml entries-->
   <string
       name="whiteboard_stroke_width"
+      comment="."
       >
     Stroke width
   </string>
   <string
       name="whiteboard_black"
+      comment="."
       >
     Black strokes
   </string>
   <string
       name="whiteboard_black_summ"
+      comment="."
       >
     Uses less memory, unless in night mode
   </string>
   <string
       name="use_input_tag"
+      comment="."
       >
     Type answer into the card
   </string>
   <string
       name="use_input_tag_summ"
+      comment="."
       >
     Use a text input box inside the card to type in the answer
   </string>
   <string
       name="dictionary"
+      comment="."
       >
     Lookup dictionary
   </string>
   <string
       name="reset_languages"
+      comment="."
       >
     Reset languages
   </string>
   <string
       name="reset_languages_summ"
+      comment="."
       >
     Reset language assignments (for text to speech and dictionaries) for all decks
   </string>
   <string
       name="reset_languages_question"
+      comment="."
       >
     Reset all language assignments?
   </string>
   <string
       name="reset_confirmation"
+      comment="."
       >
     All states reset
   </string>
   <string
       name="card_zoom"
+      comment="."
       >
     Card zoom
   </string>
   <string
       name="image_zoom"
+      comment="."
       >
     Image zoom
   </string>
   <string
       name="button_size"
+      comment="."
       >
     Answer button size
   </string>
   <string
       name="card_browser_font_size"
+      comment="."
       >
     Card browser font scaling
   </string>
   <string
       name="card_browser_hide_media"
+      comment="."
       >
     Display filenames in card browser
   </string>
   <string
       name="card_browser_hide_media_summary"
+      comment="."
       >
     Display media filenames in the card browser question/answer fields
   </string>
   <string
       name="col_path"
+      comment="."
       >
     AnkiDroid directory
   </string>
   <string
       name="fullscreen_review"
+      comment="."
       >
     Fullscreen mode
   </string>
   <string
       name="full_screen_off"
+      comment="."
       >
     Off
   </string>
   <string
       name="full_screen_system"
+      comment="."
       >
     Hide the system bars
   </string>
   <string
       name="full_screen_complete"
+      comment="."
       >
     Hide the system bars and answer buttons
   </string>
   <string
       name="full_screen_error_gestures"
+      comment="."
       >
     You must enable gestures to hide the answer buttons
   </string>
   <string
       name="answer_buttons_position"
+      comment="."
       >
     Answer buttons position
   </string>
   <string-array
       name="answer_buttons_position_labels"
+      comment="."
       >
     <item
+        comment="."
         >
       Top
     </item>
     <item
+        comment="."
         >
       Bottom
     </item>
   </string-array>
   <string
       name="gestures"
+      comment="."
       >
     Enable gestures
   </string>
   <string
       name="gestures_summ"
+      comment="."
       >
     Assign gestures to actions such as answering and editing cards.
   </string>
   <string
       name="gestures_allow_links"
+      comment="."
       >
     Ignore touch gestures on links
   </string>
   <string
       name="gestures_allow_links_summary"
+      comment="."
       >
     Touch gestures will not be processed if a link/hint is pressed.
   </string>
   <string
       name="gestures_swipe_up"
+      comment="."
       >
     Swipe up
   </string>
   <string
       name="gestures_swipe_down"
+      comment="."
       >
     Swipe down
   </string>
   <string
       name="gestures_swipe_left"
+      comment="."
       >
     Swipe left
   </string>
   <string
       name="gestures_swipe_right"
+      comment="."
       >
     Swipe right
   </string>
   <string
       name="gestures_double_tap"
+      comment="."
       >
     Double touch
   </string>
   <string
       name="gestures_tap_top"
+      comment="."
       >
     Touch top
   </string>
   <string
       name="gestures_tap_bottom"
+      comment="."
       >
     Touch bottom
   </string>
   <string
       name="gestures_tap_left"
+      comment="."
       >
     Touch left
   </string>
   <string
       name="gestures_tap_right"
+      comment="."
       >
     Touch right
   </string>
   <string
       name="gestures_volume_up"
+      comment="."
       >
     Volume up
   </string>
   <string
       name="gestures_volume_down"
+      comment="."
       >
     Volume down
   </string>
   <string
       name="more_scrolling_buttons"
+      comment="."
       >
     eReader
   </string>
   <string
       name="more_scrolling_buttons_summ"
+      comment="."
       >
     Also use kanji/katakana, emoji/kao-moji buttons for scrolling
   </string>
   <string
       name="card_browser_enable_external_context_menu"
+      comment="."
       >
     ‘%s’ Menu
   </string>
   <string
       name="card_browser_enable_external_context_menu_summary"
+      comment="."
       >
     Enables the ‘%s’ context menu globally
   </string>
   <string
       name="double_scrolling_gap"
+      comment="."
       >
     Double scrolling
   </string>
   <string
       name="double_scrolling_gap_summ"
+      comment="."
       >
     Double the scroll gap with eReader
   </string>
   <string
       name="swipe_sensitivity"
+      comment="."
       >
     Swipe sensitivity
   </string>
   <string
       name="tts"
+      comment="."
       >
     Text to speech
   </string>
   <string
       name="tts_summ"
+      comment="."
       >
     Reads out question and answer if no sound file is included
   </string>
   <string
       name="sync_fetch_missing_media"
+      comment="."
       >
     Fetch media on sync
   </string>
   <string
       name="sync_fetch_missing_media_summ"
+      comment="."
       >
     Automatically fetch missing media when syncing
   </string>
   <string
       name="sync_account"
+      comment="."
       >
     AnkiWeb account
   </string>
   <string
       name="sync_account_summ_logged_out"
+      comment="."
       >
     Not logged in
   </string>
   <string
       name="sync_account_summ_logged_in"
+      comment="."
       >
     %s
   </string>
   <string
       name="automatic_sync_choice"
+      comment="."
       >
     Automatic synchronization
   </string>
   <string
       name="automatic_sync_choice_summ"
+      comment="."
       >
     Sync automatically on app start/exit if the last sync was more than 10 minutes ago.
   </string>
   <string
       name="sync_status_badge"
+      comment="."
       >
     Display synchronization status
   </string>
   <string
       name="sync_status_badge_summ"
+      comment="."
       >
     Change the sync icon when changes can be uploaded
   </string>
   <string
       name="day_theme"
+      comment="."
       >
     Day theme
   </string>
   <string
       name="night_theme"
+      comment="."
       >
     Night theme
   </string>
   <string
       name="default_font"
+      comment="."
       >
     Default font
   </string>
   <string
       name="override_font"
+      comment="."
       >
     Default font applicability
   </string>
   <string
       name="language"
+      comment="."
       >
     Language
   </string>
   <string
       name="language_system"
+      comment="."
       >
     System language
   </string>
   <string
       name="notification_pref"
+      comment="."
       >
     Notifications
   </string>
   <string
       name="notification_pref_title"
+      comment="."
       >
     Notify when
   </string>
   <string
       name="never_notify"
+      comment="."
       >
     Never notify
   </string>
   <string
       name="notify_when_pending"
+      comment="."
       >
     Pending messages available
   </string>
   <string
       name="notification_minimum_cards_due"
+      comment="."
       >
     More than %d cards due
   </string>
   <string
       name="notification_minimum_cards_due_vibrate"
+      comment="."
       >
     Vibrate
   </string>
   <string
       name="notification_minimum_cards_due_blink"
+      comment="."
       >
     Blink light
   </string>
   <string
       name="timeout_answer_text"
+      comment="."
       >
     Automatic display answer
   </string>
   <string
       name="timeout_answer_summ"
+      comment="."
       >
     Show answer automatically without user input. Delay includes time for automatically played audio files.
   </string>
   <string
       name="timeout_answer_seconds"
+      comment="."
       >
     Time to show answer
   </string>
   <string
       name="timeout_answer_seconds_summ"
+      comment="."
       >
     XXX s
   </string>
   <string
       name="timeout_question_seconds"
+      comment="."
       >
     Time to show next question
   </string>
   <string
       name="timeout_question_seconds_summ"
+      comment="."
       >
     XXX s
   </string>
   <string
       name="select_locale_title"
+      comment="."
       >
     Select language
   </string>
   <string
       name="safe_display"
+      comment="."
       >
     Safe display mode
   </string>
   <string
       name="safe_display_summ"
+      comment="."
       >
     Disable all animations and use safer method for drawing cards. E-ink devices may require this.
   </string>
   <string
       name="disable_extended_text_ui"
+      comment="."
       >
     Disable Single-Field Edit Mode
   </string>
   <!--See: multimedia_editor_popup_cloze. We can't use format strings as this is auto-generated-->
   <string
       name="disable_extended_text_ui_summ"
+      comment="."
       >
     Allows \'Cloze Deletion\' context menu when in landscape mode.
   </string>
   <string
       name="vertical_centering"
+      comment="."
       >
     Center align
   </string>
   <string
       name="vertical_centering_summ"
+      comment="."
       >
     Center the content of cards vertically
   </string>
   <string
       name="pref_backup_max"
+      comment="."
       >
     Max number of backups
   </string>
   <string
       name="show_estimates"
+      comment="."
       >
     Show button time
   </string>
   <string
       name="show_estimates_summ"
+      comment="."
       >
     Show next review time on answer buttons
   </string>
   <string
       name="show_top_bar"
+      comment="."
       >
     Show Top Bar
   </string>
   <string
       name="show_top_bar_summ"
+      comment="."
       >
     Show card counts, flag and mark in top bar
   </string>
   <string
       name="show_progress"
+      comment="."
       >
     Show remaining
   </string>
   <string
       name="show_progress_summ"
+      comment="."
       >
     Show remaining card count
   </string>
   <string
       name="show_eta"
+      comment="."
       >
     Show ETA
   </string>
   <string
       name="show_eta_summ"
+      comment="."
       >
     Show remaining time
   </string>
   <string
       name="use_current"
+      comment="."
       >
     Deck for new cards
   </string>
   <string
       name="new_spread"
+      comment="."
       >
     New card position
   </string>
   <string
       name="learn_cutoff"
+      comment="."
       >
     Learn ahead limit
   </string>
   <string
       name="learn_cutoff_summ"
+      comment="."
       >
     XXX min
   </string>
   <string
       name="time_limit"
+      comment="."
       >
     Timebox time limit
   </string>
   <string
       name="time_limit_summ"
+      comment="."
       >
     XXX min
   </string>
   <string
       name="day_offset"
+      comment="."
       >
     Start of next day
   </string>
   <string
       name="day_offset_summ"
+      comment="."
       >
     XXX hours past midnight
   </string>
   <string
       name="sched_ver"
+      comment="."
       >
     Experimental V2 scheduler
   </string>
   <string
       name="sched_ver_summ"
+      comment="."
       >
     Enable the experimental scheduler. Forces changes in one direction on next sync
   </string>
   <string
       name="sched_ver_toggle_title"
+      comment="."
       >
     Confirm
   </string>
   <string
       name="sched_ver_2to1"
+      comment="."
       >
     This will reset any cards in learning, clear filtered decks, and change the scheduler version. Proceed?
   </string>
   <string
       name="sched_ver_1to2"
+      comment="."
       >
     The experimental scheduler could cause incorrect scheduling. Please ensure you have read the documentation first. Proceed?
   </string>
   <string
       name="pref_keep_screen_on"
+      comment="."
       >
     Keep screen on
   </string>
   <string
       name="pref_keep_screen_on_summ"
+      comment="."
       >
     Disable screen timeout
   </string>
   <string
       name="convert_fen_text"
+      comment="."
       >
     Chess notation support
   </string>
   <string
       name="convert_fen_text_summ"
+      comment="."
       >
     Draw chessboard from Forsyth–Edwards Notation. The notation must be enclosed in [fen][/fen] tags.
   </string>
   <string
       name="enable_api_title"
+      comment="."
       >
     Enable AnkiDroid API
   </string>
   <string
       name="enable_api_summary"
+      comment="."
       >
     Let other apps connect to AnkiDroid and read / write data without your intervention
   </string>
   <string
       name="custom_buttons"
+      comment="."
       >
     App bar buttons
   </string>
   <string
       name="custom_buttons_summary"
+      comment="."
       >
     Customize which actions appear in the app bar
   </string>
   <string
       name="custom_buttons_setting_always_show"
+      comment="."
       >
     Always show
   </string>
   <string
       name="custom_buttons_setting_if_room"
+      comment="."
       >
     Show if room
   </string>
   <string
       name="custom_buttons_setting_menu_only"
+      comment="."
       >
     Menu only
   </string>
   <string
       name="reset_custom_buttons"
+      comment="."
       >
     Reset to default
   </string>
   <string
       name="thirdparty_apps_title"
+      comment="."
       >
     Third-party API apps
   </string>
   <string
       name="thirdparty_apps_summary"
+      comment="."
       >
     See a list of applications which make use of the AnkiDroid API such as dictionaries, utilities.
   </string>
   <string
       name="html_javascript_debugging"
+      comment="."
       >
     HTML / Javascript Debugging
   </string>
   <string
       name="html_javascript_debugging_summ"
+      comment="."
       >
     Enable remote WebView connections, and save card HTML to AnkiDroid directory
   </string>
@@ -760,94 +907,112 @@
   <!-- Advanced statistics settings -->
   <string
       name="advanced_statistics_title"
+      comment="."
       >
     Advanced statistics
   </string>
   <string
       name="enable_advanced_statistics_title"
+      comment="."
       >
     Enable advanced statistics
   </string>
   <string
       name="enable_advanced_statistics_summ"
+      comment="."
       >
     Display forecast statistics based on a computation or simulation of future reviews (enabled) or on the future reviews already scheduled (disabled).
   </string>
   <string
       name="advanced_forecast_stats_compute_n_days_title"
+      comment="."
       >
     Compute first n days, simulate remainder
   </string>
   <string
       name="advanced_forecast_stats_compute_precision_title"
+      comment="."
       >
     Precision of computation
   </string>
   <string
       name="advanced_forecast_stats_mc_n_iterations_title"
+      comment="."
       >
     Number of iterations of the simulation
   </string>
   <!-- Custom sync server settings -->
   <string
       name="custom_sync_server_title"
+      comment="."
       >
     Custom sync server
   </string>
   <string
       name="custom_sync_server_enable_title"
+      comment="."
       >
     Use custom sync server
   </string>
   <string
       name="custom_sync_server_enable_summary"
+      comment="."
       >
     If you don\'t want to use the proprietary AnkiWeb service you can specify an alternative server here
   </string>
   <string
       name="custom_sync_server_base_url_title"
+      comment="."
       >
     Sync url
   </string>
   <string
       name="custom_sync_server_base_url_invalid"
+      comment="."
       >
     Sync url invalid
   </string>
   <string
       name="custom_sync_server_media_url_title"
+      comment="."
       >
     Media sync url
   </string>
   <string
       name="custom_sync_server_media_url_invalid"
+      comment="."
       >
     Media sync url invalid
   </string>
   <!-- studyoptions -->
   <string
       name="deck_conf_group_summ"
+      comment="."
       >
     Changes to deck group options will affect multiple decks. If you wish to change only the current deck, please add a new options group first
   </string>
   <string
       name="studyoptions_limit_select_tags"
+      comment="."
       >
     Select tags
   </string>
   <!-- Deck configurations -->
   <string
       name="deck_conf_deck_description"
+      comment="."
       >
     Deck description (affects current deck only)
   </string>
   <string
       name="deck_conf_group"
+      comment="."
       >
     Options group
   </string>
   <plurals
       name="deck_conf_group_summ"
+      comment="."
       >
     <item quantity="one">
       %1$s\n%2$d deck uses this group
@@ -858,231 +1023,277 @@
   </plurals>
   <string
       name="deck_conf_new_cards"
+      comment="."
       >
     New cards
   </string>
   <string
       name="deck_conf_rev_cards"
+      comment="."
       >
     Reviews
   </string>
   <string
       name="deck_conf_lps_cards"
+      comment="."
       >
     Lapses
   </string>
   <string
       name="deck_conf_general"
+      comment="."
       >
     General
   </string>
   <string
       name="deck_conf_reminders"
+      comment="."
       >
     Reminders
   </string>
   <string
       name="deck_conf_steps"
+      comment="."
       >
     Steps (in minutes)
   </string>
   <string
       name="deck_conf_order"
+      comment="."
       >
     Order
   </string>
   <string
       name="deck_conf_new_cards_day"
+      comment="."
       >
     New cards/day
   </string>
   <string
       name="deck_conf_graduating_ivl"
+      comment="."
       >
     Graduating interval
   </string>
   <string
       name="deck_conf_days"
+      comment="."
       >
     XXX day(s)
   </string>
   <string
       name="deck_conf_easy_ivl"
+      comment="."
       >
     Easy interval
   </string>
   <string
       name="deck_conf_start_ease"
+      comment="."
       >
     Starting ease
   </string>
   <string
       name="deck_conf_max_rev"
+      comment="."
       >
     Maximum reviews/day
   </string>
   <string
       name="deck_conf_new_bury"
+      comment="."
       >
     Bury related new cards
   </string>
   <string
       name="deck_conf_new_bury_summ"
+      comment="."
       >
     Related new cards are buried until the next day
   </string>
   <string
       name="deck_conf_rev_bury"
+      comment="."
       >
     Bury related reviews
   </string>
   <string
       name="deck_conf_rev_bury_summ"
+      comment="."
       >
     Related reviews are buried until the next day
   </string>
   <string
       name="deck_conf_use_general_timeout_settings"
+      comment="."
       >
     Use general settings
   </string>
   <string
       name="deck_conf_use_general_timeout_settings_summ"
+      comment="."
       >
     Use general \'Automatic display answer\' settings instead of using the settings for this group.
   </string>
   <string
       name="deck_conf_easy_bonus"
+      comment="."
       >
     Easy bonus
   </string>
   <string
       name="deck_conf_ivl_fct"
+      comment="."
       >
     Interval modifier
   </string>
   <string
       name="deck_conf_max_ivl"
+      comment="."
       >
     Maximum interval
   </string>
   <string
       name="deck_conf_new_lps_ivl"
+      comment="."
       >
     New interval
   </string>
   <string
       name="deck_conf_min_ivl"
+      comment="."
       >
     Minimum interval
   </string>
   <string
       name="deck_conf_leech_thres"
+      comment="."
       >
     Leech threshold
   </string>
   <string
       name="deck_conf_fails"
+      comment="."
       >
     XXX lapse(s)
   </string>
   <string
       name="deck_conf_leech_action"
+      comment="."
       >
     Leech action
   </string>
   <string
       name="deck_conf_max_time"
+      comment="."
       >
     Maximal answer time
   </string>
   <string
       name="deck_conf_seconds"
+      comment="."
       >
     XXX seconds
   </string>
   <string
       name="deck_conf_timer"
+      comment="."
       >
     Show answer timer
   </string>
   <string
       name="deck_conf_autoplay"
+      comment="."
       >
     Automatically play audio
   </string>
   <string
       name="deck_conf_replayq"
+      comment="."
       >
     Replay question
   </string>
   <string
       name="deck_conf_replayq_summ"
+      comment="."
       >
     When answer shown, replay both question and answer audio
   </string>
   <string
       name="deck_conf_manage"
+      comment="."
       >
     Group management
   </string>
   <string
       name="deck_conf_current_group"
+      comment="."
       >
     Current group
   </string>
   <string
       name="deck_conf_rename"
+      comment="."
       >
     Rename
   </string>
   <string
       name="deck_conf_reset"
+      comment="."
       >
     Restore defaults
   </string>
   <string
       name="deck_conf_reset_title"
+      comment="."
       >
     Restore defaults
   </string>
   <string
       name="deck_conf_reset_message"
+      comment="."
       >
     Restore current options group to default values?
   </string>
   <string
       name="deck_conf_add"
+      comment="."
       >
     Add
   </string>
   <string
       name="deck_conf_add_summ"
+      comment="."
       >
     Create a copy of the current options group
   </string>
   <string
       name="deck_conf_remove"
+      comment="."
       >
     Remove
   </string>
   <string
       name="deck_conf_remove_title"
+      comment="."
       >
     Remove
   </string>
   <string
       name="deck_conf_remove_message"
+      comment="."
       >
     Remove current options group?
   </string>
   <string
       name="deck_conf_set_subdecks"
+      comment="."
       >
     Set for all subdecks
   </string>
   <plurals
       name="deck_conf_set_subdecks_summ"
+      comment="."
       >
     <item quantity="one">%s subdeck will use this group</item>
     <item quantity="other">
@@ -1093,71 +1304,85 @@
 
   <string
       name="deck_conf_set_subdecks_title"
+      comment="."
       >
     Set for all subdecks
   </string>
   <string
       name="deck_conf_set_subdecks_message"
+      comment="."
       >
     Set current options group for all of this deck’s subdecks?
   </string>
   <string
       name="pref_browser_editor_font"
+      comment="."
       >
     Browser and editor font
   </string>
   <string
       name="deck_conf_cram_filter"
+      comment="."
       >
     Filter
   </string>
   <string
       name="deck_conf_cram_options"
+      comment="."
       >
     Options
   </string>
   <string
       name="deck_conf_cram_search"
+      comment="."
       >
     Search
   </string>
   <string
       name="deck_conf_cram_limit"
+      comment="."
       >
     Limit to
   </string>
   <string
       name="deck_conf_cram_order"
+      comment="."
       >
     cards selected by
   </string>
   <string
       name="deck_conf_cram_reschedule"
+      comment="."
       >
     Reschedule
   </string>
   <string
       name="deck_conf_cram_reschedule_summ"
+      comment="."
       >
     Reschedule cards based on my answers in this deck
   </string>
   <string
       name="deck_conf_cram_steps"
+      comment="."
       >
     Custom steps (in minutes)
   </string>
   <string
       name="deck_conf_cram_steps_summ"
+      comment="."
       >
     Define custom steps
   </string>
   <string
       name="deck_conf_reminders_enabled"
+      comment="."
       >
     Enable reminder notifications for decks in this deck group
   </string>
   <string
       name="deck_conf_reminders_time"
+      comment="."
       >
     Remind at
   </string>
@@ -1165,16 +1390,19 @@
   <!-- analytics options -->
   <string
       name="analytics_dialog_title"
+      comment="."
       >
     Help make AnkiDroid better!
   </string>
   <string
       name="analytics_title"
+      comment="."
       >
     Share feature usage
   </string>
   <string
       name="analytics_summ"
+      comment="."
       >
     You can contribute to AnkiDroid by helping the development team see which features people use
   </string>

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -261,10 +261,12 @@
   <string-array
       name="answer_buttons_position_labels"
       >
-    <item>
+    <item
+        >
       Top
     </item>
-    <item>
+    <item
+        >
       Bottom
     </item>
   </string-array>

--- a/AnkiDroid/src/main/res/values/11-arrays.xml
+++ b/AnkiDroid/src/main/res/values/11-arrays.xml
@@ -15,7 +15,9 @@
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <resources>
-  <string-array name="error_reporting_choice_labels">
+  <string-array
+      name="error_reporting_choice_labels"
+      >
     <item>
       Always report
     </item>
@@ -26,7 +28,9 @@
       Ask me
     </item>
   </string-array>
-  <string-array name="gestures_labels">
+  <string-array
+      name="gestures_labels"
+      >
     <item>
       No action
     </item>
@@ -109,7 +113,9 @@
       Page Down
     </item>
   </string-array>
-  <string-array name="leech_action_labels">
+  <string-array
+      name="leech_action_labels"
+      >
     <item>
       Suspend card
     </item>
@@ -117,7 +123,9 @@
       Tag only
     </item>
   </string-array>
-  <string-array name="new_order_labels">
+  <string-array
+      name="new_order_labels"
+      >
     <item>
       New cards in random order
     </item>
@@ -125,7 +133,9 @@
       New cards in order added
     </item>
   </string-array>
-  <string-array name="cram_deck_conf_order_labels">
+  <string-array
+      name="cram_deck_conf_order_labels"
+      >
     <item>
       Oldest seen first
     </item>
@@ -154,7 +164,9 @@
       Relative overdueness
     </item>
   </string-array>
-  <string-array name="add_to_cur_labels">
+  <string-array
+      name="add_to_cur_labels"
+      >
     <item>
       Use current deck
     </item>
@@ -162,7 +174,9 @@
       Decide by note type
     </item>
   </string-array>
-  <string-array name="new_spread_labels">
+  <string-array
+      name="new_spread_labels"
+      >
     <item>
       Mix new cards and reviews
     </item>
@@ -173,7 +187,9 @@
       New cards before reviews
     </item>
   </string-array>
-  <string-array name="override_font_labels">
+  <string-array
+      name="override_font_labels"
+      >
     <item>
       When no font specified on flashcards
     </item>
@@ -181,7 +197,9 @@
       Always
     </item>
   </string-array>
-  <string-array name="day_theme_labels">
+  <string-array
+      name="day_theme_labels"
+      >
     <item>
       Light
     </item>
@@ -189,7 +207,9 @@
       Plain
     </item>
   </string-array>
-  <string-array name="night_theme_labels">
+  <string-array
+      name="night_theme_labels"
+      >
     <item>
       Black
     </item>

--- a/AnkiDroid/src/main/res/values/11-arrays.xml
+++ b/AnkiDroid/src/main/res/values/11-arrays.xml
@@ -13,79 +13,188 @@
 ~
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
---><resources>
-    <string-array name="error_reporting_choice_labels">
-        <item>Always report</item>
-        <item>Never report</item>
-        <item>Ask me</item>
-    </string-array>
-    <string-array name="gestures_labels">
-        <item>No action</item>
-        <item>Show answer</item>
-        <item>Answer button 1</item>
-        <item>Answer button 2</item>
-        <item>Answer button 3</item>
-        <item>Answer button 4</item>
-        <item>Answer recommended (green)</item>
-        <item>Answer better than recommended</item>
-        <item>Undo</item>
-        <item>Edit note</item>
-        <item>Tag note</item>
-        <item>Mark note</item>
-        <item>Lookup expression</item>
-        <item>Bury card</item>
-        <item>Suspend card</item>
-        <item>Delete note</item>
-        <item>Play media</item>
-        <item>Abort learning</item>
-        <item>Bury note</item>
-        <item>Suspend note</item>
-        <item>Toggle Red Flag</item>
-        <item>Toggle Orange Flag</item>
-        <item>Toggle Green Flag</item>
-        <item>Toggle Blue Flag</item>
-        <item>Remove Flag</item>
-        <item>Page Up</item>
-        <item>Page Down</item>
-    </string-array>
-    <string-array name="leech_action_labels">
-        <item>Suspend card</item>
-        <item>Tag only</item>
-    </string-array>
-    <string-array name="new_order_labels">
-        <item>New cards in random order</item>
-        <item>New cards in order added</item>
-    </string-array>
-    <string-array name="cram_deck_conf_order_labels">
-        <item>Oldest seen first</item>
-        <item>Random</item>
-        <item>Increasing intervals</item>
-        <item>Decreasing intervals</item>
-        <item>Most lapsed</item>
-        <item>Order added</item>
-        <item>Order due</item>
-        <item>Latest added first</item>
-        <item>Relative overdueness</item>
-    </string-array>
-    <string-array name="add_to_cur_labels">
-        <item>Use current deck</item>
-        <item>Decide by note type</item>
-    </string-array>
-    <string-array name="new_spread_labels">
-        <item>Mix new cards and reviews</item>
-        <item>New cards after reviews</item>
-        <item>New cards before reviews</item>
-    </string-array>
-    <string-array name="override_font_labels">
-        <item>When no font specified on flashcards</item>
-        <item>Always</item>
-    </string-array>
-    <string-array name="day_theme_labels">
-        <item>Light</item>
-        <item>Plain</item>
-    </string-array>
-    <string-array name="night_theme_labels">
-        <item>Black</item>
-        <item>Dark</item>
-    </string-array>
+-->
+<resources>
+  <string-array name="error_reporting_choice_labels">
+    <item>
+      Always report
+    </item>
+    <item>
+      Never report
+    </item>
+    <item>
+      Ask me
+    </item>
+  </string-array>
+  <string-array name="gestures_labels">
+    <item>
+      No action
+    </item>
+    <item>
+      Show answer
+    </item>
+    <item>
+      Answer button 1
+    </item>
+    <item>
+      Answer button 2
+    </item>
+    <item>
+      Answer button 3
+    </item>
+    <item>
+      Answer button 4
+    </item>
+    <item>
+      Answer recommended (green)
+    </item>
+    <item>
+      Answer better than recommended
+    </item>
+    <item>
+      Undo
+    </item>
+    <item>
+      Edit note
+    </item>
+    <item>
+      Tag note
+    </item>
+    <item>
+      Mark note
+    </item>
+    <item>
+      Lookup expression
+    </item>
+    <item>
+      Bury card
+    </item>
+    <item>
+      Suspend card
+    </item>
+    <item>
+      Delete note
+    </item>
+    <item>
+      Play media
+    </item>
+    <item>
+      Abort learning
+    </item>
+    <item>
+      Bury note
+    </item>
+    <item>
+      Suspend note
+    </item>
+    <item>
+      Toggle Red Flag
+    </item>
+    <item>
+      Toggle Orange Flag
+    </item>
+    <item>
+      Toggle Green Flag
+    </item>
+    <item>
+      Toggle Blue Flag
+    </item>
+    <item>
+      Remove Flag
+    </item>
+    <item>
+      Page Up
+    </item>
+    <item>
+      Page Down
+    </item>
+  </string-array>
+  <string-array name="leech_action_labels">
+    <item>
+      Suspend card
+    </item>
+    <item>
+      Tag only
+    </item>
+  </string-array>
+  <string-array name="new_order_labels">
+    <item>
+      New cards in random order
+    </item>
+    <item>
+      New cards in order added
+    </item>
+  </string-array>
+  <string-array name="cram_deck_conf_order_labels">
+    <item>
+      Oldest seen first
+    </item>
+    <item>
+      Random
+    </item>
+    <item>
+      Increasing intervals
+    </item>
+    <item>
+      Decreasing intervals
+    </item>
+    <item>
+      Most lapsed
+    </item>
+    <item>
+      Order added
+    </item>
+    <item>
+      Order due
+    </item>
+    <item>
+      Latest added first
+    </item>
+    <item>
+      Relative overdueness
+    </item>
+  </string-array>
+  <string-array name="add_to_cur_labels">
+    <item>
+      Use current deck
+    </item>
+    <item>
+      Decide by note type
+    </item>
+  </string-array>
+  <string-array name="new_spread_labels">
+    <item>
+      Mix new cards and reviews
+    </item>
+    <item>
+      New cards after reviews
+    </item>
+    <item>
+      New cards before reviews
+    </item>
+  </string-array>
+  <string-array name="override_font_labels">
+    <item>
+      When no font specified on flashcards
+    </item>
+    <item>
+      Always
+    </item>
+  </string-array>
+  <string-array name="day_theme_labels">
+    <item>
+      Light
+    </item>
+    <item>
+      Plain
+    </item>
+  </string-array>
+  <string-array name="night_theme_labels">
+    <item>
+      Black
+    </item>
+    <item>
+      Dark
+    </item>
+  </string-array>
 </resources>

--- a/AnkiDroid/src/main/res/values/11-arrays.xml
+++ b/AnkiDroid/src/main/res/values/11-arrays.xml
@@ -18,202 +18,256 @@
   <string-array
       name="error_reporting_choice_labels"
       >
-    <item>
+    <item
+        >
       Always report
     </item>
-    <item>
+    <item
+        >
       Never report
     </item>
-    <item>
+    <item
+        >
       Ask me
     </item>
   </string-array>
   <string-array
       name="gestures_labels"
       >
-    <item>
+    <item
+        >
       No action
     </item>
-    <item>
+    <item
+        >
       Show answer
     </item>
-    <item>
+    <item
+        >
       Answer button 1
     </item>
-    <item>
+    <item
+        >
       Answer button 2
     </item>
-    <item>
+    <item
+        >
       Answer button 3
     </item>
-    <item>
+    <item
+        >
       Answer button 4
     </item>
-    <item>
+    <item
+        >
       Answer recommended (green)
     </item>
-    <item>
+    <item
+        >
       Answer better than recommended
     </item>
-    <item>
+    <item
+        >
       Undo
     </item>
-    <item>
+    <item
+        >
       Edit note
     </item>
-    <item>
+    <item
+        >
       Tag note
     </item>
-    <item>
+    <item
+        >
       Mark note
     </item>
-    <item>
+    <item
+        >
       Lookup expression
     </item>
-    <item>
+    <item
+        >
       Bury card
     </item>
-    <item>
+    <item
+        >
       Suspend card
     </item>
-    <item>
+    <item
+        >
       Delete note
     </item>
-    <item>
+    <item
+        >
       Play media
     </item>
-    <item>
+    <item
+        >
       Abort learning
     </item>
-    <item>
+    <item
+        >
       Bury note
     </item>
-    <item>
+    <item
+        >
       Suspend note
     </item>
-    <item>
+    <item
+        >
       Toggle Red Flag
     </item>
-    <item>
+    <item
+        >
       Toggle Orange Flag
     </item>
-    <item>
+    <item
+        >
       Toggle Green Flag
     </item>
-    <item>
+    <item
+        >
       Toggle Blue Flag
     </item>
-    <item>
+    <item
+        >
       Remove Flag
     </item>
-    <item>
+    <item
+        >
       Page Up
     </item>
-    <item>
+    <item
+        >
       Page Down
     </item>
   </string-array>
   <string-array
       name="leech_action_labels"
       >
-    <item>
+    <item
+        >
       Suspend card
     </item>
-    <item>
+    <item
+        >
       Tag only
     </item>
   </string-array>
   <string-array
       name="new_order_labels"
       >
-    <item>
+    <item
+        >
       New cards in random order
     </item>
-    <item>
+    <item
+        >
       New cards in order added
     </item>
   </string-array>
   <string-array
       name="cram_deck_conf_order_labels"
       >
-    <item>
+    <item
+        >
       Oldest seen first
     </item>
-    <item>
+    <item
+        >
       Random
     </item>
-    <item>
+    <item
+        >
       Increasing intervals
     </item>
-    <item>
+    <item
+        >
       Decreasing intervals
     </item>
-    <item>
+    <item
+        >
       Most lapsed
     </item>
-    <item>
+    <item
+        >
       Order added
     </item>
-    <item>
+    <item
+        >
       Order due
     </item>
-    <item>
+    <item
+        >
       Latest added first
     </item>
-    <item>
+    <item
+        >
       Relative overdueness
     </item>
   </string-array>
   <string-array
       name="add_to_cur_labels"
       >
-    <item>
+    <item
+        >
       Use current deck
     </item>
-    <item>
+    <item
+        >
       Decide by note type
     </item>
   </string-array>
   <string-array
       name="new_spread_labels"
       >
-    <item>
+    <item
+        >
       Mix new cards and reviews
     </item>
-    <item>
+    <item
+        >
       New cards after reviews
     </item>
-    <item>
+    <item
+        >
       New cards before reviews
     </item>
   </string-array>
   <string-array
       name="override_font_labels"
       >
-    <item>
+    <item
+        >
       When no font specified on flashcards
     </item>
-    <item>
+    <item
+        >
       Always
     </item>
   </string-array>
   <string-array
       name="day_theme_labels"
       >
-    <item>
+    <item
+        >
       Light
     </item>
-    <item>
+    <item
+        >
       Plain
     </item>
   </string-array>
   <string-array
       name="night_theme_labels"
       >
-    <item>
+    <item
+        >
       Black
     </item>
-    <item>
+    <item
+        >
       Dark
     </item>
   </string-array>

--- a/AnkiDroid/src/main/res/values/11-arrays.xml
+++ b/AnkiDroid/src/main/res/values/11-arrays.xml
@@ -17,256 +17,320 @@
 <resources>
   <string-array
       name="error_reporting_choice_labels"
+      comment="."
       >
     <item
+        comment="."
         >
       Always report
     </item>
     <item
+        comment="."
         >
       Never report
     </item>
     <item
+        comment="."
         >
       Ask me
     </item>
   </string-array>
   <string-array
       name="gestures_labels"
+      comment="."
       >
     <item
+        comment="."
         >
       No action
     </item>
     <item
+        comment="."
         >
       Show answer
     </item>
     <item
+        comment="."
         >
       Answer button 1
     </item>
     <item
+        comment="."
         >
       Answer button 2
     </item>
     <item
+        comment="."
         >
       Answer button 3
     </item>
     <item
+        comment="."
         >
       Answer button 4
     </item>
     <item
+        comment="."
         >
       Answer recommended (green)
     </item>
     <item
+        comment="."
         >
       Answer better than recommended
     </item>
     <item
+        comment="."
         >
       Undo
     </item>
     <item
+        comment="."
         >
       Edit note
     </item>
     <item
+        comment="."
         >
       Tag note
     </item>
     <item
+        comment="."
         >
       Mark note
     </item>
     <item
+        comment="."
         >
       Lookup expression
     </item>
     <item
+        comment="."
         >
       Bury card
     </item>
     <item
+        comment="."
         >
       Suspend card
     </item>
     <item
+        comment="."
         >
       Delete note
     </item>
     <item
+        comment="."
         >
       Play media
     </item>
     <item
+        comment="."
         >
       Abort learning
     </item>
     <item
+        comment="."
         >
       Bury note
     </item>
     <item
+        comment="."
         >
       Suspend note
     </item>
     <item
+        comment="."
         >
       Toggle Red Flag
     </item>
     <item
+        comment="."
         >
       Toggle Orange Flag
     </item>
     <item
+        comment="."
         >
       Toggle Green Flag
     </item>
     <item
+        comment="."
         >
       Toggle Blue Flag
     </item>
     <item
+        comment="."
         >
       Remove Flag
     </item>
     <item
+        comment="."
         >
       Page Up
     </item>
     <item
+        comment="."
         >
       Page Down
     </item>
   </string-array>
   <string-array
       name="leech_action_labels"
+      comment="."
       >
     <item
+        comment="."
         >
       Suspend card
     </item>
     <item
+        comment="."
         >
       Tag only
     </item>
   </string-array>
   <string-array
       name="new_order_labels"
+      comment="."
       >
     <item
+        comment="."
         >
       New cards in random order
     </item>
     <item
+        comment="."
         >
       New cards in order added
     </item>
   </string-array>
   <string-array
       name="cram_deck_conf_order_labels"
+      comment="."
       >
     <item
+        comment="."
         >
       Oldest seen first
     </item>
     <item
+        comment="."
         >
       Random
     </item>
     <item
+        comment="."
         >
       Increasing intervals
     </item>
     <item
+        comment="."
         >
       Decreasing intervals
     </item>
     <item
+        comment="."
         >
       Most lapsed
     </item>
     <item
+        comment="."
         >
       Order added
     </item>
     <item
+        comment="."
         >
       Order due
     </item>
     <item
+        comment="."
         >
       Latest added first
     </item>
     <item
+        comment="."
         >
       Relative overdueness
     </item>
   </string-array>
   <string-array
       name="add_to_cur_labels"
+      comment="."
       >
     <item
+        comment="."
         >
       Use current deck
     </item>
     <item
+        comment="."
         >
       Decide by note type
     </item>
   </string-array>
   <string-array
       name="new_spread_labels"
+      comment="."
       >
     <item
+        comment="."
         >
       Mix new cards and reviews
     </item>
     <item
+        comment="."
         >
       New cards after reviews
     </item>
     <item
+        comment="."
         >
       New cards before reviews
     </item>
   </string-array>
   <string-array
       name="override_font_labels"
+      comment="."
       >
     <item
+        comment="."
         >
       When no font specified on flashcards
     </item>
     <item
+        comment="."
         >
       Always
     </item>
   </string-array>
   <string-array
       name="day_theme_labels"
+      comment="."
       >
     <item
+        comment="."
         >
       Light
     </item>
     <item
+        comment="."
         >
       Plain
     </item>
   </string-array>
   <string-array
       name="night_theme_labels"
+      comment="."
       >
     <item
+        comment="."
         >
       Black
     </item>
     <item
+        comment="."
         >
       Dark
     </item>

--- a/AnkiDroid/src/main/res/values/12-dont-translate.xml
+++ b/AnkiDroid/src/main/res/values/12-dont-translate.xml
@@ -19,7 +19,9 @@
   <string
       name="crowdin_test_string_do_not_translate"
       >
-    In order to ensure this string is not shown as untranslated, translate it the way you want. Probably using a single letter, so that it\'s quick. This string will never appear in ankidroid and is present here only to test crowdin feature.
+    You can ignore this string. It\'s used only for test. You can also
+translate it to ensure that you don\'t get notification that a string is missing. (In this case, simply uses a single
+letter to save time)
   </string>
 </resources>
 

--- a/AnkiDroid/src/main/res/values/12-dont-translate.xml
+++ b/AnkiDroid/src/main/res/values/12-dont-translate.xml
@@ -18,6 +18,7 @@
 <resources>
   <string
       name="crowdin_test_string_do_not_translate"
+      comment="."
       >
     You can ignore this string. It\'s used only for test. You can also
 translate it to ensure that you don\'t get notification that a string is missing. (In this case, simply uses a single

--- a/AnkiDroid/src/main/res/values/16-multimedia-editor.xml
+++ b/AnkiDroid/src/main/res/values/16-multimedia-editor.xml
@@ -12,112 +12,227 @@
 ~
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
---><resources>
-    <!-- Main editor popup menu items -->
-    <string name="multimedia_editor_popup_image">Add image</string>
-    <string name="multimedia_editor_popup_audio_clip">Add audio clip</string>
-    <string name="multimedia_editor_popup_audio">Record audio</string>
-    <string name="multimedia_editor_popup_text">Advanced editor</string>
-    <string name="multimedia_editor_popup_cloze">Cloze deletion</string>
+-->
+<resources>
+  <!-- Main editor popup menu items -->
+  <string name="multimedia_editor_popup_image">
+    Add image
+  </string>
+  <string name="multimedia_editor_popup_audio_clip">
+    Add audio clip
+  </string>
+  <string name="multimedia_editor_popup_audio">
+    Record audio
+  </string>
+  <string name="multimedia_editor_popup_text">
+    Advanced editor
+  </string>
+  <string name="multimedia_editor_popup_cloze">
+    Cloze deletion
+  </string>
 
-    <!-- Translation activity (Glosbe) -->
-    <string name="multimedia_editor_trans_poweredglosbe">Powered by glosbe.com</string>
-    <!-- these are like translate f r o m  and t o  some othe languages -->
-    <string name="multimedia_editor_trans_from">From</string>
-    <string name="multimedia_editor_trans_to">To</string>
-    <!-- imperative for the button title -->
-    <string name="multimedia_editor_trans_translate">Translate</string>
-    <!-- waiting message -->
-    <string name="multimedia_editor_trans_translating_online">Translating online</string>
-    <!-- pick the right translation imperative -->
-    <string name="multimedia_editor_trans_pick_translation">Pick translation</string>
-    <!-- in controller when fails -->
-    <string name="multimedia_editor_trans_translation_failed">Translation failed</string>
-    <!-- from controller -->
-    <!-- dialog title to ask for translation source -->
-    <string name="multimedia_editor_trans_pick_translation_source">Pick dictionary</string>
-    <!-- dialog asking to install ColorDict -->
-    <string name="multimedia_editor_trans_install_color_dict">Install ColorDict first</string>
+  <!-- Translation activity (Glosbe) -->
+  <string name="multimedia_editor_trans_poweredglosbe">
+    Powered by glosbe.com
+  </string>
+  <!-- these are like translate f r o m  and t o  some othe languages -->
+  <string name="multimedia_editor_trans_from">
+    From
+  </string>
+  <string name="multimedia_editor_trans_to">
+    To
+  </string>
+  <!-- imperative for the button title -->
+  <string name="multimedia_editor_trans_translate">
+    Translate
+  </string>
+  <!-- waiting message -->
+  <string name="multimedia_editor_trans_translating_online">
+    Translating online
+  </string>
+  <!-- pick the right translation imperative -->
+  <string name="multimedia_editor_trans_pick_translation">
+    Pick translation
+  </string>
+  <!-- in controller when fails -->
+  <string name="multimedia_editor_trans_translation_failed">
+    Translation failed
+  </string>
+  <!-- from controller -->
+  <!-- dialog title to ask for translation source -->
+  <string name="multimedia_editor_trans_pick_translation_source">
+    Pick dictionary
+  </string>
+  <!-- dialog asking to install ColorDict -->
+  <string name="multimedia_editor_trans_install_color_dict">
+    Install ColorDict first
+  </string>
 
-    <!-- Pronunciation activity (Beolingus) -->
-    <string name="multimedia_editor_pron_load">Load</string>
-    <string name="multimedia_editor_pron_looking_up">Looking up pronunciation</string>
-    <!-- in controller when fails -->
-    <string name="multimedia_editor_pron_pronunciation_failed">Pronunciation failed</string>
-    <string name="multimedia_editor_word_search_try_lower_case">Try using only lower case characters</string>
-    <string name="multimedia_editor_poweredbeolingus">Powered by Beolingus</string>
+  <!-- Pronunciation activity (Beolingus) -->
+  <string name="multimedia_editor_pron_load">
+    Load
+  </string>
+  <string name="multimedia_editor_pron_looking_up">
+    Looking up pronunciation
+  </string>
+  <!-- in controller when fails -->
+  <string name="multimedia_editor_pron_pronunciation_failed">
+    Pronunciation failed
+  </string>
+  <string name="multimedia_editor_word_search_try_lower_case">
+    Try using only lower case characters
+  </string>
+  <string name="multimedia_editor_poweredbeolingus">
+    Powered by Beolingus
+  </string>
 
-    <!-- Field editing general -->
-    <!-- these are button names to convert field type -->
-    <string name="multimedia_editor_field_editing_text">Text</string>
-    <string name="multimedia_editor_field_editing_image">Image</string>
-    <string name="multimedia_editor_field_editing_audio">Audio recording</string>
-    <string name="multimedia_editor_field_editing_audio_clip">Audio Clip</string>
-    <string name="multimedia_editor_field_editing_done">Done</string>
+  <!-- Field editing general -->
+  <!-- these are button names to convert field type -->
+  <string name="multimedia_editor_field_editing_text">
+    Text
+  </string>
+  <string name="multimedia_editor_field_editing_image">
+    Image
+  </string>
+  <string name="multimedia_editor_field_editing_audio">
+    Audio recording
+  </string>
+  <string name="multimedia_editor_field_editing_audio_clip">
+    Audio Clip
+  </string>
+  <string name="multimedia_editor_field_editing_done">
+    Done
+  </string>
 
-    <!-- Text field editing -->
-    <!-- buttons -->
-    <string name="multimedia_editor_text_field_editing_search_label">Search for:</string>
-    <string name="multimedia_editor_text_field_editing_show">Image</string>
-    <string name="multimedia_editor_text_field_editing_say">Pronunciation</string>
-    <string name="multimedia_editor_text_field_editing_clear">Clear</string>
-    <string name="multimedia_editor_text_field_editing_clone">Clone from</string>
-    <string name="multimedia_editor_text_field_editing_translate">Translation</string>
-    <!-- message to user, when there is no text or many words, but the user tries something -->
-    <string name="multimedia_editor_text_field_editing_no_text">Input some text first</string>
-    <string name="multimedia_editor_text_field_editing_many_words">Dictionary usually expects one word</string>
-    <!-- message when cloning -->
-    <string name="multimedia_editor_text_field_editing_clone_source">Take from</string>
+  <!-- Text field editing -->
+  <!-- buttons -->
+  <string name="multimedia_editor_text_field_editing_search_label">
+    Search for:
+  </string>
+  <string name="multimedia_editor_text_field_editing_show">
+    Image
+  </string>
+  <string name="multimedia_editor_text_field_editing_say">
+    Pronunciation
+  </string>
+  <string name="multimedia_editor_text_field_editing_clear">
+    Clear
+  </string>
+  <string name="multimedia_editor_text_field_editing_clone">
+    Clone from
+  </string>
+  <string name="multimedia_editor_text_field_editing_translate">
+    Translation
+  </string>
+  <!-- message to user, when there is no text or many words, but the user tries something -->
+  <string name="multimedia_editor_text_field_editing_no_text">
+    Input some text first
+  </string>
+  <string name="multimedia_editor_text_field_editing_many_words">
+    Dictionary usually expects one word
+  </string>
+  <!-- message when cloning -->
+  <string name="multimedia_editor_text_field_editing_clone_source">
+    Take from
+  </string>
 
-    <!-- Multimedia card editor activity -->
-    <!-- for buttons -->
-    <!-- delete confirmation -->
-    <!-- Image editing -->
-    <!-- for buttons -->
-    <string name="multimedia_editor_image_field_editing_galery">Gallery</string>
-    <string name="multimedia_editor_image_field_editing_photo">Camera</string>
-    <string name="multimedia_editor_image_field_editing_library">Library</string>
+  <!-- Multimedia card editor activity -->
+  <!-- for buttons -->
+  <!-- delete confirmation -->
+  <!-- Image editing -->
+  <!-- for buttons -->
+  <string name="multimedia_editor_image_field_editing_galery">
+    Gallery
+  </string>
+  <string name="multimedia_editor_image_field_editing_photo">
+    Camera
+  </string>
+  <string name="multimedia_editor_image_field_editing_library">
+    Library
+  </string>
 
-    <!-- General -->
-    <!-- message on the progress dialog for the user to wait, means process -->
-    <string name="multimedia_editor_general_downloading">Downloading</string>
-    <!-- when process finishes -->
-    <string name="multimedia_editor_general_done">Done</string>
+  <!-- General -->
+  <!-- message on the progress dialog for the user to wait, means process -->
+  <string name="multimedia_editor_general_downloading">
+    Downloading
+  </string>
+  <!-- when process finishes -->
+  <string name="multimedia_editor_general_done">
+    Done
+  </string>
 
-    <!-- General word search and failures -->
-    <string name="multimedia_editor_error_word_not_found">The word was not found</string>
+  <!-- General word search and failures -->
+  <string name="multimedia_editor_error_word_not_found">
+    The word was not found
+  </string>
 
-    <!-- failure when contacting glosbe or similar -->
-    <string name="multimedia_editor_trans_getting_failure">Getting translation failed</string>
-    <string name="multimedia_editor_searching_word">Searching the word</string>
+  <!-- failure when contacting glosbe or similar -->
+  <string name="multimedia_editor_trans_getting_failure">
+    Getting translation failed
+  </string>
+  <string name="multimedia_editor_searching_word">
+    Searching the word
+  </string>
 
-    <!-- General -->
-    <string name="multimedia_editor_progress_wait_title">Wait</string>
-    <!-- not a good message, when an unexpected error happens -->
-    <string name="multimedia_editor_something_wrong">Something went wrong</string>
-    <string name="multimedia_editor_attach_mm_content">Attach multimedia content to the %1$s field</string>
-    <string name="multimedia_editor_attach_media">Attach media</string>
+  <!-- General -->
+  <string name="multimedia_editor_progress_wait_title">
+    Wait
+  </string>
+  <!-- not a good message, when an unexpected error happens -->
+  <string name="multimedia_editor_something_wrong">
+    Something went wrong
+  </string>
+  <string name="multimedia_editor_attach_mm_content">
+    Attach multimedia content to the %1$s field
+  </string>
+  <string name="multimedia_editor_attach_media">
+    Attach media
+  </string>
 
-    <!-- Audio view -->
-    <!-- Message when recording fails -->
-    <string name="multimedia_editor_audio_view_recording_failed">Recording failed</string>
-    <string name="multimedia_editor_audio_view_playing_failed">Playing failed</string>
-    <string name="multimedia_editor_audio_view_create_failed">Unable to create recorder tool bar</string>
+  <!-- Audio view -->
+  <!-- Message when recording fails -->
+  <string name="multimedia_editor_audio_view_recording_failed">
+    Recording failed
+  </string>
+  <string name="multimedia_editor_audio_view_playing_failed">
+    Playing failed
+  </string>
+  <string name="multimedia_editor_audio_view_create_failed">
+    Unable to create recorder tool bar
+  </string>
 
-    <!-- Activity titles -->
+  <!-- Activity titles -->
 
-    <string name="title_activity_edit_text">Editing field</string>
-    <string name="title_activity_translation">Translation</string>
-    <string name="title_activity_load_pronounciation">Pronunciation</string>
+  <string name="title_activity_edit_text">
+    Editing field
+  </string>
+  <string name="title_activity_translation">
+    Translation
+  </string>
+  <string name="title_activity_load_pronounciation">
+    Pronunciation
+  </string>
 
-	<!-- Network failure -->
-	<string name="network_no_connection">No connection</string>
+  <!-- Network failure -->
+  <string name="network_no_connection">
+    No connection
+  </string>
 
-    <!-- Crop function-->
-    <string name="crop_image">Do you want to crop this image?</string>
-    <string name="crop_button">Crop image</string>
-    <string name="save_dialog_content">Current image size is %sMB. Default image size limit is 1MB. Do you want to crop it?</string>
-    <string name="select_image_failed">"Select image failed, Please retry"</string>
-    <string name="activity_result_unexpected">App returned an unexpected value. You may need to use a different app</string>
+  <!-- Crop function-->
+  <string name="crop_image">
+    Do you want to crop this image?
+  </string>
+  <string name="crop_button">
+    Crop image
+  </string>
+  <string name="save_dialog_content">
+    Current image size is %sMB. Default image size limit is 1MB. Do you want to crop it?
+  </string>
+  <string name="select_image_failed">
+    "Select image failed, Please retry"
+  </string>
+  <string name="activity_result_unexpected">
+    App returned an unexpected value. You may need to use a different app
+  </string>
 
 </resources>

--- a/AnkiDroid/src/main/res/values/16-multimedia-editor.xml
+++ b/AnkiDroid/src/main/res/values/16-multimedia-editor.xml
@@ -17,26 +17,31 @@
   <!-- Main editor popup menu items -->
   <string
       name="multimedia_editor_popup_image"
+      comment="."
       >
     Add image
   </string>
   <string
       name="multimedia_editor_popup_audio_clip"
+      comment="."
       >
     Add audio clip
   </string>
   <string
       name="multimedia_editor_popup_audio"
+      comment="."
       >
     Record audio
   </string>
   <string
       name="multimedia_editor_popup_text"
+      comment="."
       >
     Advanced editor
   </string>
   <string
       name="multimedia_editor_popup_cloze"
+      comment="."
       >
     Cloze deletion
   </string>
@@ -44,41 +49,48 @@
   <!-- Translation activity (Glosbe) -->
   <string
       name="multimedia_editor_trans_poweredglosbe"
+      comment="."
       >
     Powered by glosbe.com
   </string>
   <!-- these are like translate f r o m  and t o  some othe languages -->
   <string
       name="multimedia_editor_trans_from"
+      comment="."
       >
     From
   </string>
   <string
       name="multimedia_editor_trans_to"
+      comment="."
       >
     To
   </string>
   <!-- imperative for the button title -->
   <string
       name="multimedia_editor_trans_translate"
+      comment="."
       >
     Translate
   </string>
   <!-- waiting message -->
   <string
       name="multimedia_editor_trans_translating_online"
+      comment="."
       >
     Translating online
   </string>
   <!-- pick the right translation imperative -->
   <string
       name="multimedia_editor_trans_pick_translation"
+      comment="."
       >
     Pick translation
   </string>
   <!-- in controller when fails -->
   <string
       name="multimedia_editor_trans_translation_failed"
+      comment="."
       >
     Translation failed
   </string>
@@ -86,12 +98,14 @@
   <!-- dialog title to ask for translation source -->
   <string
       name="multimedia_editor_trans_pick_translation_source"
+      comment="."
       >
     Pick dictionary
   </string>
   <!-- dialog asking to install ColorDict -->
   <string
       name="multimedia_editor_trans_install_color_dict"
+      comment="."
       >
     Install ColorDict first
   </string>
@@ -99,27 +113,32 @@
   <!-- Pronunciation activity (Beolingus) -->
   <string
       name="multimedia_editor_pron_load"
+      comment="."
       >
     Load
   </string>
   <string
       name="multimedia_editor_pron_looking_up"
+      comment="."
       >
     Looking up pronunciation
   </string>
   <!-- in controller when fails -->
   <string
       name="multimedia_editor_pron_pronunciation_failed"
+      comment="."
       >
     Pronunciation failed
   </string>
   <string
       name="multimedia_editor_word_search_try_lower_case"
+      comment="."
       >
     Try using only lower case characters
   </string>
   <string
       name="multimedia_editor_poweredbeolingus"
+      comment="."
       >
     Powered by Beolingus
   </string>
@@ -128,26 +147,31 @@
   <!-- these are button names to convert field type -->
   <string
       name="multimedia_editor_field_editing_text"
+      comment="."
       >
     Text
   </string>
   <string
       name="multimedia_editor_field_editing_image"
+      comment="."
       >
     Image
   </string>
   <string
       name="multimedia_editor_field_editing_audio"
+      comment="."
       >
     Audio recording
   </string>
   <string
       name="multimedia_editor_field_editing_audio_clip"
+      comment="."
       >
     Audio Clip
   </string>
   <string
       name="multimedia_editor_field_editing_done"
+      comment="."
       >
     Done
   </string>
@@ -156,48 +180,57 @@
   <!-- buttons -->
   <string
       name="multimedia_editor_text_field_editing_search_label"
+      comment="."
       >
     Search for:
   </string>
   <string
       name="multimedia_editor_text_field_editing_show"
+      comment="."
       >
     Image
   </string>
   <string
       name="multimedia_editor_text_field_editing_say"
+      comment="."
       >
     Pronunciation
   </string>
   <string
       name="multimedia_editor_text_field_editing_clear"
+      comment="."
       >
     Clear
   </string>
   <string
       name="multimedia_editor_text_field_editing_clone"
+      comment="."
       >
     Clone from
   </string>
   <string
       name="multimedia_editor_text_field_editing_translate"
+      comment="."
       >
     Translation
   </string>
   <!-- message to user, when there is no text or many words, but the user tries something -->
   <string
       name="multimedia_editor_text_field_editing_no_text"
+      comment="."
       >
     Input some text first
   </string>
   <string
       name="multimedia_editor_text_field_editing_many_words"
+      comment="."
       >
     Dictionary usually expects one word
   </string>
   <!-- message when cloning -->
   <string
       name="multimedia_editor_text_field_editing_clone_source"
+      comment="."
       >
     Take from
   </string>
@@ -209,16 +242,19 @@
   <!-- for buttons -->
   <string
       name="multimedia_editor_image_field_editing_galery"
+      comment="."
       >
     Gallery
   </string>
   <string
       name="multimedia_editor_image_field_editing_photo"
+      comment="."
       >
     Camera
   </string>
   <string
       name="multimedia_editor_image_field_editing_library"
+      comment="."
       >
     Library
   </string>
@@ -227,12 +263,14 @@
   <!-- message on the progress dialog for the user to wait, means process -->
   <string
       name="multimedia_editor_general_downloading"
+      comment="."
       >
     Downloading
   </string>
   <!-- when process finishes -->
   <string
       name="multimedia_editor_general_done"
+      comment="."
       >
     Done
   </string>
@@ -240,6 +278,7 @@
   <!-- General word search and failures -->
   <string
       name="multimedia_editor_error_word_not_found"
+      comment="."
       >
     The word was not found
   </string>
@@ -247,11 +286,13 @@
   <!-- failure when contacting glosbe or similar -->
   <string
       name="multimedia_editor_trans_getting_failure"
+      comment="."
       >
     Getting translation failed
   </string>
   <string
       name="multimedia_editor_searching_word"
+      comment="."
       >
     Searching the word
   </string>
@@ -259,22 +300,26 @@
   <!-- General -->
   <string
       name="multimedia_editor_progress_wait_title"
+      comment="."
       >
     Wait
   </string>
   <!-- not a good message, when an unexpected error happens -->
   <string
       name="multimedia_editor_something_wrong"
+      comment="."
       >
     Something went wrong
   </string>
   <string
       name="multimedia_editor_attach_mm_content"
+      comment="."
       >
     Attach multimedia content to the %1$s field
   </string>
   <string
       name="multimedia_editor_attach_media"
+      comment="."
       >
     Attach media
   </string>
@@ -283,16 +328,19 @@
   <!-- Message when recording fails -->
   <string
       name="multimedia_editor_audio_view_recording_failed"
+      comment="."
       >
     Recording failed
   </string>
   <string
       name="multimedia_editor_audio_view_playing_failed"
+      comment="."
       >
     Playing failed
   </string>
   <string
       name="multimedia_editor_audio_view_create_failed"
+      comment="."
       >
     Unable to create recorder tool bar
   </string>
@@ -301,16 +349,19 @@
 
   <string
       name="title_activity_edit_text"
+      comment="."
       >
     Editing field
   </string>
   <string
       name="title_activity_translation"
+      comment="."
       >
     Translation
   </string>
   <string
       name="title_activity_load_pronounciation"
+      comment="."
       >
     Pronunciation
   </string>
@@ -318,6 +369,7 @@
   <!-- Network failure -->
   <string
       name="network_no_connection"
+      comment="."
       >
     No connection
   </string>
@@ -325,26 +377,31 @@
   <!-- Crop function-->
   <string
       name="crop_image"
+      comment="."
       >
     Do you want to crop this image?
   </string>
   <string
       name="crop_button"
+      comment="."
       >
     Crop image
   </string>
   <string
       name="save_dialog_content"
+      comment="."
       >
     Current image size is %sMB. Default image size limit is 1MB. Do you want to crop it?
   </string>
   <string
       name="select_image_failed"
+      comment="."
       >
     "Select image failed, Please retry"
   </string>
   <string
       name="activity_result_unexpected"
+      comment="."
       >
     App returned an unexpected value. You may need to use a different app
   </string>

--- a/AnkiDroid/src/main/res/values/16-multimedia-editor.xml
+++ b/AnkiDroid/src/main/res/values/16-multimedia-editor.xml
@@ -15,124 +15,190 @@
 -->
 <resources>
   <!-- Main editor popup menu items -->
-  <string name="multimedia_editor_popup_image">
+  <string
+      name="multimedia_editor_popup_image"
+      >
     Add image
   </string>
-  <string name="multimedia_editor_popup_audio_clip">
+  <string
+      name="multimedia_editor_popup_audio_clip"
+      >
     Add audio clip
   </string>
-  <string name="multimedia_editor_popup_audio">
+  <string
+      name="multimedia_editor_popup_audio"
+      >
     Record audio
   </string>
-  <string name="multimedia_editor_popup_text">
+  <string
+      name="multimedia_editor_popup_text"
+      >
     Advanced editor
   </string>
-  <string name="multimedia_editor_popup_cloze">
+  <string
+      name="multimedia_editor_popup_cloze"
+      >
     Cloze deletion
   </string>
 
   <!-- Translation activity (Glosbe) -->
-  <string name="multimedia_editor_trans_poweredglosbe">
+  <string
+      name="multimedia_editor_trans_poweredglosbe"
+      >
     Powered by glosbe.com
   </string>
   <!-- these are like translate f r o m  and t o  some othe languages -->
-  <string name="multimedia_editor_trans_from">
+  <string
+      name="multimedia_editor_trans_from"
+      >
     From
   </string>
-  <string name="multimedia_editor_trans_to">
+  <string
+      name="multimedia_editor_trans_to"
+      >
     To
   </string>
   <!-- imperative for the button title -->
-  <string name="multimedia_editor_trans_translate">
+  <string
+      name="multimedia_editor_trans_translate"
+      >
     Translate
   </string>
   <!-- waiting message -->
-  <string name="multimedia_editor_trans_translating_online">
+  <string
+      name="multimedia_editor_trans_translating_online"
+      >
     Translating online
   </string>
   <!-- pick the right translation imperative -->
-  <string name="multimedia_editor_trans_pick_translation">
+  <string
+      name="multimedia_editor_trans_pick_translation"
+      >
     Pick translation
   </string>
   <!-- in controller when fails -->
-  <string name="multimedia_editor_trans_translation_failed">
+  <string
+      name="multimedia_editor_trans_translation_failed"
+      >
     Translation failed
   </string>
   <!-- from controller -->
   <!-- dialog title to ask for translation source -->
-  <string name="multimedia_editor_trans_pick_translation_source">
+  <string
+      name="multimedia_editor_trans_pick_translation_source"
+      >
     Pick dictionary
   </string>
   <!-- dialog asking to install ColorDict -->
-  <string name="multimedia_editor_trans_install_color_dict">
+  <string
+      name="multimedia_editor_trans_install_color_dict"
+      >
     Install ColorDict first
   </string>
 
   <!-- Pronunciation activity (Beolingus) -->
-  <string name="multimedia_editor_pron_load">
+  <string
+      name="multimedia_editor_pron_load"
+      >
     Load
   </string>
-  <string name="multimedia_editor_pron_looking_up">
+  <string
+      name="multimedia_editor_pron_looking_up"
+      >
     Looking up pronunciation
   </string>
   <!-- in controller when fails -->
-  <string name="multimedia_editor_pron_pronunciation_failed">
+  <string
+      name="multimedia_editor_pron_pronunciation_failed"
+      >
     Pronunciation failed
   </string>
-  <string name="multimedia_editor_word_search_try_lower_case">
+  <string
+      name="multimedia_editor_word_search_try_lower_case"
+      >
     Try using only lower case characters
   </string>
-  <string name="multimedia_editor_poweredbeolingus">
+  <string
+      name="multimedia_editor_poweredbeolingus"
+      >
     Powered by Beolingus
   </string>
 
   <!-- Field editing general -->
   <!-- these are button names to convert field type -->
-  <string name="multimedia_editor_field_editing_text">
+  <string
+      name="multimedia_editor_field_editing_text"
+      >
     Text
   </string>
-  <string name="multimedia_editor_field_editing_image">
+  <string
+      name="multimedia_editor_field_editing_image"
+      >
     Image
   </string>
-  <string name="multimedia_editor_field_editing_audio">
+  <string
+      name="multimedia_editor_field_editing_audio"
+      >
     Audio recording
   </string>
-  <string name="multimedia_editor_field_editing_audio_clip">
+  <string
+      name="multimedia_editor_field_editing_audio_clip"
+      >
     Audio Clip
   </string>
-  <string name="multimedia_editor_field_editing_done">
+  <string
+      name="multimedia_editor_field_editing_done"
+      >
     Done
   </string>
 
   <!-- Text field editing -->
   <!-- buttons -->
-  <string name="multimedia_editor_text_field_editing_search_label">
+  <string
+      name="multimedia_editor_text_field_editing_search_label"
+      >
     Search for:
   </string>
-  <string name="multimedia_editor_text_field_editing_show">
+  <string
+      name="multimedia_editor_text_field_editing_show"
+      >
     Image
   </string>
-  <string name="multimedia_editor_text_field_editing_say">
+  <string
+      name="multimedia_editor_text_field_editing_say"
+      >
     Pronunciation
   </string>
-  <string name="multimedia_editor_text_field_editing_clear">
+  <string
+      name="multimedia_editor_text_field_editing_clear"
+      >
     Clear
   </string>
-  <string name="multimedia_editor_text_field_editing_clone">
+  <string
+      name="multimedia_editor_text_field_editing_clone"
+      >
     Clone from
   </string>
-  <string name="multimedia_editor_text_field_editing_translate">
+  <string
+      name="multimedia_editor_text_field_editing_translate"
+      >
     Translation
   </string>
   <!-- message to user, when there is no text or many words, but the user tries something -->
-  <string name="multimedia_editor_text_field_editing_no_text">
+  <string
+      name="multimedia_editor_text_field_editing_no_text"
+      >
     Input some text first
   </string>
-  <string name="multimedia_editor_text_field_editing_many_words">
+  <string
+      name="multimedia_editor_text_field_editing_many_words"
+      >
     Dictionary usually expects one word
   </string>
   <!-- message when cloning -->
-  <string name="multimedia_editor_text_field_editing_clone_source">
+  <string
+      name="multimedia_editor_text_field_editing_clone_source"
+      >
     Take from
   </string>
 
@@ -141,97 +207,145 @@
   <!-- delete confirmation -->
   <!-- Image editing -->
   <!-- for buttons -->
-  <string name="multimedia_editor_image_field_editing_galery">
+  <string
+      name="multimedia_editor_image_field_editing_galery"
+      >
     Gallery
   </string>
-  <string name="multimedia_editor_image_field_editing_photo">
+  <string
+      name="multimedia_editor_image_field_editing_photo"
+      >
     Camera
   </string>
-  <string name="multimedia_editor_image_field_editing_library">
+  <string
+      name="multimedia_editor_image_field_editing_library"
+      >
     Library
   </string>
 
   <!-- General -->
   <!-- message on the progress dialog for the user to wait, means process -->
-  <string name="multimedia_editor_general_downloading">
+  <string
+      name="multimedia_editor_general_downloading"
+      >
     Downloading
   </string>
   <!-- when process finishes -->
-  <string name="multimedia_editor_general_done">
+  <string
+      name="multimedia_editor_general_done"
+      >
     Done
   </string>
 
   <!-- General word search and failures -->
-  <string name="multimedia_editor_error_word_not_found">
+  <string
+      name="multimedia_editor_error_word_not_found"
+      >
     The word was not found
   </string>
 
   <!-- failure when contacting glosbe or similar -->
-  <string name="multimedia_editor_trans_getting_failure">
+  <string
+      name="multimedia_editor_trans_getting_failure"
+      >
     Getting translation failed
   </string>
-  <string name="multimedia_editor_searching_word">
+  <string
+      name="multimedia_editor_searching_word"
+      >
     Searching the word
   </string>
 
   <!-- General -->
-  <string name="multimedia_editor_progress_wait_title">
+  <string
+      name="multimedia_editor_progress_wait_title"
+      >
     Wait
   </string>
   <!-- not a good message, when an unexpected error happens -->
-  <string name="multimedia_editor_something_wrong">
+  <string
+      name="multimedia_editor_something_wrong"
+      >
     Something went wrong
   </string>
-  <string name="multimedia_editor_attach_mm_content">
+  <string
+      name="multimedia_editor_attach_mm_content"
+      >
     Attach multimedia content to the %1$s field
   </string>
-  <string name="multimedia_editor_attach_media">
+  <string
+      name="multimedia_editor_attach_media"
+      >
     Attach media
   </string>
 
   <!-- Audio view -->
   <!-- Message when recording fails -->
-  <string name="multimedia_editor_audio_view_recording_failed">
+  <string
+      name="multimedia_editor_audio_view_recording_failed"
+      >
     Recording failed
   </string>
-  <string name="multimedia_editor_audio_view_playing_failed">
+  <string
+      name="multimedia_editor_audio_view_playing_failed"
+      >
     Playing failed
   </string>
-  <string name="multimedia_editor_audio_view_create_failed">
+  <string
+      name="multimedia_editor_audio_view_create_failed"
+      >
     Unable to create recorder tool bar
   </string>
 
   <!-- Activity titles -->
 
-  <string name="title_activity_edit_text">
+  <string
+      name="title_activity_edit_text"
+      >
     Editing field
   </string>
-  <string name="title_activity_translation">
+  <string
+      name="title_activity_translation"
+      >
     Translation
   </string>
-  <string name="title_activity_load_pronounciation">
+  <string
+      name="title_activity_load_pronounciation"
+      >
     Pronunciation
   </string>
 
   <!-- Network failure -->
-  <string name="network_no_connection">
+  <string
+      name="network_no_connection"
+      >
     No connection
   </string>
 
   <!-- Crop function-->
-  <string name="crop_image">
+  <string
+      name="crop_image"
+      >
     Do you want to crop this image?
   </string>
-  <string name="crop_button">
+  <string
+      name="crop_button"
+      >
     Crop image
   </string>
-  <string name="save_dialog_content">
+  <string
+      name="save_dialog_content"
+      >
     Current image size is %sMB. Default image size limit is 1MB. Do you want to crop it?
   </string>
-  <string name="select_image_failed">
+  <string
+      name="select_image_failed"
+      >
     "Select image failed, Please retry"
   </string>
-  <string name="activity_result_unexpected">
+  <string
+      name="activity_result_unexpected"
+      >
     App returned an unexpected value. You may need to use a different app
   </string>
 

--- a/AnkiDroid/src/main/res/values/17-model-manager.xml
+++ b/AnkiDroid/src/main/res/values/17-model-manager.xml
@@ -4,11 +4,13 @@
   <!--Menu Labels-->
   <string
       name="model_browser_label"
+      comment="."
       >
     Manage note types
   </string>
   <string
       name="model_editor_label"
+      comment="."
       >
     Manage fields
   </string>
@@ -17,26 +19,31 @@
   <!--Toasts-->
   <string
       name="toast_last_model"
+      comment="."
       >
     You cannot delete your last note type
   </string>
   <string
       name="toast_last_field"
+      comment="."
       >
     Note types must have at least one field
   </string>
   <string
       name="toast_empty_name"
+      comment="."
       >
     You must enter a name
   </string>
   <string
       name="toast_duplicate_field"
+      comment="."
       >
     Field name already used
   </string>
   <string
       name="toast_out_of_range"
+      comment="."
       >
     You must enter a valid value
   </string>
@@ -46,6 +53,7 @@
 
   <plurals
       name="model_browser_types_available"
+      comment="."
       >
     <item quantity="one">
       %d note type available
@@ -57,6 +65,7 @@
 
   <plurals
       name="model_browser_of_type"
+      comment="."
       >
     <item quantity="one">
       %d note
@@ -70,26 +79,31 @@
   <!--Browser-->
   <string
       name="model_browser_delete"
+      comment="."
       >
     Delete note type
   </string>
   <string
       name="model_browser_rename"
+      comment="."
       >
     Rename
   </string>
   <string
       name="model_browser_options"
+      comment="."
       >
     Options
   </string>
   <string
       name="model_browser_template"
+      comment="."
       >
     Edit cards
   </string>
   <string
       name="model_browser_add"
+      comment="."
       >
     Add note type
   </string>
@@ -98,6 +112,7 @@
   <!--Rename-->
   <string
       name="rename_model"
+      comment="."
       >
     Rename note type
   </string>
@@ -105,11 +120,13 @@
   <!--Language Hint-->
   <string
       name="model_field_editor_language_hint_dialog_title"
+      comment="."
       >
     Keyboard language hint
   </string>
   <string
       name="model_field_editor_language_hint_dialog_success_result"
+      comment="."
       >
     Set language hint to %s
   </string>
@@ -117,61 +134,73 @@
   <!--Field Editing-->
   <string
       name="model_field_editor_title"
+      comment="."
       >
     Edit fields
   </string>
   <string
       name="model_field_editor_add"
+      comment="."
       >
     Add field
   </string>
   <string
       name="model_field_editor_delete"
+      comment="."
       >
     Delete field
   </string>
   <string
       name="model_field_editor_options"
+      comment="."
       >
     Field options
   </string>
   <string
       name="model_field_editor_rename"
+      comment="."
       >
     Rename field
   </string>
   <string
       name="model_field_editor_language_hint"
+      comment="."
       >
     Set keyboard language hint
   </string>
   <string
       name="model_field_editor_reposition_menu"
+      comment="."
       >
     Reposition field
   </string>
   <string
       name="model_field_editor_reposition"
+      comment="."
       >
     Reposition field (enter a value %1$d–%2$d)
   </string>
   <string
       name="model_field_editor_toggle_sticky"
+      comment="."
       >
     Remember last input when adding
   </string>
   <string
       name="model_field_editor_changing"
+      comment="."
       >
     Updating fields
   </string>
   <string
       name="model_field_editor_sort_field"
+      comment="."
       >
     Sort by this field
   </string>
   <string
       name="model_clone_suffix"
+      comment="."
       >
     copy
   </string>
@@ -180,11 +209,13 @@
   <!--Warnings-->
   <string
       name="model_delete_warning"
+      comment="."
       >
     Are you sure you wish to delete this note type?
   </string>
   <string
       name="field_delete_warning"
+      comment="."
       >
     Are you sure you wish to delete this field?
   </string>
@@ -193,11 +224,13 @@
   <!--Model Add Suffixes-->
   <string
       name="model_browser_add_add"
+      comment="."
       >
     Add: %1$s
   </string> <!--This prefix is used for standard note types-->
   <string
       name="model_browser_add_clone"
+      comment="."
       >
     Clone: %1$s
   </string>
@@ -205,26 +238,31 @@
   <!--Browser Appearance-->
   <string
       name="card_template_browser_appearance_summary"
+      comment="."
       >
     Enter the template that the card browser will use to display your cards. Use this to display a more concise answer.\n\nA front template of\n“The capital of {{Country}} is:”\ncould be compressed in the card browser to\n“Capital: {{Country}}”
   </string>
   <string
       name="card_template_browser_appearance_question_format"
+      comment="."
       >
     Question Format
   </string>
   <string
       name="card_template_browser_appearance_answer_format"
+      comment="."
       >
     Answer Format
   </string>
   <string
       name="card_template_browser_appearance_restore_default_dialog"
+      comment="."
       >
     Restore Default Values?
   </string>
   <string
       name="card_template_browser_appearance_saving_note"
+      comment="."
       >
     These changes are applied when the card template is saved
   </string>
@@ -232,41 +270,49 @@
   <!-- Deck Override -->
   <string
       name="card_template_editor_deck_override_on"
+      comment="."
       >
     Deck Override (on)
   </string>
   <string
       name="card_template_editor_deck_override_off"
+      comment="."
       >
     Deck Override (off)
   </string>
   <string
       name="model_manager_deck_override_added_message"
+      comment="."
       >
     Set ‘%1$s’ default deck to ‘%2$s’
   </string>
   <string
       name="model_manager_deck_override_removed_message"
+      comment="."
       >
     Removed default deck for ‘%s’
   </string>
   <string
       name="model_manager_deck_override_cloze_error"
+      comment="."
       >
     Cannot set Deck Override for Cloze notes
   </string>
   <string
       name="model_manager_deck_override_dynamic_deck_error"
+      comment="."
       >
     Cannot set Deck Override to a filtered deck
   </string>
   <string
       name="deck_override_explanation"
+      comment="."
       >
     Select deck to place new ‘%s’ cards into
   </string>
   <string
       name="deck_picker_dialog_filter_decks"
+      comment="."
       >
     Filter decks
   </string>

--- a/AnkiDroid/src/main/res/values/17-model-manager.xml
+++ b/AnkiDroid/src/main/res/values/17-model-manager.xml
@@ -2,35 +2,51 @@
 <resources>
 
   <!--Menu Labels-->
-  <string name="model_browser_label">
+  <string
+      name="model_browser_label"
+      >
     Manage note types
   </string>
-  <string name="model_editor_label">
+  <string
+      name="model_editor_label"
+      >
     Manage fields
   </string>
 
 
   <!--Toasts-->
-  <string name="toast_last_model">
+  <string
+      name="toast_last_model"
+      >
     You cannot delete your last note type
   </string>
-  <string name="toast_last_field">
+  <string
+      name="toast_last_field"
+      >
     Note types must have at least one field
   </string>
-  <string name="toast_empty_name">
+  <string
+      name="toast_empty_name"
+      >
     You must enter a name
   </string>
-  <string name="toast_duplicate_field">
+  <string
+      name="toast_duplicate_field"
+      >
     Field name already used
   </string>
-  <string name="toast_out_of_range">
+  <string
+      name="toast_out_of_range"
+      >
     You must enter a valid value
   </string>
 
 
   <!--Plurals-->
 
-  <plurals name="model_browser_types_available">
+  <plurals
+      name="model_browser_types_available"
+      >
     <item quantity="one">
       %d note type available
     </item>
@@ -39,7 +55,9 @@
     </item>
   </plurals>
 
-  <plurals name="model_browser_of_type">
+  <plurals
+      name="model_browser_of_type"
+      >
     <item quantity="one">
       %d note
     </item>
@@ -50,138 +68,214 @@
 
 
   <!--Button Values-->
-  <string name="model_editor_action_add_model">
+  <string
+      name="model_editor_action_add_model"
+      >
     Add note type
   </string>
 
 
   <!--Browser-->
-  <string name="model_browser_delete">
+  <string
+      name="model_browser_delete"
+      >
     Delete note type
   </string>
-  <string name="model_browser_rename">
+  <string
+      name="model_browser_rename"
+      >
     Rename
   </string>
-  <string name="model_browser_options">
+  <string
+      name="model_browser_options"
+      >
     Options
   </string>
-  <string name="model_browser_template">
+  <string
+      name="model_browser_template"
+      >
     Edit cards
   </string>
-  <string name="model_browser_add">
+  <string
+      name="model_browser_add"
+      >
     Add note type
   </string>
 
 
   <!--Rename-->
-  <string name="rename_model">
+  <string
+      name="rename_model"
+      >
     Rename note type
   </string>
 
   <!--Language Hint-->
-  <string name="model_field_editor_language_hint_dialog_title">
+  <string
+      name="model_field_editor_language_hint_dialog_title"
+      >
     Keyboard language hint
   </string>
-  <string name="model_field_editor_language_hint_dialog_success_result">
+  <string
+      name="model_field_editor_language_hint_dialog_success_result"
+      >
     Set language hint to %s
   </string>
 
   <!--Field Editing-->
-  <string name="model_field_editor_title">
+  <string
+      name="model_field_editor_title"
+      >
     Edit fields
   </string>
-  <string name="model_field_editor_add">
+  <string
+      name="model_field_editor_add"
+      >
     Add field
   </string>
-  <string name="model_field_editor_delete">
+  <string
+      name="model_field_editor_delete"
+      >
     Delete field
   </string>
-  <string name="model_field_editor_options">
+  <string
+      name="model_field_editor_options"
+      >
     Field options
   </string>
-  <string name="model_field_editor_rename">
+  <string
+      name="model_field_editor_rename"
+      >
     Rename field
   </string>
-  <string name="model_field_editor_language_hint">
+  <string
+      name="model_field_editor_language_hint"
+      >
     Set keyboard language hint
   </string>
-  <string name="model_field_editor_reposition_menu">
+  <string
+      name="model_field_editor_reposition_menu"
+      >
     Reposition field
   </string>
-  <string name="model_field_editor_reposition">
+  <string
+      name="model_field_editor_reposition"
+      >
     Reposition field (enter a value %1$d–%2$d)
   </string>
-  <string name="model_field_editor_toggle_sticky">
+  <string
+      name="model_field_editor_toggle_sticky"
+      >
     Remember last input when adding
   </string>
-  <string name="model_field_editor_changing">
+  <string
+      name="model_field_editor_changing"
+      >
     Updating fields
   </string>
-  <string name="model_field_editor_sort_field">
+  <string
+      name="model_field_editor_sort_field"
+      >
     Sort by this field
   </string>
-  <string name="model_clone_suffix">
+  <string
+      name="model_clone_suffix"
+      >
     copy
   </string>
 
 
   <!--Warnings-->
-  <string name="model_delete_warning">
+  <string
+      name="model_delete_warning"
+      >
     Are you sure you wish to delete this note type?
   </string>
-  <string name="field_delete_warning">
+  <string
+      name="field_delete_warning"
+      >
     Are you sure you wish to delete this field?
   </string>
 
 
   <!--Model Add Suffixes-->
-  <string name="model_browser_add_add">
+  <string
+      name="model_browser_add_add"
+      >
     Add: %1$s
   </string> <!--This prefix is used for standard note types-->
-  <string name="model_browser_add_clone">
+  <string
+      name="model_browser_add_clone"
+      >
     Clone: %1$s
   </string>
 
   <!--Browser Appearance-->
-  <string name="card_template_browser_appearance_summary">
+  <string
+      name="card_template_browser_appearance_summary"
+      >
     Enter the template that the card browser will use to display your cards. Use this to display a more concise answer.\n\nA front template of\n“The capital of {{Country}} is:”\ncould be compressed in the card browser to\n“Capital: {{Country}}”
   </string>
-  <string name="card_template_browser_appearance_question_format">
+  <string
+      name="card_template_browser_appearance_question_format"
+      >
     Question Format
   </string>
-  <string name="card_template_browser_appearance_answer_format">
+  <string
+      name="card_template_browser_appearance_answer_format"
+      >
     Answer Format
   </string>
-  <string name="card_template_browser_appearance_restore_default_dialog">
+  <string
+      name="card_template_browser_appearance_restore_default_dialog"
+      >
     Restore Default Values?
   </string>
-  <string name="card_template_browser_appearance_saving_note">
+  <string
+      name="card_template_browser_appearance_saving_note"
+      >
     These changes are applied when the card template is saved
   </string>
 
   <!-- Deck Override -->
-  <string name="card_template_editor_deck_override_on">
+  <string
+      name="card_template_editor_deck_override_on"
+      >
     Deck Override (on)
   </string>
-  <string name="card_template_editor_deck_override_off">
+  <string
+      name="card_template_editor_deck_override_off"
+      >
     Deck Override (off)
   </string>
-  <string name="model_manager_deck_override_added_message">
+  <string
+      name="model_manager_deck_override_added_message"
+      >
     Set ‘%1$s’ default deck to ‘%2$s’
   </string>
-  <string name="model_manager_deck_override_removed_message">
+  <string
+      name="model_manager_deck_override_removed_message"
+      >
     Removed default deck for ‘%s’
   </string>
-  <string name="model_manager_deck_override_cloze_error">
+  <string
+      name="model_manager_deck_override_cloze_error"
+      >
     Cannot set Deck Override for Cloze notes
   </string>
-  <string name="model_manager_deck_override_dynamic_deck_error">
+  <string
+      name="model_manager_deck_override_dynamic_deck_error"
+      >
     Cannot set Deck Override to a filtered deck
   </string>
-  <string name="deck_override_explanation">
+  <string
+      name="deck_override_explanation"
+      >
     Select deck to place new ‘%s’ cards into
   </string>
-  <string name="deck_picker_dialog_filter_decks">
+  <string
+      name="deck_picker_dialog_filter_decks"
+      >
     Filter decks
   </string>
 </resources>

--- a/AnkiDroid/src/main/res/values/17-model-manager.xml
+++ b/AnkiDroid/src/main/res/values/17-model-manager.xml
@@ -67,14 +67,6 @@
   </plurals>
 
 
-  <!--Button Values-->
-  <string
-      name="model_editor_action_add_model"
-      >
-    Add note type
-  </string>
-
-
   <!--Browser-->
   <string
       name="model_browser_delete"

--- a/AnkiDroid/src/main/res/values/17-model-manager.xml
+++ b/AnkiDroid/src/main/res/values/17-model-manager.xml
@@ -1,91 +1,187 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <!--Menu Labels-->
-    <string name="model_browser_label">Manage note types</string>
-    <string name="model_editor_label">Manage fields</string>
+  <!--Menu Labels-->
+  <string name="model_browser_label">
+    Manage note types
+  </string>
+  <string name="model_editor_label">
+    Manage fields
+  </string>
 
 
-    <!--Toasts-->
-    <string name="toast_last_model">You cannot delete your last note type</string>
-    <string name="toast_last_field">Note types must have at least one field</string>
-    <string name="toast_empty_name">You must enter a name</string>
-    <string name="toast_duplicate_field">Field name already used</string>
-    <string name="toast_out_of_range">You must enter a valid value</string>
+  <!--Toasts-->
+  <string name="toast_last_model">
+    You cannot delete your last note type
+  </string>
+  <string name="toast_last_field">
+    Note types must have at least one field
+  </string>
+  <string name="toast_empty_name">
+    You must enter a name
+  </string>
+  <string name="toast_duplicate_field">
+    Field name already used
+  </string>
+  <string name="toast_out_of_range">
+    You must enter a valid value
+  </string>
 
 
-    <!--Plurals-->
+  <!--Plurals-->
 
-    <plurals name="model_browser_types_available">
-        <item quantity="one">%d note type available</item>
-        <item quantity="other">%d note types available</item>
-    </plurals>
+  <plurals name="model_browser_types_available">
+    <item quantity="one">
+      %d note type available
+    </item>
+    <item quantity="other">
+      %d note types available
+    </item>
+  </plurals>
 
-    <plurals name="model_browser_of_type">
-        <item quantity="one">%d note</item>
-        <item quantity="other">%d notes</item>
-    </plurals>
-
-
-    <!--Button Values-->
-    <string name="model_editor_action_add_model">Add note type</string>
-
-
-    <!--Browser-->
-    <string name="model_browser_delete">Delete note type</string>
-    <string name="model_browser_rename">Rename</string>
-    <string name="model_browser_options">Options</string>
-    <string name="model_browser_template">Edit cards</string>
-    <string name="model_browser_add">Add note type</string>
+  <plurals name="model_browser_of_type">
+    <item quantity="one">
+      %d note
+    </item>
+    <item quantity="other">
+      %d notes
+    </item>
+  </plurals>
 
 
-    <!--Rename-->
-    <string name="rename_model">Rename note type</string>
-
-    <!--Language Hint-->
-    <string name="model_field_editor_language_hint_dialog_title">Keyboard language hint</string>
-    <string name="model_field_editor_language_hint_dialog_success_result">Set language hint to %s</string>
-
-    <!--Field Editing-->
-    <string name="model_field_editor_title">Edit fields</string>.
-    <string name="model_field_editor_add">Add field</string>
-    <string name="model_field_editor_delete">Delete field</string>
-    <string name="model_field_editor_options">Field options</string>
-    <string name="model_field_editor_rename">Rename field</string>
-    <string name="model_field_editor_language_hint">Set keyboard language hint</string>
-    <string name="model_field_editor_reposition_menu">Reposition field</string>
-    <string name="model_field_editor_reposition">Reposition field (enter a value %1$d–%2$d)</string>
-    <string name="model_field_editor_toggle_sticky">Remember last input when adding</string>
-    <string name="model_field_editor_changing">Updating fields</string>
-    <string name="model_field_editor_sort_field">Sort by this field</string>
-    <string name="model_clone_suffix">copy</string>
+  <!--Button Values-->
+  <string name="model_editor_action_add_model">
+    Add note type
+  </string>
 
 
-    <!--Warnings-->
-    <string name="model_delete_warning">Are you sure you wish to delete this note type?</string>
-    <string name="field_delete_warning">Are you sure you wish to delete this field?</string>
+  <!--Browser-->
+  <string name="model_browser_delete">
+    Delete note type
+  </string>
+  <string name="model_browser_rename">
+    Rename
+  </string>
+  <string name="model_browser_options">
+    Options
+  </string>
+  <string name="model_browser_template">
+    Edit cards
+  </string>
+  <string name="model_browser_add">
+    Add note type
+  </string>
 
 
-    <!--Model Add Suffixes-->
-    <string name="model_browser_add_add">Add: %1$s </string> <!--This prefix is used for standard note types-->
-    <string name="model_browser_add_clone">Clone: %1$s </string>
+  <!--Rename-->
+  <string name="rename_model">
+    Rename note type
+  </string>
 
-    <!--Browser Appearance-->
-    <string name="card_template_browser_appearance_summary">Enter the template that the card browser will use to display your cards. Use this to display a more concise answer.\n\nA front template of\n“The capital of {{Country}} is:”\ncould be compressed in the card browser to\n“Capital: {{Country}}”</string>
-    <string name="card_template_browser_appearance_question_format">Question Format</string>
-    <string name="card_template_browser_appearance_answer_format">Answer Format</string>
-    <string name="card_template_browser_appearance_restore_default_dialog">Restore Default Values?</string>
-    <string name="card_template_browser_appearance_saving_note">These changes are applied when the card template is saved</string>
+  <!--Language Hint-->
+  <string name="model_field_editor_language_hint_dialog_title">
+    Keyboard language hint
+  </string>
+  <string name="model_field_editor_language_hint_dialog_success_result">
+    Set language hint to %s
+  </string>
 
-    <!-- Deck Override -->
-    <string name="card_template_editor_deck_override_on">Deck Override (on)</string>
-    <string name="card_template_editor_deck_override_off">Deck Override (off)</string>
-    <string name="model_manager_deck_override_added_message">Set ‘%1$s’ default deck to ‘%2$s’</string>
-    <string name="model_manager_deck_override_removed_message">Removed default deck for ‘%s’</string>
-    <string name="model_manager_deck_override_cloze_error">Cannot set Deck Override for Cloze notes</string>
-    <string name="model_manager_deck_override_dynamic_deck_error">Cannot set Deck Override to a filtered deck</string>
-    <string name="deck_override_explanation">Select deck to place new ‘%s’ cards into</string>
-    <string name="deck_picker_dialog_filter_decks">Filter decks</string>
+  <!--Field Editing-->
+  <string name="model_field_editor_title">
+    Edit fields
+  </string>
+  <string name="model_field_editor_add">
+    Add field
+  </string>
+  <string name="model_field_editor_delete">
+    Delete field
+  </string>
+  <string name="model_field_editor_options">
+    Field options
+  </string>
+  <string name="model_field_editor_rename">
+    Rename field
+  </string>
+  <string name="model_field_editor_language_hint">
+    Set keyboard language hint
+  </string>
+  <string name="model_field_editor_reposition_menu">
+    Reposition field
+  </string>
+  <string name="model_field_editor_reposition">
+    Reposition field (enter a value %1$d–%2$d)
+  </string>
+  <string name="model_field_editor_toggle_sticky">
+    Remember last input when adding
+  </string>
+  <string name="model_field_editor_changing">
+    Updating fields
+  </string>
+  <string name="model_field_editor_sort_field">
+    Sort by this field
+  </string>
+  <string name="model_clone_suffix">
+    copy
+  </string>
 
 
+  <!--Warnings-->
+  <string name="model_delete_warning">
+    Are you sure you wish to delete this note type?
+  </string>
+  <string name="field_delete_warning">
+    Are you sure you wish to delete this field?
+  </string>
+
+
+  <!--Model Add Suffixes-->
+  <string name="model_browser_add_add">
+    Add: %1$s
+  </string> <!--This prefix is used for standard note types-->
+  <string name="model_browser_add_clone">
+    Clone: %1$s
+  </string>
+
+  <!--Browser Appearance-->
+  <string name="card_template_browser_appearance_summary">
+    Enter the template that the card browser will use to display your cards. Use this to display a more concise answer.\n\nA front template of\n“The capital of {{Country}} is:”\ncould be compressed in the card browser to\n“Capital: {{Country}}”
+  </string>
+  <string name="card_template_browser_appearance_question_format">
+    Question Format
+  </string>
+  <string name="card_template_browser_appearance_answer_format">
+    Answer Format
+  </string>
+  <string name="card_template_browser_appearance_restore_default_dialog">
+    Restore Default Values?
+  </string>
+  <string name="card_template_browser_appearance_saving_note">
+    These changes are applied when the card template is saved
+  </string>
+
+  <!-- Deck Override -->
+  <string name="card_template_editor_deck_override_on">
+    Deck Override (on)
+  </string>
+  <string name="card_template_editor_deck_override_off">
+    Deck Override (off)
+  </string>
+  <string name="model_manager_deck_override_added_message">
+    Set ‘%1$s’ default deck to ‘%2$s’
+  </string>
+  <string name="model_manager_deck_override_removed_message">
+    Removed default deck for ‘%s’
+  </string>
+  <string name="model_manager_deck_override_cloze_error">
+    Cannot set Deck Override for Cloze notes
+  </string>
+  <string name="model_manager_deck_override_dynamic_deck_error">
+    Cannot set Deck Override to a filtered deck
+  </string>
+  <string name="deck_override_explanation">
+    Select deck to place new ‘%s’ cards into
+  </string>
+  <string name="deck_picker_dialog_filter_decks">
+    Filter decks
+  </string>
 </resources>

--- a/AnkiDroid/src/main/res/values/18-standard-models.xml
+++ b/AnkiDroid/src/main/res/values/18-standard-models.xml
@@ -2,23 +2,49 @@
 <resources>
 
     <!--Fields-->
-    <string name="front_field_name">Front</string>
-    <string name="back_field_name">Back</string>
-    <string name="text_field_name">Text</string>
-    <string name="extra_field_name">Extra</string>
-    <string name="field_to_ask_front_name">Add Reverse</string>
+    <string name="front_field_name">
+      Front
+    </string>
+    <string name="back_field_name">
+      Back
+    </string>
+    <string name="text_field_name">
+      Text
+    </string>
+    <string name="extra_field_name">
+      Extra
+    </string>
+    <string name="field_to_ask_front_name">
+      Add Reverse
+    </string>
 
 
     <!--Card type-->
-    <string name="card_one_name">Card 1</string>
-    <string name="card_two_name">Card 2</string>
-    <string name="card_cloze_name">Cloze</string>
+    <string name="card_one_name">
+      Card 1
+    </string>
+    <string name="card_two_name">
+      Card 2
+    </string>
+    <string name="card_cloze_name">
+      Cloze
+    </string>
 
 
     <!--Note type-->
-    <string name="basic_model_name">Basic</string>
-    <string name="cloze_model_name">Cloze</string>
-    <string name="basic_typing_model_name">Basic (type in the answer)</string>
-    <string name="forward_reverse_model_name">Basic (and reversed card)</string>
-    <string name="forward_optional_reverse_model_name">Basic (optional reversed card)</string>
+    <string name="basic_model_name">
+      Basic
+    </string>
+    <string name="cloze_model_name">
+      Cloze
+    </string>
+    <string name="basic_typing_model_name">
+      Basic (type in the answer)
+    </string>
+    <string name="forward_reverse_model_name">
+      Basic (and reversed card)
+    </string>
+    <string name="forward_optional_reverse_model_name">
+      Basic (optional reversed card)
+    </string>
 </resources>

--- a/AnkiDroid/src/main/res/values/18-standard-models.xml
+++ b/AnkiDroid/src/main/res/values/18-standard-models.xml
@@ -4,26 +4,31 @@
     <!--Fields-->
     <string
         name="front_field_name"
+        comment="."
         >
       Front
     </string>
     <string
         name="back_field_name"
+        comment="."
         >
       Back
     </string>
     <string
         name="text_field_name"
+        comment="."
         >
       Text
     </string>
     <string
         name="extra_field_name"
+        comment="."
         >
       Extra
     </string>
     <string
         name="field_to_ask_front_name"
+        comment="."
         >
       Add Reverse
     </string>
@@ -32,16 +37,19 @@
     <!--Card type-->
     <string
         name="card_one_name"
+        comment="."
         >
       Card 1
     </string>
     <string
         name="card_two_name"
+        comment="."
         >
       Card 2
     </string>
     <string
         name="card_cloze_name"
+        comment="."
         >
       Cloze
     </string>
@@ -50,26 +58,31 @@
     <!--Note type-->
     <string
         name="basic_model_name"
+        comment="."
         >
       Basic
     </string>
     <string
         name="cloze_model_name"
+        comment="."
         >
       Cloze
     </string>
     <string
         name="basic_typing_model_name"
+        comment="."
         >
       Basic (type in the answer)
     </string>
     <string
         name="forward_reverse_model_name"
+        comment="."
         >
       Basic (and reversed card)
     </string>
     <string
         name="forward_optional_reverse_model_name"
+        comment="."
         >
       Basic (optional reversed card)
     </string>

--- a/AnkiDroid/src/main/res/values/18-standard-models.xml
+++ b/AnkiDroid/src/main/res/values/18-standard-models.xml
@@ -2,49 +2,75 @@
 <resources>
 
     <!--Fields-->
-    <string name="front_field_name">
+    <string
+        name="front_field_name"
+        >
       Front
     </string>
-    <string name="back_field_name">
+    <string
+        name="back_field_name"
+        >
       Back
     </string>
-    <string name="text_field_name">
+    <string
+        name="text_field_name"
+        >
       Text
     </string>
-    <string name="extra_field_name">
+    <string
+        name="extra_field_name"
+        >
       Extra
     </string>
-    <string name="field_to_ask_front_name">
+    <string
+        name="field_to_ask_front_name"
+        >
       Add Reverse
     </string>
 
 
     <!--Card type-->
-    <string name="card_one_name">
+    <string
+        name="card_one_name"
+        >
       Card 1
     </string>
-    <string name="card_two_name">
+    <string
+        name="card_two_name"
+        >
       Card 2
     </string>
-    <string name="card_cloze_name">
+    <string
+        name="card_cloze_name"
+        >
       Cloze
     </string>
 
 
     <!--Note type-->
-    <string name="basic_model_name">
+    <string
+        name="basic_model_name"
+        >
       Basic
     </string>
-    <string name="cloze_model_name">
+    <string
+        name="cloze_model_name"
+        >
       Cloze
     </string>
-    <string name="basic_typing_model_name">
+    <string
+        name="basic_typing_model_name"
+        >
       Basic (type in the answer)
     </string>
-    <string name="forward_reverse_model_name">
+    <string
+        name="forward_reverse_model_name"
+        >
       Basic (and reversed card)
     </string>
-    <string name="forward_optional_reverse_model_name">
+    <string
+        name="forward_optional_reverse_model_name"
+        >
       Basic (optional reversed card)
     </string>
 </resources>

--- a/AnkiDroid/src/main/res/xml/preferences_custom_buttons.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_custom_buttons.xml
@@ -44,7 +44,7 @@ MENU_DISABLED = 3
             android:entries="@array/custom_button_labels"
             android:entryValues="@array/custom_button_values"
             android:key="customButtonFlag"
-            android:title="@string/menu_flag" />
+            android:title="@string/menu_flag_card" />
         <ListPreference
             android:defaultValue="1"
             android:entries="@array/custom_button_labels"

--- a/tools/manage-crowdin.sh
+++ b/tools/manage-crowdin.sh
@@ -53,6 +53,10 @@ for i in "${I18N_FILES[@]}"; do
   echo "$i"
   I18N_FILE_TARGET_NAME="${i}.xml"
   I18N_FILE_SOURCE_NAME="${I18N_FILE_BASE}${I18N_FILE_TARGET_NAME}"
+  I18N_FILE_TRIMMED_NAME="${I18N_FILE_BASE}trimmed_${I18N_FILE_TARGET_NAME}"
+  # Trim line. Start/end of lines is useful for readability but not for strings.
+  # Start/end of white space is emphasized and distracting on crowdin
+  cat I18N_FILE_SOURCE_NAME | sed -e "s/^ *\([^ ].*[^ ]\) *$/\\1/" > I18N_FILE_TRIMMED_NAME
 
   if [ "$i" == "14-marketdescription" ]; then
     I18N_FILE_TARGET_NAME="14-marketdescription.txt"
@@ -62,9 +66,9 @@ for i in "${I18N_FILES[@]}"; do
   if [ "$I18N_FILE_TARGET_NAME" != "" ]; then  
     echo "Update of Master File ${I18N_FILE_TARGET_NAME} from ${I18N_FILE_SOURCE_NAME}"
 
-    echo "FILE arg is -F \"files[${I18N_FILE_TARGET_NAME}]=@${I18N_FILE_SOURCE_NAME}\" "
+    echo "FILE arg is -F \"files[${I18N_FILE_TARGET_NAME}]=@${I18N_FILE_TRIMMED_NAME}\" "
     curl \
-      -F "files[${I18N_FILE_TARGET_NAME}]=@${I18N_FILE_SOURCE_NAME}" \
+      -F "files[${I18N_FILE_TARGET_NAME}]=@${I18N_FILE_TRIMMED_NAME}" \
       -F "update_option=update_without_changes" \
       https://api.crowdin.com/api/project/${PROJECT_IDENTIFIER}/update-file?key=${CROWDIN_KEY}
   fi


### PR DESCRIPTION
Currently, AnkiDroid is quite hard to translate. Because most strings have little to no context. As an example "Empty deck" may appears on a button to "empty this deck", or on a warning to state that "this deck is empty". And there is no way for translators to know which one is meant. Actually, I can imagine that they guess it's the first one and don't realize it may mean the second one. 

A usual translator will probably have little idea of what means "apkg failed validation" unless they know internals very well. 

Actually, there are some strings I don't even understand myself, even with codebase access, knowing ankidroid quite well I believe, and knowing an important part of the codebase.

My point is that almost all strings should get a comment for translators. Personally, either the string is easy to comment and I can do it taking little time. Or I don't understand the string, I need to go in the code to see where it's used, and this prove that the comment was actually useful.

Furthermore, if each string has a comment, this will show the correct way to behaves to new contributors and they'll directly add comments with their strings, so this work won't have to be repeated.

This is my goal here. Not yet done, but showing what was done over the week-end will allow for feedback. It's based over https://github.com/ankidroid/Anki-Android/pull/6982 . Without this other PR, it would be a nightmare to do any conflict resolution.

One commit delete ressources that are used nowhere. We can remove this commit if we want, if we expect to ever add the string back. However, I don't believe any string should lack context, and I don't see how to add context to a not-used string.

Some of those commits delete ressources that seems to be duplicate. If something is both a message and a menu entry (as in the "empty deck" example), I leave the duplication. However, when the only difference is that they are label of menu item in different windows, or that one if the title of an activity and the other one is the title of a window, I actually can't imagine reason to keep duplicate and give more works to our translators. Actually, it may even be more complex to explain to them why they would need to give distinct translation while the context can't explain it. Each deletion of duplicate is its own commit, so that if you disagree it can be removed. If you agree, on the other hand, we can move those commits in their own PR so that they can be considered separately.



I should note I realize that it's going to be a huge amount of work reviewing it if you expect to actually check every single comment I I added. I do not know which amount of review is needed here. On the one hand, this is NF, there should be absolutely no difference for user directly. On the other hand, if I makes an error, it may be hard to detect it later and it will lead to a lot of bad translation probably if the translators trust the context. And to be perfectly honest, over a thousand strings, it would be hard to imagine there is not a single error