### PR TITLE
NF: Remove generic time from Collection

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/ImportTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/ImportTest.java
@@ -37,7 +37,6 @@ import com.ichi2.libanki.importer.Importer;
 
 import com.ichi2.libanki.importer.NoteImporter;
 import com.ichi2.libanki.importer.TextImporter;
-import com.ichi2.libanki.utils.Time;
 import com.ichi2.utils.JSONException;
 import com.ichi2.utils.JSONObject;
 
@@ -65,7 +64,7 @@ import static org.junit.Assert.assertTrue;
 @RunWith(androidx.test.runner.AndroidJUnit4.class)
 public class ImportTest {
 
-    private Collection<Time> testCol;
+    private Collection testCol;
 
     @Rule
     public GrantPermissionRule mRuntimePermissionRule =

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
@@ -102,10 +102,10 @@ public class CollectionHelper {
      * @param context context which can be used to get the setting for the path to the Collection
      * @return instance of the Collection
      */
-    public synchronized Collection<Time> getCol(Context context) {
+    public synchronized Collection getCol(Context context) {
         return getCol(context, new SystemTime());
     }
-    public synchronized <T extends Time> Collection<T> getCol(Context context, @NonNull T time) {
+    public synchronized Collection getCol(Context context, @NonNull Time time) {
         // Open collection
         if (!colIsOpen()) {
             String path = getCollectionPath(context);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -38,7 +38,6 @@ import com.ichi2.libanki.sched.AbstractSched;
 import com.ichi2.libanki.sched.Sched;
 import com.ichi2.libanki.sched.SchedV2;
 import com.ichi2.libanki.template.Template;
-import com.ichi2.libanki.utils.SystemTime;
 import com.ichi2.libanki.utils.Time;
 import com.ichi2.upgrade.Upgrade;
 import com.ichi2.utils.DatabaseChangeDecorator;
@@ -90,7 +89,7 @@ import static com.ichi2.libanki.Collection.DismissType.REVIEW;
 @SuppressWarnings({"PMD.ExcessiveClassLength", "PMD.AvoidThrowingRawExceptionTypes","PMD.AvoidReassigningParameters",
         "PMD.NPathComplexity","PMD.MethodNamingConventions","PMD.AvoidBranchingStatementAsLastInLoop",
         "PMD.SwitchStmtsShouldHaveDefault","PMD.CollapsibleIfStatements","PMD.EmptyIfStmt","PMD.ExcessiveMethodLength"})
-public class Collection<T extends Time> {
+public class Collection {
 
     private Context mContext;
 
@@ -131,7 +130,7 @@ public class Collection<T extends Time> {
     private static final List<Integer> fSupportedSchedulerVersions = Arrays.asList(1, 2);
 
     // Not in libAnki.
-    private final T mTime;
+    private final Time mTime;
 
     // other options
     public static final String defaultConf = "{"
@@ -170,7 +169,7 @@ public class Collection<T extends Time> {
     private static final int UNDO_SIZE_MAX = 20;
 
     @VisibleForTesting
-    public Collection(Context context, DB db, String path, boolean server, boolean log, @NonNull T time) {
+    public Collection(Context context, DB db, String path, boolean server, boolean log, @NonNull Time time) {
         mContext = context;
         mDebugLog = log;
         mDb = db;
@@ -2223,7 +2222,7 @@ public class Collection<T extends Time> {
     }
 
     @NonNull
-    public T getTime() {
+    public Time getTime() {
         return mTime;
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -97,7 +97,7 @@ public class Models {
     // private static final Pattern sModelPattern = Pattern.compile("%\\(modelTags\\)s");
     // private static final Pattern sTemplPattern = Pattern.compile("%\\(cardModel\\)s");
 
-    private Collection<Time> mCol;
+    private Collection mCol;
     private boolean mChanged;
     private HashMap<Long, Model> mModels;
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Storage.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Storage.java
@@ -46,10 +46,10 @@ public class Storage {
     }
 
 
-    public static Collection<Time> Collection(Context context, String path, boolean server, boolean log) {
+    public static Collection Collection(Context context, String path, boolean server, boolean log) {
         return Collection(context, path, server, log, new SystemTime());
     }
-    public static <T extends Time> Collection<T> Collection(Context context, String path, boolean server, boolean log, @NonNull T time) {
+    public static Collection Collection(Context context, String path, boolean server, boolean log, @NonNull Time time) {
         assert path.endsWith(".anki2");
         File dbFile = new File(path);
         boolean create = !dbFile.exists();
@@ -65,7 +65,7 @@ public class Storage {
             }
             db.execute("PRAGMA temp_store = memory");
             // add db to col and do any remaining upgrades
-            Collection<T> col = new Collection(context, db, path, server, log, time);
+            Collection col = new Collection(context, db, path, server, log, time);
             if (ver < Consts.SCHEMA_VERSION) {
                 _upgrade(col, ver);
             } else if (ver > Consts.SCHEMA_VERSION) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
@@ -36,7 +36,6 @@ import com.ichi2.anki.AnkiFont;
 import com.ichi2.anki.CollectionHelper;
 import com.ichi2.anki.R;
 import com.ichi2.compat.CompatHelper;
-import com.ichi2.libanki.utils.Time;
 import com.ichi2.utils.ImportUtils;
 
 import com.ichi2.utils.JSONArray;

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.java
@@ -15,7 +15,6 @@ import com.ichi2.libanki.Consts;
 import com.ichi2.libanki.Model;
 import com.ichi2.libanki.Models;
 import com.ichi2.libanki.Note;
-import com.ichi2.libanki.utils.Time;
 import com.ichi2.testutils.MockTime;
 import com.ichi2.testutils.PreferenceUtils;
 import com.ichi2.utils.JSONArray;
@@ -186,9 +185,9 @@ public class ReviewerTest extends RobolectricTest {
     @Test
     public synchronized void testMultipleCards() throws ConfirmModSchemaException, InterruptedException {
         addNoteWithThreeCards();
-        Collection<MockTime> col = getCol();
+        Collection col = getCol();
         JSONObject nw = col.getDecks().confForDid(1).getJSONObject("new");
-        MockTime time = col.getTime();
+        MockTime time = getCollectionTime();
         nw.put("delays", new JSONArray(new int[] {1, 10, 60, 120}));
 
         waitForAsyncTasksToComplete();

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
@@ -173,11 +173,14 @@ public class RobolectricTest {
     /** A collection. Created one second ago, not near cutoff time.
     * Each time time is checked, it advance by 10 ms. Not enough to create any change visible to user, but ensure
      * we don't get two equal time.*/
-    protected Collection<MockTime> getCol() {
+    protected Collection getCol() {
         // 2020/08/07, 07:00:00. Normally not near day cutoff.
         MockTime time = new MockTime(1596783600000L, 10);
-        Collection<MockTime> col = CollectionHelper.getInstance().getCol(getTargetContext(), time);
-        return col;
+        return CollectionHelper.getInstance().getCol(getTargetContext(), time);
+    }
+
+    protected MockTime getCollectionTime() {
+        return (MockTime) getCol().getTime();
     }
 
     /** Call this method in your test if you to test behavior with a null collection */

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/AbstractSchedTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/AbstractSchedTest.java
@@ -291,8 +291,7 @@ mw.col.sched.extendLimits(1, 0)
 
 
     protected void undoAndRedo(boolean preload) {
-        Collection<MockTime> col = getCol();
-        MockTime time = col.getTime();
+        Collection col = getCol();
         DeckConfig conf = col.getDecks().confForDid(1);
         conf.getJSONObject("new").put("delays", new JSONArray(new double[] {1, 3, 5, 10}));
         col.getConf().put("collapseTime", 20 * 60);
@@ -310,7 +309,6 @@ mw.col.sched.extendLimits(1, 0)
         }
 
         sched.answerCard(card, sched.getGoodNewButton());
-        //time.addM(15);
 
         card = sched.getCard();
         assertNotNull(card);


### PR DESCRIPTION
Was unnecessary (test-only) and added a lot of compiler warnings

Untested (outside unit tests still passing)