### PR TITLE
Enable TV Support for Reviewer

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -117,6 +117,7 @@ import com.ichi2.libanki.template.Template;
 import com.ichi2.themes.HtmlColors;
 import com.ichi2.themes.Themes;
 import com.ichi2.utils.AdaptionUtil;
+import com.ichi2.utils.AndroidUiUtils;
 import com.ichi2.utils.DiffEngine;
 import com.ichi2.utils.FunctionalInterfaces.Consumer;
 import com.ichi2.utils.FunctionalInterfaces.Function;
@@ -657,7 +658,21 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
             }
             // set the correct mark/unmark icon on action bar
             refreshActionBar();
+            focusDefaultLayout();
+        }
+    }
+
+
+    private void focusDefaultLayout() {
+        if (!AndroidUiUtils.isRunningOnTv(this)) {
             findViewById(R.id.root_layout).requestFocus();
+        } else {
+            View flip = findViewById(R.id.answer_options_layout);
+            if (flip == null) {
+                return;
+            }
+            Timber.d("Requesting focus for flip button");
+            flip.requestFocus();
         }
     }
 
@@ -1542,7 +1557,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
 
 
     @SuppressLint("SetJavaScriptEnabled") // they request we review carefully because of XSS security, we have
-    private WebView createWebView() {
+    protected WebView createWebView() {
         WebView webView = new MyWebView(this);
         webView.setScrollBarStyle(View.SCROLLBARS_OUTSIDE_OVERLAY);
         webView.getSettings().setDisplayZoomControls(false);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
@@ -2,7 +2,6 @@
 package com.ichi2.anki;
 
 import android.app.Activity;
-import android.app.ActivityManager;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.ActivityNotFoundException;
@@ -26,6 +25,8 @@ import androidx.fragment.app.FragmentTransaction;
 import androidx.core.app.NotificationCompat;
 import androidx.core.content.ContextCompat;
 import androidx.appcompat.app.AppCompatActivity;
+
+import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup.LayoutParams;
@@ -39,13 +40,13 @@ import com.ichi2.anki.dialogs.AsyncDialogFragment;
 import com.ichi2.anki.dialogs.DialogHandler;
 import com.ichi2.anki.dialogs.SimpleMessageDialog;
 import com.ichi2.async.CollectionLoader;
-import com.ichi2.compat.CompatHelper;
 import com.ichi2.compat.customtabs.CustomTabActivityHelper;
 import com.ichi2.compat.customtabs.CustomTabsFallback;
 import com.ichi2.compat.customtabs.CustomTabsHelper;
 import com.ichi2.libanki.Collection;
 import com.ichi2.themes.Themes;
 import com.ichi2.utils.AdaptionUtil;
+import com.ichi2.utils.AndroidUiUtils;
 
 import timber.log.Timber;
 
@@ -174,6 +175,18 @@ public class AnkiActivity extends AppCompatActivity implements SimpleMessageDial
         }
         super.setContentView(view);
     }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        // We can't access the icons yet on a TV, so show them all in the menu
+        if (AndroidUiUtils.isRunningOnTv(this)) {
+            for (int i = 0; i < menu.size(); i++) {
+                menu.getItem(i).setShowAsAction(MenuItem.SHOW_AS_ACTION_NEVER);
+            }
+        }
+        return super.onCreateOptionsMenu(menu);
+    }
+
 
 
     @Override

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
@@ -30,6 +30,8 @@ import androidx.core.view.GravityCompat;
 import androidx.appcompat.app.ActionBarDrawerToggle;
 import androidx.appcompat.widget.SwitchCompat;
 import androidx.appcompat.widget.Toolbar;
+
+import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -387,11 +389,43 @@ public abstract class NavigationDrawerActivity extends AnkiActivity implements N
         activity.finishWithoutAnimation();
     }
 
