### PR TITLE
Normalize name in deckDueList's cache

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -223,7 +223,7 @@ public class Sched extends SchedV2 {
             int nlim = _deckNewLimitSingle(deck);
             int rlim = _deckRevLimitSingle(deck);
             if (!TextUtils.isEmpty(p)) {
-                Integer[] parentLims = lims.get(p);
+                Integer[] parentLims = lims.get(Decks.normalizeName(p));
                 // 'temporary for diagnosis of bug #6383'
                 Assert.that(parentLims != null, "Deck %s is supposed to have parent %s. It has not be found.", deckName, p);
                 nlim = Math.min(nlim, parentLims[0]);
@@ -238,7 +238,7 @@ public class Sched extends SchedV2 {
             // save to list
             data.add(new DeckDueTreeNode(mCol, deck.getString("name"), deck.getLong("id"), rev, lrn, _new));
             // add deck as a parent
-            lims.put(deck.getString("name"), new Integer[]{nlim, rlim});
+            lims.put(Decks.normalizeName(deck.getString("name")), new Integer[]{nlim, rlim});
         }
         return data;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -487,7 +487,7 @@ public class SchedV2 extends AbstractSched {
             int nlim = _deckNewLimitSingle(deck);
             Integer plim = null;
             if (!TextUtils.isEmpty(p)) {
-                Integer[] parentLims = lims.get(p);
+                Integer[] parentLims = lims.get(Decks.normalizeName(p));
                 // 'temporary for diagnosis of bug #6383'
                 Assert.that(parentLims != null, "Deck %s is supposed to have parent %s. It has not be found.", deckName, p);
                 nlim = Math.min(nlim, parentLims[0]);
@@ -503,7 +503,7 @@ public class SchedV2 extends AbstractSched {
             // save to list
             data.add(new DeckDueTreeNode(mCol, deck.getString("name"), deck.getLong("id"), rev, lrn, _new));
             // add deck as a parent
-            lims.put(deck.getString("name"), new Integer[]{nlim, rlim});
+            lims.put(Decks.normalizeName(deck.getString("name")), new Integer[]{nlim, rlim});
         }
         return data;
     }


### PR DESCRIPTION
It seems to be a problem dating at least from 2.9. If there was a deck FOO with a child foo::BAR, the cache would
believe the parent is missing because it would not detect that it has cached values for "foo". 

Note that having both FOO and foo::BAR is not something that should normally occur in the first place. It is not clear
what caused it. I can imagine that it can be done by:
* creating FOO
* syncing
* renaming FOO to foo
* on another device, syncing
* creating FOO::BAR
* syncing on both device

as "foo" will be more recent than "FOO" it will be kept, without renaming its children

## Pull Request template

## Fixes
Fixes #6383 
## Approach
Using normalized name in cache ensure this problem disappear.

## How Has This Been Tested?

Opening the collection given in the bug report on this version and seeing it works


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
