### PR TITLE
NF: Models.get takes a Long

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1908,7 +1908,7 @@ public class NoteEditor extends AnkiActivity {
             // If a new column was selected then change the key used to map from mCards to the column TextView
             //Timber.i("NoteEditor:: onItemSelected() fired on mNoteTypeSpinner");
             long oldModelId = getCol().getModels().current().getLong("id");
-            long newId = mAllModelIds.get(pos);
+            @NonNull Long newId = mAllModelIds.get(pos);
             Timber.i("Changing note type to '%d", newId);
             if (oldModelId != newId) {
                 Model model = getCol().getModels().get(newId);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -800,7 +800,7 @@ public class Collection {
                     return null;
                 }
                 Long nid = cur.getLong(0);
-                long mid = cur.getLong(1);
+                @NonNull Long mid = cur.getLong(1);
                 String flds = cur.getString(2);
                 Model model = getModels().get(mid);
                 ArrayList<Integer> avail = getModels().availOrds(model, Utils.splitFields(flds));

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -277,7 +277,7 @@ public class Models {
 
 
     /** get model with ID, or null. */
-    public @Nullable Model get(long id) {
+    public @Nullable Model get(@NonNull Long id) {
         if (mModels.containsKey(id)) {
             return mModels.get(id);
         } else {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -366,7 +366,7 @@ public class Models {
     }
 
 
-    public boolean have(long id) {
+    public boolean have(@NonNull Long id) {
         return mModels.containsKey(id);
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
@@ -51,6 +51,7 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import androidx.annotation.NonNull;
 import timber.log.Timber;
 
 import com.ichi2.async.TaskData;
@@ -248,9 +249,10 @@ public class Anki2Importer extends Importer {
                     dupes += 1;
                     if (mAllowUpdate) {
                         Object[] n = mNotes.get(note[GUID]);
+                        //todo: oldNid could be Long instead of long.
                         long oldNid = (Long) n[0];
                         long oldMod = (Long) n[1];
-                        long oldMid = (Long) n[2];
+                        @NonNull Long oldMid = (Long) n[2];
                         // will update if incoming note more recent
                         if (oldMod < (Long) note[MOD]) {
                             // safe if note types identical
@@ -349,8 +351,8 @@ public class Anki2Importer extends Importer {
     // returns true if note should be added
     private boolean _uniquifyNote(Object[] note) {
         String origGuid = (String) note[GUID];
-        long srcMid = (Long) note[MID];
-        long dstMid = _mid(srcMid);
+        @NonNull Long srcMid = (Long) note[MID];
+        @NonNull Long dstMid = _mid(srcMid);
         // duplicate Schemas?
         if (srcMid == dstMid) {
             return !mNotes.containsKey(origGuid);
@@ -381,12 +383,12 @@ public class Anki2Importer extends Importer {
 
 
     /** Return local id for remote MID. */
-    private long _mid(long srcMid) {
+    @NonNull private Long _mid(Long srcMid) {
         // already processed this mid?
         if (mModelMap.containsKey(srcMid)) {
             return mModelMap.get(srcMid);
         }
-        long mid = srcMid;
+        @NonNull Long mid = srcMid;
         Model srcModel = mSrc.getModels().get(srcMid);
         String srcScm = mSrc.getModels().scmhash(srcModel);
         while (true) {
@@ -394,7 +396,7 @@ public class Anki2Importer extends Importer {
             if (!mDst.getModels().have(mid)) {
                 // copy it over
                 Model model = srcModel.deepClone();
-                model.put("id", mid);
+                model.put("id", (long) mid);
                 model.put("mod", mCol.getTime().intTime());
                 model.put("usn", mCol.usn());
                 mDst.getModels().update(model);


### PR DESCRIPTION
This is an answer to https://github.com/ankidroid/Anki-Android/pull/7453#discussion_r510957882

Models#get calls a hashmap, so it actually uses a Long. Sometime we have the Long and so using `long` is just uselessly inneficient. This correct this.

Note that this is not something that I found out to be actually significant in the profiler (but I never tried the profiler on the import method either)