### PR TITLE
[BugFix]: Restore backups as writable database

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -50,6 +50,7 @@ import com.ichi2.libanki.DeckConfig;
 import com.ichi2.libanki.Deck;
 import com.ichi2.libanki.importer.AnkiPackageImporter;
 
+import com.ichi2.libanki.utils.Time;
 import com.ichi2.utils.JSONArray;
 import com.ichi2.utils.JSONException;
 import com.ichi2.utils.JSONObject;
@@ -1445,9 +1446,10 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
 
         if (hasValidCol()) {
             // unload collection and trigger a backup
+            Time time = CollectionHelper.getInstance().getTimeSafe(mContext);
             CollectionHelper.getInstance().closeCollection(true, "Importing new collection");
             CollectionHelper.getInstance().lockCollection();
-            BackupManager.performBackupInBackground(colPath, true, CollectionHelper.getInstance().getTimeSafe(mContext));
+            BackupManager.performBackupInBackground(colPath, true, time);
         }
         // overwrite collection
         File f = new File(colFile);

--- a/AnkiDroid/src/test/java/com/ichi2/anki/BackupManagerIntegrationTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/BackupManagerIntegrationTest.java
@@ -1,0 +1,78 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki;
+
+import com.ichi2.async.CollectionTask.TASK_TYPE;
+import com.ichi2.async.TaskData;
+import com.ichi2.testutils.AnkiAssert;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.shadows.ShadowStatFs;
+
+import java.io.File;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@RunWith(AndroidJUnit4.class)
+public class BackupManagerIntegrationTest extends RobolectricTest {
+
+    @Test
+    @Ignore("Fails on line: if (!f.renameTo(new File(colPath))) {")
+    public void restoreBackupLeavesCollectionWritable() throws InterruptedException {
+        getCol();
+        String path = createBackup();
+
+        // Perform a write
+        addNoteUsingBasicModel("Hello", "World");
+
+        waitForTask(TASK_TYPE.IMPORT_REPLACE, new TaskData(path), 1000);
+
+        assertThat("database should be read-write", getCol().getDb().getDatabase().isReadOnly(), is(false));
+        AnkiAssert.assertDoesNotThrow(() -> addNoteUsingBasicModel("Hello", "World"));
+    }
+
+
+    private String createBackup() {
+        int blockCount = 100000;
+        ShadowStatFs.registerStats(new File(getCol().getPath()).getParentFile().getPath(), blockCount, blockCount, blockCount);
+
+        assertThat("Backup should work", BackupManager.performBackupInBackground(getCol().getPath(), getCol().getTime()), is(true));
+
+        return spinUntilBackupExists(1000);
+    }
+
+
+    private String spinUntilBackupExists(int timeoutMs) {
+        long time = System.currentTimeMillis();
+        while (true) {
+            File colFile = new File(getCol().getPath());
+            File[] backups = BackupManager.getBackups(colFile);
+            if (backups.length > 0) {
+                return backups[0].getAbsolutePath();
+            }
+
+            if (System.currentTimeMillis() - time > timeoutMs) {
+                throw new RuntimeException("span for longer than " + timeoutMs);
+            }
+        }
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
@@ -54,6 +54,7 @@ import org.robolectric.shadows.ShadowLog;
 
 import java.util.ArrayList;
 
+import androidx.annotation.Nullable;
 import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory;
 import androidx.test.core.app.ApplicationProvider;
 import timber.log.Timber;
@@ -287,7 +288,14 @@ public class RobolectricTest {
     }
 
 
+
+
     protected synchronized void waitForTask(CollectionTask.TASK_TYPE taskType, int timeoutMs) throws InterruptedException {
+        waitForTask(taskType, null, timeoutMs);
+    }
+
+
+    protected synchronized void waitForTask(CollectionTask.TASK_TYPE taskType, @Nullable TaskData data, int timeoutMs) throws InterruptedException {
         boolean[] completed = new boolean[] { false };
         TaskListener listener = new TaskListener() {
             @Override
@@ -298,13 +306,18 @@ public class RobolectricTest {
 
             @Override
             public void onPostExecute(TaskData result) {
+
+                if (result == null || !result.getBoolean()) {
+                    throw new IllegalArgumentException("Task failed");
+                }
                 completed[0] = true;
                 synchronized (RobolectricTest.this) {
                     RobolectricTest.this.notify();
                 }
             }
         };
-        CollectionTask.launchCollectionTask(taskType, listener);
+        CollectionTask.launchCollectionTask(taskType, listener, data);
+
 
         wait(timeoutMs);
 


### PR DESCRIPTION
## Purpose / Description
App crashed after a database write if backups were restored from

## Fixes
Fixes #7083 

## Approach
Simple 1-line fix to move time acquisition to before database locking

## How Has This Been Tested?

🛑 Manually, sadly, I could not get the test to fail on Windows

## Learning

By default, Robolectric assigns you 0 disk space

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code