### PR TITLE
Fix TagsDialog not attached to Context

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -975,6 +975,13 @@ public class NoteEditor extends AnkiActivity {
 
 
     @Override
+    protected void onResume() {
+        dismissAllDialogFragments(); // dismiss "tags" as it may have been attached after onPause is called
+        super.onResume();
+    }
+
+
+    @Override
     protected void onDestroy() {
         super.onDestroy();
         if (mUnmountReceiver != null) {


### PR DESCRIPTION
## Purpose / Description
Opening the Previewer then quickly opening tags showed the dialog on return
Using this dialog crashed.


## Fixes
Fixes #7263

## Approach
Dismiss dialogs on return to the screen as well

## How Has This Been Tested?

On my Android 9


## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code