### PR TITLE
Improve Corrupt Collection/Basic Check Failed Dialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.java
@@ -363,7 +363,7 @@ public class AnkiActivity extends AppCompatActivity implements SimpleMessageDial
         }
     }
 
-    protected void openUrl(Uri url) {
+    public void openUrl(Uri url) {
         //DEFECT: We might want a custom view for the toast, given i8n may make the text too long for some OSes to
         //display the toast
         if (!AdaptionUtil.hasWebBrowser(this)) {
@@ -477,7 +477,7 @@ public class AnkiActivity extends AppCompatActivity implements SimpleMessageDial
         showAsyncDialogFragment(newFragment);
     }
 
-    protected void showSimpleMessageDialog(String title, String message, boolean reload) {
+    protected void showSimpleMessageDialog(String title, @Nullable String message, boolean reload) {
         AsyncDialogFragment newFragment = SimpleMessageDialog.newInstance(title, message, reload);
         showAsyncDialogFragment(newFragment);
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -1391,7 +1391,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
     /**
      *  Show simple error dialog with just the message and OK button. Reload the activity when dialog closed.
      */
-    private void showSyncErrorMessage(String message) {
+    private void showSyncErrorMessage(@Nullable String message) {
         String title = getResources().getString(R.string.sync_error);
         showSimpleMessageDialog(title, message, true);
     }
@@ -1812,9 +1812,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
                             showSyncErrorDialog(SyncErrorDialog.DIALOG_SYNC_CONFLICT_RESOLUTION);
                         }
                     } else if ("dbError".equals(resultType) || "basicCheckFailed".equals(resultType)) {
-                        String repairUrl = res.getString(R.string.repair_deck);
-                        dialogMessage = res.getString(R.string.sync_corrupt_database, repairUrl);
-                        showSyncErrorMessage(joinSyncMessages(dialogMessage, syncMessage));
+                        showSyncErrorDialog(SyncErrorDialog.DIALOG_SYNC_CORRUPT_COLLECTION, syncMessage);
                     } else if ("overwriteError".equals(resultType)) {
                         dialogMessage = res.getString(R.string.sync_overwrite_error);
                         showSyncErrorMessage(joinSyncMessages(dialogMessage, syncMessage));
@@ -1962,8 +1960,8 @@ public class DeckPicker extends NavigationDrawerActivity implements
         return msg;
     }
 
-
-    private String joinSyncMessages(String dialogMessage, String syncMessage) {
+    @Nullable
+    public static String joinSyncMessages(@Nullable String dialogMessage, @Nullable  String syncMessage) {
         // If both strings have text, separate them by a new line, otherwise return whichever has text
         if (!TextUtils.isEmpty(dialogMessage) && !TextUtils.isEmpty(syncMessage)) {
             return dialogMessage + "\n\n" + syncMessage;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -1811,7 +1811,10 @@ public class DeckPicker extends NavigationDrawerActivity implements
                             // If can't be resolved then automatically then show conflict resolution dialog
                             showSyncErrorDialog(SyncErrorDialog.DIALOG_SYNC_CONFLICT_RESOLUTION);
                         }
-                    } else if ("dbError".equals(resultType) || "basicCheckFailed".equals(resultType)) {
+                    } else if ("basicCheckFailed".equals(resultType)) {
+                        dialogMessage = res.getString(R.string.sync_basic_check_failed, res.getString(R.string.check_db));
+                        showSyncErrorMessage(joinSyncMessages(dialogMessage, syncMessage));
+                    } else if ("dbError".equals(resultType)) {
                         showSyncErrorDialog(SyncErrorDialog.DIALOG_SYNC_CORRUPT_COLLECTION, syncMessage);
                     } else if ("overwriteError".equals(resultType)) {
                         dialogMessage = res.getString(R.string.sync_overwrite_error);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SimpleMessageDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SimpleMessageDialog.java
@@ -7,6 +7,8 @@ import com.afollestad.materialdialogs.MaterialDialog;
 import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.R;
 
+import androidx.annotation.Nullable;
+
 public class SimpleMessageDialog extends AsyncDialogFragment {
 
     public interface SimpleMessageDialogListener {
@@ -19,7 +21,7 @@ public class SimpleMessageDialog extends AsyncDialogFragment {
     }
 
 
-    public static SimpleMessageDialog newInstance(String title, String message, boolean reload) {
+    public static SimpleMessageDialog newInstance(String title, @Nullable String message, boolean reload) {
         SimpleMessageDialog f = new SimpleMessageDialog();
         Bundle args = new Bundle();
         args.putString("title", title);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SyncErrorDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SyncErrorDialog.java
@@ -1,12 +1,17 @@
 
 package com.ichi2.anki.dialogs;
 
+import android.net.Uri;
 import android.os.Bundle;
 import android.os.Message;
 
 import com.afollestad.materialdialogs.MaterialDialog;
+import com.ichi2.anki.AnkiActivity;
+import com.ichi2.anki.DeckPicker;
 import com.ichi2.anki.R;
 import com.ichi2.libanki.Collection;
+
+import androidx.annotation.Nullable;
 
 public class SyncErrorDialog extends AsyncDialogFragment {
     public static final int DIALOG_USER_NOT_LOGGED_IN_SYNC = 0;
@@ -18,6 +23,7 @@ public class SyncErrorDialog extends AsyncDialogFragment {
     public static final int DIALOG_SYNC_SANITY_ERROR_CONFIRM_KEEP_LOCAL = 7;
     public static final int DIALOG_SYNC_SANITY_ERROR_CONFIRM_KEEP_REMOTE = 8;
     public static final int DIALOG_MEDIA_SYNC_ERROR = 9;
+    public static final int DIALOG_SYNC_CORRUPT_COLLECTION = 10;
 
     public interface SyncErrorDialogListener {
         void showSyncErrorDialog(int dialogType);
@@ -151,6 +157,15 @@ public class SyncErrorDialog extends AsyncDialogFragment {
                         })
                         .show();
             }
+            case DIALOG_SYNC_CORRUPT_COLLECTION: {
+                return
+                        builder.positiveText(R.string.dialog_ok)
+                        .neutralText(R.string.sync_corrupt_collection_get_help)
+                        .onNeutral((dialog, which) -> ((AnkiActivity)(requireActivity())).openUrl(Uri.parse(getString(R.string.repair_deck))))
+                        .cancelable(false)
+                        .show();
+
+            }
             default:
                 return null;
         }
@@ -186,7 +201,7 @@ public class SyncErrorDialog extends AsyncDialogFragment {
         }
     }
 
-
+    @Nullable
     private String getMessage() {
         switch (getArguments().getInt("dialogType")) {
             case DIALOG_USER_NOT_LOGGED_IN_SYNC:
@@ -203,6 +218,13 @@ public class SyncErrorDialog extends AsyncDialogFragment {
                 return res().getString(R.string.sync_conflict_local_confirm);
             case DIALOG_SYNC_SANITY_ERROR_CONFIRM_KEEP_REMOTE:
                 return res().getString(R.string.sync_conflict_remote_confirm);
+            case DIALOG_SYNC_CORRUPT_COLLECTION: {
+                String syncMessage = getArguments().getString("dialogMessage");
+                String repairUrl = getString(R.string.repair_deck);
+                String dialogMessage = getString(R.string.sync_corrupt_database, repairUrl);
+                return DeckPicker.joinSyncMessages(dialogMessage, syncMessage);
+            }
+
             default:
                 return getArguments().getString("dialogMessage");
         }

--- a/AnkiDroid/src/main/res/values/04-network.xml
+++ b/AnkiDroid/src/main/res/values/04-network.xml
@@ -100,6 +100,8 @@
     <string name="sync_media_db_error">Media sync failed because current database is corrupt. A media check is recommended.</string>
     <string name="sync_media_error">Error syncing media data</string>
     <string name="sync_media_error_check">Error while syncing media. A media check is recommended.</string>
+    <!-- Please run ‘Check database’ before syncing -->
+    <string name="sync_basic_check_failed">Please run ‘%s’ before syncing</string>
     <string name="sync_sanity_local">Local</string>
     <string name="sync_sanity_remote">Remote</string>
     <string name="force_full_sync_title">Force full sync</string>

--- a/AnkiDroid/src/main/res/values/04-network.xml
+++ b/AnkiDroid/src/main/res/values/04-network.xml
@@ -117,4 +117,7 @@
     <string name="sync_menu_title">Sync</string>
     <string name="sync_menu_title_full_sync">Sync (full)</string>
     <string name="sync_menu_title_no_account">Sync (log in)</string>
+
+    <!-- An option on a message box to open the "corrupt collection" webpage -->
+    <string name="sync_corrupt_collection_get_help">Help</string>
 </resources>

--- a/AnkiDroid/src/main/res/values/constants.xml
+++ b/AnkiDroid/src/main/res/values/constants.xml
@@ -146,7 +146,7 @@
     <string name="link_faq_tts">https://github.com/ankidroid/Anki-Android/wiki/FAQ#tts--text-to-speech-is-not-speaking</string>
     <string name="link_faq_missing_media" tools:ignore="Typos">https://github.com/ankidroid/Anki-Android/wiki/FAQ#why-doesnt-my-sound-or-image-work-on-ankidroid</string>
     <string name="shared_decks_url">https://ankiweb.net/shared/decks/</string>
-    <string name="repair_deck">http://ankisrs.net/docs/manual.html#corrupt-collections</string>
+    <string name="repair_deck">https://docs.ankiweb.net/#/files?id=corrupt-collections</string>
     <string name="resetpw_url">http://ankiweb.net/account/resetpw</string>
     <string name="register_url">https://ankiweb.net/account/register</string>
     <string name="changelog_url">https://docs.ankidroid.org/changelog.html</string>


### PR DESCRIPTION
## Purpose / Description
* Failing the basic check showed a "Corrupt" message instead of a "Check Database" message
* On corrupt database, the link was dead
* There was no help button, instead a link needed to be typed into the browser

## Fixes
Fixes #7151

## Approach
Make a "basicCheckFailed" error

## How Has This Been Tested?

Tested on my Android 9 via changing the result type to "basicCheckFailed"

## Learning (optional, can help others)
Question everything

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code