### PR TITLE
Navigation: Allow Safe Display (No Animation)

### DIFF
--- a/AnkiDroid/src/main/java/androidx/drawerlayout/widget/ClosableDrawerLayout.java
+++ b/AnkiDroid/src/main/java/androidx/drawerlayout/widget/ClosableDrawerLayout.java
@@ -1,0 +1,57 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// ಠ_ಠ This is required to override a package-private method to block animations
+package androidx.drawerlayout.widget;
+
+import android.content.Context;
+import android.util.AttributeSet;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.view.GravityCompat;
+
+public class ClosableDrawerLayout extends DrawerLayout {
+    private boolean mAnimationEnabled = true;
+
+    public ClosableDrawerLayout(@NonNull Context context) {
+        super(context);
+    }
+
+
+    public ClosableDrawerLayout(@NonNull Context context, @Nullable AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+
+    public ClosableDrawerLayout(@NonNull Context context, @Nullable AttributeSet attrs, int defStyle) {
+        super(context, attrs, defStyle);
+    }
+
+    public void setAnimationEnabled(boolean useAnimation) {
+        mAnimationEnabled = useAnimation;
+    }
+
+    // This is called internally (onTouchEvent outside the control will close it), so we need it here
+    @Override
+    void closeDrawers(boolean peekingOnly) {
+        if (mAnimationEnabled) {
+            super.closeDrawers(peekingOnly);
+        } else {
+            closeDrawer(GravityCompat.START, false);
+        }
+    }
+}

--- a/AnkiDroid/src/main/res/layout-xlarge/homescreen.xml
+++ b/AnkiDroid/src/main/res/layout-xlarge/homescreen.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.drawerlayout.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.drawerlayout.widget.ClosableDrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
                                            android:id="@+id/drawer_layout"
                                            android:layout_width="match_parent"
                                            android:layout_height="match_parent"
@@ -22,5 +22,5 @@
                      android:layout_height="fill_parent"/>
     </LinearLayout>
     <include layout="@layout/navigation_drawer" />
-</androidx.drawerlayout.widget.DrawerLayout>
+</androidx.drawerlayout.widget.ClosableDrawerLayout>
 

--- a/AnkiDroid/src/main/res/layout/activity_anki_stats.xml
+++ b/AnkiDroid/src/main/res/layout/activity_anki_stats.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.drawerlayout.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.drawerlayout.widget.ClosableDrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
                                            xmlns:tools="http://schemas.android.com/tools"
                                            android:id="@+id/drawer_layout"
                                            android:layout_width="match_parent"
@@ -29,4 +29,4 @@
 		<include layout="@layout/anki_progress"/>
 	</androidx.coordinatorlayout.widget.CoordinatorLayout>
 	<include layout="@layout/navigation_drawer" />
-</androidx.drawerlayout.widget.DrawerLayout>
+</androidx.drawerlayout.widget.ClosableDrawerLayout>

--- a/AnkiDroid/src/main/res/layout/card_browser.xml
+++ b/AnkiDroid/src/main/res/layout/card_browser.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.drawerlayout.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.drawerlayout.widget.ClosableDrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
                                            xmlns:app="http://schemas.android.com/apk/res-auto"
                                            android:id="@+id/drawer_layout"
                                            android:layout_width="match_parent"
@@ -52,4 +52,4 @@
         <include layout="@layout/anki_progress"/>
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
     <include layout="@layout/navigation_drawer" />
-</androidx.drawerlayout.widget.DrawerLayout>
+</androidx.drawerlayout.widget.ClosableDrawerLayout>

--- a/AnkiDroid/src/main/res/layout/homescreen.xml
+++ b/AnkiDroid/src/main/res/layout/homescreen.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.drawerlayout.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.drawerlayout.widget.ClosableDrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
                                            android:id="@+id/drawer_layout"
                                            android:layout_width="match_parent"
                                            android:layout_height="match_parent"
                                            android:fitsSystemWindows="true">
     <include layout="@layout/deck_picker"/>
     <include layout="@layout/navigation_drawer" />
-</androidx.drawerlayout.widget.DrawerLayout>
+</androidx.drawerlayout.widget.ClosableDrawerLayout>

--- a/AnkiDroid/src/main/res/layout/reviewer.xml
+++ b/AnkiDroid/src/main/res/layout/reviewer.xml
@@ -1,4 +1,4 @@
-<androidx.drawerlayout.widget.DrawerLayout
+<androidx.drawerlayout.widget.ClosableDrawerLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/drawer_layout"
     android:layout_width="fill_parent"
@@ -49,4 +49,4 @@
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
     <!-- Left navigation drawer -->
     <include layout="@layout/navigation_drawer" />
-</androidx.drawerlayout.widget.DrawerLayout>
+</androidx.drawerlayout.widget.ClosableDrawerLayout>

--- a/AnkiDroid/src/main/res/layout/reviewer_fullscreen.xml
+++ b/AnkiDroid/src/main/res/layout/reviewer_fullscreen.xml
@@ -1,4 +1,4 @@
-<androidx.drawerlayout.widget.DrawerLayout
+<androidx.drawerlayout.widget.ClosableDrawerLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/drawer_layout"
     android:layout_width="fill_parent"
@@ -46,4 +46,4 @@
         </FrameLayout>
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
     <include layout="@layout/navigation_drawer" />
-</androidx.drawerlayout.widget.DrawerLayout>
+</androidx.drawerlayout.widget.ClosableDrawerLayout>

--- a/AnkiDroid/src/main/res/layout/reviewer_fullscreen_noanswers.xml
+++ b/AnkiDroid/src/main/res/layout/reviewer_fullscreen_noanswers.xml
@@ -1,4 +1,4 @@
-<androidx.drawerlayout.widget.DrawerLayout
+<androidx.drawerlayout.widget.ClosableDrawerLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/drawer_layout"
     android:layout_width="fill_parent"
@@ -45,4 +45,4 @@
         </RelativeLayout>
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
     <include layout="@layout/navigation_drawer" />
-</androidx.drawerlayout.widget.DrawerLayout>
+</androidx.drawerlayout.widget.ClosableDrawerLayout>

--- a/AnkiDroid/src/main/res/layout/studyoptions.xml
+++ b/AnkiDroid/src/main/res/layout/studyoptions.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.drawerlayout.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.drawerlayout.widget.ClosableDrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
                                            android:id="@+id/drawer_layout"
                                            android:layout_width="match_parent"
                                            android:layout_height="match_parent"
@@ -19,5 +19,5 @@
         </LinearLayout>
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
     <include layout="@layout/navigation_drawer" />
-</androidx.drawerlayout.widget.DrawerLayout>
+</androidx.drawerlayout.widget.ClosableDrawerLayout>
 


### PR DESCRIPTION
## Purpose / Description
Safe Display did not disable the nav drawer

## Fixes
Fixes some of #7119
Related: #7114

## Approach
* Override a class (in namespace `androidx.drawerlayout.widget`)
* Override the package-protected `closeDrawers(boolean)` which uses animations
* Call openDrawer(Gravity, boolean), where the boolean is whether to animate

## How Has This Been Tested?

Tested on my Android 9 with `Safe Display` on and off.

## Learning 

UI sucks

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code