### PR TITLE
NF: optimize genCard

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
@@ -734,7 +734,7 @@ public class CardContentProvider extends ContentProvider {
                 if (model == null) {
                     return -1;
                 }
-                List<Long> cids = col.genCards(col.getModels().nids(model));
+                List<Long> cids = col.genCards(col.getModels().nids(model), model);
                 col.remCards(cids);
                 return cids.size();
             default:

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -720,16 +720,20 @@ public class Collection {
     /**
      * Generate cards for non-empty templates, return ids to remove.
      */
-	public ArrayList<Long> genCards(List<Long> nids) {
-	    return genCards(Utils.collection2Array(nids));
+	public ArrayList<Long> genCards(List<Long> nids, @NonNull Model model) {
+	    return genCards(Utils.collection2Array(nids), model);
 	}
 
-    public <T extends ProgressSender<TaskData> & CancelListener> ArrayList<Long> genCards(List<Long> nids, @Nullable T task) {
-       return genCards(Utils.collection2Array(nids), task);
+    public <T extends ProgressSender<TaskData> & CancelListener> ArrayList<Long> genCards(List<Long> nids, @NonNull Model model, @Nullable T task) {
+       return genCards(Utils.collection2Array(nids), model, task);
     }
 
-    public ArrayList<Long> genCards(long[] nids) {
-       return genCards(nids, null);
+    public ArrayList<Long> genCards(long[] nids, long mid) {
+        return genCards(nids, getModels().get(mid), null);
+    }
+
+    public ArrayList<Long> genCards(long[] nids, @NonNull Model model) {
+        return genCards(nids, model, null);
     }
 
     /**
@@ -737,7 +741,7 @@ public class Collection {
      * @param task Task to check for cancellation and update number of card processed
      * @return Cards that should be removed because they should not be generated
      */
-    public <T extends ProgressSender<TaskData> & CancelListener> ArrayList<Long> genCards(long[] nids, @Nullable T task) {
+    public <T extends ProgressSender<TaskData> & CancelListener> ArrayList<Long> genCards(long[] nids, @NonNull Model model, @Nullable T task) {
         // build map of (nid,ord) so we don't create dupes
         String snids = Utils.ids2str(nids);
         // For each note, indicates ords of cards it contains
@@ -793,16 +797,14 @@ public class Collection {
         int usn = usn();
         cur = null;
         try {
-            cur = mDb.getDatabase().query("SELECT id, mid, flds FROM notes WHERE id IN " + snids, null);
+            cur = mDb.getDatabase().query("SELECT id, flds FROM notes WHERE id IN " + snids, null);
             while (cur.moveToNext()) {
                 if (task != null && task.isCancelled()) {
                     Timber.v("Empty card cancelled");
                     return null;
                 }
                 @NonNull Long nid = cur.getLong(0);
-                @NonNull Long mid = cur.getLong(1);
-                String flds = cur.getString(2);
-                Model model = getModels().get(mid);
+                String flds = cur.getString(1);
                 ArrayList<Integer> avail = Models.availOrds(model, Utils.splitFields(flds));
                 if (task != null) {
                     task.doProgress(new TaskData(avail.size()));
@@ -1034,7 +1036,7 @@ public class Collection {
     public List<Long> emptyCids(@Nullable CollectionTask task) {
         List<Long> rem = new ArrayList<>();
         for (Model m : getModels().all()) {
-            rem.addAll(genCards(getModels().nids(m), task));
+            rem.addAll(genCards(getModels().nids(m), m, task));
         }
         return rem;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -853,7 +853,7 @@ public class Models {
 
     @SuppressWarnings("PMD.UnusedLocalVariable") // unused upstream as well
     private void _syncTemplates(Model m) {
-        ArrayList<Long> rem = mCol.genCards(Utils.collection2Array(nids(m)));
+        ArrayList<Long> rem = mCol.genCards(Utils.collection2Array(nids(m)), m);
     }
 
 
@@ -864,7 +864,7 @@ public class Models {
     /**
      * Change a model
      * @param m The model to change.
-     * @param nids The list of notes that the change applies to.
+     * @param nids The list of notes that the change applies to. They are all of note type n
      * @param newModel For replacing the old model with another one. Should be self if the model is not changing
      * @param fmap Map for switching fields. This is ord->ord and there should not be duplicate targets
      * @param cmap Map for switching cards. This is ord->ord and there should not be duplicate targets
@@ -879,7 +879,7 @@ public class Models {
         if (cmap != null) {
             _changeCards(nids, m, newModel, cmap);
         }
-        mCol.genCards(nids);
+        mCol.genCards(nids, newModel);
     }
 
     private void _changeNotes(long[] nids, Model newModel, Map<Integer, Integer> map) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Note.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Note.java
@@ -324,7 +324,7 @@ public class Note implements Cloneable {
      */
     private void _postFlush() {
         if (!mNewlyAdded) {
-            mCol.genCards(new long[] { mId });
+            mCol.genCards(new long[] { mId }, mModel);
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/NoteImporter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/NoteImporter.java
@@ -249,7 +249,7 @@ public class NoteImporter extends Importer {
         // make sure to update sflds, etc
         mCol.updateFieldCache(collection2Array(_ids));
         // generate cards
-        if (!mCol.genCards(_ids).isEmpty()) {
+        if (!mCol.genCards(_ids, mModel).isEmpty()) {
             this.getLog().add(0, getString(R.string.note_importer_empty_cards_found));
         }
 


### PR DESCRIPTION
Each time gen card is called, all notes have the same note type. So it's useless to look for it in the database. It's
even more useless to redo some computation.

Note that the replace function does not become more costly. Mostly because it's dead code that is only called in test


Things go so quickly today that I got a conflict while submitting the PR