### PR TITLE
NF: Copyright remove javadoc in favor of c like comment

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.java
@@ -1,21 +1,21 @@
-/***************************************************************************************
- *                                                                                      *
- * Copyright (c) 2015 Frank Oltmanns <frank.oltmanns@gmail.com>                         *
- * Copyright (c) 2015 Timothy Rae <timothy.rae@gmail.com>                               *
- * Copyright (c) 2016 Mark Carter <mark@marcardar.com>                                  *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/**************************************************************************************
+ *
+ Copyright (c) 2015 Frank Oltmanns <frank.oltmanns@gmail.com>                         *
+ Copyright (c) 2015 Timothy Rae <timothy.rae@gmail.com>                               *
+ Copyright (c) 2016 Mark Carter <mark@marcardar.com>                                  *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki.tests;
 

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/InstrumentedTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/InstrumentedTest.java
@@ -1,19 +1,19 @@
-/***************************************************************************************
- *                                                                                      *
- * Copyright (c) 2020 Mike Hardy <github@mikehardy.net>                                 *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/**************************************************************************************
+ *
+ Copyright (c) 2020 Mike Hardy <github@mikehardy.net>                                 *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki.tests;
 import android.os.Build;

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/NotificationChannelTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/NotificationChannelTest.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2018 Mike Hardy <mike@mikehardy.net>                                   *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2018 Mike Hardy <mike@mikehardy.net>                                   *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki.tests;
 

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/Shared.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/Shared.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2014 Houssam Salem <houssam.salem.au@gmail.com>                        *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2014 Houssam Salem <houssam.salem.au@gmail.com>                        *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki.tests;
 

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/ImportTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/ImportTest.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2016 Houssam Salem <houssam.salem.au@gmail.com>                        *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2016 Houssam Salem <houssam.salem.au@gmail.com>                        *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 package com.ichi2.anki.tests.libanki;
 
 

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/MediaTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/MediaTest.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2014 Houssam Salem <houssam.salem.au@gmail.com>                        *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2014 Houssam Salem <houssam.salem.au@gmail.com>                        *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 package com.ichi2.anki.tests.libanki;
 
 import android.Manifest;

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/utils/DiffEngineTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/utils/DiffEngineTest.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2020 Mike Hardy <mike@mikehardy.net>                                   *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2020 Mike Hardy <mike@mikehardy.net>                                   *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki.utils;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1,22 +1,22 @@
-/****************************************************************************************
- * Copyright (c) 2011 Kostas Spyropoulos <inigo.aldana@gmail.com>                       *
- * Copyright (c) 2014 Bruno Romero de Azevedo <brunodea@inf.ufsm.br>                    *
- * Copyright (c) 2014–15 Roland Sieker <ospalh@gmail.com>                               *
- * Copyright (c) 2015 Timothy Rae <perceptualchaos2@gmail.com>                          *
- * Copyright (c) 2016 Mark Carter <mark@marcardar.com>                                  *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2011 Kostas Spyropoulos <inigo.aldana@gmail.com>                       *
+ Copyright (c) 2014 Bruno Romero de Azevedo <brunodea@inf.ufsm.br>                    *
+ Copyright (c) 2014–15 Roland Sieker <ospalh@gmail.com>                               *
+ Copyright (c) 2015 Timothy Rae <perceptualchaos2@gmail.com>                          *
+ Copyright (c) 2016 Mark Carter <mark@marcardar.com>                                  *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 // TODO: implement own menu? http://www.codeproject.com/Articles/173121/Android-Menus-My-Way
 
 package com.ichi2.anki;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -1,20 +1,20 @@
-/****************************************************************************************
- * Copyright (c) 2009 Edu Zamora <edu.zasu@gmail.com>                                   *
- * Copyright (c) 2009 Casey Link <unnamedrambler@gmail.com>                             *
- * Copyright (c) 2014 Timothy Rae <perceptualchaos2@gmail.com>                          *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2009 Edu Zamora <edu.zasu@gmail.com>                                   *
+ Copyright (c) 2009 Casey Link <unnamedrambler@gmail.com>                             *
+ Copyright (c) 2014 Timothy Rae <perceptualchaos2@gmail.com>                          *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.java
@@ -1,18 +1,18 @@
-/***************************************************************************************
- * Copyright (c) 2011 Norbert Nagold <norbert.nagold@gmail.com>                         *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/**************************************************************************************
+ Copyright (c) 2011 Norbert Nagold <norbert.nagold@gmail.com>                         *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1,20 +1,20 @@
-/****************************************************************************************
- * Copyright (c) 2010 Norbert Nagold <norbert.nagold@gmail.com>                         *
- * Copyright (c) 2012 Kostas Spyropoulos <inigo.aldana@gmail.com>                       *
- * Copyright (c) 2014 Timothy Rae <perceptualchaos2@gmail.com>                          *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2010 Norbert Nagold <norbert.nagold@gmail.com>                         *
+ Copyright (c) 2012 Kostas Spyropoulos <inigo.aldana@gmail.com>                       *
+ Copyright (c) 2014 Timothy Rae <perceptualchaos2@gmail.com>                          *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
@@ -1,20 +1,20 @@
-/***************************************************************************************
- *                                                                                      *
- * Copyright (c) 2014 Timothy Rae <perceptualchaos2@gmail.com>                          *
- * Copyright (c) 2018 Mike Hardy <mike@mikehardy.net>                                   *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/**************************************************************************************
+ *
+ Copyright (c) 2014 Timothy Rae <perceptualchaos2@gmail.com>                          *
+ Copyright (c) 2018 Mike Hardy <mike@mikehardy.net>                                   *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.java
@@ -1,18 +1,18 @@
-/***************************************************************************************
- * Copyright (c) 2020 Mike Hardy <mike@mikehardy.net>                                   *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/**************************************************************************************
+ Copyright (c) 2020 Mike Hardy <mike@mikehardy.net>                                   *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
@@ -1,18 +1,18 @@
-/***************************************************************************************
- * Copyright (c) 2015 Timothy Rae <perceptualchaos2@gmail.com>                          *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/**************************************************************************************
+ Copyright (c) 2015 Timothy Rae <perceptualchaos2@gmail.com>                          *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
@@ -1,22 +1,22 @@
 
 package com.ichi2.anki;
 
-/****************************************************************************************
- * Copyright (c) 2009 Casey Link <unnamedrambler@gmail.com>                             *
- * Copyright (c) 2012 Norbert Nagold <norbert.nagold@gmail.com>                         *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2009 Casey Link <unnamedrambler@gmail.com>                             *
+ Copyright (c) 2012 Norbert Nagold <norbert.nagold@gmail.com>                         *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 import android.app.AlarmManager;
 import android.app.PendingIntent;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -1,23 +1,23 @@
-/****************************************************************************************
- * Copyright (c) 2009 Andrew Dubya <andrewdubya@gmail.com>                              *
- * Copyright (c) 2009 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
- * Copyright (c) 2009 Edu Zamora <edu.zasu@gmail.com>                                   *
- * Copyright (c) 2009 Daniel Svard <daniel.svard@gmail.com>                             *
- * Copyright (c) 2010 Norbert Nagold <norbert.nagold@gmail.com>                         *
- * Copyright (c) 2014 Timothy Rae <perceptualchaos2@gmail.com>
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2009 Andrew Dubya <andrewdubya@gmail.com>                              *
+ Copyright (c) 2009 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
+ Copyright (c) 2009 Edu Zamora <edu.zasu@gmail.com>                                   *
+ Copyright (c) 2009 Daniel Svard <daniel.svard@gmail.com>                             *
+ Copyright (c) 2010 Norbert Nagold <norbert.nagold@gmail.com>                         *
+ Copyright (c) 2014 Timothy Rae <perceptualchaos2@gmail.com>
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FilteredDeckOptions.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FilteredDeckOptions.java
@@ -1,22 +1,22 @@
 
 package com.ichi2.anki;
 
-/****************************************************************************************
- * Copyright (c) 2009 Casey Link <unnamedrambler@gmail.com>                             *
- * Copyright (c) 2012 Norbert Nagold <norbert.nagold@gmail.com>                         *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2009 Casey Link <unnamedrambler@gmail.com>                             *
+ Copyright (c) 2012 Norbert Nagold <norbert.nagold@gmail.com>                         *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 import android.content.BroadcastReceiver;
 import android.content.ContentValues;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Info.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Info.java
@@ -1,20 +1,20 @@
-/***************************************************************************************
- * Copyright (c) 2009 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
- * Copyright (c) 2009 Edu Zamora <edu.zasu@gmail.com>                                   *
- * Copyright (c) 2015 Tim Rae <perceptualchaos2@gmail.com>                              *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/**************************************************************************************
+ Copyright (c) 2009 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
+ Copyright (c) 2009 Edu Zamora <edu.zasu@gmail.com>                                   *
+ Copyright (c) 2015 Tim Rae <perceptualchaos2@gmail.com>                              *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.java
@@ -1,19 +1,19 @@
-/****************************************************************************************
- * Copyright (c) 2015 Ryan Annis <squeenix@live.ca>                                     *
- * Copyright (c) 2015 Timothy Rae <perceptualchaos2@gmail.com>                          *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2015 Ryan Annis <squeenix@live.ca>                                     *
+ Copyright (c) 2015 Timothy Rae <perceptualchaos2@gmail.com>                          *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 package com.ichi2.anki;
 
 import android.content.Context;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.java
@@ -1,19 +1,19 @@
-/****************************************************************************************
- * Copyright (c) 2015 Ryan Annis <squeenix@live.ca>                                     *
- * Copyright (c) 2015 Timothy Rae <perceptualchaos2@gmail.com>                          *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2015 Ryan Annis <squeenix@live.ca>                                     *
+ Copyright (c) 2015 Timothy Rae <perceptualchaos2@gmail.com>                          *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 package com.ichi2.anki;
 
 import android.os.Build;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.java
@@ -1,16 +1,16 @@
-/***************************************************************************************
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/**************************************************************************************
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2014 Timothy Rae <perceptualchaos2@gmail.com>                          *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2014 Timothy Rae <perceptualchaos2@gmail.com>                          *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 package com.ichi2.anki;
 
 import android.content.Intent;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1,20 +1,20 @@
-/***************************************************************************************
- *                                                                                      *
- * Copyright (c) 2012 Norbert Nagold <norbert.nagold@gmail.com>                         *
- * Copyright (c) 2014 Timothy Rae <perceptualchaos2@gmail.com>                          *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/**************************************************************************************
+ *
+ Copyright (c) 2012 Norbert Nagold <norbert.nagold@gmail.com>                         *
+ Copyright (c) 2014 Timothy Rae <perceptualchaos2@gmail.com>                          *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NotificationChannels.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NotificationChannels.java
@@ -1,19 +1,19 @@
-/****************************************************************************************
- * Copyright (c) 2018 Timothy Rae <perceptualchaos2@gmail.com>                          *
- * Copyright (c) 2018 Mike Hardy <mike@mikehardy.net>                                   *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2018 Timothy Rae <perceptualchaos2@gmail.com>                          *
+ Copyright (c) 2018 Mike Hardy <mike@mikehardy.net>                                   *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -1,22 +1,22 @@
-/***************************************************************************************
- * Copyright (c) 2009 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
- * Copyright (c) 2009 Edu Zamora <edu.zasu@gmail.com>                                   *
- * Copyright (c) 2010 Norbert Nagold <norbert.nagold@gmail.com>                         *
- * Copyright (c) 2012 Kostas Spyropoulos <inigo.aldana@gmail.com>                       *
- * Copyright (c) 2015 Timothy Rae <perceptualchaos2@gmail.com>                          *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/**************************************************************************************
+ Copyright (c) 2009 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
+ Copyright (c) 2009 Edu Zamora <edu.zasu@gmail.com>                                   *
+ Copyright (c) 2010 Norbert Nagold <norbert.nagold@gmail.com>                         *
+ Copyright (c) 2012 Kostas Spyropoulos <inigo.aldana@gmail.com>                       *
+ Copyright (c) 2015 Timothy Rae <perceptualchaos2@gmail.com>                          *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.java
@@ -1,20 +1,20 @@
-/***************************************************************************************
- * Copyright (c) 2011 Kostas Spyropoulos <inigo.aldana@gmail.com>                       *
- * Copyright (c) 2013 Jolta Technologies                                                *
- * Copyright (c) 2014 Bruno Romero de Azevedo <brunodea@inf.ufsm.br>                    *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/**************************************************************************************
+ Copyright (c) 2011 Kostas Spyropoulos <inigo.aldana@gmail.com>                       *
+ Copyright (c) 2013 Jolta Technologies                                                *
+ Copyright (c) 2014 Bruno Romero de Azevedo <brunodea@inf.ufsm.br>                    *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2011 Norbert Nagold <norbert.nagold@gmail.com>                         *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2011 Norbert Nagold <norbert.nagold@gmail.com>                         *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -1,19 +1,19 @@
-/****************************************************************************************
- * Copyright (c) 2011 Kostas Spyropoulos <inigo.aldana@gmail.com>                       *
- * Copyright (c) 2014 Bruno Romero de Azevedo <brunodea@inf.ufsm.br>                    *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2011 Kostas Spyropoulos <inigo.aldana@gmail.com>                       *
+ Copyright (c) 2014 Bruno Romero de Azevedo <brunodea@inf.ufsm.br>                    *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 // TODO: implement own menu? http://www.codeproject.com/Articles/173121/Android-Menus-My-Way
 
 package com.ichi2.anki;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2014 Michael Goldbach <michael@m-goldbach.net>                         *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2014 Michael Goldbach <michael@m-goldbach.net>                         *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 package com.ichi2.anki;
 
 import android.content.Intent;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.java
@@ -1,18 +1,18 @@
-/***************************************************************************************
- * Copyright (c) 2012 Norbert Nagold <norbert.nagold@gmail.com>                         *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/**************************************************************************************
+ Copyright (c) 2012 Norbert Nagold <norbert.nagold@gmail.com>                         *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
@@ -1,16 +1,16 @@
-/****************************************************************************************
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program. If not, see <http://www.gnu.org/licenses/>.                            *
- ****************************************************************************************/
+/***************************************************************************************
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program. If not, see <http://www.gnu.org/licenses/>.                            *
+ */
 
 package com.ichi2.anki;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/TemporaryModel.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/TemporaryModel.java
