### PR TITLE
Remove useless conversions

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -952,8 +952,8 @@ public class NoteEditor extends AnkiActivity {
      * @throws ConfirmModSchemaException If a full sync will be required
      */
     private void changeNoteType(Model oldModel, Model newModel) throws ConfirmModSchemaException {
-        final long [] noteIds = {mEditorNote.getId()};
-        getCol().getModels().change(oldModel, noteIds, newModel, mModelChangeFieldMap, mModelChangeCardMap);
+        final long noteId = mEditorNote.getId();
+        getCol().getModels().change(oldModel, noteId, newModel, mModelChangeFieldMap, mModelChangeCardMap);
         // refresh the note object to reflect the database changes
         mEditorNote.load();
         // close note editor

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -725,16 +725,16 @@ public class Collection {
     /**
      * Generate cards for non-empty templates, return ids to remove.
      */
-	public ArrayList<Long> genCards(List<Long> nids, @NonNull Model model) {
+	public ArrayList<Long> genCards(java.util.Collection<Long> nids, @NonNull Model model) {
 	    return genCards(Utils.collection2Array(nids), model);
 	}
 
-    public <T extends ProgressSender<TaskData> & CancelListener> ArrayList<Long> genCards(List<Long> nids, @NonNull Model model, @Nullable T task) {
+    public <T extends ProgressSender<TaskData> & CancelListener> ArrayList<Long> genCards(java.util.Collection<Long> nids, @NonNull Model model, @Nullable T task) {
        return genCards(Utils.collection2Array(nids), model, task);
     }
 
-    public ArrayList<Long> genCards(long[] nids, long mid) {
-        return genCards(nids, getModels().get(mid), null);
+    public ArrayList<Long> genCards(java.util.Collection<Long> nids, long mid) {
+        return genCards(nids, getModels().get(mid));
     }
 
     public ArrayList<Long> genCards(long[] nids, @NonNull Model model) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1098,9 +1098,23 @@ public class Collection {
     }
 
 
-    /** Update field checksums and sort cache, after find&replace, etc. */
+    /** Update field checksums and sort cache, after find&replace, etc.
+     * @param nids*/
+    public void updateFieldCache(java.util.Collection<Long> nids) {
+        String snids = Utils.ids2str(nids);
+        updateFieldCache(snids);
+    }
+
+    /** Update field checksums and sort cache, after find&replace, etc.
+     * @param nids*/
     public void updateFieldCache(long[] nids) {
         String snids = Utils.ids2str(nids);
+        updateFieldCache(snids);
+    }
+
+    /** Update field checksums and sort cache, after find&replace, etc.
+     * @param snids comma separated nids*/
+    public void updateFieldCache(String snids) {
         ArrayList<Object[]> r = new ArrayList<>();
         for (Object[] o : _fieldData(snids)) {
             String[] fields = Utils.splitFields((String) o[2]);
@@ -1709,7 +1723,7 @@ public class Collection {
         // field cache
         for (Model m : getModels().all()) {
             notifyProgress.run();
-            updateFieldCache(Utils.collection2Array(getModels().nids(m)));
+            updateFieldCache(getModels().nids(m));
         }
         return Collections.emptyList();
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -749,6 +749,15 @@ public class Collection {
     public <T extends ProgressSender<TaskData> & CancelListener> ArrayList<Long> genCards(long[] nids, @NonNull Model model, @Nullable T task) {
         // build map of (nid,ord) so we don't create dupes
         String snids = Utils.ids2str(nids);
+        return genCards(snids, model, task);
+    }
+
+    /**
+     * @param snids All ids of nodes of a note type, separated by comma
+     * @param task Task to check for cancellation and update number of card processed
+     * @return Cards that should be removed because they should not be generated
+     */
+    public <T extends ProgressSender<TaskData> & CancelListener> ArrayList<Long> genCards(String snids, @NonNull Model model, @Nullable T task) {
         // For each note, indicates ords of cards it contains
         HashMap<Long, HashMap<Integer, Long>> have = new HashMap<>();
         // For each note, the deck containing all of its cards, or 0 if siblings in multiple deck

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -741,6 +741,14 @@ public class Collection {
         return genCards(nids, model, null);
     }
 
+    public ArrayList<Long> genCards(long nid, @NonNull Model model) {
+        return genCards(nid, model, null);
+    }
+
+    public <T extends ProgressSender<TaskData> & CancelListener> ArrayList<Long> genCards(long nid, @NonNull Model model, @Nullable T task) {
+        return genCards("(" + nid + ")", model, task);
+    }
+
     /**
      * @param nids All ids of nodes of a note type
      * @param task Task to check for cancellation and update number of card processed

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
@@ -935,7 +935,7 @@ public class Finder {
             long mid = entry.getKey();
             java.util.Collection<Long> nids_ = entry.getValue();
             long[] pnids = Utils.toPrimitive(nids_);
-            col.updateFieldCache(pnids);
+            col.updateFieldCache(nidss);
             col.genCards(pnids, mid);
         }
         return d.size();

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
@@ -934,7 +934,7 @@ public class Finder {
         for (Map.Entry<Long, java.util.Collection<Long>> entry : midToNid.entrySet()) {
             long mid = entry.getKey();
             java.util.Collection<Long> nids_ = entry.getValue();
-            long[] pnids = Utils.toPrimitive(nids);
+            long[] pnids = Utils.toPrimitive(nids_);
             col.updateFieldCache(pnids);
             col.genCards(pnids, mid);
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
@@ -934,9 +934,8 @@ public class Finder {
         for (Map.Entry<Long, java.util.Collection<Long>> entry : midToNid.entrySet()) {
             long mid = entry.getKey();
             java.util.Collection<Long> nids_ = entry.getValue();
-            long[] pnids = Utils.toPrimitive(nids_);
-            col.updateFieldCache(nidss);
-            col.genCards(pnids, mid);
+            col.updateFieldCache(nids_);
+            col.genCards(nids_, mid);
         }
         return d.size();
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -865,14 +865,15 @@ public class Models {
     /**
      * Change a model
      * @param m The model to change.
-     * @param nids The list of notes that the change applies to. They are all of note type n
+     * @param nid The notes that the change applies to.
      * @param newModel For replacing the old model with another one. Should be self if the model is not changing
      * @param fmap Map for switching fields. This is ord->ord and there should not be duplicate targets
      * @param cmap Map for switching cards. This is ord->ord and there should not be duplicate targets
      * @throws ConfirmModSchemaException 
      */
-    public void change(Model m, long[] nids, Model newModel, Map<Integer, Integer> fmap, Map<Integer, Integer> cmap) throws ConfirmModSchemaException {
+    public void change(Model m, long nid, Model newModel, Map<Integer, Integer> fmap, Map<Integer, Integer> cmap) throws ConfirmModSchemaException {
         mCol.modSchema();
+        long[] nids = new long[] {nid};
         assert (newModel.getLong("id") == m.getLong("id")) || (fmap != null && cmap != null);
         if (fmap != null) {
             _changeNotes(nids, newModel, fmap);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -879,7 +879,7 @@ public class Models {
             _changeNotes(nids, newModel, fmap);
         }
         if (cmap != null) {
-            _changeCards(nids, m, newModel, cmap);
+            _changeCards(nid, m, newModel, cmap);
         }
         mCol.genCards(nids, newModel);
     }
@@ -914,7 +914,7 @@ public class Models {
         mCol.updateFieldCache(nids);
     }
 
-    private void _changeCards(long[] nids, Model oldModel, Model newModel, Map<Integer, Integer> map) {
+    private void _changeCards(long nid, Model oldModel, Model newModel, Map<Integer, Integer> map) {
         List<Object[]> d = new ArrayList<>();
         List<Long> deleted = new ArrayList<>();
         Cursor cur = null;
@@ -923,7 +923,7 @@ public class Models {
         int nflds = newModel.getJSONArray("tmpls").length();
         try {
             cur = mCol.getDb().getDatabase().query(
-                    "select id, ord from cards where nid in " + Utils.ids2str(nids), null);
+                    "select id, ord from cards where nid = ?", new Object[] {nid});
             while (cur.moveToNext()) {
                 // if the src model is a cloze, we ignore the map, as the gui doesn't currently
                 // support mapping them

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -873,7 +873,6 @@ public class Models {
      */
     public void change(Model m, long nid, Model newModel, Map<Integer, Integer> fmap, Map<Integer, Integer> cmap) throws ConfirmModSchemaException {
         mCol.modSchema();
-        long[] nids = new long[] {nid};
         assert (newModel.getLong("id") == m.getLong("id")) || (fmap != null && cmap != null);
         if (fmap != null) {
             _changeNote(nid, newModel, fmap);
@@ -881,7 +880,7 @@ public class Models {
         if (cmap != null) {
             _changeCards(nid, m, newModel, cmap);
         }
-        mCol.genCards(nids, newModel);
+        mCol.genCards(nid, newModel);
     }
 
     private void _changeNote(long nid, Model newModel, Map<Integer, Integer> map) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -462,7 +462,7 @@ public class Models {
     public void setSortIdx(Model m, int idx) throws ConfirmModSchemaException{
         mCol.modSchema();
         m.put("sortf", idx);
-        mCol.updateFieldCache(Utils.toPrimitive(nids(m)));
+        mCol.updateFieldCache(nids(m));
         save(m);
     }
 
@@ -535,7 +535,7 @@ public class Models {
         _transformFields(m, new TransformFieldDelete(idx));
         if (idx == sortIdx(m)) {
             // need to rebuild
-            mCol.updateFieldCache(Utils.toPrimitive(nids(m)));
+            mCol.updateFieldCache(nids(m));
         }
         renameField(m, field, null);
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -876,7 +876,7 @@ public class Models {
         long[] nids = new long[] {nid};
         assert (newModel.getLong("id") == m.getLong("id")) || (fmap != null && cmap != null);
         if (fmap != null) {
-            _changeNotes(nids, newModel, fmap);
+            _changeNote(nid, newModel, fmap);
         }
         if (cmap != null) {
             _changeCards(nid, m, newModel, cmap);
@@ -884,15 +884,14 @@ public class Models {
         mCol.genCards(nids, newModel);
     }
 
-    private void _changeNotes(long[] nids, Model newModel, Map<Integer, Integer> map) {
+    private void _changeNote(long nid, Model newModel, Map<Integer, Integer> map) {
         List<Object[]> d = new ArrayList<>();
         int nfields = newModel.getJSONArray("flds").length();
         long mid = newModel.getLong("id");
         try (Cursor cur = mCol.getDb().getDatabase().query(
-                "select id, flds from notes where id in " + Utils.ids2str(nids), null)) {
+                "select flds from notes where id = ?", new Object[] {nid})) {
             while (cur.moveToNext()) {
-                long nid = cur.getLong(0);
-                String[] flds = Utils.splitFields(cur.getString(1));
+                String[] flds = Utils.splitFields(cur.getString(0));
                 Map<Integer, String> newflds = new HashMap<>();
 
                 for (Entry<Integer, Integer> entry : map.entrySet()) {
@@ -911,7 +910,7 @@ public class Models {
             }
         }
         mCol.getDb().executeMany("update notes set flds=?,mid=?,mod=?,usn=? where id = ?", d);
-        mCol.updateFieldCache(nids);
+        mCol.updateFieldCache(new long[] {nid});
     }
 
     private void _changeCards(long nid, Model oldModel, Model newModel, Map<Integer, Integer> map) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -37,7 +37,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -853,7 +853,7 @@ public class Models {
 
     @SuppressWarnings("PMD.UnusedLocalVariable") // unused upstream as well
     private void _syncTemplates(Model m) {
-        ArrayList<Long> rem = mCol.genCards(Utils.collection2Array(nids(m)), m);
+        ArrayList<Long> rem = mCol.genCards(nids(m), m);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -888,27 +888,23 @@ public class Models {
         List<Object[]> d = new ArrayList<>();
         int nfields = newModel.getJSONArray("flds").length();
         long mid = newModel.getLong("id");
-        try (Cursor cur = mCol.getDb().getDatabase().query(
-                "select flds from notes where id = ?", new Object[] {nid})) {
-            while (cur.moveToNext()) {
-                String[] flds = Utils.splitFields(cur.getString(0));
-                Map<Integer, String> newflds = new HashMap<>();
+        String sflds = mCol.getDb().queryString("select flds from notes where id = ?", nid);
+        String[] flds = Utils.splitFields(sflds);
+        Map<Integer, String> newflds = new HashMap<>();
 
-                for (Entry<Integer, Integer> entry : map.entrySet()) {
-                    newflds.put(entry.getValue(), flds[entry.getKey()]);
-                }
-                List<String> flds2 = new ArrayList<>();
-                for (int c = 0; c < nfields; ++c) {
-                    if (newflds.containsKey(c)) {
-                        flds2.add(newflds.get(c));
-                    } else {
-                        flds2.add("");
-                    }
-                }
-                String joinedFlds = Utils.joinFields(flds2.toArray(new String[flds2.size()]));
-                d.add(new Object[] { joinedFlds, mid, mCol.getTime().intTime(), mCol.usn(), nid });
+        for (Entry<Integer, Integer> entry : map.entrySet()) {
+            newflds.put(entry.getValue(), flds[entry.getKey()]);
+        }
+        List<String> flds2 = new ArrayList<>();
+        for (int c = 0; c < nfields; ++c) {
+            if (newflds.containsKey(c)) {
+                flds2.add(newflds.get(c));
+            } else {
+                flds2.add("");
             }
         }
+        String joinedFlds = Utils.joinFields(flds2.toArray(new String[flds2.size()]));
+        d.add(new Object[] {joinedFlds, mid, mCol.getTime().intTime(), mCol.usn(), nid});
         mCol.getDb().executeMany("update notes set flds=?,mid=?,mod=?,usn=? where id = ?", d);
         mCol.updateFieldCache(new long[] {nid});
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Note.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Note.java
@@ -324,7 +324,7 @@ public class Note implements Cloneable {
      */
     private void _postFlush() {
         if (!mNewlyAdded) {
-            mCol.genCards(new long[] { mId }, mModel);
+            mCol.genCards(mId, mModel);
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Tags.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Tags.java
@@ -129,7 +129,7 @@ public class Tags {
 
 
     /** Add any missing tags from notes to the tags list. */
-    public void registerNotes(long[] nids) {
+    public void registerNotes(java.util.Collection<Long> nids) {
         // when called with a null argument, the old list is cleared first.
         String lim;
         if (nids != null) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
@@ -291,9 +291,8 @@ public class Anki2Importer extends Importer {
                 // add to col partially, so as to avoid OOM
                 if (dirty.size() >= thresExecDirty) {
                     totalDirtyCount  += dirty.size();
-                    long[] das = Utils.collection2Array(dirty);
                     mDst.updateFieldCache(dirty);
-                    mDst.getTags().registerNotes(das);
+                    mDst.getTags().registerNotes(dirty);
                     dirty.clear();
                     Timber.d("dirty notes: %d", totalDirtyCount);
                 }
@@ -334,9 +333,8 @@ public class Anki2Importer extends Importer {
             DB.safeEndInTransaction(mDst.getDb());
         }
 
-        long[] das = Utils.collection2Array(dirty);
         mDst.updateFieldCache(dirty);
-        mDst.getTags().registerNotes(das);
+        mDst.getTags().registerNotes(dirty);
     }
 
     private void addNotes(List<Object[]> add) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
@@ -292,7 +292,7 @@ public class Anki2Importer extends Importer {
                 if (dirty.size() >= thresExecDirty) {
                     totalDirtyCount  += dirty.size();
                     long[] das = Utils.collection2Array(dirty);
-                    mDst.updateFieldCache(das);
+                    mDst.updateFieldCache(dirty);
                     mDst.getTags().registerNotes(das);
                     dirty.clear();
                     Timber.d("dirty notes: %d", totalDirtyCount);
@@ -335,7 +335,7 @@ public class Anki2Importer extends Importer {
         }
 
         long[] das = Utils.collection2Array(dirty);
-        mDst.updateFieldCache(das);
+        mDst.updateFieldCache(dirty);
         mDst.getTags().registerNotes(das);
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/NoteImporter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/NoteImporter.java
@@ -247,7 +247,7 @@ public class NoteImporter extends Importer {
         addNew(_new);
         addUpdates(updates);
         // make sure to update sflds, etc
-        mCol.updateFieldCache(collection2Array(_ids));
+        mCol.updateFieldCache(_ids);
         // generate cards
         if (!mCol.genCards(_ids, mModel).isEmpty()) {
             this.getLog().add(0, getString(R.string.note_importer_empty_cards_found));

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/ModelTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/ModelTest.java
@@ -342,7 +342,7 @@ public class ModelTest extends RobolectricTest {
         Map<Integer, Integer> map = new HashMap<>();
         map.put(0, 1);
         map.put(1, 0);
-        col.getModels().change(basic, new long[] {note.getId()}, basic, map, null);
+        col.getModels().change(basic, note.getId(), basic, map, null);
         note.load();
         assertEquals("b123", note.getItem("Front"));
         assertEquals("note", note.getItem("Back"));
@@ -353,7 +353,7 @@ public class ModelTest extends RobolectricTest {
         assertThat(c1.q(), containsString("note"));
         assertEquals(0, c0.getOrd());
         assertEquals(1, c1.getOrd());
-        col.getModels().change(basic, new long[] {note.getId()}, basic, null, map);
+        col.getModels().change(basic, note.getId(), basic, null, map);
         note.load();
         c0.load();
         c1.load();
@@ -371,7 +371,7 @@ public class ModelTest extends RobolectricTest {
         //     // The low precision timer on Windows reveals a race condition
         //     time.sleep(0.05);
         // }
-        col.getModels().change(basic, new long[] {note.getId()}, basic, null, map);
+        col.getModels().change(basic, note.getId(), basic, null, map);
         note.load();
         c0.load();
         // the card was deleted
@@ -380,7 +380,7 @@ public class ModelTest extends RobolectricTest {
         // an unmapped field becomes blank
         assertEquals("b123", note.getItem("Front"));
         assertEquals("note", note.getItem("Back"));
-        col.getModels().change(basic, new long[] {note.getId()}, basic, map, null);
+        col.getModels().change(basic, note.getId(), basic, map, null);
         note.load();
         assertEquals("", note.getItem("Front"));
         assertEquals("note", note.getItem("Back"));
@@ -397,7 +397,7 @@ public class ModelTest extends RobolectricTest {
         map = new HashMap<>();
         map.put(0, 0);
         map.put(1, 1);
-        col.getModels().change(basic, new long[] {note.getId()}, cloze, map, map);
+        col.getModels().change(basic, note.getId(), cloze, map, map);
         note.load();
         assertEquals("f2", note.getItem("Text"));
         assertEquals(2, note.numberOfCards());
@@ -406,7 +406,7 @@ public class ModelTest extends RobolectricTest {
         assertEquals(2, col.getDb().queryScalar("select count() from cards where nid = ?", note.getId()));
         map = new HashMap<>();
         map.put(0, 0);
-        col.getModels().change(cloze, new long[] {note.getId()}, basic, map, map);
+        col.getModels().change(cloze, note.getId(), basic, map, map);
         assertEquals(1, col.getDb().queryScalar("select count() from cards where nid = ?", note.getId()));
     }
 


### PR DESCRIPTION
There are quite a few conversion that are useless. `long` to `long[]` to array joined by comma. `List<long>` to `long[]` to array joined by comma... In all of those cases, the end result is always longs joined by comma. I removed useless conversions to save time