### PR TITLE
NF: _tmplsFromOrds quicker

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -695,6 +695,12 @@ public class Collection {
     }
 
 
+    /**
+     * @param model A note type
+     * @param avail Ords of cards from this note type.
+     * @return One template by element i of avail, for the i-th card. For standard template, avail should contains only existing ords.
+     * for cloze, avail should contains only non-negative numbers, and the i-th card is a copy of the first card, with a different ord.
+     */
     private ArrayList<JSONObject> _tmplsFromOrds(Model model, ArrayList<Integer> avail) {
         ArrayList<JSONObject> ok = new ArrayList<>();
         JSONArray tmpls;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -706,10 +706,8 @@ public class Collection {
         JSONArray tmpls;
         if (model.getInt("type") == Consts.MODEL_STD) {
             tmpls = model.getJSONArray("tmpls");
-            for (JSONObject t : tmpls.jsonObjectIterable()) {
-                if (avail.contains(t.getInt("ord"))) {
-                    ok.add(t);
-                }
+            for (Integer ord : avail) {
+                ok.add(tmpls.getJSONObject(ord));
             }
         } else {
             // cloze - generate temporary templates from first


### PR DESCRIPTION
Currently, avail traverse the list uselessly. This ensure that we get the speed of random access

On my collection, it reduces the time spent in `_tmplsFromOrds` from 30 seconds to 11 seconds