### PR TITLE
NF: Use interface instead of CollectionTask in libanki

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1038,7 +1038,7 @@ public class Collection {
     }
 
 
-    public List<Long> emptyCids(@Nullable CollectionTask task) {
+    public <T extends ProgressSender<TaskData> & CancelListener> List<Long> emptyCids(@Nullable T task) {
         List<Long> rem = new ArrayList<>();
         for (Model m : getModels().all()) {
             rem.addAll(genCards(getModels().nids(m), m, task));
@@ -1233,7 +1233,7 @@ public class Collection {
         return findCards(search, order, null);
     }
 
-    public List<Long> findCards(String search, boolean order, CollectionTask task) {
+    public List<Long> findCards(String search, boolean order, CancelListener task) {
         return new Finder(this).findCards(search, order, task);
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
@@ -25,7 +25,6 @@ import android.text.TextUtils;
 import android.util.Pair;
 
 import com.ichi2.async.CancelListener;
-import com.ichi2.async.CollectionTask;
 
 import com.ichi2.libanki.Deck;
 import com.ichi2.utils.JSONArray;
@@ -83,7 +82,7 @@ public class Finder {
     }
 
     @CheckResult
-    public List<Long> findCards(String query, boolean _order, CollectionTask task) {
+    public List<Long> findCards(String query, boolean _order, CancelListener task) {
         return _findCards(query, _order, task);
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
@@ -8,7 +8,7 @@ import android.widget.Toast;
 
 
 import com.ichi2.anki.R;
-import com.ichi2.async.CollectionTask;
+import com.ichi2.async.CancelListener;
 import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Consts;
 import com.ichi2.libanki.Deck;
@@ -166,9 +166,9 @@ public abstract class AbstractSched {
     public abstract @NonNull List<DeckDueTreeNode> deckDueList();
 
     /**
-     * @param collectionTask A task that is potentially cancelled
+     * @param cancelListener A task that is potentially cancelled
      * @return the due tree. null if task is cancelled*/
-    public abstract @Nullable List<DeckDueTreeNode> deckDueTree(CollectionTask collectionTask);
+    public abstract @Nullable List<DeckDueTreeNode> deckDueTree(CancelListener cancelListener);
 
     /**
      * @return the due tree. null if task is cancelled. */

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -24,7 +24,6 @@ import android.database.SQLException;
 import android.text.TextUtils;
 
 import com.ichi2.async.CancelListener;
-import com.ichi2.async.CollectionTask;
 import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Consts;
@@ -211,14 +210,14 @@ public class Sched extends SchedV2 {
      * Returns [deckname, did, rev, lrn, new]
      */
     @Override
-    public @Nullable List<DeckDueTreeNode> deckDueList(@Nullable CancelListener collectionTask) {
+    public @Nullable List<DeckDueTreeNode> deckDueList(@Nullable CancelListener cancelListener) {
         _checkDay();
         mCol.getDecks().checkIntegrity();
         ArrayList<Deck> decks = mCol.getDecks().allSorted();
         HashMap<String, Integer[]> lims = new HashMap<>();
         ArrayList<DeckDueTreeNode> deckNodes = new ArrayList<>();
         for (Deck deck : decks) {
-            if (collectionTask != null && collectionTask.isCancelled()) {
+            if (cancelListener != null && cancelListener.isCancelled()) {
                 return null;
             }
             String deckName = deck.getString("name");

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -33,7 +33,6 @@ import android.util.Pair;
 
 import com.ichi2.anki.R;
 import com.ichi2.async.CancelListener;
-import com.ichi2.async.CollectionTask;
 import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Consts;
@@ -532,8 +531,8 @@ public class SchedV2 extends AbstractSched {
     }
 
     @Nullable
-    public List<DeckDueTreeNode> deckDueTree(@Nullable CollectionTask collectionTask) {
-        List<DeckDueTreeNode> deckDueTree = deckDueList(collectionTask);
+    public List<DeckDueTreeNode> deckDueTree(@Nullable CancelListener cancelListener) {
+        List<DeckDueTreeNode> deckDueTree = deckDueList(cancelListener);
         if (deckDueTree == null) {
             return null;
         }


### PR DESCRIPTION
I guess that would please @david-allison-1 , removing CollectionTask from libanki