### PR TITLE
NF: Remove warning that member could be local variable

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -304,7 +304,6 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
 
     private boolean mButtonHeightSet = false;
 
-    private boolean mConfigurationChanged = false;
     private int mShowChosenAnswerLength = 2000;
 
     /**
@@ -2200,9 +2199,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         }
         fillFlashcard();
 
-        if (!mConfigurationChanged) {
-            playSounds(false); // Play sounds if appropriate
-        }
+        playSounds(false); // Play sounds if appropriate
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -210,8 +210,6 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
     // JS api list enable/disable status
     private HashMap<String, Boolean> mJsApiListMap = new HashMap<String, Boolean>();
 
-    private boolean isInFullscreen;
-
     /**
      * Broadcast that informs us when the sd card is about to be unmounted
      */
@@ -884,8 +882,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
     }
 
     protected boolean isFullscreen() {
-        isInFullscreen = !getSupportActionBar().isShowing();
-        return isInFullscreen;
+        return !getSupportActionBar().isShowing();
     }
 
     @ Override

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -304,7 +304,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
 
     private boolean mButtonHeightSet = false;
 
-    private int mShowChosenAnswerLength = 2000;
+    private static final int sShowChosenAnswerLength = 2000;
 
     /**
      * A record of the last time the "show answer" or ease buttons were pressed. We keep track
@@ -1375,7 +1375,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
 
         // remove chosen answer hint after a while
         mTimerHandler.removeCallbacks(removeChosenAnswerText);
-        mTimerHandler.postDelayed(removeChosenAnswerText, mShowChosenAnswerLength);
+        mTimerHandler.postDelayed(removeChosenAnswerText, sShowChosenAnswerLength);
         mSoundPlayer.stopSounds();
         mCurrentEase = ease;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
@@ -46,8 +46,6 @@ public class CollectionHelper {
 
     // Collection instance belonging to sInstance
     private Collection mCollection;
-    // Path to collection, cached for the reopenCollection() method
-    private String mPath;
     // Name of anki2 file
     public static final String COLLECTION_FILENAME = "collection.anki2";
 
@@ -112,7 +110,7 @@ public class CollectionHelper {
             // Check that the directory has been created and initialized
             try {
                 initializeAnkiDroidDirectory(getParentDirectory(path));
-                mPath = path;
+                // Path to collection, cached for the reopenCollection() method
             } catch (StorageAccessException e) {
                 Timber.e(e, "Could not initialize AnkiDroid directory");
                 return null;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.java
@@ -84,7 +84,6 @@ public class ModelBrowser extends AnkiActivity {
     private ModelBrowserContextMenu mContextMenu;
 
     private ArrayList<String> mNewModelNames;
-    private ArrayList<String> mNewModelLabels;
 
 
     // ----------------------------------------------------------------------------
@@ -311,30 +310,30 @@ public class ModelBrowser extends AnkiActivity {
         String clone = getResources().getString(R.string.model_browser_add_clone);
 
         //Populates arrayadapters listing the mModels (includes prefixes/suffixes)
-        mNewModelLabels = new ArrayList<>();
+        ArrayList<String> newModelLabels = new ArrayList<>();
         ArrayList<String> existingModelsNames = new ArrayList<>();
 
         //Used to fetch model names
         mNewModelNames = new ArrayList<>();
         for (StdModels StdModels: StdModels.stdModels) {
             String defaultName = StdModels.getDefaultName();
-            mNewModelLabels.add(String.format(add, defaultName));
+            newModelLabels.add(String.format(add, defaultName));
             mNewModelNames.add(defaultName);
         }
 
-        final int numStdModels = mNewModelLabels.size();
+        final int numStdModels = newModelLabels.size();
 
         if (mModels != null) {
             for (Model model : mModels) {
                 String name = model.getString("name");
-                mNewModelLabels.add(String.format(clone, name));
+                newModelLabels.add(String.format(clone, name));
                 mNewModelNames.add(name);
                 existingModelsNames.add(name);
             }
         }
 
         final Spinner addSelectionSpinner = new Spinner(this);
-        ArrayAdapter<String> mNewModelAdapter = new ArrayAdapter<>(this, R.layout.dropdown_deck_item, mNewModelLabels);
+        ArrayAdapter<String> mNewModelAdapter = new ArrayAdapter<>(this, R.layout.dropdown_deck_item, newModelLabels);
 
         addSelectionSpinner.setAdapter(mNewModelAdapter);
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -118,7 +118,8 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
 
     private static final int RESULT_LOAD_IMG = 111;
     private CheckBoxPreference backgroundImage;
-    private static long fileLength;
+
+
     // ----------------------------------------------------------------------------
     // Overridden methods
     // ----------------------------------------------------------------------------
@@ -449,7 +450,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                     File sourceFile = new File(imgPathString);
 
                     // file size in MB
-                    fileLength = sourceFile.length() / (1024 * 1024);
+                    long fileLength = sourceFile.length() / (1024 * 1024);
 
                     String currentAnkiDroidDirectory = CollectionHelper.getCurrentAnkiDroidDirectory(this);
                     String imageName = "DeckPickerBackground.png";

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.java
@@ -75,7 +75,6 @@ public class Whiteboard extends View {
 
     private boolean mSecondFingerWithinTapTolerance;
     private boolean mCurrentlyDrawing = false;
-    private boolean mMonochrome;
     private boolean mUndoModeActive = false;
     private final int foregroundColor;
     private final LinearLayout mColorPalette;
@@ -83,17 +82,16 @@ public class Whiteboard extends View {
     public Whiteboard(AbstractFlashcardViewer cardViewer, boolean inverted, boolean monochrome) {
         super(cardViewer, null);
         mCardViewer = new WeakReference<>(cardViewer);
-        mMonochrome = monochrome;
 
 
         if (!inverted) {
-            if (mMonochrome) {
+            if (monochrome) {
                 foregroundColor = Color.BLACK;
             } else {
                 foregroundColor = ContextCompat.getColor(cardViewer, R.color.wb_fg_color);
             }
         } else {
-            if (mMonochrome) {
+            if (monochrome) {
                 foregroundColor = Color.WHITE;
             } else {
                 foregroundColor = ContextCompat.getColor(cardViewer, R.color.wb_fg_color_inv);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.java
@@ -75,7 +75,6 @@ public class Whiteboard extends View {
 
     private boolean mSecondFingerWithinTapTolerance;
     private boolean mCurrentlyDrawing = false;
-    private boolean mInvertedColors;
     private boolean mMonochrome;
     private boolean mUndoModeActive = false;
     private final int foregroundColor;
@@ -84,11 +83,10 @@ public class Whiteboard extends View {
     public Whiteboard(AbstractFlashcardViewer cardViewer, boolean inverted, boolean monochrome) {
         super(cardViewer, null);
         mCardViewer = new WeakReference<>(cardViewer);
-        mInvertedColors = inverted;
         mMonochrome = monochrome;
 
 
-        if (!mInvertedColors) {
+        if (!inverted) {
             if (mMonochrome) {
                 foregroundColor = Color.BLACK;
             } else {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -103,7 +103,6 @@ public class Models {
 
     // BEGIN SQL table entries
     private int mId;
-    private String mName = "";
     //private long mCrt = mCol.getTime().intTime();
     //private long mMod = mCol.getTime().intTime();
     //private JSONObject mConf;
@@ -1207,7 +1206,7 @@ public class Models {
      * @return the name
      */
     public String getName() {
-        return mName;
+        return "";
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
@@ -71,13 +71,6 @@ public class Anki2Importer extends Importer {
 
     private Map<String, Object[]> mNotes;
 
-    /**
-     * Since we can't use a tuple as a key in Java, we resort to indexing twice with nested maps.
-     * Python: (guid, ord) -> cid
-     * Java: guid -> ord -> cid
-     */
-    @SuppressWarnings("PMD.SingularField")
-    private Map<String, Map<Integer, Long>> mCards;
     private Map<Long, Long> mDecks;
     private Map<Long, Long> mModelMap;
     private Map<String, String> mChangedGuids;
@@ -516,7 +509,12 @@ public class Anki2Importer extends Importer {
             }
         }
         // build map of guid -> (ord -> cid) and used id cache
-        mCards = new HashMap<>();
+        /**
+         * Since we can't use a tuple as a key in Java, we resort to indexing twice with nested maps.
+         * Python: (guid, ord) -> cid
+         * Java: guid -> ord -> cid
+         */
+        Map<String, Map<Integer, Long>> mCards = new HashMap<>();
         Map<Long, Boolean> existing = new HashMap<>();
         Cursor cur = null;
         try {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/TextImporter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/TextImporter.java
@@ -42,8 +42,6 @@ public class TextImporter extends NoteImporter {
 
     private CsvDialect dialect;
     private int numFields;
-    // appears unused
-    private int mIgnored;
 
 
     private boolean mFirstLineWasTags;
@@ -100,7 +98,6 @@ public class TextImporter extends NoteImporter {
             log.add(getString(R.string.csv_importer_error_exception, e));
         }
         mLog = log;
-        mIgnored = ignored;
         fileobj.close();
         return notes;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/TextImporter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/TextImporter.java
@@ -35,7 +35,6 @@ public class TextImporter extends NoteImporter {
     private boolean mNeedDelimiter = true;
     String mPatterns = "\t|,;:";
 
-    private final Object lines;
     private FileObj fileobj;
     private char delimiter;
     private String[] tagsToAdd;
@@ -49,7 +48,6 @@ public class TextImporter extends NoteImporter {
 
     public TextImporter(Collection col, String file) {
         super(col, file);
-        lines = null;
         fileobj = null;
         delimiter = '\0';
         tagsToAdd = new String[0];

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/python/CsvReaderIterator.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/python/CsvReaderIterator.java
@@ -43,9 +43,9 @@ public class CsvReaderIterator implements Iterator<List<String>> {
     private List<String> fields;
     private int numeric_field;
 
+    private final static int field_size = 5000;
     // These were modified from a bare array and size to a StringBuilder
-    private char[] field = new char[5000];
-    private int field_size = 5000;
+    private char[] field = new char[field_size];
 
 
     public CsvReaderIterator(@NonNull CsvReader reader) {
@@ -100,7 +100,7 @@ public class CsvReaderIterator implements Iterator<List<String>> {
 //                    _csvstate_global->field_limit);
 //            return -1;
 //        }
-        if (this.field_len == this.field_size)
+        if (this.field_len == field_size)
             return -1;
         this.field[this.field_len++] = c;
         return 0;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -67,10 +67,6 @@ public class Sched extends SchedV2 {
     private static final int[] FACTOR_ADDITION_VALUES = { -150, 0, 150 };
 
     private final @NonNull String mName = "std";
-    private final boolean mSpreadRev = true;
-
-
-
 
     // Queues
     private @NonNull LinkedList<Long> mRevDids = new LinkedList<>();
@@ -876,9 +872,7 @@ public class Sched extends SchedV2 {
 
     @SuppressWarnings("PMD.UnusedFormalParameter") // it's unused upstream as well
     private int _adjRevIvl(@NonNull Card card, int idealIvl) {
-        if (mSpreadRev) {
-            idealIvl = _fuzzedIvl(idealIvl);
-        }
+        idealIvl = _fuzzedIvl(idealIvl);
         return idealIvl;
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -66,8 +66,6 @@ public class Sched extends SchedV2 {
     // Not in libanki
     private static final int[] FACTOR_ADDITION_VALUES = { -150, 0, 150 };
 
-    private final @NonNull String mName = "std";
-
     // Queues
     private @NonNull LinkedList<Long> mRevDids = new LinkedList<>();
 
@@ -1262,7 +1260,7 @@ public class Sched extends SchedV2 {
     /* Need to override. Otherwise it get SchedV2.mName variable*/
     @Override
     public String getName() {
-        return mName;
+        return "std";
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -82,7 +82,6 @@ public class SchedV2 extends AbstractSched {
     public static final int RESCHEDULE_FACTOR = Consts.STARTING_FACTOR;
 
     private final String mName = "std2";
-    private boolean mHaveCustomStudy = true;
 
     protected int mQueueLimit;
     protected int mReportLimit;
@@ -2231,15 +2230,11 @@ public class SchedV2 extends AbstractSched {
         }
         if (haveBuried()) {
             String now;
-            if (mHaveCustomStudy) {
-                now = " " + context.getString(R.string.sched_unbury_action);
-            } else {
-                now = "";
-            }
+            now = " " + context.getString(R.string.sched_unbury_action);
             sb.append("\n\n");
             sb.append("" + context.getString(R.string.sched_has_buried) + now);
         }
-        if (mHaveCustomStudy && mCol.getDecks().current().getInt("dyn") == 0) {
+        if (mCol.getDecks().current().getInt("dyn") == 0) {
             sb.append("\n\n");
             sb.append(context.getString(R.string.studyoptions_congrats_custom));
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -81,8 +81,6 @@ public class SchedV2 extends AbstractSched {
     private static final int[] FACTOR_ADDITION_VALUES = { -150, 0, 150 };
     public static final int RESCHEDULE_FACTOR = Consts.STARTING_FACTOR;
 
-    private final String mName = "std2";
-
     protected int mQueueLimit;
     protected int mReportLimit;
     private int mDynReportLimit;
@@ -2809,7 +2807,7 @@ public class SchedV2 extends AbstractSched {
 
 
     public String getName() {
-        return mName;
+        return "std2";
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.java
@@ -66,16 +66,13 @@ public class Syncer {
 
     private Collection mCol;
     private HttpSyncer mServer;
-    private long mRMod;
     //private long mRScm;
     private int mMaxUsn;
 
     private HostNum mHostNum;
-    private long mLMod;
     //private long mLScm;
     private int mMinUsn;
     private boolean mLNewer;
-    private JSONObject mRChg;
     private String mSyncMsg;
 
     private LinkedList<String> mTablesLeft;
@@ -126,14 +123,14 @@ public class Syncer {
                 throwExceptionIfCancelled(con);
                 long rscm = rMeta.getLong("scm");
                 int rts = rMeta.getInt("ts");
-                mRMod = rMeta.getLong("mod");
+                long rMod = rMeta.getLong("mod");
                 mMaxUsn = rMeta.getInt("usn");
                 // skip uname, AnkiDroid already stores and shows it
                 trySetHostNum(rMeta);
                 Timber.i("Sync: building local meta data");
                 JSONObject lMeta = meta();
                 mCol.log("lmeta", lMeta);
-                mLMod = lMeta.getLong("mod");
+                long lMod = lMeta.getLong("mod");
                 mMinUsn = lMeta.getInt("usn");
                 long lscm = lMeta.getLong("scm");
                 int lts = lMeta.getInt("ts");
@@ -143,7 +140,7 @@ public class Syncer {
                     mCol.log("clock off");
                     return new Object[] { "clockOff", diff };
                 }
-                if (mLMod == mRMod) {
+                if (lMod == rMod) {
                     Timber.i("Sync: no changes - returning");
                     mCol.log("no changes");
                     return new Object[] { "noChanges" };
@@ -152,7 +149,7 @@ public class Syncer {
                     mCol.log("schema diff");
                     return new Object[] { "fullSync" };
                 }
-                mLNewer = mLMod > mRMod;
+                mLNewer = lMod > rMod;
                 // step 1.5: check collection is valid
                 if (!mCol.basicCheck()) {
                     mCol.log("basic check");
@@ -310,10 +307,9 @@ public class Syncer {
 
 
     public JSONObject applyChanges(JSONObject changes) throws UnexpectedSchemaChange {
-        mRChg = changes;
         JSONObject lchg = changes();
         // merge our side before returning
-        mergeChanges(lchg, mRChg);
+        mergeChanges(lchg, changes);
         return lchg;
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/themes/StyledProgressDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/themes/StyledProgressDialog.java
@@ -30,12 +30,9 @@ import timber.log.Timber;
 
 public class StyledProgressDialog extends Dialog {
 
-    private Context mContext;
-
 
     public StyledProgressDialog(Context context) {
         super(context);
-        mContext = context;
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/ui/SlidingTabStrip.java
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/SlidingTabStrip.java
@@ -41,9 +41,7 @@ class SlidingTabStrip extends LinearLayout {
  
     private final int mSelectedIndicatorThickness;
     private final Paint mSelectedIndicatorPaint;
- 
-    private final int mDefaultBottomBorderColor;
- 
+
     private final Paint mDividerPaint;
     private final float mDividerHeight;
  
@@ -66,8 +64,8 @@ class SlidingTabStrip extends LinearLayout {
         TypedValue outValue = new TypedValue();
         context.getTheme().resolveAttribute(android.R.attr.colorForeground, outValue, true);
         final int themeForegroundColor =  outValue.data;
- 
-        mDefaultBottomBorderColor = setColorAlpha(themeForegroundColor,
+
+        int defaultBottomBorderColor = setColorAlpha(themeForegroundColor,
                 DEFAULT_BOTTOM_BORDER_COLOR_ALPHA);
  
         mDefaultTabColorizer = new SimpleTabColorizer();
@@ -77,7 +75,7 @@ class SlidingTabStrip extends LinearLayout {
  
         mBottomBorderThickness = (int) (DEFAULT_BOTTOM_BORDER_THICKNESS_DIPS * density);
         mBottomBorderPaint = new Paint();
-        mBottomBorderPaint.setColor(mDefaultBottomBorderColor);
+        mBottomBorderPaint.setColor(defaultBottomBorderColor);
  
         mSelectedIndicatorThickness = (int) (SELECTED_INDICATOR_THICKNESS_DIPS * density);
         mSelectedIndicatorPaint = new Paint();

--- a/AnkiDroid/src/main/java/com/ichi2/widget/AnkiDroidWidgetSmall.java
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/AnkiDroidWidgetSmall.java
@@ -118,9 +118,6 @@ public class AnkiDroidWidgetSmall extends AppWidgetProvider {
         private int dueCardsCount;
 
 
-        /** The cached estimated reviewing time. */
-        private int eta;
-
         public void doUpdate(Context context) {
             AppWidgetManager.getInstance(context)
                     .updateAppWidget(new ComponentName(context, AnkiDroidWidgetSmall.class), buildUpdate(context, true));
@@ -180,7 +177,8 @@ public class AnkiDroidWidgetSmall extends AppWidgetProvider {
                     // Compute the total number of cards due.
                     int[] counts = WidgetStatus.fetchSmall(context);
                     dueCardsCount = counts[0];
-                    eta = counts[1];
+                    /** The cached estimated reviewing time. */
+                    int eta = counts[1];
                     if (dueCardsCount <= 0) {
                         if (dueCardsCount == 0) {
                             updateViews.setViewVisibility(R.id.ankidroid_widget_small_finish_layout, View.VISIBLE);

--- a/AnkiDroid/src/main/java/com/ichi2/widget/WidgetStatus.java
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/WidgetStatus.java
@@ -40,7 +40,6 @@ import timber.log.Timber;
 public final class WidgetStatus {
 
     private static boolean sSmallWidgetEnabled = false;
-    private static boolean sNotificationEnabled = false;
     private static AsyncTask<Context, Void, Context> sUpdateDeckStatusAsyncTask;
 
 
@@ -58,9 +57,9 @@ public final class WidgetStatus {
     public static void update(Context context) {
         SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(context);
         sSmallWidgetEnabled = preferences.getBoolean("widgetSmallEnabled", false);
-        sNotificationEnabled = Integer.parseInt(preferences.getString("minimumCardsDueForNotification", "1000001")) < 1000000;
+        boolean notificationEnabled = Integer.parseInt(preferences.getString("minimumCardsDueForNotification", "1000001")) < 1000000;
         boolean canExecuteTask = ((sUpdateDeckStatusAsyncTask == null) || (sUpdateDeckStatusAsyncTask.getStatus() == AsyncTask.Status.FINISHED));
-        if ((sSmallWidgetEnabled || sNotificationEnabled) && canExecuteTask) {
+        if ((sSmallWidgetEnabled || notificationEnabled) && canExecuteTask) {
             Timber.d("WidgetStatus.update(): updating");
             sUpdateDeckStatusAsyncTask = new UpdateDeckStatusAsyncTask();
             sUpdateDeckStatusAsyncTask.execute(context);


### PR DESCRIPTION
The change was made by Android studio, but I double checked all of them. I feel like most of the time it actually simplifies the code. In particular when it ensures that I don't believe that a variable contains actual information used outside of the only method where it is set and read.