### PR TITLE
NF: Refactor EditFieldLine

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditLine.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditLine.java
@@ -67,6 +67,7 @@ public class FieldEditLine extends FrameLayout {
         LayoutInflater.from(getContext()).inflate(R.layout.card_multimedia_editline, this, true);
         this.mEditText = findViewById(R.id.id_note_editText);
         this.mLabel = findViewById(R.id.id_label);
+        mEditText.init();
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditLine.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditLine.java
@@ -23,6 +23,7 @@ import android.util.AttributeSet;
 import android.view.ActionMode;
 import android.view.LayoutInflater;
 import android.widget.FrameLayout;
+import android.widget.ImageButton;
 import android.widget.TextView;
 
 import java.util.Locale;
@@ -34,6 +35,7 @@ import androidx.annotation.RequiresApi;
 public class FieldEditLine extends FrameLayout {
     private FieldEditText mEditText;
     private TextView mLabel;
+    private ImageButton mMediaButton;
 
     private String mName;
 
@@ -67,6 +69,7 @@ public class FieldEditLine extends FrameLayout {
         LayoutInflater.from(getContext()).inflate(R.layout.card_multimedia_editline, this, true);
         this.mEditText = findViewById(R.id.id_note_editText);
         this.mLabel = findViewById(R.id.id_label);
+        this.mMediaButton = findViewById(R.id.id_media_button);
         mEditText.init();
         mLabel.setPadding((int) UIUtils.getDensityAdjustedValue(getContext(), 3.4f), 0, 0, 0);
     }
@@ -110,5 +113,10 @@ public class FieldEditLine extends FrameLayout {
 
     public String getName() {
         return mName;
+    }
+
+
+    public ImageButton getMediaButton() {
+        return mMediaButton;
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditLine.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditLine.java
@@ -68,6 +68,7 @@ public class FieldEditLine extends FrameLayout {
         this.mEditText = findViewById(R.id.id_note_editText);
         this.mLabel = findViewById(R.id.id_label);
         mEditText.init();
+        mLabel.setPadding((int) UIUtils.getDensityAdjustedValue(getContext(), 3.4f), 0, 0, 0);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditLine.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditLine.java
@@ -24,6 +24,7 @@ import android.view.ActionMode;
 import android.view.LayoutInflater;
 import android.widget.EditText;
 import android.widget.FrameLayout;
+import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -31,6 +32,9 @@ import androidx.annotation.RequiresApi;
 
 public class FieldEditLine extends FrameLayout {
     private EditText mEditText;
+    private TextView mLabel;
+
+    private String mName;
 
 
     public FieldEditLine(@NonNull Context context) {
@@ -61,6 +65,7 @@ public class FieldEditLine extends FrameLayout {
     private void init() {
         LayoutInflater.from(getContext()).inflate(R.layout.card_multimedia_editline, this, true);
         this.mEditText = findViewById(R.id.id_note_editText);
+        this.mLabel = findViewById(R.id.id_label);
     }
 
 
@@ -76,5 +81,17 @@ public class FieldEditLine extends FrameLayout {
         if (typeface != null) {
             mEditText.setTypeface(typeface);
         }
+    }
+
+
+    public void setName(String name) {
+        mName = name;
+        mEditText.setContentDescription(name);
+        mLabel.setText(name);
+    }
+
+
+    public String getName() {
+        return mName;
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditLine.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditLine.java
@@ -97,6 +97,10 @@ public class FieldEditLine extends FrameLayout {
         }
     }
 
+    public void setContent(String content) {
+        mEditText.setContent(content);
+    }
+
     public String getName() {
         return mName;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditLine.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditLine.java
@@ -17,6 +17,7 @@
 package com.ichi2.anki;
 
 import android.content.Context;
+import android.graphics.Typeface;
 import android.os.Build;
 import android.util.AttributeSet;
 import android.view.ActionMode;
@@ -67,6 +68,13 @@ public class FieldEditLine extends FrameLayout {
         mEditText.setCustomSelectionActionModeCallback(callback);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             mEditText.setCustomInsertionActionModeCallback(callback);
+        }
+    }
+
+
+    public void setTypeface(@Nullable Typeface typeface) {
+        if (typeface != null) {
+            mEditText.setTypeface(typeface);
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditLine.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditLine.java
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki;
+
+import android.content.Context;
+import android.os.Build;
+import android.util.AttributeSet;
+import android.view.LayoutInflater;
+import android.widget.FrameLayout;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
+
+public class FieldEditLine extends FrameLayout {
+    public FieldEditLine(@NonNull Context context) {
+        super(context);
+        init();
+    }
+
+
+    public FieldEditLine(@NonNull Context context, @Nullable AttributeSet attrs) {
+        super(context, attrs);
+        init();
+    }
+
+
+    public FieldEditLine(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        init();
+    }
+
+
+    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+    public FieldEditLine(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+        super(context, attrs, defStyleAttr, defStyleRes);
+        init();
+    }
+
+
+    private void init() {
+        LayoutInflater.from(getContext()).inflate(R.layout.card_multimedia_editline, this, true);
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditLine.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditLine.java
@@ -101,6 +101,11 @@ public class FieldEditLine extends FrameLayout {
         mEditText.setContent(content);
     }
 
+
+    public void setOrd(int i) {
+        mEditText.setOrd(i);
+    }
+
     public String getName() {
         return mName;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditLine.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditLine.java
@@ -19,7 +19,9 @@ package com.ichi2.anki;
 import android.content.Context;
 import android.os.Build;
 import android.util.AttributeSet;
+import android.view.ActionMode;
 import android.view.LayoutInflater;
+import android.widget.EditText;
 import android.widget.FrameLayout;
 
 import androidx.annotation.NonNull;
@@ -27,6 +29,9 @@ import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 
 public class FieldEditLine extends FrameLayout {
+    private EditText mEditText;
+
+
     public FieldEditLine(@NonNull Context context) {
         super(context);
         init();
@@ -54,5 +59,14 @@ public class FieldEditLine extends FrameLayout {
 
     private void init() {
         LayoutInflater.from(getContext()).inflate(R.layout.card_multimedia_editline, this, true);
+        this.mEditText = findViewById(R.id.id_note_editText);
+    }
+
+
+    public void setActionModeCallbacks(ActionMode.Callback callback) {
+        mEditText.setCustomSelectionActionModeCallback(callback);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            mEditText.setCustomInsertionActionModeCallback(callback);
+        }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditLine.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditLine.java
@@ -22,16 +22,17 @@ import android.os.Build;
 import android.util.AttributeSet;
 import android.view.ActionMode;
 import android.view.LayoutInflater;
-import android.widget.EditText;
 import android.widget.FrameLayout;
 import android.widget.TextView;
+
+import java.util.Locale;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 
 public class FieldEditLine extends FrameLayout {
-    private EditText mEditText;
+    private FieldEditText mEditText;
     private TextView mLabel;
 
     private String mName;
@@ -90,6 +91,11 @@ public class FieldEditLine extends FrameLayout {
         mLabel.setText(name);
     }
 
+    public void setHintLocale(@Nullable Locale hintLocale) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && hintLocale != null) {
+            mEditText.setHintLocale(hintLocale);
+        }
+    }
 
     public String getName() {
         return mName;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.java
@@ -91,15 +91,9 @@ public class FieldEditText extends FixedEditText {
     }
 
 
-    public void init(int ord, String content) {
+    public void init(int ord) {
         mOrd = ord;
 
-        if (content == null) {
-            content = "";
-        } else {
-            content = content.replaceAll("<br(\\s*/*)>", NEW_LINE);
-        }
-        setText(content);
         setMinimumWidth(400);
         mOrigBackground = getBackground();
         // Fixes bug where new instances of this object have wrong colors, probably
@@ -146,6 +140,17 @@ public class FieldEditText extends FixedEditText {
     public void setSelectionChangeListener(TextSelectionListener listener) {
         this.mSelectionChangeListener = listener;
     }
+
+
+    public void setContent(String content) {
+        if (content == null) {
+            content = "";
+        } else {
+            content = content.replaceAll("<br(\\s*/*)>", NEW_LINE);
+        }
+        setText(content);
+    }
+
 
     public interface TextSelectionListener {
         void onSelectionChanged(int selStart, int selEnd);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.java
@@ -91,7 +91,7 @@ public class FieldEditText extends FixedEditText {
     }
 
 
-    public void init(int ord, String content, @Nullable Locale hintLocale) {
+    public void init(int ord, String content) {
         mOrd = ord;
 
         if (content == null) {
@@ -100,9 +100,6 @@ public class FieldEditText extends FixedEditText {
             content = content.replaceAll("<br(\\s*/*)>", NEW_LINE);
         }
         setText(content);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && hintLocale != null) {
-            setHintLocale(hintLocale);
-        }
         setMinimumWidth(400);
         mOrigBackground = getBackground();
         // Fixes bug where new instances of this object have wrong colors, probably

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.java
@@ -81,13 +81,6 @@ public class FieldEditText extends FixedEditText {
     }
 
 
-    public TextView getLabel() {
-        TextView label = new FixedTextView(this.getContext());
-        label.setText(mName);
-        return label;
-    }
-
-
     public int getOrd() {
         return mOrd;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.java
@@ -91,9 +91,7 @@ public class FieldEditText extends FixedEditText {
     }
 
 
-    public void init(int ord) {
-        mOrd = ord;
-
+    public void init() {
         setMinimumWidth(400);
         mOrigBackground = getBackground();
         // Fixes bug where new instances of this object have wrong colors, probably
@@ -149,6 +147,11 @@ public class FieldEditText extends FixedEditText {
             content = content.replaceAll("<br(\\s*/*)>", NEW_LINE);
         }
         setText(content);
+    }
+
+
+    public void setOrd(int ord) {
+        mOrd = ord;
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.java
@@ -91,9 +91,8 @@ public class FieldEditText extends FixedEditText {
     }
 
 
-    public void init(int ord, String name, String content, @Nullable Locale hintLocale) {
+    public void init(int ord, String content, @Nullable Locale hintLocale) {
         mOrd = ord;
-        mName = name;
 
         if (content == null) {
             content = "";
@@ -101,7 +100,6 @@ public class FieldEditText extends FixedEditText {
             content = content.replaceAll("<br(\\s*/*)>", NEW_LINE);
         }
         setText(content);
-        setContentDescription(name);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && hintLocale != null) {
             setHintLocale(hintLocale);
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1353,6 +1353,7 @@ public class NoteEditor extends AnkiActivity {
 
             edit_line_view.setTypeface(mCustomTypeface);
             edit_line_view.setName(fields[i][0]);
+            edit_line_view.setHintLocale(getHintLocaleForField(edit_line_view.getName()));
             initFieldEditText(newTextbox, i, fields[i], !editModelMode, clipboard);
 
             TextView label = edit_line_view.findViewById(R.id.id_label);
@@ -1496,10 +1497,8 @@ public class NoteEditor extends AnkiActivity {
 
 
     private void initFieldEditText(FieldEditText editText, final int index, String[] values, boolean enabled, @Nullable ClipboardManager clipboard) {
-        String name = values[0];
         String content = values[1];
-        Locale hintLocale = getHintLocaleForField(name);
-        editText.init(index, content, hintLocale);
+        editText.init(index, content);
 
         // HACK: To be removed after #7124
         // Additional cloze icon using GBoard Clipboard function for MIUI users

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1359,7 +1359,7 @@ public class NoteEditor extends AnkiActivity {
             initFieldEditText(newTextbox, i, !editModelMode, clipboard);
             mEditFields.add(newTextbox);
 
-            ImageButton mediaButton = edit_line_view.findViewById(R.id.id_media_button);
+            ImageButton mediaButton = edit_line_view.getMediaButton();
             // Load icons from attributes
             int[] icons = Themes.getResFromAttr(this, new int[] { R.attr.attachFileImage, R.attr.upDownImage});
             // Make the icon change between media icon and switch field icon depending on whether editing note type

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1354,7 +1354,8 @@ public class NoteEditor extends AnkiActivity {
 
             initFieldEditText(newTextbox, i, fields[i], mCustomTypeface, !editModelMode, clipboard);
 
-            TextView label = newTextbox.getLabel();
+            TextView label = edit_line_view.findViewById(R.id.id_label);
+            label.setText(newTextbox.getName());
             label.setPadding((int) UIUtils.getDensityAdjustedValue(this, 3.4f), 0, 0, 0);
             mEditFields.add(newTextbox);
 
@@ -1374,7 +1375,6 @@ public class NoteEditor extends AnkiActivity {
                 setMMButtonListener(mediaButton, i);
             }
             mediaButton.setContentDescription(getString(R.string.multimedia_editor_attach_mm_content, fields[i][0]));
-            mFieldsLayoutContainer.addView(label);
             mFieldsLayoutContainer.addView(edit_line_view);
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1353,8 +1353,9 @@ public class NoteEditor extends AnkiActivity {
 
             edit_line_view.setTypeface(mCustomTypeface);
             edit_line_view.setName(fields[i][0]);
+            edit_line_view.setContent(fields[i][1]);
             edit_line_view.setHintLocale(getHintLocaleForField(edit_line_view.getName()));
-            initFieldEditText(newTextbox, i, fields[i], !editModelMode, clipboard);
+            initFieldEditText(newTextbox, i, !editModelMode, clipboard);
 
             TextView label = edit_line_view.findViewById(R.id.id_label);
             label.setPadding((int) UIUtils.getDensityAdjustedValue(this, 3.4f), 0, 0, 0);
@@ -1496,9 +1497,8 @@ public class NoteEditor extends AnkiActivity {
     }
 
 
-    private void initFieldEditText(FieldEditText editText, final int index, String[] values, boolean enabled, @Nullable ClipboardManager clipboard) {
-        String content = values[1];
-        editText.init(index, content);
+    private void initFieldEditText(FieldEditText editText, final int index, boolean enabled, @Nullable ClipboardManager clipboard) {
+        editText.init(index);
 
         // HACK: To be removed after #7124
         // Additional cloze icon using GBoard Clipboard function for MIUI users

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1357,9 +1357,6 @@ public class NoteEditor extends AnkiActivity {
             edit_line_view.setOrd(i);
             edit_line_view.setHintLocale(getHintLocaleForField(edit_line_view.getName()));
             initFieldEditText(newTextbox, i, !editModelMode, clipboard);
-
-            TextView label = edit_line_view.findViewById(R.id.id_label);
-            label.setPadding((int) UIUtils.getDensityAdjustedValue(this, 3.4f), 0, 0, 0);
             mEditFields.add(newTextbox);
 
             ImageButton mediaButton = edit_line_view.findViewById(R.id.id_media_button);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1354,6 +1354,7 @@ public class NoteEditor extends AnkiActivity {
             edit_line_view.setTypeface(mCustomTypeface);
             edit_line_view.setName(fields[i][0]);
             edit_line_view.setContent(fields[i][1]);
+            edit_line_view.setOrd(i);
             edit_line_view.setHintLocale(getHintLocaleForField(edit_line_view.getName()));
             initFieldEditText(newTextbox, i, !editModelMode, clipboard);
 
@@ -1498,7 +1499,7 @@ public class NoteEditor extends AnkiActivity {
 
 
     private void initFieldEditText(FieldEditText editText, final int index, boolean enabled, @Nullable ClipboardManager clipboard) {
-        editText.init(index);
+        editText.init();
 
         // HACK: To be removed after #7124
         // Additional cloze icon using GBoard Clipboard function for MIUI users

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1499,8 +1499,6 @@ public class NoteEditor extends AnkiActivity {
 
 
     private void initFieldEditText(FieldEditText editText, final int index, boolean enabled, @Nullable ClipboardManager clipboard) {
-        editText.init();
-
         // HACK: To be removed after #7124
         // Additional cloze icon using GBoard Clipboard function for MIUI users
         if (clipboard != null && !AdaptionUtil.canUseContextMenu() && AnkiDroidApp.getSharedPrefs(this).getBoolean("enableMIUIClipboardHack", true)) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1341,7 +1341,7 @@ public class NoteEditor extends AnkiActivity {
         ClipboardManager clipboard = ContextCompat.getSystemService(this, ClipboardManager.class);
 
         for (int i = 0; i < fields.length; i++) {
-            View edit_line_view = getLayoutInflater().inflate(R.layout.card_multimedia_editline, mFieldsLayoutContainer, false);
+            View edit_line_view = new FieldEditLine(this);
             FieldEditText newTextbox = edit_line_view.findViewById(R.id.id_note_editText);
 
             if (Build.VERSION.SDK_INT >= 23) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1341,15 +1341,16 @@ public class NoteEditor extends AnkiActivity {
         ClipboardManager clipboard = ContextCompat.getSystemService(this, ClipboardManager.class);
 
         for (int i = 0; i < fields.length; i++) {
-            View edit_line_view = new FieldEditLine(this);
+            FieldEditLine edit_line_view = new FieldEditLine(this);
             FieldEditText newTextbox = edit_line_view.findViewById(R.id.id_note_editText);
 
+            // TODO: Remove the >= 23 check - one callback works on API 11.
             if (Build.VERSION.SDK_INT >= 23) {
                 // Use custom implementation of ActionMode.Callback customize selection and insert menus
                 Field f = new Field(getFieldByIndex(i), getCol());
                 ActionModeCallback actionModeCallback = new ActionModeCallback(newTextbox, f);
-                newTextbox.setCustomSelectionActionModeCallback(actionModeCallback);
-                newTextbox.setCustomInsertionActionModeCallback(actionModeCallback);
+                edit_line_view.setActionModeCallbacks(actionModeCallback);
+
             }
 
             initFieldEditText(newTextbox, i, fields[i], mCustomTypeface, !editModelMode, clipboard);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -60,7 +60,6 @@ import android.widget.Spinner;
 import android.widget.TextView;
 
 import com.afollestad.materialdialogs.MaterialDialog;
-import com.ichi2.anim.ActivityTransitionAnimation;
 import com.ichi2.anki.dialogs.ConfirmationDialog;
 import com.ichi2.anki.dialogs.DiscardChangesDialog;
 import com.ichi2.anki.dialogs.LocaleSelectionDialog;
@@ -121,7 +120,6 @@ import static com.ichi2.compat.Compat.ACTION_PROCESS_TEXT;
 import static com.ichi2.compat.Compat.EXTRA_PROCESS_TEXT;
 
 import com.ichi2.async.TaskData;import static com.ichi2.anim.ActivityTransitionAnimation.Direction.*;
-import static com.ichi2.anim.ActivityTransitionAnimation.Direction.*;
 
 /**
  * Allows the user to edit a note, for instance if there is a typo. A card is a presentation of a note, and has two
@@ -1353,7 +1351,8 @@ public class NoteEditor extends AnkiActivity {
 
             }
 
-            initFieldEditText(newTextbox, i, fields[i], mCustomTypeface, !editModelMode, clipboard);
+            edit_line_view.setTypeface(mCustomTypeface);
+            initFieldEditText(newTextbox, i, fields[i], !editModelMode, clipboard);
 
             TextView label = edit_line_view.findViewById(R.id.id_label);
             label.setText(newTextbox.getName());
@@ -1496,14 +1495,11 @@ public class NoteEditor extends AnkiActivity {
     }
 
 
-    private void initFieldEditText(FieldEditText editText, final int index, String[] values, Typeface customTypeface, boolean enabled, @Nullable ClipboardManager clipboard) {
+    private void initFieldEditText(FieldEditText editText, final int index, String[] values, boolean enabled, @Nullable ClipboardManager clipboard) {
         String name = values[0];
         String content = values[1];
         Locale hintLocale = getHintLocaleForField(name);
         editText.init(index, name, content, hintLocale);
-        if (customTypeface != null) {
-            editText.setTypeface(customTypeface);
-        }
 
         // HACK: To be removed after #7124
         // Additional cloze icon using GBoard Clipboard function for MIUI users

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1352,10 +1352,10 @@ public class NoteEditor extends AnkiActivity {
             }
 
             edit_line_view.setTypeface(mCustomTypeface);
+            edit_line_view.setName(fields[i][0]);
             initFieldEditText(newTextbox, i, fields[i], !editModelMode, clipboard);
 
             TextView label = edit_line_view.findViewById(R.id.id_label);
-            label.setText(newTextbox.getName());
             label.setPadding((int) UIUtils.getDensityAdjustedValue(this, 3.4f), 0, 0, 0);
             mEditFields.add(newTextbox);
 
@@ -1499,7 +1499,7 @@ public class NoteEditor extends AnkiActivity {
         String name = values[0];
         String content = values[1];
         Locale hintLocale = getHintLocaleForField(name);
-        editText.init(index, name, content, hintLocale);
+        editText.init(index, content, hintLocale);
 
         // HACK: To be removed after #7124
         // Additional cloze icon using GBoard Clipboard function for MIUI users

--- a/AnkiDroid/src/main/res/layout/card_multimedia_editline.xml
+++ b/AnkiDroid/src/main/res/layout/card_multimedia_editline.xml
@@ -6,6 +6,15 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content" >
 
+    <com.ichi2.ui.FixedTextView
+        android:id="@+id/id_label"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:drawablePadding="8dp"
+        android:layout_alignParentLeft="true"
+        tools:text="Label"
+        />
+
     <com.ichi2.anki.FieldEditText
         android:id="@+id/id_note_editText"
         android:layout_width="match_parent"
@@ -13,6 +22,7 @@
         android:drawablePadding="8dp"
         android:layout_alignParentLeft="true"
         android:layout_toLeftOf="@+id/id_media_button"
+        android:layout_below="@id/id_label"
         android:layout_alignTop="@+id/id_media_button"
         tools:text="This is a lot of target content to test how multiline values are displayed"
          />
@@ -24,6 +34,7 @@
         android:gravity="right|center_vertical"
         android:background="?attr/attachFileImage"
         android:layout_alignParentRight="true"
+        android:layout_below="@id/id_label"
         tools:background="@drawable/ic_attachment_black_24dp"/>
 
 

--- a/AnkiDroid/src/main/res/layout/card_multimedia_editline.xml
+++ b/AnkiDroid/src/main/res/layout/card_multimedia_editline.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
 
     android:layout_width="match_parent"
     android:layout_height="wrap_content" >
@@ -13,6 +14,7 @@
         android:layout_alignParentLeft="true"
         android:layout_toLeftOf="@+id/id_media_button"
         android:layout_alignTop="@+id/id_media_button"
+        tools:text="This is a lot of target content to test how multiline values are displayed"
          />
 
     <ImageButton
@@ -21,7 +23,8 @@
         android:layout_height="wrap_content"
         android:gravity="right|center_vertical"
         android:background="?attr/attachFileImage"
-        android:layout_alignParentRight="true"  />
+        android:layout_alignParentRight="true"
+        tools:background="@drawable/ic_attachment_black_24dp"/>
 
 
 </RelativeLayout>

--- a/AnkiDroid/src/main/res/layout/note_editor.xml
+++ b/AnkiDroid/src/main/res/layout/note_editor.xml
@@ -2,6 +2,7 @@
 <androidx.coordinatorlayout.widget.CoordinatorLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/root_layout"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
@@ -101,7 +102,8 @@
                             android:layout_marginLeft="5dip"
                             android:layout_marginRight="5dip"
                             android:clickable="false"
-                            android:gravity="left|center_vertical" />
+                            android:gravity="left|center_vertical"
+                            tools:text="Tags: AnkiDroid"/>
                     </LinearLayout>
                 </LinearLayout>
                 <LinearLayout
@@ -124,6 +126,7 @@
                             android:layout_marginLeft="5dip"
                             android:layout_marginRight="5dip"
                             android:clickable="false"
+                            tools:text="Cards: Card 1"
                             android:gravity="left|center_vertical" />
                     </LinearLayout>
                 </LinearLayout>


### PR DESCRIPTION
## Purpose / Description
I have a later PR to improve the UX of `EditFieldLine`, and I felt it was best to clean up the code before.

* This makes the label the responsibility of the line, rather than the textbox.
* This also improves the design-time preview of `NoteEditor`

## Learning

There doesn't seem to be a good `tools:` attribute for the design-time contents of a layout - I wanted a sample EditFieldLine in `note_editor.xml` and this didn't seem feasible after a quick google.

## How Has This Been Tested?

My Android 9 - class works the same as before.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)