### PR TITLE
NF: always int

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1611,7 +1611,7 @@ public class NoteEditor extends AnkiActivity {
             popup.getMenu().add(Menu.NONE, items.length, Menu.NONE, R.string.nothing);
             popup.setOnMenuItemClickListener(item -> {
                 // Get menu item id
-                Integer idx = item.getItemId();
+                int idx = item.getItemId();
                 Timber.i("NoteEditor:: User chose to remap to old field %d", idx);
                 // Retrieve any existing mappings between newFieldIndex and idx
                 Integer previousMapping = MapUtil.getKeyByValue(mModelChangeFieldMap, newFieldIndex);


### PR DESCRIPTION
getItemId return `int`, so no need to encapsulate