### PR TITLE
Implement special field decoration mode

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -94,6 +94,7 @@ import com.ichi2.utils.AdaptionUtil;
 import com.ichi2.utils.DeckComparator;
 import com.ichi2.utils.FunctionalInterfaces.Consumer;
 import com.ichi2.utils.NamedJSONComparator;
+import com.ichi2.utils.NoteFieldDecorator;
 import com.ichi2.widget.WidgetStatus;
 
 import com.ichi2.utils.JSONArray;
@@ -1498,6 +1499,29 @@ public class NoteEditor extends AnkiActivity {
 
         // Listen for changes in the first field so we can re-check duplicate status.
         editText.addTextChangedListener(new EditFieldTextWatcher(index));
+        if (index == 0) {
+            editText.setOnFocusChangeListener((v, hasFocus) -> {
+                try {
+                    if (hasFocus) {
+                        // we only want to decorate when we lose focus
+                        return;
+                    }
+                    String[] currentFieldStrings = getCurrentFieldStrings();
+                    if (currentFieldStrings.length != 2 || currentFieldStrings[1].length() > 0) {
+                        // we only decorate on 2-field cards while second field is still empty
+                        return;
+                    }
+                    String firstField = currentFieldStrings[0];
+                    String decoratedText = NoteFieldDecorator.aplicaHuevo(firstField);
+                    if (!decoratedText.equals(firstField)) {
+                        // we only apply the decoration if it is actually different from the first field
+                        setFieldValueFromUi(1, decoratedText);
+                    }
+                } catch (Exception e) {
+                    Timber.w(e, "Unable to decorate text field");
+                }
+            });
+        }
         editText.setEnabled(enabled);
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/utils/NoteFieldDecorator.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/NoteFieldDecorator.java
@@ -1,0 +1,94 @@
+/****************************************************************************************
+ * Copyright (c) 2020 Mike Hardy <github@mikehardy.net>                                 *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+
+package com.ichi2.utils;
+
+import java.util.Random;
+
+public class NoteFieldDecorator {
+
+    private static Random random = new Random();
+
+    private static String[] huevoDecorations = {
+            "\uD83D\uDC8C",
+            "\uD83D\uDE3B",
+            "\uD83D\uDC96",
+            "\uD83D\uDC97",
+            "\uD83D\uDC93",
+            "\uD83D\uDC9E",
+            "\uD83D\uDC95",
+            "\uD83D\uDC9F",
+            "\uD83D\uDCAF",
+            "\uD83D\uDE03",
+            "\uD83D\uDE0D"
+    };
+
+    private static String[] huevoOpciones = {
+            "qnr",
+            "gvzenr",
+            "aboantb",
+            "avpbynf-enbhy",
+            "Neguhe-Zvypuvbe",
+            "zvxruneql",
+            "qnivq-nyyvfba-1",
+            "vavwh",
+            "uffz",
+            "syreqn",
+            "rqh-mnzben",
+            "ntehraroret",
+            "bfcnyu",
+            "znaqer",
+            "qnavry-fineq",
+            "vasvalgr7",
+            "Oynvfbeoynqr",
+            "genfuphggre",
+            "qzvgel-gvzbsrri",
+            "inabfgra",
+            "unacvatpuvarfr",
+            "jro5atnl"
+    };
+
+    public static String aplicaHuevo(String fieldText) {
+        String revuelto = huevoRevuelto(fieldText);
+        for (String huevo : huevoOpciones) {
+            if (huevo.equalsIgnoreCase(revuelto)) {
+                String decoration = huevoDecorations[getRandomIndex(huevoDecorations.length)];
+                return String.format("%s%s %s %s%s", decoration, decoration, fieldText, decoration, decoration);
+            }
+        }
+        return fieldText;
+    }
+
+    private static int getRandomIndex(int max) {
+        return random.nextInt(max);
+    }
+
+    private static String huevoRevuelto(String huevo) {
+        if (huevo == null || huevo.length() == 0) {
+            return huevo;
+        }
+        StringBuilder revuelto = new StringBuilder();
+        for (int i = 0; i < huevo.length(); i++) {
+            char c = huevo.charAt(i);
+            if       (c >= 'a' && c <= 'm') c += 13;
+            else if  (c >= 'A' && c <= 'M') c += 13;
+            else if  (c >= 'n' && c <= 'z') c -= 13;
+            else if  (c >= 'N' && c <= 'Z') c -= 13;
+            revuelto.append(c);
+        }
+        return revuelto.toString();
+    }
+}


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

There are some cases of Note Editing, specifically if you have a 2 field card, and the second field is empty, where you should apply special decoration to the card based on the first field

## Approach

Special attention was paid to backwards compatibility, specifically that the unicode characters accessed were available on Android API16, as this is a potential source of error that I have personally experienced when accessing this range of the unicode set

Some effort was spent making sure that the Spanish language in particular was supported and that when considering a 26-letter alphabet, the desired decorations could readily be converted between our chosen storage mechanism and their regular representation with an easily reversible storage encoding by dividing the 26 letters into two 13-letter spaces with a rotating transform.

## How Has This Been Tested?

Manually tested in Android 29 and Android 16 emulator

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
