### PR TITLE
"{{|" was considered as "{{#"

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/template/Template.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/template/Template.java
@@ -62,7 +62,7 @@ public class Template {
     private static final String sCtag = Pattern.quote("}}");
 
     // The regular expression used to find a #section
-    private static final Pattern sSection_re = Pattern.compile(sOtag + "[#|^]([^}]*)" + sCtag + "(.+?)" + sOtag + "/\\1" + sCtag, Pattern.MULTILINE | Pattern.DOTALL);
+    private static final Pattern sSection_re = Pattern.compile(sOtag + "[#^]([^}]*)" + sCtag + "(.+?)" + sOtag + "/\\1" + sCtag, Pattern.MULTILINE | Pattern.DOTALL);
 
     // The regular expression used to find a tag.
     private static final Pattern sTag_re = Pattern.compile(sOtag + "([#=&!>{])?(.+?)\\1?" + sCtag + "+");

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/ModelTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/ModelTest.java
@@ -460,7 +460,6 @@ public class ModelTest extends RobolectricTest {
     }
 
     @Test
-    @Ignore("Handled in next commit")
     public void regression_test_pipe() {
         Collection col = getCol();
         Models mm = col.getModels();

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/ModelTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/ModelTest.java
@@ -5,6 +5,7 @@ import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.utils.JSONArray;
 import com.ichi2.utils.JSONObject;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -18,6 +19,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4;
 import static com.ichi2.libanki.Consts.MODEL_CLOZE;
 import static com.ichi2.libanki.Utils.stripHTML;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertArrayEquals;
@@ -455,5 +457,19 @@ public class ModelTest extends RobolectricTest {
         assertTrue(Arrays.asList(new String[] {"any", "all"}).contains(r.getString(1)));
         // TODO: Port anki@4e33775ed4346ef136ece6ef5efec5ba46057c6b
         assertEquals(new JSONArray("[0]"), r.getJSONArray(2));
+    }
+
+    @Test
+    @Ignore("Handled in next commit")
+    public void regression_test_pipe() {
+        Collection col = getCol();
+        Models mm = col.getModels();
+        Model basic = mm.byName("Basic");
+        JSONObject template = basic.getJSONArray("tmpls").getJSONObject(0);
+        template.put("qfmt", "{{|Front}}{{Front}}{{/Front}}{{Front}}");
+        mm.save(basic, true);
+        Note note = addNoteUsingBasicModel("foo", "bar");
+        Card c = note.cards().get(0);
+        assertThat(c.q(), containsString("unknown field"));
     }
 }


### PR DESCRIPTION
I added a regression test

This has probably never been a problem, as there is no reason to expect anyone ever used "{{|" in a template.
However, that'll be useful to port new card generation rules