### PR TITLE
NF: Split collection task

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.java
@@ -36,6 +36,7 @@ import com.ichi2.anki.CollectionHelper;
 import com.ichi2.anki.FlashCardsContract;
 import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.async.CollectionTask;
+import com.ichi2.async.TaskManager;
 import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Consts;
@@ -793,9 +794,9 @@ public class ContentProviderTest extends InstrumentedTest {
         for(int i = 0; i < 10; i++) {//minimizing fails, when sched.reset() randomly chooses between multiple cards
             col.reset();
             nextCard = sched.getCard();
-            CollectionTask.waitToFinish();
+            TaskManager.waitToFinish();
             if(nextCard != null && nextCard.note().getId() == noteID && nextCard.getOrd() == cardOrd)break;
-            CollectionTask.waitToFinish();
+            TaskManager.waitToFinish();
 
         }
         assertNotNull("Check that there actually is a next scheduled card", nextCard);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -102,6 +102,7 @@ import com.ichi2.anki.reviewer.ReviewerUi;
 import com.ichi2.anki.cardviewer.TypedAnswer;
 import com.ichi2.async.CollectionTask;
 import com.ichi2.async.TaskListener;
+import com.ichi2.async.TaskManager;
 import com.ichi2.compat.CompatHelper;
 import com.ichi2.libanki.Decks;
 import com.ichi2.libanki.sched.AbstractSched;
@@ -534,7 +535,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
                 sDisplayAnswer = false;
             }
             mCurrentCard = value.getCard();
