### PR TITLE
Correct #7076

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -935,7 +935,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         // Initialize dictionary lookup feature
         Lookup.initialize(this);
 
-        updateScreenCounts();
+        updateActionBar();
         supportInvalidateOptionsMenu();
     }
 
@@ -966,7 +966,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         mSoundPlayer.setContext(new WeakReference<Activity>(this));
         // Reset the activity title
         setTitle();
-        updateScreenCounts();
+        updateActionBar();
         selectNavigationItem(-1);
     }
 
@@ -1823,7 +1823,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
 
 
     private void updateForNewCard() {
-        updateScreenCounts();
+        updateActionBar();
 
         // Clean answer field
         if (typeAnswer()) {
@@ -1836,7 +1836,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
     }
 
 
-    protected void updateScreenCounts() {
+    protected void updateActionBar() {
         if (mCurrentCard == null) return;
         ActionBar actionBar = getSupportActionBar();
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -52,9 +52,8 @@ import androidx.core.content.ContextCompat;
 import androidx.core.net.ConnectivityManagerCompat;
 import androidx.core.view.GestureDetectorCompat;
 import androidx.appcompat.app.ActionBar;
-import android.text.SpannableString;
+
 import android.text.TextUtils;
-import android.text.style.UnderlineSpan;
 import android.util.Pair;
 import android.util.TypedValue;
 import android.view.GestureDetector.SimpleOnGestureListener;
@@ -1837,6 +1836,10 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
 
 
     protected void updateActionBar() {
+        updateDeckName();
+    }
+
+    protected void updateDeckName() {
         if (mCurrentCard == null) return;
         ActionBar actionBar = getSupportActionBar();
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.java
@@ -201,11 +201,6 @@ public class Previewer extends AbstractFlashcardViewer {
     }
 
 
-    // we don't want the Activity title to be changed.
-    @Override
-    protected void updateActionBar() { /* do nothing */ }
-
-
     @Override
     public boolean executeCommand(int which) {
         /* do nothing */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.java
@@ -203,7 +203,7 @@ public class Previewer extends AbstractFlashcardViewer {
 
     // we don't want the Activity title to be changed.
     @Override
-    protected void updateScreenCounts() { /* do nothing */ }
+    protected void updateActionBar() { /* do nothing */ }
 
 
     @Override

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -788,6 +788,11 @@ public class Reviewer extends AbstractFlashcardViewer {
 
     @Override
     protected void updateActionBar() {
+        super.updateActionBar();
+        updateScreenCounts();
+    }
+
+    protected void updateScreenCounts() {
         if (mCurrentCard == null) return;
         super.updateActionBar();
         ActionBar actionBar = getSupportActionBar();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -787,9 +787,9 @@ public class Reviewer extends AbstractFlashcardViewer {
     }
 
     @Override
-    protected void updateScreenCounts() {
+    protected void updateActionBar() {
         if (mCurrentCard == null) return;
-        super.updateScreenCounts();
+        super.updateActionBar();
         ActionBar actionBar = getSupportActionBar();
         int[] counts = mSched.counts(mCurrentCard);
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -789,6 +789,7 @@ public class Reviewer extends AbstractFlashcardViewer {
     @Override
     protected void updateScreenCounts() {
         if (mCurrentCard == null) return;
+        super.updateScreenCounts();
         ActionBar actionBar = getSupportActionBar();
         int[] counts = mSched.counts(mCurrentCard);
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.java
@@ -1,3 +1,4 @@
+
 package com.ichi2.anki;
 
 import android.content.Intent;
@@ -12,6 +13,8 @@ import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Consts;
+import com.ichi2.libanki.Deck;
+import com.ichi2.libanki.Decks;
 import com.ichi2.libanki.Model;
 import com.ichi2.libanki.Models;
 import com.ichi2.libanki.Note;
@@ -356,5 +359,22 @@ public class ReviewerTest extends RobolectricTest {
             return visibleButtons;
         }
     }
+
+    @Test
+    public void baseDeckName() {
+        Collection col = getCol();
+        Models models = col.getModels();
+
+        Decks decks = col.getDecks();
+        Long didAb = decks.id("A::B");
+        Model basic = models.byName(AnkiDroidApp.getAppResources().getString(R.string.basic_model_name));
+        basic.put("did", didAb);
+        addNoteUsingBasicModel("foo", "bar");
+        Long didA = decks.id("A");
+        decks.select(didA);
+        Reviewer reviewer = startReviewer();
+        assertThat(reviewer.getSupportActionBar().getTitle(), is("B"));
+    }
+
 }
 


### PR DESCRIPTION
When I split updateScreenCounts in two, in 08bb0597601de2995c81e16ee6b187b68a60a49a, I forgot to call super. So of
course the part of the method which is general to all reviewer was not called.

Tested by running an emulator, adding cards in a new deck A::B, reviewing A and seeing that the title shown is "B"

Edit:
* The previewer show deck but no count

![2020-09-13-195430_622x1151_scrot](https://user-images.githubusercontent.com/357361/93025026-06543600-f5fb-11ea-96be-2969f0dfd437.png)

Fixes #7076
