### PR TITLE
NF: Use a single "AnkiDroid" ressource

### DIFF
--- a/AnkiDroid/src/main/res/layout/widget_small.xml
+++ b/AnkiDroid/src/main/res/layout/widget_small.xml
@@ -13,7 +13,7 @@
         android:layout_gravity="center"
         android:background="#00FFFFFF"
         android:clickable="false"
-        android:contentDescription="@string/widget_small_button"
+        android:contentDescription="@string/app_name"
         android:focusable="false"
         android:scaleType="fitCenter"
         android:src="@drawable/widget_bg_small"/>

--- a/AnkiDroid/src/main/res/values/08-widget.xml
+++ b/AnkiDroid/src/main/res/values/08-widget.xml
@@ -39,8 +39,6 @@
 
     <string name="widget_small">AnkiDroid small</string>
 
-    <string name="widget_small_button">AnkiDroid</string>
-
     <plurals name="widget_cards_due">
         <item quantity="one">%d card due</item>
         <item quantity="other">%d cards due</item>

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -22,7 +22,6 @@
     <string name="disabled">Disabled</string>
     <string name="enabled">Enabled</string>
     <!-- preferences.xml categories-->
-    <string name="pref_cat_general">AnkiDroid</string>
     <string name="pref_cat_general_summ">General settings</string>
     <string name="pref_cat_reviewing">Reviewing</string>
     <string name="pref_cat_reviewing_summ">Non-deck-specific reviewer settings</string>

--- a/AnkiDroid/src/main/res/xml/preference_headers.xml
+++ b/AnkiDroid/src/main/res/xml/preference_headers.xml
@@ -24,7 +24,7 @@
     <header
         android:fragment="com.ichi2.anki.Preferences$SettingsFragment"
         android:summary="@string/pref_cat_general_summ"
-        android:title="@string/pref_cat_general">
+        android:title="@string/app_name">
         <extra
             android:name="subscreen"
             android:value="com.ichi2.anki.prefs.general" />

--- a/AnkiDroid/src/main/res/xml/preferences_general.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_general.xml
@@ -22,7 +22,7 @@
 
 <!--  General Preferences -->
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
-    android:title="@string/pref_cat_general"
+    android:title="@string/app_name"
     android:summary="@string/pref_cat_general_summ" >
     <PreferenceCategory android:title="@string/button_sync" >
         <Preference
@@ -50,7 +50,7 @@
             android:summary="@string/sync_status_badge_summ"
             android:title="@string/sync_status_badge" />
     </PreferenceCategory>
-    <PreferenceCategory android:title="@string/pref_cat_general">
+    <PreferenceCategory android:title="@string/app_name">
         <ListPreference
             android:entries="@array/add_to_cur_labels"
             android:entryValues="@array/add_to_cur_values"


### PR DESCRIPTION
Currently, we translate AnkiDroid only sometime. E.g. the name of the small icon is translated, however, it's not translated the information screen. This increase consistency, assuming we never went it translated (as it's a name).