### PR TITLE
Dependency updates 20201004

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -256,7 +256,7 @@ dependencies {
     implementation 'org.jsoup:jsoup:1.13.1'
     api project(":api")
 
-    testImplementation 'org.junit.vintage:junit-vintage-engine:5.6.2'
+    testImplementation 'org.junit.vintage:junit-vintage-engine:5.7.0'
     testImplementation 'org.mockito:mockito-inline:3.5.13'
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
     testImplementation 'net.lachlanmckee:timber-junit-rule:1.0.1'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -222,7 +222,7 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.browser:browser:1.2.0'
-    implementation 'androidx.exifinterface:exifinterface:1.2.0'
+    implementation 'androidx.exifinterface:exifinterface:1.3.0'
     implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'
     implementation "androidx.multidex:multidex:2.0.1"
     implementation "androidx.preference:preference:1.1.1"

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -218,7 +218,7 @@ dependencies {
 
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     // Note: the design support library can be quite buggy, so test everything thoroughly before updating it
-    implementation 'com.google.android.material:material:1.2.0'
+    implementation 'com.google.android.material:material:1.2.1'
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.browser:browser:1.2.0'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -257,7 +257,7 @@ dependencies {
     api project(":api")
 
     testImplementation 'org.junit.vintage:junit-vintage-engine:5.6.2'
-    testImplementation 'org.mockito:mockito-inline:3.5.9'
+    testImplementation 'org.mockito:mockito-inline:3.5.13'
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
     testImplementation 'net.lachlanmckee:timber-junit-rule:1.0.1'
     testImplementation "org.robolectric:robolectric:4.4"

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -51,7 +51,7 @@ apply from: "../lint.gradle"
 dependencies {
     api fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.annotation:annotation:1.1.0'
-    testImplementation 'org.junit.vintage:junit-vintage-engine:5.6.2'
+    testImplementation 'org.junit.vintage:junit-vintage-engine:5.7.0'
     testImplementation 'org.robolectric:robolectric:4.4'
 
     lintPublish project(":lint-rules")

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -9,12 +9,12 @@ repositories {
     jcenter()
 }
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
 
     defaultConfig {
-        minSdkVersion 8
+        minSdkVersion 14
         //noinspection OldTargetApi
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 11016   // 4th digit: 1=alpha, 2=beta, 3=official
         versionName version
     }
@@ -52,7 +52,7 @@ dependencies {
     api fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'androidx.annotation:annotation:1.1.0'
     testImplementation 'org.junit.vintage:junit-vintage-engine:5.6.2'
-    testImplementation 'org.robolectric:robolectric:4.3.1'
+    testImplementation 'org.robolectric:robolectric:4.4'
 
     lintPublish project(":lint-rules")
 }

--- a/api/src/test/resources/robolectric.properties
+++ b/api/src/test/resources/robolectric.properties
@@ -1,0 +1,3 @@
+# SDK 29 requires JDK 9 (JDK 11 is the LTS). We do this for now to avoid having a
+# nonstandard Android workflow
+sdk=28


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

Standard dependency tracker PR, this one has quite a pile because the robolectric 4.4 / API29 item was so large for AnkiDroid took a while.

This does the same robolectric 4.4 / API29 change for the api module, plus all the items queued up

## Approach
Let dependabot run on my local fork and merge it's PRs...

## How Has This Been Tested?

Tested locally against API16, 29 and 30 emulators with `./gradlew clean jacocoTestReport` - all seems fine?
