### PR TITLE
NF: remove "Card Browser" duplication

### DIFF
--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -192,7 +192,7 @@
         </activity-alias>
         <activity
             android:name="com.ichi2.anki.CardBrowser"
-            android:label="@string/card_browser_label"
+            android:label="@string/card_browser"
             android:exported="true"
             android:configChanges="keyboardHidden|orientation|locale|screenSize"
             android:parentActivityName=".DeckPicker"

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -196,7 +196,6 @@
     <string name="read_write_permission_description">access existing notes, cards, note types, and decks, as well as create new ones</string>
 
     <!-- Context Menu -->
-    <string name="card_browser_label">Card Browser</string>
     <string name="card_browser_context_menu">Card Browser</string>
 
     <string name="context_menu_anki_card_label">Anki Card</string>


### PR DESCRIPTION
This string was duplicated, and there seems to be no reason for the label of the activity to be didstinct from the label in the menu