### PR TITLE
Fix #7118: Adding Filter by flag icon to card browser.

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -67,7 +67,6 @@ import com.ichi2.anki.dialogs.RescheduleDialog;
 import com.ichi2.anki.dialogs.SimpleMessageDialog;
 import com.ichi2.anki.dialogs.TagsDialog;
 import com.ichi2.anki.receiver.SdCardReceiver;
-import com.ichi2.anki.reviewer.ReviewerUi;
 import com.ichi2.anki.widgets.DeckDropDownAdapter;
 import com.ichi2.async.CollectionTask;
 import com.ichi2.async.TaskListenerWithContext;
@@ -805,7 +804,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
 
     @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
+    public boolean onCreateOptionsMenu(final Menu menu) {
         Timber.d("onCreateOptionsMenu()");
         mActionBarMenu = menu;
         if (!mInMultiSelectMode) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -828,8 +828,6 @@ public class CardBrowser extends NavigationDrawerActivity implements
                     // SearchView doesn't support empty queries so we always reset the search when collapsing
                     mSearchTerms = "";
                     mSearchView.setQuery(mSearchTerms, false);
-                    mCurrentFlag = 0;
-                    setFlagColor(menu);
                     searchCards();
                     // invalidate options menu so that disappeared icons would appear again
                     supportInvalidateOptionsMenu();
@@ -889,35 +887,6 @@ public class CardBrowser extends NavigationDrawerActivity implements
         onSelectionChanged();
         updatePreviewMenuItem();
         return super.onCreateOptionsMenu(menu);
-    }
-
-    @Override
-    public boolean onPrepareOptionsMenu(Menu menu) {
-        setFlagColor(menu);
-        return super.onPrepareOptionsMenu(menu);
-    }
-
-    private void setFlagColor(Menu menu) {
-        @Nullable MenuItem flag_icon = menu.findItem(R.id.action_search_by_flag);
-        if (flag_icon != null) {
-            switch (mCurrentFlag) {
-                case 1:
-                    flag_icon.setIcon(R.drawable.ic_flag_red);
-                    break;
-                case 2:
-                    flag_icon.setIcon(R.drawable.ic_flag_orange);
-                    break;
-                case 3:
-                    flag_icon.setIcon(R.drawable.ic_flag_green);
-                    break;
-                case 4:
-                    flag_icon.setIcon(R.drawable.ic_flag_blue);
-                    break;
-                default:
-                    flag_icon.setIcon(R.drawable.ic_flag_transparent);
-                    break;
-            }
-        }
     }
 
     @Override
@@ -1003,7 +972,6 @@ public class CardBrowser extends NavigationDrawerActivity implements
     /** Updates flag icon color and cards shown with given color */
     private void selectionWithFlagTask(int flag) {
         mCurrentFlag = flag;
-        invalidateOptionsMenu();
         filterByFlag();
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1003,11 +1003,10 @@ public class CardBrowser extends NavigationDrawerActivity implements
                                 new TaskData(new Object[]{getSelectedCardIds(), Collection.DismissType.FLAG, flag}));
     }
 
-    private void selectionWithFlagTask (int flag) {
-        // Change icon to match color of selected flag.
+    /** Updates flag icon color and cards shown with given color */
+    private void selectionWithFlagTask(int flag) {
         mCurrentFlag = flag;
         invalidateOptionsMenu();
-        // Update mSearchTerms to match selected flag.
         filterByFlag();
     }
 
@@ -1554,9 +1553,19 @@ public class CardBrowser extends NavigationDrawerActivity implements
         searchCards();
     }
 
+
+    /** Updates search terms to only show cards with selected flag. */
     private void filterByFlag() {
         mSearchView.setQuery("", false);
-        mSearchTerms = "flag:" + mCurrentFlag;
+        String flagSearchTerm = "flag:" + mCurrentFlag;
+        if (mSearchTerms.contains("flag:")) {
+            mSearchTerms = mSearchTerms.replaceFirst("flag:.", "flag:" + mCurrentFlag);
+        }
+        else if (!mSearchTerms.isEmpty()) {
+            mSearchTerms = flagSearchTerm + " " + mSearchTerms;
+        } else {
+            mSearchTerms = flagSearchTerm;
+        }
         searchCards();
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1006,6 +1006,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
         mCurrentFlag = flag;
         invalidateOptionsMenu();
         // Update mSearchTerms to match selected flag.
+        filterByFlag();
     }
 
     @Override
@@ -1548,6 +1549,12 @@ public class CardBrowser extends NavigationDrawerActivity implements
             sb.append(")"); // Only if we added anything to the tag list
         }
         mSearchTerms = sb.toString();
