### PR TITLE
Empty card: update at most once by second

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -2783,10 +2783,13 @@ public class DeckPicker extends NavigationDrawerActivity implements
     }
     private static class HandleEmptyCardListener extends TaskListenerWithContext<DeckPicker> {
         private final int mNumberOfCards;
+        private final int mOnePercent;
+        private int mIncreaseSinceLastUpdate = 0;
 
         public HandleEmptyCardListener(DeckPicker deckPicker) {
             super(deckPicker);
             mNumberOfCards = deckPicker.getCol().cardCount();
+            mOnePercent = mNumberOfCards / 100;
         }
 
         private void confirmCancel(@NonNull DeckPicker deckPicker, @NonNull CollectionTask task) {
@@ -2818,7 +2821,12 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
         @Override
         public void actualOnProgressUpdate(@NonNull DeckPicker deckPicker, @NonNull TaskData progress) {
-            deckPicker.mProgressDialog.incrementProgress(progress.getInt());
+            mIncreaseSinceLastUpdate += progress.getInt();
+            // Increase each time at least a percent of card has been processed since last update
+            if (mIncreaseSinceLastUpdate > mOnePercent) {
+                deckPicker.mProgressDialog.incrementProgress(mIncreaseSinceLastUpdate);
+                mIncreaseSinceLastUpdate = 0;
+            }
         }
 
         @Override


### PR DESCRIPTION
Checking the profiler, I see that some significant amount of time is spent enqueuing various update. (To be more specific, this time become significant when all the remaining optimization are merged. Otherwise, it's not the main factor at all)

Maybe one second is too big a delay, there is a clear loss in fluidity. But on the other hand, I believe that one update by second gives a correct amount of information