### PR TITLE
Add Note Editor Toolbar

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -231,6 +231,8 @@ public class NoteEditor extends AnkiActivity {
 
     private FieldState mFieldState = FieldState.fromEditor(this);
 
+    private Toolbar mToolbar;
+
     private SaveNoteHandler saveNoteHandler() {
         return new SaveNoteHandler(this);
     }
@@ -450,8 +452,8 @@ public class NoteEditor extends AnkiActivity {
 
         View mainView = findViewById(android.R.id.content);
 
-        Toolbar toolbar = findViewById(R.id.editor_toolbar);
-        toolbar.setFormatListener(formatter -> {
+        mToolbar = findViewById(R.id.editor_toolbar);
+        mToolbar.setFormatListener(formatter -> {
             View currentFocus = getCurrentFocus();
             if (!(currentFocus instanceof FieldEditText)) {
                 return;
@@ -1756,7 +1758,32 @@ public class NoteEditor extends AnkiActivity {
         updateDeckPosition();
         updateTags();
         updateCards(mEditorNote.model());
+        updateToolbar();
         populateEditFields(changeType, false);
+    }
+
+
+    private void updateToolbar() {
+        View clozeIcon = mToolbar.getClozeIcon();
+        if (Models.isCloze(mEditorNote.model())) {
+            Toolbar.TextFormatter clozeFormatter = s -> {
+                Toolbar.TextWrapper.StringFormat stringFormat = new Toolbar.TextWrapper.StringFormat();
+                String prefix = "{{c" + getNextClozeIndex() + "::";
+                stringFormat.result = prefix + s + "}}";
+                if (s.length() == 0) {
+                    stringFormat.start = prefix.length();
+                    stringFormat.end = prefix.length();
+                } else {
+                    stringFormat.start = 0;
+                    stringFormat.end = stringFormat.result.length();
+                }
+                return stringFormat;
+            };
+            clozeIcon.setOnClickListener(l -> mToolbar.onFormat(clozeFormatter));
+            clozeIcon.setVisibility(View.VISIBLE);
+        } else {
+            clozeIcon.setVisibility(View.GONE);
+        }
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/CustomToolbarButton.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/CustomToolbarButton.java
@@ -1,0 +1,112 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.noteeditor;
+
+import android.text.TextUtils;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import static com.ichi2.libanki.Consts.FIELD_SEPARATOR;
+
+public class CustomToolbarButton {
+
+    private static final int KEEP_EMPTY_ENTRIES = -1;
+
+    private int mIndex;
+    private final String mPrefix;
+    private final String mSuffix;
+
+
+    public CustomToolbarButton(int index, String prefix, String suffix) {
+        mIndex = index;
+        mPrefix = prefix;
+        mSuffix = suffix;
+    }
+
+    @Nullable
+    public static CustomToolbarButton fromString(String s) {
+        if (s == null || s.length() == 0) {
+            return null;
+        }
+
+        String[] fields = s.split(FIELD_SEPARATOR, KEEP_EMPTY_ENTRIES);
+
+        if (fields.length != 3) {
+            return null;
+        }
+
+        int index;
+        try {
+            index = Integer.parseInt(fields[0]);
+        } catch (Exception e) {
+            return null;
+        }
+
+        return new CustomToolbarButton(index, fields[1], fields[2]);
+    }
+
+
+    @NonNull
+    public static ArrayList<CustomToolbarButton> fromStringSet(Set<String> hs) {
+        ArrayList<CustomToolbarButton> buttons = new ArrayList<>();
+
+        for (String s : hs) {
+            CustomToolbarButton customToolbarButton = CustomToolbarButton.fromString(s);
+            if (customToolbarButton != null) {
+                buttons.add(customToolbarButton);
+            }
+        }
+        Collections.sort(buttons, (o1, o2) -> Integer.compare(o1.getIndex(), o2.getIndex()));
+
+        for (int i = 0; i < buttons.size(); i++) {
+            buttons.get(i).mIndex = i;
+        }
+
+        return buttons;
+    }
+
+
+    public static Set<String> toStringSet(ArrayList<CustomToolbarButton> buttons) {
+        HashSet<String> ret = new HashSet<>();
+        for (CustomToolbarButton b : buttons) {
+            String[] values = new String[] { Integer.toString(b.mIndex), b.mPrefix, b.mSuffix };
+
+            for (int i = 0; i < values.length; i++) {
+                values[i] = values[i].replace(FIELD_SEPARATOR, "");
+            }
+
+            ret.add(TextUtils.join(FIELD_SEPARATOR, values));
+        }
+        return ret;
+    }
+
+
+    public Toolbar.TextFormatter toFormatter() {
+        return new Toolbar.TextWrapper(mPrefix, mSuffix);
+    }
+
+
+    public int getIndex() {
+        return mIndex;
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.java
@@ -1,0 +1,168 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.noteeditor;
+
+import android.content.Context;
+import android.os.Build;
+import android.util.AttributeSet;
+import android.view.LayoutInflater;
+import android.widget.FrameLayout;
+
+import com.afollestad.materialdialogs.MaterialDialog;
+import com.ichi2.anki.R;
+
+import androidx.annotation.IdRes;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
+
+public class Toolbar extends FrameLayout {
+
+    private TextFormatListener mFormatCallback;
+
+    public Toolbar(@NonNull Context context) {
+        super(context);
+        init();
+    }
+
+
+    public Toolbar(@NonNull Context context, @Nullable AttributeSet attrs) {
+        super(context, attrs);
+        init();
+    }
+
+
+    public Toolbar(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        init();
+    }
+
+
+    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+    public Toolbar(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr, int defStyleRes) {
+        super(context, attrs, defStyleAttr, defStyleRes);
+        init();
+    }
+
+    private void init() {
+        LayoutInflater.from(getContext()).inflate(R.layout.note_editor_toolbar, this, true);
+        setClick(R.id.note_editor_toolbar_button_bold, "<b>", "</b>");
+        setClick(R.id.note_editor_toolbar_button_italic, "<em>", "</em>");
+        setClick(R.id.note_editor_toolbar_button_underline, "<u>", "</u>");
+
+        setClick(R.id.note_editor_toolbar_button_insert_mathjax, "\\(", "\\)");
+        setClick(R.id.note_editor_toolbar_button_horizontal_rule, "", "<hr>");
+        findViewById(R.id.note_editor_toolbar_button_font_size).setOnClickListener(l -> displayFontSizeDialog());
+        findViewById(R.id.note_editor_toolbar_button_title).setOnClickListener(l -> displayInsertHeadingDialog());
+    }
+
+    public void setFormatListener(TextFormatListener formatter) {
+        mFormatCallback = formatter;
+    }
+
+    private void displayFontSizeDialog() {
+        String[] results = getResources().getStringArray(R.array.html_size_codes);
+
+        // Might be better to add this as a fragment - let's see.
+        new MaterialDialog.Builder(getContext())
+                .items(R.array.html_size_code_labels)
+                .itemsCallback((dialog, view, pos, string) -> {
+                    String prefix = "<span style=\"font-size:" + results[pos] + "\">";
+                    String suffix = "</span>";
+                    TextWrapper formatter = new TextWrapper(prefix, suffix);
+                    onFormat(formatter);
+                })
+                .title(R.string.menu_font_size)
+                .show();
+    }
+
+
+    private void displayInsertHeadingDialog() {
+        new MaterialDialog.Builder(getContext())
+                .items(new String[] { "h1", "h2", "h3", "h4", "h5" })
+                .itemsCallback((dialog, view, pos, string) -> {
+                    String prefix = "<" + string + ">";
+                    String suffix = "</" + string +">";
+                    TextWrapper formatter = new TextWrapper(prefix, suffix);
+                    onFormat(formatter);
+                })
+                .title(R.string.insert_heading)
+                .show();
+    }
+
+
+
+    private void setClick(@IdRes int id, String prefix, String suffix) {
+        setClick(id, new TextWrapper(prefix, suffix));
+    }
+
+
+    private void setClick(int id, TextFormatter textWrapper) {
+        findViewById(id).setOnClickListener(l -> onFormat(textWrapper));
+    }
+
+
+    private void onFormat(TextFormatter formatter) {
+        if (mFormatCallback == null) {
+            return;
+        }
+
+        mFormatCallback.performFormat(formatter);
+    }
+
+
+    public interface TextFormatListener {
+        void performFormat(TextFormatter formatter);
+    }
+
+    public interface TextFormatter {
+        TextWrapper.StringFormat format(String s);
+    }
+
+    public static class TextWrapper implements TextFormatter {
+        private final String mPrefix;
+        private final String mSuffix;
+
+        public TextWrapper(String prefix, String suffix) {
+            this.mPrefix = prefix;
+            this.mSuffix = suffix;
+        }
+
+
+        @Override
+        public StringFormat format(String s) {
+            StringFormat stringFormat = new StringFormat();
+            stringFormat.result = mPrefix + s + mSuffix;
+            if (s.length() == 0) {
+                stringFormat.start = mPrefix.length();
+                stringFormat.end = mPrefix.length();
+            } else {
+                stringFormat.start = 0;
+                stringFormat.end = stringFormat.result.length();
+            }
+
+            return stringFormat;
+        }
+
+        public static class StringFormat {
+            public String result;
+            public int start;
+            public int end;
+        }
+    }
+
+}

--- a/AnkiDroid/src/main/res/drawable/ic_add_equation_black_24dp.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_add_equation_black_24dp.xml
@@ -1,0 +1,32 @@
+<!--
+  ~  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+  ~
+  ~  This program is free software; you can redistribute it and/or modify it under
+  ~  the terms of the GNU General Public License as published by the Free Software
+  ~  Foundation; either version 3 of the License, or (at your option) any later
+  ~  version.
+  ~
+  ~  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+  ~  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  ~  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+  ~
+  ~  You should have received a copy of the GNU General Public License along with
+  ~  this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="6.35"
+    android:viewportHeight="6.3500004"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="m1.55908,1.09864l0,0.45734l1.49035,1.80764 -1.49035,1.80764l0,0.45734L3.90364,5.6286A1.2456,1.2456 0,0 1,3.68453 5.14646L2.32131,5.14646l-0.0093,-0.01602 1.38751,-1.72651l0,-0.07441L2.312,1.5968 2.32131,1.58078l1.7017,0l0.04703,0.51986l0.52555,0L4.59558,1.09864Z"
+      android:strokeWidth="2.0067153"/>
+  <path
+      android:pathData="M5.01769,4.32581L4.79055,4.32581v0.45427L4.33628,4.78009v0.22715h0.45427v0.45427h0.22714v-0.45427h0.45427v-0.22715L5.01769,4.78009ZM4.90413,3.758c-0.62689,0 -1.13567,0.50878 -1.13567,1.13566 0,0.62691 0.50878,1.13569 1.13567,1.13569 0.62689,0 1.13568,-0.50878 1.13568,-1.13569 0,-0.62688 -0.50878,-1.13566 -1.13568,-1.13566zM4.90413,5.80222c-0.50083,0 -0.90854,-0.40771 -0.90854,-0.90856 0,-0.50081 0.40771,-0.90855 0.90854,-0.90855 0.50083,0 0.90854,0.40774 0.90854,0.90855 0,0.50085 -0.40771,0.90856 -0.90854,0.90856z"
+      android:strokeWidth="0.11356759"
+      android:fillColor="#000006"
+      android:fillAlpha="1"/>
+</vector>

--- a/AnkiDroid/src/main/res/drawable/ic_add_toolbar_icon.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_add_toolbar_icon.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/black"
+      android:pathData="M19,3L5,3c-1.11,0 -2,0.9 -2,2v14c0,1.1 0.89,2 2,2h14c1.1,0 2,-0.9 2,-2L21,5c0,-1.1 -0.9,-2 -2,-2zM17,13h-4v4h-2v-4L7,13v-2h4L11,7h2v4h4v2z"/>
+</vector>

--- a/AnkiDroid/src/main/res/drawable/ic_format_bold_black_24dp.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_format_bold_black_24dp.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/black"
+      android:pathData="M15.6,10.79c0.97,-0.67 1.65,-1.77 1.65,-2.79 0,-2.26 -1.75,-4 -4,-4L7,4v14h7.04c2.09,0 3.71,-1.7 3.71,-3.79 0,-1.52 -0.86,-2.82 -2.15,-3.42zM10,6.5h3c0.83,0 1.5,0.67 1.5,1.5s-0.67,1.5 -1.5,1.5h-3v-3zM13.5,15.5L10,15.5v-3h3.5c0.83,0 1.5,0.67 1.5,1.5s-0.67,1.5 -1.5,1.5z"/>
+</vector>

--- a/AnkiDroid/src/main/res/drawable/ic_format_font_size_24dp.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_format_font_size_24dp.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/black"
+      android:pathData="M2.5,4v3h5v12h3V7h5V4H2.5zM21.5,9h-9v3h3v7h3v-7h3V9z"/>
+</vector>

--- a/AnkiDroid/src/main/res/drawable/ic_format_italic_black_24dp.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_format_italic_black_24dp.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/black"
+      android:pathData="M10,4v3h2.21l-3.42,8H6v3h8v-3h-2.21l3.42,-8H18V4z"/>
+</vector>

--- a/AnkiDroid/src/main/res/drawable/ic_format_title_black_24dp.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_format_title_black_24dp.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/black"
+      android:pathData="M5,4v3h5.5v12h3V7H19V4z"/>
+</vector>

--- a/AnkiDroid/src/main/res/drawable/ic_format_underlined_black_24dp.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_format_underlined_black_24dp.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/black"
+      android:pathData="M12,17c3.31,0 6,-2.69 6,-6L18,3h-2.5v8c0,1.93 -1.57,3.5 -3.5,3.5S8.5,12.93 8.5,11L8.5,3L6,3v8c0,3.31 2.69,6 6,6zM5,19v2h14v-2L5,19z"/>
+</vector>

--- a/AnkiDroid/src/main/res/drawable/ic_horizontal_rule_black_24dp.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_horizontal_rule_black_24dp.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M19,13H2v-2h20v2z"/>
+</vector>

--- a/AnkiDroid/src/main/res/layout/note_editor.xml
+++ b/AnkiDroid/src/main/res/layout/note_editor.xml
@@ -8,9 +8,11 @@
     android:layout_height="fill_parent"
     android:fitsSystemWindows="true">
     <LinearLayout
+            android:id="@+id/note_editor_layout"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:orientation="vertical">
+            android:orientation="vertical"
+            android:layout_marginBottom="28dp">
 
         <include layout="@layout/toolbar" />
 
@@ -135,5 +137,13 @@
 
         </ScrollView>
     </LinearLayout>
+
+    <com.ichi2.anki.noteeditor.Toolbar
+        android:background="#D6D7D7"
+        android:layout_gravity="bottom"
+        android:id="@+id/editor_toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"/>
+
     <include layout="@layout/anki_progress"/>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/AnkiDroid/src/main/res/layout/note_editor_toolbar.xml
+++ b/AnkiDroid/src/main/res/layout/note_editor_toolbar.xml
@@ -79,5 +79,14 @@
             app:srcCompat="@drawable/ic_add_equation_black_24dp"
             style="@style/note_editor_toolbar_button" />
 
+        <!-- We can't dynamically add this on API 16,
+         which is a shame, as we need the note editor to know the cloze ordinal
+         so make it invisible and bring it back and add the listener when appropriate -->
+        <androidx.appcompat.widget.AppCompatImageButton
+            android:id="@+id/note_editor_toolbar_button_cloze"
+            android:visibility="gone"
+            android:contentDescription="@string/insert_cloze"
+            app:srcCompat="@drawable/ic_cloze_black_24dp"
+            style="@style/note_editor_toolbar_button" />
     </LinearLayout>
 </HorizontalScrollView>

--- a/AnkiDroid/src/main/res/layout/note_editor_toolbar.xml
+++ b/AnkiDroid/src/main/res/layout/note_editor_toolbar.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+  ~
+  ~  This program is free software; you can redistribute it and/or modify it under
+  ~  the terms of the GNU General Public License as published by the Free Software
+  ~  Foundation; either version 3 of the License, or (at your option) any later
+  ~  version.
+  ~
+  ~  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+  ~  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  ~  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+  ~
+  ~  You should have received a copy of the GNU General Public License along with
+  ~  this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+
+<HorizontalScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    
+    android:id="@+id/toolbar_scrollview"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:scrollbarStyle="insideOverlay"
+    android:scrollbars="horizontal">
+
+    <LinearLayout
+        android:id="@+id/editor_toolbar_internal"
+        app:contentInsetLeft="0dp"
+        app:contentInsetStart="0dp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:background="?android:attr/selectableItemBackground"
+        android:orientation="horizontal">
+
+        <androidx.appcompat.widget.AppCompatImageButton
+            android:id="@+id/note_editor_toolbar_button_bold"
+            app:srcCompat="@drawable/ic_format_bold_black_24dp"
+            android:contentDescription="@string/format_insert_bold"
+            style="@style/note_editor_toolbar_button" />
+
+        <androidx.appcompat.widget.AppCompatImageButton
+            android:id="@+id/note_editor_toolbar_button_italic"
+            app:srcCompat="@drawable/ic_format_italic_black_24dp"
+            android:contentDescription="@string/format_insert_italic"
+            style="@style/note_editor_toolbar_button" />
+
+        <androidx.appcompat.widget.AppCompatImageButton
+            android:id="@+id/note_editor_toolbar_button_underline"
+            app:srcCompat="@drawable/ic_format_underlined_black_24dp"
+            android:contentDescription="@string/format_insert_underline"
+            style="@style/note_editor_toolbar_button" />
+
+        <androidx.appcompat.widget.AppCompatImageButton
+            android:id="@+id/note_editor_toolbar_button_horizontal_rule"
+            app:srcCompat="@drawable/ic_horizontal_rule_black_24dp"
+            android:contentDescription="@string/insert_horizontal_line"
+            style="@style/note_editor_toolbar_button" />
+
+        <androidx.appcompat.widget.AppCompatImageButton
+            android:id="@+id/note_editor_toolbar_button_title"
+            app:srcCompat="@drawable/ic_format_title_black_24dp"
+            android:contentDescription="@string/insert_heading"
+            style="@style/note_editor_toolbar_button" />
+
+        <androidx.appcompat.widget.AppCompatImageButton
+            android:id="@+id/note_editor_toolbar_button_font_size"
+            android:contentDescription="@string/format_font_size"
+            app:srcCompat="@drawable/ic_format_font_size_24dp"
+            style="@style/note_editor_toolbar_button" />
+
+
+        <androidx.appcompat.widget.AppCompatImageButton
+            android:id="@+id/note_editor_toolbar_button_insert_mathjax"
+            android:contentDescription="@string/insert_mathjax"
+            app:srcCompat="@drawable/ic_add_equation_black_24dp"
+            style="@style/note_editor_toolbar_button" />
+
+    </LinearLayout>
+</HorizontalScrollView>

--- a/AnkiDroid/src/main/res/layout/note_editor_toolbar.xml
+++ b/AnkiDroid/src/main/res/layout/note_editor_toolbar.xml
@@ -30,9 +30,10 @@
         android:id="@+id/editor_toolbar_internal"
         app:contentInsetLeft="0dp"
         app:contentInsetStart="0dp"
+        app:contentInsetEnd="0dp"
+        app:contentInsetRight="0dp"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
         android:background="?android:attr/selectableItemBackground"
         android:orientation="horizontal">
 

--- a/AnkiDroid/src/main/res/layout/note_editor_toolbar_add_custom_item.xml
+++ b/AnkiDroid/src/main/res/layout/note_editor_toolbar_add_custom_item.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+  ~
+  ~  This program is free software; you can redistribute it and/or modify it under
+  ~  the terms of the GNU General Public License as published by the Free Software
+  ~  Foundation; either version 3 of the License, or (at your option) any later
+  ~  version.
+  ~
+  ~  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+  ~  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  ~  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+  ~
+  ~  You should have received a copy of the GNU General Public License along with
+  ~  this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android" android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <com.ichi2.ui.FixedTextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/toolbar_item_explain_remove"
+        android:paddingBottom="15dp"/>
+
+    <com.google.android.material.textfield.TextInputLayout
+
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/before_text">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/note_editor_toolbar_before"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="@dimen/content_vertical_padding"/>
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/after_text">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/note_editor_toolbar_after"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="@dimen/content_vertical_padding"/>
+    </com.google.android.material.textfield.TextInputLayout>
+
+
+</LinearLayout>

--- a/AnkiDroid/src/main/res/menu/popupmenu_multimedia_options.xml
+++ b/AnkiDroid/src/main/res/menu/popupmenu_multimedia_options.xml
@@ -16,10 +16,6 @@
             android:id="@+id/menu_multimedia_text"
             android:title="@string/multimedia_editor_popup_text"/>
         <item
-            android:id="@+id/menu_multimedia_add_cloze"
-            android:title="@string/multimedia_editor_popup_cloze"
-            android:visible="false"/>
-        <item
             android:id="@+id/menu_multimedia_clear_field"
             android:title="@string/multimedia_editor_popup_clear_field"/>
     </group>

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -347,4 +347,10 @@
     <string name="format_font_size">Change Font Size</string>
     <string name="insert_mathjax">Insert MathJax Equation</string>
     <string name="insert_cloze">Insert Cloze Deletion</string>
+
+    <string name="before_text">HTML Before Selection</string>
+    <string name="after_text">HTML After Selection</string>
+    <string name="add_toolbar_item">Create Toolbar Item</string>
+    <string name="toolbar_item_explain_remove">Enter HTML to be inserted before and after the selected text\n\nLong press a toolbar item to remove it</string>
+    <string name="remove_toolbar_item">Remove Toolbar Item?</string>
 </resources>

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -338,4 +338,12 @@
 
     <!-- A Menu item to change the Font Size (currently in the Note Editor) -->
     <string name="menu_font_size">Font Size</string>
+
+    <string name="format_insert_bold">Format as Bold</string>
+    <string name="format_insert_italic">Format as Italic</string>
+    <string name="format_insert_underline">Format as Underline</string>
+    <string name="insert_horizontal_line">Insert Horizontal Line</string>
+    <string name="insert_heading">Insert Heading</string>
+    <string name="format_font_size">Change Font Size</string>
+    <string name="insert_mathjax">Insert MathJax Equation</string>
 </resources>

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -346,4 +346,5 @@
     <string name="insert_heading">Insert Heading</string>
     <string name="format_font_size">Change Font Size</string>
     <string name="insert_mathjax">Insert MathJax Equation</string>
+    <string name="insert_cloze">Insert Cloze Deletion</string>
 </resources>

--- a/AnkiDroid/src/main/res/values/11-arrays.xml
+++ b/AnkiDroid/src/main/res/values/11-arrays.xml
@@ -88,4 +88,13 @@
         <item>Black</item>
         <item>Dark</item>
     </string-array>
+    <string-array name="html_size_code_labels">
+        <item>xx-small</item>
+        <item>x-small</item>
+        <item>small</item>
+        <item>medium</item>
+        <item>large</item>
+        <item>x-large</item>
+        <item>xx-large</item>
+    </string-array>
 </resources>

--- a/AnkiDroid/src/main/res/values/constants.xml
+++ b/AnkiDroid/src/main/res/values/constants.xml
@@ -223,4 +223,13 @@
         <item>top</item>
         <item>bottom</item>
     </string-array>
+    <string-array name="html_size_codes">
+        <item>xx-small</item>
+        <item>x-small</item>
+        <item>small</item>
+        <item>medium</item>
+        <item>large</item>
+        <item>x-large</item>
+        <item>xx-large</item>
+    </string-array>
 </resources>

--- a/AnkiDroid/src/main/res/values/styles.xml
+++ b/AnkiDroid/src/main/res/values/styles.xml
@@ -126,10 +126,10 @@
         <item name="android:layout_marginLeft">10dp</item>
     </style>
 
+    <!-- padding is hardcoded in Toolbar.java (32) to allow for fixing the scrollview -->
     <style name="note_editor_toolbar_button">
         <item name="android:layout_width">wrap_content</item>
         <item name="android:layout_height">wrap_content</item>
-        <item name="android:layout_gravity">center_horizontal</item>
         <item name="android:padding">4dp</item>
     </style>
 </resources>

--- a/AnkiDroid/src/main/res/values/styles.xml
+++ b/AnkiDroid/src/main/res/values/styles.xml
@@ -125,4 +125,11 @@
         <item name="android:layout_marginStart">10dp</item>
         <item name="android:layout_marginLeft">10dp</item>
     </style>
+
+    <style name="note_editor_toolbar_button">
+        <item name="android:layout_width">wrap_content</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:layout_gravity">center_horizontal</item>
+        <item name="android:padding">4dp</item>
+    </style>
 </resources>


### PR DESCRIPTION
## Purpose / Description
Was widely requested that we add an editing toolbar for the Note Editor - This allows quick access to a set of commands

## Fixes
Fixes #7124
Related: #1377 
Reverts: #7126
Reverts: #6497

## Approach

Add a toolbar

Allow the user to add their own commands. These are saved in SharedPreferences

## How Has This Been Tested?

API 16, 21 and 29 emulator

![note_editor_toolbar_remove_item](https://user-images.githubusercontent.com/62114487/97119815-b349c480-170a-11eb-8ec2-5c20ee2d6a13.png)
![note_editor_toolbar_create_toolbar](https://user-images.githubusercontent.com/62114487/97119816-b3e25b00-170a-11eb-8fd9-828f6fe45430.png)
![note_editor_toolbar_font_size](https://user-images.githubusercontent.com/62114487/97119818-b5138800-170a-11eb-9588-a7aedb58e520.png)
![note_editor_toolbar_heading](https://user-images.githubusercontent.com/62114487/97119819-b5ac1e80-170a-11eb-816e-d2862a20e91a.png)
![note_editor_toolbar](https://user-images.githubusercontent.com/62114487/97119820-b5ac1e80-170a-11eb-844f-51aa5c68288d.png)


## Learning

HorizontalScrollView does not work well with centered content.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)