### PR TITLE
Add copyright to compat implementations

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV16.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV16.java
@@ -1,3 +1,18 @@
+/***************************************************************************************
+ * Copyright (c) 2016 Timothy Rae <perceptualchaos2@gmail.com>                          *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
 
 package com.ichi2.compat;
 

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV17.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV17.java
@@ -1,3 +1,18 @@
+/***************************************************************************************
+ * Copyright (c) 2016 rubyu <ruby.u.g@gmail.com>                                        *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
 
 package com.ichi2.compat;
 

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV18.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV18.java
@@ -1,3 +1,19 @@
+/***************************************************************************************
+ * Copyright (c) 2018 Mike Hardy <github@mikehardy.net>                                 *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+
 package com.ichi2.compat;
 
 import android.annotation.TargetApi;

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV19.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV19.java
@@ -1,3 +1,18 @@
+/***************************************************************************************
+ * Copyright (c) 2015 Houssam Salem <houssam.salem.au@gmail.com>                        *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
 
 package com.ichi2.compat;
 

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.java
@@ -1,3 +1,18 @@
+/***************************************************************************************
+ * Copyright (c) 2015 Timothy Rae <perceptualchaos2@gmail.com>                          *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
 
 package com.ichi2.compat;
 

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV23.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV23.java
@@ -1,3 +1,19 @@
+/***************************************************************************************
+ * Copyright (c) 2017 Profpatsch <mail@profpatsch.de>                                   *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+
 package com.ichi2.compat;
 
 import android.annotation.TargetApi;

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV24.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV24.java
@@ -1,3 +1,19 @@
+/***************************************************************************************
+ * Copyright (c) 2018 Mike Hardy <github@mikehardy.net>                                 *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+
 package com.ichi2.compat;
 
 import android.annotation.TargetApi;

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV28.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV28.java
@@ -1,3 +1,19 @@
+/***************************************************************************************
+ * Copyright (c) 2019 Maxim Ilyukhin <maxim.ilyukhin@orionhealth.com>                   *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+
 package com.ichi2.compat;
 
 import android.annotation.TargetApi;


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

The compat objects were missing copyright

## Fixes
Per request from @david-allison-1 

## Approach

I just looked through git log on each object and attributed it to the original author

