### PR TITLE
Fix images deleted after editing (issue #7377)

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
@@ -259,9 +259,11 @@ public class BasicImageFieldController extends FieldControllerBase implements IF
 
 
     private void saveImageForRevert() {
-        deletePreviousImage();
-        mPreviousImagePath = mViewModel.mImagePath;
-        mPreviousImageUri = mViewModel.mImageUri;
+        if (!mViewModel.isPreExistingImage) {
+            deletePreviousImage();
+            mPreviousImagePath = mViewModel.mImagePath;
+            mPreviousImageUri = mViewModel.mImageUri;
+        }
     }
 
 
@@ -785,6 +787,7 @@ public class BasicImageFieldController extends FieldControllerBase implements IF
     private static class ImageViewModel {
         public final @Nullable String mImagePath;
         public final @Nullable Uri mImageUri;
+        public boolean isPreExistingImage = false;
 
         private ImageViewModel(@Nullable String mImagePath, @Nullable Uri mImageUri) {
             this.mImagePath = mImagePath;
@@ -818,7 +821,9 @@ public class BasicImageFieldController extends FieldControllerBase implements IF
             if (newImageUri == null && newImagePath != null) {
                 newImageUri = getUriForFile(new File(newImagePath), context);
             }
-            return new ImageViewModel(newImagePath, newImageUri);
+            ImageViewModel ivm = new ImageViewModel(newImagePath, newImageUri);
+            ivm.isPreExistingImage = true;
+            return ivm;
         }
 
 


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

This PR is an attempt to fix #7377

Here I'd like to write a more detailed description of the issue, along with a proposed solution

Steps to reproduce this problem:

1. in CardBrowser, tap on the 'add note' button (=> NoteEditor is launched)
2. select a field, tap on the attach button, choose 'add image'
3. choose an image to add to the field (this image can be from Gallery or Camera, this is not important)
4. save the image, and then save the note
5. open the note again in NoteEditor
6. select the same field as above, tap on the attach button
7. tap on the camera button to add another image to the field
8. save the image, and then save the note

Now, the expected result is: the note has 2 images
But the actual result is: image 1 has been deleted, only image 2 remains

I think that the reason for this problem is because in BasicImageFieldController, variable mViewModel is used to store both:
\* The preexisting image, which is fetched from ImageField when BasicImageFieldController is launched, and
\* The new image captured from camera

In the steps above:
After step 6, the preexisting image is put into mViewModel
After step 7, mViewModel.mImagePath/Uri is put into mPreviousImagePath/Uri
In step 8, onDone() is called which deletes the preexisting image

This PR proposes a solution by adding a boolean field to ImageViewModel, in order to differentiate between the 2 images put into mViewModel. Now if deletePreviousImage() is called, it will only delete the image taken from camera, not the preexisting one.


## How Has This Been Tested?

I've verified that this solution works in emulator API 30. I also ran all relevant automated tests and they're all passed.

## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
