### PR TITLE
NF: remove warning "Non-atomic operation on volatile field"

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HttpSyncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HttpSyncer.java
@@ -53,6 +53,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.zip.GZIPOutputStream;
 
 import javax.net.ssl.SSLException;
@@ -80,8 +81,8 @@ public class HttpSyncer {
 
     public static final String ANKIWEB_STATUS_OK = "OK";
 
-    public volatile long bytesSent = 0;
-    public volatile long bytesReceived = 0;
+    public volatile AtomicLong bytesSent = new AtomicLong();
+    public volatile AtomicLong bytesReceived = new AtomicLong();
     public volatile long mNextSendS = 1024;
     public volatile long mNextSendR = 1024;
 
@@ -228,7 +229,7 @@ public class HttpSyncer {
             requestBuilder.url(parseUrl(url));
 
             requestBuilder.post(new CountingFileRequestBody(tmpFileBuffer, ANKI_POST_TYPE.toString(), num -> {
-                bytesSent += num;
+                bytesSent.addAndGet(num);
                 publishProgress();
             }));
             Request httpPost = requestBuilder.build();
@@ -287,7 +288,7 @@ public class HttpSyncer {
             int len;
             while ((len = source.read(buf)) >= 0) {
                 output.write(buf, 0, len);
-                bytesReceived += len;
+                bytesReceived.addAndGet(len);
                 publishProgress();
             }
         } catch (IOException e) {
@@ -314,7 +315,7 @@ public class HttpSyncer {
             StringBuilder sb = new StringBuilder();
             while ((line = rd.readLine()) != null && (maxSize == -1 || sb.length() < maxSize)) {
                 sb.append(line);
-                bytesReceived += line.length();
+                bytesReceived.addAndGet(line.length());
                 publishProgress();
             }
             rd.close();
@@ -327,10 +328,10 @@ public class HttpSyncer {
 
     private void publishProgress() {
         Timber.d("Publishing progress");
-        if (mCon != null && (mNextSendR <= bytesReceived || mNextSendS <= bytesSent)) {
-            long bR = bytesReceived;
-            long bS = bytesSent;
-            Timber.d("Current progress: %d, %d", bytesReceived, bytesSent);
+        if (mCon != null && (mNextSendR <= bytesReceived.get() || mNextSendS <= bytesSent.get())) {
+            long bR = bytesReceived.get();
+            long bS = bytesSent.get();
+            Timber.d("Current progress: %d, %d", bR, bS);
             mNextSendR = (bR / 1024 + 1) * 1024;
             mNextSendS = (bS / 1024 + 1) * 1024;
             mCon.publishProgress(0, bS, bR);
@@ -417,7 +418,7 @@ public class HttpSyncer {
                 int len;
                 while ((len = mInputStream.read(tmp)) != -1) {
                     outstream.write(tmp, 0, len);
-                    bytesSent += len;
+                    bytesSent.addAndGet(len);
                     publishProgress();
                 }
                 outstream.flush();


### PR DESCRIPTION
I must admit I don't know why it should be volatile. It does not seems we can do download on multi thread
