### PR TITLE
Regression Test to check if Decks with wildcard characters in their name can be searched.

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/libanki/FinderTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/FinderTest.java
@@ -16,8 +16,10 @@
 
 package com.ichi2.libanki;
 
+import android.content.Intent;
 import android.util.Pair;
 
+import com.ichi2.anki.CardBrowser;
 import com.ichi2.anki.RobolectricTest;
 import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.libanki.sched.SchedV2;
@@ -335,6 +337,25 @@ public class FinderTest extends RobolectricTest {
         // assertThrows(Exception.class, () -> col.findCards("flag:12"));
     }
 
+    @Test
+    public void test_deckNameContainingWildcardCanBeSearched() {
+        String val = "*Yr1::Med2::CAS4::F4: Renal::BRS (zanki)::HY";
+        Collection col = getCol();
+        long currentDid = col.getDecks().id(val);
+        col.getDecks().select(currentDid);
+        Note note = col.newNote();
+        note.setItem("Front", "foo");
+        note.setItem("Back", "bar");
+        note.model().put("did", currentDid);
+        col.addNote(note);
+        long did = note.firstCard().getDid();
+        assertEquals(currentDid, did);
+        CardBrowser cb = super.startActivityNormallyOpenCollectionWithIntent(CardBrowser.class, new Intent());
+        int pos = cb.getChangeDeckPositionFromId(currentDid);
+        cb.selectDropDownItem(pos + 1);    //Adjusting for All Decks option at position 0
+        advanceRobolectricLooperWithSleep();
+        assertEquals(1L, cb.getCardCount());
+    }
 
     @Test
     public void test_findReplace() {


### PR DESCRIPTION

## Pull Request template

## Purpose / Description
There was no test written to check if the Decks with wildcard characters in their names can be searched correctly(first doing an exact match search and if that fails, doing a regex based search). This PR adds a test inside FinderTest.java making sure that a card is visible regardless of the deck containing wildcard characters. 

tl;dr: A test written to make sure issue #6288 doesn't occur.

The issue mentioned above will be fixed by PR #7392 after which this test will stop failing. 

## Fixes
Fixes #7394 

## Approach

- Created a Deck with the name `"*Yr1::Med2::CAS4::F4: Renal::BRS (zanki)::HY"`
- Saved the `did` for the deck above and created a note inside the deck.
- Opened CardBrowser.java through RoboelectricTest and selected our deck from the drop down menu.
- Asserted that the number of cards in CardBrowser is equal to 1.

## How Has This Been Tested?

Ran the above test both with and without PR #7392, test passed with PR, failed without it.

## Learning (optional, can help others)
Anyone new to testing can refer to #7394 where there's a lot of discussion and I've noted down some things I learnt.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
