### PR TITLE
Card Browser: Display cards deleted when deleting notes

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1725,6 +1725,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
             super(browser);
         }
 
+        private int mCardsDeleted = -1;
+
         @Override
         public void actualOnPreExecute(@NonNull CardBrowser browser) {
             super.actualOnPreExecute(browser);
@@ -1736,6 +1738,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
             Card[] cards = (Card[]) value.getObjArray();
             //we don't need to reorder cards here as we've already deselected all notes,
             browser.removeNotesView(cards, false);
+            mCardsDeleted = cards.length;
         }
 
 
@@ -1745,7 +1748,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
             browser.mActionBarTitle.setText(Integer.toString(browser.checkedCardCount()));
             browser.invalidateOptionsMenu();    // maybe the availability of undo changed
             // snackbar to offer undo
-            browser.mUndoSnackbar = UIUtils.showSnackbar(browser, browser.getString(R.string.deleted_message), SNACKBAR_DURATION, R.string.undo, v -> CollectionTask.launchCollectionTask(UNDO, browser.mUndoHandler), browser.mCardsListView, null);
+            String deletedMessage = browser.getResources().getQuantityString(R.plurals.card_browser_cards_deleted, mCardsDeleted, mCardsDeleted);
+            browser.mUndoSnackbar = UIUtils.showSnackbar(browser, deletedMessage, SNACKBAR_DURATION, R.string.undo, v -> CollectionTask.launchCollectionTask(UNDO, browser.mUndoHandler), browser.mCardsListView, null);
             browser.searchCards();
         }
     }

--- a/AnkiDroid/src/main/res/values/07-cardbrowser.xml
+++ b/AnkiDroid/src/main/res/values/07-cardbrowser.xml
@@ -39,7 +39,6 @@
     <string name="delete_cards_title">Delete notes?</string>
     <string name="delete_card_message">Delete all cards of this note?\nSearch field: %s</string>
     <string name="delete_card_mult_message">Delete all cards of all selected notes?\n(Not only selected cards)</string>
-    <string name="deleted_message">Notes deleted</string>
     <string name="changed_deck_message">Moved to %s</string>
     <string name="card_browser_suspended_cards">(un)suspended cards</string>
     <string name="card_browser_show_marked">Filter marked</string>
@@ -84,4 +83,9 @@
     <string name="card_browser_no_cards_in_deck">No cards found in deck ‘%s’</string>
     <string name="card_browser_search_all_decks">Search all decks</string>
     <string name="card_browser_unknown_deck_name">Unknown</string>
+
+    <plurals name="card_browser_cards_deleted">
+        <item quantity="one">%d card deleted</item>
+        <item quantity="other">%d cards deleted</item>
+    </plurals>
 </resources>


### PR DESCRIPTION
Previously, it showed "Notes Deleted", which is confusing

Knowing the number will ensure that users know that one note may map to several cards

## How Has This Been Tested?

On my phone - total is now displayed

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code