### PR TITLE
HACK - Use Clipboard to allow MIUI Cloze

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.java
@@ -35,6 +35,8 @@ public class FieldEditText extends AppCompatEditText {
     private String mName;
     private int mOrd;
     private Drawable mOrigBackground;
+    @Nullable
+    private TextSelectionListener mSelectionChangeListener;
 
 
     public FieldEditText(Context context) {
@@ -118,6 +120,19 @@ public class FieldEditText extends AppCompatEditText {
     }
 
 
+    @Override
+    protected void onSelectionChanged(int selStart, int selEnd) {
+        if (mSelectionChangeListener != null) {
+            try {
+                mSelectionChangeListener.onSelectionChanged(selStart, selEnd);
+            } catch (Exception e) {
+                Timber.w(e, "mSelectionChangeListener");
+            }
+        }
+        super.onSelectionChanged(selStart, selEnd);
+    }
+
+
 
     @RequiresApi(api = Build.VERSION_CODES.N)
     public void setHintLocale(@NonNull Locale locale) {
@@ -138,5 +153,13 @@ public class FieldEditText extends AppCompatEditText {
      */
     public void setDefaultStyle() {
         setBackgroundDrawable(mOrigBackground);
+    }
+
+    public void setSelectionChangeListener(TextSelectionListener listener) {
+        this.mSelectionChangeListener = listener;
+    }
+
+    public interface TextSelectionListener {
+        void onSelectionChanged(int selStart, int selEnd);
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -886,6 +886,14 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                 plugins.removePreference(doubleScrolling);
             }
         }
+
+        if (AdaptionUtil.canUseContextMenu()) {
+            PreferenceCategory workarounds = (PreferenceCategory) screen.findPreference("category_workarounds");
+            if (workarounds != null) {
+                CheckBoxPreference miuiClipboardHack = (CheckBoxPreference) screen.findPreference("enableMIUIClipboardHack");
+                workarounds.removePreference(miuiClipboardHack);
+            }
+        }
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/utils/AdaptionUtil.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/AdaptionUtil.java
@@ -17,6 +17,7 @@
 package com.ichi2.utils;
 
 import android.app.ActivityManager;
+import android.content.ComponentName;
 import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
@@ -37,6 +38,7 @@ public class AdaptionUtil {
     private static boolean sIsRestrictedLearningDevice = false;
     private static boolean sHasRunWebBrowserCheck = false;
     private static boolean sHasWebBrowser = true;
+    private static Boolean sIsRunningMiUI = null;
 
     public static boolean hasWebBrowser(Context context) {
         if (sHasRunWebBrowserCheck) {
@@ -120,5 +122,35 @@ public class AdaptionUtil {
             sHasRunRestrictedLearningDeviceCheck = true;
         }
         return sIsRestrictedLearningDevice;
+    }
+
+    public static boolean canUseContextMenu() {
+        return !isRunningMiui();
+    }
+
+    private static boolean isRunningMiui() {
+        if (sIsRunningMiUI == null) {
+            sIsRunningMiUI = queryIsMiui();
+        }
+        return sIsRunningMiUI;
+    }
+
+    // https://stackoverflow.com/questions/47610456/how-to-detect-miui-rom-programmatically-in-android
+    private static boolean isIntentResolved(Context ctx, Intent intent) {
+        return (intent != null && ctx.getPackageManager().resolveActivity(intent, PackageManager.MATCH_DEFAULT_ONLY) != null);
+    }
+
+    private static boolean queryIsMiui() {
+        Context ctx = AnkiDroidApp.getInstance();
+        return isIntentResolved(ctx, new Intent("miui.intent.action.OP_AUTO_START").addCategory(Intent.CATEGORY_DEFAULT))
+                || isIntentResolved(ctx, new Intent().setComponent(new ComponentName("com.miui.securitycenter", "com.miui.permcenter.autostart.AutoStartManagementActivity")))
+                || isIntentResolved(ctx, new Intent("miui.intent.action.POWER_HIDE_MODE_APP_LIST").addCategory(Intent.CATEGORY_DEFAULT))
+                || isIntentResolved(ctx, new Intent().setComponent(new ComponentName("com.miui.securitycenter", "com.miui.powercenter.PowerSettings")));
+    }
+
+
+    @SuppressWarnings( {"unused", "RedundantSuppression"})
+    public static boolean shouldCurrentUserBuyDifferentPhone() {
+        return isRunningMiui();
     }
 }

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -269,4 +269,8 @@
     <string name="analytics_dialog_title">Help make AnkiDroid better!</string>
     <string name="analytics_title">Share feature usage</string>
     <string name="analytics_summ">You can contribute to AnkiDroid by helping the development team see which features people use</string>
-"</resources>
+
+
+    <string name="enable_miui_keyboard_hack">\'Paste\' to insert cloze deletion</string>
+    <string name="enable_miui_keyboard_hack_summ">In the Note Editor, \'Paste\' will turn the selected text into a cloze</string>
+</resources>

--- a/AnkiDroid/src/main/res/xml/preferences_advanced.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_advanced.xml
@@ -68,6 +68,13 @@
                 android:key="disableExtendedTextUi"
                 android:summary="@string/disable_extended_text_ui_summ"
                 android:title="@string/disable_extended_text_ui" />
+
+            <!-- HACK before 7124 MIUI Clipboard Cloze -->
+            <CheckBoxPreference
+                android:defaultValue="true"
+                android:key="enableMIUIClipboardHack"
+                android:summary="@string/enable_miui_keyboard_hack_summ"
+                android:title="@string/enable_miui_keyboard_hack_summ" />
         </PreferenceCategory>
         <PreferenceCategory
             android:key="category_plugins"


### PR DESCRIPTION
NOTE: Defaults to true 

## Purpose / Description
MIUI users can't use Cloze due to the OS being a pain.

We've had a lot of 5* ratings and support queries about this, let's send some love back to these users.

## Approach
We add the selected value to the clipboard surrounded by cloze marks

This allows MIUI users with GBoard to paste it in immediately (and other keyboards to use Paste)

HACK before #7124 obsoletes this

## How Has This Been Tested?

Android 9: I returned false for `hasContextMenu` and it worked
API 16 emulator

* Preference is not visible normally
* Only work with Cloze
* Preference is enabled by default and handles this case
* Preference can be disabled
* Works

## Learning

https://stackoverflow.com/questions/47610456/how-to-detect-miui-rom-programmatically-in-android

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code