### PR TITLE
Fix AnkiDroidApp.sInstance-is-null crash during dialog inflation

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/AsyncDialogFragment.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/AsyncDialogFragment.java
@@ -5,6 +5,8 @@ import android.os.Message;
 import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.analytics.AnalyticsDialogFragment;
 
+import timber.log.Timber;
+
 public abstract class AsyncDialogFragment extends AnalyticsDialogFragment {
     /* provide methods for text to show in notification bar when the DialogFragment
        can't be shown due to the host activity being in stopped state.
@@ -19,6 +21,11 @@ public abstract class AsyncDialogFragment extends AnalyticsDialogFragment {
     }
 
     protected Resources res() {
-        return AnkiDroidApp.getAppResources();
+        try {
+            return AnkiDroidApp.getAppResources();
+        } catch (Exception e) {
+            Timber.w(e, "AnkiDroidApp.getAppResources failure. Returning Fragment resources as fallback.");
+            return getResources();
+        }
     }
 } 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

This is our top crash on play store for 2.13.5

The crash trace indicated that somehow database dialog fragment inflater
was called via an Activity.onCreate call chain, and somehow it was before
Application.onCreate got to the point where sInstance was set.

How? It's only on Huawei phones and they appear to have a separate ActivityThread
so I'm guessing it's a vendor-specific race. In this case resources have fallback
access via the Dialog inheritance chain so I implement a fallback

This seems like a major violation of lifecycle order of operations so I'm not
inclined to dive much deeper but we can avoid a crash and provide a reasonable fallback
at least


## Fixes
Unlogged

```
java.lang.RuntimeException: 
  at android.app.ActivityThread.performLaunchActivity (ActivityThread.java:3303)
  at android.app.ActivityThread.handleLaunchActivity (ActivityThread.java:3411)
  at android.app.ActivityThread.-wrap12 (Unknown Source)
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:1994)
  at android.os.Handler.dispatchMessage (Handler.java:108)
  at android.os.Looper.loop (Looper.java:166)
  at android.app.ActivityThread.main (ActivityThread.java:7529)
  at java.lang.reflect.Method.invoke (Method.java)
  at com.android.internal.os.Zygote$MethodAndArgsCaller.run (Zygote.java:245)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:921)
Caused by: java.lang.NullPointerException: 
  at com.ichi2.anki.AnkiDroidApp.getAppResources (AnkiDroidApp.java:341)
  at com.ichi2.anki.dialogs.AsyncDialogFragment.res (AsyncDialogFragment.java:22)
  at com.ichi2.anki.dialogs.DatabaseErrorDialog.getTitle (DatabaseErrorDialog.java:383)
  at com.ichi2.anki.dialogs.DatabaseErrorDialog.onCreateDialog (DatabaseErrorDialog.java:71)
  at com.ichi2.anki.dialogs.DatabaseErrorDialog.onCreateDialog (DatabaseErrorDialog.java:28)
  at androidx.fragment.app.DialogFragment.onGetLayoutInflater (DialogFragment.java:380)
  at androidx.fragment.app.Fragment.performGetLayoutInflater (Fragment.java:1412)
  at androidx.fragment.app.FragmentManagerImpl.moveToState (FragmentManagerImpl.java:881)
  at androidx.fragment.app.FragmentManagerImpl.moveFragmentToExpectedState (FragmentManagerImpl.java:1238)
  at androidx.fragment.app.FragmentManagerImpl.moveToState (FragmentManagerImpl.java:1303)
  at androidx.fragment.app.FragmentManagerImpl.dispatchStateChange (FragmentManagerImpl.java:2659)
  at androidx.fragment.app.FragmentManagerImpl.dispatchActivityCreated (FragmentManagerImpl.java:2613)
  at androidx.fragment.app.FragmentController.dispatchActivityCreated (FragmentController.java:246)
  at androidx.fragment.app.FragmentActivity.onStart (FragmentActivity.java:542)
  at androidx.appcompat.app.AppCompatActivity.onStart (AppCompatActivity.java:210)
  at com.ichi2.anki.AnkiActivity.onStart (AnkiActivity.java:94)
  at android.app.Instrumentation.callActivityOnStart (Instrumentation.java:1339)
  at android.app.Activity.performStart (Activity.java:7403)
  at android.app.ActivityThread.performLaunchActivity (ActivityThread.java:3266)
  at android.app.ActivityThread.handleLaunchActivity (ActivityThread.java:3411)
  at android.app.ActivityThread.-wrap12 (Unknown Source)
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:1994)
  at android.os.Handler.dispatchMessage (Handler.java:108)
  at android.os.Looper.loop (Looper.java:166)
  at android.app.ActivityThread.main (ActivityThread.java:7529)
  at java.lang.reflect.Method.invoke (Method.java)
  at com.android.internal.os.Zygote$MethodAndArgsCaller.run (Zygote.java:245)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:921)
```

https://play.google.com/console/u/0/developers/5338425030304417978/app/4973711737547064258/vitals/crashes/31b9b3ea/details?days=30&versionCode=321300305%2C221300305%2C121300305

## Approach
Access resources (which may not be our preferred language-overridden resources, unfortunately) via inheritance chain vs AnkiDroidApp.sInstance

## How Has This Been Tested?

I don't have a Huawei device nor know how to trigger this so just `./gradlew jacocoTestReport` and git push...

## Learning (optional, can help others)
I always thought a ContentProvider was started before everything, and worst case the Application.onCreate would finish before Activity.onCreate was called, but what do I know?

## Checklist


- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
