### PR TITLE
Improve custom sync server URL error

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -116,9 +116,7 @@ import com.ichi2.libanki.Models;
 import com.ichi2.libanki.Utils;
 import com.ichi2.libanki.importer.AnkiPackageImporter;
 import com.ichi2.libanki.sched.AbstractDeckTreeNode;
-import com.ichi2.libanki.sched.DeckDueTreeNode;
-import com.ichi2.libanki.utils.SystemTime;
-import com.ichi2.libanki.utils.Time;
+import com.ichi2.libanki.sync.CustomSyncServerUrlException;
 import com.ichi2.libanki.utils.TimeUtils;
 import com.ichi2.themes.StyledProgressDialog;
 import com.ichi2.ui.BadgeDrawableBuilder;
@@ -1854,6 +1852,11 @@ public class DeckPicker extends NavigationDrawerActivity implements
                         dialogMessage = res.getString(R.string.sync_media_error_check);
                         showSyncErrorDialog(SyncErrorDialog.DIALOG_MEDIA_SYNC_ERROR,
                                 joinSyncMessages(dialogMessage, syncMessage));
+                    } else if ("customSyncServerUrl".equals(resultType)) {
+                        String url = result.length > 1 && result[1] instanceof CustomSyncServerUrlException
+                                ? ((CustomSyncServerUrlException)result[1]).getUrl() : "unknown";
+                        dialogMessage = res.getString(R.string.sync_error_invalid_sync_server, url);
+                        showSyncErrorMessage(joinSyncMessages(dialogMessage, syncMessage));
                     } else {
                         if (result.length > 1 && result[1] instanceof Integer) {
                             int code = (Integer) result[1];

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/CustomSyncServerUrlException.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/CustomSyncServerUrlException.java
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.libanki.sync;
+
+public class CustomSyncServerUrlException extends RuntimeException {
+    private final String mUrl;
+
+
+    public CustomSyncServerUrlException(String url, IllegalArgumentException ex) {
+        super(getMessage(url), ex);
+        this.mUrl = url;
+    }
+
+
+    private static String getMessage(String url) {
+        return "Invalid Custom Sync Server URL: " + url;
+    }
+
+
+    @Override
+    public String getLocalizedMessage() {
+        // Janky. Connection uses this as a string to return, which is switched on to determine the message in DeckPicker
+        return "customSyncServerUrl";
+    }
+
+
+    public String getUrl() {
+        return mUrl;
+    }
+}

--- a/AnkiDroid/src/main/res/values/04-network.xml
+++ b/AnkiDroid/src/main/res/values/04-network.xml
@@ -78,6 +78,7 @@
     <string name="sync_overwrite_error">Your current collection couldn’t be overwritten by the downloaded file</string>
     <string name="sync_connection_error">Connection timed out. Either your internet connection is experiencing problems, or you have a very large file in your media folder.</string>
     <string name="sync_write_access_error">The downloaded file couldn’t be saved to the SD card. Either the card is mounted read-only or there isn’t enough space.</string>
+    <string name="sync_error_invalid_sync_server">The Custom Sync Server in Advanced Settings is invalid (%s). Please enter a valid server, or disable the setting.</string>
     <string name="sync_deletions_message">Syncing deletions…</string>
     <string name="sync_small_objects_message">Syncing small objects…</string>
     <string name="sync_finish_message">Finishing syncing…</string>


### PR DESCRIPTION
## Purpose / Description
This won't occur for new users, as there's now validation in the preferences, but some existing users have this issue and it would be useful to fix it for them.

Adding because it's the first error of the 2.13 beta, and it's hopefully caused by a user, rather than a bot.

## Fixes
Fixes #5843

## Approach
Return a custom exception and explain what it means


## How Has This Been Tested?

```java
        getSharedPrefs(this).edit().putString("syncBaseUrl", "<see image>").commit();
```

Tested on my Android 9 device

![image](https://user-images.githubusercontent.com/62114487/92730325-86646c80-f36b-11ea-831d-464e3f1b8771.png)

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code