### PR TITLE
Revert diffutils library update, add test

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -232,7 +232,8 @@ dependencies {
     implementation 'io.requery:sqlite-android:3.32.2'
     implementation 'com.afollestad.material-dialogs:core:0.9.6.0'
     implementation 'com.getbase:floatingactionbutton:1.10.1'
-    implementation "io.github.java-diff-utils:java-diff-utils:4.7"
+    // io.github.java-diff-utils:java-diff-utils is the natural successor here, but requires API24, #7091
+    implementation 'org.bitbucket.cowwoc:diff-match-patch:1.2'
     // #6419  - API 27 (& maybe others) could not perform new ZipFile() on a 2GB+ apkg
     // noinspection GradleDependency - pinned at 1.12 until API21 minSdkVersion (File.toPath usage)
     implementation 'org.apache.commons:commons-compress:1.12'

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/utils/DiffEngineTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/utils/DiffEngineTest.java
@@ -1,0 +1,40 @@
+/****************************************************************************************
+ * Copyright (c) 2020 Mike Hardy <mike@mikehardy.net>                                   *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+
+package com.ichi2.anki.utils;
+
+import com.ichi2.utils.DiffEngine;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static org.junit.Assert.assertArrayEquals;
+
+@RunWith(AndroidJUnit4.class)
+public class DiffEngineTest {
+
+
+    @Test
+    public void testSimpleDiff() {
+        DiffEngine diffEngine = new DiffEngine();
+        String[] diffs = diffEngine.diffedHtmlStrings("typed", "correct");
+        String[] expectedDiffs = { "<span class=\"typeBad\">correct</span>", "<span class=\"typeMissed\">typed</span>" };
+        assertArrayEquals("Diff results were unexpected", expectedDiffs, diffs);
+    }
+}

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/utils/DiffEngineTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/utils/DiffEngineTest.java
@@ -34,7 +34,10 @@ public class DiffEngineTest {
     public void testSimpleDiff() {
         DiffEngine diffEngine = new DiffEngine();
         String[] diffs = diffEngine.diffedHtmlStrings("typed", "correct");
-        String[] expectedDiffs = { "<span class=\"typeBad\">correct</span>", "<span class=\"typeMissed\">typed</span>" };
+        String[] expectedDiffs = {
+                "<span class=\"typeBad\">corr</span><span class=\"typeGood\">e</span><span class=\"typeBad\">ct</span>",
+                "<span class=\"typeMissed\">typ</span><span class=\"typeGood\">e</span><span class=\"typeMissed\">d</span>"
+        };
         assertArrayEquals("Diff results were unexpected", expectedDiffs, diffs);
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/DiffEngine.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/DiffEngine.java
@@ -18,18 +18,15 @@ package com.ichi2.utils;
 
 import android.text.Html;
 
-import com.github.difflib.text.DiffRow;
-import com.github.difflib.text.DiffRowGenerator;
-
-import java.util.Arrays;
-import java.util.List;
-
+import org.bitbucket.cowwoc.diffmatchpatch.DiffMatchPatch;
 
 /**
  * Functions for diff, match and patch. Computes the difference between two texts to create a patch. Applies the patch
  * onto another text, allowing for errors.
  */
 public class DiffEngine {
+
+    private DiffMatchPatch diffMatchPatch = new DiffMatchPatch();
 
 
     /**
@@ -42,30 +39,17 @@ public class DiffEngine {
     public String[] diffedHtmlStrings(String typed, String correct) {
         StringBuilder prettyTyped = new StringBuilder();
         StringBuilder prettyCorrect = new StringBuilder();
-
-        DiffRowGenerator generator = DiffRowGenerator.create()
-                .reportLinesUnchanged(true)
-                .build();
-
-        List<DiffRow> diffRows = generator.generateDiffRows(
-                Arrays.asList(typed.split("\\s+")),
-                Arrays.asList(correct.split("\\s+")));
-
-        for (DiffRow aDiff : diffRows) {
-            switch (aDiff.getTag()) {
-                case CHANGE:
-                    prettyTyped.append(wrapBad(aDiff.getNewLine()));
-                    prettyCorrect.append(wrapMissing(aDiff.getOldLine()));
-                    break;
+        for (DiffMatchPatch.Diff aDiff : diffMatchPatch.diffMain(typed, correct)) {
+            switch (aDiff.operation) {
                 case INSERT:
-                    prettyTyped.append(wrapBad(aDiff.getOldLine()));
+                    prettyTyped.append(wrapBad(aDiff.text));
                     break;
                 case DELETE:
-                    prettyCorrect.append(wrapMissing(aDiff.getOldLine()));
+                    prettyCorrect.append(wrapMissing(aDiff.text));
                     break;
                 case EQUAL:
-                    prettyTyped.append(wrapGood(aDiff.getOldLine()));
-                    prettyCorrect.append(wrapGood(aDiff.getOldLine()));
+                    prettyTyped.append(wrapGood(aDiff.text));
+                    prettyCorrect.append(wrapGood(aDiff.text));
                     break;
             }
         }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

The currently-active diffutils Java library unfortunately uses some Java8 features that D8/R8 cannot desugar appropriately for Android's older than API24, so it caused runtime crashes on API23 and below.

This adds a regression test that runs on device and helped a) point out the API break which helped investigate the exact API support line and that it was not salvageable and b) makes sure I don't accidentally do it again

This reverts #6858 

Then this alters the test output slightly as I discovered during the revert I had inadvertently altered the diff presentation at the same time (unexpected, unwanted change!)

I reopened the related deprecation issue #6537 to track this until we have `minSdkVersion 24`


## Fixes
Fixes #7091

## Approach

Test and revert

## How Has This Been Tested?

API16, API22, API23, API24, API29 emulators

## Learning (optional, can help others)

Android Studio and the android gradle plugin can do a lot of magical de-sugaring, but they can't do Function.apply even if they *could* do method references, and the ART JVM doesn't give very good error messages when it blows up while running static initializers.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
