### PR TITLE
Discard current card in deck picker

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -211,7 +211,8 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
     private String mExportFileName;
 
-    private List<AbstractDeckTreeNode> mDueTree;
+    @VisibleForTesting
+    public List<AbstractDeckTreeNode> mDueTree;
 
     /**
      * Flag to indicate whether the activity will perform a sync in its onResume.

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
@@ -135,8 +135,6 @@ public abstract class AbstractSched {
     public abstract @NonNull List<DeckTreeNode> quickDeckDueTree();
     /** New count for a single deck. */
     public abstract int _newForDeck(long did, int lim);
-    /** Limit for deck without parent limits. */
-    public abstract int _deckNewLimitSingle(Deck g);
     public abstract int totalNewForCurrentDeck();
     public abstract int totalRevForCurrentDeck();
     public abstract @NonNull Pair<Integer, Integer> _fuzzIvlRange(int ivl);

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.java
@@ -7,6 +7,11 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
 
+import com.ichi2.libanki.Collection;
+import com.ichi2.libanki.Deck;
+import com.ichi2.libanki.DeckConfig;
+import com.ichi2.libanki.sched.AbstractSched;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.LooperMode;
@@ -152,5 +157,24 @@ public class DeckPickerTest extends RobolectricTest {
             });
         }
         verify(editor, never()).remove(UPGRADE_VERSION_KEY);
+    }
+
+    @Test
+    public void limitAppliedAfterReview() {
+        Collection col = getCol();
+        AbstractSched sched = col.getSched();
+        Deck deck = col.getDecks().get(1);
+        DeckConfig dconf = col.getDecks().getConf(1);
+        dconf.getJSONObject("new").put("perDay", 10);
+        for (int i = 0; i < 11; i++) {
+            addNoteUsingBasicModel("Which card is this ?", Integer.toString(i));
+        }
+        // This set a card as current card
+        sched.getCard();
+        try (ActivityScenario<DeckPicker> scenario = ActivityScenario.launch(DeckPicker.class)) {
+            scenario.onActivity(deckPicker -> {
+                assertEquals(10, deckPicker.mDueTree.get(0).getNewCount());
+            });
+        }
     }
 }


### PR DESCRIPTION
This correct partially https://github.com/ankidroid/Anki-Android/issues/7162#issuecomment-695347169 (in the sens that it corrects the comment made by David below the main error)

You also have a regression test with it.

I didn't realize there was asynchronicity I uncorrectly considered. When the reviewer is destroyed, the currentCard should be discarded. However, I didn't realize that the deck picker would start computing before the Reviewer is destroyed. For safety, I tells the Deck Picker to state that the current card does not exists anymore.

This would break if at any point we decide to allow the deck picker and the reviewer to be opened simultaneously. But to be honest, a lot of things would break in the scheduler, so that's not an actual concern.

The discarding is done in CollectionTask. This way, if some API ask for number of cards to be reviewed and call `deckDueTree`, this won't change the current card and won't disturb the state of the scheduler.