### PR TITLE
NF: remove duplicate ressource "repair"

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.java
@@ -386,7 +386,7 @@ public class DatabaseErrorDialog extends AsyncDialogFragment {
             case DIALOG_ERROR_HANDLING:
                 return res().getString(R.string.error_handling_title);
             case DIALOG_REPAIR_COLLECTION:
-                return res().getString(R.string.backup_repair_deck);
+                return res().getString(R.string.dialog_positive_repair);
             case DIALOG_RESTORE_BACKUP:
                 return res().getString(R.string.backup_restore);
             case DIALOG_NEW_COLLECTION:

--- a/AnkiDroid/src/main/res/values/09-backup.xml
+++ b/AnkiDroid/src/main/res/values/09-backup.xml
@@ -32,7 +32,6 @@
     <string name="error_handling_options">Options</string>
     <string name="backup_retry_opening">Retry opening</string>
     <string name="backup_error_menu_repair">Repair database</string>
-    <string name="backup_repair_deck">Repair</string>
     <!-- Collection used to be called deck. Name is kept for consistency with translation software -->
     <string name="backup_repair_deck_progress">Repairing database…</string>
     <string name="backup_error">Error</string>


### PR DESCRIPTION
Both are used in the same context. Furthermore "deck" is misleading, since it's an old word for "collection"