### PR TITLE
Switch 'Anki Card' and 'Card Browser' in System Text Context Menu

### DIFF
--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -176,6 +176,7 @@
         <activity-alias
             android:name="com.ichi2.anki.CardBrowserContextMenuAction"
             android:label="@string/card_browser_context_menu"
+            android:enabled="false"
             android:targetActivity="com.ichi2.anki.CardBrowser">
             <intent-filter>
                 <action android:name="android.intent.action.PROCESS_TEXT" />
@@ -270,7 +271,7 @@
         <activity-alias
             android:name="com.ichi2.anki.AnkiCardContextMenuAction"
             android:label="@string/context_menu_anki_card_label"
-            android:enabled="false"
+            android:enabled="true"
             android:targetActivity=".NoteEditor">
             <intent-filter>
                 <action android:name="android.intent.action.PROCESS_TEXT" />

--- a/AnkiDroid/src/main/java/com/ichi2/anki/contextmenu/AnkiCardContextMenu.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/contextmenu/AnkiCardContextMenu.java
@@ -43,7 +43,7 @@ public class AnkiCardContextMenu extends SystemContextMenu {
 
     @Override
     protected boolean getDefaultEnabledStatus() {
-        return false;
+        return true;
     }
 
     @NonNull

--- a/AnkiDroid/src/main/java/com/ichi2/anki/contextmenu/CardBrowserContextMenu.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/contextmenu/CardBrowserContextMenu.java
@@ -42,7 +42,7 @@ public class CardBrowserContextMenu extends SystemContextMenu {
 
     @Override
     protected boolean getDefaultEnabledStatus() {
-        return true;
+        return false;
     }
 
     @NonNull

--- a/AnkiDroid/src/main/res/xml/preferences_advanced.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_advanced.xml
@@ -130,11 +130,11 @@
             card_browser_enable_external_context_menu -->
             <CheckBoxPreference
                 android:id="@+id/card_browser_external_context_menu"
-                android:defaultValue="true"
+                android:defaultValue="false"
                 android:key="card_browser_enable_external_context_menu"/>
             <CheckBoxPreference
                 android:id="@+id/anki_card_external_context_menu"
-                android:defaultValue="false"
+                android:defaultValue="true"
                 android:key="anki_card_enable_external_context_menu"/>
         </PreferenceCategory>
 


### PR DESCRIPTION
I feel 'Anki Card' will get more use

----

Draft as untested and I'm not sure whether this will be accepted.

For existing users, this will enable both of the menu items if they previously viewed the settings, which may not be ideal