### PR TITLE
IMPORT_REPLACE: run when collection corrupt

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Media.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Media.java
@@ -56,6 +56,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipOutputStream;
 
+import androidx.annotation.NonNull;
 import timber.log.Timber;
 
 import static java.lang.Math.min;
@@ -124,7 +125,7 @@ public class Media {
             return;
         }
         // media directory
-        mDir = col.getPath().replaceFirst("\\.anki2$", ".media");
+        mDir = getCollectionMediaPath(col.getPath());
         File fd = new File(mDir);
         if (!fd.exists()) {
             if (!fd.mkdir()) {
@@ -133,6 +134,12 @@ public class Media {
         }
         // change database
         connect();
+    }
+
+
+    @NonNull
+    public static String getCollectionMediaPath(String collectionPath) {
+        return collectionPath.replaceFirst("\\.anki2$", ".media");
     }
 
 


### PR DESCRIPTION
## Purpose / Description
This is used in anti-corruption procedures, so should not require a valid collection for it to work.

## Fixes
Fixes #7073

## Approach
Stop using `getCol()` and ensure the method does not require an open col

## How Has This Been Tested?

On my device - a corrupt database (v15) can now use restore from backup

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code