### PR TITLE
Add Language Icon to Preferences

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -31,7 +31,9 @@ import android.content.SharedPreferences;
 import android.content.SharedPreferences.OnSharedPreferenceChangeListener;
 import android.content.pm.PackageManager;
 import android.database.Cursor;
+import android.graphics.drawable.Drawable;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.preference.CheckBoxPreference;
 import android.preference.EditTextPreference;
@@ -90,6 +92,7 @@ import java.util.TreeMap;
 import androidx.annotation.NonNull;
 import androidx.annotation.StringRes;
 import androidx.annotation.VisibleForTesting;
+import androidx.vectordrawable.graphics.drawable.VectorDrawableCompat;
 import timber.log.Timber;
 
 interface PreferenceContext {
@@ -196,6 +199,24 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                     mCategory.removePreference(mCheckBoxPref_Vibrate);
                     mCategory.removePreference(mCheckBoxPref_Blink);
                 }
+                try {
+                    // This works on an API 19 emulator
+                    // use icon= once we're past API 21
+                    // ----
+                    // android.content.res.Resources$NotFoundException: File res/drawable/ic_language_black_24dp.xml
+                    // from drawable resource ID #0x7f0800d7. If the resource you are trying to use is a vector
+                    // resource, you may be referencing it in an unsupported way.
+                    // See AppCompatDelegate.setCompatVectorFromResourcesEnabled() for more info.
+                    Drawable languageIcon = VectorDrawableCompat.create(
+                            getResources(),
+                            R.drawable.ic_language_black_24dp,
+                            getTheme());
+
+                    screen.findPreference("language").setIcon(languageIcon);
+                } catch (Exception e) {
+                    Timber.w(e, "Failed to set language icon");
+                }
+
 
                 // Build languages
                 initializeLanguageDialog(screen);

--- a/AnkiDroid/src/main/res/drawable/ic_language_black_24dp.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_language_black_24dp.xml
@@ -1,0 +1,26 @@
+<!--
+  ~  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+  ~
+  ~  This program is free software; you can redistribute it and/or modify it under
+  ~  the terms of the GNU General Public License as published by the Free Software
+  ~  Foundation; either version 3 of the License, or (at your option) any later
+  ~  version.
+  ~
+  ~  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+  ~  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  ~  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+  ~
+  ~  You should have received a copy of the GNU General Public License along with
+  ~  this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M12.87,15.07l-2.54,-2.51 0.03,-0.03c1.74,-1.94 2.98,-4.17 3.71,-6.53L17,6L17,4h-7L10,2L8,2v2L1,4v1.99h11.17C11.5,7.92 10.44,9.75 9,11.35 8.07,10.32 7.3,9.19 6.69,8h-2c0.73,1.63 1.73,3.17 2.98,4.56l-5.09,5.02L4,19l5,-5 3.11,3.11 0.76,-2.04zM18.5,10h-2L12,22h2l1.12,-3h4.75L21,22h2l-4.5,-12zM15.88,17l1.62,-4.33L19.12,17h-3.24z"/>
+</vector>


### PR DESCRIPTION
A little out-of-place visually, but helps users change language

## How Has This Been Tested?

API 16 and my Android 9 phone

Works with Dark Mode

![image](https://user-images.githubusercontent.com/62114487/94086518-23f77b80-fe03-11ea-8076-faa24db3fa75.png)

## Learning

I didn't think this would be possible on Android 16 as there was attributes in the `Drawable`, pleasantly surprised

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code