+        searchCards();
+    }
+
+    private void filterByFlag() {
+        mSearchView.setQuery("", false);
+        mSearchTerms = "flag:" + mCurrentFlag;
         searchCards();
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -67,6 +67,7 @@ import com.ichi2.anki.dialogs.RescheduleDialog;
 import com.ichi2.anki.dialogs.SimpleMessageDialog;
 import com.ichi2.anki.dialogs.TagsDialog;
 import com.ichi2.anki.receiver.SdCardReceiver;
+import com.ichi2.anki.reviewer.ReviewerUi;
 import com.ichi2.anki.widgets.DeckDropDownAdapter;
 import com.ichi2.async.CollectionTask;
 import com.ichi2.async.TaskListenerWithContext;
@@ -144,6 +145,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
     private MultiColumnListAdapter mCardsAdapter;
     private String mSearchTerms;
     private String mRestrictOnDeck;
+    private int mCurrentFlag;
 
     private MenuItem mSearchItem;
     private MenuItem mSaveSearchItem;
@@ -803,7 +805,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
 
     @Override
-    public boolean onCreateOptionsMenu(final Menu menu) {
+    public boolean onCreateOptionsMenu(Menu menu) {
         Timber.d("onCreateOptionsMenu()");
         mActionBarMenu = menu;
         if (!mInMultiSelectMode) {
@@ -889,6 +891,37 @@ public class CardBrowser extends NavigationDrawerActivity implements
     }
 
     @Override
+    public boolean onPrepareOptionsMenu(Menu menu) {
+        setFlagColor(menu);
+        return super.onPrepareOptionsMenu(menu);
+    }
+
+    private void setFlagColor(Menu menu) {
+        @Nullable MenuItem flag_icon = menu.findItem(R.id.action_search_by_flag);
+        if (flag_icon != null) {
+            switch (mCurrentFlag) {
+                case 1:
+                    flag_icon.setIcon(R.drawable.ic_flag_red);
+                    break;
+                case 2:
+                    flag_icon.setIcon(R.drawable.ic_flag_orange);
+                    break;
+                case 3:
+                    flag_icon.setIcon(R.drawable.ic_flag_green);
+                    break;
+                case 4:
+                    flag_icon.setIcon(R.drawable.ic_flag_blue);
+                    break;
+                default:
+                    flag_icon.setIcon(R.drawable.ic_flag_transparent);
+                    break;
+            }
+            // int alpha = (getControlBlocked() != ReviewerUi.ControlBlock.SLOW) ? Themes.ALPHA_ICON_ENABLED_LIGHT : Themes.ALPHA_ICON_DISABLED_LIGHT ;
+            // flag_icon.getIcon().mutate().setAlpha(alpha);
+        }
+    }
+
+    @Override
     protected void onNavigationPressed() {
         if (mInMultiSelectMode) {
             endMultiSelectMode();
@@ -966,6 +999,13 @@ public class CardBrowser extends NavigationDrawerActivity implements
         CollectionTask.launchCollectionTask(DISMISS_MULTI,
                                 flagCardHandler(),
                                 new TaskData(new Object[]{getSelectedCardIds(), Collection.DismissType.FLAG, flag}));
+    }
+
+    private void selectionWithFlagTask (int flag) {
+        // Change icon to match color of selected flag.
+        mCurrentFlag = flag;
+        invalidateOptionsMenu();
+        // Update mSearchTerms to match selected flag.
     }
 
     @Override
@@ -1051,6 +1091,26 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
             case R.id.action_flag_four:
                 flagTask(4);
+                return true;
+
+            case R.id.action_select_flag_zero:
+                selectionWithFlagTask(0);
+                return true;
+
+            case R.id.action_select_flag_one:
+                selectionWithFlagTask(1);
+                return true;
+
+            case R.id.action_select_flag_two:
+                selectionWithFlagTask(2);
+                return true;
+
+            case R.id.action_select_flag_three:
+                selectionWithFlagTask(3);
+                return true;
+
+            case R.id.action_select_flag_four:
+                selectionWithFlagTask(4);
                 return true;
 
             case R.id.action_delete_card:

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -918,8 +918,6 @@ public class CardBrowser extends NavigationDrawerActivity implements
                     flag_icon.setIcon(R.drawable.ic_flag_transparent);
                     break;
             }
-            // int alpha = (getControlBlocked() != ReviewerUi.ControlBlock.SLOW) ? Themes.ALPHA_ICON_ENABLED_LIGHT : Themes.ALPHA_ICON_DISABLED_LIGHT ;
-            // flag_icon.getIcon().mutate().setAlpha(alpha);
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1557,7 +1557,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
         mSearchView.setQuery("", false);
         String flagSearchTerm = "flag:" + mCurrentFlag;
         if (mSearchTerms.contains("flag:")) {
-            mSearchTerms = mSearchTerms.replaceFirst("flag:.", "flag:" + mCurrentFlag);
+            mSearchTerms = mSearchTerms.replaceFirst("flag:.", flagSearchTerm);
         }
         else if (!mSearchTerms.isEmpty()) {
             mSearchTerms = flagSearchTerm + " " + mSearchTerms;
@@ -2736,6 +2736,12 @@ public class CardBrowser extends NavigationDrawerActivity implements
     @VisibleForTesting
     void filterByTag(String... tags) {
         filterByTag(Arrays.asList(tags), 0);
+    }
+
+    @VisibleForTesting
+    void filterByFlag(int flag) {
+        mCurrentFlag = flag;
+        filterByFlag();
     }
 
     @VisibleForTesting

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -829,6 +829,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
                     // SearchView doesn't support empty queries so we always reset the search when collapsing
                     mSearchTerms = "";
                     mSearchView.setQuery(mSearchTerms, false);
+                    mCurrentFlag = 0;
+                    setFlagColor(menu);
                     searchCards();
                     // invalidate options menu so that disappeared icons would appear again
                     supportInvalidateOptionsMenu();

--- a/AnkiDroid/src/main/res/menu/card_browser.xml
+++ b/AnkiDroid/src/main/res/menu/card_browser.xml
@@ -2,34 +2,6 @@
     xmlns:ankidroid="http://schemas.android.com/apk/res-auto" >
 
     <item
-        ankidroid:showAsAction="ifRoom"
-        android:id="@+id/action_search_by_flag"
-        android:title="@string/card_browser_search_by_flag"
-        android:icon="@drawable/ic_flag_transparent">
-        <menu>
-            <item
-                android:id="@+id/action_select_flag_zero"
-                android:title="@string/menu_flag_card_zero"/>
-            <item
-                android:id="@+id/action_select_flag_one"
-                android:title="@string/menu_flag_card_one"
-                android:icon="@drawable/ic_flag_red"/>
-            <item
-                android:id="@+id/action_select_flag_two"
-                android:title="@string/menu_flag_card_two"
-                android:icon="@drawable/ic_flag_orange"/>
-            <item
-                android:id="@+id/action_select_flag_three"
-                android:title="@string/menu_flag_card_three"
-                android:icon="@drawable/ic_flag_green"/>
-            <item
-                android:id="@+id/action_select_flag_four"
-                android:title="@string/menu_flag_card_four"
-                android:icon="@drawable/ic_flag_blue"/>
-        </menu>
-    </item>
-
-    <item
         android:id="@+id/action_add_note_from_card_browser"
         android:icon="@drawable/ic_add_white_24dp"
         android:title="@string/note_editor_add_note"
@@ -60,6 +32,33 @@
     <item
         android:id="@+id/action_search_by_tag"
         android:title="@string/card_browser_search_by_tag"/>
+
+    <item
+        ankidroid:showAsAction="never"
+        android:id="@+id/action_search_by_flag"
+        android:title="@string/card_browser_search_by_flag">
+        <menu>
+            <item
+                android:id="@+id/action_select_flag_zero"
+                android:title="@string/menu_flag_card_zero"/>
+            <item
+                android:id="@+id/action_select_flag_one"
+                android:title="@string/menu_flag_card_one"
+                android:icon="@drawable/ic_flag_red"/>
+            <item
+                android:id="@+id/action_select_flag_two"
+                android:title="@string/menu_flag_card_two"
+                android:icon="@drawable/ic_flag_orange"/>
+            <item
+                android:id="@+id/action_select_flag_three"
+                android:title="@string/menu_flag_card_three"
+                android:icon="@drawable/ic_flag_green"/>
+            <item
+                android:id="@+id/action_select_flag_four"
+                android:title="@string/menu_flag_card_four"
+                android:icon="@drawable/ic_flag_blue"/>
+        </menu>
+    </item>
 
     <item
         ankidroid:showAsAction="ifRoom"

--- a/AnkiDroid/src/main/res/menu/card_browser.xml
+++ b/AnkiDroid/src/main/res/menu/card_browser.xml
@@ -2,10 +2,39 @@
     xmlns:ankidroid="http://schemas.android.com/apk/res-auto" >
 
     <item
+        ankidroid:showAsAction="ifRoom"
+        android:id="@+id/action_search_by_flag"
+        android:title="@string/card_browser_search_by_flag"
+        android:icon="@drawable/ic_flag_transparent">
+        <menu>
+            <item
+                android:id="@+id/action_select_flag_zero"
+                android:title="@string/menu_flag_card_zero"/>
+            <item
+                android:id="@+id/action_select_flag_one"
+                android:title="@string/menu_flag_card_one"
+                android:icon="@drawable/ic_flag_red"/>
+            <item
+                android:id="@+id/action_select_flag_two"
+                android:title="@string/menu_flag_card_two"
+                android:icon="@drawable/ic_flag_orange"/>
+            <item
+                android:id="@+id/action_select_flag_three"
+                android:title="@string/menu_flag_card_three"
+                android:icon="@drawable/ic_flag_green"/>
+            <item
+                android:id="@+id/action_select_flag_four"
+                android:title="@string/menu_flag_card_four"
+                android:icon="@drawable/ic_flag_blue"/>
+        </menu>
+    </item>
+
+    <item
         android:id="@+id/action_add_note_from_card_browser"
         android:icon="@drawable/ic_add_white_24dp"
         android:title="@string/note_editor_add_note"
         ankidroid:showAsAction="ifRoom"/>
+
     <item
         android:id="@+id/action_search"
         android:icon="@drawable/ic_search_white_24dp"

--- a/AnkiDroid/src/main/res/values/07-cardbrowser.xml
+++ b/AnkiDroid/src/main/res/values/07-cardbrowser.xml
@@ -44,6 +44,7 @@
     <string name="card_browser_show_marked">Filter marked</string>
     <string name="card_browser_show_suspended">Filter suspended</string>
     <string name="card_browser_search_by_tag">Filter by tag</string>
+    <string name="card_browser_search_by_flag">Filter by flag</string>
     <string name="card_browser_tags_shown">Tags: %1$s</string>
     <string name="card_browser_list_my_searches">My searches</string>
     <string name="card_browser_list_my_searches_save">Save search</string>

--- a/AnkiDroid/src/main/res/values/strings.xml
+++ b/AnkiDroid/src/main/res/values/strings.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="ga_trackingId" translatable="false">UA-125800786-1</string>
-    <string name="card_browser_search_by_flag">Filter by flag</string>
     <!-- If you go over limits, further hits are dropped, setting a sampling percentage can help -->
     <!-- Current limits: 10MM/month globally, 200K/user && 500/session, 1 ever 2s + 60 in a session -->
     <!-- https://developers.google.com/analytics/devguides/collection/android/v4/limits-quotas -->

--- a/AnkiDroid/src/main/res/values/strings.xml
+++ b/AnkiDroid/src/main/res/values/strings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="ga_trackingId" translatable="false">UA-125800786-1</string>
+    <string name="card_browser_search_by_flag">Filter by flag</string>
     <!-- If you go over limits, further hits are dropped, setting a sampling percentage can help -->
     <!-- Current limits: 10MM/month globally, 200K/user && 500/session, 1 ever 2s + 60 in a session -->
     <!-- https://developers.google.com/analytics/devguides/collection/android/v4/limits-quotas -->

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
@@ -303,6 +303,24 @@ public class CardBrowserTest extends RobolectricTest {
     }
 
     @Test
+    public void filterByFlagDisplaysProperly() {
+        Note cardWithRedFlag = addNoteUsingBasicModel("Card with red flag", "Reverse");
+        flagCardForNote(cardWithRedFlag, 1);
+
+        Note cardWithGreenFlag = addNoteUsingBasicModel("Card with green flag", "Reverse");
+        flagCardForNote(cardWithGreenFlag, 3);
+
+        Note anotherCardWithRedFlag = addNoteUsingBasicModel("Second card with red flag", "Reverse");
+        flagCardForNote(anotherCardWithRedFlag, 1);
+
+        CardBrowser b = getBrowserWithNoNewCards();
+        b.filterByFlag(1);
+        advanceRobolectricLooperWithSleep();
+
+        assertThat("Flagged cards should be returned", b.getCardCount(), is(2));
+    }
+
+    @Test
     public void previewWorksAfterSort() {
         // #7286
         long cid1 = addNoteUsingBasicModel("Hello", "World").cards().get(0).getId();


### PR DESCRIPTION
## Purpose / Description
Users don't know that they can type: flag:1 etc... this needs a visual item in the Card Browser Action bar - similar to the item in the Reviewer.

## Fixes
Fixes #7118

## Approach
1. Flag icon is added to card browser menu with ifRoom option. After that change it will replace "Add card button" on most mobile phones, since there is not enough room for both and search icon.
2. When flag is selected, searchTerms are updated to have `flag:N`.
3. If there was already search term looked for by user, selecting flag will prepend `flag:N` to search terms.
4. If user has selected a flag and then wants to switch to other `flag:N` term is replaced with correct flag, without removing existing search terms.
5. Only one flag can be selected at one time, when using Search by flag option.

## How Has This Been Tested?
* Added unit test for checking if my function is selecting correct cards.
* Tested it on emulated device in Android Studio (Pixel 3a API 30)

## Learning (optional, can help others)
None

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
