### PR TITLE
Note Editor Toolbar: Add Keyboard Shortcuts

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -691,6 +691,11 @@ public class NoteEditor extends AnkiActivity {
 
     @Override
     public boolean onKeyUp(int keyCode, KeyEvent event) {
+
+        if (mToolbar != null && mToolbar.onKeyUp(keyCode, event)) {
+            return true;
+        }
+
         switch(keyCode) {
 
             //some hardware keyboards swap between mobile/desktop mode...
@@ -1778,10 +1783,16 @@ public class NoteEditor extends AnkiActivity {
 
         for (CustomToolbarButton b : buttons) {
 
-            String text = Integer.toString(b.getIndex() + 1);
+            // 0th button shows as '1' and is Ctrl + 1
+            int visualIndex = b.getIndex() + 1;
+            String text = Integer.toString(visualIndex);
             Drawable bmp = mToolbar.createDrawableForString(text);
 
             View v = mToolbar.insertItem(0, bmp, b.toFormatter());
+
+            // Allow Ctrl + 1...Ctrl + 0 for item 10.
+            v.setTag(Integer.toString(visualIndex % 10));
+
             v.setOnLongClickListener(discard -> {
                 suggestRemoveButton(b);
                 return true;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.java
@@ -29,6 +29,7 @@ import android.util.AttributeSet;
 import android.util.DisplayMetrics;
 import android.util.TypedValue;
 import android.view.Gravity;
+import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -37,6 +38,8 @@ import android.widget.LinearLayout;
 
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.ichi2.anki.R;
+import com.ichi2.libanki.Utils;
+import com.ichi2.utils.ViewGroupUtils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -48,6 +51,7 @@ import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 import androidx.appcompat.widget.AppCompatImageButton;
 import androidx.vectordrawable.graphics.drawable.VectorDrawableCompat;
+import timber.log.Timber;
 
 public class Toolbar extends FrameLayout {
 
@@ -103,6 +107,38 @@ public class Toolbar extends FrameLayout {
         findViewById(R.id.note_editor_toolbar_button_font_size).setOnClickListener(l -> displayFontSizeDialog());
         findViewById(R.id.note_editor_toolbar_button_title).setOnClickListener(l -> displayInsertHeadingDialog());
         this.mClozeIcon = findViewById(R.id.note_editor_toolbar_button_cloze);
+    }
+
+
+    @Override
+    public boolean onKeyUp(int keyCode, KeyEvent event) {
+        // hack to see if only CTRL is pressed - might not be perfect.
+        // I'll avoid checking "function" here as it may be required to press Ctrl
+        if (!event.isCtrlPressed() || event.isAltPressed() || event.isShiftPressed() || event.isMetaPressed()) {
+            return false;
+        }
+
+        char c;
+        try {
+            c = (char) event.getUnicodeChar(0);
+        } catch (Exception e) {
+            return false;
+        }
+
+        if (c == '\0') {
+            return false;
+        }
+
+        String expected = Character.toString(c);
+        for (View v : ViewGroupUtils.getAllChildrenRecursive(this)) {
+            if (Utils.equals(expected, v.getTag())) {
+                Timber.i("Handling Ctrl + %s", c);
+                v.performClick();
+                return true;
+            }
+        }
+
+        return super.onKeyUp(keyCode, event);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ViewGroupUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ViewGroupUtils.java
@@ -33,4 +33,17 @@ public class ViewGroupUtils {
         }
         return views;
     }
+
+    @NonNull
+    public static List<View> getAllChildrenRecursive(@NonNull ViewGroup viewGroup) {
+        List<View> views = new ArrayList<>();
+        for (int i = 0; i < viewGroup.getChildCount(); i++) {
+            View child = viewGroup.getChildAt(i);
+            views.add(child);
+            if (child instanceof ViewGroup) {
+                views.addAll(getAllChildrenRecursive((ViewGroup) child));
+            }
+        }
+        return views;
+    }
 }

--- a/AnkiDroid/src/main/res/layout/note_editor_toolbar.xml
+++ b/AnkiDroid/src/main/res/layout/note_editor_toolbar.xml
@@ -42,36 +42,42 @@
             android:id="@+id/note_editor_toolbar_button_bold"
             app:srcCompat="@drawable/ic_format_bold_black_24dp"
             android:contentDescription="@string/format_insert_bold"
+            android:tag="b"
             style="@style/note_editor_toolbar_button" />
 
         <androidx.appcompat.widget.AppCompatImageButton
             android:id="@+id/note_editor_toolbar_button_italic"
             app:srcCompat="@drawable/ic_format_italic_black_24dp"
             android:contentDescription="@string/format_insert_italic"
+            android:tag="i"
             style="@style/note_editor_toolbar_button" />
 
         <androidx.appcompat.widget.AppCompatImageButton
             android:id="@+id/note_editor_toolbar_button_underline"
             app:srcCompat="@drawable/ic_format_underlined_black_24dp"
             android:contentDescription="@string/format_insert_underline"
+            android:tag="u"
             style="@style/note_editor_toolbar_button" />
 
         <androidx.appcompat.widget.AppCompatImageButton
             android:id="@+id/note_editor_toolbar_button_horizontal_rule"
             app:srcCompat="@drawable/ic_horizontal_rule_black_24dp"
             android:contentDescription="@string/insert_horizontal_line"
+            android:tag="r"
             style="@style/note_editor_toolbar_button" />
 
         <androidx.appcompat.widget.AppCompatImageButton
             android:id="@+id/note_editor_toolbar_button_title"
             app:srcCompat="@drawable/ic_format_title_black_24dp"
             android:contentDescription="@string/insert_heading"
+            android:tag="h"
             style="@style/note_editor_toolbar_button" />
 
         <androidx.appcompat.widget.AppCompatImageButton
             android:id="@+id/note_editor_toolbar_button_font_size"
             android:contentDescription="@string/format_font_size"
             app:srcCompat="@drawable/ic_format_font_size_24dp"
+            android:tag="f"
             style="@style/note_editor_toolbar_button" />
 
 
@@ -79,6 +85,7 @@
             android:id="@+id/note_editor_toolbar_button_insert_mathjax"
             android:contentDescription="@string/insert_mathjax"
             app:srcCompat="@drawable/ic_add_equation_black_24dp"
+            android:tag="m"
             style="@style/note_editor_toolbar_button" />
 
         <!-- We can't dynamically add this on API 16,


### PR DESCRIPTION
Including Ctrl+1..0 for custom items

We do this via a tag.

'L' already opens the Card Template Editor

Related #7124 


## How Has This Been Tested?

Android 9 phone

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] Strings resources: All strings added as resources are unique or contain a comment for seemingly duplicate strings to explain the difference between both resources
