### PR TITLE
Inversion: Stop lowercasing invalid color codes

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/themes/HtmlColors.java
+++ b/AnkiDroid/src/main/java/com/ichi2/themes/HtmlColors.java
@@ -65,6 +65,9 @@ public class HtmlColors {
                                 0xff - Integer.parseInt(m2.group(2)),
                                 0xff - Integer.parseInt(m2.group(3)));
                     }
+                } else {
+                    // nameToHex lowercases invalid input - reverse this.
+                    color = m1.group(2);
                 }
             } catch (NumberFormatException e) {
                 // shouldn't happen but ignore anyway

--- a/AnkiDroid/src/test/java/com/ichi2/themes/HtmlColorsTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/themes/HtmlColorsTest.java
@@ -1,0 +1,30 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.themes;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class HtmlColorsTest {
+    @Test
+    public void testDleColorInversion() {
+        // An invalid color code should not be changed.
+        assertThat(HtmlColors.invertColors(" color:DLE "), is(" color:DLE "));
+    }
+}


### PR DESCRIPTION
## Purpose / Description
The input: " color:DLE " was changed to " color:dle ", this was unintentional

## Fixes
Fixes #7059

## Approach
Use the input value if nothing was matched

## How Has This Been Tested?

Unit test only

## Learning
We need more work on color inversion

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code