### PR TITLE
cram->filtered

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
@@ -331,13 +331,13 @@ public class StudyOptionsFragment extends Fragment implements Toolbar.OnMenuItem
             case R.id.action_rebuild:
                 Timber.i("StudyOptionsFragment:: rebuild cram deck button pressed");
                 mProgressDialog = StyledProgressDialog.show(getActivity(), "",
-                        getResources().getString(R.string.rebuild_cram_deck), true);
+                        getResources().getString(R.string.rebuild_filtered_deck), true);
                 CollectionTask.launchCollectionTask(REBUILD_CRAM, getCollectionTaskListener(true));
                 return true;
             case R.id.action_empty:
                 Timber.i("StudyOptionsFragment:: empty cram deck button pressed");
                 mProgressDialog = StyledProgressDialog.show(getActivity(), "",
-                        getResources().getString(R.string.empty_cram_deck), false);
+                        getResources().getString(R.string.empty_filtered_deck), false);
                 CollectionTask.launchCollectionTask(EMPTY_CRAM, getCollectionTaskListener(true));
                 return true;
             case R.id.action_rename:
@@ -457,7 +457,7 @@ public class StudyOptionsFragment extends Fragment implements Toolbar.OnMenuItem
                     deck.remove("empty");
                 }
                     mProgressDialog = StyledProgressDialog.show(getActivity(), "",
-                            getResources().getString(R.string.rebuild_cram_deck), true);
+                            getResources().getString(R.string.rebuild_filtered_deck), true);
                     CollectionTask.launchCollectionTask(REBUILD_CRAM, getCollectionTaskListener(true));
             } else {
                 CollectionTask.waitToFinish();

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -138,11 +138,11 @@
     <string name="time_quantity_days_hours">%1$d d %2$d h</string>
     <string name="time_quantity_months">%.1f mo</string>
     <string name="time_quantity_years">%.1f yr</string><!-- or "%.1f a" -->
-    <string name="rebuild_cram_deck">Rebuilding cram deck…</string>
+    <string name="rebuild_filtered_deck">Rebuilding filtered deck…</string>
     <string name="rebuild_cram_label">Rebuild</string>
     <string name="empty_cram_label">Empty</string>
     <string name="create_subdeck">Create subdeck</string>
-    <string name="empty_cram_deck">Emptying cram deck…</string>
+    <string name="empty_filtered_deck">Emptying filtered deck…</string>
     <string name="custom_study_deck_name">Custom study session</string>
     <string name="custom_study_deck_exists">Rename the existing custom study deck first</string>
     <string name="empty_deck">This deck is empty</string>


### PR DESCRIPTION
Currently, from deck picker, you can "create filtered deck" and then "rebuilding cram deck". This is not consistent. If
I believe upstream, you can cram using filtered deck, but there is no notion of "cram deck". Or at least, there is not
such a notion anymore.

In this case, I believe changing the string name is useful, because if in foreign language cram and filtered had been
translated differently, then their translation is not what we actually want.