### PR TITLE
Direct icon to deck

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -31,11 +31,14 @@ import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
 import android.content.pm.PackageManager;
+import android.content.pm.ShortcutInfo;
+import android.content.pm.ShortcutManager;
 import android.content.res.Resources;
 import android.content.res.TypedArray;
 import android.database.SQLException;
 import android.graphics.PixelFormat;
 import android.graphics.drawable.Drawable;
+import android.graphics.drawable.Icon;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
@@ -48,6 +51,7 @@ import com.google.android.material.snackbar.Snackbar;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
 import androidx.annotation.StringRes;
 import androidx.annotation.VisibleForTesting;
 import androidx.appcompat.widget.SearchView;
@@ -142,6 +146,8 @@ import java.util.TreeMap;
 
 import timber.log.Timber;
 
+import static com.ichi2.anki.services.ReminderService.EXTRA_DECK_OPTION_ID;
+import static com.ichi2.anki.services.ReminderService.getReviewDeckIntent;
 import static com.ichi2.async.CollectionTask.TASK_TYPE.*;
 import static com.ichi2.async.Connection.ConflictResolution.FULL_DOWNLOAD;
 
@@ -2549,6 +2555,21 @@ public class DeckPicker extends NavigationDrawerActivity implements
         showDialogFragment(ExportDialog.newInstance(msg, did));
     }
 
+    @RequiresApi(Build.VERSION_CODES.O)
+    public void createIcon(Context context) {
+        // This code should not be reachable with lower versions
+        ShortcutManager shortcutManager = context.getSystemService(ShortcutManager.class);
+        ShortcutInfo info = new ShortcutInfo.Builder(context, Long.toString(mContextMenuDid))
+                .setIntent(new Intent(context, Reviewer.class)
+                        .setAction(Intent.ACTION_VIEW)
+                        .putExtra("deckId", mContextMenuDid)
+                )
+                .setShortLabel(Decks.basename(getCol().getDecks().name(mContextMenuDid)))
+                .setLongLabel(getCol().getDecks().name(mContextMenuDid))
+                .setIcon(Icon.createWithResource(context, R.mipmap.ic_launcher))
+                .build();
+        shortcutManager.requestPinShortcut(info, null);
+    }
 
     // Callback to show dialog to rename the current deck
     public void renameDeckDialog() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.java
@@ -29,11 +29,15 @@ import com.ichi2.anki.StudyOptionsFragment;
 import com.ichi2.anki.analytics.AnalyticsDialogFragment;
 import com.ichi2.libanki.Collection;
 
+import java.lang.annotation.Retention;
 import java.util.ArrayList;
 import java.util.HashMap;
 
+import androidx.annotation.IntDef;
 import androidx.annotation.NonNull;
 import timber.log.Timber;