+
+    public void toggleDrawer() {
+        if (!isDrawerOpen()) {
+            openDrawer();
+        } else {
+            closeDrawer();
+        }
+    }
+
+
     private void openDrawer() {
         mDrawerLayout.openDrawer(GravityCompat.START, animationEnabled());
     }
 
     private void closeDrawer() {
         mDrawerLayout.closeDrawer(GravityCompat.START, animationEnabled());
+    }
+
+
+    public void focusNavigation() {
+        // mNavigationView.getMenu().getItem(0).setChecked(true);
+        selectNavigationItem(R.id.nav_decks);
+        mNavigationView.requestFocus();
+    }
+
+
+    @Override
+    public boolean onKeyDown(int keyCode, KeyEvent event) {
+        if (!isDrawerOpen()) {
+            return super.onKeyDown(keyCode, event);
+        }
+
+        if (keyCode == KeyEvent.KEYCODE_DPAD_RIGHT) {
+            closeDrawer();
+            return true;
+        }
+
+        return super.onKeyDown(keyCode, event);
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -18,11 +18,13 @@
 
 package com.ichi2.anki;
 
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
+import android.content.res.ColorStateList;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.os.Bundle;
@@ -45,6 +47,7 @@ import android.widget.TextView;
 import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
+import androidx.appcompat.view.menu.MenuBuilder;
 import androidx.appcompat.app.ActionBar;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
@@ -544,6 +547,9 @@ public class Reviewer extends AbstractFlashcardViewer {
     public boolean onCreateOptionsMenu(Menu menu) {
         // NOTE: This is called every time a new question is shown via invalidate options menu
         getMenuInflater().inflate(R.menu.reviewer, menu);
+
+        displayIconsOnTv(menu);
+
         mActionButtons.setCustomButtonsStatus(menu);
         int alpha = (getControlBlocked() != ReviewerUi.ControlBlock.SLOW) ? Themes.ALPHA_ICON_ENABLED_LIGHT : Themes.ALPHA_ICON_DISABLED_LIGHT ;
         MenuItem markCardIcon = menu.findItem(R.id.action_mark_card);
@@ -674,6 +680,42 @@ public class Reviewer extends AbstractFlashcardViewer {
     }
 
 
+    @SuppressLint("RestrictedApi") // setIconTintList
+    private void displayIconsOnTv(Menu menu) {
+        try {
+            if (AndroidUiUtils.isRunningOnTv(this) && menu instanceof MenuBuilder) {
+                MenuBuilder m = (MenuBuilder) menu;
+                m.setOptionalIconsVisible(true);
+            }
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                for (int i = 0; i < menu.size(); i++) {
+                    MenuItem m = menu.getItem(i);
+
+                    if (m == null || isFlagResource(m.getItemId())) {
+                        continue;
+                    }
+
+                    int color = Themes.getColorFromAttr(this, R.attr.navDrawerItemColor);
+                    m.setIconTintList(ColorStateList.valueOf(color));
+
+                }
+            }
+
+        } catch (Exception e) {
+            Timber.w(e, "Failed to display icons");
+        } catch (Error e) {
+            Timber.w(e, "Failed to display icons");
+        }
+    }
+
+
+    private boolean isFlagResource(int itemId) {
+        return itemId == R.id.action_flag_four
+                || itemId == R.id.action_flag_three
+                || itemId == R.id.action_flag_two
+                || itemId == R.id.action_flag_one;
+    }
     @Override
     public boolean onKeyDown(int keyCode, KeyEvent event) {
         if (mProcessor.onKeyDown(keyCode, event) || super.onKeyDown(keyCode, event)) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtonStatus.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtonStatus.java
@@ -76,6 +76,12 @@ public class ActionButtonStatus {
         for(int itemId : mCustomButtons.keySet()) {
             if (mCustomButtons.get(itemId) != MENU_DISABLED) {
                 MenuItem item = menu.findItem(itemId);
+                if (item == null) {
+                    // Happens with TV - removing flag icon
+                    Timber.w("Could not find Menu Item %d", itemId);
+                    continue;
+                }
+
                 item.setShowAsAction(mCustomButtons.get(itemId));
                 Drawable icon = item.getIcon();
                 item.setEnabled(!mReviewerUi.isControlBlocked());

--- a/AnkiDroid/src/main/java/com/ichi2/ui/TvNavigationElement.java
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/TvNavigationElement.java
@@ -1,0 +1,115 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.ui;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.content.ContextWrapper;
+import android.graphics.Rect;
+import android.os.Build;
+import android.util.AttributeSet;
+import android.view.View;
+
+import com.ichi2.anki.NavigationDrawerActivity;
+
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
+import androidx.appcompat.app.ActionBar;
+import androidx.appcompat.app.AppCompatActivity;
+import timber.log.Timber;
+
+/** Hack to allow the navigation and options menu to appear when on a TV
+ *  This is a view to handle dispatchUnhandledMove without using onKeyUp/Down
+ *  (which interferes with other view events) */
+public class TvNavigationElement extends View {
+    public TvNavigationElement(Context context) {
+        super(context);
+    }
+
+
+    public TvNavigationElement(Context context, @Nullable AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+
+    public TvNavigationElement(Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+
+    @SuppressWarnings( {"unused", "RedundantSuppression"})
+    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+    public TvNavigationElement(Context context, @Nullable AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+        super(context, attrs, defStyleAttr, defStyleRes);
+    }
+
+
+    @Override
+    protected void onFocusChanged(boolean gainFocus, int direction, @Nullable Rect previouslyFocusedRect) {
+        Timber.d("onFocusChanged %d", direction);
+        super.onFocusChanged(gainFocus, direction, previouslyFocusedRect);
+    }
+
+
+    @Override
+    public boolean dispatchUnhandledMove(View focused, int direction) {
+        Timber.d("dispatchUnhandledMove %d", direction);
+
+        AppCompatActivity activity = getActivity();
+        if (activity == null) {
+            return super.dispatchUnhandledMove(focused, direction);
+        }
+
+        if (direction == FOCUS_LEFT && activity instanceof NavigationDrawerActivity) {
+            // COULD_BE_BETTER: This leaves focus on the top item when navigation occurs.
+            NavigationDrawerActivity navigationDrawerActivity = (NavigationDrawerActivity) activity;
+            navigationDrawerActivity.toggleDrawer();
+            navigationDrawerActivity.focusNavigation();
+            return true;
+        }
+
+        if (direction == FOCUS_RIGHT) {
+            Timber.d("Opening options menu");
+            // COULD_BE_BETTER: This crashes inside the framework if right is pressed on the
+            openOptionsMenu(activity);
+            return true;
+        }
+        return super.dispatchUnhandledMove(focused, direction);
+    }
+
+
+    @SuppressLint("RestrictedApi")
+    private void openOptionsMenu(AppCompatActivity activity) {
+        // This occasionally glitches graphically on my emulator
+        ActionBar supportActionBar = activity.getSupportActionBar();
+        if (supportActionBar != null) {
+            supportActionBar.openOptionsMenu();
+        }
+    }
+
+
+    private AppCompatActivity getActivity() {
+        Context context = getContext();
+        while (context instanceof ContextWrapper) {
+            if (context instanceof AppCompatActivity) {
+                return (AppCompatActivity)context;
+            }
+            context = ((ContextWrapper)context).getBaseContext();
+        }
+        return null;
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/utils/AndroidUiUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/AndroidUiUtils.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.utils;
+
+import android.app.UiModeManager;
+import android.content.Context;
+import android.content.res.Configuration;
+
+import static androidx.core.content.ContextCompat.getSystemService;
+
+public class AndroidUiUtils {
+    public static boolean isRunningOnTv(Context context) {
+        UiModeManager uiModeManager = getSystemService(context, UiModeManager.class);
+        if (uiModeManager == null) {
+            return false;
+        }
+        return uiModeManager.getCurrentModeType() == Configuration.UI_MODE_TYPE_TELEVISION;
+    }
+
+}

--- a/AnkiDroid/src/main/res/layout-television/reviewer.xml
+++ b/AnkiDroid/src/main/res/layout-television/reviewer.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+  ~
+  ~  This program is free software; you can redistribute it and/or modify it under
+  ~  the terms of the GNU General Public License as published by the Free Software
+  ~  Foundation; either version 3 of the License, or (at your option) any later
+  ~  version.
+  ~
+  ~  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+  ~  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  ~  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+  ~
+  ~  You should have received a copy of the GNU General Public License along with
+  ~  this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<androidx.drawerlayout.widget.DrawerLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/drawer_layout"
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:fitsSystemWindows="true"
+    android:focusable="false" >
+    <!-- First child of DrawerLayout assumed to be main content, others are drawers.
+     We use a Coordinator layout as root View for main content as it allows snackbars
+     to be swiped off screen. Other behaviors can also be added in the future if necessary -->
+    <androidx.coordinatorlayout.widget.CoordinatorLayout
+        android:id="@+id/root_layout"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" >
+        <!-- Bring in each component from separate files as we have fullscreen versions of reviewer -->
+        <RelativeLayout
+            android:id="@+id/front_frame"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+            <include layout="@layout/toolbar"
+                android:focusable="false" />
+
+            <include
+                layout="@layout/reviewer_topbar"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_below="@id/toolbar"
+                android:focusable="false" />
+
+            <include
+                layout="@layout/reviewer_mic_tool_bar"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_below="@id/top_bar"
+                android:focusable="false"/>
+
+            <include
+                layout="@layout/reviewer_flashcard"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_below="@id/mic_tool_bar_layer"
+                android:focusable="false" />
+
+            <include
+                android:id="@+id/reviewer_whiteboard_pen_color_layout"
+                layout="@layout/reviewer_whiteboard_pen_color"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_centerHorizontal="true"
+                android:layout_above="@+id/bottom_area_layout"
+                android:focusable="true" />
+
+            <!-- Move this to AnkiActivity -->
+            <com.ichi2.ui.TvNavigationElement
+                android:id="@+id/tv_nav_view"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:focusable="true"/>
+
+            <include layout="@layout/reviewer_answer_buttons"
+                android:focusable="true" >
+                <requestFocus />
+            </include>
+        </RelativeLayout>
+    </androidx.coordinatorlayout.widget.CoordinatorLayout>
+    <!-- Left navigation drawer -->
+    <include layout="@layout/navigation_drawer" />
+</androidx.drawerlayout.widget.DrawerLayout>

--- a/AnkiDroid/src/main/res/layout/reviewer_answer_buttons.xml
+++ b/AnkiDroid/src/main/res/layout/reviewer_answer_buttons.xml
@@ -71,12 +71,15 @@
             android:layout_width="fill_parent"
             android:layout_height="fill_parent"
             android:visibility="gone"
+            android:focusable="false"
             android:orientation="horizontal">
 
             <LinearLayout
                 style="@style/FooterButton"
                 android:background="?attr/againButtonRef"
                 android:id="@+id/flashcard_layout_ease1"
+                android:nextFocusRight="@id/flashcard_layout_ease2"
+                android:nextFocusLeft="@id/flashcard_layout_ease4"
                 android:layout_width="0dip"
                 android:layout_height="@dimen/touch_target"
                 android:layout_weight="1"
@@ -97,6 +100,8 @@
                 style="@style/FooterButton"
                 android:background="?attr/hardButtonRef"
                 android:id="@+id/flashcard_layout_ease2"
+                android:nextFocusRight="@id/flashcard_layout_ease3"
+                android:nextFocusLeft="@id/flashcard_layout_ease1"
                 android:layout_width="0dip"
                 android:layout_height="@dimen/touch_target"
                 android:layout_weight="1"
@@ -117,6 +122,8 @@
                 style="@style/FooterButton"
                 android:background="?attr/goodButtonRef"
                 android:id="@+id/flashcard_layout_ease3"
+                android:nextFocusRight="@id/flashcard_layout_ease4"
+                android:nextFocusLeft="@id/flashcard_layout_ease2"
                 android:layout_width="0dip"
                 android:layout_height="@dimen/touch_target"
                 android:layout_weight="1"
@@ -137,6 +144,8 @@
                 style="@style/FooterButton"
                 android:background="?attr/easyButtonRef"
                 android:id="@+id/flashcard_layout_ease4"
+                android:nextFocusRight="@id/flashcard_layout_ease1"
+                android:nextFocusLeft="@id/flashcard_layout_ease3"
                 android:layout_width="0dip"
                 android:layout_height="@dimen/touch_target"
                 android:layout_weight="1"
@@ -159,10 +168,12 @@
             android:layout_width="fill_parent"
             android:layout_height="@dimen/touch_target"
             android:orientation="vertical"
+            android:focusable="true"
             tools:visibility="gone">
 
             <Button
                 style="@style/FooterButton"
+                android:duplicateParentState="true"
                 android:background="?attr/hardButtonRef"
                 android:id="@+id/flip_card"
                 android:layout_width="fill_parent"

--- a/AnkiDroid/src/main/res/menu-television/reviewer.xml
+++ b/AnkiDroid/src/main/res/menu-television/reviewer.xml
@@ -1,0 +1,132 @@
+<!--
+  ~  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+  ~
+  ~  This program is free software; you can redistribute it and/or modify it under
+  ~  the terms of the GNU General Public License as published by the Free Software
+  ~  Foundation; either version 3 of the License, or (at your option) any later
+  ~  version.
+  ~
+  ~  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+  ~  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  ~  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+  ~
+  ~  You should have received a copy of the GNU General Public License along with
+  ~  this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:ankidroid="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/action_clear_whiteboard"
+        android:title="@string/clear_whiteboard"
+        android:icon="@drawable/ic_clear_white_24dp"
+        android:visible="false"
+        ankidroid:showAsAction="always"/>
+    <item
+        android:id="@+id/action_hide_whiteboard"
+        android:title="@string/hide_whiteboard"
+        android:icon="@drawable/ic_gesture_white_24dp"
+        android:visible="false"
+        ankidroid:showAsAction="always"/>
+    <item
+        android:id="@+id/action_change_whiteboard_pen_color"
+        android:icon="@drawable/ic_color_lens_white_24dp"
+        android:title="@string/title_whiteboard_pen_color"
+        android:visible="false"
+        ankidroid:showAsAction="ifRoom"/>
+    <item
+        android:id="@+id/action_undo"
+        android:enabled="false"
+        android:icon="@drawable/ic_undo_white_24dp"
+        android:title="@string/undo"
+        ankidroid:showAsAction="always"/>
+    <item
+        android:id="@+id/action_flag_zero"
+        android:title="@string/menu_flag_card_zero"/>
+    <item
+        android:id="@+id/action_flag_one"
+        android:title="@string/menu_flag_card_one"
+        android:icon="@drawable/ic_flag_red"/>
+    <item
+        android:id="@+id/action_flag_two"
+        android:title="@string/menu_flag_card_two"
+        android:icon="@drawable/ic_flag_orange"/>
+    <item
+        android:id="@+id/action_flag_three"
+        android:title="@string/menu_flag_card_three"
+        android:icon="@drawable/ic_flag_green"/>
+    <item
+        android:id="@+id/action_flag_four"
+        android:title="@string/menu_flag_card_four"
+        android:icon="@drawable/ic_flag_blue"/>
+    <item
+        android:id="@+id/action_save_whiteboard"
+        android:title="@string/save_whiteboard"
+        android:visible="false"
+        ankidroid:showAsAction="never"/>
+    <item
+        android:id="@+id/action_toggle_whiteboard"
+        android:title="@string/enable_whiteboard"
+        android:icon="@drawable/ic_gesture_white_24dp"
+        ankidroid:showAsAction="never"/>
+    <item
+        android:id="@+id/action_edit"
+        android:icon="@drawable/ic_mode_edit_white_24dp"
+        android:title="@string/cardeditor_title_edit_card"
+        ankidroid:showAsAction="ifRoom"/>
+    <item
+        android:id="@+id/action_add_note_reviewer"
+        android:title="@string/menu_add_note"
+        android:icon="@drawable/ic_add_white_24dp"
+        ankidroid:showAsAction="never"/>
+    <item
+        android:id="@+id/action_tag"
+        android:icon="@drawable/ic_tag"
+        android:title="@string/menu_edit_tags"
+        ankidroid:showAsAction="never"/>
+    <item
+        android:id="@+id/action_replay"
+        android:title="@string/replay_audio"
+        android:icon="@drawable/ic_play_circle_white"
+        ankidroid:showAsAction="ifRoom"/>
+    <item
+        android:id="@+id/action_toggle_mic_tool_bar"
+        android:title="@string/toggle_mic_tool_bar"
+        android:icon="@drawable/ic_action_mic"
+        ankidroid:showAsAction="never"/>
+    <item
+        android:id="@+id/action_bury"
+        android:title="@string/menu_bury"
+        android:icon="@drawable/ic_flip_to_back_white_24dp"/>
+    <item
+        android:id="@+id/action_suspend"
+        android:title="@string/menu_suspend"
+        android:icon="@drawable/ic_action_suspend" />
+    <item
+        android:id="@+id/action_delete"
+        android:title="@string/menu_delete_note"
+        android:icon="@drawable/ic_delete_white_24dp"/>
+    <item
+        android:id="@+id/action_mark_card"
+        android:icon="@drawable/ic_star_outline_white_24dp"
+        android:title="@string/menu_mark_note"
+        ankidroid:showAsAction="ifRoom"/>
+    <item
+        android:id="@+id/action_schedule"
+        android:title="@string/card_editor_reschedule_card"
+        android:icon="@drawable/ic_card_reschedule_white">
+        <menu/>
+    </item>
+    <item
+        android:id="@+id/action_search_dictionary"
+        android:title="@string/menu_select"
+        android:visible="false"/>
+    <item
+        android:id="@+id/action_open_deck_options"
+        android:title="@string/study_options" />
+    <item
+        android:id="@+id/action_select_tts"
+        android:title="@string/select_tts"
+        android:visible="false" />
+</menu>


### PR DESCRIPTION
## Purpose / Description
Enable TV Support for the reviewer

This is much better than it was, but there's still room for improvement. I'm not sure if this takes it in the right direction as most of this feels hacky.

This is fairly hacky - we use a hidden view to handle the additional nav events to show the nav drawer/options.

~~It feels like there's an extra element, so pressing up to access the menu sometimes does not work. I haven't been able to figure out why.~~

~~We get a crash from the framework when navigating back from an option menu with submenus (flags in the reviewer, for example)~~


## Fixes
Fixes #1643 (reviewer)

## How Has This Been Tested?

Android TV emulator

## Learning

We shouldn't be using action bars and should write our own UI


## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code