### PR TITLE
NF: Reviewer check whether a card is empty more quickly

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.java
@@ -353,9 +353,7 @@ public class Card implements Cloneable {
 
 
     public boolean isEmpty() {
-        // TODO: optimize. Checking all cards to deal with this only card is inefficient
-        ArrayList<Integer> ords = Models.availOrds(model(), note().getFields());
-        return !ords.contains(mOrd);
+        return Models.emptyCard(model(), mOrd, note().getFields());
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.java
@@ -354,7 +354,7 @@ public class Card implements Cloneable {
 
     public boolean isEmpty() {
         // TODO: optimize. Checking all cards to deal with this only card is inefficient
-        ArrayList<Integer> ords = mCol.getModels().availOrds(model(), note().getFields());
+        ArrayList<Integer> ords = Models.availOrds(model(), note().getFields());
         return !ords.contains(mOrd);
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -690,7 +690,7 @@ public class Collection {
      */
     public ArrayList<JSONObject> findTemplates(Note note) {
         Model model = note.model();
-        ArrayList<Integer> avail = getModels().availOrds(model, note.getFields());
+        ArrayList<Integer> avail = Models.availOrds(model, note.getFields());
         return _tmplsFromOrds(model, avail);
     }
 
@@ -803,7 +803,7 @@ public class Collection {
                 long mid = cur.getLong(1);
                 String flds = cur.getString(2);
                 Model model = getModels().get(mid);
-                ArrayList<Integer> avail = getModels().availOrds(model, Utils.splitFields(flds));
+                ArrayList<Integer> avail = Models.availOrds(model, Utils.splitFields(flds));
                 if (task != null) {
                     task.doProgress(new TaskData(avail.size()));
                 }
@@ -1161,7 +1161,7 @@ public class Collection {
             d.put(type, html);
             // empty cloze?
             if ("q".equals(type) && model.getInt("type") == Consts.MODEL_CLOZE) {
-                if (getModels()._availClozeOrds(model, flist, false).size() == 0) {
+                if (Models._availClozeOrds(model, flist, false).size() == 0) {
                     String link = String.format("<a href=%s#cloze>%s</a>", Consts.HELP_SITE, "help");
                     d.put("q", mContext.getString(R.string.empty_cloze_warning, link));
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -46,6 +46,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import androidx.annotation.NonNull;
+import static com.ichi2.libanki.Utils.trimArray;
 
 @SuppressWarnings({"PMD.ExcessiveClassLength", "PMD.AvoidThrowingRawExceptionTypes","PMD.AvoidReassigningParameters",
         "PMD.NPathComplexity","PMD.MethodNamingConventions",
@@ -1053,11 +1054,7 @@ public class Models {
         if (m.getInt("type") == Consts.MODEL_CLOZE) {
             return _availClozeOrds(m, sfld);
         }
-        int nbField = sfld.length;
-        String[] fields = new String[nbField];
-        for (int i = 0; i < nbField; i++) {
-            fields[i] = sfld[i].trim();
-        }
+        String[] fields = trimArray(sfld);
         ArrayList<Integer> avail = new ArrayList<>();
         JSONArray reqArray = m.getJSONArray("req");
         templates: for (int i = 0; i < reqArray.length(); i++) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -1046,6 +1046,33 @@ public class Models {
 
 
     /**
+     * @param m A model
+     * @param ord a card type number of this model
+     * @param sfld Fields of a note of this model. (Not trimmed)
+     * @return Whether this card is empty
+     */
+    public static boolean emptyCard(Model m, int ord, String[] sfld) {
+        if (m.getInt("type") == Consts.MODEL_CLOZE) {
+            // For cloze, getting the list of cloze numbes is linear in the size of the template
+            // So computing the full list is almost as efficient as checking for a particular number
+            return !_availClozeOrds(m, sfld, false).contains(ord);
+        }
+        return emptyStandardCard(m.getJSONArray("req").getJSONArray(ord), sfld);
+    }
+
+    /**
+     * @param sr The requirement telling whether a card should be generated.
+     * @param sfld The vector of fields of a note. (Not trimmed)
+     * @return Whether the standard card is empty
+     */
+    public static boolean emptyStandardCard(JSONArray sr, String[] sfld) {
+        String[] fields = trimArray(sfld);
+        String type = sr.getString(1);
+        JSONArray req = sr.getJSONArray(2);
+        return emptyStandardCard(type, req, fields);
+    }
+
+    /**
      * @param type Whether the rules to generate this card is is any, all, none
      * @param req The fields that must be fill (all), or that suffices (any) to generate the card
      * @param trimmedFields the field of a note. Fields are assumed to be trimmed

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -1049,7 +1049,7 @@ public class Models {
      * @param sfld The fields of a note of type m. (Assume the size of the array is the number of fields)
      * @return The indexes (in increasing order) of cards that should be generated according to req rules. If it is a
      * cloze type, at least one ord will be return.*/
-    public ArrayList<Integer> availOrds(Model m, String[] sfld) {
+    public static ArrayList<Integer> availOrds(Model m, String[] sfld) {
         if (m.getInt("type") == Consts.MODEL_CLOZE) {
             return _availClozeOrds(m, sfld);
         }
@@ -1103,7 +1103,7 @@ public class Models {
      * @param sflds The fields of a note of type m. (Assume the size of the array is the number of fields)
      * @return The indexes (in increasing order) of cards that should be generated according to req rules.
      */
-    public ArrayList<Integer> _availClozeOrds(Model m, String[] sflds) {
+    public static ArrayList<Integer> _availClozeOrds(Model m, String[] sflds) {
         return _availClozeOrds(m, sflds, true);
     }
 
@@ -1114,7 +1114,7 @@ public class Models {
      * @param allowEmpty Whether we allow to generate at least one card even if they are all empty
      * @return The indexes (in increasing order) of cards that should be generated according to req rules.
      * If empty is not allowed, it will contains ord 1.*/
-    public ArrayList<Integer> _availClozeOrds(Model m, String[] sflds, boolean allowEmpty) {
+    public static ArrayList<Integer> _availClozeOrds(Model m, String[] sflds, boolean allowEmpty) {
         Map<String, Pair<Integer, JSONObject>> map = fieldMap(m);
         Set<Integer> ords = new HashSet<>();
         List<String> matches = new ArrayList<>();

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -1054,6 +1054,11 @@ public class Models {
         if (m.getInt("type") == Consts.MODEL_CLOZE) {
             return _availClozeOrds(m, sfld);
         }
+        return _availStandardOrds(m, sfld);
+    }
+
+    /** Given a joined field string and a standard note type, return available template ordinals */
+    public static ArrayList<Integer> _availStandardOrds(Model m, String[] sfld) {
         String[] fields = trimArray(sfld);
         ArrayList<Integer> avail = new ArrayList<>();
         JSONArray reqArray = m.getJSONArray("req");

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
@@ -1074,4 +1074,17 @@ public class Utils {
         return left == right || (left != null && left.equals(right));
     }
 
+    /**
+     * @param sflds Some fields
+     * @return Array with the same elements, trimmed
+     */
+    public static @NonNull String[] trimArray(@NonNull String[] sflds) {
+        int nbField = sflds.length;
+        String[] fields = new String[nbField];
+        for (int i = 0; i < nbField; i++) {
+            fields[i] = sflds[i].trim();
+        }
+        return fields;
+    }
+
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/NoteImporter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/NoteImporter.java
@@ -388,7 +388,7 @@ public class NoteImporter extends Importer {
             }
         }
         note.fieldsStr = joinFields(fields);
-        ArrayList<Integer> ords = mCol.getModels().availOrds(mModel, fields);
+        ArrayList<Integer> ords = Models.availOrds(mModel, fields);
         if (ords.isEmpty()) {
             mEmptyNotes = true;
             return false;


### PR DESCRIPTION
Cards with a lot of siblings takes time to be displayed. I never noticed because those cards also have a lot of fields, so I assumed it was the cause of the problem. Indeed, it used to be, but card generation was improved enough that it is not the bottleneck anymore. The bottle neck is very silly: to know whether a card is empty, we compute the list of non-empty cards of the note, and then check whether the card belongs to this set... That is entirely useless, since it consider all siblings in a process where siblings data is immediately discarded.

This PR change that, by splitting the method availOrds in three. One part deal with clozed note (this part is already efficient), one part deal with with standard note, and from this part I exctracted the part which deals with each card individually. I added a method which, given a single card, state whether it is empty without considering its neighbors. 