### PR TITLE
NF: remove sudo from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: true
 language: bash
 # ignored on non-linux platforms, but bionic is required for nested virtualization
 dist: bionic


### PR DESCRIPTION
According to travis:
> root: deprecated key sudo (The key `sudo` has no effect anymore.)
