### PR TITLE
NF: save current search to avoid doing it twice

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -137,6 +137,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
     * When the list is changed, the position member of its elements should get changed.*/
     @NonNull
     private CardCollection<CardCache> mCards = new CardCollection<>();
+    // The search query, and the index of the order of the search currently being executed or shown
+    private Pair<String, Integer> mCurrentSearch = null;
     private ArrayList<Deck> mDropDownDecks;
     private ListView mCardsListView;
     private SearchView mSearchView;
@@ -1412,13 +1414,13 @@ public class CardBrowser extends NavigationDrawerActivity implements
         CollectionTask.cancelAllTasks(SEARCH_CARDS);
         CollectionTask.cancelAllTasks(RENDER_BROWSER_QA);
         CollectionTask.cancelAllTasks(CHECK_CARD_SELECTION);
+        mCurrentSearch = null;
         mCards.clear();
         mCheckedCards.clear();
     }
 
     private void searchCards() {
         // cancel the previous search & render tasks if still running
-        invalidate();
         String searchText;
         if (mSearchTerms == null) {
             mSearchTerms = "";
@@ -1432,6 +1434,14 @@ public class CardBrowser extends NavigationDrawerActivity implements
         } else {
             searchText = mRestrictOnDeck + mSearchTerms;
         }
+        Pair<String, Integer> search = new Pair<>(searchText, mOrder);
+        if (search.equals(mCurrentSearch)) {
+            Timber.w("Search order \"%s\" with order %s cancelled because it already was searched", searchText, fSortTypes[mOrder]);
+            // We currently have exactly the same search
+            return;
+        }
+        invalidate();
+        mCurrentSearch = search;
         if (colIsOpen() && mCardsAdapter!= null) {
             // clear the existing card list
             mCards.reset();


### PR DESCRIPTION
This follow @david-allison-1 's idea in https://github.com/ankidroid/Anki-Android/pull/7516#pullrequestreview-517240860

It saves the current search, so that it's not done a second time. Current search is deleted when the data is emptied.

It reduces computation time from 20 seconds to 16.5 seconds on a deck