### PR TITLE
Auto-reformat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ Thumbs.db
 
 # IDEA/Android Studio Ignore exceptions - this lets you share things you specifically want all team members to use
 !/.idea/codeStyles/
+!.idea/saveactions_settings.xml
 
 # Crowdin files
 ankidroid.zip

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -24,8 +24,18 @@
         <package name="" withSubpackages="true" static="true" />
       </value>
     </option>
+    <AndroidXmlCodeStyleSettings>
+      <option name="USE_CUSTOM_SETTINGS" value="false" />
+    </AndroidXmlCodeStyleSettings>
     <JavaCodeStyleSettings>
-      <option name="BLANK_LINES_AROUND_INITIALIZER" value="2" />
+      <option name="FIELD_NAME_PREFIX" value="m" />
+      <option name="STATIC_FIELD_NAME_PREFIX" value="s" />
+      <option name="GENERATE_FINAL_LOCALS" value="true" />
+      <option name="GENERATE_FINAL_PARAMETERS" value="true" />
+      <option name="VISIBILITY" value="private" />
+      <option name="INSERT_INNER_CLASS_IMPORTS" value="true" />
+      <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="10" />
+      <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="4" />
       <option name="IMPORT_LAYOUT_TABLE">
         <value>
           <package name="android" withSubpackages="true" static="false" />
@@ -48,6 +58,7 @@
           <emptyLine />
         </value>
       </option>
+      <option name="JD_DO_NOT_WRAP_ONE_LINE_COMMENTS" value="true" />
     </JavaCodeStyleSettings>
     <JetCodeStyleSettings>
       <option name="PACKAGES_TO_USE_STAR_IMPORTS">
@@ -68,18 +79,29 @@
       </option>
     </JetCodeStyleSettings>
     <XML>
+      <option name="XML_ATTRIBUTE_WRAP" value="2" />
+      <option name="XML_ALIGN_ATTRIBUTES" value="true" />
       <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
     </XML>
     <codeStyleSettings language="JAVA">
       <option name="RIGHT_MARGIN" value="120" />
-      <option name="BLANK_LINES_AROUND_CLASS" value="3" />
-      <option name="BLANK_LINES_AROUND_METHOD" value="2" />
+      <option name="KEEP_LINE_BREAKS" value="false" />
+      <option name="KEEP_FIRST_COLUMN_COMMENT" value="false" />
+      <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+      <option name="BLANK_LINES_AROUND_CLASS" value="2" />
+      <option name="ALIGN_MULTILINE_CHAINED_METHODS" value="true" />
+      <option name="ALIGN_MULTILINE_THROWS_LIST" value="true" />
+      <option name="ALIGN_MULTILINE_EXTENDS_LIST" value="true" />
+      <option name="ALIGN_MULTILINE_METHOD_BRACKETS" value="true" />
       <option name="SPACE_BEFORE_ARRAY_INITIALIZER_LBRACE" value="true" />
       <option name="SPACE_BEFORE_ANNOTATION_ARRAY_INITIALIZER_LBRACE" value="true" />
+      <option name="WRAP_FIRST_METHOD_IN_CALL_CHAIN" value="true" />
       <option name="IF_BRACE_FORCE" value="3" />
       <option name="DOWHILE_BRACE_FORCE" value="3" />
       <option name="WHILE_BRACE_FORCE" value="3" />
       <option name="FOR_BRACE_FORCE" value="3" />
+      <option name="WRAP_LONG_LINES" value="true" />
+      <option name="ENUM_CONSTANTS_WRAP" value="2" />
     </codeStyleSettings>
     <codeStyleSettings language="XML">
       <indentOptions>

--- a/.idea/saveactions_settings.xml
+++ b/.idea/saveactions_settings.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+    <component name="SaveActionSettings">
+        <option name="actions">
+            <set>
+                <option value="activate" />
+                <option value="activateOnBatch" />
+                <option value="noActionIfCompileErrors" />
+                <option value="organizeImports" />
+                <option value="reformatChangedCode" />
+                <option value="rearrange" />
+                <option value="fieldCanBeFinal" />
+                <option value="localCanBeFinal" />
+                <option value="localCanBeFinalExceptImplicit" />
+                <option value="methodMayBeStatic" />
+                <option value="missingOverrideAnnotation" />
+                <option value="useBlocks" />
+                <option value="unnecessaryThis" />
+                <option value="finalPrivateMethod" />
+                <option value="unnecessaryFinalOnLocalVariableOrParameter" />
+                <option value="explicitTypeCanBeDiamond" />
+                <option value="unnecessarySemicolon" />
+                <option value="accessCanBeTightened" />
+            </set>
+        </option>
+        <option name="configurationPath"
+                value="" />
+    </component>
+</project>

--- a/tools/git-hooks/README.md
+++ b/tools/git-hooks/README.md
@@ -1,0 +1,7 @@
+This directory contains hooks that contributors should call in their git repo.
+
+On a unix system, in git's top level folder, type
+```bash
+ln -s tools/git-hooks/pre-push .git/hooks/
+```
+to ensure that pre-push is executed before push.

--- a/tools/git-hooks/pre-push
+++ b/tools/git-hooks/pre-push
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# Change `android-studio` by a command which
+# run android-studio on your device
+
+android-studio format -r AnkiDroid/src/
+
+git diff --exit-code
+exit $?


### PR DESCRIPTION
This PR contains two things. 

A shell script. If this shell script is used as a  hook to push, then all files will be reformatted before being pushed. If any change is not already commited, the push won't be accepted. This is not perfect, because it means you can't push anymore if you have some uncommitted change and you indeed wanted them to remain uncommitted. 
The script assume that you use android-studio, and that you can call it by simply using `android-studio`; I don't know how it would work on windows
The biggest problem is that this script does not work if android studio is opened. You can't ask from command line to reformat everything WITHOUT closing android studio first.

Lastly, since I didn't want actual reformatting to occur in this PR, I had to disable the hook in order to push this PR.


If we have access to InteliJ Idea or Android-studio on travis, we could do the same thing, ask to reformat, and if any change occured, reject.

The second and more interesting thing is that occurs is that it adds configuration for the plug-in "reformat on save". If you install this plug-in, each time you save a file, it'll be reformatted according to rules (assuming the file compiles), so you should never have to deal with reformatting again.


This hopefully would start to answer requests you had last time I wanted to apply a consistent formatting to files.
You can download this branch and run the hook to see how it would work and whether the formatting option please you or whether you'd want to change them.

I like having xml using more lines, this will lead to smaller conflict durring rebase. 
