### PR TITLE
Always generate a card

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -92,7 +92,6 @@ import com.ichi2.async.TaskManager;
 import com.ichi2.compat.CompatHelper;
 import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
-import com.ichi2.libanki.Consts;
 import com.ichi2.libanki.Models;
 import com.ichi2.libanki.Model;
 import com.ichi2.libanki.Note;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
@@ -770,7 +770,7 @@ public class CardContentProvider extends ContentProvider {
     }
 
     /**
-     * This implementation optimizes for when the notes are grouped according to model
+     * This implementation optimizes for when the notes are grouped according to model.
      */
     private int bulkInsertNotes(ContentValues[] valuesArr, long deckId) {
         if (valuesArr == null || valuesArr.length == 0) {
@@ -803,6 +803,7 @@ public class CardContentProvider extends ContentProvider {
                 if (flds == null) {
                     continue;
                 }
+                Models.AllowEmpty allowEmpty = Models.AllowEmpty.fromBoolean(values.getAsBoolean(FlashCardsContract.Note.ALLOW_EMPTY));
                 Long thisModelId = values.getAsLong(FlashCardsContract.Note.MID);
                 if (thisModelId == null || thisModelId < 0) {
                     Timber.d("Unable to get model at index: %d", i);
@@ -832,7 +833,7 @@ public class CardContentProvider extends ContentProvider {
                     newNote.setTagsFromStr(tags);
                 }
                 // Add to collection
-                col.addNote(newNote);
+                col.addNote(newNote, allowEmpty);
                 for (Card card : newNote.cards()) {
                     card.setDid(deckId);
                     card.flush();
@@ -868,6 +869,7 @@ public class CardContentProvider extends ContentProvider {
                 Long modelId = values.getAsLong(FlashCardsContract.Note.MID);
                 String flds = values.getAsString(FlashCardsContract.Note.FLDS);
                 String tags = values.getAsString(FlashCardsContract.Note.TAGS);
+                Models.AllowEmpty allowEmpty = Models.AllowEmpty.fromBoolean(values.getAsBoolean(FlashCardsContract.Note.ALLOW_EMPTY));
                 // Create empty note
                 com.ichi2.libanki.Note newNote = new com.ichi2.libanki.Note(col, col.getModels().get(modelId));
                 // Set fields
@@ -884,7 +886,7 @@ public class CardContentProvider extends ContentProvider {
                     newNote.setTagsFromStr(tags);
                 }
                 // Add to collection
-                col.addNote(newNote);
+                col.addNote(newNote, allowEmpty);
                 col.save();
                 return Uri.withAppendedPath(FlashCardsContract.Note.CONTENT_URI, Long.toString(newNote.getId()));
             }

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -35,6 +35,7 @@ import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.anki.exception.ImportExportException;
 import com.ichi2.libanki.Media;
 import com.ichi2.libanki.Model;
+import com.ichi2.libanki.Models;
 import com.ichi2.libanki.Undoable;
 import com.ichi2.libanki.WrongId;
 import com.ichi2.libanki.sched.AbstractSched;
@@ -100,7 +101,6 @@ import static com.ichi2.libanki.Consts.DECK_DYN;
 import static com.ichi2.libanki.Undoable.*;
 import static com.ichi2.utils.BooleanGetter.False;
 import static com.ichi2.utils.BooleanGetter.True;
-import static com.ichi2.utils.BooleanGetter.fromBoolean;
 
 /**
  * Loading in the background, so that AnkiDroid does not look like frozen.
@@ -264,10 +264,16 @@ public class CollectionTask<ProgressListener, ProgressBackground extends Progres
 
     public static class AddNote extends Task<Integer, Boolean> {
         private final Note note;
+        private final Models.AllowEmpty allowEmpty;
 
+
+        public AddNote(Note note, Models.AllowEmpty allowEmpty) {
+            this.note = note;
+            this.allowEmpty = allowEmpty;
+        }
 
         public AddNote(Note note) {
-            this.note = note;
+            this(note, Models.AllowEmpty.ONLY_CLOZE);
         }
 
 
@@ -276,7 +282,7 @@ public class CollectionTask<ProgressListener, ProgressBackground extends Progres
             try {
                 DB db = col.getDb();
                 db.executeInTransaction(() -> {
-                        int value = col.addNote(note);
+                        int value = col.addNote(note, allowEmpty);
                         collectionTask.doProgress(value);
                     });
             } catch (RuntimeException e) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -652,11 +652,22 @@ public class Collection {
 
 
     /**
-     * Add a note to the collection. Return number of new cards.
+     * @param note A note to add if it generates card
+     * @return Number of card added.
      */
     public int addNote(Note note) {
+        return addNote(note, Models.AllowEmpty.ONLY_CLOZE);
+    }
+
+    /**
+     * Add a note and cards to the collection. If allowEmpty, at least one card is generated.
+     * @param note  The note to add to the collection
+     * @param allowEmpty Whether we accept to add it even if it should generate no card. Useful to import note even if buggy
+     * @return Number of card added
+     */
+    public int addNote(Note note, Models.AllowEmpty allowEmpty) {
         // check we have card models available, then save
-        ArrayList<JSONObject> cms = findTemplates(note);
+        ArrayList<JSONObject> cms = findTemplates(note, allowEmpty);
         // Todo: upstream, we accept to add a not even if it generates no card. Should be ported to ankidroid
         if (cms.size() == 0) {
             return 0;
@@ -700,13 +711,18 @@ public class Collection {
       Card creation ************************************************************ ***********************************
      */
 
+    public ArrayList<JSONObject> findTemplates(Note note) {
+        return findTemplates(note, Models.AllowEmpty.ONLY_CLOZE);
+    }
+
     /**
      * @param note A note
+     * @param allowEmpty whether we allow to have a card which is actually empty if it is necessary to return a non-empty list
      * @return (active), non-empty templates.
      */
-    public ArrayList<JSONObject> findTemplates(Note note) {
+    public ArrayList<JSONObject> findTemplates(Note note, Models.AllowEmpty allowEmpty) {
         Model model = note.model();
-        ArrayList<Integer> avail = Models.availOrds(model, note.getFields());
+        ArrayList<Integer> avail = Models.availOrds(model, note.getFields(), allowEmpty);
         return _tmplsFromOrds(model, avail);
     }
 
@@ -844,7 +860,7 @@ public class Collection {
                 }
                 @NonNull Long nid = cur.getLong(0);
                 String flds = cur.getString(1);
-                ArrayList<Integer> avail = Models.availOrds(model, Utils.splitFields(flds), nodes);
+                ArrayList<Integer> avail = Models.availOrds(model, Utils.splitFields(flds), nodes, Models.AllowEmpty.ONLY_CLOZE);
                 if (task != null) {
                     task.doProgress(avail.size());
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -860,7 +860,7 @@ public class Collection {
                 }
                 @NonNull Long nid = cur.getLong(0);
                 String flds = cur.getString(1);
-                ArrayList<Integer> avail = Models.availOrds(model, Utils.splitFields(flds), nodes, Models.AllowEmpty.ONLY_CLOZE);
+                ArrayList<Integer> avail = Models.availOrds(model, Utils.splitFields(flds), nodes, Models.AllowEmpty.TRUE);
                 if (task != null) {
                     task.doProgress(avail.size());
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/NoteImporter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/NoteImporter.java
@@ -379,7 +379,7 @@ public class NoteImporter extends Importer {
             }
         }
         note.fieldsStr = joinFields(fields);
-        ArrayList<Integer> ords = Models.availOrds(mModel, fields, mTemplateParsed);
+        ArrayList<Integer> ords = Models.availOrds(mModel, fields, mTemplateParsed, Models.AllowEmpty.ONLY_CLOZE);
         if (ords.isEmpty()) {
             mEmptyNotes = true;
             return false;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/NoteImporter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/NoteImporter.java
@@ -379,7 +379,7 @@ public class NoteImporter extends Importer {
             }
         }
         note.fieldsStr = joinFields(fields);
-        ArrayList<Integer> ords = Models.availOrds(mModel, fields, mTemplateParsed, Models.AllowEmpty.ONLY_CLOZE);
+        ArrayList<Integer> ords = Models.availOrds(mModel, fields, mTemplateParsed, Models.AllowEmpty.TRUE);
         if (ords.isEmpty()) {
             mEmptyNotes = true;
             return false;

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/ClozeTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/ClozeTest.java
@@ -41,6 +41,8 @@ public class ClozeTest extends RobolectricTest {
         // a cloze model with no clozes is not empty
         f.setItem("Text", "nothing");
         assertThat(d.addNote(f), is(greaterThan(0)));
+        Card card = f.cards().get(0);
+        assertTrue(card.isEmpty());
         // try with one cloze
         f = d.newNote(d.getModels().byName("Cloze"));
         f.setItem("Text", "hello {{c1::world}}");

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/ModelTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/ModelTest.java
@@ -214,17 +214,26 @@ public class ModelTest extends RobolectricTest {
         assertEquals("Cloze", note.model().getString("name"));
         // a cloze model with no clozes is not empty
         note.setItem("Text", "nothing");
-        assertNotEquals(0, col.addNote(note));
+        assertEquals(1, col.addNote(note));
+        assertEquals(1, col.addNote(note, Models.AllowEmpty.TRUE));
+        assertEquals(1, col.addNote(note, Models.AllowEmpty.ONLY_CLOZE));
+        assertEquals(0, col.addNote(note, Models.AllowEmpty.FALSE));
         // try with one cloze
         note = col.newNote();
         note.setItem("Text", "hello {{c1::world}}");
         assertEquals(1, col.addNote(note));
+        assertEquals(1, col.addNote(note, Models.AllowEmpty.TRUE));
+        assertEquals(1, col.addNote(note, Models.AllowEmpty.ONLY_CLOZE));
+        assertEquals(1, col.addNote(note, Models.AllowEmpty.FALSE));
         assertThat(note.cards().get(0).q(), containsString("hello <span class=cloze>[...]</span>"));
         assertThat(note.cards().get(0).a(), containsString("hello <span class=cloze>world</span>"));
         // and with a comment
         note = col.newNote();
         note.setItem("Text", "hello {{c1::world::typical}}");
         assertEquals(1, col.addNote(note));
+        assertEquals(1, col.addNote(note, Models.AllowEmpty.TRUE));
+        assertEquals(1, col.addNote(note, Models.AllowEmpty.ONLY_CLOZE));
+        assertEquals(1, col.addNote(note, Models.AllowEmpty.FALSE));
         assertThat(note.cards().get(0).q(), containsString("<span class=cloze>[typical]</span>"));
         assertThat(note.cards().get(0).a(), containsString("<span class=cloze>world</span>"));
         // and with 2 clozes
@@ -241,19 +250,41 @@ public class ModelTest extends RobolectricTest {
         assertThat(c2.a(), containsString("world <span class=cloze>bar</span>"));
         // if there are multiple answers for a single cloze, they are given in a
         // list
-        note = col.newNote();
         note.setItem("Text", "a {{c1::b}} {{c1::c}}");
         assertEquals(1, col.addNote(note));
+        assertEquals(1, col.addNote(note, Models.AllowEmpty.TRUE));
+        assertEquals(1, col.addNote(note, Models.AllowEmpty.ONLY_CLOZE));
+        assertEquals(1, col.addNote(note, Models.AllowEmpty.FALSE));
         assertThat(note.cards().get(0).a(), containsString("<span class=cloze>b</span> <span class=cloze>c</span>"));
         // if we add another cloze, a card should be generated
-        int cnt = col.cardCount();
         note.setItem("Text", "{{c2::hello}} {{c1::foo}}");
-        note.flush();
-        assertEquals(cnt + 1, col.cardCount());
+        assertEquals(2, col.addNote(note));
+        assertEquals(2, col.addNote(note, Models.AllowEmpty.TRUE));
+        assertEquals(2, col.addNote(note, Models.AllowEmpty.ONLY_CLOZE));
+        assertEquals(2, col.addNote(note, Models.AllowEmpty.FALSE));
         // 0 or negative indices are not supported
         note.setItem("Text", "{{c0::zero}} {{c-1:foo}}");
+        assertEquals(1, col.addNote(note));
+        assertEquals(1, col.addNote(note, Models.AllowEmpty.TRUE));
+        assertEquals(1, col.addNote(note, Models.AllowEmpty.ONLY_CLOZE));
+        assertEquals(0, col.addNote(note, Models.AllowEmpty.FALSE));
+
+        note = col.newNote();
+        note.setItem("Text", "hello {{c1::world}}");
+        col.addNote(note);
+        assertEquals(1, note.numberOfCards());
+        note.setItem("Text", "hello {{c2::world}}");
         note.flush();
         assertEquals(2, note.numberOfCards());
+        note.setItem("Text", "{{c1::hello}} {{c2::world}}");
+        note.flush();
+        assertEquals(2, note.numberOfCards());
+        note.setItem("Text", "{{c1::hello}} {{c3::world}}");
+        note.flush();
+        assertEquals(3, note.numberOfCards());
+        note.setItem("Text", "{{c0::hello}} {{c-1::world}}");
+        note.flush();
+        assertEquals(3, note.numberOfCards());
     }
 
 
@@ -466,15 +497,34 @@ public class ModelTest extends RobolectricTest {
         Collection col = getCol();
         Models mm = col.getModels();
         Model basic = mm.byName("Basic");
+        Model reverse = mm.byName("Basic (and reversed card)");
+
         assertEquals(new ArrayList<>(), Models._availStandardOrds(basic, new String[]{"", ""}));
         assertEquals(new ArrayList<>(), Models._availStandardOrds(basic, new String[]{"", "Back"}));
         assertEquals(new ArrayList<>(Arrays.asList(0)), Models._availStandardOrds(basic, new String[]{"Foo", ""}));
         assertEquals(new ArrayList<>(Arrays.asList()), Models._availStandardOrds(basic, new String[]{"  \t ", ""}));
-        Model reverse = mm.byName("Basic (and reversed card)");
         assertEquals(new ArrayList<>(), Models._availStandardOrds(reverse, new String[]{"", ""}));
         assertEquals(new ArrayList<>(Arrays.asList(0)), Models._availStandardOrds(reverse, new String[]{"Foo", ""}));
         assertEquals(new ArrayList<>(Arrays.asList(0, 1)), Models._availStandardOrds(reverse, new String[]{"Foo", "Bar"}));
         assertEquals(new ArrayList<>(Arrays.asList(1)), Models._availStandardOrds(reverse, new String[]{"  \t ", "Bar"}));
+
+        assertEquals(new ArrayList<>(), Models._availStandardOrds(basic, new String[]{"", ""}, false) );
+        assertEquals(new ArrayList<>(), Models._availStandardOrds(basic, new String[]{"", "Back"}, false));
+        assertEquals(new ArrayList<>(Arrays.asList(0)), Models._availStandardOrds(basic, new String[]{"Foo", ""}, false));
+        assertEquals(new ArrayList<>(Arrays.asList()), Models._availStandardOrds(basic, new String[]{"  \t ", ""}, false));
+        assertEquals(new ArrayList<>(), Models._availStandardOrds(reverse, new String[]{"", ""}, false));
+        assertEquals(new ArrayList<>(Arrays.asList(0)), Models._availStandardOrds(reverse, new String[]{"Foo", ""}, false));
+        assertEquals(new ArrayList<>(Arrays.asList(0, 1)), Models._availStandardOrds(reverse, new String[]{"Foo", "Bar"}, false));
+        assertEquals(new ArrayList<>(Arrays.asList(1)), Models._availStandardOrds(reverse, new String[]{"  \t ", "Bar"}, false));
+
+        assertEquals(new ArrayList<>(Arrays.asList(0)), Models._availStandardOrds(basic, new String[]{"", ""}, true) );
+        assertEquals(new ArrayList<>(Arrays.asList(0)), Models._availStandardOrds(basic, new String[]{"", "Back"}, true));
+        assertEquals(new ArrayList<>(Arrays.asList(0)), Models._availStandardOrds(basic, new String[]{"Foo", ""}, true));
+        assertEquals(new ArrayList<>(Arrays.asList(0)), Models._availStandardOrds(basic, new String[]{"  \t ", ""}, true));
+        assertEquals(new ArrayList<>(Arrays.asList(0)), Models._availStandardOrds(reverse, new String[]{"", ""}, true));
+        assertEquals(new ArrayList<>(Arrays.asList(0)), Models._availStandardOrds(reverse, new String[]{"Foo", ""}, true));
+        assertEquals(new ArrayList<>(Arrays.asList(0, 1)), Models._availStandardOrds(reverse, new String[]{"Foo", "Bar"}, true));
+        assertEquals(new ArrayList<>(Arrays.asList(1)), Models._availStandardOrds(reverse, new String[]{"  \t ", "Bar"}, true));
     }
 
     @Test
@@ -482,14 +532,35 @@ public class ModelTest extends RobolectricTest {
         Collection col = getCol();
         Models mm = col.getModels();
         Model basic = mm.byName("Basic");
+        Model reverse = mm.byName("Basic (and reversed card)");
+
         assertEquals(new ArrayList<>(), Models.availOrds(basic, new String[]{"", ""}));
         assertEquals(new ArrayList<>(), Models.availOrds(basic, new String[]{"", "Back"}));
         assertEquals(new ArrayList<>(Arrays.asList(0)), Models.availOrds(basic, new String[]{"Foo", ""}));
         assertEquals(new ArrayList<>(Arrays.asList()), Models.availOrds(basic, new String[]{"  \t ", ""}));
-        Model reverse = mm.byName("Basic (and reversed card)");
         assertEquals(new ArrayList<>(), Models.availOrds(reverse, new String[]{"", ""}));
         assertEquals(new ArrayList<>(Arrays.asList(0)), Models.availOrds(reverse, new String[]{"Foo", ""}));
         assertEquals(new ArrayList<>(Arrays.asList(0, 1)), Models.availOrds(reverse, new String[]{"Foo", "Bar"}));
         assertEquals(new ArrayList<>(Arrays.asList(1)), Models.availOrds(reverse, new String[]{"  \t ", "Bar"}));
+
+        for (Models.AllowEmpty allow : new Models.AllowEmpty[] {Models.AllowEmpty.ONLY_CLOZE, Models.AllowEmpty.FALSE}) {
+            assertEquals(new ArrayList<>(), Models.availOrds(basic, new String[] {"", ""}, allow));
+            assertEquals(new ArrayList<>(), Models.availOrds(basic, new String[] {"", "Back"}, allow));
+            assertEquals(new ArrayList<>(Arrays.asList(0)), Models.availOrds(basic, new String[] {"Foo", ""}, allow));
+            assertEquals(new ArrayList<>(Arrays.asList()), Models.availOrds(basic, new String[] {"  \t ", ""}, allow));
+            assertEquals(new ArrayList<>(), Models.availOrds(reverse, new String[] {"", ""}, allow));
+            assertEquals(new ArrayList<>(Arrays.asList(0)), Models.availOrds(reverse, new String[] {"Foo", ""}, allow));
+            assertEquals(new ArrayList<>(Arrays.asList(0, 1)), Models.availOrds(reverse, new String[] {"Foo", "Bar"}, allow));
+            assertEquals(new ArrayList<>(Arrays.asList(1)), Models.availOrds(reverse, new String[] {"  \t ", "Bar"}, allow));
+        }
+
+        assertEquals(new ArrayList<>(Arrays.asList(0)), Models.availOrds(basic, new String[]{"", ""}, Models.AllowEmpty.TRUE));
+        assertEquals(new ArrayList<>(Arrays.asList(0)), Models.availOrds(basic, new String[]{"", "Back"}, Models.AllowEmpty.TRUE));
+        assertEquals(new ArrayList<>(Arrays.asList(0)), Models.availOrds(basic, new String[]{"Foo", ""}, Models.AllowEmpty.TRUE));
+        assertEquals(new ArrayList<>(Arrays.asList(0)), Models.availOrds(basic, new String[]{"  \t ", ""}, Models.AllowEmpty.TRUE));
+        assertEquals(new ArrayList<>(Arrays.asList(0)), Models.availOrds(reverse, new String[]{"", ""}, Models.AllowEmpty.TRUE));
+        assertEquals(new ArrayList<>(Arrays.asList(0)), Models.availOrds(reverse, new String[]{"Foo", ""}, Models.AllowEmpty.TRUE));
+        assertEquals(new ArrayList<>(Arrays.asList(0, 1)), Models.availOrds(reverse, new String[]{"Foo", "Bar"}, Models.AllowEmpty.TRUE));
+        assertEquals(new ArrayList<>(Arrays.asList(1)), Models.availOrds(reverse, new String[]{"  \t ", "Bar"}, Models.AllowEmpty.TRUE));
     }
 }

--- a/api/src/main/java/com/ichi2/anki/FlashCardsContract.java
+++ b/api/src/main/java/com/ichi2/anki/FlashCardsContract.java
@@ -298,6 +298,7 @@ public class FlashCardsContract {
         public static final String _ID = "_id";
         public static final String GUID = "guid";
         public static final String MID = "mid";
+        public static final String ALLOW_EMPTY = "allow_empty";
         public static final String MOD = "mod";
         public static final String USN = "usn";
         public static final String TAGS = "tags";
@@ -311,6 +312,7 @@ public class FlashCardsContract {
                 Note._ID,
                 Note.GUID,
                 Note.MID,
+                Note.ALLOW_EMPTY,
                 Note.MOD,
                 Note.USN,
                 Note.TAGS,


### PR DESCRIPTION
This partially port a change from Anki 2.1.28. Notes with no card are not deleted, instead first card is generated. This also change import of decks. It does not change when cards should be generated from the add card window (this would require a change in UI, so we would need to discuss what we want to do exactly to port this change)

This ensure that "Empty cards" does not delete note with no cards, so no data is lost. 

# Test:

create a basic and a cloze card.

Edit them to remove front and cloze 1.

Click on "empty card"

See that it does not offer any deletion (i.e. no deletion of note, as in upstream)
