### PR TITLE
NF: avoid looping over try/catch

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DB.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DB.java
@@ -233,8 +233,11 @@ public class DB {
             String methodName = getCursorMethodName(type.getSimpleName());
             while (cursor.moveToNext()) {
                 try {
-                    // The magical line. Almost as illegible as python code ;)
-                    results.add(type.cast(Cursor.class.getMethod(methodName, int.class).invoke(cursor, 0)));
+                    do {
+                        // The magical line. Almost as illegible as python code ;)
+                        results.add(type.cast(Cursor.class.getMethod(methodName, int.class).invoke(cursor, 0)));
+                    } while (cursor.moveToNext());
+                    break;
                 } catch (InvocationTargetException e) {
                     if (cursor.isNull(0)) { // null value encountered
                         nullExceptionCount++;


### PR DESCRIPTION
Usually, the slowest part of the code is database. In particular, entering a try/catch is costly, so it should try to be avoided if possible. This ensure that as long as no exception is raised, the run remains inside the same try/catch.