### PR TITLE
NF: update Travis CI build toold / platform to 29

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -100,8 +100,8 @@ before_install:
   - if [ "$FINALIZE_COVERAGE" = "FALSE" ]; then yes | travis_retry sdkmanager --licenses >/dev/null; fi # accept all sdkmanager warnings
   - if [ "$FINALIZE_COVERAGE" = "FALSE" ]; then echo y | travis_retry sdkmanager --no_https "platform-tools" >/dev/null; fi
   - if [ "$FINALIZE_COVERAGE" = "FALSE" ]; then echo y | travis_retry sdkmanager --no_https "tools" >/dev/null; fi # A second time per Travis docs, gets latest versions
-  - if [ "$FINALIZE_COVERAGE" = "FALSE" ]; then echo y | travis_retry sdkmanager --no_https "build-tools;28.0.3" >/dev/null; fi # Implicit gradle dependency - gradle drives changes
-  - if [ "$FINALIZE_COVERAGE" = "FALSE" ]; then echo y | travis_retry sdkmanager --no_https "platforms;android-28" >/dev/null; fi # We need the API of the current compileSdkVersion from gradle.properties
+  - if [ "$FINALIZE_COVERAGE" = "FALSE" ]; then echo y | travis_retry sdkmanager --no_https "build-tools;29.0.2" >/dev/null; fi # Implicit gradle dependency - gradle drives changes
+  - if [ "$FINALIZE_COVERAGE" = "FALSE" ]; then echo y | travis_retry sdkmanager --no_https "platforms;android-29" >/dev/null; fi # We need the API of the current compileSdkVersion from gradle.properties
 
 install:
   # In our setup, install only runs on matrix entries we want full emulator tests on

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -15,7 +15,7 @@ repositories {
 }
 def homePath = System.properties['user.home']
 android {
-    compileSdkVersion 29
+    compileSdkVersion 29 // change .travis.yml build tools at same time
 
     defaultConfig {
         applicationId "com.ichi2.anki"
@@ -45,7 +45,7 @@ android {
         versionName="2.14alpha21"
         minSdkVersion 16
         //noinspection OldTargetApi - also performed in api/build.fradle
-        targetSdkVersion 29
+        targetSdkVersion 29 // change .travis.yml platform download at same time
         multiDexEnabled true
         testApplicationId "com.ichi2.anki.tests"
         vectorDrawables.useSupportLibrary = true


### PR DESCRIPTION
These were missed in the forward port to API29 which caused non-retry
downloads of build tools and android platform SDK during build instead
of before the build

updating the old API28 download to be the needed 29 ones and commenting
build.gradle to note the cross-dependency for next time