@@ -1,19 +1,19 @@
-/***************************************************************************************
- *                                                                                      *
- * Copyright (c) 2020 Mike Hardy <mike@mikehardy.net>                                   *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/**************************************************************************************
+ *
+ Copyright (c) 2020 Mike Hardy <mike@mikehardy.net>                                   *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.java
@@ -1,20 +1,20 @@
-/****************************************************************************************
- * Copyright (c) 2009 Andrew <andrewdubya@gmail.com>                                    *
- * Copyright (c) 2009 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
- * Copyright (c) 2009 Edu Zamora <edu.zasu@gmail.com>                                   *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2009 Andrew <andrewdubya@gmail.com>                                    *
+ Copyright (c) 2009 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
+ Copyright (c) 2009 Edu Zamora <edu.zasu@gmail.com>                                   *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/analytics/AnkiDroidCrashReportDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/analytics/AnkiDroidCrashReportDialog.java
@@ -1,19 +1,19 @@
-/***************************************************************************************
- * Copyright (c) 2015 Timothy Rae <perceptualchaos2@gmail.com>                          *
- * Copyright (c) 2020 Mike Hardy <github@mikehardy.net>                                 *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/**************************************************************************************
+ Copyright (c) 2015 Timothy Rae <perceptualchaos2@gmail.com>                          *
+ Copyright (c) 2020 Mike Hardy <github@mikehardy.net>                                 *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki.analytics;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2018 Mike Hardy <mike@mikehardy.net>                                   *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2018 Mike Hardy <mike@mikehardy.net>                                   *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki.analytics;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ContextMenuHelper.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ContextMenuHelper.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2015 Timothy Rae <perceptualchaos2@gmail.com>                          *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2015 Timothy Rae <perceptualchaos2@gmail.com>                          *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 package com.ichi2.anki.dialogs;
 
 import java.util.ArrayList;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2015 Timothy Rae <perceptualchaos2@gmail.com>                          *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2015 Timothy Rae <perceptualchaos2@gmail.com>                          *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 package com.ichi2.anki.dialogs;
 
 import android.app.Dialog;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2015 Timothy Rae <perceptualchaos2@gmail.com>                          *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2015 Timothy Rae <perceptualchaos2@gmail.com>                          *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 package com.ichi2.anki.dialogs;
 
 import android.app.Dialog;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/AudioView.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/AudioView.java
@@ -1,21 +1,21 @@
-/****************************************************************************************
- * Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
- * Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
- * Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
- * Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
+ Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
+ Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
+ Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki.multimediacard;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/IMultimediaEditableNote.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/IMultimediaEditableNote.java
@@ -1,21 +1,21 @@
-/****************************************************************************************
- * Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
- * Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
- * Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
- * Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
+ Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
+ Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
+ Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki.multimediacard;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/LoadPronounciationActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/LoadPronounciationActivity.java
@@ -1,21 +1,21 @@
-/****************************************************************************************
- * Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
- * Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
- * Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
- * Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
+ Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
+ Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
+ Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki.multimediacard.activity;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
@@ -1,21 +1,21 @@
-/****************************************************************************************
- * Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
- * Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
- * Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
- * Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
+ Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
+ Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
+ Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki.multimediacard.activity;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/PickStringDialogFragment.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/PickStringDialogFragment.java
@@ -1,21 +1,21 @@
-/****************************************************************************************
- * Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
- * Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
- * Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
- * Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
+ Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
+ Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
+ Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki.multimediacard.activity;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/TranslationActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/TranslationActivity.java
@@ -1,21 +1,21 @@
-/****************************************************************************************
- * Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
- * Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
- * Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
- * Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
+ Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
+ Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
+ Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki.multimediacard.activity;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/beolingus/parsing/BeolingusParser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/beolingus/parsing/BeolingusParser.java
@@ -1,21 +1,21 @@
-/****************************************************************************************
- * Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
- * Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
- * Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
- * Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
+ Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
+ Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
+ Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki.multimediacard.beolingus.parsing;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/AudioField.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/AudioField.java
@@ -1,21 +1,21 @@
-/****************************************************************************************
- * Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
- * Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
- * Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
- * Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
+ Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
+ Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
+ Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki.multimediacard.fields;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicAudioClipFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicAudioClipFieldController.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2020 Mike Hardy <github@mikehardy.net>                                 *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2020 Mike Hardy <github@mikehardy.net>                                 *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 package com.ichi2.anki.multimediacard.fields;
 
 import android.app.Activity;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicAudioRecordingFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicAudioRecordingFieldController.java
@@ -1,21 +1,21 @@
-/****************************************************************************************
- * Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
- * Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
- * Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
- * Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
+ Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
+ Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
+ Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki.multimediacard.fields;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicControllerFactory.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicControllerFactory.java
@@ -1,21 +1,21 @@
-/****************************************************************************************
- * Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
- * Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
- * Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
- * Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
+ Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
+ Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
+ Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki.multimediacard.fields;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
@@ -1,22 +1,22 @@
-/****************************************************************************************
- * Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
- * Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
- * Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
- * Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
- * Copyright (c) 2020 Mike Hardy <github@mikehardy.net>                                 *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
+ Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
+ Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
+ Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
+ Copyright (c) 2020 Mike Hardy <github@mikehardy.net>                                 *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki.multimediacard.fields;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicTextFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicTextFieldController.java
@@ -1,21 +1,21 @@
-/****************************************************************************************
- * Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
- * Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
- * Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
- * Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
+ Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
+ Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
+ Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki.multimediacard.fields;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/EFieldType.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/EFieldType.java
@@ -1,21 +1,21 @@
-/****************************************************************************************
- * Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
- * Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
- * Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
- * Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
+ Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
+ Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
+ Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki.multimediacard.fields;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/FieldBase.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/FieldBase.java
@@ -1,21 +1,21 @@
-/****************************************************************************************
- * Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
- * Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
- * Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
- * Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
+ Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
+ Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
+ Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki.multimediacard.fields;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/FieldControllerBase.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/FieldControllerBase.java
@@ -1,21 +1,21 @@
-/****************************************************************************************
- * Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
- * Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
- * Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
- * Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
+ Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
+ Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
+ Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki.multimediacard.fields;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/IControllerFactory.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/IControllerFactory.java
@@ -1,22 +1,22 @@
-/***********************************************import com.ichi2.anki.IFieldController;
-import com.ichi2.anki.multimediacard.IField;
-shrestha@gmail.com>                          *
- * Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
- * Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
- * Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/**********************************************import com.ichi2.anki.IFieldController;
+ import com.ichi2.anki.multimediacard.IField;
+ shrestha@gmail.com>                          *
+ Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
+ Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
+ Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki.multimediacard.fields;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/IField.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/IField.java
@@ -1,21 +1,21 @@
-/****************************************************************************************
- * Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
- * Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
- * Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
- * Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
+ Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
+ Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
+ Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki.multimediacard.fields;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/IFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/IFieldController.java
@@ -1,21 +1,21 @@
-/****************************************************************************************
- * Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
- * Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
- * Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
- * Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
+ Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
+ Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
+ Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki.multimediacard.fields;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/ImageField.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/ImageField.java
@@ -1,21 +1,21 @@
-/****************************************************************************************
- * Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
- * Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
- * Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
- * Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
+ Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
+ Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
+ Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki.multimediacard.fields;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/TextField.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/TextField.java
@@ -1,21 +1,21 @@
-/****************************************************************************************
- * Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
- * Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
- * Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
- * Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
+ Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
+ Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
+ Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki.multimediacard.fields;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/glosbe/json/Meaning.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/glosbe/json/Meaning.java
@@ -1,21 +1,21 @@
-/****************************************************************************************
- * Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
- * Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
- * Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
- * Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
+ Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
+ Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
+ Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki.multimediacard.glosbe.json;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/glosbe/json/Phrase.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/glosbe/json/Phrase.java
@@ -1,21 +1,21 @@
-/****************************************************************************************
- * Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
- * Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
- * Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
- * Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
+ Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
+ Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
+ Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki.multimediacard.glosbe.json;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/glosbe/json/Response.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/glosbe/json/Response.java
@@ -1,21 +1,21 @@
-/****************************************************************************************
- * Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
- * Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
- * Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
- * Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
+ Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
+ Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
+ Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki.multimediacard.glosbe.json;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/glosbe/json/Tuc.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/glosbe/json/Tuc.java
@@ -1,21 +1,21 @@
-/****************************************************************************************
- * Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
- * Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
- * Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
- * Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
+ Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
+ Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
+ Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki.multimediacard.glosbe.json;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/impl/MultimediaEditableNote.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/impl/MultimediaEditableNote.java
@@ -1,21 +1,21 @@
-/****************************************************************************************
- * Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
- * Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
- * Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
- * Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
+ Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
+ Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
+ Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki.multimediacard.impl;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/language/LanguageListerBase.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/language/LanguageListerBase.java
@@ -1,21 +1,21 @@
-/****************************************************************************************
- * Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
- * Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
- * Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
- * Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
+ Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
+ Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
+ Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki.multimediacard.language;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/language/LanguageListerBeolingus.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/language/LanguageListerBeolingus.java
@@ -1,21 +1,21 @@
-/****************************************************************************************
- * Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
- * Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
- * Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
- * Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
+ Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
+ Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
+ Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki.multimediacard.language;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/language/LanguagesListerGlosbe.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/language/LanguagesListerGlosbe.java
@@ -1,22 +1,22 @@
-/****************************************************************************************
- * Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
- * Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
- * Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
- * Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
- * Copyright (c) 2014 Timothy Rae <perceptualchaos2@gmail.com>                          *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
+ Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
+ Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
+ Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
+ Copyright (c) 2014 Timothy Rae <perceptualchaos2@gmail.com>                          *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki.multimediacard.language;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
@@ -1,21 +1,21 @@
-/***************************************************************************************
- *                                                                                      *
- * Copyright (c) 2015 Frank Oltmanns <frank.oltmanns@gmail.com>                         *
- * Copyright (c) 2015 Timothy Rae <timothy.rae@gmail.com>                               *
- * Copyright (c) 2016 Mark Carter <mark@marcardar.com>                                  *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/**************************************************************************************
+ *
+ Copyright (c) 2015 Frank Oltmanns <frank.oltmanns@gmail.com>                         *
+ Copyright (c) 2015 Timothy Rae <timothy.rae@gmail.com>                               *
+ Copyright (c) 2016 Mark Carter <mark@marcardar.com>                                  *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki.provider;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/receiver/SdCardReceiver.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/receiver/SdCardReceiver.java
@@ -1,18 +1,18 @@
-/***************************************************************************************
- * Copyright (c) 2012 Norbert Nagold <norbert.nagold@gmail.com>                         *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/**************************************************************************************
+ Copyright (c) 2012 Norbert Nagold <norbert.nagold@gmail.com>                         *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki.receiver;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ReviewerCustomFonts.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ReviewerCustomFonts.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki.reviewer;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/runtimetools/TaskOperations.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/runtimetools/TaskOperations.java
@@ -1,21 +1,21 @@
-/****************************************************************************************
- * Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
- * Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
- * Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
- * Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
+ Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
+ Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
+ Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki.runtimetools;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.java
@@ -1,21 +1,21 @@
-/****************************************************************************************
- * Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
- * Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
- * Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
- * Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
+ Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
+ Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
+ Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki.servicelayer;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/NotificationService.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/NotificationService.java
@@ -1,16 +1,16 @@
-/***************************************************************************************
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/**************************************************************************************
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki.services;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/ReminderService.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/ReminderService.java
@@ -1,16 +1,16 @@
-/***************************************************************************************
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/**************************************************************************************
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki.services;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/stats/AnkiStatsTaskHandler.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/stats/AnkiStatsTaskHandler.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2014 Michael Goldbach <michael@m-goldbach.net>                         *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2014 Michael Goldbach <michael@m-goldbach.net>                         *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 package com.ichi2.anki.stats;
 
 import android.content.res.Resources;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/stats/ChartBuilder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/stats/ChartBuilder.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2014 Michael Goldbach <michael@m-goldbach.net>                         *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2014 Michael Goldbach <michael@m-goldbach.net>                         *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 package com.ichi2.anki.stats;
 
 import android.graphics.Paint;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/stats/ChartView.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/stats/ChartView.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 package com.ichi2.anki.stats;
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/stats/OverviewStatsBuilder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/stats/OverviewStatsBuilder.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2014 Michael Goldbach <michael@m-goldbach.net>                         *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2014 Michael Goldbach <michael@m-goldbach.net>                         *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 package com.ichi2.anki.stats;
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/stats/StatsMetaInfo.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/stats/StatsMetaInfo.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2016 Jeffrey van Prehn <jvanprehn@gmail.com>                           *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2016 Jeffrey van Prehn <jvanprehn@gmail.com>                           *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki.stats;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/web/HttpFetcher.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/web/HttpFetcher.java
@@ -1,22 +1,22 @@
-/****************************************************************************************
- * Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
- * Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
- * Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
- * Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
- * Copyright (c) 2020 Mike Hardy <github@mikehardy.net>                                 *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
+ Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
+ Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
+ Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
+ Copyright (c) 2020 Mike Hardy <github@mikehardy.net>                                 *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki.web;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2015 Houssam Salem <houssam.salem.au@gmail.com>                        *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2015 Houssam Salem <houssam.salem.au@gmail.com>                        *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki.widgets;
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/FabBehavior.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/FabBehavior.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2015 Timothy Rae <perceptualchaos2@gmail.com>                          *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2015 Timothy Rae <perceptualchaos2@gmail.com>                          *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 package com.ichi2.anki.widgets;
 
 import android.content.Context;

--- a/AnkiDroid/src/main/java/com/ichi2/async/BaseAsyncTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/BaseAsyncTask.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.async;
 

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -1,20 +1,20 @@
-/****************************************************************************************
- * Copyright (c) 2009 Daniel Svärd <daniel.svard@gmail.com>                             *
- * Copyright (c) 2009 Edu Zamora <edu.zasu@gmail.com>                                   *
- * Copyright (c) 2011 Norbert Nagold <norbert.nagold@gmail.com>                         *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2009 Daniel Svärd <daniel.svard@gmail.com>                             *
+ Copyright (c) 2009 Edu Zamora <edu.zasu@gmail.com>                                   *
+ Copyright (c) 2011 Norbert Nagold <norbert.nagold@gmail.com>                         *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.async;
 

--- a/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
@@ -1,20 +1,20 @@
-/****************************************************************************************
- * Copyright (c) 2009 Edu Zamora <edu.zasu@gmail.com>                                   *
- * Copyright (c) 2011 Kostas Spyropoulos <inigo.aldana@gmail.com>                       *
- * Copyright (c) 2012 Norbert Nagold <norbert.nagold@gmail.com>                         *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2009 Edu Zamora <edu.zasu@gmail.com>                                   *
+ Copyright (c) 2011 Kostas Spyropoulos <inigo.aldana@gmail.com>                       *
+ Copyright (c) 2012 Norbert Nagold <norbert.nagold@gmail.com>                         *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.async;
 

--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2011 Flavio Lerda <flerda@gmail.com>                                   *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2011 Flavio Lerda <flerda@gmail.com>                                   *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.compat;
 

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatHelper.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatHelper.java
@@ -1,18 +1,18 @@
-/***************************************************************************************
- * Copyright (c) 2015 Timothy Rae <perceptualchaos2@gmail.com>                          *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/**************************************************************************************
+ Copyright (c) 2015 Timothy Rae <perceptualchaos2@gmail.com>                          *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.compat;
 

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV16.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV16.java
@@ -1,18 +1,18 @@
-/***************************************************************************************
- * Copyright (c) 2016 Timothy Rae <perceptualchaos2@gmail.com>                          *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/**************************************************************************************
+ Copyright (c) 2016 Timothy Rae <perceptualchaos2@gmail.com>                          *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.compat;
 

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV17.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV17.java
@@ -1,18 +1,18 @@
-/***************************************************************************************
- * Copyright (c) 2016 rubyu <ruby.u.g@gmail.com>                                        *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/**************************************************************************************
+ Copyright (c) 2016 rubyu <ruby.u.g@gmail.com>                                        *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.compat;
 

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV18.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV18.java
@@ -1,18 +1,18 @@
-/***************************************************************************************
- * Copyright (c) 2018 Mike Hardy <github@mikehardy.net>                                 *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/**************************************************************************************
+ Copyright (c) 2018 Mike Hardy <github@mikehardy.net>                                 *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.compat;
 

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV19.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV19.java
@@ -1,18 +1,18 @@
-/***************************************************************************************
- * Copyright (c) 2015 Houssam Salem <houssam.salem.au@gmail.com>                        *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/**************************************************************************************
+ Copyright (c) 2015 Houssam Salem <houssam.salem.au@gmail.com>                        *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.compat;
 

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV21.java
@@ -1,18 +1,18 @@
-/***************************************************************************************
- * Copyright (c) 2015 Timothy Rae <perceptualchaos2@gmail.com>                          *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/**************************************************************************************
+ Copyright (c) 2015 Timothy Rae <perceptualchaos2@gmail.com>                          *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.compat;
 

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV23.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV23.java
@@ -1,18 +1,18 @@
-/***************************************************************************************
- * Copyright (c) 2017 Profpatsch <mail@profpatsch.de>                                   *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/**************************************************************************************
+ Copyright (c) 2017 Profpatsch <mail@profpatsch.de>                                   *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.compat;
 

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV24.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV24.java
@@ -1,18 +1,18 @@
-/***************************************************************************************
- * Copyright (c) 2018 Mike Hardy <github@mikehardy.net>                                 *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/**************************************************************************************
+ Copyright (c) 2018 Mike Hardy <github@mikehardy.net>                                 *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.compat;
 

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV26.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV26.java
@@ -1,18 +1,18 @@
-/***************************************************************************************
- * Copyright (c) 2018 Mike Hardy <github@mikehardy.net>                                 *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/**************************************************************************************
+ Copyright (c) 2018 Mike Hardy <github@mikehardy.net>                                 *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.compat;
 

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV28.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV28.java
@@ -1,18 +1,18 @@
-/***************************************************************************************
- * Copyright (c) 2019 Maxim Ilyukhin <maxim.ilyukhin@orionhealth.com>                   *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/**************************************************************************************
+ Copyright (c) 2019 Maxim Ilyukhin <maxim.ilyukhin@orionhealth.com>                   *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.compat;
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2014 Timothy Rae   <perceptualchaos2@gmail.com>                        *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2014 Timothy Rae   <perceptualchaos2@gmail.com>                        *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.libanki;
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.java
@@ -1,20 +1,20 @@
-/****************************************************************************************
- * Copyright (c) 2009 Daniel Svärd <daniel.svard@gmail.com>                             *
- * Copyright (c) 2011 Norbert Nagold <norbert.nagold@gmail.com>                         *
- * Copyright (c) 2014 Houssam Salem <houssam.salem.au@gmail.com>                        *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2009 Daniel Svärd <daniel.svard@gmail.com>                             *
+ Copyright (c) 2011 Norbert Nagold <norbert.nagold@gmail.com>                         *
+ Copyright (c) 2014 Houssam Salem <houssam.salem.au@gmail.com>                        *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.libanki;
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1,19 +1,19 @@
-/****************************************************************************************
- * Copyright (c) 2011 Norbert Nagold <norbert.nagold@gmail.com>                         *
- * Copyright (c) 2012 Kostas Spyropoulos <inigo.aldana@gmail.com>                       *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General private License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General private License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General private License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2011 Norbert Nagold <norbert.nagold@gmail.com>                         *
+ Copyright (c) 2012 Kostas Spyropoulos <inigo.aldana@gmail.com>                       *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General private License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General private License for more details.             *
+ *
+ You should have received a copy of the GNU General private License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.libanki;
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Consts.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Consts.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2014 Houssam Salem <houssam.salem.au@gmail.com>                        *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2014 Houssam Salem <houssam.salem.au@gmail.com>                        *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.libanki;
 import java.lang.annotation.Retention;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DB.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DB.java
@@ -1,22 +1,22 @@
-/****************************************************************************************
- * Copyright (c) 2009 Daniel Svärd <daniel.svard@gmail.com>                             *
- * Copyright (c) 2009 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
- * Copyright (c) 2009 Andrew <andrewdubya@gmail.com>                                    *
- * Copyright (c) 2011 Norbert Nagold <norbert.nagold@gmail.com>                         *
- * Copyright (c) 2018 Mike Hardy <mike@mikehardy.net>                                   *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2009 Daniel Svärd <daniel.svard@gmail.com>                             *
+ Copyright (c) 2009 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
+ Copyright (c) 2009 Andrew <andrewdubya@gmail.com>                                    *
+ Copyright (c) 2011 Norbert Nagold <norbert.nagold@gmail.com>                         *
+ Copyright (c) 2018 Mike Hardy <mike@mikehardy.net>                                   *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.libanki;
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -1,23 +1,23 @@
-/****************************************************************************************
- * Copyright (c) 2009 Daniel Svärd <daniel.svard@gmail.com>                             *
- * Copyright (c) 2009 Casey Link <unnamedrambler@gmail.com>                             *
- * Copyright (c) 2009 Edu Zamora <edu.zasu@gmail.com>                                   *
- * Copyright (c) 2010 Norbert Nagold <norbert.nagold@gmail.com>                         *
- * Copyright (c) 2015 Houssam Salem <houssam.salem.au@gmail.com>                        *
- * Copyright (c) 2018 Chris Williams <chris@chrispwill.com>                             *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2009 Daniel Svärd <daniel.svard@gmail.com>                             *
+ Copyright (c) 2009 Casey Link <unnamedrambler@gmail.com>                             *
+ Copyright (c) 2009 Edu Zamora <edu.zasu@gmail.com>                                   *
+ Copyright (c) 2010 Norbert Nagold <norbert.nagold@gmail.com>                         *
+ Copyright (c) 2015 Houssam Salem <houssam.salem.au@gmail.com>                        *
+ Copyright (c) 2018 Chris Williams <chris@chrispwill.com>                             *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.libanki;
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
@@ -1,20 +1,20 @@
-/****************************************************************************************
- * Copyright (c) 2012 Norbert Nagold <norbert.nagold@gmail.com>                         *
- * Copyright (c) 2012 Kostas Spyropoulos <inigo.aldana@gmail.com>                       *
- * Copyright (c) 2014 Houssam Salem <houssam.salem.au@gmail.com>                        *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2012 Norbert Nagold <norbert.nagold@gmail.com>                         *
+ Copyright (c) 2012 Kostas Spyropoulos <inigo.aldana@gmail.com>                       *
+ Copyright (c) 2014 Houssam Salem <houssam.salem.au@gmail.com>                        *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.libanki;
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/LaTeX.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/LaTeX.java
@@ -1,20 +1,20 @@
-/***************************************************************************************
- * Copyright (c) 2009 Edu Zamora <edu.zasu@gmail.com>                                   *
- * Copyright (c) 2012 Kostas Spyropoulos <inigo.aldana@gmail.com>                       *
- * Copyright (c) 2015 Houssam Salem <houssam.salem.au@gmail.com>                        *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/**************************************************************************************
+ Copyright (c) 2009 Edu Zamora <edu.zasu@gmail.com>                                   *
+ Copyright (c) 2012 Kostas Spyropoulos <inigo.aldana@gmail.com>                       *
+ Copyright (c) 2015 Houssam Salem <houssam.salem.au@gmail.com>                        *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.libanki;
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Media.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Media.java
@@ -1,19 +1,19 @@
-/****************************************************************************************
- * Copyright (c) 2011 Kostas Spyropoulos <inigo.aldana@gmail.com>                       *
- * Copyright (c) 2014 Houssam Salem <houssam.salem.au@gmail.com>                        *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2011 Kostas Spyropoulos <inigo.aldana@gmail.com>                       *
+ Copyright (c) 2014 Houssam Salem <houssam.salem.au@gmail.com>                        *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.libanki;
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -1,21 +1,21 @@
-/****************************************************************************************
- * Copyright (c) 2009 Daniel Svärd <daniel.svard@gmail.com>                             *
- * Copyright (c) 2010 Rick Gruber-Riemer <rick@vanosten.net>                            *
- * Copyright (c) 2011 Norbert Nagold <norbert.nagold@gmail.com>                         *
- * Copyright (c) 2011 Kostas Spyropoulos <inigo.aldana@gmail.com>                       *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2009 Daniel Svärd <daniel.svard@gmail.com>                             *
+ Copyright (c) 2010 Rick Gruber-Riemer <rick@vanosten.net>                            *
+ Copyright (c) 2011 Norbert Nagold <norbert.nagold@gmail.com>                         *
+ Copyright (c) 2011 Kostas Spyropoulos <inigo.aldana@gmail.com>                       *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.libanki;
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Note.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Note.java
@@ -1,19 +1,19 @@
-/****************************************************************************************
- * Copyright (c) 2011 Norbert Nagold <norbert.nagold@gmail.com>                         *
- * Copyright (c) 2014 Houssam Salem <houssam.salem.au@gmail.com>                        *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2011 Norbert Nagold <norbert.nagold@gmail.com>                         *
+ Copyright (c) 2014 Houssam Salem <houssam.salem.au@gmail.com>                        *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.libanki;
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.java
@@ -1,19 +1,19 @@
-/****************************************************************************************
- * Copyright (c) 2009 Edu Zamora <edu.zasu@gmail.com>                                   *
- * Copyright (c) 2014 Timothy rae <perceptualchaos2@gmail.com>                          *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2009 Edu Zamora <edu.zasu@gmail.com>                                   *
+ Copyright (c) 2014 Timothy rae <perceptualchaos2@gmail.com>                          *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.libanki;
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Storage.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Storage.java
@@ -1,18 +1,18 @@
-/***************************************************************************************
- * Copyright (c) 2011 Norbert Nagold <norbert.nagold@gmail.com>                         *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/**************************************************************************************
+ Copyright (c) 2011 Norbert Nagold <norbert.nagold@gmail.com>                         *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.libanki;
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Tags.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Tags.java
@@ -1,20 +1,20 @@
-/****************************************************************************************
- * Copyright (c) 2011 Norbert Nagold <norbert.nagold@gmail.com>                         *
- * Copyright (c) 2012 Kostas Spyropoulos <inigo.aldana@gmail.com>                       *
- * Copyright (c) 2014 Houssam Salem <houssam.salem.au@gmail.com>                        *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2011 Norbert Nagold <norbert.nagold@gmail.com>                         *
+ Copyright (c) 2012 Kostas Spyropoulos <inigo.aldana@gmail.com>                       *
+ Copyright (c) 2014 Houssam Salem <houssam.salem.au@gmail.com>                        *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.libanki;
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
@@ -1,21 +1,21 @@
-/****************************************************************************************
- * Copyright (c) 2009 Daniel Svärd <daniel.svard@gmail.com>                             *
- * Copyright (c) 2009 Edu Zamora <edu.zasu@gmail.com>                                   *
- * Copyright (c) 2011 Norbert Nagold <norbert.nagold@gmail.com>                         *
- * Copyright (c) 2012 Kostas Spyropoulos <inigo.aldana@gmail.com>                       *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2009 Daniel Svärd <daniel.svard@gmail.com>                             *
+ Copyright (c) 2009 Edu Zamora <edu.zasu@gmail.com>                                   *
+ Copyright (c) 2011 Norbert Nagold <norbert.nagold@gmail.com>                         *
+ Copyright (c) 2012 Kostas Spyropoulos <inigo.aldana@gmail.com>                       *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.libanki;
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/hooks/ChessFilter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/hooks/ChessFilter.java
@@ -1,18 +1,18 @@
-/***************************************************************************************
- * Copyright (c) 2012 Kostas Spyropoulos <inigo.aldana@gmail.com>                       *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/**************************************************************************************
+ Copyright (c) 2012 Kostas Spyropoulos <inigo.aldana@gmail.com>                       *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.libanki.hooks;
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
@@ -1,19 +1,19 @@
-/***************************************************************************************
- * Copyright (c) 2012 Norbert Nagold <norbert.nagold@gmail.com>                         *
- * Copyright (c) 2016 Houssam Salem <houssam.salem.au@gmail.com>                        *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/**************************************************************************************
+ Copyright (c) 2012 Norbert Nagold <norbert.nagold@gmail.com>                         *
+ Copyright (c) 2016 Houssam Salem <houssam.salem.au@gmail.com>                        *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.libanki.importer;
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/AnkiPackageImporter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/AnkiPackageImporter.java
@@ -1,18 +1,18 @@
-/***************************************************************************************
-  * Copyright (c) 2016 Houssam Salem <houssam.salem.au@gmail.com>                        *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/**************************************************************************************
+ Copyright (c) 2016 Houssam Salem <houssam.salem.au@gmail.com>                        *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.libanki.importer;
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Importer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Importer.java
@@ -1,18 +1,18 @@
-/***************************************************************************************
- * Copyright (c) 2016 Houssam Salem <houssam.salem.au@gmail.com>                        *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/**************************************************************************************
+ Copyright (c) 2016 Houssam Salem <houssam.salem.au@gmail.com>                        *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.libanki.importer;
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -1,20 +1,20 @@
-/****************************************************************************************
- * Copyright (c) 2011 Norbert Nagold <norbert.nagold@gmail.com>                         *
- * Copyright (c) 2012 Kostas Spyropoulos <inigo.aldana@gmail.com>                       *
- * Copyright (c) 2013 Houssam Salem <houssam.salem.au@gmail.com>                        *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General private License as published by the Free Software       *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General private License for more details.            *
- *                                                                                      *
- * You should have received a copy of the GNU General private License along with        *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2011 Norbert Nagold <norbert.nagold@gmail.com>                         *
+ Copyright (c) 2012 Kostas Spyropoulos <inigo.aldana@gmail.com>                       *
+ Copyright (c) 2013 Houssam Salem <houssam.salem.au@gmail.com>                        *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General private License as published by the Free Software       *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General private License for more details.            *
+ *
+ You should have received a copy of the GNU General private License along with        *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.libanki.sched;
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -1,21 +1,21 @@
-/****************************************************************************************
- * Copyright (c) 2011 Norbert Nagold <norbert.nagold@gmail.com>                         *
- * Copyright (c) 2012 Kostas Spyropoulos <inigo.aldana@gmail.com>                       *
- * Copyright (c) 2013 Houssam Salem <houssam.salem.au@gmail.com>                        *
- * Copyright (c) 2018 Chris Williams <chris@chrispwill.com>                             *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General private License as published by the Free Software       *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General private License for more details.            *
- *                                                                                      *
- * You should have received a copy of the GNU General private License along with        *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2011 Norbert Nagold <norbert.nagold@gmail.com>                         *
+ Copyright (c) 2012 Kostas Spyropoulos <inigo.aldana@gmail.com>                       *
+ Copyright (c) 2013 Houssam Salem <houssam.salem.au@gmail.com>                        *
+ Copyright (c) 2018 Chris Williams <chris@chrispwill.com>                             *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General private License as published by the Free Software       *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General private License for more details.            *
+ *
+ You should have received a copy of the GNU General private License along with        *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.libanki.sched;
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/stats/AdvancedStatistics.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/stats/AdvancedStatistics.java
@@ -1,19 +1,19 @@
-/****************************************************************************************
-/****************************************************************************************
- * Copyright (c) 2016 Jeffrey van Prehn <jvanprehn@gmail.com>                           *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ /****************************************************************************************
+ Copyright (c) 2016 Jeffrey van Prehn <jvanprehn@gmail.com>                           *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.libanki.stats;
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/stats/Stats.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/stats/Stats.java
@@ -1,19 +1,19 @@
-/****************************************************************************************
- * Copyright (c) 2011 Norbert Nagold <norbert.nagold@gmail.com>                         *
- * Copyright (c) 2014 Michael Goldbach <michael@m-goldbach.net>                         *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2011 Norbert Nagold <norbert.nagold@gmail.com>                         *
+ Copyright (c) 2014 Michael Goldbach <michael@m-goldbach.net>                         *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.libanki.stats;
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/CountingFileRequestBody.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/CountingFileRequestBody.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2019 Mike Hardy <github@mikehardy.net>                                 *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2019 Mike Hardy <github@mikehardy.net>                                 *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.libanki.sync;
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/FullSyncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/FullSyncer.java
@@ -1,18 +1,18 @@
-/***************************************************************************************
- * Copyright (c) 2012 Norbert Nagold <norbert.nagold@gmail.com>                         *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/**************************************************************************************
+ Copyright (c) 2012 Norbert Nagold <norbert.nagold@gmail.com>                         *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.libanki.sync;
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HttpSyncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HttpSyncer.java
@@ -1,21 +1,21 @@
-/***************************************************************************************
- * Copyright (c) 2012 Norbert Nagold <norbert.nagold@gmail.com>                         *
- * Copyright (c) 2012 Kostas Spyropoulos <inigo.aldana@gmail.com>                       *
- * Copyright (c) 2014 Timothy Rae <perceptualchaos2@gmail.com>                          *
- * Copyright (c) 2019 Mike Hardy <github@mikehardy.net>                                 *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/**************************************************************************************
+ Copyright (c) 2012 Norbert Nagold <norbert.nagold@gmail.com>                         *
+ Copyright (c) 2012 Kostas Spyropoulos <inigo.aldana@gmail.com>                       *
+ Copyright (c) 2014 Timothy Rae <perceptualchaos2@gmail.com>                          *
+ Copyright (c) 2019 Mike Hardy <github@mikehardy.net>                                 *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.libanki.sync;
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/MediaSyncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/MediaSyncer.java
@@ -1,19 +1,19 @@
-/****************************************************************************************
- * Copyright (c) 2012 Kostas Spyropoulos <inigo.aldana@gmail.com>                       *
- * Copyright (c) 2014 Houssam Salem <houssam.salem.au@gmail.com>                        *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2012 Kostas Spyropoulos <inigo.aldana@gmail.com>                       *
+ Copyright (c) 2014 Houssam Salem <houssam.salem.au@gmail.com>                        *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.libanki.sync;
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteMediaServer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteMediaServer.java
@@ -1,19 +1,19 @@
-/****************************************************************************************
- * Copyright (c) 2012 Kostas Spyropoulos <inigo.aldana@gmail.com>                       *
- * Copyright (c) 2014 Houssam Salem <houssam.salem.au@gmail.com>                        *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2012 Kostas Spyropoulos <inigo.aldana@gmail.com>                       *
+ Copyright (c) 2014 Houssam Salem <houssam.salem.au@gmail.com>                        *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.libanki.sync;
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteServer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteServer.java
@@ -1,19 +1,19 @@
-/***************************************************************************************
- * Copyright (c) 2012 Norbert Nagold <norbert.nagold@gmail.com>                         *
- * Copyright (c) 2014 Timothy Rae <perceptualchaos2@gmail.com>                          *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/**************************************************************************************
+ Copyright (c) 2012 Norbert Nagold <norbert.nagold@gmail.com>                         *
+ Copyright (c) 2014 Timothy Rae <perceptualchaos2@gmail.com>                          *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.libanki.sync;
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.java
@@ -1,19 +1,19 @@
-/***************************************************************************************
- * Copyright (c) 2011 Norbert Nagold <norbert.nagold@gmail.com>                         *
- * Copyright (c) 2014 Timothy Rae <perceptualchaos2@gmail.com>                          *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/**************************************************************************************
+ Copyright (c) 2011 Norbert Nagold <norbert.nagold@gmail.com>                         *
+ Copyright (c) 2014 Timothy Rae <perceptualchaos2@gmail.com>                          *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.libanki.sync;
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Tls12SocketFactory.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Tls12SocketFactory.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2019 Mike Hardy <github@mikehardy.net>                                 *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2019 Mike Hardy <github@mikehardy.net>                                 *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.libanki.sync;
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/template/FuriganaFilters.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/template/FuriganaFilters.java
@@ -1,18 +1,18 @@
-/***************************************************************************************
- * Copyright (c) 2012 Kostas Spyropoulos <inigo.aldana@gmail.com>                       *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/**************************************************************************************
+ Copyright (c) 2012 Kostas Spyropoulos <inigo.aldana@gmail.com>                       *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.libanki.template;
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/template/Template.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/template/Template.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2015 Houssam Salem <houssam.salem.au@gmail.com>                        *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2015 Houssam Salem <houssam.salem.au@gmail.com>                        *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.libanki.template;
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/utils/NoteUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/utils/NoteUtils.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2020 arthur milchior <arthur@milchior.fr>                              *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2020 arthur milchior <arthur@milchior.fr>                              *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.libanki.utils;
 

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/CustomDialogPreference.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/CustomDialogPreference.java
@@ -1,18 +1,18 @@
-/***************************************************************************************
- * Copyright (c) 2011 Norbert Nagold <norbert.nagold@gmail.com>                         *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/**************************************************************************************
+ Copyright (c) 2011 Norbert Nagold <norbert.nagold@gmail.com>                         *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.preferences;
 

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/NumberRangePreference.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/NumberRangePreference.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2013 Houssam Salem <houssam.salem.au@gmail.com>                        *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2013 Houssam Salem <houssam.salem.au@gmail.com>                        *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.preferences;
 

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/StepsPreference.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/StepsPreference.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2013 Houssam Salem <houssam.salem.au@gmail.com>                        *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2013 Houssam Salem <houssam.salem.au@gmail.com>                        *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.preferences;
 

--- a/AnkiDroid/src/main/java/com/ichi2/themes/StyledProgressDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/themes/StyledProgressDialog.java
@@ -1,20 +1,20 @@
-/****************************************************************************************
- * Copyright (c) 2011 Norbert Nagold <norbert.nagold@gmail.com>                         *
- *                                                                                      *
- * based on custom Dialog windows by antoine vianey                                     *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2011 Norbert Nagold <norbert.nagold@gmail.com>                         *
+ *
+ based on custom Dialog windows by antoine vianey                                     *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.themes;
 

--- a/AnkiDroid/src/main/java/com/ichi2/themes/Themes.java
+++ b/AnkiDroid/src/main/java/com/ichi2/themes/Themes.java
@@ -1,19 +1,19 @@
-/***************************************************************************************
- * Copyright (c) 2011 Norbert Nagold <norbert.nagold@gmail.com>                         *
- * Copyright (c) 2015 Timothy Rae <perceptualchaos2@gmail.com>                          *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/**************************************************************************************
+ Copyright (c) 2011 Norbert Nagold <norbert.nagold@gmail.com>                         *
+ Copyright (c) 2015 Timothy Rae <perceptualchaos2@gmail.com>                          *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.themes;
 

--- a/AnkiDroid/src/main/java/com/ichi2/ui/ConfirmationPreference.java
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/ConfirmationPreference.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2018 Mike Hardy <mike@mikehardy.net>                                   *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2018 Mike Hardy <mike@mikehardy.net>                                   *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.ui;
 

--- a/AnkiDroid/src/main/java/com/ichi2/utils/AdaptionUtil.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/AdaptionUtil.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2020 gaoyingjun@xiaomi.com                                             *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2020 gaoyingjun@xiaomi.com                                             *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.utils;
 

--- a/AnkiDroid/src/main/java/com/ichi2/utils/Assert.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/Assert.java
@@ -1,19 +1,19 @@
-/****************************************************************************************
- * Copyright (c) 2009 Bitonator                                                         *
- * https://stackoverflow.com/questions/6176441/how-to-use-assert-in-android/47267127#47267127 * 
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2009 Bitonator                                                         *
+ https://stackoverflow.com/questions/6176441/how-to-use-assert-in-android/47267127#47267127 *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.utils;
 

--- a/AnkiDroid/src/main/java/com/ichi2/utils/BitmapUtil.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/BitmapUtil.java
@@ -1,21 +1,21 @@
-/****************************************************************************************
- * Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
- * Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
- * Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
- * Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
+ Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
+ Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
+ Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.utils;
 

--- a/AnkiDroid/src/main/java/com/ichi2/utils/DiffEngine.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/DiffEngine.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2018 Mike Hardy <mike@mikehardy.net>                                   *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2018 Mike Hardy <mike@mikehardy.net>                                   *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.utils;
 

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ExifUtil.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ExifUtil.java
@@ -1,21 +1,21 @@
-/****************************************************************************************
- * Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
- * Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
- * Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
- * Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2013 Bibek Shrestha <bibekshrestha@gmail.com>                          *
+ Copyright (c) 2013 Zaur Molotnikov <qutorial@gmail.com>                              *
+ Copyright (c) 2013 Nicolas Raoul <nicolas.raoul@gmail.com>                           *
+ Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.utils;
 

--- a/AnkiDroid/src/main/java/com/ichi2/utils/LanguageUtil.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/LanguageUtil.java
@@ -1,16 +1,16 @@
-/****************************************************************************************
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.utils;
 

--- a/AnkiDroid/src/main/java/com/ichi2/utils/MethodLogger.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/MethodLogger.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.utils;
 

--- a/AnkiDroid/src/main/java/com/ichi2/utils/NoteFieldDecorator.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/NoteFieldDecorator.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2020 Mike Hardy <github@mikehardy.net>                                 *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2020 Mike Hardy <github@mikehardy.net>                                 *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.utils;
 

--- a/AnkiDroid/src/main/java/com/ichi2/utils/Threads.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/Threads.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2013 Flavio Lerda <flerda@gmail.com>                                   *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.utils;
 

--- a/AnkiDroid/src/main/java/com/ichi2/widget/AddNoteWidget.java
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/AddNoteWidget.java
@@ -1,16 +1,16 @@
-/***************************************************************************************
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/**************************************************************************************
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.widget;
 

--- a/AnkiDroid/src/main/java/com/ichi2/widget/AnkiDroidWidgetSmall.java
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/AnkiDroidWidgetSmall.java
@@ -1,16 +1,16 @@
-/***************************************************************************************
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/**************************************************************************************
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.widget;
 

--- a/AnkiDroid/src/main/java/com/ichi2/widget/WidgetStatus.java
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/WidgetStatus.java
@@ -1,16 +1,16 @@
-/***************************************************************************************
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/**************************************************************************************
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.widget;
 

--- a/AnkiDroid/src/main/java/com/wildplot/android/parsing/Atom.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/parsing/Atom.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 package com.wildplot.android.parsing;
 
 import com.wildplot.android.parsing.AtomTypes.*;

--- a/AnkiDroid/src/main/java/com/wildplot/android/parsing/AtomTypes/FunctionXAtom.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/parsing/AtomTypes/FunctionXAtom.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 package com.wildplot.android.parsing.AtomTypes;
 
 import com.wildplot.android.parsing.*;

--- a/AnkiDroid/src/main/java/com/wildplot/android/parsing/AtomTypes/FunctionXYAtom.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/parsing/AtomTypes/FunctionXYAtom.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.wildplot.android.parsing.AtomTypes;
 

--- a/AnkiDroid/src/main/java/com/wildplot/android/parsing/AtomTypes/MathFunctionAtom.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/parsing/AtomTypes/MathFunctionAtom.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 package com.wildplot.android.parsing.AtomTypes;
 
 import com.wildplot.android.parsing.Expression;

--- a/AnkiDroid/src/main/java/com/wildplot/android/parsing/AtomTypes/NumberAtom.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/parsing/AtomTypes/NumberAtom.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 package com.wildplot.android.parsing.AtomTypes;
 
 import com.wildplot.android.parsing.Atom;

--- a/AnkiDroid/src/main/java/com/wildplot/android/parsing/AtomTypes/VariableAtom.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/parsing/AtomTypes/VariableAtom.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 package com.wildplot.android.parsing.AtomTypes;
 
 import com.wildplot.android.parsing.Atom;

--- a/AnkiDroid/src/main/java/com/wildplot/android/parsing/AtomTypes/XVariableAtom.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/parsing/AtomTypes/XVariableAtom.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 package com.wildplot.android.parsing.AtomTypes;
 
 import com.wildplot.android.parsing.Atom;

--- a/AnkiDroid/src/main/java/com/wildplot/android/parsing/AtomTypes/YVariableAtom.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/parsing/AtomTypes/YVariableAtom.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 package com.wildplot.android.parsing.AtomTypes;
 
 import com.wildplot.android.parsing.Atom;

--- a/AnkiDroid/src/main/java/com/wildplot/android/parsing/Expression.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/parsing/Expression.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 package com.wildplot.android.parsing;
 
 

--- a/AnkiDroid/src/main/java/com/wildplot/android/parsing/ExpressionFormatException.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/parsing/ExpressionFormatException.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 package com.wildplot.android.parsing;
 
 

--- a/AnkiDroid/src/main/java/com/wildplot/android/parsing/Factor.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/parsing/Factor.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 package com.wildplot.android.parsing;
 
 

--- a/AnkiDroid/src/main/java/com/wildplot/android/parsing/Pow.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/parsing/Pow.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 package com.wildplot.android.parsing;
 
 

--- a/AnkiDroid/src/main/java/com/wildplot/android/parsing/Term.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/parsing/Term.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 package com.wildplot.android.parsing;
 
 

--- a/AnkiDroid/src/main/java/com/wildplot/android/parsing/TopLevelParser.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/parsing/TopLevelParser.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 package com.wildplot.android.parsing;
 
 import com.wildplot.android.rendering.interfaces.Function2D;

--- a/AnkiDroid/src/main/java/com/wildplot/android/parsing/TreeElement.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/parsing/TreeElement.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 package com.wildplot.android.parsing;
 
 

--- a/AnkiDroid/src/main/java/com/wildplot/android/rendering/BarGraph.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/rendering/BarGraph.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 package com.wildplot.android.rendering;
 
 import com.wildplot.android.rendering.graphics.wrapper.ColorWrap;

--- a/AnkiDroid/src/main/java/com/wildplot/android/rendering/DrawableContainer.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/rendering/DrawableContainer.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 package com.wildplot.android.rendering;
 
 import com.wildplot.android.rendering.graphics.wrapper.GraphicsWrap;

--- a/AnkiDroid/src/main/java/com/wildplot/android/rendering/LegendDrawable.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/rendering/LegendDrawable.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 package com.wildplot.android.rendering;
 
 import com.wildplot.android.rendering.graphics.wrapper.ColorWrap;

--- a/AnkiDroid/src/main/java/com/wildplot/android/rendering/Lines.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/rendering/Lines.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 package com.wildplot.android.rendering;
 
 import com.wildplot.android.rendering.graphics.wrapper.*;

--- a/AnkiDroid/src/main/java/com/wildplot/android/rendering/MultiScreenPart.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/rendering/MultiScreenPart.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 package com.wildplot.android.rendering;
 
 import com.wildplot.android.rendering.interfaces.Drawable;

--- a/AnkiDroid/src/main/java/com/wildplot/android/rendering/PieChart.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/rendering/PieChart.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 package com.wildplot.android.rendering;
 
 import com.wildplot.android.rendering.graphics.wrapper.ColorWrap;

--- a/AnkiDroid/src/main/java/com/wildplot/android/rendering/PlotSheet.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/rendering/PlotSheet.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 package com.wildplot.android.rendering;
 
 

--- a/AnkiDroid/src/main/java/com/wildplot/android/rendering/XAxis.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/rendering/XAxis.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 package com.wildplot.android.rendering;
 
 

--- a/AnkiDroid/src/main/java/com/wildplot/android/rendering/XGrid.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/rendering/XGrid.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 package com.wildplot.android.rendering;
 
 import com.wildplot.android.rendering.graphics.wrapper.ColorWrap;

--- a/AnkiDroid/src/main/java/com/wildplot/android/rendering/YAxis.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/rendering/YAxis.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 package com.wildplot.android.rendering;
 
 import com.wildplot.android.rendering.graphics.wrapper.FontMetricsWrap;

--- a/AnkiDroid/src/main/java/com/wildplot/android/rendering/YGrid.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/rendering/YGrid.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 package com.wildplot.android.rendering;
 
 import com.wildplot.android.rendering.graphics.wrapper.ColorWrap;

--- a/AnkiDroid/src/main/java/com/wildplot/android/rendering/graphics/wrapper/BasicStrokeWrap.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/rendering/graphics/wrapper/BasicStrokeWrap.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 package com.wildplot.android.rendering.graphics.wrapper;
 
 public class BasicStrokeWrap extends StrokeWrap {

--- a/AnkiDroid/src/main/java/com/wildplot/android/rendering/graphics/wrapper/ColorWrap.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/rendering/graphics/wrapper/ColorWrap.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 package com.wildplot.android.rendering.graphics.wrapper;
 
 public class ColorWrap {

--- a/AnkiDroid/src/main/java/com/wildplot/android/rendering/graphics/wrapper/FontMetricsWrap.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/rendering/graphics/wrapper/FontMetricsWrap.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 package com.wildplot.android.rendering.graphics.wrapper;
 
 public class FontMetricsWrap {

--- a/AnkiDroid/src/main/java/com/wildplot/android/rendering/graphics/wrapper/GraphicsWrap.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/rendering/graphics/wrapper/GraphicsWrap.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 package com.wildplot.android.rendering.graphics.wrapper;
 
 import android.graphics.Canvas;

--- a/AnkiDroid/src/main/java/com/wildplot/android/rendering/graphics/wrapper/RectangleWrap.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/rendering/graphics/wrapper/RectangleWrap.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 package com.wildplot.android.rendering.graphics.wrapper;
 
 import android.graphics.Rect;

--- a/AnkiDroid/src/main/java/com/wildplot/android/rendering/graphics/wrapper/StrokeWrap.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/rendering/graphics/wrapper/StrokeWrap.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 package com.wildplot.android.rendering.graphics.wrapper;
 
 public class StrokeWrap {

--- a/AnkiDroid/src/main/java/com/wildplot/android/rendering/interfaces/Drawable.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/rendering/interfaces/Drawable.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 package com.wildplot.android.rendering.interfaces;
 
 import com.wildplot.android.rendering.graphics.wrapper.GraphicsWrap;

--- a/AnkiDroid/src/main/java/com/wildplot/android/rendering/interfaces/Function2D.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/rendering/interfaces/Function2D.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2014 Michael Goldbach <michael@wildplot.com>                           *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 package com.wildplot.android.rendering.interfaces;
 
 /**

--- a/AnkiDroid/src/main/java/com/wildplot/android/rendering/interfaces/Function3D.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/rendering/interfaces/Function3D.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2014 Michael Goldbach <trashcutter@googlemail.com>                     *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2014 Michael Goldbach <trashcutter@googlemail.com>                     *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 package com.wildplot.android.rendering.interfaces;
 
 /**

--- a/AnkiDroid/src/main/java/com/wildplot/android/rendering/interfaces/Legendable.java
+++ b/AnkiDroid/src/main/java/com/wildplot/android/rendering/interfaces/Legendable.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2014 Michael Goldbach <trashcutter@googlemail.com>                     *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2014 Michael Goldbach <trashcutter@googlemail.com>                     *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 package com.wildplot.android.rendering.interfaces;
 
 import com.wildplot.android.rendering.graphics.wrapper.ColorWrap;

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AnalyticsTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AnalyticsTest.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2018 Mike Hardy <mike@mikehardy.net>                                   *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2018 Mike Hardy <mike@mikehardy.net>                                   *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki;
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateEditorTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateEditorTest.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2020 Mike Hardy <mike@mikehardy.net>                                   *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2020 Mike Hardy <mike@mikehardy.net>                                   *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki;
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplatePreviewerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplatePreviewerTest.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2018 Mike Hardy <mike@mikehardy.net>                                   *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2018 Mike Hardy <mike@mikehardy.net>                                   *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki;
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ProductionCrashReportingTreeTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ProductionCrashReportingTreeTest.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2018 Mike Hardy <mike@mikehardy.net>                                   *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2018 Mike Hardy <mike@mikehardy.net>                                   *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki;
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2018 Mike Hardy <mike@mikehardy.net>                                   *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2018 Mike Hardy <mike@mikehardy.net>                                   *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki;
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/TemporaryModelTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/TemporaryModelTest.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2020 Mike Hardy <mike@mikehardy.net>                                   *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/**************************************************************************************
+ Copyright (c) 2020 Mike Hardy <mike@mikehardy.net>                                   *
+
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki;
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/TestUtils.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/TestUtils.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2018 Mike Hardy <mike@mikehardy.net>                                   *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2018 Mike Hardy <mike@mikehardy.net>                                   *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki;
 

--- a/AnkiDroid/src/test/java/com/ichi2/compat/CompatCopyFileTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/compat/CompatCopyFileTest.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2018 Mike Hardy <mike@mikehardy.net>                                   *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2018 Mike Hardy <mike@mikehardy.net>                                   *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.compat;
 

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/UtilsTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/UtilsTest.java
@@ -1,18 +1,18 @@
-/****************************************************************************************
- * Copyright (c) 2018 Mike Hardy <mike@mikehardy.net>                                   *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/***************************************************************************************
+ Copyright (c) 2018 Mike Hardy <mike@mikehardy.net>                                   *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU General Public License as published by the Free Software        *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU General Public License along with         *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.libanki;
 

--- a/api/src/main/java/com/ichi2/anki/api/AddContentApi.java
+++ b/api/src/main/java/com/ichi2/anki/api/AddContentApi.java
@@ -1,20 +1,20 @@
-/***************************************************************************************
- *                                                                                      *
- * Copyright (c) 2015 Timothy Rae <perceptualchaos2@gmail.com>                          *
- * Copyright (c) 2016 Mark Carter <mark@marcardar.com>                                  *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU Lesser General Public License as published by the Free Software *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU Lesser General Public License along with  *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/**************************************************************************************
+ *
+ Copyright (c) 2015 Timothy Rae <perceptualchaos2@gmail.com>                          *
+ Copyright (c) 2016 Mark Carter <mark@marcardar.com>                                  *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU Lesser General Public License as published by the Free Software *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU Lesser General Public License along with  *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki.api;
 

--- a/api/src/main/java/com/ichi2/anki/api/NoteInfo.java
+++ b/api/src/main/java/com/ichi2/anki/api/NoteInfo.java
@@ -1,19 +1,19 @@
-/***************************************************************************************
- *                                                                                      *
- * Copyright (c) 2016 Timothy Rae <perceptualchaos2@gmail.com>                          *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU Lesser General Public License as published by the Free Software *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU Lesser General Public License along with  *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/**************************************************************************************
+ *
+ Copyright (c) 2016 Timothy Rae <perceptualchaos2@gmail.com>                          *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU Lesser General Public License as published by the Free Software *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU Lesser General Public License along with  *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki.api;
 

--- a/api/src/main/java/com/ichi2/anki/api/Utils.java
+++ b/api/src/main/java/com/ichi2/anki/api/Utils.java
@@ -1,19 +1,19 @@
-/***************************************************************************************
- *                                                                                      *
- * Copyright (c) 2016 Timothy Rae <perceptualchaos2@gmail.com>                          *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU Lesser General Public License as published by the Free Software *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU Lesser General Public License along with  *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/**************************************************************************************
+ *
+ Copyright (c) 2016 Timothy Rae <perceptualchaos2@gmail.com>                          *
+ *
+ This program is free software; you can redistribute it and/or modify it under        *
+ the terms of the GNU Lesser General Public License as published by the Free Software *
+ Foundation; either version 3 of the License, or (at your option) any later           *
+ version.                                                                             *
+ *
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *
+ You should have received a copy of the GNU Lesser General Public License along with  *
+ this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ */
 
 package com.ichi2.anki.api;
 


### PR DESCRIPTION
This seems to be what is advised as far as copyright goes in java.

Furthermore, I can't ignore this kind of warning for copyright only, so need to either ignore relevant warning, or
correct copyright