### PR TITLE
Fix double-clicking skipping the cards

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1637,6 +1637,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
     }
 
     protected void displayAnswerBottomBar() {
+        mFlipCardLayout.setClickable(false);
         mEaseButtonsLayout.setVisibility(View.VISIBLE);
 
         Runnable after = () -> mFlipCardLayout.setVisibility(View.GONE);
@@ -1645,8 +1646,8 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         if (animationDisabled()) {
             after.run();
         } else {
-            mEaseButtonsLayout.setAlpha(0);
-            mEaseButtonsLayout.animate().alpha(1).setDuration(mShortAnimDuration).withEndAction(after);
+            mFlipCardLayout.setAlpha(1);
+            mFlipCardLayout.animate().alpha(0).setDuration(mShortAnimDuration).withEndAction(after);
         }
     }
 
@@ -1665,13 +1666,14 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         };
 
         boolean easeButtonsVisible = mEaseButtonsLayout.getVisibility() == View.VISIBLE;
+        mFlipCardLayout.setClickable(true);
         mFlipCardLayout.setVisibility(View.VISIBLE);
 
         if (animationDisabled() || !easeButtonsVisible) {
             after.run();
         } else {
-            mEaseButtonsLayout.setAlpha(1);
-            mEaseButtonsLayout.animate().alpha(0).setDuration(mShortAnimDuration).withEndAction(after);
+            mFlipCardLayout.setAlpha(0);
+            mFlipCardLayout.animate().alpha(1).setDuration(mShortAnimDuration).withEndAction(after);
         }
 
         focusAnswerCompletionField();

--- a/AnkiDroid/src/main/res/layout/reviewer_answer_buttons.xml
+++ b/AnkiDroid/src/main/res/layout/reviewer_answer_buttons.xml
@@ -67,29 +67,10 @@
         android:layout_height="fill_parent">
 
         <LinearLayout
-            android:id="@+id/flashcard_layout_flip"
-            android:layout_width="fill_parent"
-            android:layout_height="@dimen/touch_target"
-            android:orientation="vertical">
-
-            <Button
-                style="@style/FooterButton"
-                android:background="?attr/hardButtonRef"
-                android:id="@+id/flip_card"
-                android:layout_width="fill_parent"
-                android:layout_height="fill_parent"
-                android:clickable="false"
-                android:text="@string/show_answer"
-                android:textColor="?attr/answerButtonTextColor" />
-        </LinearLayout>
-
-        <LinearLayout
             android:id="@+id/ease_buttons"
             android:layout_width="fill_parent"
             android:layout_height="fill_parent"
-            android:orientation="horizontal"
-            android:visibility="gone"
-            tools:visibility="visible">
+            android:orientation="horizontal">
 
             <LinearLayout
                 style="@style/FooterButton"
@@ -170,6 +151,24 @@
                     android:text="@string/ease_button_easy"
                     style="@style/EasyButtonEaseStyle" />
             </LinearLayout>
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/flashcard_layout_flip"
+            android:layout_width="fill_parent"
+            android:layout_height="@dimen/touch_target"
+            android:orientation="vertical"
+            tools:visibility="gone">
+
+            <Button
+                style="@style/FooterButton"
+                android:background="?attr/hardButtonRef"
+                android:id="@+id/flip_card"
+                android:layout_width="fill_parent"
+                android:layout_height="fill_parent"
+                android:clickable="false"
+                android:text="@string/show_answer"
+                android:textColor="?attr/answerButtonTextColor" />
         </LinearLayout>
     </FrameLayout>
 </LinearLayout>


### PR DESCRIPTION
## Purpose / Description
This pull request addresses the problem of skipping cards when clicking fast enough in card reviewer.

## Fixes
Fixes #7138 

## Approach
This pull request disables show answer button when ease buttons are enabled and reorders them to be able to press the right buttons when animation has not yet finished.

## How Has This Been Tested?

Ran on Android 9, it was fine. But please test it

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
