### PR TITLE
Disable fullscreen in Previewer

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -2862,10 +2862,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
             }
 
             // Go back to immersive mode if the user had temporarily exited it (and then execute swipe gesture)
-            if (mPrefFullscreenReview > 0 &&
-                    CompatHelper.getCompat().isImmersiveSystemUiVisible(AbstractFlashcardViewer.this)) {
-                delayedHide(INITIAL_HIDE_DELAY);
-            }
+            AbstractFlashcardViewer.this.onFling();
             if (mGesturesEnabled) {
                 try {
                     float dy = e2.getY() - e1.getY();
@@ -2937,9 +2934,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         @Override
         public boolean onSingleTapConfirmed(MotionEvent e) {
             // Go back to immersive mode if the user had temporarily exited it (and ignore the tap gesture)
-            if (mPrefFullscreenReview > 0 &&
-                    CompatHelper.getCompat().isImmersiveSystemUiVisible(AbstractFlashcardViewer.this)) {
-                delayedHide(INITIAL_HIDE_DELAY);
+            if (onSingleTap()) {
                 return true;
             }
             return executeTouchCommand(e);
@@ -2983,6 +2978,17 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
             return true;
         }
     }
+
+
+    protected boolean onSingleTap() {
+        return false;
+    }
+
+
+    protected void onFling() {
+
+    }
+
 
     /** #6141 - blocks clicking links from executing "touch" gestures.
      * COULD_BE_BETTER: Make base class static and move this out of the CardViewer */
@@ -3067,21 +3073,6 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
             return type == HitTestResult.SRC_ANCHOR_TYPE
                     || type == HitTestResult.SRC_IMAGE_ANCHOR_TYPE;
         }
-    }
-
-    protected final Handler mFullScreenHandler = new Handler() {
-        @Override
-        public void handleMessage(Message msg) {
-            if (mPrefFullscreenReview > 0) {
-                CompatHelper.getCompat().setFullScreen(AbstractFlashcardViewer.this);
-            }
-        }
-    };
-
-    protected void delayedHide(int delayMillis) {
-        Timber.d("Fullscreen delayed hide in %dms", delayMillis);
-        mFullScreenHandler.removeMessages(0);
-        mFullScreenHandler.sendEmptyMessageDelayed(0, delayMillis);
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -26,6 +26,8 @@ import android.content.pm.PackageManager;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.Handler;
+import android.os.Message;
 import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -782,6 +784,40 @@ public class Reviewer extends AbstractFlashcardViewer {
         if (mPrefWhiteboard) {
             setWhiteboardVisibility(mShowWhiteboard);
         }
+    }
+
+    @Override
+    protected boolean onSingleTap() {
+        if (mPrefFullscreenReview &&
+                CompatHelper.getCompat().isImmersiveSystemUiVisible(this)) {
+            delayedHide(INITIAL_HIDE_DELAY);
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    protected void onFling() {
+        if (mPrefFullscreenReview &&
+                CompatHelper.getCompat().isImmersiveSystemUiVisible(this)) {
+            delayedHide(INITIAL_HIDE_DELAY);
+        }
+    }
+
+
+    protected final Handler mFullScreenHandler = new Handler() {
+        @Override
+        public void handleMessage(Message msg) {
+            if (mPrefFullscreenReview) {
+                CompatHelper.getCompat().setFullScreen(Reviewer.this);
+            }
+        }
+    };
+
+    protected void delayedHide(int delayMillis) {
+        Timber.d("Fullscreen delayed hide in %dms", delayMillis);
+        mFullScreenHandler.removeMessages(0);
+        mFullScreenHandler.sendEmptyMessageDelayed(0, delayMillis);
     }
 
 


### PR DESCRIPTION

## Purpose / Description
Fullscreen caused the answer buttons to be shown twice after #6975/#6961.
It didn't make sense in the previewer to me, so I removed it.

## Fixes
Fixes #7027

## Approach
Only show fullscreen in the reviewer

## How Has This Been Tested?

On my device - as expected

## Learning

We need to eventually perform a better split between `AbstractFlashCardViewer` and `Reviewer`

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code