### PR TITLE
Improve File Import: Error Handling for Zip Validation 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -355,12 +355,12 @@ public class AnkiDroidApp extends MultiDexApplication {
     }
 
 
-    public static void sendExceptionReport(Throwable e, String origin, String additionalInfo) {
+    public static void sendExceptionReport(Throwable e, String origin, @Nullable String additionalInfo) {
         sendExceptionReport(e, origin, additionalInfo, false);
     }
 
 
-    public static void sendExceptionReport(Throwable e, String origin, String additionalInfo, boolean onlyIfSilent) {
+    public static void sendExceptionReport(Throwable e, String origin, @Nullable String additionalInfo, boolean onlyIfSilent) {
         UsageAnalytics.sendAnalyticsException(e, false);
 
         if (onlyIfSilent) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -839,9 +839,9 @@ public class DeckPicker extends NavigationDrawerActivity implements
             // The collection path was inaccessible on startup so just close the activity and let user restart
             finishWithoutAnimation();
         } else if ((requestCode == PICK_APKG_FILE) && (resultCode == RESULT_OK)) {
-            String errorMessage = ImportUtils.handleFileImport(this, intent);
-            if (errorMessage != null) {
-                ImportUtils.showImportUnsuccessfulDialog(this, errorMessage, false);
+            ImportUtils.ImportResult importResult = ImportUtils.handleFileImport(this, intent);
+            if (!importResult.isSuccess()) {
+                ImportUtils.showImportUnsuccessfulDialog(this, importResult.getHumanReadableMessage(), false);
             }
         } else if ((requestCode == PICK_EXPORT_FILE) && (resultCode == RESULT_OK)) {
             if (exportToProvider(intent, true)) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.java
@@ -9,6 +9,7 @@ import com.ichi2.anki.dialogs.DialogHandler;
 import com.ichi2.anki.services.ReminderService;
 import com.ichi2.utils.FunctionalInterfaces.Consumer;
 import com.ichi2.utils.ImportUtils;
+import com.ichi2.utils.ImportUtils.ImportResult;
 import com.ichi2.utils.Permissions;
 
 import androidx.annotation.CheckResult;
@@ -119,9 +120,9 @@ public class IntentHandler extends Activity {
 
     private void handleFileImport(Intent intent, Intent reloadIntent, String action) {
         Timber.i("Handling file import");
-        String errorMessage = ImportUtils.handleFileImport(this, intent);
+        ImportResult importResult = ImportUtils.handleFileImport(this, intent);
         // Start DeckPicker if we correctly processed ACTION_VIEW
-        if (errorMessage == null) {
+        if (importResult.isSuccess()) {
             Timber.d("onCreate() import successful");
             reloadIntent.setAction(action);
             reloadIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
@@ -130,8 +131,7 @@ public class IntentHandler extends Activity {
         } else {
             Timber.i("File import failed");
             // Don't import the file if it didn't load properly or doesn't have apkg extension
-            //Themes.showThemedToast(this, getResources().getString(R.string.import_log_no_apkg), true);
-            ImportUtils.showImportUnsuccessfulDialog(this, errorMessage, true);
+            ImportUtils.showImportUnsuccessfulDialog(this, importResult.getHumanReadableMessage(), true);
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
@@ -49,7 +49,8 @@ public class ImportUtils {
      * @param intent contains the file to import
      * @return null if successful, otherwise error message
      */
-    public static String handleFileImport(Context context, Intent intent) {
+    @NonNull
+    public static ImportResult handleFileImport(Context context, Intent intent) {
         return new FileImporter().handleFileImport(context, intent);
     }
 
@@ -85,7 +86,8 @@ public class ImportUtils {
          * @param intent contains the file to import
          * @return null if successful, otherwise error message
          */
-        public String handleFileImport(Context context, Intent intent) {
+        @NonNull
+        public ImportResult handleFileImport(Context context, Intent intent) {
             // This intent is used for opening apkg package files
             // We want to go immediately to DeckPicker, clearing any history in the process
             Timber.i("IntentHandler/ User requested to view a file");
@@ -97,19 +99,18 @@ public class ImportUtils {
             } catch (Exception e) {
                 AnkiDroidApp.sendExceptionReport(e, "handleFileImport");
                 Timber.e(e, "failed to handle import intent");
-                return context.getString(R.string.import_error_exception, e.getLocalizedMessage());
+                return ImportResult.fromErrorString(context.getString(R.string.import_error_exception, e.getLocalizedMessage()));
             }
         }
 
         //Added to remove exception handlers
-        private String handleFileImportInternal(Context context, Intent intent) {
-            String errorMessage = null;
-
+        @NonNull
+        private ImportResult handleFileImportInternal(Context context, Intent intent) {
             if (intent.getData() == null) {
                 Timber.i("No intent data. Attempting to read clip data.");
                 if (intent.getClipData() == null
                         || intent.getClipData().getItemCount() == 0) {
-                    return context.getString(R.string.import_error_unhandled_request);
+                    return ImportResult.fromErrorString(context.getString(R.string.import_error_unhandled_request));
                 }
                 Uri clipUri = intent.getClipData().getItemAt(0).getUri();
                 return handleContentProviderFile(context, intent, clipUri);
@@ -127,19 +128,21 @@ public class ImportUtils {
                 if (isValidPackageName(filename)) {
                     // If file has apkg extension then send message to show Import dialog
                     sendShowImportFileDialogMsg(filename);
+                    return ImportResult.fromSuccess();
                 } else {
-                    errorMessage = context.getResources().getString(R.string.import_error_not_apkg_extension, filename);
+                    return ImportResult.fromErrorString(context.getResources().getString(R.string.import_error_not_apkg_extension, filename));
                 }
+            } else {
+                return ImportResult.fromSuccess(); // TODO: This was previously implicit, and is incorrect.
             }
-            return errorMessage;
         }
 
 
-        private String handleContentProviderFile(Context context, Intent intent, Uri data) {
+        @NonNull
+        private ImportResult handleContentProviderFile(Context context, Intent intent, Uri data) {
             //Note: intent.getData() can be null. Use data instead.
 
             // Get the original filename from the content provider URI
-            String errorMessage;
             String filename = getFileNameFromContentProvider(context, data);
 
             // Hack to fix bug where ContentResolver not returning filename correctly
@@ -151,7 +154,7 @@ public class ImportUtils {
                 } else {
                     Timber.e("Could not retrieve filename from ContentProvider or read content as ZipFile");
                     AnkiDroidApp.sendExceptionReport(new RuntimeException("Could not import apkg from ContentProvider"), "IntentHandler.java", "apkg import failed");
-                    return AnkiDroidApp.getAppResources().getString(R.string.import_error_content_provider, AnkiDroidApp.getManualUrl() + "#importing");
+                    return ImportResult.fromErrorString(AnkiDroidApp.getAppResources().getString(R.string.import_error_content_provider, AnkiDroidApp.getManualUrl() + "#importing"));
                 }
             }
 
@@ -159,31 +162,31 @@ public class ImportUtils {
                 if (isAnkiDatabase(filename)) {
                     //.anki2 files aren't supported by Anki Desktop, we should eventually support them, because we can
                     //but for now, show a "nice" error.
-                    return context.getResources().getString(R.string.import_error_load_imported_database);
+                    return ImportResult.fromErrorString(context.getResources().getString(R.string.import_error_load_imported_database));
                 } else {
                     // Don't import if file doesn't have an Anki package extension
-                    return context.getResources().getString(R.string.import_error_not_apkg_extension, filename);
+                    return ImportResult.fromErrorString(context.getResources().getString(R.string.import_error_not_apkg_extension, filename));
                 }
             } else {
                 // Copy to temporary file
                 filename = ensureValidLength(filename);
                 String tempOutDir = Uri.fromFile(new File(context.getCacheDir(), filename)).getEncodedPath();
-                errorMessage = copyFileToCache(context, data, tempOutDir) ? null : context.getString(R.string.import_error_copy_file_to_cache);
+                String errorMessage = copyFileToCache(context, data, tempOutDir) ? null : context.getString(R.string.import_error_copy_file_to_cache);
                 // Show import dialog
                 if (errorMessage != null) {
                     AnkiDroidApp.sendExceptionReport(new RuntimeException("Error importing apkg file"), "IntentHandler.java", "apkg import failed");
-                    return errorMessage;
+                    return ImportResult.fromErrorString(errorMessage);
                 }
 
                 errorMessage = validateZipFile(context, tempOutDir);
                 if (errorMessage != null) {
                     //noinspection ResultOfMethodCallIgnored
                     new File(tempOutDir).delete();
-                    return errorMessage;
+                    return ImportResult.fromErrorString(errorMessage);
                 }
 
                 sendShowImportFileDialogMsg(tempOutDir);
-                return null;
+                return ImportResult.fromSuccess();
             }
         }
 
@@ -393,6 +396,31 @@ public class ImportUtils {
                 }
             }
             return true;
+        }
+    }
+
+    public static class ImportResult {
+        private final String mMessage;
+
+
+        public ImportResult(String message) {
+            this.mMessage = message;
+        }
+
+        public static ImportResult fromErrorString(String message) {
+            return new ImportResult(message);
+        }
+
+        public static ImportResult fromSuccess() {
+            return new ImportResult(null);
+        }
+
+        public boolean isSuccess() {
+            return mMessage == null;
+        }
+
+        public String getHumanReadableMessage() {
+            return mMessage;
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
@@ -133,7 +133,7 @@ public class ImportUtils {
                     return ImportResult.fromErrorString(context.getResources().getString(R.string.import_error_not_apkg_extension, filename));
                 }
             } else {
-                return ImportResult.fromSuccess(); // TODO: This was previously implicit, and is incorrect.
+                return ImportResult.fromErrorString(context.getResources().getString(R.string.import_error_unhandled_scheme, intent.getData()));
             }
         }
 

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -172,6 +172,7 @@
     <string name="import_error_load_imported_database">Anki Database (.anki2) replacements are not yet supported. Please see the manual for replacement instructions.</string>
     <string name="import_error_content_provider">The selected file couldn’t be imported automatically by AnkiDroid. Please see the user manual for how to manually import anki files: \n%s</string>
     <string name="import_error_copy_file_to_cache">copyFileToCache() failed (possibly out of storage space)</string>
+    <string name="import_error_unhandled_scheme">Unhandled import from: “%s”</string>
     <string name="import_replacing">Replacing collection…</string>
     <string name="import_interrupted">Import interrupted</string>
     <string name="export_include_schedule">Include scheduling</string>

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -167,6 +167,7 @@
     <string name="import_log_file_cache_cleared">Error importing file, likely a cache clear during processing.\nPlease try again</string>
     <string name="import_succeeded_but_check_database">Data import succeeded but post-import cleanup failed. Run check database later. Root cause: %s</string>
     <string name="import_error_unhandled_request">Unable to process import request</string>
+    <string name="import_error_corrupt_zip">The apkg file is corrupt. Please delete and re-download it.\n\nRoot cause: %s</string>
     <string name="import_error_exception">Failed to import package\n\n%s</string>
     <string name="import_error_not_apkg_extension">Filename “%s” doesn’t have .apkg or .colpkg extension</string>
     <string name="import_error_load_imported_database">Anki Database (.anki2) replacements are not yet supported. Please see the manual for replacement instructions.</string>


### PR DESCRIPTION
## Purpose / Description
A user didn't understand "archive is not a ZIP archive" meant the file is corrupt. We improve this error message, and perform more silent exception logging to help diagnose these unknown issues in the future.

## Fixes
Fixes #7050 

## Approach
* Change the dialog
* Send a silent exception report if the exception type is unknown
* Return a class so we can better handle displaying a string to the user.

## How Has This Been Tested?

![image](https://user-images.githubusercontent.com/62114487/92668445-ba597680-f306-11ea-8365-56d72ee989f9.png)


## Learning (optional, can help others)
We can always do better with exception reports

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code