### PR TITLE
Prevent using the same string for the title and summary of a preference

### DIFF
--- a/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.java
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.java
@@ -7,6 +7,7 @@ import com.ichi2.anki.lint.rules.DirectSystemTimeInstantiation;
 import com.ichi2.anki.lint.rules.DirectSystemCurrentTimeMillisUsage;
 import com.ichi2.anki.lint.rules.DirectDateInstantiation;
 import com.ichi2.anki.lint.rules.DirectGregorianInstantiation;
+import com.ichi2.anki.lint.rules.DuplicateTextInPreferencesXml;
 import com.ichi2.anki.lint.rules.InconsistentAnnotationUsage;
 
 import org.jetbrains.annotations.NotNull;
@@ -25,6 +26,7 @@ public class IssueRegistry extends com.android.tools.lint.client.api.IssueRegist
         issues.add(DirectGregorianInstantiation.ISSUE);
         issues.add(DirectSystemTimeInstantiation.ISSUE);
         issues.add(InconsistentAnnotationUsage.ISSUE);
+        issues.add(DuplicateTextInPreferencesXml.ISSUE);
         return issues;
     }
 

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DuplicateTextInPreferencesXml.java
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DuplicateTextInPreferencesXml.java
@@ -1,0 +1,70 @@
+package com.ichi2.anki.lint.rules;
+
+import com.android.annotations.Nullable;
+import com.android.resources.ResourceFolderType;
+import com.android.tools.lint.detector.api.Implementation;
+import com.android.tools.lint.detector.api.Issue;
+import com.android.tools.lint.detector.api.ResourceXmlDetector;
+import com.android.tools.lint.detector.api.Scope;
+import com.android.tools.lint.detector.api.XmlContext;
+import com.android.tools.lint.detector.api.XmlScannerConstants;
+import com.google.common.annotations.VisibleForTesting;
+import com.ichi2.anki.lint.utils.Constants;
+
+import org.w3c.dom.Element;
+
+import java.util.Collection;
+
+/**
+ * A Lint check to prevent using the same string for the title and summary of a preference.
+ */
+public class DuplicateTextInPreferencesXml extends ResourceXmlDetector {
+
+    @VisibleForTesting
+    static final String ID = "DuplicateTextInPreferencesXml";
+    @VisibleForTesting
+    static final String DESCRIPTION = "Do not use the same string for the title and summary of a preference";
+    private static final String EXPLANATION = "Use different strings for the title and summary of a preference to better " +
+            "explain what that preference is for";
+    private static final Implementation implementation = new Implementation(DuplicateTextInPreferencesXml.class, Scope.RESOURCE_FILE_SCOPE);
+    public static final Issue ISSUE = Issue.create(
+            ID,
+            DESCRIPTION,
+            EXPLANATION,
+            Constants.ANKI_TIME_CATEGORY,
+            Constants.ANKI_TIME_PRIORITY,
+            Constants.ANKI_TIME_SEVERITY,
+            implementation
+    );
+    private static final String ATTR_TITLE = "android:title";
+    private static final String ATTR_SUMMARY = "android:summary";
+
+
+    public DuplicateTextInPreferencesXml() {
+    }
+
+
+    @Nullable
+    @Override
+    public Collection<String> getApplicableElements() {
+        return XmlScannerConstants.ALL;
+    }
+
+
+    @Override
+    public void visitElement(XmlContext context, Element element) {
+        if (element.hasAttribute(ATTR_TITLE) && element.hasAttribute(ATTR_SUMMARY)) {
+            String titleValue = element.getAttribute(ATTR_TITLE);
+            String summaryValue = element.getAttribute(ATTR_SUMMARY);
+            if (titleValue.equals(summaryValue)) {
+                context.report(ISSUE, element, context.getLocation(element), DESCRIPTION);
+            }
+        }
+    }
+
+
+    @Override
+    public boolean appliesTo(ResourceFolderType folderType) {
+        return folderType == ResourceFolderType.XML;
+    }
+}

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/DuplicateTextInPreferencesXmlTest.java
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/DuplicateTextInPreferencesXmlTest.java
@@ -1,0 +1,74 @@
+package com.ichi2.anki.lint.rules;
+
+import com.android.tools.lint.checks.infrastructure.TestFiles;
+
+import org.junit.Test;
+
+import static com.android.tools.lint.checks.infrastructure.TestFiles.xml;
+import static com.android.tools.lint.checks.infrastructure.TestLintTask.lint;
+
+public class DuplicateTextInPreferencesXmlTest {
+
+    private final String invalidXmlFile = "" +
+            "<PreferenceScreen xmlns:android=\"http://schemas.android.com/apk/res/android\"" +
+            "    xmlns:app=\"http://arbitrary.app.namespace/com.ichi2.anki\"" +
+            "    android:title=\"@string/pref_cat_advanced_summ\"                           " +
+            "    android:summary=\"@string/pref_cat_advanced_summ\"                         " +
+            "    android:key=\"pref_screen_advanced\">                                      " +
+            "        <EditTextPreference                                                    " +
+            "            android:defaultValue=\"/sdcard/AnkiDroid\"                         " +
+            "            android:key=\"deckPath\"                                           " +
+            "            android:summary=\"@string/preference_summary_literal\"             " +
+            "            android:title=\"@string/preference_summary_literal\" />            " +
+            "        <com.ichi2.ui.ConfirmationPreference                                   " +
+            "            android:key=\"force_full_sync\"                                    " +
+            "            android:title=\"@string/force_full_sync_title\"                    " +
+            "            android:summary=\"@string/force_full_sync_summary\" />             " +
+            "</PreferenceScreen>";
+
+    private final String validXmlFile = "" +
+            "<PreferenceScreen xmlns:android=\"http://schemas.android.com/apk/res/android\"" +
+            "    xmlns:app=\"http://arbitrary.app.namespace/com.ichi2.anki\"" +
+            "    android:title=\"@string/pref_cat_advanced\"                                " +
+            "    android:summary=\"@string/pref_cat_advanced_summ\"                         " +
+            "    android:key=\"pref_screen_advanced\">                                      " +
+            "        <EditTextPreference                                                    " +
+            "            android:defaultValue=\"/sdcard/AnkiDroid\"                         " +
+            "            android:key=\"deckPath\"                                           " +
+            "            android:summary=\"@string/preference_summary_literal\"             " +
+            "            android:title=\"@string/preference_literal\" />                    " +
+            "        <com.ichi2.ui.ConfirmationPreference                                   " +
+            "            android:key=\"force_full_sync\"                                    " +
+            "            android:title=\"@string/force_full_sync_title\"                    " +
+            "            android:summary=\"@string/force_full_sync_summary\" />             " +
+            "</PreferenceScreen>";
+
+
+    @Test
+    public void showsErrorForInvalidFile() {
+        lint().allowMissingSdk()
+                .allowCompilationErrors()
+                .files(xml("res/xml/invalidpreference.xml", invalidXmlFile))
+                .issues(DuplicateTextInPreferencesXml.ISSUE)
+                .run()
+                .expectErrorCount(2)
+                .expect("res/xml/invalidpreference.xml:1: Error: Do not use the same string for the title and summary of a preference [DuplicateTextInPreferencesXml]\n" +
+                        "<PreferenceScreen xmlns:android=\"http://schemas.android.com/apk/res/android\"    xmlns:app=\"http://arbitrary.app.namespace/com.ichi2.anki\"    android:title=\"@string/pref_cat_advanced_summ\"                               android:summary=\"@string/pref_cat_advanced_summ\"                             android:key=\"pref_screen_advanced\">                                              <EditTextPreference                                                                android:defaultValue=\"/sdcard/AnkiDroid\"                                     android:key=\"deckPath\"                                                       android:summary=\"@string/preference_summary_literal\"                         android:title=\"@string/preference_summary_literal\" />                    <com.ichi2.ui.ConfirmationPreference                                               android:key=\"force_full_sync\"                                                android:title=\"@string/force_full_sync_title\"                                android:summary=\"@string/force_full_sync_summary\" />             </PreferenceScreen>\n" +
+                        "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n" +
+                        "res/xml/invalidpreference.xml:1: Error: Do not use the same string for the title and summary of a preference [DuplicateTextInPreferencesXml]\n" +
+                        "<PreferenceScreen xmlns:android=\"http://schemas.android.com/apk/res/android\"    xmlns:app=\"http://arbitrary.app.namespace/com.ichi2.anki\"    android:title=\"@string/pref_cat_advanced_summ\"                               android:summary=\"@string/pref_cat_advanced_summ\"                             android:key=\"pref_screen_advanced\">                                              <EditTextPreference                                                                android:defaultValue=\"/sdcard/AnkiDroid\"                                     android:key=\"deckPath\"                                                       android:summary=\"@string/preference_summary_literal\"                         android:title=\"@string/preference_summary_literal\" />                    <com.ichi2.ui.ConfirmationPreference                                               android:key=\"force_full_sync\"                                                android:title=\"@string/force_full_sync_title\"                                android:summary=\"@string/force_full_sync_summary\" />             </PreferenceScreen>\n" +
+                        "                                                                                                                                                                                                                                                                                                                                                                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n" +
+                        "2 errors, 0 warnings");
+    }
+
+    @Test
+    public void showsNoErrorForValidFile() {
+        lint().allowMissingSdk()
+                .allowCompilationErrors()
+                .files(xml("res/xml/validpreference.xml", validXmlFile))
+                .issues(DuplicateTextInPreferencesXml.ISSUE)
+                .run()
+                .expectClean();
+    }
+
+}


### PR DESCRIPTION
## Purpose / Description
This PR implements the Lint check requested in #7156 which will prevent a developer to use the same string as both a title and a summary for a preference declared in xml.
Note that I didn't manage to make Android Studio to highlight this issues in the file xml, but this is most likely due to the IDE itself as I saw others having issues with this kind of lint checks(running on resource files) . Even so the rule should still be useful to avoid the issue before making a new release.

## How Has This Been Tested?
I've manually ran the checks against faulty files and the code also has basic unit tests for the code itself in module _lint-rules_.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code

_Edit by @david-allison-1_

## Fixes

Fixes #7156
