### PR TITLE
Remove travis warning about upper/lower char

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiFont.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiFont.java
@@ -63,29 +63,29 @@ public class AnkiFont {
             return null;
         }
 
-        if (tf.isBold() || name.toLowerCase(Locale.US).contains("bold")) {
+        if (tf.isBold() || name.toLowerCase(Locale.ROOT).contains("bold")) {
             attributes.add("font-weight: bolder;");
             family = family.replaceFirst("(?i)-?Bold", "");
-        } else if (name.toLowerCase(Locale.US).contains("light")) {
+        } else if (name.toLowerCase(Locale.ROOT).contains("light")) {
             attributes.add("font-weight: lighter;");
             family = family.replaceFirst("(?i)-?Light", "");
         } else {
             attributes.add("font-weight: normal;");
         }
-        if (tf.isItalic() || name.toLowerCase(Locale.US).contains("italic")) {
+        if (tf.isItalic() || name.toLowerCase(Locale.ROOT).contains("italic")) {
             attributes.add("font-style: italic;");
             family = family.replaceFirst("(?i)-?Italic", "");
-        } else if (name.toLowerCase(Locale.US).contains("oblique")) {
+        } else if (name.toLowerCase(Locale.ROOT).contains("oblique")) {
             attributes.add("font-style: oblique;");
             family = family.replaceFirst("(?i)-?Oblique", "");
         } else {
             attributes.add("font-style: normal;");
         }
-        if (name.toLowerCase(Locale.US).contains("condensed") || name.toLowerCase(Locale.US).contains("narrow")) {
+        if (name.toLowerCase(Locale.ROOT).contains("condensed") || name.toLowerCase(Locale.ROOT).contains("narrow")) {
             attributes.add("font-stretch: condensed;");
             family = family.replaceFirst("(?i)-?Condensed", "");
             family = family.replaceFirst("(?i)-?Narrow(er)?", "");
-        } else if (name.toLowerCase(Locale.US).contains("expanded") || name.toLowerCase(Locale.US).contains("wide")) {
+        } else if (name.toLowerCase(Locale.ROOT).contains("expanded") || name.toLowerCase(Locale.ROOT).contains("wide")) {
             attributes.add("font-stretch: expanded;");
             family = family.replaceFirst("(?i)-?Expanded", "");
             family = family.replaceFirst("(?i)-?Wide(r)?", "");

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.java
@@ -39,6 +39,7 @@ import com.ichi2.utils.FilterResultsUtils;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 
 import androidx.annotation.NonNull;
@@ -255,9 +256,9 @@ public class DeckSelectionDialog extends AnalyticsDialogFragment {
                 if (constraint.length() == 0) {
                     mFilteredDecks.addAll(allDecks);
                 } else {
-                    final String filterPattern = constraint.toString().toLowerCase().trim();
+                    final String filterPattern = constraint.toString().toLowerCase(Locale.getDefault()).trim();
                     for (SelectableDeck deck : allDecks) {
-                        if (deck.getName().toLowerCase().contains(filterPattern)) {
+                        if (deck.getName().toLowerCase(Locale.getDefault()).contains(filterPattern)) {
                             mFilteredDecks.add(deck);
                         }
                     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/LocaleSelectionDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/LocaleSelectionDialog.java
@@ -245,10 +245,10 @@ public class LocaleSelectionDialog extends AnalyticsDialogFragment {
                         return filterResults;
                     }
 
-                    String normalisedConstraint = constraint.toString().toLowerCase();
+                    String normalisedConstraint = constraint.toString().toLowerCase(Locale.getDefault());
                     ArrayList<Locale> locales = new ArrayList<>();
                     for (Locale l : selectableLocales) {
-                        if (l.getDisplayName().toLowerCase().contains(normalisedConstraint)) {
+                        if (l.getDisplayName().toLowerCase(Locale.getDefault()).contains(normalisedConstraint)) {
                             locales.add(l);
                         }
                     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TagsDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TagsDialog.java
@@ -31,6 +31,7 @@ import com.ichi2.utils.FilterResultsUtils;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Locale;
 import java.util.TreeSet;
 
 public class TagsDialog extends AnalyticsDialogFragment {
@@ -343,9 +344,9 @@ public class TagsDialog extends AnalyticsDialogFragment {
                 if (constraint.length() == 0) {
                     mFilteredTags.addAll(mAllTags);
                 } else {
-                    final String filterPattern = constraint.toString().toLowerCase().trim();
+                    final String filterPattern = constraint.toString().toLowerCase(Locale.getDefault()).trim();
                     for (String tag : mAllTags) {
-                        if (tag.toLowerCase().contains(filterPattern)) {
+                        if (tag.toLowerCase(Locale.getDefault()).contains(filterPattern)) {
                             mFilteredTags.add(tag);
                         }
                     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/beolingus/parsing/BeolingusParser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/beolingus/parsing/BeolingusParser.java
@@ -19,6 +19,7 @@
 
 package com.ichi2.anki.multimediacard.beolingus.parsing;
 
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -44,7 +45,7 @@ public class BeolingusParser {
             //Perform .contains() due to #5376 (a "%20{noun}" suffix).
             //Perform .toLowerCase() due to #5810 ("hello" should match "Hello").
             //See #5810 for discussion on Locale complexities. Currently unhandled.
-            if (m.group(2).toLowerCase().contains(wordToSearchFor.toLowerCase())) {
+            if (m.group(2).toLowerCase(Locale.ROOT).contains(wordToSearchFor.toLowerCase(Locale.ROOT))) {
                 Timber.d("pronunciation URL is https://dict.tu-chemnitz.de%s", m.group(1));
                 return "https://dict.tu-chemnitz.de" + m.group(1);
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/stats/OverviewStatsBuilder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/stats/OverviewStatsBuilder.java
@@ -133,8 +133,9 @@ public class OverviewStatsBuilder {
         // FORECAST
         // Fill in the forecast summaries first
         calculateForecastOverview(mType, oStats);
+        Locale l = Locale.getDefault();
 
-        stringBuilder.append(_subtitle(res.getString(R.string.stats_forecast).toUpperCase()));
+        stringBuilder.append(_subtitle(res.getString(R.string.stats_forecast).toUpperCase(l)));
         stringBuilder.append(res.getString(R.string.stats_overview_forecast_total, oStats.forecastTotalReviews));
         stringBuilder.append("<br>");
         stringBuilder.append(res.getString(R.string.stats_overview_forecast_average, oStats.forecastAverageReviews));
@@ -144,7 +145,7 @@ public class OverviewStatsBuilder {
         stringBuilder.append("<br>");
 
         // REVIEW COUNT
-        stringBuilder.append(_subtitle(res.getString(R.string.stats_review_count).toUpperCase()));
+        stringBuilder.append(_subtitle(res.getString(R.string.stats_review_count).toUpperCase(l)));
         stringBuilder.append(daysStudied);
         stringBuilder.append("<br>");
         stringBuilder.append(res.getString(R.string.stats_overview_forecast_total, oStats.totalReviews));
@@ -160,7 +161,7 @@ public class OverviewStatsBuilder {
         //TODO: AnkiDroid uses 30 days on 2020-06-09, whereas Anki Desktop used 31
 
         //REVIEW TIME
-        stringBuilder.append(_subtitle(res.getString(R.string.stats_review_time).toUpperCase()));
+        stringBuilder.append(_subtitle(res.getString(R.string.stats_review_time).toUpperCase(l)));
         stringBuilder.append(daysStudied);
         stringBuilder.append("<br>");
         //TODO: Anki Desktop allows changing to hours / days here.
@@ -179,7 +180,7 @@ public class OverviewStatsBuilder {
         stringBuilder.append("<br>");
 
         // ADDED
-        stringBuilder.append(_subtitle(res.getString(R.string.stats_added).toUpperCase()));
+        stringBuilder.append(_subtitle(res.getString(R.string.stats_added).toUpperCase(l)));
         stringBuilder.append(res.getString(R.string.stats_overview_total_new_cards, oStats.totalNewCards));
         stringBuilder.append("<br>");
         stringBuilder.append(res.getString(R.string.stats_overview_new_cards_per_day, oStats.newCardsPerDay));
@@ -187,7 +188,7 @@ public class OverviewStatsBuilder {
         stringBuilder.append("<br>");
 
         // INTERVALS
-        stringBuilder.append(_subtitle(res.getString(R.string.stats_review_intervals).toUpperCase()));
+        stringBuilder.append(_subtitle(res.getString(R.string.stats_review_intervals).toUpperCase(l)));
         stringBuilder.append(res.getString(R.string.stats_overview_average_interval));
         stringBuilder.append(Utils.roundedTimeSpan(mWebView.getContext(), (int) Math.round(oStats.averageInterval * Stats.SECONDS_PER_DAY)));
         stringBuilder.append("<br>");
@@ -195,7 +196,7 @@ public class OverviewStatsBuilder {
         stringBuilder.append(Utils.roundedTimeSpan(mWebView.getContext(), (int) Math.round(oStats.longestInterval * Stats.SECONDS_PER_DAY)));
 
         //ANSWER BUTTONS
-        stringBuilder.append(_subtitle(res.getString(R.string.stats_answer_buttons).toUpperCase()));
+        stringBuilder.append(_subtitle(res.getString(R.string.stats_answer_buttons).toUpperCase(l)));
         stringBuilder.append(res.getString(R.string.stats_overview_answer_buttons_learn, oStats.newCardsOverview.getPercentage(), oStats.newCardsOverview.correct, oStats.newCardsOverview.total));
         stringBuilder.append("<br>");
         stringBuilder.append(res.getString(R.string.stats_overview_answer_buttons_young, oStats.youngCardsOverview.getPercentage(), oStats.youngCardsOverview.correct, oStats.youngCardsOverview.total));
@@ -203,7 +204,7 @@ public class OverviewStatsBuilder {
         stringBuilder.append(res.getString(R.string.stats_overview_answer_buttons_mature,  oStats.matureCardsOverview.getPercentage(), oStats.matureCardsOverview.correct, oStats.matureCardsOverview.total));
 
         //CARD TYPES
-        stringBuilder.append(_subtitle(res.getString(R.string.title_activity_template_editor).toUpperCase()));
+        stringBuilder.append(_subtitle(res.getString(R.string.title_activity_template_editor).toUpperCase(l)));
         stringBuilder.append(res.getString(R.string.stats_overview_card_types_total_cards, oStats.totalCards));
         stringBuilder.append("<br>");
         stringBuilder.append(res.getString(R.string.stats_overview_card_types_total_notes, oStats.totalNotes));

--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.java
@@ -395,7 +395,7 @@ public class DeckAdapter extends RecyclerView.Adapter<DeckAdapter.ViewHolder> im
             if (TextUtils.isEmpty(constraint)) {
                 mFilteredDecks.addAll(allDecks);
             } else {
-                final String filterPattern = constraint.toString().toLowerCase().trim();
+                final String filterPattern = constraint.toString().toLowerCase(Locale.getDefault()).trim();
                 List<AbstractDeckTreeNode> filteredDecks = filterDecks(filterPattern, allDecks);
                 mFilteredDecks.addAll(filteredDecks);
             }
@@ -445,7 +445,7 @@ public class DeckAdapter extends RecyclerView.Adapter<DeckAdapter.ViewHolder> im
 
         private <T extends AbstractDeckTreeNode<T>> boolean containsFilterString(String filterPattern, T root) {
             String deckName = root.getFullDeckName();
-            return deckName.toLowerCase().contains(filterPattern) || deckName.toLowerCase(Locale.US).contains(filterPattern);
+            return deckName.toLowerCase(Locale.getDefault()).contains(filterPattern) || deckName.toLowerCase(Locale.getDefault()).contains(filterPattern);
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DB.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DB.java
@@ -317,7 +317,7 @@ public class DB {
 
 
     public void execute(String sql, Object... object) {
-        String s = sql.trim().toLowerCase(Locale.US);
+        String s = sql.trim().toLowerCase(Locale.ROOT);
         // mark modified?
         for (String mo : MOD_SQLS) {
             if (s.startsWith(mo)) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Deck.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Deck.java
@@ -18,6 +18,8 @@ package com.ichi2.libanki;
 
 import com.ichi2.utils.JSONObject;
 
+import androidx.annotation.CheckResult;
+
 public class Deck extends JSONObject {
     public Deck(JSONObject json) {
         super(json);
@@ -32,9 +34,9 @@ public class Deck extends JSONObject {
     }
 
     @Override
+    @CheckResult
     public Deck deepClone() {
         Deck clone = new Deck();
-        deepClonedInto(clone);
-        return clone;
+        return deepClonedInto(clone);
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -42,6 +42,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -1128,7 +1129,7 @@ public class Decks {
     private static final HashMap<String, String> normalized = new HashMap<>();
     public static String normalizeName(String name) {
         if (!normalized.containsKey(name)) {
-            normalized.put(name, Normalizer.normalize(name, Normalizer.Form.NFC).toLowerCase());
+            normalized.put(name, Normalizer.normalize(name, Normalizer.Form.NFC).toLowerCase(Locale.ROOT));
         }
         return normalized.get(name);
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
@@ -297,7 +297,7 @@ public class Finder {
                 // commands
             } else if (token.contains(":")) {
                 String[] spl = token.split(":", 2);
-                String cmd = spl[0].toLowerCase(Locale.US);
+                String cmd = spl[0].toLowerCase(Locale.ROOT);
                 String val = spl[1];
 
                 switch (cmd) {
@@ -551,7 +551,7 @@ public class Finder {
         if (!m.matches()) {
             return null;
         }
-        String prop = m.group(1).toLowerCase(Locale.US);
+        String prop = m.group(1).toLowerCase(Locale.ROOT);
         String cmp = m.group(2);
         String sval = m.group(3);
         int val;
@@ -952,9 +952,9 @@ public class Finder {
         for (JSONObject m : col.getModels().all()) {
             JSONArray flds = m.getJSONArray("flds");
             for (JSONObject f: flds.jsonObjectIterable()) {
-                if (!fields.contains(f.getString("name").toLowerCase(Locale.US))) {
+                if (!fields.contains(f.getString("name").toLowerCase(Locale.ROOT))) {
                     names.add(f.getString("name"));
-                    fields.add(f.getString("name").toLowerCase(Locale.US));
+                    fields.add(f.getString("name").toLowerCase(Locale.ROOT));
                 }
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Media.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Media.java
@@ -325,7 +325,7 @@ public class Media {
                 m = p.matcher(s);
                 while (m.find()) {
                     String fname = m.group(fnameIdx);
-                    boolean isLocal = !fRemotePattern.matcher(fname.toLowerCase(Locale.US)).find();
+                    boolean isLocal = !fRemotePattern.matcher(fname.toLowerCase(Locale.getDefault())).find();
                     if (isLocal || includeRemote) {
                         l.add(fname);
                     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Model.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Model.java
@@ -19,6 +19,8 @@ package com.ichi2.libanki;
 
 import com.ichi2.utils.JSONObject;
 
+import androidx.annotation.CheckResult;
+
 /**
  * Represents a note type, a.k.a. Model.
  * The content of an object is described in https://github.com/ankidroid/Anki-Android/wiki/Database-Structure
@@ -39,9 +41,9 @@ public class Model extends JSONObject {
     }
 
     @Override
+    @CheckResult
     public Model deepClone() {
         Model clone = new Model();
-        deepClonedInto(clone);
-        return clone;
+        return deepClonedInto(clone);
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.java
@@ -42,6 +42,7 @@ import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -304,7 +305,7 @@ public class Sound {
 //                    Integer.parseInt(soundPath.substring(3, 4)));
         } else {
             // Check if the file extension is that of a known video format
-            final String extension = soundPath.substring(soundPath.lastIndexOf(".") + 1).toLowerCase();
+            final String extension = soundPath.substring(soundPath.lastIndexOf(".") + 1).toLowerCase(Locale.getDefault());
             boolean isVideo = Arrays.asList(VIDEO_WHITELIST).contains(extension);
             if (!isVideo) {
                 final String guessedType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension);

--- a/AnkiDroid/src/main/java/com/ichi2/utils/DatabaseChangeDecorator.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/DatabaseChangeDecorator.java
@@ -56,8 +56,8 @@ public class DatabaseChangeDecorator implements SupportSQLiteDatabase {
         if (!needsComplexCheck()) {
             return;
         }
-        String lower = sql.toLowerCase();
-        String upper = sql.toUpperCase();
+        String lower = sql.toLowerCase(Locale.ROOT);
+        String upper = sql.toUpperCase(Locale.ROOT);
         for (String modString : MOD_SQLS) {
             if (startsWithIgnoreCase(lower, upper, modString)) {
                 markDataAsChanged();
@@ -69,7 +69,7 @@ public class DatabaseChangeDecorator implements SupportSQLiteDatabase {
 
     private boolean startsWithIgnoreCase(String lowerHaystack, String upperHaystack, String needle) {
         // Needs to do both according to https://stackoverflow.com/a/38947571
-        return lowerHaystack.startsWith(needle) || upperHaystack.startsWith(needle.toUpperCase());
+        return lowerHaystack.startsWith(needle) || upperHaystack.startsWith(needle.toUpperCase(Locale.ROOT));
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.java
@@ -60,7 +60,7 @@ public class ImportUtils {
     }
 
     public static boolean isCollectionPackage(String filename) {
-        return filename != null && (filename.toLowerCase().endsWith(".colpkg") || "collection.apkg".equals(filename));
+        return filename != null && (filename.toLowerCase(Locale.ROOT).endsWith(".colpkg") || "collection.apkg".equals(filename));
     }
 
     /** @return Whether the file is either a deck, or a collection package */
@@ -303,7 +303,7 @@ public class ImportUtils {
         }
 
         private static boolean isDeckPackage(String filename) {
-            return filename != null && filename.toLowerCase().endsWith(".apkg") && !"collection.apkg".equals(filename);
+            return filename != null && filename.toLowerCase(Locale.ROOT).endsWith(".apkg") && !"collection.apkg".equals(filename);
         }
 
 
@@ -315,7 +315,7 @@ public class ImportUtils {
             String extensionSegment = fileParts[fileParts.length - 1];
             //either "apkg", or "apkg (1)".
             // COULD_BE_BETTE: accepts .apkgaa"
-            return extensionSegment.toLowerCase(Locale.US).startsWith(extension);
+            return extensionSegment.toLowerCase(Locale.ROOT).startsWith(extension);
         }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/utils/JSONObject.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/JSONObject.java
@@ -345,8 +345,7 @@ public class JSONObject extends org.json.JSONObject implements Iterable<String> 
     @CheckResult
     public JSONObject deepClone() {
         JSONObject clone = new JSONObject();
-        deepClonedInto(clone);
-        return clone;
+        return deepClonedInto(clone);
     }
 
     /** deep clone this into clone.
@@ -357,7 +356,6 @@ public class JSONObject extends org.json.JSONObject implements Iterable<String> 
         j.deepClonedInto(t);
         ```
         in order to obtain a deep clone of `j` of type ```T```. */
-    @CheckResult
     protected <T extends JSONObject> T deepClonedInto(T clone) {
         for (String key: this) {
             if (get(key) instanceof JSONObject) {


### PR DESCRIPTION
Travis state that US and no information should be avoided. Instead I use root for internal (sql, comparing deck name, checking whether an
extension is apkg, anki2, ....) and getDefault() for everything facing the user, such as title of section, media file
