### PR TITLE
Add Analytics event for failing Sanity Check

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -364,6 +364,11 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                     analyticsDebugMode.setTitle("Switch Analytics to dev mode");
                     analyticsDebugMode.setSummary("Touch here to use Analytics dev tag and 100% sample rate");
                     analyticsDebugMode.setOnPreferenceClickListener(preference -> {
+                        if (UsageAnalytics.isEnabled()) {
+                            UIUtils.showThemedToast(this, "Analytics set to dev mode", true);
+                        } else {
+                            UIUtils.showThemedToast(this, "Done! Enable Analytics in 'General' settings to use.", true);
+                        }
                         UsageAnalytics.setDevMode();
                         return true;
                     });

--- a/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.java
@@ -350,6 +350,11 @@ public class UsageAnalytics {
         }
     }
 
+    public static boolean isEnabled() {
+        SharedPreferences userPrefs = AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance());
+        return userPrefs.getBoolean(ANALYTICS_OPTIN_KEY, false);
+    }
+
 
 
     public static class Category {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.java
@@ -349,4 +349,10 @@ public class UsageAnalytics {
             return this;
         }
     }
+
+
+
+    public static class Category {
+        public static final String SYNC = "Sync";
+    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.java
@@ -47,6 +47,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+import androidx.annotation.NonNull;
 import okhttp3.Response;
 import timber.log.Timber;
 
@@ -222,8 +223,7 @@ public class Syncer {
                 JSONObject c = sanityCheck();
                 JSONObject sanity = mServer.sanityCheck2(c);
                 if (sanity == null || !"ok".equals(sanity.optString("status", "bad"))) {
-                    mCol.log("sanity check failed", c, sanity);
-                    return _forceFullSync();
+                    return sanityCheckError(c, sanity);
                 }
                 // finalize
                 publishProgress(con, R.string.sync_finish_message);
@@ -265,12 +265,17 @@ public class Syncer {
         }
     }
 
+    @NonNull
+    protected Object[] sanityCheckError(JSONObject c, JSONObject sanity) {
+        mCol.log("sanity check failed", c, sanity);
+        _forceFullSync();
+        return new Object[] { "sanityCheckError", null };
+    }
 
-    private Object[] _forceFullSync() {
+    private void _forceFullSync() {
         // roll back and force full sync
         mCol.modSchemaNoCheck();
         mCol.save();
-        return new Object[] { "sanityCheckError", null };
     }
 
     private void publishProgress(Connection con, int id) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.java
@@ -23,6 +23,7 @@ import android.database.SQLException;
 
 import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.R;
+import com.ichi2.anki.analytics.UsageAnalytics;
 import com.ichi2.anki.exception.UnknownHttpResponseException;
 import com.ichi2.async.Connection;
 import com.ichi2.libanki.DB;
@@ -268,6 +269,7 @@ public class Syncer {
     @NonNull
     protected Object[] sanityCheckError(JSONObject c, JSONObject sanity) {
         mCol.log("sanity check failed", c, sanity);
+        UsageAnalytics.sendAnalyticsEvent(UsageAnalytics.Category.SYNC, "sanityCheckError");
         _forceFullSync();
         return new Object[] { "sanityCheckError", null };
     }


### PR DESCRIPTION
## Purpose / Description
We've had an uptick in users mentioning syncing errors, this is potentially one of the causes (where our scheduler does not match with the AnkiWeb scheduler)


## Related
#6207

## How Has This Been Tested?

⚠️  On my device - I'm not sure if this "Category"/"Action" setup is correct, but it's similar to how we do other analytic events.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code