### PR TITLE
Add "Search Decks" to Deck Picker

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -2203,8 +2203,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
         // Reset the schedule so that we get the counts for the currently selected deck
         mFocusedDeck = did;
         // Get some info about the deck to handle special cases
-        int pos = mDeckListAdapter.findDeckPosition(did);
-        AbstractDeckTreeNode deckDueTreeNode = mDeckListAdapter.getDeckList().get(pos);
+        AbstractDeckTreeNode deckDueTreeNode = mDeckListAdapter.getNodeByDid(did);
         if (!deckDueTreeNode.shouldDisplayCounts() || deckDueTreeNode.knownToHaveRep()) {
             // If we don't yet have numbers, we trust the user that they knows what they opens, tries to open it.
             // If there is nothing to review, it'll come back to deck picker.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.java
@@ -34,6 +34,7 @@ import com.ichi2.anki.analytics.AnalyticsDialogFragment;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Deck;
 import com.ichi2.utils.FunctionalInterfaces;
+import com.ichi2.utils.FilterResultsUtils;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -251,7 +252,6 @@ public class DeckSelectionDialog extends AnalyticsDialogFragment {
             protected FilterResults performFiltering(CharSequence constraint) {
                 mFilteredDecks.clear();
                 ArrayList<SelectableDeck> allDecks = DecksArrayAdapter.this.mAllDecksList;
-                final FilterResults filterResults = new FilterResults();
                 if (constraint.length() == 0) {
                     mFilteredDecks.addAll(allDecks);
                 } else {
@@ -263,9 +263,7 @@ public class DeckSelectionDialog extends AnalyticsDialogFragment {
                     }
                 }
 
-                filterResults.values = mFilteredDecks;
-                filterResults.count = mFilteredDecks.size();
-                return filterResults;
+                return FilterResultsUtils.fromCollection(mFilteredDecks);
             }
 
             @Override

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TagsDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TagsDialog.java
@@ -27,10 +27,10 @@ import com.afollestad.materialdialogs.MaterialDialog;
 import com.ichi2.anki.R;
 import com.ichi2.anki.UIUtils;
 import com.ichi2.anki.analytics.AnalyticsDialogFragment;
+import com.ichi2.utils.FilterResultsUtils;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
 import java.util.TreeSet;
 
 public class TagsDialog extends AnalyticsDialogFragment {
@@ -346,7 +346,6 @@ public class TagsDialog extends AnalyticsDialogFragment {
             @Override
             protected FilterResults performFiltering(CharSequence constraint) {
                 mFilteredTags.clear();
-                final FilterResults filterResults = new FilterResults();
                 if (constraint.length() == 0) {
                     mFilteredTags.addAll(mAllTags);
                 } else {
@@ -358,9 +357,7 @@ public class TagsDialog extends AnalyticsDialogFragment {
                     }
                 }
 
-                filterResults.values = mFilteredTags;
-                filterResults.count = mFilteredTags.size();
-                return filterResults;
+                return FilterResultsUtils.fromCollection(mFilteredTags);
             }
 
             @Override

--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.java
@@ -167,6 +167,11 @@ public class DeckAdapter extends RecyclerView.Adapter<DeckAdapter.ViewHolder> {
         notifyDataSetChanged();
     }
 
+    public AbstractDeckTreeNode getNodeByDid(long did) {
+        int pos = findDeckPosition(did);
+        return getDeckList().get(pos);
+    }
+
 
     @Override
     public DeckAdapter.ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
@@ -346,7 +351,7 @@ public class DeckAdapter extends RecyclerView.Adapter<DeckAdapter.ViewHolder> {
         }
     }
 
-    public List<AbstractDeckTreeNode> getDeckList() {
+    private List<AbstractDeckTreeNode> getDeckList() {
         return mDeckList;
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractDeckTreeNode.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractDeckTreeNode.java
@@ -191,4 +191,6 @@ public abstract class AbstractDeckTreeNode<T extends AbstractDeckTreeNode<T>> im
         return false;
     }
 
+
+    public abstract T withChildren(List<T> children);
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/DeckDueTreeNode.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/DeckDueTreeNode.java
@@ -120,4 +120,20 @@ public class DeckDueTreeNode extends AbstractDeckTreeNode<DeckDueTreeNode> {
     public boolean knownToHaveRep() {
         return mRevCount > 0 || mNewCount > 0 || mLrnCount > 0;
     }
+
+
+    @Override
+    public DeckDueTreeNode withChildren(List<DeckDueTreeNode> children) {
+        Collection col = getCol();
+        String name = getFullDeckName();
+        long did = getDid();
+        DeckDueTreeNode node = new DeckDueTreeNode(col, name, did, mRevCount, mLrnCount, mNewCount);
+        // We've already calculated the counts, don't bother doing it again, just set the variable.
+        node.setChildrenSuper(children);
+        return node;
+    }
+
+    private void setChildrenSuper(List<DeckDueTreeNode> children) {
+        super.setChildren(children, false);
+    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/DeckTreeNode.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/DeckTreeNode.java
@@ -2,8 +2,21 @@ package com.ichi2.libanki.sched;
 
 import com.ichi2.libanki.Collection;
 
+import java.util.List;
+
 public class DeckTreeNode extends AbstractDeckTreeNode<DeckTreeNode> {
     public DeckTreeNode(Collection col, String mName, long mDid) {
         super(col, mName, mDid);
+    }
+
+
+    @Override
+    public DeckTreeNode withChildren(List<DeckTreeNode> children) {
+        Collection col = getCol();
+        String name = getFullDeckName();
+        long did = getDid();
+        DeckTreeNode node = new DeckTreeNode(col, name, did);
+        node.setChildren(children, false);
+        return node;
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/FilterResultsUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/FilterResultsUtils.java
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.utils;
+
+import android.widget.Filter;
+
+public abstract class FilterResultsUtils extends Filter {
+    private FilterResultsUtils() {
+
+    }
+
+    public static <T> FilterResults fromCollection(java.util.Collection<T> collection) {
+        FilterResults filterResults = new FilterResults();
+        filterResults.count = collection.size();
+        filterResults.values = collection;
+        return filterResults;
+    }
+}

--- a/AnkiDroid/src/main/res/menu/deck_picker.xml
+++ b/AnkiDroid/src/main/res/menu/deck_picker.xml
@@ -1,11 +1,16 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:ankidroid="http://schemas.android.com/apk/res-auto" >
-
     <item
         android:id="@+id/action_sync"
         android:icon="@drawable/ic_sync_white_24dp"
         android:title="@string/sync_menu_title"
         ankidroid:showAsAction="always"/>
+    <item
+        android:id="@+id/deck_picker_action_filter"
+        android:icon="@drawable/ic_search_white_24dp"
+        android:title="@string/search_decks"
+        ankidroid:actionViewClass="androidx.appcompat.widget.SearchView"
+        ankidroid:showAsAction="always|collapseActionView"/>
     <item
         android:id="@+id/action_undo"
         android:icon="@drawable/ic_undo_white_24dp"

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -329,4 +329,5 @@
 
     <!-- Deck Picker -->
     <string name="deck_picker_failed_deck_load">Failed to load deck ‘%s’</string>
+    <string name="search_decks">Search decks</string>
 </resources>


### PR DESCRIPTION
## Purpose / Description
Some users wanted this


## Fixes
Fixes #7116

## Approach

* `SearchView` and `Filter`
* If a deck matches the search string, then all children are visible
* If a deck matches the search string, then all parents are visible


## How Has This Been Tested?

On my Android 9 with the AnKing deck. Worked as expected. 
* "Create Deck" result is only visible if searched
* Decks which are not visible can be reviewed if the parent is selected.
* Nesting works as expected
* Tested on my Android Emulator
* Keyboard shortcuts no longer get in the way

![image](https://user-images.githubusercontent.com/62114487/93721127-c0144f00-fb85-11ea-8bea-9f795c4d3e4a.png)
![image](https://user-images.githubusercontent.com/62114487/93721131-c86c8a00-fb85-11ea-874b-1e9ab8c2e549.png)
![image](https://user-images.githubusercontent.com/62114487/93721138-ce626b00-fb85-11ea-8c3c-b2afe7052f02.png)

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code