### PR TITLE
Deck Picker: Make bottom bar opaque

### DIFF
--- a/AnkiDroid/src/main/res/layout/deck_picker.xml
+++ b/AnkiDroid/src/main/res/layout/deck_picker.xml
@@ -38,6 +38,7 @@
                         android:fastScrollEnabled="true"
                         android:focusable="true"
                         android:paddingBottom="72dp"
+                        android:layout_above="@id/today_stats_text_view"
                         android:scrollbars="vertical" />
 
                     <TextView


### PR DESCRIPTION
## Purpose / Description
Was a regression - This ensures that it's not obscured by the decks with the same color

## Fixes
Fixes #7121

## Approach
`android:layout_above`

## How Has This Been Tested?

Android 9 device - tested visually, same as 1.12.1

## Learning (optional, can help others)
We might need automated visual UI regression tests in the future, which are a lot of work

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code