### PR TITLE
NF: newCardName break sooner

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
@@ -854,7 +854,10 @@ public class CardTemplateEditor extends AnkiActivity implements DeckSelectionDia
                 // Cycle through all templates checking if new name exists
                 boolean exists = false;
                 for (int i = 0; i < templates.length(); i++) {
-                    exists = exists || name.equals(templates.getJSONObject(i).getString("name"));
+                    if (name.equals(templates.getJSONObject(i).getString("name"))) {
+                        exists = true;
+                        break;
+                    }
                 }
                 if (!exists) {
                     break;


### PR DESCRIPTION
While looking at related code, I found this loop which could exit sooner and uses labelled loop to avoid a variable