### PR TITLE
Note Editor: Add "Word Wrap" setting

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditLine.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditLine.java
@@ -28,6 +28,7 @@ import android.widget.TextView;
 
 import java.util.Locale;
 
+import androidx.annotation.LayoutRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
@@ -43,31 +44,35 @@ public class FieldEditLine extends FrameLayout {
 
     public FieldEditLine(@NonNull Context context) {
         super(context);
-        init();
+        init(R.layout.card_multimedia_editline);
     }
 
+    public FieldEditLine(@NonNull Context context, @LayoutRes int layout) {
+        super(context);
+        init(layout);
+    }
 
     public FieldEditLine(@NonNull Context context, @Nullable AttributeSet attrs) {
         super(context, attrs);
-        init();
+        init(R.layout.card_multimedia_editline);
     }
 
 
     public FieldEditLine(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
-        init();
+        init(R.layout.card_multimedia_editline);
     }
 
 
     @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
     public FieldEditLine(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr, int defStyleRes) {
         super(context, attrs, defStyleAttr, defStyleRes);
-        init();
+        init(R.layout.card_multimedia_editline);
     }
 
 
-    private void init() {
-        LayoutInflater.from(getContext()).inflate(R.layout.card_multimedia_editline, this, true);
+    private void init(int layout) {
+        LayoutInflater.from(getContext()).inflate(layout, this, true);
         this.mEditText = findViewById(R.id.id_note_editText);
         this.mLabel = findViewById(R.id.id_label);
         this.mMediaButton = findViewById(R.id.id_media_button);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -114,7 +114,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 import androidx.core.content.ContextCompat;
-import androidx.core.view.ViewCompat;
 import androidx.fragment.app.DialogFragment;
 import timber.log.Timber;
 
@@ -228,6 +227,8 @@ public class NoteEditor extends AnkiActivity {
     // A bundle that maps field ords to the text content of that field for use in
     // restoring the Activity.
     private Bundle mSavedFields;
+
+    private FieldLayout mFieldLayout = FieldLayout.REGULAR;
 
     private SaveNoteHandler saveNoteHandler() {
         return new SaveNoteHandler(this);
@@ -1044,6 +1045,12 @@ public class NoteEditor extends AnkiActivity {
             repositionDialog.setCallbackRunnable(this::setFontSize);
             showDialogFragment(repositionDialog);
             return true;
+        } else if (itemId == R.id.action_word_wrap) {
+            item.setChecked(!item.isChecked()); // ಠ_ಠ Yes, this is necessary on Android 9
+            mFieldLayout = item.isChecked() ? FieldLayout.REGULAR : FieldLayout.HorizontalScroll;
+            mSavedFields = getFieldsAsBundle(false);
+            populateEditFields();
+            return true;
         }
         return super.onOptionsItemSelected(item);
     }
@@ -1371,7 +1378,7 @@ public class NoteEditor extends AnkiActivity {
 
         FieldEditLine previous = null;
         for (int i = 0; i < fields.length; i++) {
-            FieldEditLine edit_line_view = new FieldEditLine(this);
+            FieldEditLine edit_line_view = new FieldEditLine(this, getEditLineLayout());
             FieldEditText newTextbox = edit_line_view.getEditText();
 
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
@@ -1426,6 +1433,15 @@ public class NoteEditor extends AnkiActivity {
             mediaButton.setContentDescription(getString(R.string.multimedia_editor_attach_mm_content, fields[i][0]));
             mFieldsLayoutContainer.addView(edit_line_view);
         }
+    }
+
+
+    private int getEditLineLayout() {
+        // TODO: Save for activity relaunch
+        if (mFieldLayout == FieldLayout.HorizontalScroll) {
+            return R.layout.card_multimedia_editline_scrollview;
+        }
+        return R.layout.card_multimedia_editline;
     }
 
 
@@ -2244,5 +2260,10 @@ public class NoteEditor extends AnkiActivity {
                 Timber.w(e, "Failed to save hint locale");
             }
         }
+    }
+
+    private enum FieldLayout {
+        REGULAR,
+        HorizontalScroll
     }
 }

--- a/AnkiDroid/src/main/res/layout/card_multimedia_editline_scrollview.xml
+++ b/AnkiDroid/src/main/res/layout/card_multimedia_editline_scrollview.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <com.ichi2.ui.FixedTextView
+        android:id="@+id/id_label"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_alignParentLeft="true"
+        app:layout_constraintBottom_toTopOf="@id/note_edit_field_scrollview"
+        app:layout_constraintEnd_toStartOf="@id/id_media_button"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="Front\nNewline" />
+
+    <ImageButton
+        android:id="@+id/id_media_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="right|center_vertical"
+        android:background="?attr/attachFileImage"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:background="@drawable/ic_attachment_black_24dp"/>
+
+    <androidx.constraintlayout.widget.Barrier
+        android:id="@+id/multimedia_barrier"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:barrierDirection="bottom"
+        app:constraint_referenced_ids="id_label, id_media_button" />
+
+    <HorizontalScrollView
+        android:id="@+id/note_edit_field_scrollview"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/multimedia_barrier"
+        android:fillViewport="true" >
+        <com.ichi2.anki.FieldEditText
+            android:id="@+id/id_note_editText"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:scrollHorizontally="true"
+            android:nextFocusForward="@id/id_media_button"
+            tools:text="This is a lot of target content to test how multiline values are displayed"  />
+    </HorizontalScrollView>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/AnkiDroid/src/main/res/menu/note_editor.xml
+++ b/AnkiDroid/src/main/res/menu/note_editor.xml
@@ -24,4 +24,9 @@
         android:id="@+id/action_font_size"
         android:title="@string/menu_font_size"
         ankidroid:showAsAction="never"/>
+    <item
+        android:id="@+id/action_word_wrap"
+        android:checkable="true"
+        android:checked="true"
+        android:title="@string/note_editor_word_wrap" />
 </menu>

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -335,4 +335,5 @@
 
     <!-- A Menu item to change the Font Size (currently in the Note Editor) -->
     <string name="menu_font_size">Font Size</string>
+    <string name="note_editor_word_wrap">Word Wrap</string>
 </resources>


### PR DESCRIPTION
Another request for a Note Editor feature for UX purposes

## Approach

New layout and `HorizontalScrollView` - this may not be maintainable (see: FlashCardViewer) and the multiple layout issues we occasionally get, so this is a major review goal

## How Has This Been Tested?

API 26 x64 emulator

![image](https://user-images.githubusercontent.com/62114487/97024242-7cc74a80-154e-11eb-9158-91766b87f794.png)

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)