### PR TITLE
Fix Build failures:  testAnki2Updates and testTabOrder

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/NoteEditorTabOrderTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/NoteEditorTabOrderTest.java
@@ -24,6 +24,7 @@ import android.os.Build;
 import android.view.KeyEvent;
 import android.view.inputmethod.BaseInputConnection;
 
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -44,7 +45,35 @@ import static org.hamcrest.Matchers.not;
 import static org.junit.Assume.assumeThat;
 
 @RunWith(androidx.test.ext.junit.runners.AndroidJUnit4.class)
-public class NoteEditorTest {
+public class NoteEditorTabOrderTest {
+
+    public NoteEditorTabOrderTest() {
+        // Rules mean that we get a failure on API 25.
+        // Even if we ignore the tests, the rules cause a failure.
+        // We can't ignore the test in @BeforeClass ("Test run failed to complete. Expected 150 tests, received 149")
+        // and @Before executes after the rule.
+        // So, disable the rules in the constructor, and ignore in before.
+        if (Build.VERSION.SDK_INT == 25 || Build.VERSION.SDK_INT == 30) {
+            activityRule = null;
+            mRuntimePermissionRule = null;
+        }
+    }
+
+    @Before
+    public void before() {
+        // TODO: Look into these assumptions and see if they can be diagnosed - both work on my emulators.
+        // If we fix them, we might be able to use instrumentation.sendKeyDownUpSync
+        /*
+        java.lang.AssertionError: Activity never becomes requested state "[DESTROYED]" (last lifecycle transition = "PAUSED")
+        at androidx.test.core.app.ActivityScenario.waitForActivityToBecomeAnyOf(ActivityScenario.java:301)
+         */
+        assumeThat("Test fails on Travis API 25", Build.VERSION.SDK_INT, not(is(25)));
+        /*
+        java.lang.AssertionError:
+        Expected: is "a"
+         */
+        assumeThat("Test fails on Travis API 30", Build.VERSION.SDK_INT, not(is(30)));
+    }
 
     @Rule public ActivityScenarioRule<NoteEditor> activityRule = new ActivityScenarioRule<>(getStartActivityIntent());
     @Rule public GrantPermissionRule mRuntimePermissionRule = GrantPermissionRule.grant(WRITE_EXTERNAL_STORAGE);
@@ -59,19 +88,6 @@ public class NoteEditorTest {
 
     @Test
     public void testTabOrder() throws Throwable {
-        // TODO: Look into these assumptions and see if they can be diagnosed - both work on my emulators.
-        // If we fix them, we might be able to use instrumentation.sendKeyDownUpSync
-        /*
-        java.lang.AssertionError: Activity never becomes requested state "[DESTROYED]" (last lifecycle transition = "PAUSED")
-        at androidx.test.core.app.ActivityScenario.waitForActivityToBecomeAnyOf(ActivityScenario.java:301)
-         */
-        assumeThat("Test fails on Travis API 25", Build.VERSION.SDK_INT, not(is(25)));
-        /*
-        java.lang.AssertionError:
-        Expected: is "a"
-         */
-        assumeThat("Test fails on Travis API 30", Build.VERSION.SDK_INT, not(is(30)));
-
         ensureCollectionLoaded();
         ActivityScenario<NoteEditor> scenario = activityRule.getScenario();
         scenario.moveToState(Lifecycle.State.RESUMED);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
@@ -1068,7 +1068,7 @@ public class Utils {
      * @param <T> A type on which equals can be called
      * @return Whether both objects are equal.
      */
-    // Similar as Objets.equals. So deprecated starting at API Level 19 where this methods exists.
+    // Similar as Objects.equals. So deprecated starting at API Level 19 where this methods exists.
     public static <T> boolean equals(@Nullable T left, @Nullable T right) {
         //noinspection EqualsReplaceableByObjectsCall
         return left == right || (left != null && left.equals(right));

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
@@ -408,7 +408,7 @@ public class Anki2Importer extends Importer {
             if (srcScm.equals(dstScm)) {
                 // they do; we can reuse this mid
                 Model model = srcModel.deepClone();
-                model.put("id", mid);
+                model.put("id", (long) mid);
                 model.put("mod", mCol.getTime().intTime());
                 model.put("usn", mCol.usn());
                 mDst.getModels().update(model);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
@@ -256,7 +256,7 @@ public class Anki2Importer extends Importer {
                         // will update if incoming note more recent
                         if (oldMod < (Long) note[MOD]) {
                             // safe if note types identical
-                            if (oldMid == (Long) note[MID]) {
+                            if (Utils.equals(oldMid, note[MID])) {
                                 // incoming note should use existing id
                                 note[0] = oldNid;
                                 note[4] = usn;
@@ -354,7 +354,7 @@ public class Anki2Importer extends Importer {
         @NonNull Long srcMid = (Long) note[MID];
         @NonNull Long dstMid = _mid(srcMid);
         // duplicate Schemas?
-        if (srcMid == dstMid) {
+        if (Utils.equals(srcMid, dstMid)) {
             return !mNotes.containsKey(origGuid);
         }
         // differing schemas and note doesn't exist?


### PR DESCRIPTION
IDE-based lint warning on comparing using == rather than `.equals()`

Please check 9674085 when reviewing - it appeared incorrect, but maybe I missed the context of the code.

## Fixes
Fixes #7467 
Fixes #7470