### PR TITLE
Add Icon for TV Launcher

### DIFF
--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -27,6 +27,9 @@
     <uses-feature android:name="android.hardware.camera.any" android:required="false" />
     <uses-feature android:name="android.hardware.audio.output" android:required="false" />
     <uses-feature android:name="android.software.app_widgets" android:required="false" />
+    <!-- Suggested if we add a TV Launcher icon. We do not use leanback currently -->
+    <uses-feature android:name="android.software.leanback" android:required="false" />
+    <uses-feature android:name="android.hardware.touchscreen" android:required="false" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.INTERNET" />
@@ -62,7 +65,7 @@
         android:usesCleartextTraffic="true"
         android:largeHeap="true"
         android:networkSecurityConfig="@xml/network_security_config"
-        >
+        android:banner="@drawable/tv_banner">
         <activity
             android:name="com.ichi2.anki.IntentHandler"
             android:label="@string/app_name"
@@ -73,6 +76,7 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
                 <category android:name="android.intent.category.MULTIWINDOW_LAUNCHER" />
+                <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
             </intent-filter>
             <!-- *.apkg matcher. NOTE: when pathPattern is used, host and scheme must also be specified -->
             <intent-filter>

--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -65,7 +65,8 @@
         android:usesCleartextTraffic="true"
         android:largeHeap="true"
         android:networkSecurityConfig="@xml/network_security_config"
-        android:banner="@drawable/tv_banner">
+        android:banner="@drawable/tv_banner"
+        >
         <activity
             android:name="com.ichi2.anki.IntentHandler"
             android:label="@string/app_name"

--- a/AnkiDroid/src/main/res/drawable-xhdpi/tv_banner.xml
+++ b/AnkiDroid/src/main/res/drawable-xhdpi/tv_banner.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+  ~
+  ~  This program is free software; you can redistribute it and/or modify it under
+  ~  the terms of the GNU General Public License as published by the Free Software
+  ~  Foundation; either version 3 of the License, or (at your option) any later
+  ~  version.
+  ~
+  ~  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+  ~  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  ~  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+  ~
+  ~  You should have received a copy of the GNU General Public License along with
+  ~  this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android" android:opacity="opaque">
+    <item>
+        <shape>
+            <solid android:color="@color/material_theme_grey" />
+            <size android:height="180dp" android:width="320dp" />
+        </shape>
+    </item>
+    <item android:top="5dp" android:left="10dp">
+        <bitmap
+            android:src="@drawable/logo_star_144dp"
+            android:gravity="center_vertical|left"/>
+    </item>
+    <item android:right="10dp">
+        <bitmap
+            android:src="@drawable/ankidroid_txt"
+            android:gravity="right|center_horizontal"/>
+    </item>
+</layer-list>


### PR DESCRIPTION
## For Review

⚠️  Confirm that this will not submit us to the TV App Store - we're not (and probably never will be) ready. the docs seem ambiguous. It seems to be a Play Console Checkbox - but need to make sure.

## Purpose / Description
Was requested 

## Fixes
Related: #1643 


## How Has This Been Tested?

It's not great - we can't resize bitmaps until API 23
![image](https://user-images.githubusercontent.com/62114487/94376405-4561ab80-0112-11eb-8955-2c46cb644160.png)


## Learning (optional, can help others)
https://developer.android.com/training/tv/start/start#tv-activity

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code