### PR TITLE
Disable distributionSha256Sum in Update Gradle Wrapper workflow.

### DIFF
--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -15,3 +15,4 @@ jobs:
         uses: gradle-update/update-gradle-wrapper-action@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          set-distribution-checksum: false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=7873ed5287f47ca03549ab8dcb6dc877ac7f0e3d7b1eb12685161d10080910ac
 distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
In https://github.com/ankidroid/Anki-Android/pull/7182 the Update Gradle Wrapper action has been introduced in order to keep the Wrapper up-to-date automatically.

To avoid Android Studio warnings about `distributionSha256Sum` (which is totally safe to use but still causes such scary warning messages), here we set the action to NOT generate the checksum value on update.

In this changeset we manually remove `distributionSha256Sum` from `gradle-wrapper.properties` and configure the action so that it won't add it back anymore.
