### PR TITLE
[BugFix] Make Reviews Fast Again: Perf Regression

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -1408,7 +1408,7 @@ public class SchedV2 extends AbstractSched {
     protected void log(long id, int usn, @Consts.BUTTON_TYPE int ease, int ivl, int lastIvl, int factor, int timeTaken, @Consts.REVLOG_TYPE int type) {
         try {
             mCol.getDb().execute("INSERT INTO revlog VALUES (?,?,?,?,?,?,?,?,?)",
-                    getTime().intTime() * 1000, id, usn, ease, ivl, lastIvl, factor, timeTaken, type);
+                    getTime().intTimeMS(), id, usn, ease, ivl, lastIvl, factor, timeTaken, type);
         } catch (SQLiteConstraintException e) {
             try {
                 Thread.sleep(10);

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedTest.java
@@ -20,6 +20,7 @@ package com.ichi2.libanki.sched;
 import android.database.Cursor;
 
 import com.ichi2.anki.AbstractFlashcardViewer;
+import com.ichi2.anki.CollectionHelper;
 import com.ichi2.anki.RobolectricTest;
 import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.libanki.Card;
@@ -30,8 +31,7 @@ import com.ichi2.libanki.DeckConfig;
 import com.ichi2.libanki.Model;
 import com.ichi2.libanki.Models;
 import com.ichi2.libanki.Note;
-import com.ichi2.libanki.Utils;
-import com.ichi2.libanki.sched.DeckDueTreeNode;
+import com.ichi2.testutils.MutableTime;
 import com.ichi2.utils.JSONArray;
 import com.ichi2.utils.JSONObject;
 
@@ -180,6 +180,22 @@ public class SchedTest extends RobolectricTest {
         List<DeckDueTreeNode> tree = sched.deckDueTree();
         Assert.assertEquals("Tree has not the expected structure", SchedV2Test.expectedTree(getCol(), false), tree);
 
+    }
+
+    @Test
+    public void testRevLogValues() {
+        MutableTime time = new MutableTime(1596540139123L, 10);
+        Collection col =  CollectionHelper.getInstance().getCol(getTargetContext(), time);
+        addNoteUsingBasicModel("Hello", "World");
+
+        AbstractSched sched = col.getSched();
+        Card c = sched.getCard();
+        time.setFrozen(true);
+        long currentTime = time.getInternalTimeMs();
+        sched.answerCard(c, 1);
+
+        long timeAnswered = col.getDb().queryLongScalar("select id from revlog");
+        assertThat(timeAnswered, is(currentTime));
     }
 
 

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/MockTime.java
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/MockTime.java
@@ -44,6 +44,10 @@ public class MockTime extends Time {
         return mTime;
     }
 
+    protected long getTime() {
+        return mTime;
+    }
+
     /** Add ms milisecond*/
     public void addMs(long ms) {
         mTime += ms;

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/MutableTime.java
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/MutableTime.java
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.testutils;
+
+public class MutableTime extends MockTime {
+    private boolean mFrozen;
+
+
+    public MutableTime(long time) {
+        super(time);
+    }
+
+
+    public MutableTime(long time, int step) {
+        super(time, step);
+    }
+
+    public void setFrozen(boolean value) {
+        mFrozen = value;
+    }
+
+    public long getInternalTimeMs() {
+        return getTime();
+    }
+
+    @Override
+    public long intTimeMS() {
+        if (mFrozen) {
+            return super.getTime();
+        } else {
+            return super.intTimeMS();
+        }
+    }
+}


### PR DESCRIPTION
## Purpose / Description
Regression: We were passing in the primary key as the seconds, rather than the milliseconds

This led to a lot of collisions when answers were performed quickly.

Introduced in 4bee8de (#6930)

## Fixes
Fixes #7305

## Approach
Use milliseconds instead of seconds

## How Has This Been Tested?

Unit tested, tested on my device

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
