### PR TITLE
Only show Changelog/Info once

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Info.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Info.java
@@ -63,6 +63,11 @@ public class Info extends AnkiActivity {
         WebView webView;
 
         mType = getIntent().getIntExtra(TYPE_EXTRA, TYPE_ABOUT);
+        // If the page crashes, we do not want to display it again (#7135 maybe)
+        if (mType == TYPE_NEW_VERSION) {
+            AnkiDroidApp.getSharedPrefs(Info.this.getBaseContext()).edit()
+                    .putString("lastVersion", VersionUtils.getPkgVersionName()).apply();
+        }
 
         setContentView(R.layout.info);
         final View mainView = findViewById(android.R.id.content);
@@ -95,12 +100,6 @@ public class Info extends AnkiActivity {
                 return;
             }
             setResult(RESULT_OK);
-            switch (mType) {
-                case TYPE_NEW_VERSION:
-                    AnkiDroidApp.getSharedPrefs(Info.this.getBaseContext()).edit()
-                            .putString("lastVersion", VersionUtils.getPkgVersionName()).apply();
-                    break;
-            }
             finishWithAnimation();
         });
 


### PR DESCRIPTION
## Purpose / Description
Maybe the changelog crashed for #7135, if it did then we wouldn't get 

This ensures that we won't get into a crash loop if the changelog crashes

## Fixes
Maybe fixes #7135

## Approach
Only show the changelog once

## How Has This Been Tested?

Doesn't crash

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code