### PR TITLE
NF: suppres wraning about >>> 32

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractDeckTreeNode.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractDeckTreeNode.java
@@ -142,7 +142,7 @@ public abstract class AbstractDeckTreeNode<T extends AbstractDeckTreeNode<T>> im
     @Override
     public int hashCode() {
         int childrenHash = mChildren == null ? 0 : mChildren.hashCode();
-        return getFullDeckName().hashCode() + (int) (childrenHash ^ (childrenHash >>> 32));
+        return getFullDeckName().hashCode() + childrenHash;
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/DeckDueTreeNode.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/DeckDueTreeNode.java
@@ -83,7 +83,7 @@ public class DeckDueTreeNode extends AbstractDeckTreeNode<DeckDueTreeNode> {
     @Override
     public int hashCode() {
         int childrenHash = getChildren() == null ? 0 : getChildren().hashCode();
-        return getFullDeckName().hashCode() + mRevCount + mLrnCount + mNewCount + (int) (childrenHash ^ (childrenHash >>> 32));
+        return getFullDeckName().hashCode() + mRevCount + mLrnCount + mNewCount + childrenHash;
     }
 
 


### PR DESCRIPTION
There was warning that ">>>32" is useless (at least in 32 bit). And assuming the hash of the list is done in a proper way, then it does not seems to had any security to do more than add the two hashes.