### PR TITLE
Split buried/suspended in statistics view

### DIFF
--- a/AnkiDroid/lint-baseline.xml
+++ b/AnkiDroid/lint-baseline.xml
@@ -9489,17 +9489,6 @@
 
     <issue
         id="UnusedResources"
-        message="The resource `R.color.stats_suspended_and_buried` appears to be unused"
-        errorLine1="    &lt;color name=&quot;stats_suspended_and_buried&quot;>#ff0&lt;/color>"
-        errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/res/values/colors.xml"
-            line="28"
-            column="12"/>
-    </issue>
-
-    <issue
-        id="UnusedResources"
         message="The resource `R.color.material_blue_grey_050` appears to be unused"
         errorLine1="    &lt;color name=&quot;material_blue_grey_050&quot;>#ffeceff1&lt;/color>"
         errorLine2="           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">

--- a/AnkiDroid/src/main/java/com/ichi2/anki/stats/ChartBuilder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/stats/ChartBuilder.java
@@ -173,26 +173,31 @@ public class ChartBuilder {
         ColorWrap[] colors = {new ColorWrap(Themes.getColorFromAttr(mChartView.getContext(), mColors[0])),
                               new ColorWrap(Themes.getColorFromAttr(mChartView.getContext(), mColors[1])),
                               new ColorWrap(Themes.getColorFromAttr(mChartView.getContext(), mColors[2])),
-                              new ColorWrap(Themes.getColorFromAttr(mChartView.getContext(), mColors[3]))};
+                              new ColorWrap(Themes.getColorFromAttr(mChartView.getContext(), mColors[3])),
+                              new ColorWrap(Themes.getColorFromAttr(mChartView.getContext(), mColors[4]))};
 
         PieChart pieChart = new PieChart(plotSheet, mSeriesList[0], colors);
         pieChart.setName(mChartView.getResources().getString(mValueLabels[0]) + ": " + (int) mSeriesList[0][0]);
         LegendDrawable legendDrawable1 = new LegendDrawable();
         LegendDrawable legendDrawable2 = new LegendDrawable();
         LegendDrawable legendDrawable3 = new LegendDrawable();
+        LegendDrawable legendDrawable4 = new LegendDrawable();
         legendDrawable1.setColor(new ColorWrap(Themes.getColorFromAttr(mChartView.getContext(), mColors[1])));
         legendDrawable2.setColor(new ColorWrap(Themes.getColorFromAttr(mChartView.getContext(), mColors[2])));
         legendDrawable3.setColor(new ColorWrap(Themes.getColorFromAttr(mChartView.getContext(), mColors[3])));
+        legendDrawable4.setColor(new ColorWrap(Themes.getColorFromAttr(mChartView.getContext(), mColors[4])));
 
         legendDrawable1.setName(mChartView.getResources().getString(mValueLabels[1]) + ": " + (int) mSeriesList[0][1]);
         legendDrawable2.setName(mChartView.getResources().getString(mValueLabels[2]) + ": " + (int) mSeriesList[0][2]);
         legendDrawable3.setName(mChartView.getResources().getString(mValueLabels[3]) + ": " + (int) mSeriesList[0][3]);
+        legendDrawable4.setName(mChartView.getResources().getString(mValueLabels[4]) + ": " + (int) mSeriesList[0][4]);
 
         plotSheet.unsetBorder();
         plotSheet.addDrawable(pieChart);
         plotSheet.addDrawable(legendDrawable1);
         plotSheet.addDrawable(legendDrawable2);
         plotSheet.addDrawable(legendDrawable3);
+        plotSheet.addDrawable(legendDrawable4);
 
         return plotSheet;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/stats/Stats.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/stats/Stats.java
