### PR TITLE
NF: Simplifies Sync by using an enum

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -67,6 +67,7 @@ import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
 import android.text.TextUtils;
+import android.util.Pair;
 import android.util.TypedValue;
 import android.view.KeyEvent;
 import android.view.Menu;
@@ -153,6 +154,8 @@ import static com.ichi2.async.Connection.ConflictResolution.FULL_DOWNLOAD;
 
 import com.ichi2.async.TaskData;
 import static com.ichi2.anim.ActivityTransitionAnimation.Direction.*;
+
+import static com.ichi2.libanki.sync.Syncer.ConnectionResultType;
 
 public class DeckPicker extends NavigationDrawerActivity implements
         StudyOptionsListener, SyncErrorDialog.SyncErrorDialogListener, ImportDialog.ImportDialogListener,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.java
@@ -22,6 +22,8 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import androidx.appcompat.widget.Toolbar;
+
+import android.util.Pair;
 import android.view.KeyEvent;
 import android.view.View;
 import android.view.inputmethod.InputMethodManager;
@@ -42,6 +44,7 @@ import com.ichi2.utils.AdaptionUtil;
 import timber.log.Timber;
 
 import static com.ichi2.anim.ActivityTransitionAnimation.Direction.FADE;
+import static com.ichi2.libanki.sync.Syncer.ConnectionResultType.*;
 
 public class MyAccount extends AnkiActivity {
     private final static int STATE_LOG_IN  = 1;
@@ -268,9 +271,9 @@ public class MyAccount extends AnkiActivity {
                     UIUtils.showSimpleSnackbar(MyAccount.this, R.string.invalid_username_password, true);
                 } else {
                     String message = getResources().getString(R.string.connection_error_message);
-                    Object[] result = (Object [])data.result;
-                    if (result != null && result.length > 1 && result[1] instanceof Exception) {
-                        showSimpleMessageDialog(message, ((Exception)result[1]).getLocalizedMessage(), false);
+                    Object[] result = data.result;
+                    if (result.length > 0 && result[0] instanceof Exception) {
+                        showSimpleMessageDialog(message, ((Exception)result[0]).getLocalizedMessage(), false);
                     } else {
                         UIUtils.showSimpleSnackbar(MyAccount.this, message, false);
                     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/CustomSyncServerUrlException.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/CustomSyncServerUrlException.java
@@ -16,6 +16,8 @@
 
 package com.ichi2.libanki.sync;
 
+import static com.ichi2.libanki.sync.Syncer.ConnectionResultType.CUSTOM_SYNC_SERVER_URL;
+
 public class CustomSyncServerUrlException extends RuntimeException {
     private final String mUrl;
 
@@ -34,7 +36,7 @@ public class CustomSyncServerUrlException extends RuntimeException {
     @Override
     public String getLocalizedMessage() {
         // Janky. Connection uses this as a string to return, which is switched on to determine the message in DeckPicker
-        return "customSyncServerUrl";
+        return CUSTOM_SYNC_SERVER_URL.toString();
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/FullSyncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/FullSyncer.java
@@ -17,6 +17,7 @@
 package com.ichi2.libanki.sync;
 
 import android.database.sqlite.SQLiteDatabaseCorruptException;
+import android.util.Pair;
 
 import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.CollectionHelper;
@@ -39,6 +40,8 @@ import java.util.Locale;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
 import timber.log.Timber;
+import static com.ichi2.libanki.sync.Syncer.ConnectionResultType.*;
+import static com.ichi2.libanki.sync.Syncer.ConnectionResultType;
 
 @SuppressWarnings({"PMD.AvoidThrowingRawExceptionTypes","PMD.NPathComplexity"})
 public class FullSyncer extends HttpSyncer {
@@ -58,7 +61,7 @@ public class FullSyncer extends HttpSyncer {
     }
 
     @Override
-    public Object[] download() throws UnknownHttpResponseException {
+    public Pair<ConnectionResultType, Object[]> download() throws UnknownHttpResponseException {
         InputStream cont;
         ResponseBody body = null;
         try {
@@ -93,14 +96,14 @@ public class FullSyncer extends HttpSyncer {
             FileInputStream fis = new FileInputStream(tpath);
             if ("upgradeRequired".equals(super.stream2String(fis, 15))) {
                 Timber.w("Full Sync - 'Upgrade Required' message received");
-                return new Object[]{"upgradeRequired"};
+                return new Pair<>(UPGRADE_REQUIRED, null);
             }
         } catch (FileNotFoundException e) {
             Timber.e(e, "Failed to create temp file when downloading collection.");
             throw new RuntimeException(e);
         } catch (IOException e) {
             Timber.e(e, "Full sync failed to download collection.");
-            return new Object[] { "sdAccessError" };
+            return new Pair<>(SD_ACCESS_ERROR, null);
         } finally {
             body.close();
         }
@@ -112,11 +115,11 @@ public class FullSyncer extends HttpSyncer {
             tempDb = new DB(tpath);
             if (!"ok".equalsIgnoreCase(tempDb.queryString("PRAGMA integrity_check"))) {
                 Timber.e("Full sync - downloaded file corrupt");
-                return new Object[] { "remoteDbError" };
+                return new Pair<>(REMOTE_DB_ERROR, null);
             }
         } catch (SQLiteDatabaseCorruptException e) {
             Timber.e("Full sync - downloaded file corrupt");
-            return new Object[] { "remoteDbError" };
+            return new Pair<>(REMOTE_DB_ERROR, null);
         } finally {
             if (tempDb != null) {
                 tempDb.close();
@@ -127,23 +130,23 @@ public class FullSyncer extends HttpSyncer {
         File newFile = new File(tpath);
         if (newFile.renameTo(new File(path))) {
             Timber.i("Full Sync Success: Overwritten collection with downloaded file");
-            return new Object[] { "success" };
+            return new Pair<>(SUCCESS, null);
         } else {
             Timber.w("Full Sync: Error overwriting collection with downloaded file");
-            return new Object[] { "overwriteError" };
+            return new Pair<>(OVERWRITE_ERROR, null);
         }
     }
 
 
     @Override
-    public Object[] upload() throws UnknownHttpResponseException {
+    public Pair<ConnectionResultType, Object[]> upload() throws UnknownHttpResponseException {
         // make sure it's ok before we try to upload
         mCon.publishProgress(R.string.sync_check_upload_file);
         if (!"ok".equalsIgnoreCase(mCol.getDb().queryString("PRAGMA integrity_check"))) {
-            return new Object[] { "dbError" };
+            return new Pair<>(DB_ERROR, null);
         }
         if (!mCol.basicCheck()) {
-            return new Object[] { "dbError" };
+            return new Pair<>(DB_ERROR, null);
         }
         // apply some adjustments, then upload
         mCol.beforeUpload();
@@ -158,9 +161,9 @@ public class FullSyncer extends HttpSyncer {
             int status = ret.code();
             if (status != 200) {
                 // error occurred
-                return new Object[] { "error", status, ret.message() };
+                return new Pair<>(ERROR, new Object[] {status, ret.message() });
             } else {
-                return new Object[] { ret.body().string() };
+                return new Pair<>(ARBITRARY_STRING, new Object[] { ret.body().string() });
             }
         } catch (IllegalStateException | IOException e) {
             throw new RuntimeException(e);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HttpSyncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HttpSyncer.java
@@ -22,6 +22,7 @@ package com.ichi2.libanki.sync;
 
 import android.content.SharedPreferences;
 import android.net.Uri;
+import android.util.Pair;
 
 import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.exception.UnknownHttpResponseException;
@@ -376,12 +377,12 @@ public class HttpSyncer {
     }
 
 
-    public Object[] download() throws UnknownHttpResponseException {
+    public Pair<Syncer.ConnectionResultType, Object[]> download() throws UnknownHttpResponseException {
         return null;
     }
 
 
-    public Object[] upload() throws UnknownHttpResponseException {
+    public Pair<Syncer.ConnectionResultType, Object[]> upload() throws UnknownHttpResponseException {
         return null;
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/MediaSyncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/MediaSyncer.java
@@ -42,6 +42,9 @@ import java.util.zip.ZipFile;
 
 import timber.log.Timber;
 
+import static com.ichi2.libanki.sync.Syncer.ConnectionResultType;
+import static com.ichi2.libanki.sync.Syncer.ConnectionResultType.*;
+
 /**
  * About conflicts:
  * - to minimize data loss, if both sides are marked for sending and one
@@ -81,7 +84,7 @@ public class MediaSyncer {
     }
 
 
-    public String sync() throws UnknownHttpResponseException, MediaSyncException {
+    public Pair<ConnectionResultType, Object> sync() throws UnknownHttpResponseException, MediaSyncException {
             // check if there have been any changes
             // If we haven't built the media db yet, do so on this sync. See note at the top
             // of this class about this difference to the original.
@@ -91,7 +94,7 @@ public class MediaSyncer {
                 try {
                     mCol.getMedia().findChanges();
                 } catch (SQLException ignored) {
-                    return "corruptMediaDB";
+                    return new Pair<>(CORRUPT, null);
                 }
             }
 
@@ -100,7 +103,7 @@ public class MediaSyncer {
             JSONObject ret = mServer.begin();
             int srvUsn = ret.getInt("usn");
             if ((lastUsn == srvUsn) && !(mCol.getMedia().haveDirty())) {
-                return "noChanges";
+                return new Pair<>(NO_CHANGES, null);
             }
             // loop through and process changes from server
             mCol.log("last local usn is " + lastUsn);
@@ -109,7 +112,7 @@ public class MediaSyncer {
                 // Allow cancellation (note: media sync has no finish command, so just throw)
                 if (Connection.getIsCancelled()) {
                     Timber.i("Sync was cancelled");
-                    throw new RuntimeException("UserAbortedSync");
+                    throw new RuntimeException(USER_ABORTED_SYNC.toString());
                 }
                 JSONArray data = mServer.mediaChanges(lastUsn);
                 mCol.log("mediaChanges resp count: ", data.length());
@@ -123,7 +126,7 @@ public class MediaSyncer {
                     // Allow cancellation (note: media sync has no finish command, so just throw)
                     if (Connection.getIsCancelled()) {
                         Timber.i("Sync was cancelled");
-                        throw new RuntimeException("UserAbortedSync");
+                        throw new RuntimeException(USER_ABORTED_SYNC.toString());
                     }
                     String fname = data.getJSONArray(i).getString(0);
                     int rusn = data.getJSONArray(i).getInt(1);
@@ -225,10 +228,10 @@ public class MediaSyncer {
             int lcnt = mCol.getMedia().mediacount();
             String sRet = mServer.mediaSanity(lcnt);
             if ("OK".equals(sRet)) {
-                return "OK";
+                return new Pair<>(OK, null);
             } else {
                 mCol.getMedia().forceResync();
-                return sRet;
+                return new Pair<>(ARBITRARY_STRING, sRet);
         }
     }
 


### PR DESCRIPTION
Sync (and login) are very complex. Some of the complexity may be unavoidable because a lot of things may break during a
sync. However, I tries at least to reduce it.

In particular, one of the main problem it has is that the state is transmitted using an array of objects whose first
object is the status as a string.

I decided to do multiple change. In a single commit because they are so linked together that I don't see how else to do
it.

Instead of strings, I use an enum for all the different cases that existed. It allows to have a full list of the
potential return value of sync. Some still lack comments, for example, it would be nice to have a clear explanation of
why there are GENERIC_ERROR and ERROR, but I don't understand the whole process well enough to be sure that they are not
essentially the same thing as I suspect.

I use a Pair to return the value, so that the returned state is clearly separated from the array of extra values. In the
payload, I added a field to contains the element of the enum class.

This is in my merge branch. Sync and both directions of full sync still works. I've not tested the failure cases
