### PR TITLE
Fix NullPointerException on invalidate()

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -136,7 +136,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
     /** List of cards in the browser.
     * When the list is changed, the position member of its elements should get changed.*/
-    private List<CardCache> mCards;
+    @NonNull
+    private List<CardCache> mCards = new ArrayList<>();
     private ArrayList<Deck> mDropDownDecks;
     private ListView mCardsListView;
     private SearchView mSearchView;


### PR DESCRIPTION
## Purpose / Description
A crash occurred

`mCards` was set `onCollectionLoaded`, which hadn't been called

## Fixes
Fixes #7145

## Approach
Set the variable to an empty list

## How Has This Been Tested?

Quick check on Android 9 - seems fine

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code