### PR TITLE
Note Editor: Use View Instance State for state restoration

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/FieldEditLineTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/FieldEditLineTest.java
@@ -1,0 +1,95 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki;
+
+import android.Manifest;
+import android.content.Intent;
+import android.os.Parcelable;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import androidx.annotation.NonNull;
+import androidx.test.ext.junit.rules.ActivityScenarioRule;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.rule.GrantPermissionRule;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@RunWith(AndroidJUnit4.class)
+public class FieldEditLineTest {
+
+    @Rule
+    public GrantPermissionRule mRuntimePermissionRule =
+            GrantPermissionRule.grant(Manifest.permission.WRITE_EXTERNAL_STORAGE);
+
+    @Rule public ActivityScenarioRule<NoteEditor> activityRule = new ActivityScenarioRule<>(getNoteEditorIntent());
+
+    @NonNull
+    private Intent getNoteEditorIntent() {
+        Intent intent = new Intent();
+        intent.setClass(AnkiDroidApp.getInstance(), NoteEditor.class);
+        intent.putExtra(NoteEditor.EXTRA_CALLER, NoteEditor.CALLER_DECKPICKER);
+        return intent;
+    }
+
+
+    @Test
+    public void testSetters() {
+        FieldEditLine line = getFieldEditLine();
+
+        line.setContent("Hello");
+        line.setName("Name");
+        line.setOrd(5);
+        FieldEditText text = line.getEditText();
+        assertThat(text.getOrd(), is(5));
+        assertThat(text.getText().toString(), is("Hello"));
+        assertThat(line.getName(), is("Name"));
+    }
+
+
+    @Test
+    public void testSaveRestore() {
+        FieldEditLine toSave = getFieldEditLine();
+
+        toSave.setContent("Hello");
+        toSave.setName("Name");
+        toSave.setOrd(5);
+
+        Parcelable b = toSave.onSaveInstanceState();
+
+        FieldEditLine restored = getFieldEditLine();
+        restored.onRestoreInstanceState(b);
+
+        FieldEditText text = restored.getEditText();
+        assertThat(text.getOrd(), is(5));
+        assertThat(text.getText().toString(), is("Hello"));
+        assertThat(toSave.getName(), is("Name"));
+    }
+
+
+    @NonNull
+    protected FieldEditLine getFieldEditLine() {
+        AtomicReference<FieldEditLine> l = new AtomicReference<>();
+        activityRule.getScenario().onActivity(a -> l.set(new FieldEditLine(a)));
+        return l.get();
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditLine.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditLine.java
@@ -19,7 +19,11 @@ package com.ichi2.anki;
 import android.content.Context;
 import android.graphics.Typeface;
 import android.os.Build;
+import android.os.Parcel;
+import android.os.Parcelable;
 import android.util.AttributeSet;
+import android.util.SparseArray;
+import android.view.AbsSavedState;
 import android.view.ActionMode;
 import android.view.LayoutInflater;
 import android.widget.FrameLayout;
@@ -130,8 +134,93 @@ public class FieldEditLine extends FrameLayout {
         return mMediaButton;
     }
 
-
     public FieldEditText getEditText() {
         return mEditText;
+    }
+
+    public void loadState(AbsSavedState state) {
+        this.onRestoreInstanceState(state);
+    }
+
+
+    @Override
+    protected void dispatchSaveInstanceState(SparseArray<Parcelable> container) {
+        dispatchFreezeSelfOnly(container);
+    }
+
+
+    @Override
+    protected void dispatchRestoreInstanceState(SparseArray<Parcelable> container) {
+        dispatchThawSelfOnly(container);
+    }
+
+
+    @Nullable
+    @Override
+    protected Parcelable onSaveInstanceState() {
+        Parcelable state = super.onSaveInstanceState();
+
+        SavedState savedState = new SavedState(state);
+        savedState.mChildrenStates = new SparseArray<>();
+        for (int i = 0; i < getChildCount(); i++) {
+            getChildAt(i).saveHierarchyState(savedState.mChildrenStates);
+        }
+
+        return savedState;
+    }
+
+
+    @Override
+    protected void onRestoreInstanceState(Parcelable state) {
+        if (!(state instanceof SavedState)) {
+            super.onRestoreInstanceState(state);
+            return;
+        }
+
+        SavedState ss = (SavedState) state;
+        super.onRestoreInstanceState(ss.getSuperState());
+        for (int i = 0; i < getChildCount(); i++) {
+            getChildAt(i).restoreHierarchyState(ss.mChildrenStates);
+        }
+    }
+
+
+    static class SavedState extends BaseSavedState {
+        private SparseArray<Parcelable> mChildrenStates;
+
+        SavedState(Parcelable superState) {
+            super(superState);
+        }
+
+        @Override
+        public void writeToParcel(Parcel out, int flags) {
+            super.writeToParcel(out, flags);
+            out.writeSparseArray(mChildrenStates);
+        }
+
+        //required field that makes Parcelables from a Parcel
+        public static final Parcelable.Creator<SavedState> CREATOR =
+            new ClassLoaderCreator<SavedState>() {
+                @Override
+                public SavedState createFromParcel(Parcel in, ClassLoader loader) {
+                    return new SavedState(in, loader);
+                }
+
+
+                @Override
+                public SavedState createFromParcel(Parcel source) {
+                    throw new IllegalStateException();
+                }
+
+
+                public SavedState[] newArray(int size) {
+                    return new SavedState[size];
+                }
+            };
+
+        private SavedState(Parcel in, ClassLoader loader) {
+            super(in);
+            this.mChildrenStates = in.readSparseArray(loader);
+        }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.java
@@ -6,6 +6,7 @@ import android.content.SharedPreferences;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.os.LocaleList;
+import android.os.Parcel;
 import android.os.Parcelable;
 import android.util.AttributeSet;
 
@@ -50,13 +51,6 @@ public class FieldEditText extends FixedEditText {
         super(context, attrs, defStyle);
     }
 
-
-    @Override
-    public Parcelable onSaveInstanceState() {
-        // content text has been saved in NoteEditor.java, restore twice caused issue#5660
-        super.onSaveInstanceState();
-        return null;
-    }
 
     @Override
     protected void onAttachedToWindow() {
@@ -146,6 +140,61 @@ public class FieldEditText extends FixedEditText {
         mOrd = ord;
     }
 
+    @Nullable
+    @Override
+    public Parcelable onSaveInstanceState() {
+        Parcelable state = super.onSaveInstanceState();
+
+        SavedState savedState = new SavedState(state);
+        savedState.mOrd = mOrd;
+
+        return savedState;
+    }
+
+
+    @Override
+    public void onRestoreInstanceState(Parcelable state) {
+        if (!(state instanceof SavedState)) {
+            super.onRestoreInstanceState(state);
+            return;
+        }
+
+        SavedState ss = (SavedState) state;
+        super.onRestoreInstanceState(ss.getSuperState());
+
+        mOrd = ss.mOrd;
+    }
+
+    static class SavedState extends BaseSavedState {
+        private int mOrd;
+
+        SavedState(Parcelable superState) {
+            super(superState);
+        }
+
+        @Override
+        public void writeToParcel(Parcel out, int flags) {
+            super.writeToParcel(out, flags);
+            out.writeInt(mOrd);
+        }
+
+        public static final Parcelable.Creator<SavedState> CREATOR =
+                new Parcelable.Creator<SavedState>() {
+                    @Override
+                    public SavedState createFromParcel(Parcel source) {
+                        return new SavedState(source);
+                    }
+
+                    public SavedState[] newArray(int size) {
+                        return new SavedState[size];
+                    }
+                };
+
+        private SavedState(Parcel in) {
+            super(in);
+            this.mOrd = in.readInt();
+        }
+    }
 
     public interface TextSelectionListener {
         void onSelectionChanged(int selStart, int selEnd);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.java
@@ -8,7 +8,6 @@ import android.os.Build;
 import android.os.LocaleList;
 import android.os.Parcelable;
 import android.util.AttributeSet;
-import android.widget.TextView;
 
 import java.util.Locale;
 
@@ -20,7 +19,6 @@ import timber.log.Timber;
 
 import com.ichi2.themes.Themes;
 import com.ichi2.ui.FixedEditText;
-import com.ichi2.ui.FixedTextView;
 
 import java.util.Objects;
 
@@ -32,7 +30,6 @@ public class FieldEditText extends FixedEditText {
     @NonNull
     public static final String NEW_LINE = Objects.requireNonNull(System.getProperty("line.separator"));
 
-    private String mName;
     private int mOrd;
     private Drawable mOrigBackground;
     @Nullable
@@ -86,11 +83,6 @@ public class FieldEditText extends FixedEditText {
     }
 
 
-    public String getName() {
-        return mName;
-    }
-
-
     public void init() {
         setMinimumWidth(400);
         mOrigBackground = getBackground();
@@ -116,7 +108,7 @@ public class FieldEditText extends FixedEditText {
 
     @RequiresApi(api = Build.VERSION_CODES.N)
     public void setHintLocale(@NonNull Locale locale) {
-        Timber.d("Setting hint locale of '%s' to '%s'", mName, locale);
+        Timber.d("Setting hint locale to '%s'", locale);
         setImeHintLocales(new LocaleList(locale));
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -781,13 +781,6 @@ public class NoteEditor extends AnkiActivity {
     }
 
 
-    private void resetEditFields(String[] content) {
-        for (int i = 0; i < Math.min(content.length, mEditFields.size()); i++) {
-            mEditFields.get(i).setText(content[i]);
-        }
-    }
-
-
     private boolean hasUnsavedChanges() {
         if (!collectionHasLoaded()) {
             return false;
@@ -1849,14 +1842,8 @@ public class NoteEditor extends AnkiActivity {
                     mCurrentDid = model.getLong("did");
                     updateDeckPosition();
                 }
-                // Reset edit fields
-                int size = mEditFields.size();
-                String[] oldValues = new String[size];
-                for (int i = 0; i < size; i++) {
-                    oldValues[i] = getCurrentFieldText(i);
-                }
+
                 refreshNoteData(FieldChangeType.changeFieldCount());
-                resetEditFields(oldValues);
                 setDuplicateFieldStyles();
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1369,9 +1369,10 @@ public class NoteEditor extends AnkiActivity {
         }
         ClipboardManager clipboard = ContextCompat.getSystemService(this, ClipboardManager.class);
 
+        List<FieldEditLine> editLines = getFieldEditLines(fields);
         FieldEditLine previous = null;
-        for (int i = 0; i < fields.length; i++) {
-            FieldEditLine edit_line_view = new FieldEditLine(this);
+        for (int i = 0; i < editLines.size(); i++) {
+            FieldEditLine edit_line_view = editLines.get(i);
             FieldEditText newTextbox = edit_line_view.getEditText();
 
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
@@ -1390,13 +1391,9 @@ public class NoteEditor extends AnkiActivity {
                 Field f = new Field(getFieldByIndex(i), getCol());
                 ActionModeCallback actionModeCallback = new ActionModeCallback(newTextbox, f);
                 edit_line_view.setActionModeCallbacks(actionModeCallback);
-
             }
 
             edit_line_view.setTypeface(mCustomTypeface);
-            edit_line_view.setName(fields[i][0]);
-            edit_line_view.setContent(fields[i][1]);
-            edit_line_view.setOrd(i);
             edit_line_view.setHintLocale(getHintLocaleForField(edit_line_view.getName()));
             initFieldEditText(newTextbox, i, !editModelMode, clipboard);
             mEditFields.add(newTextbox);
@@ -1426,6 +1423,20 @@ public class NoteEditor extends AnkiActivity {
             mediaButton.setContentDescription(getString(R.string.multimedia_editor_attach_mm_content, fields[i][0]));
             mFieldsLayoutContainer.addView(edit_line_view);
         }
+    }
+
+
+    @NonNull
+    private List<FieldEditLine> getFieldEditLines(String[][] fields) {
+        List<FieldEditLine> editLines = new ArrayList<>();
+        for (int i = 0; i < fields.length; i++) {
+            FieldEditLine edit_line_view = new FieldEditLine(this);
+            editLines.add(edit_line_view);
+            edit_line_view.setName(fields[i][0]);
+            edit_line_view.setContent(fields[i][1]);
+            edit_line_view.setOrd(i);
+        }
+        return editLines;
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/FieldState.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/FieldState.java
@@ -87,6 +87,16 @@ public class FieldState {
                 }
             }
         }
+
+        if (type.mType == Type.CHANGE_FIELD_COUNT) {
+            String[] currentFieldStrings = mEditor.getCurrentFieldStrings();
+
+            for (int i = 0; i < Math.min(currentFieldStrings.length, fieldEditLines.size()); i++) {
+                fieldEditLines.get(i).setContent(currentFieldStrings[i]);
+            }
+        }
+
+
         return fieldEditLines;
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/FieldState.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/FieldState.java
@@ -1,0 +1,175 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.noteeditor;
+
+import android.content.Context;
+import android.util.Pair;
+
+import com.ichi2.anki.FieldEditLine;
+import com.ichi2.anki.NoteEditor;
+import com.ichi2.anki.R;
+import com.ichi2.libanki.Model;
+import com.ichi2.libanki.Models;
+import com.ichi2.utils.JSONObject;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import androidx.annotation.NonNull;
+
+import static com.ichi2.utils.MapUtil.getKeyByValue;
+
+/** Responsible for recreating EditFieldLines after NoteEditor operations
+ * This primarily exists so we can use saved instance state to repopulate the dynamically created FieldEditLine
+ */
+public class FieldState {
+
+    private final NoteEditor mEditor;
+
+    private FieldState(NoteEditor editor) {
+        mEditor = editor;
+    }
+
+    private static boolean allowFieldRemapping(String[][] oldFields) {
+        return oldFields.length > 2;
+    }
+
+
+    public static FieldState fromEditor(NoteEditor editor) {
+        return new FieldState(editor);
+    }
+
+
+    @NonNull
+    public List<FieldEditLine> loadFieldEditLines(FieldChangeType type) {
+        String[][] fields = getFields(type);
+
+        List<FieldEditLine> editLines = new ArrayList<>();
+        for (int i = 0; i < fields.length; i++) {
+            FieldEditLine edit_line_view = new FieldEditLine(mEditor);
+            editLines.add(edit_line_view);
+            edit_line_view.setName(fields[i][0]);
+            edit_line_view.setContent(fields[i][1]);
+            edit_line_view.setOrd(i);
+        }
+        return editLines;
+    }
+
+
+    private String[][] getFields(FieldChangeType type) {
+        if (type.mType == Type.REFRESH_WITH_MAP) {
+            String[][] items = mEditor.getFieldsFromSelectedNote();
+            Map<String, Pair<Integer, JSONObject>> fMapNew = Models.fieldMap(type.newModel);
+            return FieldState.fromFieldMap(mEditor, items, fMapNew, type.modelChangeFieldMap);
+        }
+        if (type.mType == Type.INIT) {
+            String[][] savedFields = mEditor.consumeSavedFields();
+            if (savedFields == null) {
+                savedFields = mEditor.getFieldsFromSelectedNote();
+            }
+            return savedFields;
+        }
+        return mEditor.getFieldsFromSelectedNote();
+    }
+
+
+    private static String[][] fromFieldMap(Context context, String[][] oldFields, Map<String, Pair<Integer, JSONObject>> fMapNew, Map<Integer, Integer> mModelChangeFieldMap) {
+        // Build array of label/values to provide to field EditText views
+        String[][] fields = new String[fMapNew.size()][2];
+        for (String fname : fMapNew.keySet()) {
+            Pair<Integer, JSONObject> fieldPair = fMapNew.get(fname);
+            if (fieldPair == null) {
+                continue;
+            }
+            // Field index of new note type
+            Integer i = fieldPair.first;
+            // Add values from old note type if they exist in map, otherwise make the new field empty
+            if (mModelChangeFieldMap.containsValue(i)) {
+                // Get index of field from old note type given the field index of new note type
+                Integer j = getKeyByValue(mModelChangeFieldMap, i);
+                if (j == null) {
+                    continue;
+                }
+                // Set the new field label text
+                if (allowFieldRemapping(oldFields)) {
+                    // Show the content of old field if remapping is enabled
+                    fields[i][0] = String.format(context.getResources().getString(R.string.field_remapping), fname, oldFields[j][0]);
+                } else {
+                    fields[i][0] = fname;
+                }
+
+                // Set the new field label value
+                fields[i][1] = oldFields[j][1];
+            } else {
+                // No values from old note type exist in the mapping
+                fields[i][0] = fname;
+                fields[i][1] = "";
+            }
+        }
+        return fields;
+    }
+
+    /** How fields should be changed when the UI is rebuilt */
+    public static class FieldChangeType {
+        private final Type mType;
+
+        private Map<Integer, Integer> modelChangeFieldMap;
+        private Model newModel;
+
+        public FieldChangeType(Type type) {
+            this.mType = type;
+        }
+
+        public static FieldChangeType refreshWithMap(Model newModel, Map<Integer, Integer> modelChangeFieldMap) {
+            FieldChangeType typeClass = new FieldChangeType(Type.REFRESH_WITH_MAP);
+            typeClass.newModel = newModel;
+            typeClass.modelChangeFieldMap = modelChangeFieldMap;
+            return typeClass;
+        }
+
+        public static FieldChangeType refresh() {
+            return fromType(FieldState.Type.REFRESH);
+        }
+
+
+        public static FieldChangeType refreshWithStickyFields() {
+            return fromType(Type.CLEAR_KEEP_STICKY);
+        }
+
+
+        public static FieldChangeType changeFieldCount() {
+            return fromType(Type.CHANGE_FIELD_COUNT);
+        }
+
+        public static FieldChangeType onActivityCreation() {
+            return fromType(Type.INIT);
+        }
+
+        private static FieldChangeType fromType(Type type) {
+            return new FieldChangeType(type);
+        }
+    }
+
+    public enum Type {
+        INIT,
+        CLEAR_KEEP_STICKY,
+        CHANGE_FIELD_COUNT,
+        REFRESH,
+        REFRESH_WITH_MAP,
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/FieldState.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/FieldState.java
@@ -28,6 +28,7 @@ import com.ichi2.anki.NoteEditor;
 import com.ichi2.anki.R;
 import com.ichi2.libanki.Model;
 import com.ichi2.libanki.Models;
+import com.ichi2.utils.JSONArray;
 import com.ichi2.utils.JSONObject;
 
 import java.util.ArrayList;
@@ -73,6 +74,18 @@ public class FieldState {
         }
         for (FieldEditLine l : fieldEditLines) {
             l.setId(ViewCompat.generateViewId());
+        }
+
+        if (type.mType == Type.CLEAR_KEEP_STICKY) {
+            // we use the UI values here as the model will post-processing steps (newline -> br).
+            String[] currentFieldStrings = mEditor.getCurrentFieldStrings();
+
+            JSONArray flds = mEditor.getCurrentFields();
+            for (int fldIdx = 0; fldIdx < flds.length(); fldIdx++) {
+                if (flds.getJSONObject(fldIdx).getBoolean("sticky")) {
+                    fieldEditLines.get(fldIdx).setContent(currentFieldStrings[fldIdx]);
+                }
+            }
         }
         return fieldEditLines;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/MapUtil.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/MapUtil.java
@@ -1,0 +1,37 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.utils;
+
+import java.util.Map;
+
+public class MapUtil {
+
+    /**
+     * Convenience method for getting the corresponding key given the value in a 1-to-1 map
+     * @param map map containing 1-to-1 key/value pairs
+     * @param value value to get key for
+     * @return key corresponding to the given value
+     */
+    public static <T, E> T getKeyByValue(Map<T,E> map, E value) {
+        for (Map.Entry<T, E> entry : map.entrySet()) {
+            if (value.equals(entry.getValue())) {
+                return entry.getKey();
+            }
+        }
+        return null;
+    }
+}

--- a/AnkiDroid/src/main/res/layout/card_multimedia_editline.xml
+++ b/AnkiDroid/src/main/res/layout/card_multimedia_editline.xml
@@ -9,6 +9,7 @@
         android:id="@+id/id_label"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:freezesText="true"
         android:layout_alignParentLeft="true"
         app:layout_constraintBottom_toTopOf="@+id/id_note_editText"
         app:layout_constraintEnd_toStartOf="@id/id_media_button"


### PR DESCRIPTION
## Purpose / Description
Refactoring: Encapsulates the rendering of components into the view, rather than having them handled by the activity.

This slightly reduces the complexity of the activity

## Approach
Obtain the data from instance state ourselves, using techniques from https://speakerdeck.com/cyrilmottier/deep-dive-into-android-state-restoration

## How Has This Been Tested?

On my device - preview and exiting the app still work

## Learning 

https://speakerdeck.com/cyrilmottier/deep-dive-into-android-state-restoration - mostly, plus learning about `android:viewHierarchyState` and `android:views`

A view needs an ID to have data saved

Android really makes having dynamic views difficult

An exception thrown when creating a bundle does not crash - and the data is not marked as corrupt in the debugger.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)