### PR TITLE
Empty card progress

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -2802,6 +2802,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
                     .cancelable(true)
                     .show();
             deckPicker.mProgressDialog.setOnCancelListener(onCancel);
+            deckPicker.mProgressDialog.setCanceledOnTouchOutside(false);
         }
 
         @Override

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -2789,13 +2789,24 @@ public class DeckPicker extends NavigationDrawerActivity implements
             mNumberOfCards = deckPicker.getCol().cardCount();
         }
 
+        private void confirmCancel(@NonNull DeckPicker deckPicker, @NonNull CollectionTask task) {
+            new MaterialDialog.Builder(deckPicker)
+                    .content(R.string.confirm_cancel)
+                    .positiveText(deckPicker.getResources().getString(R.string.yes))
+                    .negativeText(deckPicker.getResources().getString(R.string.no))
+                    .onNegative((x, y) -> actualOnPreExecute(deckPicker))
+                    .onPositive((x, y) -> task.safeCancel()).show()
+                    ;
+        }
+
         @Override
         public void actualOnPreExecute(@NonNull DeckPicker deckPicker) {
             DialogInterface.OnCancelListener onCancel = (dialogInterface) -> {
                 CollectionTask mEmptyCardTask = deckPicker.mEmptyCardTask;
                 if (mEmptyCardTask != null) {
-                    mEmptyCardTask.safeCancel();
+                    confirmCancel(deckPicker, mEmptyCardTask);
                 }};
+            
             deckPicker.mProgressDialog = new MaterialDialog.Builder(deckPicker)
                     .progress(false, mNumberOfCards)
                     .title(R.string.emtpy_cards_finding)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -74,6 +74,7 @@ import android.view.WindowManager;
 import android.widget.EditText;
 import android.widget.Filterable;
 import android.widget.LinearLayout;
+import android.widget.ProgressBar;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -2778,14 +2779,24 @@ public class DeckPicker extends NavigationDrawerActivity implements
         return new HandleEmptyCardListener(this);
     }
     private static class HandleEmptyCardListener extends TaskListenerWithContext<DeckPicker> {
+        private final int mNumberOfCards;
+
         public HandleEmptyCardListener(DeckPicker deckPicker) {
             super(deckPicker);
+            mNumberOfCards = deckPicker.getCol().cardCount();
         }
 
         @Override
         public void actualOnPreExecute(@NonNull DeckPicker deckPicker) {
-            deckPicker.mProgressDialog = StyledProgressDialog.show(deckPicker, "",
-                    deckPicker.getResources().getString(R.string.emtpy_cards_finding), false);
+            deckPicker.mProgressDialog = new MaterialDialog.Builder(deckPicker)
+                    .progress(false, mNumberOfCards)
+                    .title(R.string.emtpy_cards_finding)
+                    .show();
+        }
+
+        @Override
+        public void actualOnProgressUpdate(@NonNull DeckPicker deckPicker, @NonNull TaskData progress) {
+            deckPicker.mProgressDialog.incrementProgress(progress.getInt());
         }
 
         @Override

--- a/AnkiDroid/src/main/java/com/ichi2/async/BaseAsyncTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/BaseAsyncTask.java
@@ -23,7 +23,7 @@ import com.ichi2.utils.Threads;
 
 import static com.ichi2.anki.AnkiDroidApp.sendExceptionReport;
 
-public class BaseAsyncTask<Params, Progress, Result> extends AsyncTask<Params, Progress, Result> implements CancelListener {
+public class BaseAsyncTask<Params, Progress, Result> extends AsyncTask<Params, Progress, Result> implements CancelListener, ProgressSender<Progress> {
 
     /** Set this to {@code true} to enable detailed debugging for this class. */
     private static final boolean DEBUG = false;
@@ -89,4 +89,8 @@ public class BaseAsyncTask<Params, Progress, Result> extends AsyncTask<Params, P
         return null;
     }
 
+
+    public void doProgress(Progress value) {
+        publishProgress(value);
+    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/async/BaseAsyncTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/BaseAsyncTask.java
@@ -23,7 +23,7 @@ import com.ichi2.utils.Threads;
 
 import static com.ichi2.anki.AnkiDroidApp.sendExceptionReport;
 
-public class BaseAsyncTask<Params, Progress, Result> extends AsyncTask<Params, Progress, Result> {
+public class BaseAsyncTask<Params, Progress, Result> extends AsyncTask<Params, Progress, Result> implements CancelListener {
 
     /** Set this to {@code true} to enable detailed debugging for this class. */
     private static final boolean DEBUG = false;

--- a/AnkiDroid/src/main/java/com/ichi2/async/CancelListener.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CancelListener.java
@@ -1,0 +1,22 @@
+/****************************************************************************************
+ * Copyright (c) 2020 Arthur Milchior <arthur@milchior.fr>                              *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+
+package com.ichi2.async;
+
+@FunctionalInterface
+public interface CancelListener {
+    boolean isCancelled();
+}

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -1854,7 +1854,7 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
 
     public TaskData doInBackGroundFindEmptyCards(TaskData param) {
         Collection col = getCol();
-        List<Long> cids = col.emptyCids();
+        List<Long> cids = col.emptyCids(this);
         return new TaskData(new Object[] { cids});
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -1905,10 +1905,10 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
      */
     public static class ProgressCallback {
         private final Resources res;
-        private final CollectionTask task;
+        private final ProgressSender<TaskData> task;
 
 
-        public ProgressCallback(CollectionTask task, Resources res) {
+        public ProgressCallback(ProgressSender<TaskData> task, Resources res) {
             this.res = res;
             if (res != null) {
                 this.task = task;
@@ -1938,10 +1938,5 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
         } catch (Exception e) {
             return false;
         }
-    }
-
-
-    public void doProgress(TaskData value) {
-        publishProgress(value);
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/async/ProgressSender.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/ProgressSender.java
@@ -1,0 +1,22 @@
+/****************************************************************************************
+ * Copyright (c) 2020 Arthur Milchior <arthur@milchior.fr>                              *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+
+package com.ichi2.async;
+
+@FunctionalInterface
+public interface ProgressSender<T> {
+    void doProgress(T value);
+}

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -719,11 +719,20 @@ public class Collection {
 	public ArrayList<Long> genCards(List<Long> nids) {
 	    return genCards(Utils.collection2Array(nids));
 	}
+
+
+    /**
+     * @param nids All ids of nodes of a note type
+     * @return Cards that should be removed because they should not be generated
+     */
     public ArrayList<Long> genCards(long[] nids) {
         // build map of (nid,ord) so we don't create dupes
         String snids = Utils.ids2str(nids);
+        // For each note, indicates ords of cards it contains
         HashMap<Long, HashMap<Integer, Long>> have = new HashMap<>();
+        // For each note, the deck containing all of its cards, or 0 if siblings in multiple deck
         HashMap<Long, Long> dids = new HashMap<>();
+        // For each note, an arbitrary due of one of its due card processed, if any exists
         HashMap<Long, Long> dues = new HashMap<>();
         Cursor cur = null;
         try {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
@@ -24,6 +24,7 @@ import android.text.TextUtils;
 
 import android.util.Pair;
 
+import com.ichi2.async.CancelListener;
 import com.ichi2.async.CollectionTask;
 
 import com.ichi2.libanki.Deck;
@@ -93,7 +94,7 @@ public class Finder {
     }
 
     @CheckResult
-    private List<Long> _findCards(String query, Object _order, CollectionTask task) {
+    private List<Long> _findCards(String query, Object _order, CancelListener task) {
         String[] tokens = _tokenize(query);
         Pair<String, String[]> res1 = _where(tokens);
         String preds = res1.first;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -23,6 +23,7 @@ import android.database.Cursor;
 import android.database.SQLException;
 import android.text.TextUtils;
 
+import com.ichi2.async.CancelListener;
 import com.ichi2.async.CollectionTask;
 import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
@@ -210,7 +211,7 @@ public class Sched extends SchedV2 {
      * Returns [deckname, did, rev, lrn, new]
      */
     @Override
-    public @Nullable List<DeckDueTreeNode> deckDueList(@Nullable CollectionTask collectionTask) {
+    public @Nullable List<DeckDueTreeNode> deckDueList(@Nullable CancelListener collectionTask) {
         _checkDay();
         mCol.getDecks().checkIntegrity();
         ArrayList<Deck> decks = mCol.getDecks().allSorted();

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -32,6 +32,7 @@ import android.text.style.StyleSpan;
 import android.util.Pair;
 
 import com.ichi2.anki.R;
+import com.ichi2.async.CancelListener;
 import com.ichi2.async.CollectionTask;
 import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
@@ -467,7 +468,7 @@ public class SchedV2 extends AbstractSched {
     }
 
     // Overridden
-    public @Nullable List<DeckDueTreeNode> deckDueList(@Nullable CollectionTask collectionTask) {
+    public @Nullable List<DeckDueTreeNode> deckDueList(@Nullable CancelListener collectionTask) {
         _checkDay();
         mCol.getDecks().checkIntegrity();
         ArrayList<Deck> decks = mCol.getDecks().allSorted();

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -18,6 +18,8 @@
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 --><resources>
+    <string name="yes">yes</string>
+    <string name="no">no</string>
     <!-- Navigation drawer items-->
     <string name="decks">Decks</string>
     <string name="card_browser">Card browser</string>

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -151,9 +151,11 @@
 
     <!-- Empty cards -->
     <string name="emtpy_cards_finding">Finding empty cards…</string>
+    <string name="confirm_cancel">Do you want to cancel?</string>
     <string name="empty_cards_none">No empty cards</string>
     <string name="empty_cards_count">Cards to delete: %d</string>
     <string name="empty_cards_deleted">Cards deleted: %d</string>
+
 
     <!-- Multimedia - Edit Field Activity -->
     <string name="multimedia_editor_audio_permission_refused">Could not obtain microphone permission.</string>

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/CardTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/CardTest.java
@@ -78,7 +78,7 @@ public class CardTest extends RobolectricTest {
         t = m.getJSONArray("tmpls").getJSONObject(1);
         t.put("qfmt", "{{Back}}");
         mm.save(m, true);
-        List<Long> rep = col.emptyCids();
+        List<Long> rep = col.emptyCids(null);
         col.remCards(rep);
         assertEquals(1, note.numberOfCards());
         // if we add to the note, a card should be automatically generated


### PR DESCRIPTION
On my collection, "empty cards" takes two minutes. No progress indicates where we are. I correct it by adding a number. This is not perfect, because the numerator counts cards that should exists and the denominator counts cards that already exists. So if there are missing cards in the collection, the numerator will become greater than 1. On the other hand, if cards should be deleted, we will never reach the denominator. This is still a good indication on how the process is evolving.

Furthermore, this task is now cancellable.

![Screenshot_20200927-150920_AnkiDroid.jpg](https://user-images.githubusercontent.com/357361/94367415-e9c9fa80-00de-11eb-94cf-879d51166efd.jpg)