### PR TITLE
No counts in abstract flash card viewer

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -750,10 +750,8 @@ public class Reviewer extends AbstractFlashcardViewer {
 
     @Override
     protected SharedPreferences restorePreferences() {
-        super.restorePreferences();
+        SharedPreferences preferences = super.restorePreferences();
         this.mProcessor.setup();
-        //Is this line necessary? Can we not use the return value from the call to super?
-        SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(getBaseContext());
         mBlackWhiteboard = preferences.getBoolean("blackWhiteboard", true);
         mPrefFullscreenReview = Integer.parseInt(preferences.getString("fullscreenMode", "0")) > 0;
         mActionButtons.setup(preferences);

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.java
@@ -114,7 +114,7 @@ public class ReviewerTest extends RobolectricTest {
         addNoteUsingBasicModel("Hello", "World2");
 
         Reviewer reviewer = startReviewer();
-        JavaScriptFunction javaScriptFunction = reviewer.new JavaScriptFunction();
+        JavaScriptFunction javaScriptFunction = reviewer.javaScriptFunction();
 
 
         // The answer needs to be displayed to be able to get the time.
@@ -232,7 +232,7 @@ public class ReviewerTest extends RobolectricTest {
     private void assertCounts(Reviewer r, int newCount, int stepCount, int revCount) {
 
         List<String> countList = new ArrayList<>();
-        JavaScriptFunction jsApi = r.new JavaScriptFunction();
+        JavaScriptFunction jsApi = r.javaScriptFunction();
         countList.add(jsApi.ankiGetNewCardCount());
         countList.add(jsApi.ankiGetLrnCardCount());
         countList.add(jsApi.ankiGetRevCardCount());


### PR DESCRIPTION
## Purpose / Description

Currently, previewer does not display counts, but still compute it. The trouble is that counts takes current card into consideration, assuming it's a card sent to the reviewer, so in one of the three queue. 

This ensure that the counts (and ETA) are only computed when we actually need them. This save computation time and avoid the problem #7039.

If you accept this design, I'd also suggest to move all members related to the four buttons to Reviewer, since they are never shown in the previewer


Note that this lead to a question: what should we send to JS in the previewer. After all, there is no count, no eta, no list of new card to see... So it's not easy to know what we should send if we ask it. Currently, I return "" and 0, but this may easily be changed
## Fixes
Fixes #7039

## Approach
Ensuring that counts is not called unless we actually want its values

## How Has This Been Tested?

On my phone, using preview of suspended card and reviewing

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
