### PR TITLE
CardViewer: Add Help for missing images

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/UIUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/UIUtils.java
@@ -5,6 +5,8 @@ import android.app.Activity;
 import android.content.Context;
 import android.graphics.Color;
 import com.google.android.material.snackbar.Snackbar;
+
+import androidx.annotation.NonNull;
 import androidx.core.content.ContextCompat;
 import android.view.View;
 import android.widget.TextView;
@@ -18,7 +20,6 @@ import timber.log.Timber;
 import static com.ichi2.async.CollectionTask.TASK_TYPE.*;
 import com.ichi2.async.TaskData;
 import com.ichi2.async.TaskListener;
-import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.utils.Time;
 
 public class UIUtils {
@@ -79,6 +80,15 @@ public class UIUtils {
                 return null;
             }
         }
+        Snackbar sb = getSnackbar(activity, mainText, length, actionTextResource, listener, root, callback);
+        sb.show();
+
+        return sb;
+    }
+
+
+    @NonNull
+    public static Snackbar getSnackbar(Activity activity, String mainText, int length, int actionTextResource, View.OnClickListener listener, @NonNull View root, Snackbar.Callback callback) {
         Snackbar sb = Snackbar.make(root, mainText, length);
         if (listener != null) {
             sb.setAction(actionTextResource, listener);
@@ -95,8 +105,6 @@ public class UIUtils {
             action.setTextColor(ContextCompat.getColor(activity, R.color.material_light_blue_500));
             tv.setMaxLines(2);  // prevent tablets from truncating to 1 line
         }
-        sb.show();
-
         return sb;
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/MissingImageHandler.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/MissingImageHandler.java
@@ -1,0 +1,82 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.cardviewer;
+
+import android.os.Build;
+import android.webkit.URLUtil;
+import android.webkit.WebResourceRequest;
+
+import com.ichi2.utils.FunctionalInterfaces.Consumer;
+
+import androidx.annotation.NonNull;
+import timber.log.Timber;
+
+/** Handles logic for displaying help for missing media files */
+public class MissingImageHandler {
+
+    /** Specify a maximum number of times to display, as it's somewhat annoying */
+    public static final int MAX_DISPLAY_TIMES = 2;
+
+    private int mNumberOfMissingImages = 0;
+    private boolean mHasExecuted = false;
+    @NonNull
+    private Consumer<String> mOnFailure;
+
+
+    public MissingImageHandler(@NonNull Consumer<String> onFailure) {
+        mOnFailure = onFailure;
+    }
+
+    public void processFailure(WebResourceRequest request) {
+        // We do not want this to trigger more than once on the same side of the card as the UI will flicker.
+        if (request == null || mHasExecuted) {
+            return;
+        }
+
+        // The UX of the snackbar is annoying, as it obscures the content. Assume that if a user ignores it twice, they don't care.
+        if (mNumberOfMissingImages >= MAX_DISPLAY_TIMES) {
+            return;
+        }
+
+        // This code doesn't seem to be called anyway, but we can't use request.getUrl() on < API 21.
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            return;
+        }
+
+        String url = request.getUrl().toString();
+        // We could do better here (external images failing due to no HTTPS), but failures can occur due to no network.
+        // As we don't yet check the error data, we don't know.
+        // Therefore limit this feature to the common case of local files, which should always work.
+        if (!url.contains("collection.media")) {
+            return;
+        }
+
+        try {
+            String filename = URLUtil.guessFileName(url, null, null);
+            mOnFailure.consume(filename);
+            mNumberOfMissingImages++;
+        } catch (Exception e) {
+            Timber.w(e, "Failed to notify UI of media failure");
+        } finally {
+            mHasExecuted = true;
+        }
+    }
+
+    public void onCardSideChange() {
+        mHasExecuted = false;
+    }
+}

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -320,4 +320,8 @@
     <!-- About AnkiDroid screen -->
     <string name="about_ankidroid_successfully_copied_debug">Copied debug information to clipboard</string>
     <string name="about_ankidroid_error_copy_debug_info">Error copying debug information to clipboard</string>
+
+    <!-- Card Viewer -->
+    <string name="card_viewer_could_not_find_image">Failed to load ‘%s’</string>
+    <string name="card_viewer_could_not_find_image_get_help">Help</string>
 </resources>

--- a/AnkiDroid/src/main/res/values/constants.xml
+++ b/AnkiDroid/src/main/res/values/constants.xml
@@ -13,7 +13,7 @@
 ~
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
---><resources>
+--><resources xmlns:tools="http://schemas.android.com/tools">
 
     <!--
         WARNING: These values here match static values defined in Deck.java DO
@@ -144,6 +144,7 @@
     <string name="link_manual_zh">https://docs.ankidroid.org/manual-zh.html</string>
     <string name="link_manual_getting_started">https://docs.ankidroid.org/manual.html#gettingStarted</string>
     <string name="link_faq_tts">https://github.com/ankidroid/Anki-Android/wiki/FAQ#tts--text-to-speech-is-not-speaking</string>
+    <string name="link_faq_missing_media" tools:ignore="Typos">https://github.com/ankidroid/Anki-Android/wiki/FAQ#why-doesnt-my-sound-or-image-work-on-ankidroid</string>
     <string name="shared_decks_url">https://ankiweb.net/shared/decks/</string>
     <string name="repair_deck">http://ankisrs.net/docs/manual.html#corrupt-collections</string>
     <string name="resetpw_url">http://ankiweb.net/account/resetpw</string>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/MissingImageHandlerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/MissingImageHandlerTest.java
@@ -1,0 +1,161 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.cardviewer;
+
+import android.net.Uri;
+import android.os.Build;
+import android.webkit.WebResourceRequest;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import androidx.annotation.NonNull;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assume.assumeThat;
+
+// PERF:
+// Theoretically should be able to get away with not using this, but it requires WebResourceRequest (easy to mock)
+// and URLUtil.guessFileName (static - likely harder)
+@RunWith(AndroidJUnit4.class)
+public class MissingImageHandlerTest {
+
+    private MissingImageHandler mSut;
+    private int mTimesCalled = 0;
+    private List<String> mFileNames;
+
+    @Before
+    public void before() {
+        // couldn't get Config(minSDK) to work, as that produced multiple test calls.
+        assumeThat("Can't be executed < API 21", Build.VERSION.SDK_INT, greaterThanOrEqualTo(Build.VERSION_CODES.LOLLIPOP));
+        mFileNames = new ArrayList<>();
+        mSut = new MissingImageHandler((f) -> {
+            mTimesCalled++;
+            mFileNames.add(f);
+        });
+    }
+
+    @Test
+    public void firstTimeOnNewCardSends() {
+        mSut.processFailure(getValidRequest("example.jpg"));
+        assertThat(mTimesCalled, is(1));
+        assertThat(mFileNames, contains("example.jpg"));
+    }
+
+    @Test
+    public void twoCallsOnSameSideCallsOnce() {
+        mSut.processFailure(getValidRequest("example.jpg"));
+        mSut.processFailure(getValidRequest("example2.jpg"));
+        assertThat(mTimesCalled, is(1));
+        assertThat(mFileNames, contains("example.jpg"));
+    }
+
+    @Test
+    public void callAfterFlipIsShown() {
+        mSut.processFailure(getValidRequest("example.jpg"));
+        mSut.onCardSideChange();
+        mSut.processFailure(getValidRequest("example2.jpg"));
+        assertThat(mTimesCalled, is(2));
+        assertThat(mFileNames, contains("example.jpg", "example2.jpg"));
+    }
+
+    @Test
+    public void thirdCallIsIgnored() {
+        mSut.processFailure(getValidRequest("example.jpg"));
+        mSut.onCardSideChange();
+        mSut.processFailure(getValidRequest("example2.jpg"));
+        mSut.onCardSideChange();
+        mSut.processFailure(getValidRequest("example3.jpg"));
+        assertThat(mTimesCalled, is(2));
+        assertThat(mFileNames, contains("example.jpg", "example2.jpg"));
+    }
+
+    @Test
+    public void invalidRequestIsIgnored() {
+        mSut.processFailure(getInvalidRequest("example.jpg"));
+        assertThat(mTimesCalled, is(0));
+    }
+
+    @Test
+    public void uiFailureDoesNotCrash() {
+        MissingImageHandler sut = new MissingImageHandler((f) -> { throw new RuntimeException("expected"); });
+        sut.processFailure(getValidRequest("example.jpg"));
+        assertThat("Irrelevant assert to stop lint warnings", mTimesCalled, is(0));
+    }
+
+
+    private WebResourceRequest getValidRequest(String fileName) {
+        // actual URL on Android 9
+        String url =  String.format("file:///storage/emulated/0/AnkiDroid/collection.media/%s", fileName);
+        return getWebResourceRequest(url);
+    }
+
+    private WebResourceRequest getInvalidRequest(@SuppressWarnings("SameParameterValue") String fileName) {
+        // no collection.media in the URL
+        String url =  String.format("file:///storage/emulated/0/AnkiDroid/%s", fileName);
+        return getWebResourceRequest(url);
+    }
+
+    @NonNull
+    private WebResourceRequest getWebResourceRequest(String url) {
+        return new WebResourceRequest() {
+            @Override
+            public Uri getUrl() {
+                return Uri.parse(url);
+            }
+
+
+            @Override
+            public boolean isForMainFrame() {
+                return false;
+            }
+
+
+            @Override
+            public boolean isRedirect() {
+                return false;
+            }
+
+
+            @Override
+            public boolean hasGesture() {
+                return false;
+            }
+
+
+            @Override
+            public String getMethod() {
+                return null;
+            }
+
+
+            @Override
+            public Map<String, String> getRequestHeaders() {
+                return null;
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Purpose / Description
Many users had problems with missing images due to a media sync not completing

This gives them advice, and hopefully reduces the support load

## Fixes
Fixes #7009

## Approach
_How does this change address the problem?_

## How Has This Been Tested?

##### API 16 emulator
* Nothing on API 16 (as expected)  `onReceivedError` is not called. 

##### API 22 emulator 
* Nothing (unexpected) - `onReceivedError` is not called. 

##### Android 9 physical device
* Reviewer, Previewer and Card Template Previewer work
* Link has been tested
* Unit Tested

## Learning

* Moving a snackbar is hard. I used https://stackoverflow.com/a/48472087
* https://github.com/ankidroid/Anki-Android/wiki/FAQ#why-doesnt-my-sound-or-image-work-on-ankidroid

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code