### PR TITLE
Move Set Field Language after "Share"

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -2000,7 +2000,8 @@ public class NoteEditor extends AnkiActivity {
             }
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-                menu.add(Menu.NONE, mSetLanguageId, 1, R.string.note_editor_set_field_language);
+                // This should be after "Paste as Plain Text"
+                menu.add(Menu.NONE, mSetLanguageId, 99, R.string.note_editor_set_field_language);
             }
 
 


### PR DESCRIPTION
Fixes #7141

Tested on my Android 9 device. Menu is still above system-added values, but after "Share/Paste as Plain Text"