### PR TITLE
Deprecation: Use new ClipboardManager

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1073,30 +1073,32 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
     /** We use the clipboard here for the lookup dictionary functionality
      * If the clipboard has data and we're using the functionality, then */
     private void clearClipboard() {
-        if (mClipboard != null) {
-            try {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                    mClipboard.clearPrimaryClip();
-                } else {
-                    if (!mClipboard.hasPrimaryClip()) {
-                        return;
-                    }
+        if (mClipboard == null) {
+            return;
+        }
 
-                    CharSequence descriptionLabel = ClipboardUtil.getDescriptionLabel(mClipboard.getPrimaryClip());
-                    if (!"Cleared".contentEquals(descriptionLabel)) {
-                        mClipboard.setPrimaryClip(ClipData.newPlainText("Cleared", ""));
-                    }
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                mClipboard.clearPrimaryClip();
+            } else {
+                if (!mClipboard.hasPrimaryClip()) {
+                    return;
                 }
-            } catch (Exception e) {
-                // TODO: This may no longer be relevant
 
-                // https://code.google.com/p/ankidroid/issues/detail?id=1746
-                // https://code.google.com/p/ankidroid/issues/detail?id=1820
-                // Some devices or external applications make the clipboard throw exceptions. If this happens, we
-                // must disable it or AnkiDroid will crash if it tries to use it.
-                Timber.e("Clipboard error. Disabling text selection setting.");
-                mDisableClipboard = true;
+                CharSequence descriptionLabel = ClipboardUtil.getDescriptionLabel(mClipboard.getPrimaryClip());
+                if (!"Cleared".contentEquals(descriptionLabel)) {
+                    mClipboard.setPrimaryClip(ClipData.newPlainText("Cleared", ""));
+                }
             }
+        } catch (Exception e) {
+            // TODO: This may no longer be relevant
+
+            // https://code.google.com/p/ankidroid/issues/detail?id=1746
+            // https://code.google.com/p/ankidroid/issues/detail?id=1820
+            // Some devices or external applications make the clipboard throw exceptions. If this happens, we
+            // must disable it or AnkiDroid will crash if it tries to use it.
+            Timber.e("Clipboard error. Disabling text selection setting.");
+            mDisableClipboard = true;
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ClipboardUtil.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ClipboardUtil.java
@@ -21,6 +21,7 @@ import android.content.ClipDescription;
 import android.content.ClipboardManager;
 import android.net.Uri;
 
+import androidx.annotation.CheckResult;
 import androidx.annotation.Nullable;
 
 public class ClipboardUtil {
@@ -73,5 +74,41 @@ public class ClipboardUtil {
         }
 
         return primaryClip.getItemAt(0).getUri();
+    }
+
+    @Nullable
+    @CheckResult
+    public static CharSequence getText(@Nullable ClipboardManager clipboard) {
+        if (clipboard == null) {
+            return null;
+        }
+
+        if (!clipboard.hasPrimaryClip()) {
+            return null;
+        }
+
+        ClipData data = clipboard.getPrimaryClip();
+
+        if (data.getItemCount() == 0) {
+            return null;
+        }
+
+        ClipData.Item i = data.getItemAt(0);
+
+        return i.getText();
+    }
+
+    @Nullable
+    @CheckResult
+    public static CharSequence getDescriptionLabel(@Nullable ClipData clip) {
+        if (clip == null) {
+            return null;
+        }
+
+        if (clip.getDescription() == null) {
+            return null;
+        }
+
+        return clip.getDescription().getLabel();
     }
 }


### PR DESCRIPTION
## Purpose / Description
Added in API 11, let's use it

## Fixes
Fixes #5023

## Approach
Add a ClipboardUtils class to handle the new functionality cleanly

## How Has This Been Tested?

API 16 using the "lookup dictionary"

## Learning (optional, can help others)

https://developer.android.com/reference/android/content/ClipboardManager

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] Strings resources: All strings added as resources are unique or contain a comment for seemingly duplicate strings to explain the difference between both resources