@@ -1295,8 +1295,8 @@ public class Stats {
         mTitle = R.string.stats_cards_types;
         mBackwards = false;
         mAxisTitles = new int[] { R.string.stats_answer_type, R.string.stats_answers, R.string.stats_cumulative_correct_percentage };
-        mValueLabels = new int[] {R.string.statistics_mature, R.string.statistics_young_and_learn, R.string.statistics_unlearned, R.string.statistics_suspended_and_buried};
-        mColors = new int[] { R.attr.stats_mature, R.attr.stats_young, R.attr.stats_unseen, R.attr.stats_suspended_and_buried };
+        mValueLabels = new int[] {R.string.statistics_mature, R.string.statistics_young_and_learn, R.string.statistics_unlearned, R.string.statistics_suspended_and_buried, R.string.statistics_buried};
+        mColors = new int[] { R.attr.stats_mature, R.attr.stats_young, R.attr.stats_unseen, R.attr.stats_suspended_and_buried, R.attr.stats_buried };
         mType = type;
         double[] pieData;
         Cursor cur = null;
@@ -1304,7 +1304,8 @@ public class Stats {
                 "sum(case when queue=" + Consts.QUEUE_TYPE_REV + " and ivl >= 21 then 1 else 0 end), -- mtr\n" +
                 "sum(case when queue in (" + Consts.QUEUE_TYPE_LRN + "," + Consts.QUEUE_TYPE_DAY_LEARN_RELEARN + ") or (queue=" + Consts.QUEUE_TYPE_REV + " and ivl < 21) then 1 else 0 end), -- yng/lrn\n" +
                 "sum(case when queue=" + Consts.QUEUE_TYPE_NEW + " then 1 else 0 end), -- new\n" +
-                "sum(case when queue<0 then 1 else 0 end) -- susp\n" +
+                "sum(case when queue=" + Consts.QUEUE_TYPE_SUSPENDED + " then 1 else 0 end), -- susp\n" +
+                "sum(case when queue in (" + Consts.QUEUE_TYPE_MANUALLY_BURIED + "," + Consts.QUEUE_TYPE_SIBLING_BURIED + ") then 1 else 0 end) -- buried\n" +
                 "from cards where did in " + _limit();
         Timber.d("CardsTypes query: %s", query);
 
@@ -1314,7 +1315,7 @@ public class Stats {
                     .query(query, null);
 
             cur.moveToFirst();
-            pieData = new double[]{ cur.getDouble(0), cur.getDouble(1), cur.getDouble(2), cur.getDouble(3) };
+            pieData = new double[]{ cur.getDouble(0), cur.getDouble(1), cur.getDouble(2), cur.getDouble(3), cur.getDouble(4) };
         } finally {
             if (cur != null && !cur.isClosed()) {
                 cur.close();
@@ -1335,7 +1336,7 @@ public class Stats {
 //            list.add(new double[] { Math.max(12, list.get(list.size() - 1)[0] + 1), 0, 0 });
 //        }
 
-        mSeriesList = new double[1][4];
+        mSeriesList = new double[1][5];
         mSeriesList[0] = pieData;
         mFirstElement = 0.5;
         mLastElement = 9.5;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/stats/Stats.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/stats/Stats.java
@@ -1295,8 +1295,8 @@ public class Stats {
         mTitle = R.string.stats_cards_types;
         mBackwards = false;
         mAxisTitles = new int[] { R.string.stats_answer_type, R.string.stats_answers, R.string.stats_cumulative_correct_percentage };
-        mValueLabels = new int[] {R.string.statistics_mature, R.string.statistics_young_and_learn, R.string.statistics_unlearned, R.string.statistics_suspended_and_buried, R.string.statistics_buried};
-        mColors = new int[] { R.attr.stats_mature, R.attr.stats_young, R.attr.stats_unseen, R.attr.stats_suspended_and_buried, R.attr.stats_buried };
+        mValueLabels = new int[] {R.string.statistics_mature, R.string.statistics_young_and_learn, R.string.statistics_unlearned, R.string.statistics_suspended, R.string.statistics_buried};
+        mColors = new int[] { R.attr.stats_mature, R.attr.stats_young, R.attr.stats_unseen, R.attr.stats_suspended, R.attr.stats_buried };
         mType = type;
         double[] pieData;
         Cursor cur = null;

--- a/AnkiDroid/src/main/res/values/06-statistics.xml
+++ b/AnkiDroid/src/main/res/values/06-statistics.xml
@@ -22,7 +22,7 @@
     <string name="statistics_mature">Mature</string>
     <string name="statistics_young_and_learn">Young+Learn</string>
     <string name="statistics_unlearned">Unseen</string>
-    <string name="statistics_suspended_and_buried">Suspended</string>
+    <string name="statistics_suspended">Suspended</string>
     <string name="statistics_buried">Buried</string>
     <string name="statistics_relearn">Relearn</string>
     <string name="statistics_learn">Learn</string>

--- a/AnkiDroid/src/main/res/values/06-statistics.xml
+++ b/AnkiDroid/src/main/res/values/06-statistics.xml
@@ -22,7 +22,8 @@
     <string name="statistics_mature">Mature</string>
     <string name="statistics_young_and_learn">Young+Learn</string>
     <string name="statistics_unlearned">Unseen</string>
-    <string name="statistics_suspended_and_buried">Suspended+Buried</string>
+    <string name="statistics_suspended_and_buried">Suspended</string>
+    <string name="statistics_buried">Buried</string>
     <string name="statistics_relearn">Relearn</string>
     <string name="statistics_learn">Learn</string>
     <string name="statistics_cram">Cram</string>

--- a/AnkiDroid/src/main/res/values/attrs.xml
+++ b/AnkiDroid/src/main/res/values/attrs.xml
@@ -85,6 +85,7 @@
     <attr name="stats_counts" format="color"/>
     <attr name="stats_unseen" format="color"/>
     <attr name="stats_suspended_and_buried" format="color"/>
+    <attr name="stats_buried" format="color"/>
     <attr name="stats_cumulative" format="color"/>
     <!-- Reviewer other colors -->
     <attr name="topBarColor" format="color"/>

--- a/AnkiDroid/src/main/res/values/attrs.xml
+++ b/AnkiDroid/src/main/res/values/attrs.xml
@@ -84,7 +84,7 @@
     <attr name="stats_hours" format="color"/>
     <attr name="stats_counts" format="color"/>
     <attr name="stats_unseen" format="color"/>
-    <attr name="stats_suspended_and_buried" format="color"/>
+    <attr name="stats_suspended" format="color"/>
     <attr name="stats_buried" format="color"/>
     <attr name="stats_cumulative" format="color"/>
     <!-- Reviewer other colors -->

--- a/AnkiDroid/src/main/res/values/colors.xml
+++ b/AnkiDroid/src/main/res/values/colors.xml
@@ -25,7 +25,7 @@
     <color name="stats_hours">#ccc</color>
     <color name="stats_counts">#E6000000</color>
     <color name="stats_unseen">#000</color>
-    <color name="stats_suspended_and_buried">#ff0</color>
+    <color name="stats_suspended">#ff0</color>
     <color name="stats_buried">#606264</color>
     <color name="stats_cumulative">#000000</color>
     <color name="transparent">#00000000</color>

--- a/AnkiDroid/src/main/res/values/colors.xml
+++ b/AnkiDroid/src/main/res/values/colors.xml
@@ -26,6 +26,7 @@
     <color name="stats_counts">#E6000000</color>
     <color name="stats_unseen">#000</color>
     <color name="stats_suspended_and_buried">#ff0</color>
+    <color name="stats_buried">#606264</color>
     <color name="stats_cumulative">#000000</color>
     <color name="transparent">#00000000</color>
     <color name="white">#ffffff</color>

--- a/AnkiDroid/src/main/res/values/theme_black.xml
+++ b/AnkiDroid/src/main/res/values/theme_black.xml
@@ -76,7 +76,7 @@
         <item name="stats_hours">@color/material_grey_500</item>
         <item name="stats_counts">@color/material_grey_800</item>
         <item name="stats_unseen">@color/material_grey_800</item>
-        <item name="stats_suspended_and_buried">#ff0</item>
+        <item name="stats_suspended">#ff0</item>
         <item name="stats_buried">#606264</item>
         <item name="stats_cumulative">@color/material_grey_800</item>
         <!-- Browser colors -->

--- a/AnkiDroid/src/main/res/values/theme_black.xml
+++ b/AnkiDroid/src/main/res/values/theme_black.xml
@@ -77,6 +77,7 @@
         <item name="stats_counts">@color/material_grey_800</item>
         <item name="stats_unseen">@color/material_grey_800</item>
         <item name="stats_suspended_and_buried">#ff0</item>
+        <item name="stats_buried">#606264</item>
         <item name="stats_cumulative">@color/material_grey_800</item>
         <!-- Browser colors -->
         <item name="suspendedColor">#A8A634</item>

--- a/AnkiDroid/src/main/res/values/theme_dark.xml
+++ b/AnkiDroid/src/main/res/values/theme_dark.xml
@@ -81,7 +81,7 @@
         <item name="stats_hours">#ccc</item>
         <item name="stats_counts">#E6000000</item>
         <item name="stats_unseen">#000</item>
-        <item name="stats_suspended_and_buried">#ff0</item>
+        <item name="stats_suspended">#ff0</item>
         <item name="stats_buried">#606264</item>
         <item name="stats_cumulative">@color/stats_cumulative</item>
         <!-- Browser colors -->

--- a/AnkiDroid/src/main/res/values/theme_dark.xml
+++ b/AnkiDroid/src/main/res/values/theme_dark.xml
@@ -82,6 +82,7 @@
         <item name="stats_counts">#E6000000</item>
         <item name="stats_unseen">#000</item>
         <item name="stats_suspended_and_buried">#ff0</item>
+        <item name="stats_buried">#606264</item>
         <item name="stats_cumulative">@color/stats_cumulative</item>
         <!-- Browser colors -->
         <item name="suspendedColor">@color/material_grey_700</item>

--- a/AnkiDroid/src/main/res/values/theme_light.xml
+++ b/AnkiDroid/src/main/res/values/theme_light.xml
@@ -94,7 +94,7 @@ APIs. It's visible when there aren't enough decks to fill the screen.
         <item name="stats_hours">#ccc</item>
         <item name="stats_counts">#E6000000</item>
         <item name="stats_unseen">#000</item>
-        <item name="stats_suspended_and_buried">#ff0</item>
+        <item name="stats_suspended">#ff0</item>
         <item name="stats_buried">#606264</item>
         <item name="stats_cumulative">@color/stats_cumulative</item>
         <!-- Browser colors -->

--- a/AnkiDroid/src/main/res/values/theme_light.xml
+++ b/AnkiDroid/src/main/res/values/theme_light.xml
@@ -95,6 +95,7 @@ APIs. It's visible when there aren't enough decks to fill the screen.
         <item name="stats_counts">#E6000000</item>
         <item name="stats_unseen">#000</item>
         <item name="stats_suspended_and_buried">#ff0</item>
+        <item name="stats_buried">#606264</item>
         <item name="stats_cumulative">@color/stats_cumulative</item>
         <!-- Browser colors -->
         <item name="suspendedColor">#FFFFB2</item>


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
I use templates that produce a lot of siblings, and want to be able to see my current number of buried cards without actually typing in a search. Generally, I do this by using the Statistics view to see my number of "Suspended+Buried" cards at the start of the day. If I remember that number, I can just check "Suspended+Buried" again later in the day to get a sense of how many buried cards I must have. That's kind of silly, though, and ever since I noticed desktop Anki split "Suspended+Buried" into separate "Suspended" and "Buried" stats, I've wanted the Android app to do the same.

## Fixes
I haven't filed an issue to request this feature yet. Should I do that?

## Approach
This change just extends what AnkiDroid already does to draw the card-types pie chart. It makes the "suspended+buried" subquery specific to suspended cards, adds another subquery for buried cards, and updates various places where AnkiDroid reads the results of the card-types query.

## How Has This Been Tested?
I created a new deck, turned on sibling burial, created a cloze note with two deletions, and created a handful of basic cards.  I suspended one of the basic cards, marked another as easy, and manually buried a third. When I drew the cloze card, I marked it as easy.

Then I opened the Statistics tab and confirmed that the type-counts were correct and the pie chart looked reasonable.

I did this using an emulator (Pixel 2 API 30).

This is the first time I've done any sort of Android development, so I don't know which devices or versions are likely to run into problems with this type of change. I'd be happy to repeat my tests against other configurations if that would be helpful.

## Learning (optional, can help others)
I looked around at what desktop Anki does. I think [this](https://github.com/ankitects/anki/blob/41d74592f0068428992b8e7cfd27a874c6da3823/ts/src/stats/card-counts.ts#L28) is the most relevant function.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code

I'm not sure where this fits into the template, but: I didn't update the localization key-name (per [the Development Guide in the wiki](https://github.com/ankidroid/Anki-Android/wiki/Development-Guide#handling-translations)). But it seems like that might be a good idea. `"statistics_suspended_and_buried"` is really just `"statistics_suspended"` now. Same thing is true of the `"stats_suspended_and_buried"` color attribute - maybe I can change that one safely without messing up existing translations?

Also, I'm not sure I handled the new colors correctly. I just added an arbitrary shade of gray for "Buried". I didn't poke around in desktop Anki to make sure the colors match, since I assume Ankidroid's color schemes are more complicated/configurable than desktop Anki's. Let me know if I should go find the colors and make them match.