### PR TITLE
Add WakeLock to Deck Import

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -108,6 +108,7 @@ import com.ichi2.async.Connection.Payload;
 import com.ichi2.async.CollectionTask;
 import com.ichi2.async.TaskListener;
 import com.ichi2.async.TaskListenerWithContext;
+import com.ichi2.async.WakeLockTaskListener;
 import com.ichi2.compat.CompatHelper;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Decks;
@@ -289,9 +290,9 @@ public class DeckPicker extends NavigationDrawerActivity implements
     };
 
         private final ImportAddListener mImportAddListener = new ImportAddListener(this);
-    private static class ImportAddListener extends TaskListenerWithContext<DeckPicker> {
+    private static class ImportAddListener extends WakeLockTaskListener<DeckPicker> {
         public ImportAddListener(DeckPicker deckPicker) {
-            super(deckPicker);
+            super(deckPicker, "DeckPickerImportDeck");
         }
 
         @Override

--- a/AnkiDroid/src/main/java/com/ichi2/async/TaskListenerWithContext.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/TaskListenerWithContext.java
@@ -14,11 +14,12 @@ public abstract class TaskListenerWithContext<CTX> extends TaskListener {
 
 
     final public void onPreExecute() {
+        onBeforePreExecute();
         CTX context = mContext.get();
         if (context != null) {
             actualOnPreExecute(context);
         }
-    };
+    }
 
 
     final public void onProgressUpdate(TaskData value) {
@@ -45,6 +46,7 @@ public abstract class TaskListenerWithContext<CTX> extends TaskListener {
 
 
     final public void onPostExecute(TaskData result) {
+        onBeforePostExecute(result);
         CTX context = mContext.get();
         if (context != null) {
             actualOnPostExecute(context, result);
@@ -71,5 +73,13 @@ public abstract class TaskListenerWithContext<CTX> extends TaskListener {
     /** Assumes context exists. */
     public void actualOnCancelled(@NonNull CTX context) {
         // most implementations do nothing with this, provide them a default implementation
+    }
+
+
+    protected void onBeforePreExecute() {
+    }
+
+
+    protected void onBeforePostExecute(TaskData result) {
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/async/WakeLockTaskListener.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/WakeLockTaskListener.java
@@ -1,0 +1,125 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.async;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.os.PowerManager;
+
+import com.ichi2.anki.AnkiDroidApp;
+import com.ichi2.anki.R;
+import com.ichi2.utils.Permissions;
+
+import androidx.annotation.CallSuper;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import timber.log.Timber;
+
+import static android.os.PowerManager.*;
+
+@SuppressLint("DirectSystemCurrentTimeMillisUsage")
+public abstract class WakeLockTaskListener<TContext extends Context> extends TaskListenerWithContext<TContext> {
+
+    /* 30 minutes */
+    private static final long TIMEOUT_MS = 30 * 60 * 1000L;
+
+    @Nullable
+    private final PowerManager.WakeLock mWakeLock;
+    private final String mWakeLockName;
+
+    private long startTime;
+
+
+    public WakeLockTaskListener(TContext context, String wakeLockName) {
+        super(context);
+        this.mWakeLockName = wakeLockName;
+
+        mWakeLock = getWakeLock(context, wakeLockName);
+    }
+
+
+    @Nullable
+    private PowerManager.WakeLock getWakeLock(TContext context, String wakeLockName) {
+        try {
+            PowerManager pm = (PowerManager) context.getSystemService(Context.POWER_SERVICE);
+            return pm.newWakeLock(PARTIAL_WAKE_LOCK,
+                    context.getString(R.string.app_name) + ":" + wakeLockName);
+        } catch (Exception e) {
+            Timber.w(e, "Failed to obtain WakeLock");
+            return null;
+        }
+    }
+
+
+    @Override
+    @CallSuper
+    public void onCancelled() {
+        try {
+            super.onCancelled();
+        } finally {
+            releaseLock();
+        }
+    }
+
+    @Override
+    @CallSuper
+    protected void onBeforePreExecute() {
+        startTime = getCurrentRealTime();
+        if (mWakeLock != null && Permissions.canUseWakeLock(AnkiDroidApp.getInstance().getApplicationContext())) {
+            acquireLock(mWakeLock);
+        }
+    }
+
+
+    private void acquireLock(@NonNull PowerManager.WakeLock wakeLock) {
+        try {
+            wakeLock.acquire(TIMEOUT_MS);
+        } catch (Exception e) {
+            AnkiDroidApp.sendExceptionReport(e, "wakeLock " + mWakeLockName);
+        }
+    }
+
+
+    @Override
+    @CallSuper
+    protected void onBeforePostExecute(TaskData result) {
+        releaseLock();
+    }
+
+
+    private void releaseLock() {
+        if (mWakeLock == null) {
+            return;
+        }
+        if (mWakeLock.isHeld()) {
+            try {
+                mWakeLock.release();
+            } catch (Exception e) {
+                AnkiDroidApp.sendExceptionReport(e, "wakeLock " + mWakeLockName, "failed to release lock");
+            }
+        }
+        long elapsed = getCurrentRealTime() - startTime;
+        if (elapsed > TIMEOUT_MS) {
+            // Log a silent exception
+            AnkiDroidApp.sendExceptionReport(new RuntimeException("Operation exceeded wakelock time"), mWakeLockName, Long.toString(elapsed), true);
+        }
+    }
+
+    private long getCurrentRealTime() {
+        return System.currentTimeMillis();
+    }
+}

--- a/lint-release.xml
+++ b/lint-release.xml
@@ -22,6 +22,7 @@
 <lint>
     <issue id="NewApi" severity="fatal" />
     <issue id="InlinedApi" severity="fatal" />
+    <issue id="MissingSuperCall" severity="fatal" />
     <issue id="StringFormatCount" severity="fatal" />
     <issue id="StringFormatMatches" severity="fatal" />
     <issue id="StringFormatInvalid" severity="fatal" />
@@ -80,7 +81,6 @@
     <issue id="ButtonOrder" severity="ignore" />
     <issue id="ButtonStyle" severity="ignore" />
     <issue id="ByteOrderMark" severity="ignore" />
-    <issue id="MissingSuperCall" severity="ignore" />
     <issue id="AdapterViewChildren" severity="ignore" />
     <issue id="ScrollViewCount" severity="ignore" />
     <issue id="PermissionImpliesUnsupportedChromeOsHardware" severity="ignore" />


### PR DESCRIPTION
## Purpose / Description
User needs to keep tapping on their screen to keep the import going. This is annoying on large decks

## Fixes
Related #7077 

## Approach
Take a WakeLock

## How Has This Been Tested?

Untested, don't have enough space on my phone to test, and emulator doesn't sleep

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code