### PR TITLE
Note Editor: API 21 fixes: cloze & centering

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1741,7 +1741,7 @@ public class NoteEditor extends AnkiActivity {
 
 
     private void updateToolbar() {
-        if (mToolbar == null || Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+        if (mToolbar == null) {
             return;
         }
 
@@ -1766,6 +1766,11 @@ public class NoteEditor extends AnkiActivity {
             clozeIcon.setVisibility(View.VISIBLE);
         } else {
             clozeIcon.setVisibility(View.GONE);
+        }
+
+        // Custom buttons are not supported until Lollipop due to possibly fixable DrawableCompat issue
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            return;
         }
 
 

--- a/AnkiDroid/src/main/res/layout/note_editor_toolbar.xml
+++ b/AnkiDroid/src/main/res/layout/note_editor_toolbar.xml
@@ -34,6 +34,7 @@
         app:contentInsetRight="0dp"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
         android:background="?android:attr/selectableItemBackground"
         android:orientation="horizontal">
 


### PR DESCRIPTION
* Ensures the Cloze Button appears on API 16
* Centers the Note Editor Toolbar on API 16

## How Has This Been Tested?

API 16 emulator

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] Strings resources: All strings added as resources are unique or contain a comment for seemingly duplicate strings to explain the difference between both resources
