### PR TITLE
Note Editor: Ctrl+Shift+Num to switch fields

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -106,6 +106,7 @@ import com.ichi2.utils.AdaptionUtil;
 import com.ichi2.utils.DeckComparator;
 import com.ichi2.utils.FileUtil;
 import com.ichi2.utils.FunctionalInterfaces.Consumer;
+import com.ichi2.utils.KeyUtils;
 import com.ichi2.utils.MapUtil;
 import com.ichi2.utils.NamedJSONComparator;
 import com.ichi2.utils.NoteFieldDecorator;
@@ -703,7 +704,7 @@ public class NoteEditor extends AnkiActivity {
             return true;
         }
 
-        switch(keyCode) {
+        switch (keyCode) {
 
             //some hardware keyboards swap between mobile/desktop mode...
             //when in mobile mode KEYCODE_NUMPAD_ENTER & KEYCODE_ENTER are equiv. but
@@ -760,7 +761,36 @@ public class NoteEditor extends AnkiActivity {
                 break;
         }
 
+        // 7573: Ctrl+Shift+[Num] to select a field
+        if (event.isCtrlPressed() && event.isShiftPressed() && KeyUtils.isDigit(event)) {
+            int digit = KeyUtils.getDigit(event);
+            // map: '0' -> 9; '1' to 0
+            int indexBase10 = ((digit - 1) % 10 + 10) % 10;
+            selectFieldIndex(indexBase10);
+        }
+
         return super.onKeyUp(keyCode, event);
+    }
+
+
+    private void selectFieldIndex(int index) {
+        Timber.i("Selecting field index %d", index);
+        if (mEditFields.size() <= index || index < 0) {
+            Timber.i("Index out of range: %d", index);
+            return;
+        }
+
+
+        FieldEditText field;
+        try {
+            field = mEditFields.get(index);
+        } catch (IndexOutOfBoundsException e) {
+            Timber.w(e,"Error selecting index %d", index);
+            return;
+        }
+
+        field.requestFocus();
+        Timber.d("Selected field");
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/utils/KeyUtils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/KeyUtils.java
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.utils;
+
+import android.view.KeyEvent;
+
+public class KeyUtils {
+    public static boolean isDigit(KeyEvent event) {
+        int unicodeChar = event.getUnicodeChar(0);
+        return unicodeChar >= '0' && unicodeChar <= '9';
+    }
+
+
+    public static int getDigit(KeyEvent event) {
+        int unicodeChar = event.getUnicodeChar(0);
+        return unicodeChar - '0';
+    }
+}


### PR DESCRIPTION
## Purpose / Description
User Request: `Ctrl+[Num]` would switch fields, we already have `Ctrl+[Num]` so use `Ctrl+Shift+[Num]`

## Fixes
Fixes #7573

## How Has This Been Tested?

My Android 9

## Learning
https://stackoverflow.com/questions/14997165/fastest-way-to-get-a-positive-modulo-in-c-c

## Checklist
_Please, go through these checks before submitting the PR._

- [ ] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] Strings resources: All strings added as resources are unique or contain a comment for seemingly duplicate strings to explain the difference between both resources
