### PR TITLE
[Bugfix] Allow searches on tags containing brackets

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1401,7 +1401,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
             } else {
                 sb.append("("); // Only if we really have selected tags
             }
-            sb.append("tag:").append(tag).append(" ");
+            // 7070: quote tags so brackets are properly escaped
+            sb.append("tag:").append("'").append(tag).append("'").append(" ");
             i++;
         }
         if (i > 0) {
@@ -2502,5 +2503,11 @@ public class CardBrowser extends NavigationDrawerActivity implements
             }
         }
         throw new IllegalStateException(String.format(Locale.US, "Card '%d' not found", cardId));
+    }
+
+
+    @VisibleForTesting
+    void filterByTag(String... tags) {
+        filterByTag(Arrays.asList(tags), 0);
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
@@ -283,6 +283,18 @@ public class CardBrowserTest extends RobolectricTest {
         assertThat("Activity should be cancelled as it did nothing", shadowActivity.getResultCode(), is(Activity.RESULT_CANCELED));
     }
 
+    @Test
+    public void tagWithBracketsDisplaysProperly() {
+        Note n = addNoteUsingBasicModel("Hello", "World");
+        n.addTag("sketchy::(1)");
+        n.flush();
+
+        CardBrowser b = getBrowserWithNoNewCards();
+        b.filterByTag("sketchy::(1)");
+
+        assertThat("tagged card should be returned", b.getCardCount(), is(1));
+    }
+
 
     private void flagCardForNote(Note n, int flag) {
         Card c = n.firstCard();


### PR DESCRIPTION
## Purpose / Description
A search for a tag with brackets failed

The tag search for filtered decks already used this code, so no changes necessary

## Fixes
Fixes #7070

## Approach
Quote the string

## How Has This Been Tested?

Unit test and on my phone

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code