### PR TITLE
Stop calling displayFailedToOpenDeck unless error

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -262,11 +262,10 @@ public class DeckPicker extends NavigationDrawerActivity implements
         if (mActionsMenu != null && mActionsMenu.isExpanded()) {
             mActionsMenu.collapse();
         }
-        if (!colIsOpen()) {
-            displayFailedToOpenDeck(deckId);
-            return;
-        }
+
+        boolean collectionIsOpen = false;
         try {
+            collectionIsOpen = colIsOpen();
             handleDeckSelection(deckId, dontSkipStudyOptions);
             if (mFragmented || !CompatHelper.isLollipop()) {
                 // Calling notifyDataSetChanged() will update the color of the selected deck.
@@ -274,7 +273,9 @@ public class DeckPicker extends NavigationDrawerActivity implements
                 mDeckListAdapter.notifyDataSetChanged();
             }
         } catch (Exception e) {
-            AnkiDroidApp.sendExceptionReport(e, "deckPicker::onDeckClick", Long.toString(deckId));
+            // Maybe later don't report if collectionIsOpen is false?
+            String info = deckId + " colOpen:" + collectionIsOpen;
+            AnkiDroidApp.sendExceptionReport(e, "deckPicker::onDeckClick", info);
             displayFailedToOpenDeck(deckId);
         }
     }


### PR DESCRIPTION
## Purpose / Description

User reported seeing this error constantly - could have been corruption, but I doubt it.

Maybe I was mistaken and the operation can succeed if `colIsOpen` returns false.

This will increase error report volume, but the error has better diagnostics

Maybe later we won't error report if the collection is not open


## Fixes
Fixes #7149

## How Has This Been Tested?
Untested

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code