### PR TITLE
Previewer: Enable "Edit Note"

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1142,6 +1142,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
                 Timber.i("AbstractFlashcardViewer:: Saving card...");
                 CollectionTask.launchCollectionTask(UPDATE_NOTE, mUpdateCardHandler,
                         new TaskData(sEditorCard, true));
+                onEditedNoteChanged();
             } else if (resultCode == RESULT_CANCELED && !(data!=null && data.hasExtra("reloadRequired"))) {
                 // nothing was changed by the note editor so just redraw the card
                 redrawCard();
@@ -1153,6 +1154,12 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
             clipboardSetText("");
         }
     }
+
+
+    protected void onEditedNoteChanged() {
+
+    }
+
 
     /** An action which may invalidate the current list of cards has been performed */
     protected abstract void performReload();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1133,9 +1133,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
            The card could have been rescheduled, the deck could have changed, or a change of
            note type could have lead to the card being deleted */
         if (data != null && data.hasExtra("reloadRequired")) {
-            getCol().getSched().deferReset();
-            CollectionTask.launchCollectionTask(ANSWER_CARD, mAnswerCardHandler(false),
-                    new TaskData(null, 0));
+            performReload();
         }
 
         if (requestCode == EDIT_CURRENT_CARD) {
@@ -1149,14 +1147,15 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
                 redrawCard();
             }
         } else if (requestCode == DECK_OPTIONS && resultCode == RESULT_OK) {
-            getCol().getSched().deferReset();
-            CollectionTask.launchCollectionTask(ANSWER_CARD, mAnswerCardHandler(false),
-                    new TaskData(null, 0));
+            performReload();
         }
         if (!mDisableClipboard) {
             clipboardSetText("");
         }
     }
+
+    /** An action which may invalidate the current list of cards has been performed */
+    protected abstract void performReload();
 
 
     // ----------------------------------------------------------------------------

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -166,6 +166,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
     private static final int EDIT_CARD = 0;
     private static final int ADD_NOTE = 1;
+    private static final int PREVIEW_CARDS = 2;
+
     private static final int DEFAULT_FONT_SIZE_RATIO = 100;
     // Should match order of R.array.card_browser_order_labels
     public static final int CARD_ORDER_NONE = 0;
@@ -1080,8 +1082,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
                     previewer.putExtra("index", startIndex);
                     previewer.putExtra("cardList", getAllCardIds());
                 }
-                startActivityWithoutAnimation(previewer);
-
+                startActivityForResultWithoutAnimation(previewer, PREVIEW_CARDS);
                 return true;
             }
 
@@ -1183,7 +1184,15 @@ public class CardBrowser extends NavigationDrawerActivity implements
             } else {
                 Timber.w("Note was added from browser and on return mSearchView == null");
             }
+        }
 