+
+import static java.lang.annotation.RetentionPolicy.SOURCE;
 
 public class DeckPickerContextMenu extends AnalyticsDialogFragment {
     /**
@@ -49,7 +53,19 @@ public class DeckPickerContextMenu extends AnalyticsDialogFragment {
     private static final int CONTEXT_MENU_CUSTOM_STUDY_EMPTY = 7;
     private static final int CONTEXT_MENU_CREATE_SUBDECK = 8;
     private static final int CONTEXT_MENU_CREATE_SHORTCUT = 9;
-
+    @Retention(SOURCE)
+    @IntDef( {CONTEXT_MENU_RENAME_DECK,
+            CONTEXT_MENU_DECK_OPTIONS,
+            CONTEXT_MENU_CUSTOM_STUDY,
+            CONTEXT_MENU_DELETE_DECK,
+            CONTEXT_MENU_EXPORT_DECK,
+            CONTEXT_MENU_UNBURY,
+            CONTEXT_MENU_CUSTOM_STUDY_REBUILD,
+            CONTEXT_MENU_CUSTOM_STUDY_EMPTY,
+            CONTEXT_MENU_CREATE_SUBDECK,
+            CONTEXT_MENU_CREATE_SHORTCUT,
+    })
+    public @interface DECK_PICKER_CONTEXT_MENU {};
 
     public static DeckPickerContextMenu newInstance(long did) {
         DeckPickerContextMenu f = new DeckPickerContextMenu();
@@ -98,7 +114,8 @@ public class DeckPickerContextMenu extends AnalyticsDialogFragment {
      * Retrieve the list of ids to put in the context menu list
      * @return the ids of which values to show
      */
-    private int[] getListIds() {
+    private @DECK_PICKER_CONTEXT_MENU
+    int[] getListIds() {
         Collection col = CollectionHelper.getInstance().getCol(getContext());
         long did = getArguments().getLong("did");
         ArrayList<Integer> itemIds = new ArrayList<>();
@@ -126,7 +143,8 @@ public class DeckPickerContextMenu extends AnalyticsDialogFragment {
 
     // Handle item selection on context menu which is shown when the user long-clicks on a deck
     private final MaterialDialog.ListCallback mContextMenuListener = (materialDialog, view, item, charSequence) -> {
-        switch (view.getId()) {
+        @DECK_PICKER_CONTEXT_MENU int id = view.getId();
+        switch (id) {
             case CONTEXT_MENU_DELETE_DECK:
                 Timber.i("Delete deck selected");
                 ((DeckPicker) getActivity()).confirmDeckDeletion();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.java
@@ -17,8 +17,8 @@ package com.ichi2.anki.dialogs;
 
 import android.app.Dialog;
 import android.content.res.Resources;
+import android.os.Build;
 import android.os.Bundle;
-import android.view.View;
 
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.ichi2.anki.AnkiActivity;
@@ -48,6 +48,7 @@ public class DeckPickerContextMenu extends AnalyticsDialogFragment {
     private static final int CONTEXT_MENU_CUSTOM_STUDY_REBUILD = 6;
     private static final int CONTEXT_MENU_CUSTOM_STUDY_EMPTY = 7;
     private static final int CONTEXT_MENU_CREATE_SUBDECK = 8;
+    private static final int CONTEXT_MENU_CREATE_SHORTCUT = 9;
 
 
     public static DeckPickerContextMenu newInstance(long did) {
@@ -89,6 +90,7 @@ public class DeckPickerContextMenu extends AnalyticsDialogFragment {
         keyValueMap.put(CONTEXT_MENU_CUSTOM_STUDY_REBUILD, res.getString(R.string.rebuild_cram_label));
         keyValueMap.put(CONTEXT_MENU_CUSTOM_STUDY_EMPTY, res.getString(R.string.empty_cram_label));
         keyValueMap.put(CONTEXT_MENU_CREATE_SUBDECK, res.getString(R.string.create_subdeck));
+        keyValueMap.put(CONTEXT_MENU_CREATE_SHORTCUT, res.getString(R.string.create_shortcut));
         return keyValueMap;
     }
 
@@ -115,6 +117,10 @@ public class DeckPickerContextMenu extends AnalyticsDialogFragment {
         if (col.getSched().haveBuried(did)) {
             itemIds.add(CONTEXT_MENU_UNBURY);
         }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            itemIds.add(CONTEXT_MENU_CREATE_SHORTCUT);
+        }
+
         return ContextMenuHelper.integerListToArray(itemIds);
     }
 
@@ -139,6 +145,16 @@ public class DeckPickerContextMenu extends AnalyticsDialogFragment {
                 ((AnkiActivity) getActivity()).showDialogFragment(d);
                 break;
             }
+            case CONTEXT_MENU_CREATE_SHORTCUT:
+                // This condition is theoretically useless. CONTEXT_MENU_CREATE_SHORTCUT can't be selected
+                // before version O. But there is no way to tell it to the compiler, so this condition should be added
+                // To avoid warning
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    Timber.i("Create icon for a deck");
+                    ((DeckPicker) getActivity()).createIcon(getContext());
+                }
+                break;
+
             case CONTEXT_MENU_RENAME_DECK:
                 Timber.i("Rename deck selected");
                 ((DeckPicker) getActivity()).renameDeckDialog();

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -89,6 +89,7 @@
     <string name="move_all_to_deck">Move all to deck</string>
     <string name="unbury">Unbury</string>
     <string name="rename_deck">Rename deck</string>
+    <string name="create_shortcut">Create shortcut</string>
     <string name="menu_add">Add</string>
     <string name="menu_add_note">Add note</string>
     <string name="menu_my_account" comment="Label of the window in which the user should enter their account. This text can't be found in AnkiDroid directly.">Sync account</string>


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
I like the idea to get a link opening directly the reviewer, as suggested in #6995. So you can long click on a deck, and add a shortcut opening the reviewer directly to here.

## Fixes

Fixes #6995

## Approach
Uses https://developer.android.com/guide/topics/ui/shortcuts/creating-shortcuts#java

## How Has This Been Tested?

Open deck picker, long click on a deck, click on "Create shortcut", add it on android, open another deck, close ankidroid, click on the new icon, see that the correct deck is directly opened.

![Screenshot_20201031-042419_AnkiDroid.jpg](https://user-images.githubusercontent.com/357361/97770205-901b7c80-1b31-11eb-8f17-6b461e83f9c5.jpg)

![Screenshot_20201031-044151_One UI Home.jpg](https://user-images.githubusercontent.com/357361/97770426-75e29e00-1b33-11eb-9a2a-8fdd2f338a43.jpg)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] Strings resources: All strings added as resources are unique or contain a comment for seemingly duplicate strings to explain the difference between both resources
