### PR TITLE
Fix failing to load deck after sync

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -244,36 +244,32 @@ public class DeckPicker extends NavigationDrawerActivity implements
     private final OnClickListener mDeckClickListener = new OnClickListener() {
         @Override
         public void onClick(View v) {
-            long deckId = (long) v.getTag();
-            Timber.i("DeckPicker:: Selected deck with id %d", deckId);
-            if (mActionsMenu != null && mActionsMenu.isExpanded()) {
-                mActionsMenu.collapse();
-            }
-            handleDeckSelection(deckId, false);
-            if (mFragmented || !CompatHelper.isLollipop()) {
-                // Calling notifyDataSetChanged() will update the color of the selected deck.
-                // This interferes with the ripple effect, so we don't do it if lollipop and not tablet view
-                mDeckListAdapter.notifyDataSetChanged();
-            }
+            onDeckClick(v, false);
         }
     };
 
     private final OnClickListener mCountsClickListener = new OnClickListener() {
         @Override
         public void onClick(View v) {
-            long deckId = (long) v.getTag();
-            Timber.i("DeckPicker:: Selected deck with id %d", deckId);
-            if (mActionsMenu != null && mActionsMenu.isExpanded()) {
-                mActionsMenu.collapse();
-            }
-            handleDeckSelection(deckId, true);
-            if (mFragmented || !CompatHelper.isLollipop()) {
-                // Calling notifyDataSetChanged() will update the color of the selected deck.
-                // This interferes with the ripple effect, so we don't do it if lollipop and not tablet view
-                mDeckListAdapter.notifyDataSetChanged();
-            }
+            onDeckClick(v, true);
         }
     };
+
+
+    private void onDeckClick(View v, boolean dontSkipStudyOptions) {
+        long deckId = (long) v.getTag();
+        Timber.i("DeckPicker:: Selected deck with id %d", deckId);
+        if (mActionsMenu != null && mActionsMenu.isExpanded()) {
+            mActionsMenu.collapse();
+        }
+        handleDeckSelection(deckId, dontSkipStudyOptions);
+        if (mFragmented || !CompatHelper.isLollipop()) {
+            // Calling notifyDataSetChanged() will update the color of the selected deck.
+            // This interferes with the ripple effect, so we don't do it if lollipop and not tablet view
+            mDeckListAdapter.notifyDataSetChanged();
+        }
+    }
+
 
     private final View.OnLongClickListener mDeckLongClickListener = new View.OnLongClickListener() {
         @Override

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -262,12 +262,30 @@ public class DeckPicker extends NavigationDrawerActivity implements
         if (mActionsMenu != null && mActionsMenu.isExpanded()) {
             mActionsMenu.collapse();
         }
-        handleDeckSelection(deckId, dontSkipStudyOptions);
-        if (mFragmented || !CompatHelper.isLollipop()) {
-            // Calling notifyDataSetChanged() will update the color of the selected deck.
-            // This interferes with the ripple effect, so we don't do it if lollipop and not tablet view
-            mDeckListAdapter.notifyDataSetChanged();
+        if (!colIsOpen()) {
+            displayFailedToOpenDeck(deckId);
+            return;
         }
+        try {
+            handleDeckSelection(deckId, dontSkipStudyOptions);
+            if (mFragmented || !CompatHelper.isLollipop()) {
+                // Calling notifyDataSetChanged() will update the color of the selected deck.
+                // This interferes with the ripple effect, so we don't do it if lollipop and not tablet view
+                mDeckListAdapter.notifyDataSetChanged();
+            }
+        } catch (Exception e) {
+            AnkiDroidApp.sendExceptionReport(e, "deckPicker::onDeckClick", Long.toString(deckId));
+            displayFailedToOpenDeck(deckId);
+        }
+    }
+
+
+    private void displayFailedToOpenDeck(long deckId) {
+        // #6208 - if the click is accepted before the sync completes, we get a failure.
+        // We use the Deck ID as the deck likely doesn't exist any more.
+        String message = getString(R.string.deck_picker_failed_deck_load, Long.toString(deckId));
+        UIUtils.showThemedToast(this, message, false);
+        Timber.w(message);
     }
 
 

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -326,4 +326,7 @@
     <!-- Card Viewer -->
     <string name="card_viewer_could_not_find_image">Card Content Error: Failed to load ‘%s’</string>
     <string name="card_viewer_could_not_find_image_get_help">Help</string>
+
+    <!-- Deck Picker -->
+    <string name="deck_picker_failed_deck_load">Failed to load deck ‘%s’</string>
 </resources>


### PR DESCRIPTION
## Purpose / Description

Selecting a deck after a sync completes, but before the UI is refreshed caused this error. We can probably do better, but this should fix it without needing to delve into nitty-gritty UI timing issues.

## Fixes
Fixes #6280

## Approach
Warn and log if the collection is not open
Try..catch, warn and log. If we still get an exception

## How Has This Been Tested?
Untested failure case, can still click decks on Android 9.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
