### PR TITLE
Reordered menu items in the card template editor.

### DIFF
--- a/AnkiDroid/src/main/res/menu/card_template_editor.xml
+++ b/AnkiDroid/src/main/res/menu/card_template_editor.xml
@@ -1,15 +1,15 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:ankidroid="http://schemas.android.com/apk/res-auto" >
     <item
-        android:id="@+id/action_preview"
-        android:icon="@drawable/ic_remove_red_eye_white_24dp"
-        android:title="@string/card_editor_preview_card"
-        ankidroid:showAsAction="ifRoom"
-        android:visible="true"/>
-    <item
         android:id="@+id/action_confirm"
         android:icon="@drawable/ic_done_white_24dp"
         android:title="@string/save"
+        ankidroid:showAsAction="ifRoom"
+        android:visible="true"/>
+    <item
+        android:id="@+id/action_preview"
+        android:icon="@drawable/ic_remove_red_eye_white_24dp"
+        android:title="@string/card_editor_preview_card"
         ankidroid:showAsAction="ifRoom"
         android:visible="true"/>
     <item


### PR DESCRIPTION
Now the Save icon is in the toolbar on small screens instead of Preview. Matches the icon order on the previous note editor screen.

## Fixes
Fixes #7341 

## How Has This Been Tested?

Emulator.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
