### PR TITLE
(Hopefully) Fix #7135 WebView Crash

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ACRATest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ACRATest.java
@@ -58,7 +58,6 @@ public class ACRATest {
         Instrumentation instrumentation = InstrumentationRegistry.getInstrumentation();
         mApp = (AnkiDroidApp) instrumentation.getTargetContext().getApplicationContext();
         // Note: attachBaseContext can't be called twice as we're using the same instance between all tests.
-        mApp.initializeLoggingAndCrashReporting();
         mApp.onCreate();
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -209,6 +209,10 @@ public class AnkiDroidApp extends MultiDexApplication {
         //possible since API 17, only supported way since API 25
         //for API < 17 we update the configuration directly
         super.attachBaseContext(updateContextWithLanguage(base));
+
+        // DO NOT INIT A WEBVIEW HERE (Moving Analytics to this method)
+        // Crashes only on a Physical API 19 Device - #7135
+        // After we move past API 19, we're good to go.
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -31,7 +31,6 @@ import android.os.LocaleList;
 import android.preference.PreferenceManager;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.annotation.VisibleForTesting;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import android.util.Log;
@@ -206,13 +205,10 @@ public class AnkiDroidApp extends MultiDexApplication {
 
     @Override
     protected void attachBaseContext(Context base) {
-        // update base context with preferred app language before attach
-        // possible since API 17, only supported way since API 25
-        // for API < 17 we update the configuration directly
+        //update base context with preferred app language before attach
+        //possible since API 17, only supported way since API 25
+        //for API < 17 we update the configuration directly
         super.attachBaseContext(updateContextWithLanguage(base));
-
-        sInstance = this;
-        initializeLoggingAndCrashReporting();
     }
 
     /**
@@ -221,10 +217,47 @@ public class AnkiDroidApp extends MultiDexApplication {
     @Override
     public void onCreate() {
         super.onCreate();
+        if (sInstance != null) {
+            Timber.i("onCreate() called multiple times");
+            //5887 - fix crash.
+            if (sInstance.getResources() == null) {
+                Timber.w("Skipping re-initialisation - no resources. Maybe uninstalling app?");
+                return;
+            }
+        }
+        sInstance = this;
+        // Get preferences
+        SharedPreferences preferences = getSharedPrefs(this);
+
+        // Setup logging and crash reporting
+        acraCoreConfigBuilder = new CoreConfigurationBuilder(this);
+        if (BuildConfig.DEBUG) {
+            // Enable verbose error logging and do method tracing to put the Class name as log tag
+            Timber.plant(new DebugTree());
+
+            setDebugACRAConfig(preferences);
+        } else {
+            Timber.plant(new ProductionCrashReportingTree());
+            setProductionACRAConfig(preferences);
+        }
+        Timber.tag(TAG);
+
         Timber.d("Startup - Application Start");
-        if (getResources() == null) {
-            Timber.w("Skipping re-initialisation - no resources. Maybe uninstalling app?");
-            return;
+
+        // The ACRA process needs a WebView for optimal UsageAnalytics values but it can't have the same data directory.
+        // Analytics falls back to a sensible default if this is not set.
+        if (ACRA.isACRASenderServiceProcess() && Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            try {
+                WebViewDebugging.setDataDirectorySuffix("acra");
+            } catch (Exception e) {
+                Timber.w(e, "Failed to set WebView data directory");
+            }
+        }
+
+        // analytics after ACRA, they both install UncaughtExceptionHandlers but Analytics chains while ACRA does not
+        UsageAnalytics.initialize(this);
+        if (BuildConfig.DEBUG) {
+            UsageAnalytics.setDryRun(true);
         }
 
         //Stop after analytics and logging are initialised.
@@ -277,42 +310,6 @@ public class AnkiDroidApp extends MultiDexApplication {
         NotificationService ns = new NotificationService();
         LocalBroadcastManager lbm = LocalBroadcastManager.getInstance(this);
         lbm.registerReceiver(ns, new IntentFilter(NotificationService.INTENT_ACTION));
-    }
-
-
-    @VisibleForTesting
-    public void initializeLoggingAndCrashReporting() {
-        // Get preferences
-        SharedPreferences preferences = getSharedPrefs(this);
-
-        // Setup logging and crash reporting
-        acraCoreConfigBuilder = new CoreConfigurationBuilder(this);
-        if (BuildConfig.DEBUG) {
-            // Enable verbose error logging and do method tracing to put the Class name as log tag
-            Timber.plant(new DebugTree());
-
-            setDebugACRAConfig(preferences);
-        } else {
-            Timber.plant(new ProductionCrashReportingTree());
-            setProductionACRAConfig(preferences);
-        }
-        Timber.tag(TAG);
-
-        // The ACRA process needs a WebView for optimal UsageAnalytics values but it can't have the same data directory.
-        // Analytics falls back to a sensible default if this is not set.
-        if (ACRA.isACRASenderServiceProcess() && Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-            try {
-                WebViewDebugging.setDataDirectorySuffix("acra");
-            } catch (Exception e) {
-                Timber.w(e, "Failed to set WebView data directory");
-            }
-        }
-
-        // analytics after ACRA, they both install UncaughtExceptionHandlers but Analytics chains while ACRA does not
-        UsageAnalytics.initialize(this);
-        if (BuildConfig.DEBUG) {
-            UsageAnalytics.setDryRun(true);
-        }
     }
 
 


### PR DESCRIPTION
## Purpose / Description
All WebViews crashed on API 19 after 2.13.0. 

I believe 85b3ff0 is the change which causes it

## Fixes
Fixes #7135 

## Approach
Don't init a WebView in `attachBaseContext`

## How Has This Been Tested?

Untestable - needs to be released to alpha to be tested

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code