### PR TITLE
NF: remove mPreviousTask

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/async/TaskManager.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/TaskManager.java
@@ -70,7 +70,7 @@ public class TaskManager {
     public static <ProgressListener, ProgressBackground extends ProgressListener, ResultListener, ResultBackground extends ResultListener> CollectionTask<ProgressListener, ProgressBackground, ResultListener, ResultBackground> launchCollectionTask(@NonNull CollectionTask.Task<ProgressBackground, ResultBackground> task,
                                                                                                                                                                                                                                                        @Nullable TaskListener<ProgressListener, ResultListener> listener) {
         // Start new task
-        CollectionTask<ProgressListener, ProgressBackground, ResultListener, ResultBackground> newTask = new CollectionTask<>(task, listener, sLatestInstance);
+        CollectionTask<ProgressListener, ProgressBackground, ResultListener, ResultBackground> newTask = new CollectionTask<>(task, listener);
         newTask.execute();
         return newTask;
     }


### PR DESCRIPTION
AsyncTask already guarantee that no two tasks run simultaenously.
And this is no guarantee that two task don't run together, because it just check that the task running when `this` was
created is ended, not that all tasks created before `this` ended

I know AsyncTask is deprecated, and one day we may need to move. I don't know what the evolution will be, but I strongly believe that removing code that is currently useless and would not do what we want even without AsyncTask's assumption will only help the eventual move