### PR TITLE
[BugFix] Card Browser Preview works after sorting

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -238,6 +238,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
             mOrder = which;
             mOrderAsc = false;
             if (mOrder == 0) {
+                // if the sort value in the card browser was changed, then perform a new search
                 getCol().getConf().put("sortType", fSortTypes[1]);
                 AnkiDroidApp.getSharedPrefs(getBaseContext()).edit()
                         .putBoolean("cardBrowserNoSorting", true)
@@ -251,6 +252,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
             getCol().getConf().put("sortBackwards", mOrderAsc);
             searchCards();
         } else if (which != CARD_ORDER_NONE) {
+            // if the same element is selected again, reverse the order
             mOrderAsc = !mOrderAsc;
             getCol().getConf().put("sortBackwards", mOrderAsc);
             mCards.reverse();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -2637,4 +2637,10 @@ public class CardBrowser extends NavigationDrawerActivity implements
     void filterByTag(String... tags) {
         filterByTag(Arrays.asList(tags), 0);
     }
+
+    @VisibleForTesting
+    void replaceSelectionWith(int[] positions) {
+        mCheckedCards.clear();
+        checkedCardsAtPositions(positions);
+    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -1212,8 +1212,6 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
 
 
     private TaskData doInBackgroundRenderBrowserQA(TaskData param) {
-        //TODO: Convert this to accept the following to make thread-safe:
-        //(Range<Position>, Function<Position, BrowserCard>)
         Timber.d("doInBackgroundRenderBrowserQA");
         Collection col = getCol();
         List<CardBrowser.CardCache> cards = (List<CardBrowser.CardCache>) param.getObjArray()[0];

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
@@ -295,6 +295,35 @@ public class CardBrowserTest extends RobolectricTest {
         assertThat("tagged card should be returned", b.getCardCount(), is(1));
     }
 
+    @Test
+    @Ignore("7286")
+    public void previewWorksAfterSort() {
+        // #7286
+        long cid1 = addNoteUsingBasicModel("Hello", "World").cards().get(0).getId();
+        long cid2 = addNoteUsingBasicModel("Hello2", "World2").cards().get(0).getId();
+
+        CardBrowser b = getBrowserWithNoNewCards();
+
+        assertThat(b.getPropertiesForCardId(cid1).getPosition(), is(0));
+        assertThat(b.getPropertiesForCardId(cid2).getPosition(), is(1));
+
+        b.checkedCardsAtPositions(new int[] { 0 });
+        Intent previewIntent = b.getPreviewIntent();
+        assertThat("before: index", previewIntent.getIntExtra("index", -100), is(0));
+        assertThat("before: cards", previewIntent.getLongArrayExtra("cardList"), is(new long[] { cid1, cid2 }));
+
+        // reverse
+        b.changeCardOrder(1);
+
+        assertThat(b.getPropertiesForCardId(cid1).getPosition(), is(1));
+        assertThat(b.getPropertiesForCardId(cid2).getPosition(), is(0));
+
+        b.replaceSelectionWith(new int[] { 0 });
+        Intent intentAfterReverse = b.getPreviewIntent();
+        assertThat("after: index", intentAfterReverse.getIntExtra("index", -100), is(0));
+        assertThat("after: cards", intentAfterReverse.getLongArrayExtra("cardList"), is(new long[] { cid2, cid1 }));
+    }
+
 
     private void flagCardForNote(Note n, int flag) {
         Card c = n.firstCard();

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
@@ -296,7 +296,6 @@ public class CardBrowserTest extends RobolectricTest {
     }
 
     @Test
-    @Ignore("7286")
     public void previewWorksAfterSort() {
         // #7286
         long cid1 = addNoteUsingBasicModel("Hello", "World").cards().get(0).getId();

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowser_CardCollectionTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowser_CardCollectionTest.java
@@ -1,0 +1,78 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+
+
+import androidx.annotation.NonNull;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class CardBrowser_CardCollectionTest {
+
+    @Test
+    public void reverseFixesPosition() {
+        CardBrowser.CardCollection<Positioned> cardCollection = createCollection(new Positioned(0), new Positioned(1));
+
+        assertThat(cardCollection.get(0).getPosition(), is(0));
+        assertThat(cardCollection.get(0).getInitialValue(), is(0));
+
+        cardCollection.reverse();
+
+        assertThat(cardCollection.get(0).getPosition(), is(0));
+        assertThat(cardCollection.get(0).getInitialValue(), is(1));
+    }
+
+
+    @NonNull
+    protected CardBrowser.CardCollection<Positioned> createCollection(Positioned... toInsert) {
+        CardBrowser.CardCollection<Positioned> cardCollection = new CardBrowser.CardCollection<>();
+        cardCollection.replaceWith(Arrays.asList(toInsert));
+        return cardCollection;
+    }
+
+
+    private static class Positioned implements CardBrowser.PositionAware {
+
+        private int mPosition;
+        private int mInitialValue;
+
+        public Positioned(int position) {
+            mPosition = position;
+            mInitialValue = position;
+        }
+
+        private int getInitialValue() {
+            return mInitialValue;
+        }
+
+        @Override
+        public int getPosition() {
+            return mPosition;
+        }
+
+
+        @Override
+        public void setPosition(int value) {
+            mPosition = value;
+        }
+    }
+}


### PR DESCRIPTION
## Purpose / Description
Due to the addition of `CardCache`, the `position` variable was out-of-sync with reality after performing `Collection.reverse()`

## Fixes
Fixes #7286 

## Approach
* Extract to a structure where this can no longer happen
* Fix the numbers after a `reverse()`

## How Has This Been Tested?

Unit & Integration tested

Tested on my phone briefly

## Learning
We still need more tests

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code