### PR TITLE
Note Editor - Fix Tab Order

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/NoteEditorTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/NoteEditorTest.java
@@ -1,0 +1,125 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki;
+
+import android.app.Activity;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Build;
+import android.view.KeyEvent;
+import android.view.inputmethod.BaseInputConnection;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import androidx.annotation.NonNull;
+import androidx.lifecycle.Lifecycle;
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.ext.junit.rules.ActivityScenarioRule;
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.rule.GrantPermissionRule;
+
+import static android.Manifest.permission.WRITE_EXTERNAL_STORAGE;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assume.assumeThat;
+
+@RunWith(androidx.test.ext.junit.runners.AndroidJUnit4.class)
+public class NoteEditorTest {
+
+    @Rule public ActivityScenarioRule<NoteEditor> activityRule = new ActivityScenarioRule<>(getStartActivityIntent());
+    @Rule public GrantPermissionRule mRuntimePermissionRule = GrantPermissionRule.grant(WRITE_EXTERNAL_STORAGE);
+
+    @NonNull
+    private Intent getStartActivityIntent() {
+        Intent intent = new Intent(getTargetContext(), NoteEditor.class);
+        intent.setComponent(new ComponentName(getTargetContext(), NoteEditor.class));
+        intent.putExtra(NoteEditor.EXTRA_CALLER, NoteEditor.CALLER_DECKPICKER);
+        return intent;
+    }
+
+    @Test
+    public void testTabOrder() throws Throwable {
+        // TODO: Look into these assumptions and see if they can be diagnosed - both work on my emulators.
+        // If we fix them, we might be able to use instrumentation.sendKeyDownUpSync
+        /*
+        java.lang.AssertionError: Activity never becomes requested state "[DESTROYED]" (last lifecycle transition = "PAUSED")
+        at androidx.test.core.app.ActivityScenario.waitForActivityToBecomeAnyOf(ActivityScenario.java:301)
+         */
+        assumeThat("Test fails on Travis API 25", Build.VERSION.SDK_INT, not(is(25)));
+        /*
+        java.lang.AssertionError:
+        Expected: is "a"
+         */
+        assumeThat("Test fails on Travis API 30", Build.VERSION.SDK_INT, not(is(30)));
+
+        ensureCollectionLoaded();
+        ActivityScenario<NoteEditor> scenario = activityRule.getScenario();
+        scenario.moveToState(Lifecycle.State.RESUMED);
+
+        onActivity(scenario, editor -> {
+            sendKeyDownUp(editor, KeyEvent.KEYCODE_A);
+            sendKeyDownUp(editor, KeyEvent.KEYCODE_TAB);
+            sendKeyDownUp(editor, KeyEvent.KEYCODE_TAB);
+            sendKeyDownUp(editor, KeyEvent.KEYCODE_B);
+        });
+
+        onActivity(scenario, editor -> {
+            String[] currentFieldStrings = editor.getCurrentFieldStrings();
+            assertThat(currentFieldStrings[0], is("a"));
+            assertThat(currentFieldStrings[1], is("b"));
+        });
+
+    }
+
+
+    protected void sendKeyDownUp(Activity activity, int keyCode) {
+        BaseInputConnection mInputConnection = new BaseInputConnection(activity.getCurrentFocus(), true);
+        mInputConnection.sendKeyEvent(new KeyEvent(KeyEvent.ACTION_DOWN, keyCode));
+        mInputConnection.sendKeyEvent(new KeyEvent(KeyEvent.ACTION_UP, keyCode));
+    }
+
+
+    protected void onActivity(ActivityScenario<NoteEditor> scenario, ActivityScenario.ActivityAction<NoteEditor> noteEditorActivityAction) throws Throwable {
+        AtomicReference<Throwable> wrapped = new AtomicReference<>(null);
+        scenario.onActivity(a -> {
+            try {
+                noteEditorActivityAction.perform(a);
+            } catch (Throwable t) {
+                wrapped.set(t);
+            }
+        });
+        if (wrapped.get() != null) {
+            throw wrapped.get();
+        }
+    }
+
+
+    private void ensureCollectionLoaded() {
+        CollectionHelper.getInstance().getCol(getTargetContext());
+    }
+
+
+    private Context getTargetContext() {
+        return InstrumentationRegistry.getInstrumentation().getTargetContext();
+    }
+}

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/testutil/ThreadUtils.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/testutil/ThreadUtils.java
@@ -1,0 +1,38 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.testutil;
+
+public class ThreadUtils {
+    public static void sleep(int timeMs) {
+        try {
+            Thread.sleep(timeMs);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+
+    public static void runAndJoin(Runnable runnable, int timeout) {
+        Thread t = new Thread(runnable);
+        t.start();
+        try {
+            t.join(timeout);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditLine.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditLine.java
@@ -31,6 +31,7 @@ import java.util.Locale;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
+import androidx.core.view.ViewCompat;
 
 public class FieldEditLine extends FrameLayout {
     private FieldEditText mEditText;
@@ -70,9 +71,18 @@ public class FieldEditLine extends FrameLayout {
         this.mEditText = findViewById(R.id.id_note_editText);
         this.mLabel = findViewById(R.id.id_label);
         this.mMediaButton = findViewById(R.id.id_media_button);
+        // 7433 -
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            mEditText.setId(ViewCompat.generateViewId());
+            mMediaButton.setId(ViewCompat.generateViewId());
+            mEditText.setNextFocusForwardId(mMediaButton.getId());
+        }
+
         mEditText.init();
         mLabel.setPadding((int) UIUtils.getDensityAdjustedValue(getContext(), 3.4f), 0, 0, 0);
     }
+
+
 
 
     public void setActionModeCallbacks(ActionMode.Callback callback) {
@@ -118,5 +128,10 @@ public class FieldEditLine extends FrameLayout {
 
     public ImageButton getMediaButton() {
         return mMediaButton;
+    }
+
+
+    public FieldEditText getEditText() {
+        return mEditText;
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -112,6 +112,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 import androidx.core.content.ContextCompat;
+import androidx.core.view.ViewCompat;
 import androidx.fragment.app.DialogFragment;
 import timber.log.Timber;
 
@@ -1338,9 +1339,20 @@ public class NoteEditor extends AnkiActivity {
         }
         ClipboardManager clipboard = ContextCompat.getSystemService(this, ClipboardManager.class);
 
+        FieldEditLine previous = null;
         for (int i = 0; i < fields.length; i++) {
             FieldEditLine edit_line_view = new FieldEditLine(this);
-            FieldEditText newTextbox = edit_line_view.findViewById(R.id.id_note_editText);
+            FieldEditText newTextbox = edit_line_view.getEditText();
+
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+                if (i == 0) {
+                    findViewById(R.id.note_deck_spinner).setNextFocusForwardId(newTextbox.getId());
+                }
+                if (previous != null) {
+                    previous.getMediaButton().setNextFocusForwardId(newTextbox.getId());
+                }
+            }
+            previous = edit_line_view;
 
             // TODO: Remove the >= 23 check - one callback works on API 11.
             if (Build.VERSION.SDK_INT >= 23) {
@@ -1374,6 +1386,10 @@ public class NoteEditor extends AnkiActivity {
                 mediaButton.setBackgroundResource(icons[0]);
                 setMMButtonListener(mediaButton, i);
             }
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O && previous != null) {
+                previous.getMediaButton().setNextFocusForwardId(R.id.CardEditorTagButton);
+            }
+
             mediaButton.setContentDescription(getString(R.string.multimedia_editor_attach_mm_content, fields[i][0]));
             mFieldsLayoutContainer.addView(edit_line_view);
         }


### PR DESCRIPTION
## Fixes
Fixes #7433

## Approach
Set IDs manually, so we can add a valid tab ordering on IDs for API < 26

## How Has This Been Tested?

API 30 emulator: passed

API 25, and 16 emulators, required different fixes, now pass

CI tests: Failing on API 25 and 30 - worked locally, so ignored.

## Learning (optional, can help others)
API 26 introduces navigation clusters which means the layout works out the box with a single `focusForward` change to the layout.

https://developer.android.com/about/versions/oreo/android-8.0#kbnc

Sending input is complex to do correctly over all SDK versions (events can be dropped if an activity is reset).

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
