### PR TITLE
Reviewer: Add Flag Shortcuts (Ctrl+1..4)

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/PeripheralCommand.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/PeripheralCommand.java
@@ -38,14 +38,19 @@ public class PeripheralCommand {
 
     private final @ViewerCommandDef int mCommand;
 
+    private final ModifierKeys modifierKeys;
+
+
     private PeripheralCommand(int keyCode, @ViewerCommandDef int command, @NonNull CardSide side) {
         this.mKeyCode = keyCode;
         this.mUnicodeCharacter = null;
         this.mCommand = command;
         this.mCardSide = side;
+        this.modifierKeys = ModifierKeys.none();
     }
 
-    private PeripheralCommand(@Nullable Character unicodeCharacter, @ViewerCommandDef int command, @NonNull CardSide side) {
+    private PeripheralCommand(@Nullable Character unicodeCharacter, @ViewerCommandDef int command, @NonNull CardSide side, ModifierKeys modifierKeys) {
+        this.modifierKeys = modifierKeys;
         this.mKeyCode = null;
         this.mUnicodeCharacter = unicodeCharacter;
         this.mCommand = command;
@@ -73,9 +78,12 @@ public class PeripheralCommand {
     }
 
     public static PeripheralCommand unicode(char unicodeChar, @ViewerCommandDef int command, CardSide side) {
-        return new PeripheralCommand((Character) unicodeChar, command, side);
+        return unicode(unicodeChar, command, side, ModifierKeys.none());
     }
 
+    private static PeripheralCommand unicode(char unicodeChar, @ViewerCommandDef int command, CardSide side, ModifierKeys modifierKeys) {
+        return new PeripheralCommand((Character) unicodeChar, command, side, modifierKeys);
+    }
 
     public static PeripheralCommand keyCode(int keyCode, @ViewerCommandDef int command, CardSide side) {
         return new PeripheralCommand(keyCode, command, side);
@@ -110,13 +118,53 @@ public class PeripheralCommand {
         ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_F5, COMMAND_PLAY_MEDIA, CardSide.BOTH));
         ret.add(PeripheralCommand.unicode('z', COMMAND_UNDO, CardSide.BOTH));
 
+        ret.add(PeripheralCommand.unicode('1', COMMAND_TOGGLE_FLAG_RED, CardSide.BOTH, ModifierKeys.ctrl()));
+        ret.add(PeripheralCommand.unicode('2', COMMAND_TOGGLE_FLAG_ORANGE, CardSide.BOTH, ModifierKeys.ctrl()));
+        ret.add(PeripheralCommand.unicode('3', COMMAND_TOGGLE_FLAG_GREEN, CardSide.BOTH, ModifierKeys.ctrl()));
+        ret.add(PeripheralCommand.unicode('4', COMMAND_TOGGLE_FLAG_BLUE, CardSide.BOTH, ModifierKeys.ctrl()));
+
         return ret;
     }
+
+
+    public boolean matchesModifier(KeyEvent event) {
+        return modifierKeys.matches(event);
+    }
+
 
     private enum CardSide {
         NONE,
         QUESTION,
         ANSWER,
         BOTH
+    }
+
+
+    public static class ModifierKeys {
+        private final boolean mShift;
+        private final boolean mCtrl;
+        private final boolean mAlt;
+
+
+        public ModifierKeys(boolean shift, boolean ctrl, boolean alt) {
+            this.mShift = shift;
+            this.mCtrl = ctrl;
+            this.mAlt = alt;
+        }
+
+
+        public static ModifierKeys none() {
+            return new ModifierKeys(false, false, false);
+        }
+
+        public static ModifierKeys ctrl() {
+            return new ModifierKeys(false, true, false);
+        }
+
+
+        public boolean matches(KeyEvent event) {
+            // return false if Ctrl+1 is pressed and 1 is expected
+            return mShift == event.isShiftPressed() && mCtrl == event.isCtrlPressed() && mAlt == event.isAltPressed();
+        }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/PeripheralKeymap.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/PeripheralKeymap.java
@@ -74,8 +74,8 @@ public class PeripheralKeymap {
     }
 
     private static class KeyMap {
-        public final HashMap<Integer, List<Integer>> mKeyCodeToCommand = new HashMap<>();
-        public final HashMap<Integer, List<Integer>> mUnicodeToCommand = new HashMap<>();
+        public final HashMap<Integer, List<PeripheralCommand>> mKeyCodeToCommand = new HashMap<>();
+        public final HashMap<Integer, List<PeripheralCommand>> mUnicodeToCommand = new HashMap<>();
         private final CommandProcessor mProcessor;
 
         private KeyMap(CommandProcessor commandProcessor) {
@@ -86,18 +86,29 @@ public class PeripheralKeymap {
             boolean ret = false;
 
             {
-                List<Integer> a = mKeyCodeToCommand.get(keyCode);
+                List<PeripheralCommand> a = mKeyCodeToCommand.get(keyCode);
                 if (a != null) {
-                    for (Integer command : a) {
-                        ret |= mProcessor.executeCommand(command);
+                    for (PeripheralCommand command : a) {
+                        if (!command.matchesModifier(event)) {
+                            continue;
+                        }
+
+                        ret |= mProcessor.executeCommand(command.getCommand());
                     }
                 }
             }
             {
-                List<Integer> unicodeLookup = mUnicodeToCommand.get(event.getUnicodeChar());
+                // passing in metaState: 0 means that Ctrl+1 returns '1' instead of '\0'
+                // NOTE: We do not differentiate on upper/lower case via KeyEvent.META_CAPS_LOCK_ON
+                int unicodeChar = event.getUnicodeChar(event.getMetaState() & KeyEvent.META_SHIFT_ON);
+                List<PeripheralCommand> unicodeLookup = mUnicodeToCommand.get(unicodeChar);
                 if (unicodeLookup != null) {
-                    for (Integer command : unicodeLookup) {
-                        ret |= mProcessor.executeCommand(command);
+                    for (PeripheralCommand command : unicodeLookup) {
+                        if (!command.matchesModifier(event)) {
+                            continue;
+                        }
+
+                        ret |= mProcessor.executeCommand(command.getCommand());
                     }
                 }
             }
@@ -115,7 +126,7 @@ public class PeripheralKeymap {
                     mUnicodeToCommand.put(unicodeChar, new ArrayList<>());
                 }
                 //noinspection ConstantConditions
-                mUnicodeToCommand.get(unicodeChar).add(command.getCommand());
+                mUnicodeToCommand.get(unicodeChar).add(command);
             }
 
             if (command.getKeycode() != null) {
@@ -124,7 +135,7 @@ public class PeripheralKeymap {
                     mKeyCodeToCommand.put(c, new ArrayList<>());
                 }
                 //noinspection ConstantConditions
-                mKeyCodeToCommand.get(c).add(command.getCommand());
+                mKeyCodeToCommand.get(c).add(command);
             }
         }
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerKeyboardInputTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerKeyboardInputTest.java
@@ -34,6 +34,7 @@ import static com.ichi2.anki.AbstractFlashcardViewer.EASE_3;
 import static com.ichi2.anki.AbstractFlashcardViewer.EASE_4;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -317,7 +318,8 @@ public class ReviewerKeyboardInputTest {
 
         public void handleUnicodeKeyPress(char unicodeChar) {
             KeyEvent key = mock(KeyEvent.class);
-            when(key.getUnicodeChar()).thenReturn((int)unicodeChar);
+            // COULD_BE_BETTER: We do not handle shift
+            when(key.getUnicodeChar(anyInt())).thenReturn((int)unicodeChar);
 
             try {
                 when(key.getAction()).thenReturn(KeyEvent.ACTION_DOWN);
@@ -333,10 +335,11 @@ public class ReviewerKeyboardInputTest {
             }
         }
         public void handleKeyPress(int keycode, char unicodeChar) {
-            //COULD_BE_BETTER: Saves 20 seconds on tests to remove AndroidJUnit4,
+            // COULD_BE_BETTER: Saves 20 seconds on tests to remove AndroidJUnit4,
             // but may let something slip through the cracks.
             KeyEvent e = mock(KeyEvent.class);
-            when(e.getUnicodeChar()).thenReturn((int)unicodeChar);
+            // COULD_BE_BETTER: We do not handle shift
+            when(e.getUnicodeChar(anyInt())).thenReturn((int)unicodeChar);
             when(e.getAction()).thenReturn(KeyEvent.ACTION_DOWN);
             when(e.getKeyCode()).thenReturn(keycode);
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/PeripheralKeymapTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/PeripheralKeymapTest.java
@@ -1,0 +1,73 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.reviewer;
+
+import android.view.KeyEvent;
+
+import com.ichi2.anki.cardviewer.ViewerCommand;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class PeripheralKeymapTest {
+    @Test
+    public void flagAndAnswerDoNotConflict() {
+        List<Integer> processed = new ArrayList<>();
+
+        PeripheralKeymap peripheralKeymap = new PeripheralKeymap(new MockReviewerUi(), processed::add);
+        peripheralKeymap.setup();
+        KeyEvent event = mock(KeyEvent.class);
+        when(event.getUnicodeChar()).thenReturn(0);
+        when(event.isCtrlPressed()).thenReturn(true);
+        when(event.getUnicodeChar(0)).thenReturn(49);
+
+        assertThat((char) event.getUnicodeChar(), is('\0'));
+        assertThat((char) event.getUnicodeChar(0), is('1'));
+        peripheralKeymap.onKeyUp(8, event);
+
+        assertThat(processed, hasSize(1));
+        assertThat(processed.get(0), is(ViewerCommand.COMMAND_TOGGLE_FLAG_RED));
+    }
+
+    private static class MockReviewerUi implements ReviewerUi {
+
+        @Override
+        public ControlBlock getControlBlocked() {
+            return null;
+        }
+
+
+        @Override
+        public boolean isControlBlocked() {
+            return false;
+        }
+
+
+        @Override
+        public boolean isDisplayingAnswer() {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
## Purpose / Description
User requested flag (Ctrl+1) keyboard shortcuts in the reviewer.

## Fixes
Fixes #7140
Gets closer to #6052

## Approach
* Ensure that Ctrl+'1' doesn't match '1'
* Allows mapping to handle modifier keys

## How Has This Been Tested?

Unit tested and on my phone

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code