### PR TITLE
DeckPicker: Hide "search" for new users

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -728,6 +728,9 @@ public class DeckPicker extends NavigationDrawerActivity implements
             }
         }
 
+        // Remove the filter - not necessary and search has other implications for new users.
+        menu.findItem(R.id.deck_picker_action_filter).setVisible(getCol().getDecks().count() >= 10);
+
         return super.onCreateOptionsMenu(menu);
     }
 


### PR DESCRIPTION
For discussion:

It's not necessary to search with few decks, and I expect that users may feel it means "search for a shared deck"

Slightly improves the "new user" flow