### PR TITLE
NF: loading browser faster

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -173,6 +173,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
     private static final int DEFAULT_FONT_SIZE_RATIO = 100;
     // Should match order of R.array.card_browser_order_labels
     public static final int CARD_ORDER_NONE = 0;
+    // Whether the browser is loaded. Don't do search until it is actually loaded. This avoid doing two search when opening the browser
+    private boolean mBrowserLoaded = false;
     private static final String[] fSortTypes = new String[] {
         "",
         "noteFld",
@@ -679,6 +681,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
         } else {
             selectDeckById(getCol().getDecks().selected());
         }
+        mBrowserLoaded = true;
     }
 
 
@@ -1419,6 +1422,9 @@ public class CardBrowser extends NavigationDrawerActivity implements
     private void searchCards() {
         // cancel the previous search & render tasks if still running
         invalidate();
+        if (!mBrowserLoaded) {
+            return;
+        }
         String searchText;
         if (mSearchTerms == null) {
             mSearchTerms = "";


### PR DESCRIPTION
Currently, two search occurs, and the first gets cancelled. This reduce the time from 20 seconds to 18 seconds on my collection.


I tested changing deck, changing to all deck, clicking on "search all deck", and all still works and don't start two days