### PR TITLE
BugFix: Ensure all answer buttons are hidden

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1658,17 +1658,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
 
 
     protected void hideEaseButtons() {
-        Runnable after = () -> {
-            mEaseButtonsLayout.setVisibility(View.GONE);
-            mEase1Layout.setVisibility(View.GONE);
-            mEase2Layout.setVisibility(View.GONE);
-            mEase3Layout.setVisibility(View.GONE);
-            mEase4Layout.setVisibility(View.GONE);
-            mNext1.setText("");
-            mNext2.setText("");
-            mNext3.setText("");
-            mNext4.setText("");
-        };
+        Runnable after = () -> actualHideEaseButtons();
 
         boolean easeButtonsVisible = mEaseButtonsLayout.getVisibility() == View.VISIBLE;
         mFlipCardLayout.setClickable(true);
@@ -1683,6 +1673,20 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
 
         focusAnswerCompletionField();
     }
+
+
+    private void actualHideEaseButtons() {
+        mEaseButtonsLayout.setVisibility(View.GONE);
+        mEase1Layout.setVisibility(View.GONE);
+        mEase2Layout.setVisibility(View.GONE);
+        mEase3Layout.setVisibility(View.GONE);
+        mEase4Layout.setVisibility(View.GONE);
+        mNext1.setText("");
+        mNext2.setText("");
+        mNext3.setText("");
+        mNext4.setText("");
+    }
+
 
     /**
      * Focuses the appropriate field for an answer
@@ -2024,6 +2028,8 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
 
 
     protected void displayCardAnswer() {
+        // #7294 Required in case the animation end action does not fire:
+        actualHideEaseButtons();
         Timber.d("displayCardAnswer()");
         mMissingImageHandler.onCardSideChange();
 


### PR DESCRIPTION
## Purpose / Description
This was caused as `withEndAction` would not fire if the view was hidden.


## Fixes
Fixes #7294 

## Approach
We ensure that the action occurs when the answers are displayed

## How Has This Been Tested?

Attempted and failed to get a failing unit test (animations are hard), tested visually on my Android 9

## Learning (optional, can help others)

`withEndAction` is only executed if an animation ends normally: https://developer.android.com/reference/android/view/ViewPropertyAnimator#withEndAction(java.lang.Runnable)

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code