+        // Previewing can now perform an "edit", so it can pass on a reloadRequired
+        if (requestCode == PREVIEW_CARDS && data != null
+                && (data.getBooleanExtra("reloadRequired", false) || data.getBooleanExtra("noteChanged", false))) {
+            searchCards();
+            if (getReviewerCardId() == mCurrentCardId) {
+                mReloadRequired = true;
+            }
         }
 
         if (requestCode == EDIT_CARD &&  data != null &&

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.java
@@ -117,6 +117,13 @@ public class CardTemplatePreviewer extends AbstractFlashcardViewer {
 
 
     @Override
+    protected void performReload() {
+        // This should not happen.
+        finishWithAnimation(ActivityTransitionAnimation.RIGHT);
+    }
+
+
+    @Override
     protected void onNavigationPressed() {
         Timber.i("CardTemplatePreviewer:: Navigation button pressed");
         closeCardTemplatePreviewer();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.java
@@ -21,6 +21,7 @@ package com.ichi2.anki;
 import android.os.Bundle;
 import android.view.View;
 
+import com.ichi2.anim.ActivityTransitionAnimation;
 import com.ichi2.libanki.Collection;
 
 import timber.log.Timber;
@@ -140,6 +141,12 @@ public class Previewer extends AbstractFlashcardViewer {
     public boolean executeCommand(int which) {
         /* do nothing */
         return false;
+    }
+
+    @Override
+    protected void performReload() {
+        // This should not happen.
+        finishWithAnimation(ActivityTransitionAnimation.RIGHT);
     }
 
     private View.OnClickListener mSelectScrollHandler = new View.OnClickListener() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -651,6 +651,15 @@ public class Reviewer extends AbstractFlashcardViewer {
         return super.onKeyUp(keyCode, event);
     }
 
+
+    @Override
+    protected void performReload() {
+        getCol().getSched().deferReset();
+        CollectionTask.launchCollectionTask(ANSWER_CARD, mAnswerCardHandler(false),
+                new TaskData(null, 0));
+    }
+
+
     @Override
     protected void displayAnswerBottomBar() {
         super.displayAnswerBottomBar();

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -70,6 +70,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.regex.Pattern;
 
+import androidx.annotation.CheckResult;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
@@ -2129,6 +2130,10 @@ public class Collection<T extends Time> {
     }
 
     /** Not in libAnki */
+    @CheckResult
+    public List<Long> filterToValidCards(long[] cards) {
+        return getDb().queryLongList("select id from cards where id in " + Utils.ids2str(cards));
+    }
 
     //This duplicates _loadScheduler (but returns the value and sets the report limit).
     public AbstractSched createScheduler(int reportLimit) {

--- a/AnkiDroid/src/main/res/menu/previewer.xml
+++ b/AnkiDroid/src/main/res/menu/previewer.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+  ~
+  ~  This program is free software; you can redistribute it and/or modify it under
+  ~  the terms of the GNU General Public License as published by the Free Software
+  ~  Foundation; either version 3 of the License, or (at your option) any later
+  ~  version.
+  ~
+  ~  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+  ~  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  ~  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+  ~
+  ~  You should have received a copy of the GNU General Public License along with
+  ~  this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:ankidroid="http://schemas.android.com/apk/res-auto" >
+    <item
+        android:id="@+id/action_edit"
+        android:icon="@drawable/ic_mode_edit_white_24dp"
+        android:title="@string/cardeditor_title_edit_card"
+        ankidroid:showAsAction="ifRoom"/>
+</menu>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerCommandTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerCommandTest.java
@@ -183,6 +183,12 @@ public class AbstractFlashcardViewerCommandTest {
 
 
         @Override
+        protected void performReload() {
+            // intentionally blank
+        }
+
+
+        @Override
         public ControlBlock getControlBlocked() {
             return ControlBlock.UNBLOCKED;
         }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerKeyboardInputTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerKeyboardInputTest.java
@@ -82,6 +82,13 @@ public class AbstractFlashcardViewerKeyboardInputTest {
             return mFocusTextField;
         }
 
+
+        @Override
+        protected void performReload() {
+            // intentionally blank
+        }
+
+
         @Override
         protected void displayCardAnswer() {
             mDisplayAnswer = true;

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.java
@@ -38,6 +38,13 @@ public class AbstractFlashcardViewerTest extends RobolectricTest {
         protected void setTitle() {
         }
 
+
+        @Override
+        protected void performReload() {
+            // intentionally blank
+        }
+
+
         public String getTypedInput() {
             return super.getTypedInputText();
         }


### PR DESCRIPTION
## Purpose / Description
It's a good idea to provide "Edit Note" functionality to the preview/card browser as it's easier to determine what to edit than the Card Browser window.

## Fixes
Fixes #7026 

## Approach
* Add "edit"
* If a note has been edited:
   * Flag to the Browser that a reload is required
   * Show the new card
* If a Note Type is edited:
   * Rebuild the list of valid cards
   * Flag to the Browser that a reload is required

## How Has This Been Tested?

On my phone: deleting card types, and edits.

Note that the Card Browser is a little buggy due to #7017

## Learning

I didn't know that if one card is selected in the previewer, then the previewer selects all cards to preview: dba68944a46b5ad68a2ee46ea55adc8bf5d4c540

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code