### PR TITLE
NF: Remove duplicate "restaure default"

### DIFF
--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -237,7 +237,6 @@
     <string name="deck_conf_current_group">Current group</string>
     <string name="deck_conf_rename">Rename</string>
     <string name="deck_conf_reset">Restore defaults</string>
-    <string name="deck_conf_reset_title">Restore defaults</string>
     <string name="deck_conf_reset_message">Restore current options group to default values?</string>
     <string name="deck_conf_add">Add</string>
     <string name="deck_conf_add_summ">Create a copy of the current options group</string>

--- a/AnkiDroid/src/main/res/xml/deck_options.xml
+++ b/AnkiDroid/src/main/res/xml/deck_options.xml
@@ -50,11 +50,11 @@
             <com.ichi2.preferences.CustomDialogPreference
                 android:dialogIcon="@drawable/ic_dialog_alert"
                 android:dialogMessage="@string/deck_conf_reset_message"
-                android:dialogTitle="@string/deck_conf_reset_title"
+                android:dialogTitle="@string/deck_conf_reset"
                 android:key="confRestore"
                 android:negativeButtonText="@string/dialog_cancel"
                 android:positiveButtonText="@string/dialog_positive_restore"
-                android:title="@string/deck_conf_reset_title" />
+                android:title="@string/deck_conf_reset" />
             <com.ichi2.preferences.CustomDialogPreference
                 android:dialogIcon="@drawable/ic_dialog_alert"
                 android:dialogMessage="@string/deck_conf_set_subdecks_message"


### PR DESCRIPTION
Seems a bad idea to have two strings. In theory, it could make sens to have a title shorter due to window
constraint. But both names should be related, and we have no way to ensure that translation is consistent