### PR TITLE
Show partial result in browser before showing all

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1861,6 +1861,16 @@ public class CardBrowser extends NavigationDrawerActivity implements
             super(browser);
         }
 
+
+        @Override
+        public void actualOnProgressUpdate(@NonNull CardBrowser browser, TaskData result) {
+            // Need to copy the list into a new list, because the original list is modified, and
+            // ListAdapter crash
+            mCards.replaceWith(new ArrayList<>(result.getCards()));
+            updateList();
+        }
+
+
         @Override
         public void actualOnPostExecute(@NonNull CardBrowser browser, TaskData result) {
             if (result != null) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1264,7 +1264,7 @@ public class Collection {
         return findCards(search, order, null);
     }
 
-    public List<Long> findCards(String search, boolean order, CancelListener task) {
+    public List<Long> findCards(String search, boolean order, CollectionTask.PartialSearch task) {
         return new Finder(this).findCards(search, order, task);
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
@@ -364,7 +364,12 @@ public class Finder {
     }
 
 
-    private String _query(String preds, String order) {
+    /**
+     * @param preds A sql predicate, or empty string, with c a card, n its note
+     * @param order A part of a query, ordering element of table Card, with c a card, n its note
+     * @return A query to return all card ids satifying the predicate and in the given order
+     */
+    private static String _query(String preds, String order) {
         // can we skip the note table?
         String sql;
         if (!preds.contains("n.") && !order.contains("n.")) {


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Currently, showing search result in the browser takes time. On my collection, showing a big deck with subdecks takes 20 seconds. I thought that it could be possible to first show the first cards, and then show the full result. The number of cards I chose is exactly the number of precomputed cards we were already calculating. This lead to showing a part of the result in 7 seconds, while the whole result still takes 20 seconds to show.

The progress bar is still displayed to indicate that the result is not yet fully present.  

Since the card we must show is not yet necessarily in the list, I wait until the full list is  computed to scroll to it.

## Approach
The collection task sends a progress update with the partial result.
We may also want to regularly send partial result, so that the list grow and the user actually see there is work in progress.

One of the program was that the finder deal with list of card id, and the collection task deals with list of card cache. I had to create a class which change the list of cids to the list of card caches, precompute the data of the first card to display, and ensure this caching is actually cached. I do believe that splitting the CollectionTask in smaller classes would have helped here and make code simpler, but I am not going to wait until this is fully discussed and merged/corrected to add this feature.

## How Has This Been Tested?

I run it on my phone, and check it works. I check that some partial result appears quite quicker and that there is no more delay for the full result.


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
