### PR TITLE
NF: add comment on activity's label

### DIFF
--- a/AnkiDroid/src/main/res/values-af/01-core.xml
+++ b/AnkiDroid/src/main/res/values-af/01-core.xml
@@ -201,7 +201,7 @@
     <string name="card_template_editor_save_error">Unable to save card template changes: %s</string>
     <string name="template_for_current_card_deleted">The card type for the current card was deleted.</string>
     <!-- Card Browser Appearance -->
-    <string name="card_template_browser_appearance_title">Browser appearance</string>
+    <string name="card_template_browser_appearance_title" comment="Label of the window controlling the appearance of the card browser. This text can't be found directly in AnkiDroid.">Browser appearance</string>
     <!-- Permissions -->
     <string name="read_write_permission_label">Read and write to the AnkiDroid database</string>
     <string name="read_write_permission_description">access existing notes, cards, note types, and decks, as well as create new ones</string>

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -91,7 +91,7 @@
     <string name="rename_deck">Rename deck</string>
     <string name="menu_add">Add</string>
     <string name="menu_add_note">Add note</string>
-    <string name="menu_my_account">Sync account</string>
+    <string name="menu_my_account" comment="Label of the window in which the user should enter their account. This text can't be found in AnkiDroid directly.">Sync account</string>
     <string name="menu_dismiss_note">Hide / delete</string>
     <string name="menu_bury_card">Bury card</string>
     <string name="menu_bury_note">Bury note</string>

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -125,7 +125,7 @@
     </plurals>
 
     <string name="studyoptions_welcome_title">Welcome to AnkiDroid</string>
-    <string name="fact_adder_intent_title">AnkiDroid card</string>
+    <string name="fact_adder_intent_title" comment="Label of the 'Add Note' window. This title can't be seen in AnkiDroid directly.">AnkiDroid card</string>
     <string name="note_editor_add_note">Add note</string>
     <string name="note_editor_copy_note">Copy note</string>
     <string name="card_editor_copy_card">Copy card</string>

--- a/AnkiDroid/src/main/res/values/08-widget.xml
+++ b/AnkiDroid/src/main/res/values/08-widget.xml
@@ -26,7 +26,7 @@
         <item quantity="other">%d AnkiDroid cards due</item>
     </plurals>
 
-    <string name="widget_small">AnkiDroid small</string>
+    <string name="widget_small" comment="Label of the small ankidroid widget. This text can't be found directly in AnkiDroid">AnkiDroid small</string>
 
     <plurals name="widget_cards_due">
         <item quantity="one">%d card due</item>
@@ -37,6 +37,6 @@
         <item quantity="other">%d minutes remaining</item>
     </plurals>
 
-    <string name="widget_add_note">Add note</string>
+    <string name="widget_add_note" comment="Label of the widget allowing to add note from other app. This text can't be found directly in AnkiDroid.">Add note</string>
     <string name="widget_add_note_button">Add new AnkiDroid note</string>
 </resources>

--- a/AnkiDroid/src/main/res/values/16-multimedia-editor.xml
+++ b/AnkiDroid/src/main/res/values/16-multimedia-editor.xml
@@ -105,9 +105,9 @@
 
     <!-- Activity titles -->
 
-    <string name="title_activity_edit_text">Editing field</string>
-    <string name="title_activity_translation">Translation</string>
-    <string name="title_activity_load_pronounciation">Pronunciation</string>
+    <string name="title_activity_edit_text" comment="Name of the window allowing to edit field. This text can not be seen in AnkiDroid directly.">Editing field</string>
+    <string name="title_activity_translation" comment="Name of the window allowing to translate. This text can not be seen in AnkiDroid directly.">Translation</string>
+    <string name="title_activity_load_pronounciation" comment="Name of the window allowing to load pronunciation of words. This text can not be seen in AnkiDroid directly.">Pronunciation</string>
 
 	<!-- Network failure -->
 	<string name="network_no_connection">No connection</string>

--- a/AnkiDroid/src/main/res/values/17-model-manager.xml
+++ b/AnkiDroid/src/main/res/values/17-model-manager.xml
@@ -2,8 +2,8 @@
 <resources>
 
     <!--Menu Labels-->
-    <string name="model_browser_label">Manage note types</string>
-    <string name="model_editor_label">Manage fields</string>
+    <string name="model_browser_label" comment="Label of the browser of note types. The text can't be found in AnkiDroid directly.">Manage note types</string>
+    <string name="model_editor_label" comment="Label of the window to edit the fields of a note type. This text can't be found in Ankidroid directly">Manage fields</string>
 
 
     <!--Toasts-->


### PR DESCRIPTION
So that translators understand why there is no context. Or that context must be an entire window
