### PR TITLE
TEST: Handle corrupt deck name casing

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/testutils/AnkiAssert.java
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/AnkiAssert.java
@@ -23,8 +23,7 @@ public class AnkiAssert {
         try {
             runnable.run();
         } catch (Exception e) {
-            Timber.e(e);
-            Assert.fail();
+            throw new AssertionError("method should not throw", e);
         }
     }
 


### PR DESCRIPTION
## Purpose / Description
This corrupt data came from AnkiWeb - don't quite know how, but we can't assume that decks will be added via addDeck which validates the input. This crashed the deckPicker/syncing

Regression test for #6383 - fixed in #7033

<details><summary>Fails against 2.12.1</summary>

```
java.lang.Exception: Main looper has queued unexecuted runnables. This might be the cause of the test failure. You might need a shadowOf(getMainLooper()).idle() call.

	at org.robolectric.android.internal.AndroidTestEnvironment.checkStateAfterTestFailure(AndroidTestEnvironment.java:470)
	at org.robolectric.RobolectricTestRunner$HelperTestRunner$1.evaluate(RobolectricTestRunner.java:548)
	at org.robolectric.internal.SandboxTestRunner$2.lambda$evaluate$0(SandboxTestRunner.java:252)
	at org.robolectric.internal.bytecode.Sandbox.lambda$runOnMainThread$0(Sandbox.java:89)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.AssertionError: method should not throw
	at com.ichi2.testutils.AnkiAssert.assertDoesNotThrow(AnkiAssert.java:16)
	at com.ichi2.libanki.sched.AbstractSchedTest.deckDueTreeInconsistentDecksPasses(AbstractSchedTest.java:71)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.robolectric.RobolectricTestRunner$HelperTestRunner$1.evaluate(RobolectricTestRunner.java:546)
	... 6 more
Caused by: java.lang.NullPointerException
	at com.ichi2.libanki.sched.Sched.deckDueList(Sched.java:227)
	at com.ichi2.libanki.sched.SchedV2.deckDueList(SchedV2.java:398)
	at com.ichi2.libanki.sched.AbstractSchedTest.lambda$deckDueTreeInconsistentDecksPasses$0(AbstractSchedTest.java:71)
	at com.ichi2.testutils.AnkiAssert.assertDoesNotThrow(AnkiAssert.java:14)
	... 19 more
```
</details>

## Fixes
Fixes #7038

## Approach
Unit Test

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code