### PR TITLE
Deck Export with media: Skip missing files

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
@@ -75,6 +75,7 @@ import java.util.regex.Pattern;
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipFile;
 
+import androidx.annotation.Nullable;
 import timber.log.Timber;
 
 @SuppressWarnings({"PMD.AvoidThrowingRawExceptionTypes","PMD.AvoidReassigningParameters",
@@ -676,9 +677,20 @@ public class Utils {
         return contentOfMyInputStream;
     }
 
+    public static void unzipAllFiles(ZipFile zipFile, String targetDirectory) throws IOException {
+        List<String> entryNames = new ArrayList<>();
+        Enumeration<ZipArchiveEntry> i = zipFile.getEntries();
+        while (i.hasMoreElements()) {
+            ZipArchiveEntry e = i.nextElement();
+            entryNames.add(e.getName());
+        }
 
-    public static void unzipFiles(ZipFile zipFile, String targetDirectory, String[] zipEntries,
-                                  Map<String, String> zipEntryToFilenameMap) throws IOException {
+        unzipFiles(zipFile, targetDirectory, entryNames.toArray(new String[0]), null);
+
+    }
+
+    public static void unzipFiles(ZipFile zipFile, String targetDirectory, @NonNull String[] zipEntries,
+                                  @Nullable Map<String, String> zipEntryToFilenameMap) throws IOException {
         File dir = new File(targetDirectory);
         if (!dir.exists() && !dir.mkdirs()) {
             throw new IOException("Failed to create target directory: " + targetDirectory);

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/AnkiPackageExporterTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/AnkiPackageExporterTest.java
@@ -1,0 +1,164 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.libanki;
+
+import com.ichi2.anki.RobolectricTest;
+import com.ichi2.anki.exception.ImportExportException;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import androidx.annotation.NonNull;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasSize;
+
+@RunWith(AndroidJUnit4.class)
+public class AnkiPackageExporterTest extends RobolectricTest {
+
+    @Test
+    public void missingFileInDeckExportDoesSkipsFile() throws IOException, ImportExportException {
+        // arrange
+        File mediaFilePath = addTempFileToMediaAndNote();
+        if (!mediaFilePath.delete()) {
+            throw new IllegalStateException("need to delete temp file for test to pass");
+        }
+
+        AnkiPackageExporter exporter = getExporterForDeckWithMedia();
+        Path tempExportDir = Files.createTempDirectory("AnkiDroid-missingFileInExportDoesNotThrowException-export");
+
+        File exportedFile = new File(tempExportDir.toFile(), "export.apkg");
+
+        // act
+        exporter.exportInto(exportedFile.getAbsolutePath(), getTargetContext());
+
+        // assert
+        Path unzipDirectory = unzipFilesTo(tempExportDir, exportedFile);
+
+
+        File[] files = unzipDirectory.toFile().listFiles();
+
+        // confirm the files
+        List<String> fileNames = Arrays.stream(files).map(File::getName).collect(Collectors.toList());
+        assertThat(fileNames, containsInAnyOrder("collection.anki2", "media"));
+        assertThat("Only two files should exist", fileNames, hasSize(2));
+        checkMediaExportStringIs(files, "{}");
+    }
+
+    @Test
+    public void fileInExportIsCopied() throws IOException, ImportExportException {
+        // arrange
+        File tempFileInCollection = addTempFileToMediaAndNote();
+
+        AnkiPackageExporter exporter = getExporterForDeckWithMedia();
+        Path tempExportDir = Files.createTempDirectory("AnkiDroid-missingFileInExportDoesNotThrowException-export");
+
+        File exportedFile = new File(tempExportDir.toFile(), "export.apkg");
+
+        // act
+        exporter.exportInto(exportedFile.getAbsolutePath(), getTargetContext());
+
+        // assert
+        Path unzipDirectory = unzipFilesTo(tempExportDir, exportedFile);
+
+
+        File[] files = unzipDirectory.toFile().listFiles();
+
+        // confirm the files
+        List<String> fileNames = Arrays.stream(files).map(File::getName).collect(Collectors.toList());
+        assertThat(fileNames, containsInAnyOrder("collection.anki2", "media", "0"));
+        assertThat("Three files should exist", fileNames, hasSize(3));
+
+        // {"0":"filename.txt"}
+        String expected = String.format("{\"0\":\"%s\"}", tempFileInCollection.getName());
+        checkMediaExportStringIs(files, expected);
+    }
+
+
+    private void checkMediaExportStringIs(File[] files, String s) throws IOException {
+        for (File f : files) {
+            if (!"media".equals(f.getName())) {
+                continue;
+            }
+            List<String> lines = Files.readAllLines(Paths.get(f.getAbsolutePath()));
+            assertThat(lines, contains(s));
+            return;
+        }
+
+        Assert.fail("media file not found");
+    }
+
+
+
+    @NonNull
+    private AnkiPackageExporter getExporterForDeckWithMedia() {
+        AnkiPackageExporter exporter = new AnkiPackageExporter(getCol());
+        exporter.setIncludeMedia(true);
+        exporter.setIncludeSched(true);
+        exporter.setDid(1L);
+        return exporter;
+    }
+
+
+    private Path unzipFilesTo(Path tempDirWithPrefix, File fileToUnzip) throws IOException {
+        org.apache.commons.compress.archivers.zip.ZipFile exportReader = new org.apache.commons.compress.archivers.zip.ZipFile(fileToUnzip.getAbsolutePath());
+
+        Path unzipDirectory = tempDirWithPrefix.resolve("unzipped");
+        if (!unzipDirectory.toFile().mkdir()) {
+            throw new IllegalStateException(String.format("failed to make path %s", unzipDirectory));
+        }
+
+        // we need to unzip the zipped collection
+        Utils.unzipAllFiles(exportReader, unzipDirectory.toAbsolutePath().toString());
+        return unzipDirectory;
+    }
+
+
+    private File addTempFileToMediaAndNote() throws IOException {
+        File temp = File.createTempFile("AnkiDroid-missingFileInExportDoesNotThrowException", ".txt");
+        PrintWriter writer = new PrintWriter(temp);
+        writer.println("unit test data");
+        writer.close();
+
+        String s = getCol().getMedia().addFile(temp);
+        temp.delete();
+
+        File newFile = new File(getCol().getMedia().dir(), s);
+        if (!newFile.exists()) {
+            throw new IllegalStateException("Could not create temp file");
+        }
+
+        addNoteUsingBasicModel(String.format("<img src=\"%s\">", newFile.getName()), "Back");
+
+        return newFile;
+    }
+
+}


### PR DESCRIPTION
## Purpose / Description

Anki Desktop has the same behaviour.

Previously threw a FileNotFound

## Fixes
Fixes #7023

## Approach
Check the files exist, and skip if they don't

## How Has This Been Tested?
Integration test and tested on my Android 9 phone

## Learning
This one had been live for a long time, still need more tests

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code