-            CollectionTask.launchCollectionTask(PRELOAD_NEXT_CARD); // Tasks should always be launched from GUI. So in
+            TaskManager.launchCollectionTask(PRELOAD_NEXT_CARD); // Tasks should always be launched from GUI. So in
                                                                     // listener and not in background
             if (mCurrentCard == null) {
                 // If the card is null means that there are no more cards scheduled for review.
@@ -1147,7 +1148,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
             if (resultCode == RESULT_OK) {
                 // content of note was changed so update the note and current card
                 Timber.i("AbstractFlashcardViewer:: Saving card...");
-                CollectionTask.launchCollectionTask(UPDATE_NOTE, mUpdateCardHandler,
+                TaskManager.launchCollectionTask(UPDATE_NOTE, mUpdateCardHandler,
                         new TaskData(new Object[] { sEditorCard, true, canAccessScheduler() }));
                 onEditedNoteChanged();
             } else if (resultCode == RESULT_CANCELED && !(data!=null && data.hasExtra("reloadRequired"))) {
@@ -1265,7 +1266,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
 
     protected void undo() {
         if (isUndoAvailable()) {
-            CollectionTask.launchCollectionTask(UNDO, mAnswerCardHandler(false));
+            TaskManager.launchCollectionTask(UNDO, mAnswerCardHandler(false));
         }
     }
 
@@ -1416,7 +1417,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         mSoundPlayer.stopSounds();
         mCurrentEase = ease;
 
-        CollectionTask.launchCollectionTask(ANSWER_AND_GET_CARD, mAnswerCardHandler(true),
+        TaskManager.launchCollectionTask(ANSWER_AND_GET_CARD, mAnswerCardHandler(true),
                 new TaskData(mCurrentCard, mCurrentEase));
     }
 
@@ -3193,7 +3194,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
 
     protected void dismiss(Collection.DismissType type) {
         blockControls(false);
-        CollectionTask.launchCollectionTask(DISMISS, mDismissCardHandler,
+        TaskManager.launchCollectionTask(DISMISS, mDismissCardHandler,
                 new TaskData(new Object[]{mCurrentCard, type}));
     }
 
@@ -3719,7 +3720,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
 
     @VisibleForTesting
     void loadInitialCard() {
-        CollectionTask.launchCollectionTask(GET_CARD, mAnswerCardHandler(false));
+        TaskManager.launchCollectionTask(GET_CARD, mAnswerCardHandler(false));
     }
 
     public ReviewerUi.ControlBlock getControlBlocked() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -69,6 +69,7 @@ import com.ichi2.anki.receiver.SdCardReceiver;
 import com.ichi2.anki.widgets.DeckDropDownAdapter;
 import com.ichi2.async.CollectionTask;
 import com.ichi2.async.TaskListenerWithContext;
+import com.ichi2.async.TaskManager;
 import com.ichi2.compat.Compat;
 import com.ichi2.compat.CompatHelper;
 import com.ichi2.libanki.Card;
@@ -755,7 +756,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
             return;
         }
 
-        CollectionTask.launchCollectionTask(DISMISS_MULTI,
+        TaskManager.launchCollectionTask(DISMISS_MULTI,
                 markCardHandler(),
                 new TaskData(new Object[]{getSelectedCardIds(), Collection.DismissType.MARK_NOTE_MULTI}));
     }
@@ -986,8 +987,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
         }
 
         if (!mCheckedCards.isEmpty()) {
-            CollectionTask.cancelAllTasks(CHECK_CARD_SELECTION);
-            CollectionTask.launchCollectionTask(CHECK_CARD_SELECTION,
+            TaskManager.cancelAllTasks(CHECK_CARD_SELECTION);
+            TaskManager.launchCollectionTask(CHECK_CARD_SELECTION,
                     mCheckSelectedCardsHandler,
                     new TaskData(new Object[]{mCheckedCards, getCards()}));
         }
@@ -1010,7 +1011,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
 
     private void flagTask (int flag) {
-        CollectionTask.launchCollectionTask(DISMISS_MULTI,
+        TaskManager.launchCollectionTask(DISMISS_MULTI,
                                 flagCardHandler(),
                                 new TaskData(new Object[]{getSelectedCardIds(), Collection.DismissType.FLAG, flag}));
     }
@@ -1115,7 +1116,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
             return true;
         } else if (itemId == R.id.action_suspend_card) {
-            CollectionTask.launchCollectionTask(DISMISS_MULTI,
+            TaskManager.launchCollectionTask(DISMISS_MULTI,
                     suspendCardHandler(),
                     new TaskData(new Object[] {getSelectedCardIds(), Collection.DismissType.SUSPEND_CARD_MULTI}));
 
@@ -1190,7 +1191,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
         if (!mInMultiSelectMode) {
             return;
         }
-        CollectionTask.launchCollectionTask(DISMISS_MULTI,
+        TaskManager.launchCollectionTask(DISMISS_MULTI,
                 mDeleteNoteHandler,
                 new TaskData(new Object[] {getSelectedCardIds(), Collection.DismissType.DELETE_NOTE_MULTI}));
 
@@ -1203,7 +1204,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
     @VisibleForTesting
     void onUndo() {
         if (getCol().undoAvailable()) {
-            CollectionTask.launchCollectionTask(UNDO, mUndoHandler);
+            TaskManager.launchCollectionTask(UNDO, mUndoHandler);
         }
     }
 
@@ -1225,14 +1226,14 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
     @VisibleForTesting
     void resetProgressNoConfirm(List<Long> cardIds) {
-        CollectionTask.launchCollectionTask(DISMISS_MULTI, resetProgressCardHandler(),
+        TaskManager.launchCollectionTask(DISMISS_MULTI, resetProgressCardHandler(),
                 new TaskData(new Object[] {cardIds, Collection.DismissType.RESET_CARDS}));
     }
 
 
     @VisibleForTesting
     void repositionCardsNoValidation(List<Long> cardIds, Integer position) {
-        CollectionTask.launchCollectionTask(DISMISS_MULTI, repositionCardHandler(),
+        TaskManager.launchCollectionTask(DISMISS_MULTI, repositionCardHandler(),
                 new TaskData(new Object[] {cardIds, Collection.DismissType.REPOSITION_CARDS, position}));
     }
 
@@ -1289,7 +1290,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
     @VisibleForTesting
     void rescheduleWithoutValidation(List<Long> selectedCardIds, Integer newDays) {
-        CollectionTask.launchCollectionTask(DISMISS_MULTI,
+        TaskManager.launchCollectionTask(DISMISS_MULTI,
             rescheduleCardHandler(),
             new TaskData(new Object[]{selectedCardIds, Collection.DismissType.RESCHEDULE_CARDS, newDays}));
     }
@@ -1348,7 +1349,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
         if (requestCode == EDIT_CARD && resultCode != RESULT_CANCELED) {
             Timber.i("CardBrowser:: CardBrowser: Saving card...");
-            CollectionTask.launchCollectionTask(UPDATE_NOTE, updateCardHandler(),
+            TaskManager.launchCollectionTask(UPDATE_NOTE, updateCardHandler(),
                     new TaskData(new Object[] { sCardBrowserCard, false, false }));
         } else if (requestCode == ADD_NOTE && resultCode == RESULT_OK) {
             if (mSearchView != null) {
@@ -1388,7 +1389,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
     @Override
     public void onTrimMemory(int pressureLevel) {
         super.onTrimMemory(pressureLevel);
-        CollectionTask.cancelCurrentlyExecutingTask();
+        TaskManager.cancelCurrentlyExecutingTask();
     }
 
     private long getReviewerCardId() {
@@ -1464,9 +1465,9 @@ public class CardBrowser extends NavigationDrawerActivity implements
     }
 
     private void invalidate() {
-        CollectionTask.cancelAllTasks(SEARCH_CARDS);
-        CollectionTask.cancelAllTasks(RENDER_BROWSER_QA);
-        CollectionTask.cancelAllTasks(CHECK_CARD_SELECTION);
+        TaskManager.cancelAllTasks(SEARCH_CARDS);
+        TaskManager.cancelAllTasks(RENDER_BROWSER_QA);
+        TaskManager.cancelAllTasks(CHECK_CARD_SELECTION);
         mCards.clear();
         mCheckedCards.clear();
     }
@@ -1501,7 +1502,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
             int numCardsToRender = (int) Math.ceil(mCardsListView.getHeight()/
                     TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 20, getResources().getDisplayMetrics())) + 5;
             // Perform database query to get all card ids
-            CollectionTask.launchCollectionTask(SEARCH_CARDS,
+            TaskManager.launchCollectionTask(SEARCH_CARDS,
                                                 mSearchCardsHandler,
                                                 new TaskData(new Object[] {
                                                         searchText,
@@ -1725,7 +1726,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
             }
             // snackbar to offer undo
             String deckName = browser.getCol().getDecks().name(browser.mNewDid);
-            browser.mUndoSnackbar = UIUtils.showSnackbar(browser, String.format(browser.getString(R.string.changed_deck_message), deckName), SNACKBAR_DURATION, R.string.undo, v -> CollectionTask.launchCollectionTask(UNDO, browser.mUndoHandler), browser.mCardsListView, null);
+            browser.mUndoSnackbar = UIUtils.showSnackbar(browser, String.format(browser.getString(R.string.changed_deck_message), deckName), SNACKBAR_DURATION, R.string.undo, v -> TaskManager.launchCollectionTask(UNDO, browser.mUndoHandler), browser.mCardsListView, null);
         }
     }
 
@@ -1881,7 +1882,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
             browser.invalidateOptionsMenu();    // maybe the availability of undo changed
             // snackbar to offer undo
             String deletedMessage = browser.getResources().getQuantityString(R.plurals.card_browser_cards_deleted, mCardsDeleted, mCardsDeleted);
-            browser.mUndoSnackbar = UIUtils.showSnackbar(browser, deletedMessage, SNACKBAR_DURATION, R.string.undo, v -> CollectionTask.launchCollectionTask(UNDO, browser.mUndoHandler), browser.mCardsListView, null);
+            browser.mUndoSnackbar = UIUtils.showSnackbar(browser, deletedMessage, SNACKBAR_DURATION, R.string.undo, v -> TaskManager.launchCollectionTask(UNDO, browser.mUndoHandler), browser.mCardsListView, null);
             browser.searchCards();
         }
     }
@@ -2188,8 +2189,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
                     long currentTime = SystemClock.elapsedRealtime ();
                     if ((currentTime - mLastRenderStart > 300 || lastVisibleItem >= totalItemCount)) {
                         mLastRenderStart = currentTime;
-                        CollectionTask.cancelAllTasks(RENDER_BROWSER_QA);
-                        CollectionTask.launchCollectionTask(RENDER_BROWSER_QA, mRenderQAHandler,
+                        TaskManager.cancelAllTasks(RENDER_BROWSER_QA);
+                        TaskManager.launchCollectionTask(RENDER_BROWSER_QA, mRenderQAHandler,
                                 renderBrowserQAParams(firstVisibleItem, visibleItemCount, cards));
                     }
                 }
@@ -2206,7 +2207,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
             if (scrollState == SCROLL_STATE_IDLE) {
                 int startIdx = listView.getFirstVisiblePosition();
                 int numVisible = listView.getLastVisiblePosition() - startIdx;
-                CollectionTask.launchCollectionTask(RENDER_BROWSER_QA, mRenderQAHandler,
+                TaskManager.launchCollectionTask(RENDER_BROWSER_QA, mRenderQAHandler,
                         renderBrowserQAParams(startIdx - 5, 2 * numVisible + 5, getCards()));
             }
         }
@@ -2793,7 +2794,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     void rerenderAllCards() {
-        CollectionTask.launchCollectionTask(RENDER_BROWSER_QA, mRenderQAHandler,
+        TaskManager.launchCollectionTask(RENDER_BROWSER_QA, mRenderQAHandler,
                 renderBrowserQAParams(0, mCards.size()-1, getCards()));
     }
 
@@ -2851,7 +2852,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
     @VisibleForTesting(otherwise = VisibleForTesting.NONE) //should only be called from changeDeck()
     void executeChangeCollectionTask(List<Long> ids, long newDid) {
         mNewDid = newDid; //line required for unit tests, not necessary, but a noop in regular call.
-        CollectionTask.launchCollectionTask(DISMISS_MULTI, new ChangeDeckHandler(this),
+        TaskManager.launchCollectionTask(DISMISS_MULTI, new ChangeDeckHandler(this),
                 new TaskData(new Object[]{ids, Collection.DismissType.CHANGE_DECK_MULTI, newDid}));
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
@@ -41,6 +41,7 @@ import com.ichi2.anki.receiver.SdCardReceiver;
 import com.ichi2.anki.services.ReminderService;
 import com.ichi2.async.CollectionTask;
 import com.ichi2.async.TaskListenerWithContext;
+import com.ichi2.async.TaskManager;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Consts;
 import com.ichi2.libanki.DeckConfig;
@@ -214,7 +215,7 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
                                 int oldValue = mOptions.getJSONObject("new").getInt("order");
                                 if (oldValue != newValue) {
                                     mOptions.getJSONObject("new").put("order", newValue);
-                                    CollectionTask.launchCollectionTask(REORDER, confChangeHandler(),
+                                    TaskManager.launchCollectionTask(REORDER, confChangeHandler(),
                                             new TaskData(new Object[] {mOptions}));
                                 }
                                 mOptions.getJSONObject("new").put("order", Integer.parseInt((String) value));
@@ -307,7 +308,7 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
                             case "deckConf": {
                                 long newConfId = Long.parseLong((String) value);
                                 mOptions = mCol.getDecks().getConf(newConfId);
-                                CollectionTask.launchCollectionTask(CONF_CHANGE, confChangeHandler(),
+                                TaskManager.launchCollectionTask(CONF_CHANGE, confChangeHandler(),
                                         new TaskData(new Object[] {mDeck, mOptions}));
                                 break;
                             }
@@ -320,7 +321,7 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
                             }
                             case "confReset":
                                 if ((Boolean) value) {
-                                    CollectionTask.launchCollectionTask(CONF_RESET, confChangeHandler(),
+                                    TaskManager.launchCollectionTask(CONF_RESET, confChangeHandler(),
                                             new TaskData(new Object[] {mOptions}));
                                 }
                                 break;
@@ -366,7 +367,7 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
                                 break;
                             case "confSetSubdecks":
                                 if ((Boolean) value) {
-                                    CollectionTask.launchCollectionTask(CONF_SET_SUBDECKS, confChangeHandler(),
+                                    TaskManager.launchCollectionTask(CONF_SET_SUBDECKS, confChangeHandler(),
                                             new TaskData(new Object[] {mDeck, mOptions}));
                                 }
                                 break;
@@ -538,7 +539,7 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
                 // Remove options group, asking user to confirm full sync if necessary
                 mCol.getDecks().remConf(mOptions.getLong("id"));
                 // Run the CPU intensive re-sort operation in a background thread
-                CollectionTask.launchCollectionTask(CONF_REMOVE, confChangeHandler(),
+                TaskManager.launchCollectionTask(CONF_REMOVE, confChangeHandler(),
                                         new TaskData(new Object[] { mOptions }));
                 mDeck.put("conf", 1);
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -115,6 +115,7 @@ import com.ichi2.async.Connection.Payload;
 import com.ichi2.async.CollectionTask;
 import com.ichi2.async.TaskListener;
 import com.ichi2.async.TaskListenerWithContext;
+import com.ichi2.async.TaskManager;
 import com.ichi2.compat.CompatHelper;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Decks;
@@ -983,7 +984,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
         }
         /* Complete task and enqueue fetching nonessential data for
           startup. */
-        CollectionTask.launchCollectionTask(LOAD_COLLECTION_COMPLETE);
+        TaskManager.launchCollectionTask(LOAD_COLLECTION_COMPLETE);
         // Update sync status (if we've come back from a screen)
         supportInvalidateOptionsMenu();
     }
@@ -1009,7 +1010,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
         Timber.d("onPause()");
         mActivityPaused = true;
         // The deck count will be computed on resume. No need to compute it now
-        CollectionTask.cancelAllTasks(LOAD_DECK_COUNTS);
+        TaskManager.cancelAllTasks(LOAD_DECK_COUNTS);
         super.onPause();
     }
 
@@ -1421,7 +1422,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
         String undoReviewString = getResources().getString(R.string.undo_action_review);
         final boolean isReview = undoReviewString.equals(getCol().undoName(getResources()));
         TaskListener listener = undoTaskListener(isReview);
-        CollectionTask.launchCollectionTask(UNDO, listener);
+        TaskManager.launchCollectionTask(UNDO, listener);
     }
 
 
@@ -1570,7 +1571,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
     public void repairCollection() {
         Timber.i("Repairing the Collection");
         TaskListener listener= repairCollectionTask();
-        CollectionTask.launchCollectionTask(REPAIR_COLLECTION, listener);
+        TaskManager.launchCollectionTask(REPAIR_COLLECTION, listener);
     }
 
 
@@ -1596,7 +1597,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
     private void performIntegrityCheck() {
         Timber.i("performIntegrityCheck()");
-        CollectionTask.launchCollectionTask(CHECK_DATABASE, new CheckDatabaseListener());
+        TaskManager.launchCollectionTask(CHECK_DATABASE, new CheckDatabaseListener());
     }
 
 
@@ -1632,7 +1633,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
     @Override
     public void mediaCheck() {
         TaskListener listener = mediaCheckListener();
-        CollectionTask.launchCollectionTask(CHECK_MEDIA, listener);
+        TaskManager.launchCollectionTask(CHECK_MEDIA, listener);
     }
 
     private MediaDeleteListener mediaDeleteListener() {
@@ -1662,7 +1663,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
     @Override
     public void deleteUnused(List<String> unused) {
         TaskListener listener = mediaDeleteListener();
-        CollectionTask.launchCollectionTask(DELETE_MEDIA, listener, new TaskData(new Object[] {unused}));
+        TaskManager.launchCollectionTask(DELETE_MEDIA, listener, new TaskData(new Object[] {unused}));
     }
 
 
@@ -2100,7 +2101,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
     @Override
     public void importAdd(String importPath) {
         Timber.d("importAdd() for file %s", importPath);
-        CollectionTask.launchCollectionTask(IMPORT, mImportAddListener,
+        TaskManager.launchCollectionTask(IMPORT, mImportAddListener,
                 new TaskData(importPath));
     }
 
@@ -2108,7 +2109,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
     // Callback to import a file -- replacing the existing collection
     @Override
     public void importReplace(String importPath) {
-        CollectionTask.launchCollectionTask(IMPORT_REPLACE, importReplaceListener(), new TaskData(importPath));
+        TaskManager.launchCollectionTask(IMPORT_REPLACE, importReplaceListener(), new TaskData(importPath));
     }
 
 
@@ -2140,7 +2141,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
         inputArgs[2] = did;
         inputArgs[3] = includeSched;
         inputArgs[4] = includeMedia;
-        CollectionTask.launchCollectionTask(EXPORT_APKG, exportListener(), new TaskData(inputArgs));
+        TaskManager.launchCollectionTask(EXPORT_APKG, exportListener(), new TaskData(inputArgs));
     }
 
 
@@ -2436,7 +2437,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
     private void updateDeckList(boolean quick) {
         TaskListener listener = updateDeckListListener();
         CollectionTask.TASK_TYPE taskType = quick ? LOAD_DECK_QUICK : LOAD_DECK_COUNTS;
-        CollectionTask.launchCollectionTask(taskType, listener);
+        TaskManager.launchCollectionTask(taskType, listener);
     }
 
     public void __renderPage() {
@@ -2710,7 +2711,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
     }
     public void deleteDeck(final long did) {
         TaskListener listener = deleteDeckListener(did);
-        CollectionTask.launchCollectionTask(DELETE_DECK, listener, new TaskData(did));
+        TaskManager.launchCollectionTask(DELETE_DECK, listener, new TaskData(did));
     }
     private DeleteDeckListener deleteDeckListener(long did) {
         return new DeleteDeckListener(did, this);
@@ -2788,12 +2789,12 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
     public void rebuildFiltered() {
         getCol().getDecks().select(mContextMenuDid);
-        CollectionTask.launchCollectionTask(REBUILD_CRAM, simpleProgressListener());
+        TaskManager.launchCollectionTask(REBUILD_CRAM, simpleProgressListener());
     }
 
     public void emptyFiltered() {
         getCol().getDecks().select(mContextMenuDid);
-        CollectionTask.launchCollectionTask(EMPTY_CRAM, simpleProgressListener());
+        TaskManager.launchCollectionTask(EMPTY_CRAM, simpleProgressListener());
     }
 
     @Override
@@ -2832,7 +2833,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
     }
 
     public void handleEmptyCards() {
-        mEmptyCardTask = CollectionTask.launchCollectionTask(FIND_EMPTY_CARDS, handlerEmptyCardListener());
+        mEmptyCardTask = TaskManager.launchCollectionTask(FIND_EMPTY_CARDS, handlerEmptyCardListener());
     }
     private HandleEmptyCardListener handlerEmptyCardListener() {
         return new HandleEmptyCardListener(this);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.java
@@ -42,6 +42,7 @@ import com.ichi2.anki.dialogs.ModelBrowserContextMenu;
 import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.async.CollectionTask;
 import com.ichi2.async.TaskListenerWithContext;
+import com.ichi2.async.TaskManager;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Model;
 import com.ichi2.libanki.StdModels;
@@ -229,7 +230,7 @@ public class ModelBrowser extends AnkiActivity {
 
     @Override
     public void onDestroy() {
-        CollectionTask.cancelAllTasks(COUNT_MODELS);
+        TaskManager.cancelAllTasks(COUNT_MODELS);
         super.onDestroy();
     }
 
@@ -241,7 +242,7 @@ public class ModelBrowser extends AnkiActivity {
     public void onCollectionLoaded(Collection col) {
         super.onCollectionLoaded(col);
         this.col = col;
-        CollectionTask.launchCollectionTask(COUNT_MODELS, loadingModelsHandler());
+        TaskManager.launchCollectionTask(COUNT_MODELS, loadingModelsHandler());
     }
 
 
@@ -504,14 +505,14 @@ public class ModelBrowser extends AnkiActivity {
      * Reloads everything
      */
     private void fullRefresh() {
-        CollectionTask.launchCollectionTask(COUNT_MODELS, loadingModelsHandler());
+        TaskManager.launchCollectionTask(COUNT_MODELS, loadingModelsHandler());
     }
 
     /*
      * Deletes the currently selected model
      */
     private void deleteModel() {
-        CollectionTask.launchCollectionTask(DELETE_MODEL, deleteModelHandler(),
+        TaskManager.launchCollectionTask(DELETE_MODEL, deleteModelHandler(),
                 new TaskData(mCurrentID));
         mModels.remove(mModelListPosition);
         mModelIds.remove(mModelListPosition);
@@ -613,7 +614,7 @@ public class ModelBrowser extends AnkiActivity {
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
         if (requestCode == REQUEST_TEMPLATE_EDIT) {
-            CollectionTask.launchCollectionTask(COUNT_MODELS, loadingModelsHandler());
+            TaskManager.launchCollectionTask(COUNT_MODELS, loadingModelsHandler());
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.java
@@ -33,6 +33,7 @@ import com.ichi2.anki.dialogs.ModelEditorContextMenu;
 import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.async.CollectionTask;
 import com.ichi2.async.TaskListenerWithContext;
+import com.ichi2.async.TaskManager;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Model;
 import com.ichi2.themes.StyledProgressDialog;
@@ -192,7 +193,7 @@ public class ModelFieldEditor extends AnkiActivity implements LocaleSelectionDia
                         changeHandler listener = changeFieldHandler();
                         try {
                             mCol.modSchema();
-                            CollectionTask.launchCollectionTask(ADD_FIELD, listener,
+                            TaskManager.launchCollectionTask(ADD_FIELD, listener,
                                     new TaskData(new Object[]{mMod, fieldName}));
                         } catch (ConfirmModSchemaException e) {
 
@@ -203,7 +204,7 @@ public class ModelFieldEditor extends AnkiActivity implements LocaleSelectionDia
                                 mCol.modSchemaNoCheck();
                                 String fieldName1 = mFieldNameInput.getText().toString()
                                         .replaceAll("[\\n\\r]", "");
-                                CollectionTask.launchCollectionTask(ADD_FIELD, listener,
+                                TaskManager.launchCollectionTask(ADD_FIELD, listener,
                                         new TaskData(new Object[]{mMod, fieldName1}));
                                 dismissContextMenu();
                             };
@@ -253,7 +254,7 @@ public class ModelFieldEditor extends AnkiActivity implements LocaleSelectionDia
     }
 
     private void deleteField() {
-        CollectionTask.launchCollectionTask(DELETE_FIELD, changeFieldHandler(),
+        TaskManager.launchCollectionTask(DELETE_FIELD, changeFieldHandler(),
                                 new TaskData(new Object[]{mMod, mNoteFields.getJSONObject(mCurrentPos)}));
     }
 
@@ -337,7 +338,7 @@ public class ModelFieldEditor extends AnkiActivity implements LocaleSelectionDia
                             // Input is valid, now attempt to modify
                             try {
                                 mCol.modSchema();
-                                CollectionTask.launchCollectionTask(REPOSITION_FIELD, listener,
+                                TaskManager.launchCollectionTask(REPOSITION_FIELD, listener,
                                         new TaskData(new Object[]{mMod,
                                                 mNoteFields.getJSONObject(mCurrentPos), pos - 1}));
                             } catch (ConfirmModSchemaException e) {
@@ -350,7 +351,7 @@ public class ModelFieldEditor extends AnkiActivity implements LocaleSelectionDia
                                         mCol.modSchemaNoCheck();
                                         String newPosition1 = mFieldNameInput.getText().toString();
                                         int pos1 = Integer.parseInt(newPosition1);
-                                        CollectionTask.launchCollectionTask(REPOSITION_FIELD,
+                                        TaskManager.launchCollectionTask(REPOSITION_FIELD,
                                                 listener, new TaskData(new Object[]{mMod,
                                                         mNoteFields.getJSONObject(mCurrentPos), pos1 - 1}));
                                         dismissContextMenu();
@@ -413,7 +414,7 @@ public class ModelFieldEditor extends AnkiActivity implements LocaleSelectionDia
         changeHandler listener = changeFieldHandler();
         try {
             mCol.modSchema();
-            CollectionTask.launchCollectionTask(CHANGE_SORT_FIELD, listener,
+            TaskManager.launchCollectionTask(CHANGE_SORT_FIELD, listener,
                     new TaskData(new Object[]{mMod, mCurrentPos}));
         } catch (ConfirmModSchemaException e) {
             // Handler mMod schema confirmation
@@ -421,7 +422,7 @@ public class ModelFieldEditor extends AnkiActivity implements LocaleSelectionDia
             c.setArgs(getResources().getString(R.string.full_sync_confirmation));
             Runnable confirm = () -> {
                 mCol.modSchemaNoCheck();
-                CollectionTask.launchCollectionTask(CHANGE_SORT_FIELD, listener,
+                TaskManager.launchCollectionTask(CHANGE_SORT_FIELD, listener,
                         new TaskData(new Object[]{mMod, mCurrentPos}));
                 dismissContextMenu();
             };

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -87,6 +87,7 @@ import com.ichi2.anki.receiver.SdCardReceiver;
 import com.ichi2.anki.servicelayer.NoteService;
 import com.ichi2.async.CollectionTask;
 import com.ichi2.async.TaskListenerWithContext;
+import com.ichi2.async.TaskManager;
 import com.ichi2.compat.CompatHelper;
 import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
@@ -944,7 +945,7 @@ public class NoteEditor extends AnkiActivity {
             getCol().getModels().current().put("tags", tags);
             getCol().getModels().setChanged();
             mReloadRequired = true;
-            CollectionTask.launchCollectionTask(ADD_NOTE, saveNoteHandler(), new TaskData(mEditorNote));
+            TaskManager.launchCollectionTask(ADD_NOTE, saveNoteHandler(), new TaskData(mEditorNote));
         } else {
             // Check whether note type has been changed
             final Model newModel = getCurrentlySelectedModel();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -69,6 +69,7 @@ import com.ichi2.anki.workarounds.FirefoxSnackbarWorkaround;
 import com.ichi2.async.CollectionTask;
 import com.ichi2.anki.reviewer.ActionButtons;
 import com.ichi2.async.TaskListener;
+import com.ichi2.async.TaskManager;
 import com.ichi2.compat.CompatHelper;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Collection.DismissType;
@@ -287,7 +288,7 @@ public class Reviewer extends AbstractFlashcardViewer {
 
         col.getSched().deferReset();     // Reset schedule in case card was previously loaded
         getCol().startTimebox();
-        CollectionTask.launchCollectionTask(GET_CARD, mAnswerCardHandler(false));
+        TaskManager.launchCollectionTask(GET_CARD, mAnswerCardHandler(false));
 
         disableDrawerSwipeOnConflicts();
         // Add a weak reference to current activity so that scheduler can talk to to Activity
@@ -514,7 +515,7 @@ public class Reviewer extends AbstractFlashcardViewer {
 
     private void showRescheduleCardDialog() {
         Consumer<Integer> runnable = days ->
-            CollectionTask.launchCollectionTask(DISMISS_MULTI, mRescheduleCardHandler,
+                TaskManager.launchCollectionTask(DISMISS_MULTI, mRescheduleCardHandler,
                     new TaskData(new Object[]{Collections.singleton(mCurrentCard.getId()),
                     Collection.DismissType.RESCHEDULE_CARDS, days})
             );
@@ -534,7 +535,7 @@ public class Reviewer extends AbstractFlashcardViewer {
         dialog.setArgs(title, message);
         Runnable confirm = () -> {
             Timber.i("NoteEditor:: ResetProgress button pressed");
-            CollectionTask.launchCollectionTask(DISMISS_MULTI, mResetProgressCardHandler,
+            TaskManager.launchCollectionTask(DISMISS_MULTI, mResetProgressCardHandler,
                     new TaskData(new Object[]{Collections.singleton(mCurrentCard.getId()), Collection.DismissType.RESET_CARDS}));
         };
         dialog.setConfirm(confirm);
@@ -808,7 +809,7 @@ public class Reviewer extends AbstractFlashcardViewer {
     @Override
     protected void performReload() {
         getCol().getSched().deferReset();
-        CollectionTask.launchCollectionTask(GET_CARD, mAnswerCardHandler(false));
+        TaskManager.launchCollectionTask(GET_CARD, mAnswerCardHandler(false));
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
@@ -41,6 +41,7 @@ import com.ichi2.anim.ActivityTransitionAnimation;
 import com.ichi2.anki.dialogs.CustomStudyDialog;
 import com.ichi2.async.CollectionTask;
 import com.ichi2.async.TaskListener;
+import com.ichi2.async.TaskManager;
 import com.ichi2.compat.CompatHelper;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Consts;
@@ -312,7 +313,7 @@ public class StudyOptionsFragment extends Fragment implements Toolbar.OnMenuItem
         int itemId = item.getItemId();
         if (itemId == R.id.action_undo) {
             Timber.i("StudyOptionsFragment:: Undo button pressed");
-            CollectionTask.launchCollectionTask(UNDO, undoListener);
+            TaskManager.launchCollectionTask(UNDO, undoListener);
             return true;
         } else if (itemId == R.id.action_deck_or_study_options) {
             Timber.i("StudyOptionsFragment:: Deck or study options button pressed");
@@ -338,13 +339,13 @@ public class StudyOptionsFragment extends Fragment implements Toolbar.OnMenuItem
             Timber.i("StudyOptionsFragment:: rebuild cram deck button pressed");
             mProgressDialog = StyledProgressDialog.show(getActivity(), "",
                     getResources().getString(R.string.rebuild_filtered_deck), true);
-            CollectionTask.launchCollectionTask(REBUILD_CRAM, getCollectionTaskListener(true));
+            TaskManager.launchCollectionTask(REBUILD_CRAM, getCollectionTaskListener(true));
             return true;
         } else if (itemId == R.id.action_empty) {
             Timber.i("StudyOptionsFragment:: empty cram deck button pressed");
             mProgressDialog = StyledProgressDialog.show(getActivity(), "",
                     getResources().getString(R.string.empty_filtered_deck), false);
-            CollectionTask.launchCollectionTask(EMPTY_CRAM, getCollectionTaskListener(true));
+            TaskManager.launchCollectionTask(EMPTY_CRAM, getCollectionTaskListener(true));
             return true;
         } else if (itemId == R.id.action_rename) {
             ((DeckPicker) getActivity()).renameDeckDialog(getCol().getDecks().selected());
@@ -460,9 +461,9 @@ public class StudyOptionsFragment extends Fragment implements Toolbar.OnMenuItem
                 }
                     mProgressDialog = StyledProgressDialog.show(getActivity(), "",
                             getResources().getString(R.string.rebuild_filtered_deck), true);
-                    CollectionTask.launchCollectionTask(REBUILD_CRAM, getCollectionTaskListener(true));
+                    TaskManager.launchCollectionTask(REBUILD_CRAM, getCollectionTaskListener(true));
             } else {
-                CollectionTask.waitToFinish();
+                TaskManager.waitToFinish();
                 refreshInterface(true);
             }
         } else if (requestCode == AnkiActivity.REQUEST_REVIEW) {
@@ -515,9 +516,9 @@ public class StudyOptionsFragment extends Fragment implements Toolbar.OnMenuItem
      */
     protected void refreshInterface(boolean resetSched, boolean resetDecklist) {
         Timber.d("Refreshing StudyOptionsFragment");
-        CollectionTask.cancelAllTasks(UPDATE_VALUES_FROM_DECK);
+        TaskManager.cancelAllTasks(UPDATE_VALUES_FROM_DECK);
         // Load the deck counts for the deck from Collection asynchronously
-        CollectionTask.launchCollectionTask(UPDATE_VALUES_FROM_DECK, getCollectionTaskListener(resetDecklist),
+        TaskManager.launchCollectionTask(UPDATE_VALUES_FROM_DECK, getCollectionTaskListener(resetDecklist),
                 new TaskData(new Object[]{resetSched}));
     }
 
@@ -714,7 +715,7 @@ public class StudyOptionsFragment extends Fragment implements Toolbar.OnMenuItem
         if (!mToReviewer) {
             // In the reviewer, we need the count. So don't cancel it. Otherwise, (e.g. go to browser, selecting another
             // deck) cancel counts.
-            CollectionTask.cancelAllTasks(UPDATE_VALUES_FROM_DECK);
+            TaskManager.cancelAllTasks(UPDATE_VALUES_FROM_DECK);
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/TemporaryModel.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/TemporaryModel.java
@@ -33,6 +33,7 @@ import timber.log.Timber;
 
 import com.ichi2.async.CollectionTask;
 import com.ichi2.async.TaskListener;
+import com.ichi2.async.TaskManager;
 import com.ichi2.compat.CompatHelper;
 import com.ichi2.libanki.Model;
 import com.ichi2.utils.JSONObject;
@@ -151,7 +152,7 @@ public class TemporaryModel {
         dumpChanges();
         TemporaryModel.clearTempModelFiles();
         TaskData args = new TaskData(new Object[] {mEditedModel, getAdjustedTemplateChanges()});
-        CollectionTask.launchCollectionTask(SAVE_MODEL, listener, args);
+        TaskManager.launchCollectionTask(SAVE_MODEL, listener, args);
 
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/UIUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/UIUtils.java
@@ -20,6 +20,7 @@ import timber.log.Timber;
 import static com.ichi2.async.CollectionTask.TASK_TYPE.*;
 import com.ichi2.async.TaskData;
 import com.ichi2.async.TaskListener;
+import com.ichi2.async.TaskManager;
 import com.ichi2.libanki.utils.Time;
 
 public class UIUtils {
@@ -145,7 +146,7 @@ public class UIUtils {
                     Timber.d("saveCollectionInBackground: finished");
                 }
             };
-            CollectionTask.launchCollectionTask(SAVE_COLLECTION, listener, new TaskData(syncIgnoresDatabaseModification));
+            TaskManager.launchCollectionTask(SAVE_COLLECTION, listener, new TaskData(syncIgnoresDatabaseModification));
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
@@ -46,6 +46,7 @@ import com.ichi2.anki.analytics.AnalyticsDialogFragment;
 import com.ichi2.async.CollectionTask;
 import com.ichi2.async.TaskListener;
 import com.ichi2.async.TaskListenerWithContext;
+import com.ichi2.async.TaskManager;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Consts;
 
@@ -475,7 +476,7 @@ public class CustomStudyDialog extends AnalyticsDialogFragment {
         // Rebuild the filtered deck
         Timber.i("Rebuilding Custom Study Deck");
         TaskListener listener = createCustomStudySessionListener();
-        CollectionTask.launchCollectionTask(REBUILD_CRAM, listener);
+        TaskManager.launchCollectionTask(REBUILD_CRAM, listener);
 
         // Hide the dialogs
         activity.dismissAllDialogFragments();

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -1207,7 +1207,7 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
             return new TaskData(false);
         }
 
-        Collection.CheckDatabaseResult result = col.fixIntegrity(new TaskManager.ProgressCallback(this, AnkiDroidApp.getAppResources()));
+        Collection.CheckDatabaseResult result = col.fixIntegrity(TaskManager.progressCallback(this, AnkiDroidApp.getAppResources()));
         if (result.getFailed()) {
             //we can fail due to a locked database, which requires knowledge of the failure.
             return new TaskData(false, new Object[] { result });
@@ -1289,7 +1289,7 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
         Collection col = getCol();
         String path = param.getString();
         AnkiPackageImporter imp = new AnkiPackageImporter(col, path);
-        imp.setProgressCallback(new TaskManager.ProgressCallback(this, res));
+        imp.setProgressCallback(TaskManager.progressCallback(this, res));
         try {
             imp.run();
         } catch (ImportExportException e) {

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -67,14 +67,13 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
+
 import org.apache.commons.compress.archivers.zip.ZipFile;
 
 import androidx.annotation.NonNull;
@@ -82,6 +81,7 @@ import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import timber.log.Timber;
 
+import static com.ichi2.async.TaskManager.setLatestInstance;
 import static com.ichi2.libanki.Collection.DismissType.BURY_CARD;
 import static com.ichi2.libanki.Collection.DismissType.BURY_NOTE;
 import static com.ichi2.libanki.Collection.DismissType.SUSPEND_NOTE;
@@ -139,112 +139,6 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
      * A reference to the application context to use to fetch the current Collection object.
      */
     private Context mContext;
-    /**
-     * Tasks which are running or waiting to run.
-     * */
-    private static final List<CollectionTask> sTasks = Collections.synchronizedList(new LinkedList<>());
-
-
-    /**
-     * The most recently started {@link CollectionTask} instance.
-     */
-    private static CollectionTask sLatestInstance;
-
-
-    /**
-     * Starts a new {@link CollectionTask}, with no listener
-     * <p>
-     * Tasks will be executed serially, in the order in which they are started.
-     * <p>
-     * This method must be called on the main thread.
-     *
-     * @param type of the task to start
-     * @return the newly created task
-     */
-    public static CollectionTask launchCollectionTask(TASK_TYPE type) {
-        return launchCollectionTask(type, null, null);
-    }
-
-    /**
-     * Starts a new {@link CollectionTask}, with no listener
-     * <p>
-     * Tasks will be executed serially, in the order in which they are started.
-     * <p>
-     * This method must be called on the main thread.
-     *
-     * @param type of the task to start
-     * @param param to pass to the task
-     * @return the newly created task
-     */
-    public static CollectionTask launchCollectionTask(TASK_TYPE type, TaskData param) {
-        return launchCollectionTask(type, null, param);
-    }
-
-    /**
-     * Starts a new {@link CollectionTask}, with a listener provided for callbacks during execution
-     * <p>
-     * Tasks will be executed serially, in the order in which they are started.
-     * <p>
-     * This method must be called on the main thread.
-     *
-     * @param type of the task to start
-     * @param listener to the status and result of the task, may be null
-     * @return the newly created task
-     */
-    public static CollectionTask launchCollectionTask(TASK_TYPE type, @Nullable TaskListener listener) {
-        // Start new task
-        return launchCollectionTask(type, listener, null);
-    }
-
-    /**
-     * Starts a new {@link CollectionTask}, with a listener provided for callbacks during execution
-     * <p>
-     * Tasks will be executed serially, in the order in which they are started.
-     * <p>
-     * This method must be called on the main thread.
-     *
-     * @param type of the task to start
-     * @param listener to the status and result of the task, may be null
-     * @param param to pass to the task
-     * @return the newly created task
-     */
-    public static CollectionTask launchCollectionTask(TASK_TYPE type, @Nullable TaskListener listener, TaskData param) {
-        // Start new task
-        CollectionTask newTask = new CollectionTask(type, listener, sLatestInstance);
-        newTask.execute(param);
-        return newTask;
-    }
-
-
-    /**
-     * Block the current thread until the currently running CollectionTask instance (if any) has finished.
-     */
-    public static void waitToFinish() {
-        waitToFinish(null);
-    }
-
-    /**
-     * Block the current thread until the currently running CollectionTask instance (if any) has finished.
-     * @param timeoutSeconds timeout in seconds
-     * @return whether or not the previous task was successful or not
-     */
-    public static boolean waitToFinish(Integer timeoutSeconds) {
-        try {
-            if ((sLatestInstance != null) && (sLatestInstance.getStatus() != AsyncTask.Status.FINISHED)) {
-                Timber.d("CollectionTask: waiting for task %s to finish...", sLatestInstance.mType);
-                if (timeoutSeconds != null) {
-                    sLatestInstance.get(timeoutSeconds, TimeUnit.SECONDS);
-                } else {
-                    sLatestInstance.get();
-                }
-
-            }
-            return true;
-        } catch (Exception e) {
-            Timber.e(e, "Exception waiting for task to finish");
-            return false;
-        }
-    }
 
     /**
      * Block the current thread until all CollectionTasks have finished.
@@ -256,13 +150,13 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
         // HACK: This should be better - there is currently a race condition in sLatestInstance, and no means to obtain this information.
         // This should work in all reasonable cases given how few tasks we have concurrently blocking.
         boolean result;
-        result = CollectionTask.waitToFinish(timeoutSeconds / 4);
+        result = TaskManager.waitToFinish(timeoutSeconds / 4);
         ThreadUtil.sleep(10);
-        result &= CollectionTask.waitToFinish(timeoutSeconds / 4);
+        result &= TaskManager.waitToFinish(timeoutSeconds / 4);
         ThreadUtil.sleep(10);
-        result &= CollectionTask.waitToFinish(timeoutSeconds / 4);
+        result &= TaskManager.waitToFinish(timeoutSeconds / 4);
         ThreadUtil.sleep(10);
-        result &= CollectionTask.waitToFinish(timeoutSeconds / 4);
+        result &= TaskManager.waitToFinish(timeoutSeconds / 4);
         ThreadUtil.sleep(10);
         Timber.i("Waited for all tasks to finish");
         return result;
@@ -281,54 +175,29 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
             // AsyncTask.cancel
             Timber.w(e, "Exception cancelling task");
         } finally {
-            sTasks.remove(this);
+            TaskManager.removeTask(this);
         }
         return false;
-    }
-
-
-    /** Cancel the current task only if it's of type taskType */
-    public static void cancelCurrentlyExecutingTask() {
-        CollectionTask latestInstance = sLatestInstance;
-        if (latestInstance != null) {
-            if (latestInstance.safeCancel()) {
-                Timber.i("Cancelled task %s", latestInstance.mType);
-            }
-        }
     }
 
     private Collection getCol() {
         return CollectionHelper.getInstance().getCol(mContext);
     }
 
-    /** Cancel all tasks of type taskType*/
-    public static void cancelAllTasks(TASK_TYPE taskType) {
-        int count = 0;
-        // safeCancel modifies sTasks, so iterate over a concrete copy
-        for (CollectionTask task: new ArrayList<>(sTasks)) {
-            if (task.mType != taskType) {
-                continue;
-            }
-            if (task.safeCancel()) {
-                count++;
-            }
-        }
-        if (count > 0) {
-            Timber.i("Cancelled %d instances of task %s", count, taskType);
-        }
-    }
-
 
     private final TASK_TYPE mType;
+    protected TASK_TYPE getType() {
+        return mType;
+    }
     private final TaskListener mListener;
     private CollectionTask mPreviousTask;
 
 
-    private CollectionTask(TASK_TYPE type, TaskListener listener, CollectionTask previousTask) {
+    protected CollectionTask(TASK_TYPE type, TaskListener listener, CollectionTask previousTask) {
         mType = type;
         mListener = listener;
         mPreviousTask = previousTask;
-        sTasks.add(this);
+        TaskManager.addTasks(this);
     }
 
     @Override
@@ -336,7 +205,7 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
         try {
             return actualDoInBackground(params[0]);
         } finally {
-            sTasks.remove(this);
+            TaskManager.removeTask(this);
         }
     }
 
@@ -362,7 +231,7 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
                 Timber.d(e, "previously running task was cancelled: %s", mPreviousTask.mType);
             }
         }
-        sLatestInstance = this;
+        setLatestInstance(this);
         mContext = AnkiDroidApp.getInstance().getApplicationContext();
 
         // Skip the task if the collection cannot be opened
@@ -537,7 +406,7 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
 
     @Override
     protected void onCancelled(){
-        sTasks.remove(this);
+        TaskManager.removeTask(this);
         if (mListener != null) {
             mListener.onCancelled();
         }
@@ -786,7 +655,6 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
         }
         return new TaskData(true);
     }
-
 
 
     private static class UndoSuspendCardMulti extends Undoable {
@@ -1339,7 +1207,7 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
             return new TaskData(false);
         }
 
-        Collection.CheckDatabaseResult result = col.fixIntegrity(new ProgressCallback(this, AnkiDroidApp.getAppResources()));
+        Collection.CheckDatabaseResult result = col.fixIntegrity(new TaskManager.ProgressCallback(this, AnkiDroidApp.getAppResources()));
         if (result.getFailed()) {
             //we can fail due to a locked database, which requires knowledge of the failure.
             return new TaskData(false, new Object[] { result });
@@ -1421,7 +1289,7 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
         Collection col = getCol();
         String path = param.getString();
         AnkiPackageImporter imp = new AnkiPackageImporter(col, path);
-        imp.setProgressCallback(new ProgressCallback(this, res));
+        imp.setProgressCallback(new TaskManager.ProgressCallback(this, res));
         try {
             imp.run();
         } catch (ImportExportException e) {
@@ -1972,37 +1840,6 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
         getCol().getSched().reset();
     }
 
-
-    /**
-     * Helper class for allowing inner function to publish progress of an AsyncTask.
-     */
-    public static class ProgressCallback {
-        private final Resources res;
-        private final ProgressSender<TaskData> task;
-
-
-        public ProgressCallback(ProgressSender<TaskData> task, Resources res) {
-            this.res = res;
-            if (res != null) {
-                this.task = task;
-            } else {
-                this.task = null;
-            }
-        }
-
-
-        public Resources getResources() {
-            return res;
-        }
-
-
-        public void publishProgress(TaskData value) {
-            if (task != null) {
-                task.doProgress(value);
-            }
-        }
-    }
-
     /** Whether col is readable */
     private boolean hasValidCol() {
         try {
@@ -2011,5 +1848,9 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
         } catch (Exception e) {
             return false;
         }
+    }
+
+    public void doProgress(TaskData value) {
+        publishProgress(value);
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
@@ -312,7 +312,7 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
         sIsCancellable = true;
         Timber.d("doInBackgroundSync()");
         // Block execution until any previous background task finishes, or timeout after 5s
-        boolean ok = CollectionTask.waitToFinish(5);
+        boolean ok = TaskManager.waitToFinish(5);
 
         // Unique key allowing to identify the user to AnkiWeb without password
         String hkey = (String) data.data[0];

--- a/AnkiDroid/src/main/java/com/ichi2/async/TaskManager.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/TaskManager.java
@@ -160,6 +160,10 @@ public class TaskManager {
         }
     }
 
+    public static ProgressCallback progressCallback(CollectionTask task, Resources res) {
+        return new ProgressCallback(task, res);
+    }
+
 
     /**
      * Helper class for allowing inner function to publish progress of an AsyncTask.
@@ -169,7 +173,7 @@ public class TaskManager {
         private final CollectionTask task;
 
 
-        public ProgressCallback(CollectionTask task, Resources res) {
+        protected ProgressCallback(CollectionTask task, Resources res) {
             this.res = res;
             if (res != null) {
                 this.task = task;

--- a/AnkiDroid/src/main/java/com/ichi2/async/TaskManager.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/TaskManager.java
@@ -1,0 +1,194 @@
+package com.ichi2.async;
+
+import android.content.res.Resources;
+import android.os.AsyncTask;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import androidx.annotation.Nullable;
+import timber.log.Timber;
+
+public class TaskManager {
+
+    /**
+     * Tasks which are running or waiting to run.
+     * */
+    private static final List<CollectionTask> sTasks = Collections.synchronizedList(new LinkedList<>());
+
+    protected static void addTasks(CollectionTask task) {
+        sTasks.add(task);
+    }
+
+    protected static boolean removeTask(CollectionTask task) {
+        return sTasks.remove(task);
+    }
+
+
+    /**
+     * The most recently started {@link CollectionTask} instance.
+     */
+    private static CollectionTask sLatestInstance;
+
+    protected static void setLatestInstance(CollectionTask task) {
+        sLatestInstance = task;
+    }
+
+
+    /**
+     * Starts a new {@link CollectionTask}, with no listener
+     * <p>
+     * Tasks will be executed serially, in the order in which they are started.
+     * <p>
+     * This method must be called on the main thread.
+     *
+     * @param type of the task to start
+     * @return the newly created task
+     */
+    public static CollectionTask launchCollectionTask(CollectionTask.TASK_TYPE type) {
+        return launchCollectionTask(type, null, null);
+    }
+
+    /**
+     * Starts a new {@link CollectionTask}, with no listener
+     * <p>
+     * Tasks will be executed serially, in the order in which they are started.
+     * <p>
+     * This method must be called on the main thread.
+     *
+     * @param type of the task to start
+     * @param param to pass to the task
+     * @return the newly created task
+     */
+    public static CollectionTask launchCollectionTask(CollectionTask.TASK_TYPE type, TaskData param) {
+        return launchCollectionTask(type, null, param);
+    }
+
+    /**
+     * Starts a new {@link CollectionTask}, with a listener provided for callbacks during execution
+     * <p>
+     * Tasks will be executed serially, in the order in which they are started.
+     * <p>
+     * This method must be called on the main thread.
+     *
+     * @param type of the task to start
+     * @param listener to the status and result of the task, may be null
+     * @return the newly created task
+     */
+    public static CollectionTask launchCollectionTask(CollectionTask.TASK_TYPE type, @Nullable TaskListener listener) {
+        // Start new task
+        return launchCollectionTask(type, listener, null);
+    }
+
+    /**
+     * Starts a new {@link CollectionTask}, with a listener provided for callbacks during execution
+     * <p>
+     * Tasks will be executed serially, in the order in which they are started.
+     * <p>
+     * This method must be called on the main thread.
+     *
+     * @param type of the task to start
+     * @param listener to the status and result of the task, may be null
+     * @param param to pass to the task
+     * @return the newly created task
+     */
+    public static CollectionTask launchCollectionTask(CollectionTask.TASK_TYPE type, @Nullable TaskListener listener, TaskData param) {
+        // Start new task
+        CollectionTask newTask = new CollectionTask(type, listener, sLatestInstance);
+        newTask.execute(param);
+        return newTask;
+    }
+
+
+    /**
+     * Block the current thread until the currently running CollectionTask instance (if any) has finished.
+     */
+    public static void waitToFinish() {
+        waitToFinish(null);
+    }
+
+    /**
+     * Block the current thread until the currently running CollectionTask instance (if any) has finished.
+     * @param timeout timeout in seconds
+     * @return whether or not the previous task was successful or not
+     */
+    public static boolean waitToFinish(Integer timeoutSeconds) {
+        try {
+            if ((sLatestInstance != null) && (sLatestInstance.getStatus() != AsyncTask.Status.FINISHED)) {
+                Timber.d("CollectionTask: waiting for task %s to finish...", sLatestInstance.getType());
+                if (timeoutSeconds != null) {
+                    sLatestInstance.get(timeoutSeconds, TimeUnit.SECONDS);
+                } else {
+                    sLatestInstance.get();
+                }
+
+            }
+            return true;
+        } catch (Exception e) {
+            Timber.e(e, "Exception waiting for task to finish");
+            return false;
+        }
+    }
+
+    /** Cancel the current task only if it's of type taskType */
+    public static void cancelCurrentlyExecutingTask() {
+        CollectionTask latestInstance = sLatestInstance;
+        if (latestInstance != null) {
+            if (latestInstance.safeCancel()) {
+                Timber.i("Cancelled task %s", latestInstance.getType());
+            }
+        };
+    }
+
+    /** Cancel all tasks of type taskType*/
+    public static void cancelAllTasks(CollectionTask.TASK_TYPE taskType) {
+        int count = 0;
+        // safeCancel modifies sTasks, so iterate over a concrete copy
+        for (CollectionTask task: new ArrayList<>(sTasks)) {
+            if (task.getType() != taskType) {
+                continue;
+            }
+            if (task.safeCancel()) {
+                count++;
+            }
+        }
+        if (count > 0) {
+            Timber.i("Cancelled %d instances of task %s", count, taskType);
+        }
+    }
+
+
+    /**
+     * Helper class for allowing inner function to publish progress of an AsyncTask.
+     */
+    public static class ProgressCallback {
+        private final Resources res;
+        private final CollectionTask task;
+
+
+        public ProgressCallback(CollectionTask task, Resources res) {
+            this.res = res;
+            if (res != null) {
+                this.task = task;
+            } else {
+                this.task = null;
+            }
+        }
+
+
+        public Resources getResources() {
+            return res;
+        }
+
+
+        public void publishProgress(TaskData value) {
+            if (task != null) {
+                task.doProgress(value);
+            }
+        }
+    }
+
+}

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -35,6 +35,7 @@ import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.async.CancelListener;
 import com.ichi2.async.CollectionTask;
 import com.ichi2.async.ProgressSender;
+import com.ichi2.async.TaskManager;
 import com.ichi2.libanki.exception.NoSuchDeckException;
 import com.ichi2.libanki.exception.UnknownDatabaseVersionException;
 import com.ichi2.libanki.hooks.ChessFilter;
@@ -1448,7 +1449,7 @@ public class Collection {
 
 
     /** Fix possible problems and rebuild caches. */
-    public CheckDatabaseResult fixIntegrity(CollectionTask.ProgressCallback progressCallback) {
+    public CheckDatabaseResult fixIntegrity(TaskManager.ProgressCallback progressCallback) {
         File file = new File(mPath);
         CheckDatabaseResult result = new CheckDatabaseResult(file.length());
         final int[] currentTask = {1};
@@ -1935,7 +1936,7 @@ public class Collection {
     }
 
 
-    private void fixIntegrityProgress(CollectionTask.ProgressCallback progressCallback, int current, int total) {
+    private void fixIntegrityProgress(TaskManager.ProgressCallback progressCallback, int current, int total) {
         progressCallback.publishProgress(new TaskData(
                 progressCallback.getResources().getString(R.string.check_db_message) + " " + current + " / " + total));
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Importer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Importer.java
@@ -22,6 +22,7 @@ import android.content.res.Resources;
 
 import com.ichi2.anki.exception.ImportExportException;
 import com.ichi2.async.CollectionTask;
+import com.ichi2.async.TaskManager;
 import com.ichi2.libanki.Collection;
 
 import java.util.ArrayList;
@@ -42,7 +43,7 @@ public abstract class Importer {
     protected Collection mSrc;
 
     protected final Context mContext;
-    protected CollectionTask.ProgressCallback mProgress;
+    protected TaskManager.ProgressCallback mProgress;
 
     public Importer(Collection col, String file) {
         mFile = file;
@@ -78,7 +79,7 @@ public abstract class Importer {
      * ***********************************************************
      */
 
-    public void setProgressCallback(CollectionTask.ProgressCallback progressCallback) {
+    public void setProgressCallback(TaskManager.ProgressCallback progressCallback) {
         mProgress = progressCallback;
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -34,6 +34,7 @@ import android.util.Pair;
 import com.ichi2.anki.R;
 import com.ichi2.async.CancelListener;
 import com.ichi2.async.CollectionTask;
+import com.ichi2.async.TaskManager;
 import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Consts;
@@ -192,7 +193,7 @@ public class SchedV2 extends AbstractSched {
         }
         if (!mHaveCounts) {
             // Need to reset queues once counts are reset
-            CollectionTask.launchCollectionTask(RESET);
+            TaskManager.launchCollectionTask(RESET);
         }
         return card;
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
@@ -27,6 +27,7 @@ import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.async.CollectionTask;
 import com.ichi2.async.TaskData;
 import com.ichi2.async.TaskListener;
+import com.ichi2.async.TaskManager;
 import com.ichi2.compat.customtabs.CustomTabActivityHelper;
 import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
@@ -363,7 +364,7 @@ public class RobolectricTest {
                 }
             }
         };
-        CollectionTask.launchCollectionTask(taskType, listener, data);
+        TaskManager.launchCollectionTask(taskType, listener, data);
         advanceRobolectricLooper();
 
         wait(timeoutMs);

--- a/AnkiDroid/src/test/java/com/ichi2/async/AbstractCollectionTaskTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/async/AbstractCollectionTaskTest.java
@@ -31,7 +31,7 @@ import static org.hamcrest.Matchers.notNullValue;
 public abstract class AbstractCollectionTaskTest extends RobolectricTest {
 
     protected TaskData execute(CollectionTask.TASK_TYPE taskType) {
-        CollectionTask task = CollectionTask.launchCollectionTask(taskType);
+        CollectionTask task = TaskManager.launchCollectionTask(taskType);
         try {
             return task.get();
         } catch (Exception e) {

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/CheckMediaTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/CheckMediaTest.java
@@ -18,6 +18,7 @@ package com.ichi2.libanki;
 
 import com.ichi2.anki.RobolectricTest;
 import com.ichi2.async.CollectionTask;
+import com.ichi2.async.TaskManager;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -45,7 +46,7 @@ public class CheckMediaTest extends RobolectricTest {
 
         assertThat(getCol().getMedia().getDb().queryScalar("SELECT count(*) FROM sqlite_master WHERE type='table' AND name='meta';"), is(0));
 
-        CollectionTask task = CollectionTask.launchCollectionTask(CollectionTask.TASK_TYPE.CHECK_MEDIA);
+        CollectionTask task = TaskManager.launchCollectionTask(CollectionTask.TASK_TYPE.CHECK_MEDIA);
 
         task.get();
 


### PR DESCRIPTION
This is a small part of https://github.com/ankidroid/Anki-Android/pull/7045 . It splits CollectionTasks in two. One part is `TaskManager`; the manager is in charge of adding new task, removing them, keeping track of the queue of tasks.... and `CollectionTask` keep everything that is related to actually executing a task. I believe those are distinct enough to justify being in two classes. Furthermore, it will simplify the PR #7045 by ensuring that this PR change only the files related to managing tasks and won't have to change the remaining of the code base.