### PR TITLE
Note Editor: Set Font Size Feature

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/utils/TextViewUtil.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/TextViewUtil.java
@@ -1,0 +1,25 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.utils;
+
+import android.widget.TextView;
+
+public class TextViewUtil {
+    public static float getTextSizeSp(TextView first) {
+        return first.getTextSize() / first.getResources().getDisplayMetrics().scaledDensity;
+    }
+}

--- a/AnkiDroid/src/main/res/layout/card_multimedia_editline.xml
+++ b/AnkiDroid/src/main/res/layout/card_multimedia_editline.xml
@@ -37,7 +37,6 @@
         android:id="@+id/id_note_editText"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:textStyle=""
         android:nextFocusForward="@id/id_media_button"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/AnkiDroid/src/main/res/menu/note_editor.xml
+++ b/AnkiDroid/src/main/res/menu/note_editor.xml
@@ -20,4 +20,8 @@
         android:id="@+id/action_copy_note"
         android:enabled="false"
         android:title="@string/note_editor_copy_note"/>
+    <item
+        android:id="@+id/action_font_size"
+        android:title="@string/menu_font_size"
+        ankidroid:showAsAction="never"/>
 </menu>

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -332,4 +332,7 @@
 
     <string name="ankidroid_init_failed_webview_title">Fatal Error</string>
     <string name="ankidroid_init_failed_webview">AnkiDroid relies on the System WebView which is unavailable. This can happen if the system is installing updates. Please try again in a few minutes.\n\n%s</string>
+
+    <!-- A Menu item to change the Font Size (currently in the Note Editor) -->
+    <string name="menu_font_size">Font Size</string>
 </resources>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.java
@@ -65,8 +65,7 @@ public class NoteEditorTest extends RobolectricTest {
     @Test
     public void verifyPreviewAddingNote() {
         NoteEditor n = getNoteEditorAdding(NoteType.BASIC).withFirstField("Preview Test").build();
-        ActionMenuItemView previewButton = n.findViewById(R.id.action_preview);
-        previewButton.performClick();
+        n.performPreview();
         ShadowActivity.IntentForResult intent = shadowOf(n).getNextStartedActivityForResult();
         Bundle noteEditorBundle = intent.intent.getBundleExtra("noteEditorBundle");
         assertThat("Bundle set to add note style", noteEditorBundle.getBoolean("addNote"), is(true));


### PR DESCRIPTION
## Purpose / Description
Requested to allow more text on the screen in `NoteEditor` - seemed like a useful feature

## How Has This Been Tested?

API 16 emulator

![image](https://user-images.githubusercontent.com/62114487/96876779-c3467780-1470-11eb-8048-85c5bfeaa2d1.png)
![image](https://user-images.githubusercontent.com/62114487/96877065-14ef0200-1471-11eb-912d-227ed171bf66.png)

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)