### PR TITLE
NF: remove duplicate "Full sync from server"

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -1989,7 +1989,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
                             break;
                         case FULL_DOWNLOAD:
                             Timber.i("Full Download Completed");
-                            showSyncLogMessage(R.string.sync_log_downloading_message, syncMessage);
+                            showSyncLogMessage(R.string.backup_full_sync_from_server, syncMessage);
                             break;
                         default: // should not be possible
                             Timber.i("Full Sync Completed (Unknown Direction)");

--- a/AnkiDroid/src/main/res/values/04-network.xml
+++ b/AnkiDroid/src/main/res/values/04-network.xml
@@ -64,7 +64,6 @@
     <string name="sync_title">Synchronization</string>
     <string name="sync_downloading_media">Downloading media %1$d/%2$d…</string>
     <string name="sync_log_uploading_message">Full sync from local</string>
-    <string name="sync_log_downloading_message">Full sync from server</string>
     <string name="sync_log_clocks_unsynchronized">Your clock’s off by %1$d seconds%2$s. Make sure that the date, time, and timezone on your phone are set correctly, then sync again.</string>
     <string name="sync_log_clocks_unsynchronized_tz">, the time zone’s possibly wrong</string>
     <string name="sync_log_clocks_unsynchronized_date">, the date’s possibly wrong</string>


### PR DESCRIPTION
Currently, both things can be translated differently and there is no good reason for that. If it were the case, that would just be confusing