### PR TITLE
NoteEditor: Expand/Collapse Field Content

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1350,6 +1350,8 @@ public class NoteEditor extends AnkiActivity {
             }
             previous = edit_line_view;
 
+            edit_line_view.setEnableAnimation(animationEnabled());
+
             // TODO: Remove the >= 23 check - one callback works on API 11.
             if (Build.VERSION.SDK_INT >= 23) {
                 // Use custom implementation of ActionMode.Callback customize selection and insert menus

--- a/AnkiDroid/src/main/java/com/ichi2/ui/AnimationUtil.java
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/AnimationUtil.java
@@ -1,0 +1,104 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.ui;
+
+import android.view.View;
+import android.view.animation.AlphaAnimation;
+import android.view.animation.Animation;
+import android.view.animation.AnimationSet;
+import android.view.animation.ScaleAnimation;
+
+public class AnimationUtil {
+
+    // please test this on Huawei devices (if possible) and not just on the emulator -
+    // having view.setVisibility(View.VISIBLE); on the expand worked fine on the emulator, but looked bad on my phone
+
+    /** This is a fast animation - We don't want the user incorrectly selecting the current position
+     * for the next collapse operation */
+    public static final int DURATION_MILLIS = 200;
+
+
+    public static void collapseView(View view, boolean animationEnabled) {
+        view.animate().cancel();
+
+        if (!animationEnabled) {
+            view.setVisibility(View.GONE);
+            return;
+        }
+
+        AnimationSet set = new AnimationSet(true);
+        ScaleAnimation expandAnimation = new ScaleAnimation(
+                1f, 1f,
+                1f, 0.5f);
+        expandAnimation.setDuration(DURATION_MILLIS);
+
+        expandAnimation.setAnimationListener(new Animation.AnimationListener() {
+            @Override
+            public void onAnimationStart(Animation animation) {
+
+            }
+
+
+            @Override
+            public void onAnimationEnd(Animation animation) {
+                view.setVisibility(View.GONE);
+            }
+
+
+            @Override
+            public void onAnimationRepeat(Animation animation) {
+
+            }
+        });
+
+        AlphaAnimation alphaAnimation = new AlphaAnimation(1.0f, 0f);
+        alphaAnimation.setDuration(DURATION_MILLIS);
+        alphaAnimation.setFillAfter(true);
+        set.addAnimation(expandAnimation);
+        set.addAnimation(alphaAnimation);
+
+        view.startAnimation(set);
+    }
+
+
+    public static void expandView(View view, boolean enableAnimation) {
+        view.animate().cancel();
+        if (!enableAnimation) {
+            view.setVisibility(View.VISIBLE);
+            view.setAlpha(1.0f);
+            view.setScaleY(1.0f);
+            return;
+        }
+
+        // Sadly this seems necessary - yScale didn't work.
+        AnimationSet set = new AnimationSet(true);
+        ScaleAnimation resetEditTextScale = new ScaleAnimation(
+                1f, 1f,
+                1f, 1f);
+        resetEditTextScale.setDuration(DURATION_MILLIS);
+
+
+        AlphaAnimation alphaAnimation = new AlphaAnimation(0.0f, 1.0f);
+        alphaAnimation.setFillAfter(true);
+        alphaAnimation.setDuration(DURATION_MILLIS);
+
+        set.addAnimation(resetEditTextScale);
+        set.addAnimation(alphaAnimation);
+        view.startAnimation(set);
+        view.setVisibility(View.VISIBLE);
+    }
+}

--- a/AnkiDroid/src/main/res/drawable/ic_expand_less_black_24dp.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_expand_less_black_24dp.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/black"
+      android:pathData="M12,8l-6,6 1.41,1.41L12,10.83l4.59,4.58L18,14z"/>
+</vector>

--- a/AnkiDroid/src/main/res/drawable/ic_expand_more_black_24dp_xml.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_expand_more_black_24dp_xml.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/black"
+      android:pathData="M16.59,8.59L12,13.17 7.41,8.59 6,10l6,6 6,-6z"/>
+</vector>

--- a/AnkiDroid/src/main/res/layout/card_multimedia_editline.xml
+++ b/AnkiDroid/src/main/res/layout/card_multimedia_editline.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/constraint_layout"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     xmlns:app="http://schemas.android.com/apk/res-auto">
@@ -12,7 +13,7 @@
         android:freezesText="true"
         android:layout_alignParentLeft="true"
         app:layout_constraintBottom_toTopOf="@+id/id_note_editText"
-        app:layout_constraintEnd_toStartOf="@id/id_media_button"
+        app:layout_constraintEnd_toStartOf="@id/id_expand_button"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         tools:text="Front\nNewline" />
@@ -23,16 +24,26 @@
         android:layout_height="wrap_content"
         android:gravity="right|center_vertical"
         android:background="?attr/attachFileImage"
-        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginEnd="16dp"
+        app:layout_constraintEnd_toStartOf="@id/id_expand_button"
         app:layout_constraintTop_toTopOf="parent"
         tools:background="@drawable/ic_attachment_black_24dp"/>
+
+    <ImageButton
+        android:id="@+id/id_expand_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="right|center_vertical"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:background="@drawable/ic_expand_less_black_24dp"/>
 
     <androidx.constraintlayout.widget.Barrier
         android:id="@+id/multimedia_barrier"
         android:layout_width="0dp"
         android:layout_height="0dp"
         app:barrierDirection="bottom"
-        app:constraint_referenced_ids="id_label, id_media_button" />
+        app:constraint_referenced_ids="id_label, id_media_button, id_expand_button" />
 
     <com.ichi2.anki.FieldEditText
         android:id="@+id/id_note_editText"

--- a/AnkiDroid/src/main/res/layout/note_editor.xml
+++ b/AnkiDroid/src/main/res/layout/note_editor.xml
@@ -80,6 +80,7 @@
                     android:layout_height="wrap_content"
                     android:orientation="vertical"
                     android:focusable="true"
+                    android:animateLayoutChanges="true"
                     android:paddingVertical="@dimen/keyline_1"
                     android:paddingHorizontal="6dip" />
 


### PR DESCRIPTION
Includes animation. Base requested on Reddit - seemed sensible

## How Has This Been Tested?

API 16, 19, and 30 emulator.

Huawei Honor Physical phone displayed different animation behavior than the emulators.

![image](https://user-images.githubusercontent.com/62114487/96529843-11475980-127e-11eb-862a-175d25e4df98.png)


## Learning (optional, can help others)

Animations are really hard to get right as it's near impossible to test

My normal vector compat usage didn't work for `DeckAdapter.java`, so I used a resource suffixed with `_xml`

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
