### PR TITLE
NF: Quicker split field

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Consts.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Consts.java
@@ -149,4 +149,6 @@ public class Consts {
     public static final long DEFAULT_DECK_ID = 1;
     /** Default dconf - can't be removed */
     public static final long DEFAULT_DECK_CONFIG_ID = 1;
+
+    public static final String FIELD_SEPARATOR = Character.toString('\u001f');
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
@@ -71,6 +71,8 @@ import org.apache.commons.compress.archivers.zip.ZipFile;
 import androidx.annotation.Nullable;
 import timber.log.Timber;
 
+import static com.ichi2.libanki.Consts.FIELD_SEPARATOR;
+
 @SuppressWarnings({"PMD.AvoidThrowingRawExceptionTypes","PMD.AvoidReassigningParameters",
         "PMD.MethodNamingConventions","PMD.FieldDeclarationsShouldBeAtStartOfClass"})
 public class Utils {
@@ -545,7 +547,7 @@ public class Utils {
 
     public static String[] splitFields(String fields) {
         // -1 ensures that we don't drop empty fields at the ends
-        return fields.split("\\x1f", -1);
+        return fields.split(FIELD_SEPARATOR, -1);
     }
 
     /*

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/UtilsTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/UtilsTest.java
@@ -84,4 +84,10 @@ public class UtilsTest {
         Utils.copyFile(new File(resource.toURI()), copy);
         Assert.assertEquals(TestUtils.getMD5(resourcePath), TestUtils.getMD5(copy.getCanonicalPath()));
     }
+
+    @Test
+    public void testSplit() {
+        Assert.assertArrayEquals(new String[]{"foo", "bar"}, Utils.splitFields("foobar"));
+        Assert.assertArrayEquals(new String[]{"", "foo", "", "", ""}, Utils.splitFields("foo"));
+    }
 }

--- a/api/src/main/java/com/ichi2/anki/FlashCardsContract.java
+++ b/api/src/main/java/com/ichi2/anki/FlashCardsContract.java
@@ -231,7 +231,7 @@ public class FlashCardsContract {
      * <td>String</td>
      * <td>{@link #FLDS}</td>
      * <td>read-write</td>
-     * <td>Fields of this note. Fields are separated by "\\x1f"</td>
+     * <td>Fields of this note. Fields are separated by "\\x1f", a.k.a. Consts.FIELD_SEPARATOR</td>
      * </tr>
      * <tr>
      * <td>long</td>

--- a/api/src/main/java/com/ichi2/anki/api/Utils.java
+++ b/api/src/main/java/com/ichi2/anki/api/Utils.java
@@ -36,6 +36,7 @@ class Utils {
     private static final Pattern tagPattern = Pattern.compile("<.*?>");
     private static final Pattern imgPattern = Pattern.compile("<img src=[\"']?([^\"'>]+)[\"']? ?/?>");
     private static final Pattern htmlEntitiesPattern = Pattern.compile("&#?\\w+;");
+    private static final String FIELD_SEPARATOR = Character.toString('\u001f');
 
 
     static String joinFields(String[] list) {
@@ -44,7 +45,7 @@ class Utils {
 
 
     static String[] splitFields(String fields) {
-        return fields != null? fields.split("\\x1f", -1): null;
+        return fields != null? fields.split(FIELD_SEPARATOR, -1): null;
     }
 
     static String joinTags(Set<String> tags) {


### PR DESCRIPTION
The function split is optimized for splitting around a char. We never used it because instead we used unicode encoding
in regexp. This small change will save plenty of time for all batch processing.


On Empty card, (with profiler), this reduce splitting time from 40 seconds to 18 seconds