### PR TITLE
Action to check for string ressources

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,3 +27,4 @@ _Please, go through these checks before submitting the PR._
 - [ ] You have commented your code, particularly in hard-to-understand areas
 - [ ] You have performed a self-review of your own code
 - [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
+- [ ] Strings resources: All strings added as resources are unique or contain a comment for seemingly duplicate strings to explain the difference between both resources


### PR DESCRIPTION
This occurred a few time recently because of the Card Info window. So I think this check box is worth adding even if it probably won't be needed very often. 
If we ask translators to do twice the same job, we should explain them why. Especially, if we expect a string to be translatable in two distinct ways, we should let them know which context is which. We have screenshot, but if crowdin close we loose screenshot, while we don't loose comments in ressources. And those comments would also help ensure that screen shots are correctly annotated