### PR TITLE
API 29 Dependency Updates

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -208,7 +208,7 @@ dependencies {
     // Can possibly remove if upstream PR merges https://github.com/JakeWharton/timber/pull/398
     configurations.all {
         resolutionStrategy {
-            force 'org.jetbrains:annotations:20.0.0'
+            force 'org.jetbrains:annotations:20.1.0'
         }
     }
 

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -256,7 +256,7 @@ dependencies {
     api project(":api")
 
     testImplementation 'org.junit.vintage:junit-vintage-engine:5.6.2'
-    testImplementation 'org.mockito:mockito-inline:3.5.7'
+    testImplementation 'org.mockito:mockito-inline:3.5.9'
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
     testImplementation 'net.lachlanmckee:timber-junit-rule:1.0.1'
     testImplementation "org.robolectric:robolectric:4.3.1"

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -212,7 +212,7 @@ dependencies {
         }
     }
 
-    compileOnly 'org.jetbrains:annotations:20.0.0'
+    compileOnly 'org.jetbrains:annotations:20.1.0'
     compileOnly "com.google.auto.service:auto-service-annotations:1.0-rc7"
     annotationProcessor "com.google.auto.service:auto-service:1.0-rc7"
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -28,7 +28,6 @@ import android.content.res.Resources;
 import android.os.Build;
 import android.os.Environment;
 import android.os.LocaleList;
-import android.preference.PreferenceManager;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
@@ -323,8 +322,9 @@ public class AnkiDroidApp extends MultiDexApplication {
      * @param context Context to get preferences for.
      * @return A SharedPreferences object for this instance of the app.
      */
+    @SuppressWarnings("deprecation") // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5019
     public static SharedPreferences getSharedPrefs(Context context) {
-        return PreferenceManager.getDefaultSharedPreferences(context);
+        return android.preference.PreferenceManager.getDefaultSharedPreferences(context);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.java
@@ -19,7 +19,6 @@ package com.ichi2.anki;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Environment;
-import android.preference.PreferenceManager;
 import android.text.format.Formatter;
 
 import androidx.annotation.NonNull;
@@ -232,6 +231,7 @@ public class CollectionHelper {
      * external storage directory.
      * @return the folder path
      */
+    @SuppressWarnings("deprecation") // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5304
     public static String getDefaultAnkiDroidDirectory() {
         return new File(Environment.getExternalStorageDirectory(), "AnkiDroid").getAbsolutePath();
     }
@@ -249,7 +249,7 @@ public class CollectionHelper {
      * @return the absolute path to the AnkiDroid directory.
      */
     public static String getCurrentAnkiDroidDirectory(Context context) {
-        SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context.getApplicationContext());
+        SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(context);
         return PreferenceExtensions.getOrSetString(
                 preferences,
                 "deckPath",

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
@@ -29,10 +29,6 @@ import android.content.SharedPreferences;
 import android.content.SharedPreferences.OnSharedPreferenceChangeListener;
 import android.content.res.Resources;
 import android.os.Bundle;
-import android.preference.CheckBoxPreference;
-import android.preference.ListPreference;
-import android.preference.Preference;
-import android.preference.PreferenceScreen;
 import android.text.TextUtils;
 
 import android.view.KeyEvent;
@@ -697,6 +693,7 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
     }
 
     @Override
+    @SuppressWarnings("deprecation") // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5019
     public boolean onOptionsItemSelected(MenuItem item) {
         if (item.getItemId() == android.R.id.home) {
             closeWithResult();
@@ -714,14 +711,14 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
     }
 
     // Workaround for bug 4611: http://code.google.com/p/android/issues/detail?id=4611
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings("deprecation") // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5019
     @Override
-    public boolean onPreferenceTreeClick(PreferenceScreen preferenceScreen, Preference preference)
+    public boolean onPreferenceTreeClick(android.preference.PreferenceScreen preferenceScreen, android.preference.Preference preference)
     {
         super.onPreferenceTreeClick(preferenceScreen, preference);
-        if (preference instanceof PreferenceScreen &&
-                ((PreferenceScreen) preference).getDialog() != null) {
-                    ((PreferenceScreen) preference).getDialog().getWindow().getDecorView().setBackgroundDrawable(
+        if (preference instanceof android.preference.PreferenceScreen &&
+                ((android.preference.PreferenceScreen) preference).getDialog() != null) {
+                    ((android.preference.PreferenceScreen) preference).getDialog().getWindow().getDecorView().setBackgroundDrawable(
                             this.getWindow().getDecorView().getBackground().getConstantState().newDrawable());
         }
 
@@ -759,12 +756,12 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
     }
 
 
-    @SuppressWarnings("deprecation") // Tracked as #5019 on github
+    @SuppressWarnings("deprecation") // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5019
     protected void updateSummaries() {
         Resources res = getResources();
         // for all text preferences, set summary as current database value
         for (String key : mPref.mValues.keySet()) {
-            Preference pref = this.findPreference(key);
+            android.preference.Preference pref = this.findPreference(key);
             if ("deckConf".equals(key)) {
                 String groupName = getOptionsGroupName();
                 int count = getOptionsGroupCount();
@@ -777,10 +774,10 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
             String value = null;
             if (pref == null) {
                 continue;
-            } else if (pref instanceof CheckBoxPreference) {
+            } else if (pref instanceof android.preference.CheckBoxPreference) {
                 continue;
-            } else if (pref instanceof ListPreference) {
-                ListPreference lp = (ListPreference) pref;
+            } else if (pref instanceof android.preference.ListPreference) {
+                android.preference.ListPreference lp = (android.preference.ListPreference) pref;
                 value = lp.getEntry() != null ? lp.getEntry().toString() : "";
             } else {
                 value = this.mPref.getString(key, "");
@@ -804,9 +801,9 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
     }
 
 
-    @SuppressWarnings("deprecation") // Tracked as #5019 on github
+    @SuppressWarnings("deprecation") // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5019
     protected void buildLists() {
-        ListPreference deckConfPref = (ListPreference) findPreference("deckConf");
+        android.preference.ListPreference deckConfPref = (android.preference.ListPreference) findPreference("deckConf");
         ArrayList<DeckConfig> confs = mCol.getDecks().allConf();
         Collections.sort(confs, NamedJSONComparator.instance);
         String[] confValues = new String[confs.size()];
@@ -820,12 +817,12 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
         deckConfPref.setEntryValues(confValues);
         deckConfPref.setValue(mPref.getString("deckConf", "0"));
 
-        ListPreference newOrderPref = (ListPreference) findPreference("newOrder");
+        android.preference.ListPreference newOrderPref = (android.preference.ListPreference) findPreference("newOrder");
         newOrderPref.setEntries(R.array.new_order_labels);
         newOrderPref.setEntryValues(R.array.new_order_values);
         newOrderPref.setValue(mPref.getString("newOrder", "0"));
 
-        ListPreference leechActPref = (ListPreference) findPreference("lapLeechAct");
+        android.preference.ListPreference leechActPref = (android.preference.ListPreference) findPreference("lapLeechAct");
         leechActPref.setEntries(R.array.leech_action_labels);
         leechActPref.setEntryValues(R.array.leech_action_values);
         leechActPref.setValue(mPref.getString("lapLeechAct", new Integer(Consts.LEECH_SUSPEND).toString()));

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.java
@@ -7,7 +7,6 @@ import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.os.LocaleList;
 import android.os.Parcelable;
-import android.preference.PreferenceManager;
 import android.util.AttributeSet;
 import android.widget.TextView;
 
@@ -72,7 +71,7 @@ public class FieldEditText extends AppCompatEditText {
 
     private boolean shouldDisableExtendedTextUi() {
         try {
-            SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(this.getContext());
+            SharedPreferences sp = AnkiDroidApp.getSharedPrefs(this.getContext());
             return sp.getBoolean("disableExtendedTextUi", false);
         } catch (Exception e) {
             Timber.e(e, "Failed to get extended UI preference");

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FilteredDeckOptions.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FilteredDeckOptions.java
@@ -26,10 +26,6 @@ import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.OnSharedPreferenceChangeListener;
 import android.os.Bundle;
-import android.preference.CheckBoxPreference;
-import android.preference.EditTextPreference;
-import android.preference.ListPreference;
-import android.preference.Preference;
 import android.view.KeyEvent;
 import android.view.MenuItem;
 
@@ -391,6 +387,7 @@ public class FilteredDeckOptions extends AppCompatPreferenceActivity implements 
     }
 
     @Override
+    @SuppressWarnings("deprecation") // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5019
     public boolean onOptionsItemSelected(MenuItem item) {
         if (item.getItemId() == android.R.id.home) {
             closeDeckOptions();
@@ -446,14 +443,14 @@ public class FilteredDeckOptions extends AppCompatPreferenceActivity implements 
         mAllowCommit = false;
         // for all text preferences, set summary as current database value
         for (String key : mPref.mValues.keySet()) {
-            Preference pref = this.findPreference(key);
+            android.preference.Preference pref = this.findPreference(key);
             String value;
             if (pref == null) {
                 continue;
-            } else if (pref instanceof CheckBoxPreference) {
+            } else if (pref instanceof android.preference.CheckBoxPreference) {
                 continue;
-            } else if (pref instanceof ListPreference) {
-                ListPreference lp = (ListPreference) pref;
+            } else if (pref instanceof android.preference.ListPreference) {
+                android.preference.ListPreference lp = (android.preference.ListPreference) pref;
                 CharSequence entry = lp.getEntry();
                 if (entry != null) {
                     value = entry.toString();
@@ -464,8 +461,8 @@ public class FilteredDeckOptions extends AppCompatPreferenceActivity implements 
                 value = this.mPref.getString(key, "");
             }
             // update value for EditTexts
-            if (pref instanceof EditTextPreference) {
-                ((EditTextPreference) pref).setText(value);
+            if (pref instanceof android.preference.EditTextPreference) {
+                ((android.preference.EditTextPreference) pref).setText(value);
             }
             // update summary
             if (!mPref.mSummaries.containsKey(key)) {
@@ -485,7 +482,7 @@ public class FilteredDeckOptions extends AppCompatPreferenceActivity implements 
 
     @SuppressWarnings("deprecation") // Tracked as #5019 on github
     protected void buildLists() {
-        ListPreference newOrderPref = (ListPreference) findPreference("order");
+        android.preference.ListPreference newOrderPref = (android.preference.ListPreference) findPreference("order");
         newOrderPref.setEntries(R.array.cram_deck_conf_order_labels);
         newOrderPref.setEntryValues(R.array.cram_deck_conf_order_values);
         newOrderPref.setValue(mPref.getString("order", "0"));

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -35,14 +35,6 @@ import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
-import android.preference.CheckBoxPreference;
-import android.preference.EditTextPreference;
-import android.preference.ListPreference;
-import android.preference.Preference;
-import android.preference.PreferenceActivity;
-import android.preference.PreferenceCategory;
-import android.preference.PreferenceGroup;
-import android.preference.PreferenceScreen;
 import android.provider.MediaStore;
 import android.text.TextUtils;
 import android.view.MenuItem;
@@ -97,14 +89,16 @@ import timber.log.Timber;
 
 import static com.ichi2.anim.ActivityTransitionAnimation.Direction.FADE;
 
+@SuppressWarnings("deprecation") // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5019
 interface PreferenceContext {
     void addPreferencesFromResource(int preferencesResId);
-    PreferenceScreen getPreferenceScreen();
+    android.preference.PreferenceScreen getPreferenceScreen();
 }
 
 /**
  * Preferences dialog.
  */
+@SuppressWarnings("deprecation") // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5019
 public class Preferences extends AppCompatPreferenceActivity implements PreferenceContext, OnSharedPreferenceChangeListener {
 
     /** Key of the language preference */
@@ -119,7 +113,8 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
             "learnCutoff", "timeLimit", "useCurrent", "newSpread", "dayOffset", "schedVer"};
 
     private static final int RESULT_LOAD_IMG = 111;
-    private CheckBoxPreference backgroundImage;
+    private android.preference.CheckBoxPreference backgroundImage;
+    private static long fileLength;
 
 
     // ----------------------------------------------------------------------------
@@ -181,23 +176,23 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
 
     public static Intent getPreferenceSubscreenIntent(Context context, String subscreen) {
         Intent i = new Intent(context, Preferences.class);
-        i.putExtra(PreferenceActivity.EXTRA_SHOW_FRAGMENT, "com.ichi2.anki.Preferences$SettingsFragment");
+        i.putExtra(android.preference.PreferenceActivity.EXTRA_SHOW_FRAGMENT, "com.ichi2.anki.Preferences$SettingsFragment");
         Bundle extras = new Bundle();
         extras.putString("subscreen", subscreen);
-        i.putExtra(PreferenceActivity.EXTRA_SHOW_FRAGMENT_ARGUMENTS, extras);
-        i.putExtra(PreferenceActivity.EXTRA_NO_HEADERS, true);
+        i.putExtra(android.preference.PreferenceActivity.EXTRA_SHOW_FRAGMENT_ARGUMENTS, extras);
+        i.putExtra(android.preference.PreferenceActivity.EXTRA_NO_HEADERS, true);
         return i;
     }
     private void initSubscreen(String action, PreferenceContext listener) {
-        PreferenceScreen screen;
+        android.preference.PreferenceScreen screen;
         switch (action) {
             case "com.ichi2.anki.prefs.general":
                 listener.addPreferencesFromResource(R.xml.preferences_general);
                 screen = listener.getPreferenceScreen();
                 if (AdaptionUtil.isRestrictedLearningDevice()) {
-                    CheckBoxPreference mCheckBoxPref_Vibrate = (CheckBoxPreference) screen.findPreference("widgetVibrate");
-                    CheckBoxPreference mCheckBoxPref_Blink = (CheckBoxPreference) screen.findPreference("widgetBlink");
-                    PreferenceCategory mCategory = (PreferenceCategory) screen.findPreference("category_general_notification_pref");
+                    android.preference.CheckBoxPreference mCheckBoxPref_Vibrate = (android.preference.CheckBoxPreference) screen.findPreference("widgetVibrate");
+                    android.preference.CheckBoxPreference mCheckBoxPref_Blink = (android.preference.CheckBoxPreference) screen.findPreference("widgetBlink");
+                    android.preference.PreferenceCategory mCategory = (android.preference.PreferenceCategory) screen.findPreference("category_general_notification_pref");
                     mCategory.removePreference(mCheckBoxPref_Vibrate);
                     mCategory.removePreference(mCheckBoxPref_Blink);
                 }
@@ -227,7 +222,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                 listener.addPreferencesFromResource(R.xml.preferences_reviewing);
                 screen = listener.getPreferenceScreen();
                 // Show error toast if the user tries to disable answer button without gestures on
-                ListPreference fullscreenPreference = (ListPreference)
+                android.preference.ListPreference fullscreenPreference = (android.preference.ListPreference)
                         screen.findPreference("fullscreenMode");
                 fullscreenPreference.setOnPreferenceChangeListener((preference, newValue) -> {
                     SharedPreferences prefs = AnkiDroidApp.getSharedPrefs(Preferences.this);
@@ -240,7 +235,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                     }
                 });
                 // Custom buttons options
-                Preference customButtonsPreference = screen.findPreference("custom_buttons_link");
+                android.preference.Preference customButtonsPreference = screen.findPreference("custom_buttons_link");
                 customButtonsPreference.setOnPreferenceClickListener(preference -> {
                     Intent i = getPreferenceSubscreenIntent(Preferences.this,
                             "com.ichi2.anki.prefs.custom_buttons");
@@ -251,7 +246,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
             case "com.ichi2.anki.prefs.appearance":
                 listener.addPreferencesFromResource(R.xml.preferences_appearance);
                 screen = listener.getPreferenceScreen();
-                backgroundImage = (CheckBoxPreference) screen.findPreference("deckPickerBackground");
+                backgroundImage = (android.preference.CheckBoxPreference) screen.findPreference("deckPickerBackground");
                 backgroundImage.setOnPreferenceClickListener(preference -> {
                     if (backgroundImage.isChecked()) {
                         try {
@@ -287,7 +282,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                 listener.addPreferencesFromResource(R.xml.preferences_custom_buttons);
                 screen = listener.getPreferenceScreen();
                 // Reset toolbar button customizations
-                Preference reset_custom_buttons = screen.findPreference("reset_custom_buttons");
+                android.preference.Preference reset_custom_buttons = screen.findPreference("reset_custom_buttons");
                 reset_custom_buttons.setOnPreferenceClickListener(preference -> {
                     SharedPreferences.Editor edit = AnkiDroidApp.getSharedPrefs(getBaseContext()).edit();
                     edit.remove("customButtonUndo");
@@ -314,7 +309,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                 listener.addPreferencesFromResource(R.xml.preferences_advanced);
                 screen = listener.getPreferenceScreen();
                 // Check that input is valid before committing change in the collection path
-                EditTextPreference collectionPathPreference = (EditTextPreference) screen.findPreference("deckPath");
+                android.preference.EditTextPreference collectionPathPreference = (android.preference.EditTextPreference) screen.findPreference("deckPath");
                 collectionPathPreference.setOnPreferenceChangeListener((preference, newValue) -> {
                     final String newPath = (String) newValue;
                     try {
@@ -327,7 +322,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                     }
                 });
                 // Custom sync server option
-                Preference customSyncServerPreference = screen.findPreference("custom_sync_server_link");
+                android.preference.Preference customSyncServerPreference = screen.findPreference("custom_sync_server_link");
                 customSyncServerPreference.setOnPreferenceClickListener(preference -> {
                     Intent i = getPreferenceSubscreenIntent(Preferences.this,
                             "com.ichi2.anki.prefs.custom_sync_server");
@@ -335,7 +330,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                     return true;
                 });
                 // Advanced statistics option
-                Preference advancedStatisticsPreference = screen.findPreference("advanced_statistics_link");
+                android.preference.Preference advancedStatisticsPreference = screen.findPreference("advanced_statistics_link");
                 advancedStatisticsPreference.setOnPreferenceClickListener(preference -> {
                     Intent i = getPreferenceSubscreenIntent(Preferences.this,
                             "com.ichi2.anki.prefs.advanced_statistics");
@@ -348,7 +343,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                 // Make it possible to test crash reporting, but only for DEBUG builds
                 if (BuildConfig.DEBUG && !AdaptionUtil.isUserATestClient()) {
                     Timber.i("Debug mode, allowing for test crashes");
-                    Preference triggerTestCrashPreference = new Preference(this);
+                    android.preference.Preference triggerTestCrashPreference = new android.preference.Preference(this);
                     triggerTestCrashPreference.setKey("trigger_crash_preference");
                     triggerTestCrashPreference.setTitle("Trigger test crash");
                     triggerTestCrashPreference.setSummary("Touch here for an immediate test crash");
@@ -361,7 +356,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                 // Make it possible to test analytics, but only for DEBUG builds
                 if (BuildConfig.DEBUG) {
                     Timber.i("Debug mode, allowing for dynamic analytics config");
-                    Preference analyticsDebugMode = new Preference(this);
+                    android.preference.Preference analyticsDebugMode = new android.preference.Preference(this);
                     analyticsDebugMode.setKey("analytics_debug_preference");
                     analyticsDebugMode.setTitle("Switch Analytics to dev mode");
                     analyticsDebugMode.setSummary("Touch here to use Analytics dev tag and 100% sample rate");
@@ -378,7 +373,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                 }
                 if (BuildConfig.DEBUG) {
                     Timber.i("Debug mode, allowing database lock preference");
-                    Preference lockDbPreference = new Preference(this);
+                    android.preference.Preference lockDbPreference = new android.preference.Preference(this);
                     lockDbPreference.setKey("debug_lock_database");
                     lockDbPreference.setTitle("Lock Database");
                     lockDbPreference.setSummary("Touch here to lock the database (all threads block in-process, exception if using second process)");
@@ -390,7 +385,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                 }
                 if (BuildConfig.DEBUG) {
                     Timber.i("Debug mode, adding show changelog");
-                    Preference changelogPreference = new Preference(this);
+                    android.preference.Preference changelogPreference = new android.preference.Preference(this);
                     changelogPreference.setTitle("Open Changelog");
                     Intent infoIntent = new Intent(this, Info.class);
                     infoIntent.putExtra(Info.TYPE_EXTRA, Info.TYPE_NEW_VERSION);
@@ -418,9 +413,9 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                 getSupportActionBar().setTitle(R.string.custom_sync_server_title);
                 listener.addPreferencesFromResource(R.xml.preferences_custom_sync_server);
                 screen = listener.getPreferenceScreen();
-                Preference syncUrlPreference = screen.findPreference("syncBaseUrl");
-                Preference mSyncUrlPreference = screen.findPreference("syncMediaUrl");
-                syncUrlPreference.setOnPreferenceChangeListener((Preference preference, Object newValue) -> {
+                android.preference.Preference syncUrlPreference = screen.findPreference("syncBaseUrl");
+                android.preference.Preference mSyncUrlPreference = screen.findPreference("syncMediaUrl");
+                syncUrlPreference.setOnPreferenceChangeListener((android.preference.Preference preference, Object newValue) -> {
                     String newUrl = newValue.toString();
                     if (!URLUtil.isValidUrl(newUrl)) {
                          new AlertDialog.Builder(this)
@@ -433,7 +428,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
 
                     return true;
                 });
-                mSyncUrlPreference.setOnPreferenceChangeListener((Preference preference, Object newValue) -> {
+                mSyncUrlPreference.setOnPreferenceChangeListener((android.preference.Preference preference, Object newValue) -> {
                     String newUrl = newValue.toString();
                     if (!URLUtil.isValidUrl(newUrl)) {
                         new AlertDialog.Builder(this)
@@ -455,10 +450,10 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
     }
 
 
-    private void setupContextMenuPreference(PreferenceScreen screen, String key, @StringRes int contextMenuName) {
+    private void setupContextMenuPreference(android.preference.PreferenceScreen screen, String key, @StringRes int contextMenuName) {
         // FIXME: The menu is named in the system language (as it's defined in the manifest which may be
         //  different than the app language
-        CheckBoxPreference cardBrowserContextMenuPreference = (CheckBoxPreference) screen.findPreference(key);
+        android.preference.CheckBoxPreference cardBrowserContextMenuPreference = (android.preference.CheckBoxPreference) screen.findPreference(key);
         String menuName = getString(contextMenuName);
         // Note: The below format strings are generic, not card browser specific despite the name
         cardBrowserContextMenuPreference.setTitle(getString(R.string.card_browser_enable_external_context_menu, menuName));
@@ -507,10 +502,10 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
         }
     }
 
-    private void addThirdPartyAppsListener(PreferenceScreen screen) {
+    private void addThirdPartyAppsListener(android.preference.PreferenceScreen screen) {
         //#5864 - some people don't have a browser so we can't use <intent>
         //and need to handle the keypress ourself.
-        Preference showThirdParty = screen.findPreference("thirdpartyapps_link");
+        android.preference.Preference showThirdParty = screen.findPreference("thirdpartyapps_link");
         final String githubThirdPartyAppsUrl = "https://github.com/ankidroid/Anki-Android/wiki/Third-Party-Apps";
         showThirdParty.setOnPreferenceClickListener((preference) -> {
             try {
@@ -529,15 +524,15 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
     /**
      * Loop over every preference in the list and set the summary text
      */
-    private void initAllPreferences(PreferenceScreen screen) {
+    private void initAllPreferences(android.preference.PreferenceScreen screen) {
         for (int i = 0; i < screen.getPreferenceCount(); ++i) {
-            Preference preference = screen.getPreference(i);
-            if (preference instanceof PreferenceGroup) {
-                PreferenceGroup preferenceGroup = (PreferenceGroup) preference;
+            android.preference.Preference preference = screen.getPreference(i);
+            if (preference instanceof android.preference.PreferenceGroup) {
+                android.preference.PreferenceGroup preferenceGroup = (android.preference.PreferenceGroup) preference;
                 for (int j = 0; j < preferenceGroup.getPreferenceCount(); ++j) {
-                    Preference nestedPreference = preferenceGroup.getPreference(j);
-                    if (nestedPreference instanceof PreferenceGroup) {
-                        PreferenceGroup nestedPreferenceGroup = (PreferenceGroup) nestedPreference;
+                    android.preference.Preference nestedPreference = preferenceGroup.getPreference(j);
+                    if (nestedPreference instanceof android.preference.PreferenceGroup) {
+                        android.preference.PreferenceGroup nestedPreferenceGroup = (android.preference.PreferenceGroup) nestedPreference;
                         for (int k = 0; k < nestedPreferenceGroup.getPreferenceCount(); ++k) {
                             initPreference(nestedPreferenceGroup.getPreference(k));
                         }
@@ -553,7 +548,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
 
 
 
-    private void initPreference(Preference pref) {
+    private void initPreference(android.preference.Preference pref) {
         // Load stored values from Preferences which are stored in the Collection
         if (Arrays.asList(sCollectionPreferences).contains(pref.getKey())) {
             Collection col = getCol();
@@ -562,10 +557,10 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                     JSONObject conf = col.getConf();
                     switch (pref.getKey()) {
                         case "showEstimates":
-                            ((CheckBoxPreference)pref).setChecked(conf.getBoolean("estTimes"));
+                            ((android.preference.CheckBoxPreference)pref).setChecked(conf.getBoolean("estTimes"));
                             break;
                         case "showProgress":
-                            ((CheckBoxPreference)pref).setChecked(conf.getBoolean("dueCounts"));
+                            ((android.preference.CheckBoxPreference)pref).setChecked(conf.getBoolean("dueCounts"));
                             break;
                         case "learnCutoff":
                             ((NumberRangePreference)pref).setValue(conf.getInt("collapseTime") / 60);
@@ -574,17 +569,17 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                             ((NumberRangePreference)pref).setValue(conf.getInt("timeLim") / 60);
                             break;
                         case "useCurrent":
-                            ((ListPreference)pref).setValueIndex(conf.optBoolean("addToCur", true) ? 0 : 1);
+                            ((android.preference.ListPreference)pref).setValueIndex(conf.optBoolean("addToCur", true) ? 0 : 1);
                             break;
                         case "newSpread":
-                            ((ListPreference)pref).setValueIndex(conf.getInt("newSpread"));
+                            ((android.preference.ListPreference)pref).setValueIndex(conf.getInt("newSpread"));
                             break;
                         case "dayOffset":
                             Calendar calendar = col.crtGregorianCalendar();
                             ((SeekBarPreference)pref).setValue(calendar.get(Calendar.HOUR_OF_DAY));
                             break;
                         case "schedVer":
-                            ((CheckBoxPreference)pref).setChecked(conf.optInt("schedVer", 1) == 2);
+                            ((android.preference.CheckBoxPreference)pref).setChecked(conf.optInt("schedVer", 1) == 2);
                     }
                 } catch (NumberFormatException e) {
                     throw new RuntimeException(e);
@@ -594,7 +589,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                 pref.setEnabled(false);
             }
         } else if ("minimumCardsDueForNotification".equals(pref.getKey())) {
-            updateNotificationPreference((ListPreference) pref);
+            updateNotificationPreference((android.preference.ListPreference) pref);
         }
         // Set the value from the summary cache
         CharSequence s = pref.getSummary();
@@ -613,8 +608,8 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
     @SuppressWarnings("deprecation") // Tracked as #5019 on github - convert to fragments
     private void updatePreference(SharedPreferences prefs, String key, PreferenceContext listener) {
         try {
-            PreferenceScreen screen = listener.getPreferenceScreen();
-            Preference pref = screen.findPreference(key);
+            android.preference.PreferenceScreen screen = listener.getPreferenceScreen();
+            android.preference.Preference pref = screen.findPreference(key);
             if (pref == null) {
                 Timber.e("Preferences: no preference found for the key: %s", key);
                 return;
@@ -628,23 +623,23 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                     CustomSyncServer.handleSyncServerPreferenceChange(getBaseContext());
                     break;
                 case "timeoutAnswer": {
-                    CheckBoxPreference keepScreenOn = (CheckBoxPreference) screen.findPreference("keepScreenOn");
-                    keepScreenOn.setChecked(((CheckBoxPreference) pref).isChecked());
+                    android.preference.CheckBoxPreference keepScreenOn = (android.preference.CheckBoxPreference) screen.findPreference("keepScreenOn");
+                    keepScreenOn.setChecked(((android.preference.CheckBoxPreference) pref).isChecked());
                     break;
                 }
                 case LANGUAGE:
                     closePreferences();
                     break;
                 case "showProgress":
-                    getCol().getConf().put("dueCounts", ((CheckBoxPreference) pref).isChecked());
+                    getCol().getConf().put("dueCounts", ((android.preference.CheckBoxPreference) pref).isChecked());
                     getCol().setMod();
                     break;
                 case "showEstimates":
-                    getCol().getConf().put("estTimes", ((CheckBoxPreference) pref).isChecked());
+                    getCol().getConf().put("estTimes", ((android.preference.CheckBoxPreference) pref).isChecked());
                     getCol().setMod();
                     break;
                 case "newSpread":
-                    getCol().getConf().put("newSpread", Integer.parseInt(((ListPreference) pref).getValue()));
+                    getCol().getConf().put("newSpread", Integer.parseInt(((android.preference.ListPreference) pref).getValue()));
                     getCol().setMod();
                     break;
                 case "timeLimit":
@@ -656,7 +651,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                     getCol().setMod();
                     break;
                 case "useCurrent":
-                    getCol().getConf().put("addToCur", "0".equals(((ListPreference) pref).getValue()));
+                    getCol().getConf().put("addToCur", "0".equals(((android.preference.ListPreference) pref).getValue()));
                     getCol().setMod();
                     break;
                 case "dayOffset": {
@@ -669,7 +664,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                     break;
                 }
                 case "minimumCardsDueForNotification": {
-                    ListPreference listpref = (ListPreference) screen.findPreference("minimumCardsDueForNotification");
+                    android.preference.ListPreference listpref = (android.preference.ListPreference) screen.findPreference("minimumCardsDueForNotification");
                     if (listpref != null) {
                         updateNotificationPreference(listpref);
                         if (Integer.parseInt(listpref.getValue()) < PENDING_NOTIFICATIONS_ONLY) {
@@ -695,7 +690,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                 case "syncAccount": {
                     SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(getBaseContext());
                     String username = preferences.getString("username", "");
-                    Preference syncAccount = screen.findPreference("syncAccount");
+                    android.preference.Preference syncAccount = screen.findPreference("syncAccount");
                     if (syncAccount != null) {
                         if (TextUtils.isEmpty(username)) {
                             syncAccount.setSummary(R.string.sync_account_summ_logged_out);
@@ -709,7 +704,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                     ComponentName providerName = new ComponentName(this, "com.ichi2.anki.provider.CardContentProvider");
                     PackageManager pm = getPackageManager();
                     int state;
-                    if (((CheckBoxPreference) pref).isChecked()) {
+                    if (((android.preference.CheckBoxPreference) pref).isChecked()) {
                          state = PackageManager.COMPONENT_ENABLED_STATE_ENABLED;
                         Timber.i("AnkiDroid ContentProvider enabled by user");
                     } else {
@@ -720,7 +715,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                     break;
                 }
                 case "schedVer": {
-                    boolean wantNew = ((CheckBoxPreference) pref).isChecked();
+                    boolean wantNew = ((android.preference.CheckBoxPreference) pref).isChecked();
                     boolean haveNew = getCol().schedVer() == 2;
                     // northing to do?
                     if (haveNew == wantNew) {
@@ -735,13 +730,13 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                             getCol().modSchemaNoCheck();
                             try {
                                 getCol().changeSchedulerVer(1);
-                                ((CheckBoxPreference) pref).setChecked(false);
+                                ((android.preference.CheckBoxPreference) pref).setChecked(false);
                             } catch (ConfirmModSchemaException e2) {
                                 // This should never be reached as we explicitly called modSchemaNoCheck()
                                 throw new RuntimeException(e2);
                             }
                         });
-                        builder.onNegative((dialog, which) -> ((CheckBoxPreference) pref).setChecked(true));
+                        builder.onNegative((dialog, which) -> ((android.preference.CheckBoxPreference) pref).setChecked(true));
                         builder.positiveText(R.string.dialog_ok);
                         builder.negativeText(R.string.dialog_cancel);
                         builder.show();
@@ -754,13 +749,13 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                         getCol().modSchemaNoCheck();
                         try {
                             getCol().changeSchedulerVer(2);
-                            ((CheckBoxPreference) pref).setChecked(true);
+                            ((android.preference.CheckBoxPreference) pref).setChecked(true);
                         } catch (ConfirmModSchemaException e2) {
                             // This should never be reached as we explicitly called modSchemaNoCheck()
                             throw new RuntimeException(e2);
                         }
                     });
-                    builder.onNegative((dialog, which) -> ((CheckBoxPreference) pref).setChecked(false));
+                    builder.onNegative((dialog, which) -> ((android.preference.CheckBoxPreference) pref).setChecked(false));
                     builder.positiveText(R.string.dialog_ok);
                     builder.negativeText(R.string.dialog_cancel);
                     builder.show();
@@ -782,7 +777,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
         }
     }
 
-    public void updateNotificationPreference(ListPreference listpref) {
+    public void updateNotificationPreference(android.preference.ListPreference listpref) {
         CharSequence[] entries = listpref.getEntries();
         CharSequence[] values = listpref.getEntryValues();
         for (int i = 0; i < entries.length; i++) {
@@ -795,7 +790,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
         listpref.setSummary(listpref.getEntry().toString());
     }
 
-    private void updateSummary(Preference pref) {
+    private void updateSummary(android.preference.Preference pref) {
         if (pref == null || pref.getKey() == null) {
             return;
         }
@@ -827,10 +822,10 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                 value = Integer.toString(((NumberRangePreference) pref).getValue());
             } else if (pref instanceof SeekBarPreference) {
                 value = Integer.toString(((SeekBarPreference) pref).getValue());
-            } else if (pref instanceof ListPreference) {
-                value = ((ListPreference) pref).getEntry().toString();
-            } else if (pref instanceof EditTextPreference) {
-                value = ((EditTextPreference) pref).getText();
+            } else if (pref instanceof android.preference.ListPreference) {
+                value = ((android.preference.ListPreference) pref).getEntry().toString();
+            } else if (pref instanceof android.preference.EditTextPreference) {
+                value = ((android.preference.EditTextPreference) pref).getText();
             } else {
                 return;
             }
@@ -870,8 +865,8 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
         }
     }
 
-    private void initializeLanguageDialog(PreferenceScreen screen) {
-        ListPreference languageSelection = (ListPreference) screen.findPreference(LANGUAGE);
+    private void initializeLanguageDialog(android.preference.PreferenceScreen screen) {
+        android.preference.ListPreference languageSelection = (android.preference.ListPreference) screen.findPreference(LANGUAGE);
         if (languageSelection != null) {
             Map<String, String> items = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
             for (String localeCode : LanguageUtil.APP_LANGUAGES) {
@@ -894,27 +889,27 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
         }
     }
 
-    private void removeUnnecessaryAdvancedPrefs(PreferenceScreen screen) {
-        PreferenceCategory plugins = (PreferenceCategory) screen.findPreference("category_plugins");
+    private void removeUnnecessaryAdvancedPrefs(android.preference.PreferenceScreen screen) {
+        android.preference.PreferenceCategory plugins = (android.preference.PreferenceCategory) screen.findPreference("category_plugins");
         // Disable the emoji/kana buttons to scroll preference if those keys don't exist
         if (!CompatHelper.hasKanaAndEmojiKeys()) {
-            CheckBoxPreference emojiScrolling = (CheckBoxPreference) screen.findPreference("scrolling_buttons");
+            android.preference.CheckBoxPreference emojiScrolling = (android.preference.CheckBoxPreference) screen.findPreference("scrolling_buttons");
             if (emojiScrolling != null && plugins != null) {
                 plugins.removePreference(emojiScrolling);
             }
         }
         // Disable the double scroll preference if no scrolling keys
         if (!CompatHelper.hasScrollKeys() && !CompatHelper.hasKanaAndEmojiKeys()) {
-            CheckBoxPreference doubleScrolling = (CheckBoxPreference) screen.findPreference("double_scrolling");
+            android.preference.CheckBoxPreference doubleScrolling = (android.preference.CheckBoxPreference) screen.findPreference("double_scrolling");
             if (doubleScrolling != null && plugins != null) {
                 plugins.removePreference(doubleScrolling);
             }
         }
 
         if (AdaptionUtil.canUseContextMenu()) {
-            PreferenceCategory workarounds = (PreferenceCategory) screen.findPreference("category_workarounds");
+            android.preference.PreferenceCategory workarounds = (android.preference.PreferenceCategory) screen.findPreference("category_workarounds");
             if (workarounds != null) {
-                CheckBoxPreference miuiClipboardHack = (CheckBoxPreference) screen.findPreference("enableMIUIClipboardHack");
+                android.preference.CheckBoxPreference miuiClipboardHack = (android.preference.CheckBoxPreference) screen.findPreference("enableMIUIClipboardHack");
                 workarounds.removePreference(miuiClipboardHack);
             }
         }
@@ -922,13 +917,13 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
 
 
     /** Initializes the list of custom fonts shown in the preferences. */
-    private void initializeCustomFontsDialog(PreferenceScreen screen) {
-        ListPreference defaultFontPreference = (ListPreference) screen.findPreference("defaultFont");
+    private void initializeCustomFontsDialog(android.preference.PreferenceScreen screen) {
+        android.preference.ListPreference defaultFontPreference = (android.preference.ListPreference) screen.findPreference("defaultFont");
         if (defaultFontPreference != null) {
             defaultFontPreference.setEntries(getCustomFonts("System default"));
             defaultFontPreference.setEntryValues(getCustomFonts(""));
         }
-        ListPreference browserEditorCustomFontsPreference = (ListPreference) screen.findPreference("browserEditorFont");
+        android.preference.ListPreference browserEditorCustomFontsPreference = (android.preference.ListPreference) screen.findPreference("browserEditorFont");
         browserEditorCustomFontsPreference.setEntries(getCustomFonts("System default"));
         browserEditorCustomFontsPreference.setEntryValues(getCustomFonts("", true));
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.java
@@ -486,6 +486,7 @@ public class Whiteboard extends View {
         return mCurrentlyDrawing;
     }
 
+    @SuppressWarnings("deprecation") // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5304
     protected String saveWhiteboard(Time time) throws FileNotFoundException {
 
         Bitmap bitmap = Bitmap.createBitmap(this.getWidth(), this.getHeight(), Bitmap.Config.ARGB_8888);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.java
@@ -260,7 +260,7 @@ public class Whiteboard extends View {
         // To fix issue #1336, just make the whiteboard big and square.
         final Point p = getDisplayDimenions();
         int bitmapSize = Math.max(p.x, p.y);
-        createBitmap(bitmapSize, bitmapSize, Bitmap.Config.ARGB_4444);
+        createBitmap(bitmapSize, bitmapSize, Bitmap.Config.ARGB_8888);
     }
 
     private void drawStart(float x, float y) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.java
@@ -20,7 +20,6 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.graphics.Point;
 import android.os.Build;
-import android.preference.PreferenceManager;
 import android.view.Display;
 import android.view.WindowManager;
 import android.webkit.WebSettings;
@@ -84,7 +83,7 @@ public class UsageAnalytics {
 
         installDefaultExceptionHandler();
 
-        SharedPreferences userPrefs = PreferenceManager.getDefaultSharedPreferences(context);
+        SharedPreferences userPrefs = AnkiDroidApp.getSharedPrefs(context);
         setOptIn(userPrefs.getBoolean(ANALYTICS_OPTIN_KEY, false));
         userPrefs.registerOnSharedPreferenceChangeListener((sharedPreferences, key) -> {
             if (key.equals(ANALYTICS_OPTIN_KEY)) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
@@ -762,6 +762,7 @@ public class BasicImageFieldController extends FieldControllerBase implements IF
      *
      * @return string[] 0: file path (null if does not exist), 1: display name (null if does not exist)
      */
+    @SuppressWarnings("deprecation") // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/7014
     private @NonNull Pair<String, String> getImageInfoFromContentResolver(Context context, Uri uri, String selection) {
         Timber.d("getImagePathFromContentResolver() %s", uri);
         String[] filePathColumns = {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.java
@@ -6,8 +6,8 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.preference.PreferenceManager;
 
+import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.CollectionHelper;
 import com.ichi2.anki.Preferences;
 import com.ichi2.anki.R;
@@ -122,7 +122,7 @@ public class BootService extends BroadcastReceiver {
 
     public static void scheduleNotification(Time time, Context context) {
         AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
-        SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(context);
+        SharedPreferences sp = AnkiDroidApp.getSharedPrefs(context);
         // Don't schedule a notification if the due reminders setting is not enabled
         if (Integer.parseInt(sp.getString("minimumCardsDueForNotification", Integer.toString(Preferences.PENDING_NOTIFICATIONS_ONLY))) >= Preferences.PENDING_NOTIFICATIONS_ONLY) {
             return;

--- a/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
@@ -21,7 +21,6 @@ package com.ichi2.async;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.net.ConnectivityManager;
-import android.net.NetworkInfo;
 import android.os.AsyncTask;
 import android.os.PowerManager;
 
@@ -536,6 +535,7 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
         super.publishProgress(id, up, down);
     }
 
+    @SuppressWarnings("deprecation") // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/7013
     public static boolean isOnline() {
         if (sAllowSyncOnNoConnection) {
             return true;
@@ -543,7 +543,7 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
         ConnectivityManager cm = (ConnectivityManager) AnkiDroidApp.getInstance().getApplicationContext()
                 .getSystemService(Context.CONNECTIVITY_SERVICE);
         if (cm != null) {
-            NetworkInfo netInfo = cm.getActiveNetworkInfo();
+            android.net.NetworkInfo netInfo = cm.getActiveNetworkInfo();
             return (netInfo != null) && netInfo.isConnected();
         }
         return false;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/stats/AdvancedStatistics.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/stats/AdvancedStatistics.java
@@ -20,7 +20,6 @@ package com.ichi2.libanki.stats;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.database.Cursor;
-import android.preference.PreferenceManager;
 
 import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.CollectionHelper;
@@ -1030,7 +1029,7 @@ public class AdvancedStatistics {
         private final Collection mCol;
 
         public Settings(Context context) {
-            SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context.getApplicationContext());
+            SharedPreferences prefs = AnkiDroidApp.getSharedPrefs(context);
             mCol = CollectionHelper.getInstance().getCol(context);
 
             computeNDays = prefs.getInt("advanced_forecast_stats_compute_n_days", 0);
@@ -1039,9 +1038,9 @@ public class AdvancedStatistics {
 
             simulateNIterations = prefs.getInt("advanced_forecast_stats_mc_n_iterations", 1);
 
-            Timber.d("computeNDays: " + computeNDays);
-            Timber.d("computeMaxError: " + computeMaxError);
-            Timber.d("simulateNIterations: " + simulateNIterations);
+            Timber.d("computeNDays: %s", computeNDays);
+            Timber.d("computeMaxError: %s", computeMaxError);
+            Timber.d("simulateNIterations: %s", simulateNIterations);
         }
 
         public int getComputeNDays() {

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/CustomDialogPreference.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/CustomDialogPreference.java
@@ -19,7 +19,6 @@ package com.ichi2.preferences;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.SharedPreferences.Editor;
-import android.preference.DialogPreference;
 import android.util.AttributeSet;
 import android.widget.Toast;
 
@@ -27,7 +26,8 @@ import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.MetaDB;
 import com.ichi2.anki.R;
 
-public class CustomDialogPreference extends DialogPreference implements DialogInterface.OnClickListener {
+@SuppressWarnings("deprecation") // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5019
+public class CustomDialogPreference extends android.preference.DialogPreference implements DialogInterface.OnClickListener {
     private final Context mContext;
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/NumberRangePreference.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/NumberRangePreference.java
@@ -17,7 +17,6 @@
 package com.ichi2.preferences;
 
 import android.content.Context;
-import android.preference.EditTextPreference;
 import android.text.InputFilter;
 import android.text.InputType;
 import android.text.TextUtils;
@@ -25,7 +24,8 @@ import android.util.AttributeSet;
 
 import com.ichi2.anki.AnkiDroidApp;
 
-public class NumberRangePreference extends EditTextPreference {
+@SuppressWarnings("deprecation") // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5019
+public class NumberRangePreference extends android.preference.EditTextPreference {
 
     private final int mMin;
     private final int mMax;

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/StepsPreference.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/StepsPreference.java
@@ -17,7 +17,6 @@
 package com.ichi2.preferences;
 
 import android.content.Context;
-import android.preference.EditTextPreference;
 import android.text.InputType;
 import android.text.TextUtils;
 import android.util.AttributeSet;
@@ -29,7 +28,8 @@ import com.ichi2.anki.UIUtils;
 import com.ichi2.utils.JSONArray;
 import com.ichi2.utils.JSONException;
 
-public class StepsPreference extends EditTextPreference {
+@SuppressWarnings("deprecation") // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5019
+public class StepsPreference extends android.preference.EditTextPreference {
 
     private final boolean mAllowEmpty;
 

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/TimePreference.java
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/TimePreference.java
@@ -1,7 +1,6 @@
 package com.ichi2.preferences;
 
 import android.content.Context;
-import android.preference.DialogPreference;
 import android.util.AttributeSet;
 import android.view.View;
 import android.widget.TimePicker;
@@ -9,7 +8,8 @@ import android.widget.TimePicker;
 import com.ichi2.compat.CompatHelper;
 
 
-public class TimePreference extends DialogPreference {
+@SuppressWarnings("deprecation") // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5019
+public class TimePreference extends android.preference.DialogPreference {
     public static final String DEFAULT_VALUE = "00:00";
 
     private TimePicker timePicker;

--- a/AnkiDroid/src/main/java/com/ichi2/ui/AppCompatPreferenceActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/AppCompatPreferenceActivity.java
@@ -19,7 +19,6 @@ package com.ichi2.ui;
 import android.content.Context;
 import android.content.res.Configuration;
 import android.os.Bundle;
-import android.preference.PreferenceActivity;
 import androidx.annotation.LayoutRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -39,7 +38,8 @@ import com.ichi2.anki.AnkiDroidApp;
  * This technique can be used with an {@link android.app.Activity} class, not just
  * {@link android.preference.PreferenceActivity}.
  */
-public abstract class AppCompatPreferenceActivity extends PreferenceActivity {
+@SuppressWarnings("deprecation") // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5019
+public abstract class AppCompatPreferenceActivity extends android.preference.PreferenceActivity {
 
     private AppCompatDelegate mDelegate;
 

--- a/AnkiDroid/src/main/java/com/ichi2/ui/AutoSizeCheckBoxPreference.java
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/AutoSizeCheckBoxPreference.java
@@ -18,7 +18,6 @@ package com.ichi2.ui;
 
 import android.content.Context;
 import android.os.Build;
-import android.preference.CheckBoxPreference;
 import android.util.AttributeSet;
 import android.view.View;
 import android.view.ViewGroup;
@@ -31,7 +30,8 @@ import androidx.annotation.RequiresApi;
 
 // extending androidx.preference didn't work:
 // java.lang.ClassCastException: com.ichi2.ui.AutoSizeCheckBoxPreference cannot be cast to android.preference.Preference
-public class AutoSizeCheckBoxPreference extends CheckBoxPreference {
+@SuppressWarnings("deprecation") // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5019
+public class AutoSizeCheckBoxPreference extends android.preference.CheckBoxPreference {
     @SuppressWarnings("unused")
     public AutoSizeCheckBoxPreference(Context context) {
         super(context);

--- a/AnkiDroid/src/main/java/com/ichi2/ui/ConfirmationPreference.java
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/ConfirmationPreference.java
@@ -17,10 +17,10 @@
 package com.ichi2.ui;
 
 import android.content.Context;
-import android.preference.DialogPreference;
 import android.util.AttributeSet;
 
-public class ConfirmationPreference extends DialogPreference {
+@SuppressWarnings("deprecation") // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5019
+public class ConfirmationPreference extends android.preference.DialogPreference {
 
     private Runnable cancelHandler = () -> { /* do nothing by default */ };
     private Runnable okHandler = () -> { /* do nothing by default */ };

--- a/AnkiDroid/src/main/java/com/ichi2/ui/SeekBarPreference.java
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/SeekBarPreference.java
@@ -10,7 +10,6 @@ package com.ichi2.ui;
 
 import android.app.AlertDialog;
 import android.content.Context;
-import android.preference.DialogPreference;
 import android.util.AttributeSet;
 import android.view.Gravity;
 import android.view.View;
@@ -20,7 +19,8 @@ import android.widget.TextView;
 
 import com.ichi2.anki.AnkiDroidApp;
 
-public class SeekBarPreference extends DialogPreference implements SeekBar.OnSeekBarChangeListener {
+@SuppressWarnings("deprecation") // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5019
+public class SeekBarPreference extends android.preference.DialogPreference implements SeekBar.OnSeekBarChangeListener {
     private static final String androidns = "http://schemas.android.com/apk/res/android";
 
     private SeekBar mSeekBar;

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AnalyticsTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AnalyticsTest.java
@@ -19,7 +19,6 @@ package com.ichi2.anki;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.res.Resources;
-import android.preference.PreferenceManager;
 
 import com.brsanthu.googleanalytics.GoogleAnalytics;
 import com.brsanthu.googleanalytics.GoogleAnalyticsBuilder;
@@ -104,13 +103,14 @@ public class AnalyticsTest {
 
 
     @Test
+    @SuppressWarnings("deprecation") // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5019
     public void testSendException() {
 
         try (
-                MockedStatic<PreferenceManager> ignored = mockStatic(PreferenceManager.class);
+                MockedStatic<android.preference.PreferenceManager> ignored = mockStatic(android.preference.PreferenceManager.class);
                 MockedStatic<GoogleAnalytics> ignored1 = mockStatic(GoogleAnalytics.class)) {
 
-            when(PreferenceManager.getDefaultSharedPreferences(ArgumentMatchers.any()))
+            when(android.preference.PreferenceManager.getDefaultSharedPreferences(ArgumentMatchers.any()))
                     .thenReturn(mMockSharedPreferences);
 
             when(GoogleAnalytics.builder())


### PR DESCRIPTION
**Partially copied the description from https://github.com/ankidroid/Anki-Android/pull/7015**

This PR is a subset of the changes of the above PR which should be stable, but regularly conflict with the lint/refactoring work that we're in the middle of. This will reduce the friction of getting the main API upgrade (https://github.com/ankidroid/Anki-Android/pull/7015/commits/a833b89213c28585f9fb4d18ea9355471b3a6b4e) into the codebase.

## Purpose / Description

I believe moving to the next release of Robolectric will reduce the pain of calling native methods in the Unit Tests (due to the Rust conversion). I see a `UnsatisfiedLinkError` when moving between tests with `LooperMode.LEGACY` and `LooperMode.PAUSED`, Robolectric 4.4.4 should satisfy this as `LooperMode.PAUSED` is now the default, and it's better to move forward to the latest version, rather than patch the old code to use `LooperMode.PAUSED` without taking advantage of the API/code improvements in the new version of Roblectric

----

Robolectric 4.4.4 requires API29 with associated deprecation notices, switches to JDK11 for development (been working for a while now but we'll all have to install JDK11 now and I need to update developer documentation - it's in "Project Structure" / "SDK Location" in Android Studio I believe)

## How Has This Been Tested?

It will be tested in Travis 
