### PR TITLE
Uses contentEquals (correct leo ?)

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Lookup.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Lookup.java
@@ -99,7 +99,7 @@ public class Lookup {
                 String language = getLanguage(MetaDB.LANGUAGES_QA_UNDEFINED);
                 if (language.length() > 0) {
                     for (CharSequence itemValue : itemValues) {
-                        if (language.equals(itemValue)) {
+                        if (language.contentEquals(itemValue)) {
                             lookupLeo(language, mLookupText);
                             mLookupText = "";
                             return true;


### PR DESCRIPTION
Indeed, since itemValue is not a string, this always returns false, which is probably not expected.

This probably means that this part of the code never worked as expected. Probably worth noting it somewhere.

I don't actually know what it is, so I guess we need someone actually knowing what it is and testing it to check what occurs
