### PR TITLE
Fix to #7115: Allow setting "hardFactor"

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
@@ -132,6 +132,7 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
                 JSONObject revOptions = mOptions.getJSONObject("rev");
                 mValues.put("revPerDay", revOptions.getString("perDay"));
                 mValues.put("easyBonus", Integer.toString((int) (revOptions.getDouble("ease4") * 100)));
+                mValues.put("hardFactor", Integer.toString((int) (revOptions.optDouble("hardFactor", 1.2) * 100)));
                 mValues.put("revIvlFct", Integer.toString((int) (revOptions.getDouble("ivlFct") * 100)));
                 mValues.put("revMaxIvl", revOptions.getString("maxIvl"));
                 mValues.put("revBury", Boolean.toString(revOptions.optBoolean("bury", true)));
@@ -245,6 +246,9 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
                                 break;
                             case "easyBonus":
                                 mOptions.getJSONObject("rev").put("ease4", (Integer) value / 100.0f);
+                                break;
+                            case "hardFactor":
+                                mOptions.getJSONObject("rev").put("hardFactor", (Integer) value / 100.0f);
                                 break;
                             case "revIvlFct":
                                 mOptions.getJSONObject("rev").put("ivlFct", (Integer) value / 100.0f);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
@@ -46,6 +46,7 @@ import com.ichi2.libanki.Consts;
 import com.ichi2.libanki.DeckConfig;
 import com.ichi2.libanki.Deck;
 import com.ichi2.libanki.utils.Time;
+import com.ichi2.preferences.NumberRangePreference;
 import com.ichi2.preferences.StepsPreference;
 import com.ichi2.preferences.TimePreference;
 import com.ichi2.themes.StyledProgressDialog;
@@ -676,6 +677,9 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
             mPref.registerOnSharedPreferenceChangeListener(this);
 
             this.addPreferencesFromResource(R.xml.deck_options);
+            if (this.isSchedV2()) {
+                this.enableSchedV2Preferences();
+            }
             this.buildLists();
             this.updateSummaries();
             // Set the activity title to include the name of the deck
@@ -830,6 +834,21 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
         leechActPref.setEntries(R.array.leech_action_labels);
         leechActPref.setEntryValues(R.array.leech_action_values);
         leechActPref.setValue(mPref.getString("lapLeechAct", Integer.toString(Consts.LEECH_SUSPEND)));
+    }
+
+
+    private boolean isSchedV2() {
+        return mCol.schedVer() == 2;
+    }
+
+
+    /**
+     * Enable deck preferences that are only available with Scheduler V2.
+     */
+    @SuppressWarnings("deprecation") // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5019
+    protected void enableSchedV2Preferences() {
+            NumberRangePreference hardFactorPreference = (NumberRangePreference) findPreference("hardFactor");
+            hardFactorPreference.setEnabled(true);
     }
 
 

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -216,6 +216,7 @@
     <string name="deck_conf_use_general_timeout_settings">Use general settings</string>
     <string name="deck_conf_use_general_timeout_settings_summ">Use general \'Automatic display answer\' settings instead of using the settings for this group.</string>
     <string name="deck_conf_easy_bonus">Easy bonus</string>
+    <string name="deck_conf_hard_factor">Hard interval</string>
     <string name="deck_conf_ivl_fct">Interval modifier</string>
     <string name="deck_conf_max_ivl">Maximum interval</string>
     <string name="deck_conf_new_lps_ivl">New interval</string>

--- a/AnkiDroid/src/main/res/xml/deck_options.xml
+++ b/AnkiDroid/src/main/res/xml/deck_options.xml
@@ -99,7 +99,6 @@
                 android:title="@string/deck_conf_start_ease"
                 app:max="999"
                 app:min="100" />
-
             <CheckBoxPreference
                 android:defaultValue="true"
                 android:key="newBury"
@@ -116,6 +115,12 @@
                 android:key="easyBonus"
                 android:summary="@string/deck_conf_percent"
                 android:title="@string/deck_conf_easy_bonus"
+                app:max="1000"
+                app:min="100" />
+            <com.ichi2.preferences.NumberRangePreference
+                android:key="hardFactor"
+                android:summary="@string/deck_conf_percent"
+                android:title="@string/deck_conf_hard_factor"
                 app:max="1000"
                 app:min="100" />
             <com.ichi2.preferences.NumberRangePreference

--- a/AnkiDroid/src/main/res/xml/deck_options.xml
+++ b/AnkiDroid/src/main/res/xml/deck_options.xml
@@ -121,6 +121,7 @@
                 android:key="hardFactor"
                 android:summary="@string/deck_conf_percent"
                 android:title="@string/deck_conf_hard_factor"
+                android:enabled="false"
                 app:max="1000"
                 app:min="100" />
             <com.ichi2.preferences.NumberRangePreference

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckOptionsTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckOptionsTest.java
@@ -1,0 +1,42 @@
+package com.ichi2.anki;
+
+import android.content.SharedPreferences;
+
+import com.ichi2.libanki.Collection;
+import com.ichi2.libanki.Deck;
+import com.ichi2.libanki.Decks;
+import com.ichi2.utils.JSONObject;
+
+import org.apache.http.util.Asserts;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@RunWith(AndroidJUnit4.class)
+public class DeckOptionsTest extends RobolectricTest {
+
+    @Test
+    public void changeHardFactor() {
+        Collection col = getCol();
+
+        // Verify that for newly created deck hardFactor is default.
+        JSONObject conf = col.getConf();
+        double hardFactor = conf.optDouble("hardFactor", 1.2);
+        Assert.assertEquals(1.2, hardFactor, 0.01);
+
+        // Modify hard factor.
+        conf.put("hardFactor", 1.0);
+        col.setConf(conf);
+
+        // Verify that hardFactor value has changed.
+        conf = col.getConf();
+        hardFactor = conf.optDouble("hardFactor", 1.2);
+        Assert.assertEquals(1.0, hardFactor, 0.01);
+    }
+
+}


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Hard Factor is an option of V2 Scheduler, but it is not possible to modify it from Deck Options.

## Fixes
Fixes #7115

## Approach
* Modified DeckOptions to include hardFactor and added selection field to Deck Options / Reviews tab.
* Hard Factor can be modified irrespective of user using SchedV1 / SchedV2, but this option is set in general preferences not in deck options. I'm not sure how to make it disabled if SchedV1 is used.

## How Has This Been Tested?
* Tested on emulated device - Pixel 3A. SDK 29.
* Added unit test that tests if value is not set for newly created deck and returns correct value after value is modified.

## Learning (optional, can help others)
Hard Factor is described here: https://anki.tenderapp.com/discussions/ankidesktop/31735-what-does-hard-interval-mean

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)

_edited by @david-allison-1_