### PR TITLE
Reviewer: Disable Answer button fade on open

### DIFF
--- a/AnkiDroid/src/main/res/layout/reviewer_answer_buttons.xml
+++ b/AnkiDroid/src/main/res/layout/reviewer_answer_buttons.xml
@@ -70,6 +70,7 @@
             android:id="@+id/ease_buttons"
             android:layout_width="fill_parent"
             android:layout_height="fill_parent"
+            android:visibility="gone"
             android:orientation="horizontal">
 
             <LinearLayout


### PR DESCRIPTION
Slight visual fix - the buttons faded from answers to "show" when a deck was selected

* Tested on my Android 9