### PR TITLE
LINT: Fix & Enable 'WrongConstant'

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -451,19 +451,19 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
             switch (view.getId()) {
                 case R.id.flashcard_layout_ease1:
                     Timber.i("AbstractFlashcardViewer:: EASE_1 pressed");
-                    answerCard(EASE_1);
+                    answerCard(Consts.BUTTON_ONE);
                     break;
                 case R.id.flashcard_layout_ease2:
                     Timber.i("AbstractFlashcardViewer:: EASE_2 pressed");
-                    answerCard(EASE_2);
+                    answerCard(Consts.BUTTON_TWO);
                     break;
                 case R.id.flashcard_layout_ease3:
                     Timber.i("AbstractFlashcardViewer:: EASE_3 pressed");
-                    answerCard(EASE_3);
+                    answerCard(Consts.BUTTON_THREE);
                     break;
                 case R.id.flashcard_layout_ease4:
                     Timber.i("AbstractFlashcardViewer:: EASE_4 pressed");
-                    answerCard(EASE_4);
+                    answerCard(Consts.BUTTON_FOUR);
                     break;
                 default:
                     mCurrentEase = 0;
@@ -2626,13 +2626,13 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
                 onFlag(mCurrentCard, FLAG_NONE);
                 return true;
             case COMMAND_ANSWER_FIRST_BUTTON:
-                return answerCardIfVisible(EASE_1);
+                return answerCardIfVisible(Consts.BUTTON_ONE);
             case COMMAND_ANSWER_SECOND_BUTTON:
-                return answerCardIfVisible(EASE_2);
+                return answerCardIfVisible(Consts.BUTTON_TWO);
             case COMMAND_ANSWER_THIRD_BUTTON:
-                return answerCardIfVisible(EASE_3);
+                return answerCardIfVisible(Consts.BUTTON_THREE);
             case COMMAND_ANSWER_FOURTH_BUTTON:
-                return answerCardIfVisible(EASE_4);
+                return answerCardIfVisible(Consts.BUTTON_FOUR);
             case COMMAND_ANSWER_RECOMMENDED:
                 return answerCardIfVisible(getRecommendedEase(false));
             case COMMAND_PAGE_UP:

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -1423,6 +1423,6 @@ public class Sched extends SchedV2 {
     @Override
     @VisibleForTesting
     public @Consts.BUTTON_TYPE int getGoodNewButton() {
-        return 2;
+        return Consts.BUTTON_TWO;
     }
 }

--- a/lint-release.xml
+++ b/lint-release.xml
@@ -25,6 +25,7 @@
     <issue id="ViewConstructor" severity="fatal" />
     <issue id="ViewHolder" severity="fatal" />
     <issue id="ViewTag" severity="fatal" />
+    <issue id="WrongConstant" severity="fatal" />
     <issue id="WrongViewCast" severity="fatal" />
 
     <!-- This come from Timber and we need to also ignore them  -->
@@ -296,7 +297,6 @@
     <issue id="ResourceType" severity="ignore" />
     <issue id="RestrictedApi" severity="ignore" />
     <issue id="WrongThread" severity="ignore" />
-    <issue id="WrongConstant" severity="ignore" />
     <issue id="VisibleForTests" severity="ignore" />
     <issue id="ProtectedPermissions" severity="ignore" />
     <issue id="TextFields" severity="ignore" />


### PR DESCRIPTION
## Purpose / Description
We can now start to enable lint warnings now 018c1db is in. 

## Fixes
Related: #5026

## Approach
Enable warning

## How Has This Been Tested?
Ensure build still passes

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code