### PR TITLE
Access correct cursor window size when configuring collection chunk size

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -310,9 +310,15 @@ public class Collection {
         String db_name = ((DatabaseChangeDecorator) db).getWrapped().getClass().getName();
         if ("io.requery.android.database.sqlite.SQLiteDatabase".equals(db_name)) {
             try {
-                Field cursorWindowSize = io.requery.android.database.CursorWindow.class.getDeclaredField("sCursorWindowSize");
+                Field cursorWindowSize = io.requery.android.database.CursorWindow.class.getDeclaredField("sDefaultCursorWindowSize");
                 cursorWindowSize.setAccessible(true);
-                sCursorWindowSize = cursorWindowSize.getInt(null);
+                int possibleCursorWindowSize = cursorWindowSize.getInt(null);
+                Timber.d("Reflectively discovered database default cursor window size %d", possibleCursorWindowSize);
+                if (possibleCursorWindowSize > 0) {
+                    sCursorWindowSize = possibleCursorWindowSize;
+                } else {
+                    Timber.w("Obtained unusable cursor window size: %d. Using default %d", possibleCursorWindowSize, sCursorWindowSize);
+                }
             } catch (Exception e) {
                 Timber.w(e, "Unable to get window size from requery cursor.");
             }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

We attempt to dynamically set the database cursor window chunk size we use for large text loading from sqlite, for performance reasons, but we were accessing the wrong field when attempting to do so

## Fixes

Fixes #7031 

## Approach

I use the correct field name when reflecting, exactly as @david-allison-1 pointed out with no change really, but with actual testing to make 100% sure :-)

## How Has This Been Tested?

The emulator was able to reproduce the problem, and now reproduces correct behavior:

> 2020-09-07 11:17:13.819 5569-5569/com.ichi2.anki D/Collection: Reflectively discovered database default cursor window size 2097152


## Learning (optional, can help others)

Even the simplest things can be screwed up! Haha - seriously though, I swear I tested this and saw it work, but here we are. Even Android Studio highlighted that it was a problem. An easy fix at least.

## Checklist


- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
