### PR TITLE
Conflict resolution as enum

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.java
@@ -13,6 +13,7 @@ import com.ichi2.anki.BackupManager;
 import com.ichi2.anki.CollectionHelper;
 import com.ichi2.anki.DeckPicker;
 import com.ichi2.anki.R;
+import com.ichi2.async.Connection;
 import com.ichi2.libanki.utils.Time;
 
 import java.io.File;
@@ -282,7 +283,7 @@ public class DatabaseErrorDialog extends AsyncDialogFragment {
                         .positiveText(res.getString(R.string.dialog_positive_overwrite))
                         .negativeText(res.getString(R.string.dialog_cancel))
                         .onPositive((inner_dialog, which) -> {
-                            ((DeckPicker) getActivity()).sync("download");
+                            ((DeckPicker) getActivity()).sync(Connection.ConflictResolution.FULL_DOWNLOAD);
                             dismissAllDialogFragments();
                         })
                         .show();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SyncErrorDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SyncErrorDialog.java
@@ -6,6 +6,7 @@ import android.os.Message;
 
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.ichi2.anki.R;
+import com.ichi2.async.Connection;
 import com.ichi2.libanki.Collection;
 
 public class SyncErrorDialog extends AsyncDialogFragment {
@@ -24,7 +25,7 @@ public class SyncErrorDialog extends AsyncDialogFragment {
         void showSyncErrorDialog(int dialogType, String message);
         void loginToSyncServer();
         void sync();
-        void sync(String conflict);
+        void sync(Connection.ConflictResolution conflict);
         Collection getCol();
         void mediaCheck();
         void dismissAllDialogFragments();
@@ -95,7 +96,7 @@ public class SyncErrorDialog extends AsyncDialogFragment {
                         .negativeText(res().getString(R.string.dialog_cancel))
                         .onPositive((dialog, which) -> {
                             SyncErrorDialogListener activity = (SyncErrorDialogListener) getActivity();
-                            activity.sync("upload");
+                            activity.sync(Connection.ConflictResolution.FULL_UPLOAD);
                             dismissAllDialogFragments();
                         })
                         .show();
@@ -106,7 +107,7 @@ public class SyncErrorDialog extends AsyncDialogFragment {
                         .negativeText(res().getString(R.string.dialog_cancel))
                         .onPositive((dialog, which) -> {
                             SyncErrorDialogListener activity = (SyncErrorDialogListener) getActivity();
-                            activity.sync("download");
+                            activity.sync(Connection.ConflictResolution.FULL_DOWNLOAD);
                             dismissAllDialogFragments();
                         })
                         .show();
@@ -127,7 +128,7 @@ public class SyncErrorDialog extends AsyncDialogFragment {
                 return builder.positiveText(res().getString(R.string.dialog_positive_overwrite))
                         .negativeText(res().getString(R.string.dialog_cancel))
                         .onPositive((dialog, which) -> {
-                            ((SyncErrorDialogListener) getActivity()).sync("upload");
+                            ((SyncErrorDialogListener) getActivity()).sync(Connection.ConflictResolution.FULL_UPLOAD);
                             dismissAllDialogFragments();
                         })
                         .show();
@@ -137,7 +138,7 @@ public class SyncErrorDialog extends AsyncDialogFragment {
                 return builder.positiveText(res().getString(R.string.dialog_positive_overwrite))
                         .negativeText(res().getString(R.string.dialog_cancel))
                         .onPositive((dialog, which) -> {
-                            ((SyncErrorDialogListener) getActivity()).sync("download");
+                            ((SyncErrorDialogListener) getActivity()).sync(Connection.ConflictResolution.FULL_DOWNLOAD);
                             dismissAllDialogFragments();
                         })
                         .show();

--- a/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
@@ -302,15 +302,22 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
         }
     }
 
+    /**
+     * In the payload, success means that the sync did occur correctly and that a change did occur.
+     * So success can be false without error, if no change occurred at all.*/
     private Payload doInBackgroundSync(Payload data) {
         sIsCancellable = true;
         Timber.d("doInBackgroundSync()");
         // Block execution until any previous background task finishes, or timeout after 5s
         boolean ok = CollectionTask.waitToFinish(5);
 
+        // Unique key allowing to identify the user to AnkiWeb without password
         String hkey = (String) data.data[0];
+        // Whether media should be synced too
         boolean media = (Boolean) data.data[1];
+        // If normal sync can't occur, what to do
         ConflictResolution conflictResolution = (ConflictResolution) data.data[2];
+        // A number AnkiWeb told us to send back. Probably to choose the best server for the user
         HostNum hostNum = (HostNum) data.data[3];
         // Use safe version that catches exceptions so that full sync is still possible
         Collection col = CollectionHelper.getInstance().getColSafe(AnkiDroidApp.getInstance());
@@ -469,6 +476,7 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
                 }
             }
             if (noChanges && (!media || noMediaChanges)) {
+                // This means that there is no change at all, neither media nor collection. Not that there was an error.
                 data.success = false;
                 data.result = new Object[] { "noChanges" };
                 return data;


### PR DESCRIPTION
During Sync, we uses a lot of strings to passe informations that would be better in enums. In this PR, I propose to change one string, the one which states whether we should do a full download/upload. Currently "null" is used to mean "do a normal sync or ask the user". 