### PR TITLE
Convert MissingImageHandler to static

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -378,7 +378,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
     private CardMarker mCardMarker;
 
     /** Handle providing help for "Image Not Found" */
-    private MissingImageHandler mMissingImageHandler = new MissingImageHandler(this::displayCouldNotFindImageSnackbar);
+    private static MissingImageHandler mMissingImageHandler = new MissingImageHandler();
 
     // ----------------------------------------------------------------------------
     // LISTENERS
@@ -3199,14 +3199,14 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         @Override
         public void onReceivedError(WebView view, WebResourceRequest request, WebResourceError error) {
             super.onReceivedError(view, request, error);
-            mMissingImageHandler.processFailure(request);
+            mMissingImageHandler.processFailure(request, AbstractFlashcardViewer.this::displayCouldNotFindImageSnackbar);
         }
 
 
         @Override
         public void onReceivedHttpError(WebView view, WebResourceRequest request, WebResourceResponse errorResponse) {
             super.onReceivedHttpError(view, request, errorResponse);
-            mMissingImageHandler.processFailure(request);
+            mMissingImageHandler.processFailure(request, AbstractFlashcardViewer.this::displayCouldNotFindImageSnackbar);
         }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/MissingImageHandler.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/MissingImageHandler.java
@@ -33,15 +33,13 @@ public class MissingImageHandler {
 
     private int mNumberOfMissingImages = 0;
     private boolean mHasExecuted = false;
-    @NonNull
-    private Consumer<String> mOnFailure;
 
 
-    public MissingImageHandler(@NonNull Consumer<String> onFailure) {
-        mOnFailure = onFailure;
+    public MissingImageHandler() {
+
     }
 
-    public void processFailure(WebResourceRequest request) {
+    public void processFailure(WebResourceRequest request, @NonNull Consumer<String> onFailure) {
         // We do not want this to trigger more than once on the same side of the card as the UI will flicker.
         if (request == null || mHasExecuted) {
             return;
@@ -67,7 +65,7 @@ public class MissingImageHandler {
 
         try {
             String filename = URLUtil.guessFileName(url, null, null);
-            mOnFailure.consume(filename);
+            onFailure.consume(filename);
             mNumberOfMissingImages++;
         } catch (Exception e) {
             Timber.w(e, "Failed to notify UI of media failure");


### PR DESCRIPTION
## Purpose / Description
We warned a user once per deck about missing images, this was annoying to them as the missing images were intentional.

We only want to warn the user once per application session

## Fixes
Fixes #7174

## Approach
Make the variable static - enforced to be the application lifetime.

## How Has This Been Tested?

Tested on my Android 9

## Learning

We're creeping closer to a time where DI would have benefits.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code