### PR TITLE
Note Editor: Make Field Full Width

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -238,6 +238,7 @@ dependencies {
     // #6419  - API 27 (& maybe others) could not perform new ZipFile() on a 2GB+ apkg
     // noinspection GradleDependency - pinned at 1.12 until API21 minSdkVersion (File.toPath usage)
     implementation 'org.apache.commons:commons-compress:1.12'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.2'
 
 
     // May need a resolution strategy for support libs to our versions

--- a/AnkiDroid/src/main/res/layout/card_multimedia_editline.xml
+++ b/AnkiDroid/src/main/res/layout/card_multimedia_editline.xml
@@ -1,31 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-
     android:layout_width="match_parent"
-    android:layout_height="wrap_content" >
+    android:layout_height="wrap_content"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <com.ichi2.ui.FixedTextView
         android:id="@+id/id_label"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:drawablePadding="8dp"
         android:layout_alignParentLeft="true"
-        tools:text="Label"
-        />
-
-    <com.ichi2.anki.FieldEditText
-        android:id="@+id/id_note_editText"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:drawablePadding="8dp"
-        android:layout_alignParentLeft="true"
-        android:layout_toLeftOf="@+id/id_media_button"
-        android:layout_below="@id/id_label"
-        android:layout_alignTop="@+id/id_media_button"
-        tools:text="This is a lot of target content to test how multiline values are displayed"
-         />
+        app:layout_constraintBottom_toTopOf="@+id/id_note_editText"
+        app:layout_constraintEnd_toStartOf="@id/id_media_button"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="Front\nNewline" />
 
     <ImageButton
         android:id="@+id/id_media_button"
@@ -33,9 +22,27 @@
         android:layout_height="wrap_content"
         android:gravity="right|center_vertical"
         android:background="?attr/attachFileImage"
-        android:layout_alignParentRight="true"
-        android:layout_below="@id/id_label"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
         tools:background="@drawable/ic_attachment_black_24dp"/>
 
+    <androidx.constraintlayout.widget.Barrier
+        android:id="@+id/multimedia_barrier"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:barrierDirection="bottom"
+        app:constraint_referenced_ids="id_label, id_media_button" />
 
-</RelativeLayout>
+    <com.ichi2.anki.FieldEditText
+        android:id="@+id/id_note_editText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textStyle=""
+        android:nextFocusForward="@id/id_media_button"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/multimedia_barrier"
+        tools:text="This is a lot of target content to test how multiline values are displayed" />
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/AnkiDroid/src/main/res/layout/note_editor.xml
+++ b/AnkiDroid/src/main/res/layout/note_editor.xml
@@ -80,7 +80,8 @@
                     android:layout_height="wrap_content"
                     android:orientation="vertical"
                     android:focusable="true"
-                    android:padding="@dimen/keyline_1" />
+                    android:paddingVertical="@dimen/keyline_1"
+                    android:paddingHorizontal="6dip" />
 
                 <LinearLayout
                     android:layout_width="fill_parent"


### PR DESCRIPTION
## Purpose / Description
I mentioned UI improvements and got a few - thanks to /u/NightStruck for this suggestion.

This makes the Text entry for the Note Editor fill the width of the screen

## Approach
Move the attach button to beside the label

## How Has This Been Tested?

Tested with multiline title

Tested on Android 16 emulator and my Android 9 phone

Before:
![image](https://user-images.githubusercontent.com/62114487/96472971-031b1e00-1229-11eb-8080-978955471e9a.png)

After:
![image](https://user-images.githubusercontent.com/62114487/96472981-06160e80-1229-11eb-8aa2-97ae096c6ded.png)


## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
