### PR TITLE
Counts in background

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -927,9 +927,12 @@ public class Reviewer extends AbstractFlashcardViewer {
     protected void updateScreenCounts() {
         if (mCurrentCard == null) return;
         super.updateActionBar();
-        ActionBar actionBar = getSupportActionBar();
         Counts counts = mSched.counts(mCurrentCard);
+        setCounts(counts);
+    }
 
+    private void setCounts(Counts counts){
+        ActionBar actionBar = getSupportActionBar();
         if (actionBar != null) {
             if (mPrefShowETA) {
                 eta = mSched.eta(counts, false);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -72,6 +72,7 @@ import com.ichi2.anki.workarounds.FirefoxSnackbarWorkaround;
 import com.ichi2.anki.reviewer.ActionButtons;
 import com.ichi2.async.CollectionTask;
 import com.ichi2.async.TaskListener;
+import com.ichi2.async.TaskListenerWithContext;
 import com.ichi2.async.TaskManager;
 import com.ichi2.compat.CompatHelper;
 import com.ichi2.libanki.Card;
@@ -924,11 +925,29 @@ public class Reviewer extends AbstractFlashcardViewer {
         updateScreenCounts();
     }
 
+    private CountHandler countHandler() {
+        return new CountHandler(this);
+    }
+
+    private static class CountHandler extends TaskListenerWithContext<Reviewer, Void, Counts> {
+        public CountHandler(Reviewer reviewer) {
+            super(reviewer);
+        }
+
+        @Override
+        public void actualOnPreExecute(@NonNull Reviewer context) {
+        }
+
+        @Override
+        public void actualOnPostExecute(@NonNull Reviewer reviewer, Counts counts) {
+            reviewer.setCounts(counts);
+        }
+    }
+
     protected void updateScreenCounts() {
         if (mCurrentCard == null) return;
         super.updateActionBar();
-        Counts counts = mSched.counts(mCurrentCard);
-        setCounts(counts);
+        TaskManager.launchCollectionTask(new CollectionTask.ReviewerCount(mCurrentCard), countHandler());
     }
 
     private void setCounts(Counts counts){

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -1440,19 +1440,22 @@ public class Reviewer extends AbstractFlashcardViewer {
         @JavascriptInterface
         @Override
         public String ankiGetNewCardCount() {
-            return newCount.toString();
+            /* If counts are not already computed (e.g. after undo) javascript will have to wait until they are
+             computed.  Counts are computed as soon as the question is displayed, so this will return immediately unless
+             javascript request counts so quickly that reviewer had no time to update its numbers. */
+            return Integer.toString(getCol().getSched().counts(mCurrentCard).getNew());
         }
 
         @JavascriptInterface
         @Override
         public String ankiGetLrnCardCount() {
-            return lrnCount.toString();
+            return Integer.toString(getCol().getSched().counts(mCurrentCard).getLrn());
         }
 
         @JavascriptInterface
         @Override
         public String ankiGetRevCardCount() {
-            return revCount.toString();
+            return Integer.toString(getCol().getSched().counts(mCurrentCard).getRev());
         }
 
         @JavascriptInterface

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -1920,6 +1920,19 @@ public class CollectionTask<ProgressListener, ProgressBackground extends Progres
         }
     }
 
+    public static class ReviewerCount extends Task<Void, Counts> {
+        private final Card card;
+
+        public ReviewerCount(Card card) {
+            this.card = card;
+        }
+
+        protected Counts task(Collection col, ProgressSenderAndCancelListener<Void> collectionTask) {
+            return col.getSched().counts(card);
+        }
+
+    }
+
     /**
      * Goes through selected cards and checks selected and marked attribute
      * @return If there are unselected cards, if there are unmarked cards

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -326,18 +326,21 @@ public class Sched extends SchedV2 {
     protected void _resetLrnCount() {
         _resetLrnCount(null);
     }
+
     protected void _resetLrnCount(@Nullable CancelListener cancelListener) {
         // sub-day
-        mLrnCount = mCol.getDb().queryScalar(
+        int lrnCount = mCol.getDb().queryScalar(
                 "SELECT sum(left / 1000) FROM (SELECT left FROM cards WHERE did IN " + _deckLimit()
                 + " AND queue = " + Consts.QUEUE_TYPE_LRN + " AND due < ? and id != ? LIMIT ?)",
                 mDayCutoff, currentCardId(), mReportLimit);
         if (isCancelled(cancelListener)) return;
         // day
-        mLrnCount += mCol.getDb().queryScalar(
+        lrnCount += mCol.getDb().queryScalar(
                 "SELECT count() FROM cards WHERE did IN " + _deckLimit() + " AND queue = " + Consts.QUEUE_TYPE_DAY_LEARN_RELEARN + " AND due <= ? "+
                         "AND id != ? LIMIT ?",
                 mToday, currentCardId(), mReportLimit);
+
+        mLrnCount = lrnCount;
     }
 
     @Override

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -1031,19 +1031,21 @@ public class SchedV2 extends AbstractSched {
 
     protected void _resetLrnCount(@Nullable CancelListener cancelListener) {
         _updateLrnCutoff(true);
+        // Uses a second variable to avoid concurrency issue
         // sub-day
-        mLrnCount = mCol.getDb().queryScalar(
+        int lrnCount = mCol.getDb().queryScalar(
                 "SELECT count() FROM cards WHERE did IN " + _deckLimit()
                 + " AND queue = " + Consts.QUEUE_TYPE_LRN + " AND id != ? AND due < ?", currentCardId(), mLrnCutoff);
         if (isCancelled(cancelListener)) return;
         // day
-        mLrnCount += mCol.getDb().queryScalar(
+        lrnCount += mCol.getDb().queryScalar(
                 "SELECT count() FROM cards WHERE did IN " + _deckLimit() + " AND queue = " + Consts.QUEUE_TYPE_DAY_LEARN_RELEARN + " AND due <= ? AND id != ?",
                 mToday, currentCardId());
         if (isCancelled(cancelListener)) return;
         // previews
-        mLrnCount += mCol.getDb().queryScalar(
+        lrnCount += mCol.getDb().queryScalar(
                 "SELECT count() FROM cards WHERE did IN " + _deckLimit() + " AND queue = " + Consts.QUEUE_TYPE_PREVIEW + " AND id != ? ", currentCardId());
+        mLrnCount = lrnCount;
     }
 
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

Running the profiler, I realized that one of the reason undo was still slow was that computing counts is done in foreground and not in background. So I moved it to background.

This is not a problem for normal review since counts are required to find the next card, so the only case where counts should actually be computed and can't be read from cache is when a card can be found without using `sched.getCard`, i.e. after undo.

## How Has This Been Tested?

Running it on my merge branch, reviewing, undoing, and seeing that the card's question appear almost immediately while the counts takes a few seconds to actually update.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
