### PR TITLE
Use in-memory database for most Robolectric tests

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
@@ -54,7 +54,10 @@ import org.robolectric.shadows.ShadowLog;
 
 import java.util.ArrayList;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import com.ichi2.utils.InMemorySQLiteOpenHelperFactory;
+import androidx.sqlite.db.SupportSQLiteOpenHelper;
 import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory;
 import androidx.test.core.app.ApplicationProvider;
 import timber.log.Timber;
@@ -72,13 +75,17 @@ public class RobolectricTest {
         controllersForCleanup.add(controller);
     }
 
+    protected boolean useInMemoryDatabase() {
+        return true;
+    }
+
     @Before
     public void setUp() {
         // If you want to see the Android logging (from Timber), you need to set it up here
         ShadowLog.stream = System.out;
 
         // Robolectric can't handle our default sqlite implementation of requery, it needs the framework
-        DB.setSqliteOpenHelperFactory(new FrameworkSQLiteOpenHelperFactory());
+        DB.setSqliteOpenHelperFactory(getHelperFactory());
 
         //Reset static variable for custom tabs failure.
         CustomTabActivityHelper.resetFailed();
@@ -86,6 +93,18 @@ public class RobolectricTest {
         //See: #6140 - This global ideally shouldn't exist, but it will cause crashes if set.
         DialogHandler.discardMessage();
     }
+
+
+    @NonNull
+    protected SupportSQLiteOpenHelper.Factory getHelperFactory() {
+        if (useInMemoryDatabase()) {
+            Timber.w("Using in-memory database for test. Collection should not be re-opened");
+            return new InMemorySQLiteOpenHelperFactory();
+        } else {
+            return new FrameworkSQLiteOpenHelperFactory();
+        }
+    }
+
 
     @After
     public void tearDown() {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
@@ -275,10 +275,8 @@ public class RobolectricTest {
     }
 
 
-    protected SchedV2 upgradeToSchedV2() {
-        getCol().getConf().put("schedVer", 2);
-        getCol().setMod();
-        CollectionHelper.getInstance().closeCollection(true, "upgradeToSchedV2");
+    protected SchedV2 upgradeToSchedV2() throws ConfirmModSchemaException {
+        getCol().changeSchedulerVer(2);
 
         AbstractSched sched = getCol().getSched();
         //Sched inherits from schedv2...

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/AnkiPackageExporterTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/AnkiPackageExporterTest.java
@@ -44,6 +44,12 @@ import static org.hamcrest.Matchers.hasSize;
 @RunWith(AndroidJUnit4.class)
 public class AnkiPackageExporterTest extends RobolectricTest {
 
+    @Override
+    protected boolean useInMemoryDatabase() {
+        return false;
+    }
+
+
     @Test
     public void missingFileInDeckExportDoesSkipsFile() throws IOException, ImportExportException {
         // arrange

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/FinderTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/FinderTest.java
@@ -19,6 +19,7 @@ package com.ichi2.libanki;
 import android.util.Pair;
 
 import com.ichi2.anki.RobolectricTest;
+import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.libanki.sched.SchedV2;
 import com.ichi2.libanki.utils.Time;
 import com.ichi2.utils.JSONObject;
@@ -55,7 +56,7 @@ public class FinderTest extends RobolectricTest {
 
     @Test
     @Config(qualifiers = "en")
-    public void searchForBuriedReturnsManuallyAndSiblingBuried() {
+    public void searchForBuriedReturnsManuallyAndSiblingBuried() throws ConfirmModSchemaException {
         final String searchQuery = "is:buried";
 
         SchedV2 sched = upgradeToSchedV2();  //needs to be first

--- a/AnkiDroid/src/test/java/com/ichi2/utils/InMemorySQLiteOpenHelperFactory.java
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/InMemorySQLiteOpenHelperFactory.java
@@ -1,0 +1,37 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.utils;
+
+import androidx.annotation.NonNull;
+import androidx.sqlite.db.SupportSQLiteOpenHelper;
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory;
+
+public class InMemorySQLiteOpenHelperFactory implements SupportSQLiteOpenHelper.Factory {
+    @NonNull
+    @Override
+    public SupportSQLiteOpenHelper create(
+            @NonNull SupportSQLiteOpenHelper.Configuration configuration) {
+        SupportSQLiteOpenHelper.Configuration inMemoryConfig = SupportSQLiteOpenHelper.Configuration
+                .builder(configuration.context)
+                .name(null) // in-memory
+                .callback(configuration.callback)
+                .noBackupDirectory(configuration.useNoBackupDirectory)
+                .build();
+
+        return new FrameworkSQLiteOpenHelperFactory().create(inMemoryConfig);
+    }
+}


### PR DESCRIPTION
## Purpose / Description
Shaves 4/5 minutes off a Robolectric run, about 15 minutes off my unit test run (20mins -> 5 mins)

## How Has This Been Tested?

Test-only

## Learning

https://developer.android.com/reference/android/arch/persistence/db/SupportSQLiteOpenHelper.Configuration - null name for in-memory.


## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code