### PR TITLE
Remove the hint "tags" in card browser

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1507,7 +1507,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
         //TODO: Duplication between here and CustomStudyDialog:customStudyFromTags
         mSearchView.setQuery("", false);
         String tags = selectedTags.toString();
-        mSearchView.setQueryHint(getResources().getString(R.string.card_browser_tags_shown,
+        mSearchView.setQueryHint(getResources().getString(R.string.CardEditorTags,
                 tags.substring(1, tags.length() - 1)));
         StringBuilder sb = new StringBuilder();
         switch (option) {

--- a/AnkiDroid/src/main/res/values/07-cardbrowser.xml
+++ b/AnkiDroid/src/main/res/values/07-cardbrowser.xml
@@ -45,7 +45,6 @@
     <string name="card_browser_show_suspended">Filter suspended</string>
     <string name="card_browser_search_by_tag">Filter by tag</string>
     <string name="card_browser_search_by_flag">Filter by flag</string>
-    <string name="card_browser_tags_shown">Tags: %1$s</string>
     <string name="card_browser_list_my_searches">My searches</string>
     <string name="card_browser_list_my_searches_save">Save search</string>
     <string name="card_browser_list_my_searches_title">Choose a saved search</string>


### PR DESCRIPTION
If you use tag filter, the search bar is populated by the search query which looks for any of the card with one of the
selected tag. If furthermore you empty the search bar, then the hint change. This hint is misleading, since it seems to
indicate that you should enter tags in some way, while if you enter some text, it will actually be a standard search.