### PR TITLE
Bump lint from 27.0.2 to 27.1.0

### DIFF
--- a/lint-rules/build.gradle
+++ b/lint-rules/build.gradle
@@ -12,7 +12,7 @@ repositories {
 
 dependencies {
     compileOnly "com.android.tools.lint:lint-api:27.1.0"
-    compileOnly "com.android.tools.lint:lint:27.0.2"
+    compileOnly "com.android.tools.lint:lint:27.1.0"
 
     testImplementation "junit:junit:4.13.1"
     testImplementation "com.android.tools.lint:lint:27.1.0"


### PR DESCRIPTION
Missed this in the last batch of dependency updates but it brings the lint-rules space all up to 27.1.0

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>
