### PR TITLE
Add Lint check: Use of JetBrains annotations

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/RescheduleDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/RescheduleDialog.java
@@ -1,3 +1,19 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package com.ichi2.anki.dialogs;
 
 import android.content.res.Resources;
@@ -7,8 +23,8 @@ import com.ichi2.libanki.Card;
 import com.ichi2.libanki.sched.SchedV2;
 import com.ichi2.utils.FunctionalInterfaces.Consumer;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import androidx.annotation.CheckResult;
 
@@ -17,7 +33,7 @@ public class RescheduleDialog extends IntegerDialog {
         super();
     }
 
-    @NotNull
+    @NonNull
     @CheckResult
     public static RescheduleDialog rescheduleSingleCard(Resources resources, Card currentCard,
                                                         Consumer<Integer> consumer) {
@@ -38,7 +54,7 @@ public class RescheduleDialog extends IntegerDialog {
         return rescheduleDialog;
     }
 
-    @NotNull
+    @NonNull
     @CheckResult
     public static RescheduleDialog rescheduleMultipleCards(Resources resources, Consumer<Integer> consumer, int cardCount) {
         RescheduleDialog rescheduleDialog = new RescheduleDialog();

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.java
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.java
@@ -7,6 +7,7 @@ import com.ichi2.anki.lint.rules.DirectSystemTimeInstantiation;
 import com.ichi2.anki.lint.rules.DirectSystemCurrentTimeMillisUsage;
 import com.ichi2.anki.lint.rules.DirectDateInstantiation;
 import com.ichi2.anki.lint.rules.DirectGregorianInstantiation;
+import com.ichi2.anki.lint.rules.InconsistentAnnotationUsage;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -23,6 +24,7 @@ public class IssueRegistry extends com.android.tools.lint.client.api.IssueRegist
         issues.add(DirectDateInstantiation.ISSUE);
         issues.add(DirectGregorianInstantiation.ISSUE);
         issues.add(DirectSystemTimeInstantiation.ISSUE);
+        issues.add(InconsistentAnnotationUsage.ISSUE);
         return issues;
     }
 

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/InconsistentAnnotationUsage.java
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/InconsistentAnnotationUsage.java
@@ -1,0 +1,73 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.lint.rules;
+
+import com.android.annotations.NonNull;
+import com.android.tools.lint.detector.api.Implementation;
+import com.android.tools.lint.detector.api.Issue;
+import com.android.tools.lint.detector.api.JavaContext;
+import com.android.tools.lint.detector.api.Scope;
+import com.android.tools.lint.detector.api.SourceCodeScanner;
+import com.google.common.annotations.VisibleForTesting;
+import com.ichi2.anki.lint.utils.Constants;
+import com.ichi2.anki.lint.utils.ImportStatementDetector;
+
+import org.jetbrains.uast.UElement;
+import org.jetbrains.uast.UImportStatement;
+
+public class InconsistentAnnotationUsage extends ImportStatementDetector implements SourceCodeScanner {
+    @VisibleForTesting
+    static final String ID = "InconsistentAnnotationUsage";
+    @VisibleForTesting
+    static final String DESCRIPTION = "Use androidx.annotation.NonNull and androidx.annotation.Nullable. See explanation for IDE-level fix";
+    private static final String EXPLANATION = "AnkiDroid uses androidx nullability annotations over JetBrains for nullability. " +
+            "The annotations library can be specified in Settings - Inspections - @NotNull/@Nullable problems";
+    private static Implementation implementation = new Implementation(InconsistentAnnotationUsage.class, Scope.JAVA_FILE_SCOPE);
+    public static final Issue ISSUE = Issue.create(
+            ID,
+            DESCRIPTION,
+            EXPLANATION,
+            Constants.ANKI_TIME_CATEGORY,
+            Constants.ANKI_TIME_PRIORITY,
+            Constants.ANKI_TIME_SEVERITY,
+            implementation
+    );
+
+    public InconsistentAnnotationUsage() {
+
+    }
+
+
+    @Override
+    public void visitImportStatement(@NonNull JavaContext context, @NonNull UImportStatement node) {
+
+        UElement importReference = node.getImportReference();
+        if (importReference != null && isJetbrains(importReference.asRenderString())) {
+            context.report(
+                    ISSUE,
+                    node,
+                    context.getLocation(node),
+                    DESCRIPTION
+            );
+        }
+    }
+
+
+    private boolean isJetbrains(String importReference) {
+        return importReference.equals("org.jetbrains.annotations.NotNull") || importReference.equals("org.jetbrains.annotations.Nullable");
+    }
+}

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/utils/ImportStatementDetector.java
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/utils/ImportStatementDetector.java
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.lint.utils;
+
+import com.android.tools.lint.client.api.UElementHandler;
+import com.android.tools.lint.detector.api.Detector;
+import com.android.tools.lint.detector.api.JavaContext;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.uast.UElement;
+import org.jetbrains.uast.UImportStatement;
+
+import java.util.Collections;
+import java.util.List;
+
+public abstract class ImportStatementDetector extends Detector {
+
+    public abstract void visitImportStatement(@NotNull JavaContext context, @NotNull UImportStatement node);
+
+
+    @Nullable
+    @Override
+    public List<Class<? extends UElement>> getApplicableUastTypes() {
+        return Collections.singletonList(UImportStatement.class);
+    }
+
+    @Nullable
+    @Override
+    public UElementHandler createUastHandler(@NotNull JavaContext context) {
+        return new UElementHandler() {
+            @Override
+            public void visitImportStatement(@NotNull UImportStatement node) {
+                // do not call super
+                ImportStatementDetector.this.visitImportStatement(context, node);
+            }
+        };
+    }
+}

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/InconsistentAnnotationUsageTest.java
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/InconsistentAnnotationUsageTest.java
@@ -1,0 +1,85 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.lint.rules;
+
+import org.junit.Test;
+
+import static com.android.tools.lint.checks.infrastructure.TestFile.JavaTestFile.create;
+import static com.android.tools.lint.checks.infrastructure.TestLintTask.lint;
+import static org.junit.Assert.assertTrue;
+
+public class InconsistentAnnotationUsageTest {
+
+    private final String mNotNullUsage = "                                  \n" +
+            "package java.util;                                             \n" +
+            "                                                               \n" +
+            "import org.jetbrains.annotations.NotNull;                      \n";
+
+    private final String mNullable = "                                      \n" +
+            "package java.util;                                             \n" +
+            "                                                               \n" +
+            "import org.jetbrains.annotations.Nullable;                     \n";
+
+    // Should be OK
+    private final String mContract = "                                      \n" +
+            "package java.util;                                             \n" +
+            "                                                               \n" +
+            "import org.jetbrains.annotations.Contract;                     \n";
+
+
+
+    @Test
+    public void showsErrorForNotNull() {
+        lint()
+                .allowMissingSdk()
+                .allowCompilationErrors()
+                .files(create(mNotNullUsage))
+                .issues(InconsistentAnnotationUsage.ISSUE)
+                .run()
+                .expectErrorCount(1)
+                .check(output -> {
+                    assertTrue(output.contains(InconsistentAnnotationUsage.ID));
+                    assertTrue(output.contains(InconsistentAnnotationUsage.DESCRIPTION));
+                });
+    }
+
+    @Test
+    public void showsErrorForNullable() {
+        lint()
+                .allowMissingSdk()
+                .allowCompilationErrors()
+                .files(create(mNullable))
+                .issues(InconsistentAnnotationUsage.ISSUE)
+                .run()
+                .expectErrorCount(1)
+                .check(output -> {
+                    assertTrue(output.contains(InconsistentAnnotationUsage.ID));
+                    assertTrue(output.contains(InconsistentAnnotationUsage.DESCRIPTION));
+                });
+    }
+
+    @Test
+    public void noErrorForContract() {
+        lint()
+                .allowMissingSdk()
+                .allowCompilationErrors()
+                .files(create(mContract))
+                .issues(InconsistentAnnotationUsage.ISSUE)
+                .run()
+                .expectErrorCount(0);
+    }
+}


### PR DESCRIPTION
## Purpose / Description
A common issue for new users is not using `androidx.annotation.NonNull` and instead using `org.jetbrains.annotations.NotNull`

This adds a lint error to the IDE, which also explains the setting to change to stop the error, reducing friction for code review.

## Related
#5026

## Approach
Add a lint check for `org.jetbrains.annotations.NotNull` and `org.jetbrains.annotations.Nullable`

## How Has This Been Tested?
* Previously failed on a class I made, now passes.
* Unit tested

## Learning

* Custom lint errors appear in the IDE
* The `explanation` field for the lint error is hard to find, so there is a CTA in the description
* Custom lint errors are awesome

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code