### PR TITLE
Note Editor: Allow pasting images into fields

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/utils/FileUtil.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/FileUtil.java
@@ -1,13 +1,10 @@
 package com.ichi2.utils;
 
 import android.content.ContentResolver;
-import android.content.Context;
 import android.net.Uri;
 import android.os.StatFs;
 
 import com.ichi2.compat.CompatHelper;
-import com.ichi2.libanki.utils.SystemTime;
-import com.ichi2.libanki.utils.TimeUtils;
 
 
 import java.io.File;
@@ -15,10 +12,11 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.AbstractMap;
+import java.util.Map;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.core.util.Pair;
 import timber.log.Timber;
 
 public class FileUtil {
@@ -74,4 +72,20 @@ public class FileUtil {
         return internalFile;
     }
 
+
+    /**
+     * @return Key: Filename; Value: extension including dot
+     */
+    @Nullable
+    public static Map.Entry<String, String> getFileNameAndExtension(@Nullable String fileName) {
+        if (fileName == null) {
+            return null;
+        }
+        int index = fileName.lastIndexOf(".");
+        if (index < 1) {
+            return null;
+        }
+
+        return new AbstractMap.SimpleEntry<>(fileName.substring(0, index), fileName.substring(index));
+    }
 }

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -353,4 +353,6 @@
     <string name="add_toolbar_item">Create Toolbar Item</string>
     <string name="toolbar_item_explain_remove">Enter HTML to be inserted before and after the selected text\n\nLong press a toolbar item to remove it</string>
     <string name="remove_toolbar_item">Remove Toolbar Item?</string>
+
+    <string name="note_editor_paste_too_large">The image is too large to paste, please insert the image manually</string>
 </resources>

--- a/AnkiDroid/src/test/java/com/ichi2/utils/FileUtilTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/FileUtilTest.java
@@ -1,0 +1,57 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.utils;
+
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+public class FileUtilTest {
+
+    @Test
+    public void testFileNameNull() {
+        assertThat(FileUtil.getFileNameAndExtension(null), nullValue());
+    }
+
+    @Test
+    public void testFileNameEmpty() {
+        assertThat(FileUtil.getFileNameAndExtension(""), nullValue());
+    }
+
+    @Test
+    public void testFileNameNoDot() {
+        assertThat(FileUtil.getFileNameAndExtension("abc"), nullValue());
+    }
+
+    @Test
+    public void testFileNameNormal() {
+        Map.Entry<String, String> fileNameAndExtension = FileUtil.getFileNameAndExtension("abc.jpg");
+        assertThat(fileNameAndExtension.getKey(), is("abc"));
+        assertThat(fileNameAndExtension.getValue(), is(".jpg"));
+    }
+
+    @Test
+    public void testFileNameTwoDot() {
+        Map.Entry<String, String> fileNameAndExtension = FileUtil.getFileNameAndExtension("a.b.c");
+        assertThat(fileNameAndExtension.getKey(), is("a.b"));
+        assertThat(fileNameAndExtension.getValue(), is(".c"));
+    }
+}


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
User wanted to be able to paste into fields on a Chromebook

This can be tested via inserting gifs via gboard.

Limited to 1MB.

## Fixes
Fixes #7566

## Approach

Override `onCreateInputConnection` and send the image to be pasted

## How Has This Been Tested?

Android 9 phone - probably not enough.

## Learning (optional, can help others)
https://stackoverflow.com/questions/56525255/image-keyboard-selecting-rich-contentgif-stickers-reopens-activity

Can be tested with the GBoard gif keyboard

![image](https://user-images.githubusercontent.com/62114487/97641586-23be5180-1a3b-11eb-9ef3-101b81387eb3.png)


## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] Strings resources: All strings added as resources are unique or contain a comment for seemingly duplicate strings to explain the difference between both resources