### PR TITLE
Import simplified

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.java
@@ -706,6 +706,14 @@ public class Utils {
 
     }
 
+
+    /**
+     * @param zipFile A zip file
+     * @param targetDirectory Directory in which to unzip some of the zipped field
+     * @param zipEntries files of the zip folder to unzip
+     * @param zipEntryToFilenameMap Renaming rules from name in zip file to name in the device
+     * @throws IOException if the directory can't be created
+     */
     public static void unzipFiles(ZipFile zipFile, String targetDirectory, @NonNull String[] zipEntries,
                                   @Nullable Map<String, String> zipEntryToFilenameMap) throws IOException {
         File dir = new File(targetDirectory);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
@@ -279,7 +279,7 @@ public class Anki2Importer extends Importer {
                         // will update if incoming note more recent
                         if (oldMod < mod) {
                             // safe if note types identical
-                            if (Utils.equals(oldMid, mid)) {
+                            if (oldMid == mid) {
                                 // incoming note should use existing id
                                 nid = oldNid;
                                 flds = _mungeMedia(mid, flds);
@@ -370,9 +370,9 @@ public class Anki2Importer extends Importer {
     // determine if note is a duplicate, and adjust mid and/or guid as required
     // returns true if note should be added and its mid
     private Pair<Boolean, Long> _uniquifyNote(@NonNull String origGuid, long srcMid) {
-        @NonNull Long dstMid = _mid(srcMid);
+        long dstMid = _mid(srcMid);
         // duplicate Schemas?
-        if (Utils.equals(srcMid, dstMid)) {
+        if (srcMid == dstMid) {
             return new Pair<>(!mNotes.containsKey(origGuid), srcMid);
         }
         // differing schemas and note doesn't exist?
@@ -400,12 +400,12 @@ public class Anki2Importer extends Importer {
 
 
     /** Return local id for remote MID. */
-    @NonNull private Long _mid(Long srcMid) {
+    private long _mid(long srcMid) {
         // already processed this mid?
         if (mModelMap.containsKey(srcMid)) {
             return mModelMap.get(srcMid);
         }
-        @NonNull Long mid = srcMid;
+        long mid = srcMid;
         Model srcModel = mSrc.getModels().get(srcMid);
         String srcScm = mSrc.getModels().scmhash(srcModel);
         while (true) {
@@ -413,7 +413,7 @@ public class Anki2Importer extends Importer {
             if (!mDst.getModels().have(mid)) {
                 // copy it over
                 Model model = srcModel.deepClone();
-                model.put("id", (long) mid);
+                model.put("id", mid);
                 model.put("mod", mCol.getTime().intTime());
                 model.put("usn", mCol.usn());
                 mDst.getModels().update(model);
@@ -425,7 +425,7 @@ public class Anki2Importer extends Importer {
             if (srcScm.equals(dstScm)) {
                 // they do; we can reuse this mid
                 Model model = srcModel.deepClone();
-                model.put("id", (long) mid);
+                model.put("id", mid);
                 model.put("mod", mCol.getTime().intTime());
                 model.put("usn", mCol.usn());
                 mDst.getModels().update(model);
@@ -527,7 +527,7 @@ public class Anki2Importer extends Importer {
                 if (mCards.containsKey(guid)) {
                     mCards.get(guid).put(ord, cid);
                 } else {
-                    Map<Integer, Long> map = new HashMap<>();
+                    Map<Integer, Long> map = new HashMap<>(); // The size is at most the number of card type in the note type.
                     map.put(ord, cid);
                     mCards.put(guid, map);
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/Anki2Importer.java
@@ -69,10 +69,6 @@ import static com.ichi2.libanki.Consts.QUEUE_TYPE_REV;
         "PMD.SwitchStmtsShouldHaveDefault","PMD.CollapsibleIfStatements","PMD.EmptyIfStmt"})
 public class Anki2Importer extends Importer {
 
-    private static final int GUID = 1;
-    private static final int MID = 2;
-    private static final int MOD = 3;
-
     private static final int MEDIAPICKLIMIT = 1024;
 
     private final String mDeckPrefix;
@@ -234,50 +230,59 @@ public class Anki2Importer extends Importer {
 
             while (cur.moveToNext()) {
                 // turn the db result into a mutable list
-                Object[] note = new Object[]{cur.getLong(0), cur.getString(1), cur.getLong(2),
-                        cur.getLong(3), cur.getInt(4), cur.getString(5), cur.getString(6),
-                        cur.getString(7), cur.getLong(8), cur.getInt(9), cur.getString(10)};
-                Pair<Boolean, Long> shouldAddAndNewMid = _uniquifyNote((String)note[GUID], (long)note[MID]);
+                long nid = cur.getLong(0);
+                String guid = cur.getString(1);
+                long mid = cur.getLong(2);
+                long mod = cur.getLong(3);
+                int oldUsn = cur.getInt(4);
+                String tags = cur.getString(5);
+                String flds = cur.getString(6);
+                String sfld = cur.getString(7);
+                long csum = cur.getLong(8);
+                int flag = cur.getInt(9);
+                String data = cur.getString(10);
+
+                Pair<Boolean, Long> shouldAddAndNewMid = _uniquifyNote(guid, mid);
                 boolean shouldAdd = shouldAddAndNewMid.first;
-                note[MID] = shouldAddAndNewMid.second;
+                mid = shouldAddAndNewMid.second;
                 if (shouldAdd) {
-                    // ensure id is unique
-                    while (existing.contains(note[0])) {
-                        note[0] = ((Long) note[0]) + 999;
+                    // ensure nid is unique
+                    while (existing.contains(nid)) {
+                        nid += 999;
                     }
-                    existing.add((Long) note[0]);
+                    existing.add(nid);
                     // bump usn
-                    note[4] = usn;
+                    oldUsn = usn;
                     // update media references in case of dupes
-                    note[6] = _mungeMedia((Long) note[MID], (String) note[6]);
-                    add.add(note);
-                    dirty.add((Long) note[0]);
+                    flds = _mungeMedia(mid, flds);
+                    add.add(new Object[]{nid, guid, mid, mod, oldUsn, tags, flds, sfld, csum, flag, data});
+                    dirty.add(nid);
                     // note we have the added guid
-                    mNotes.put((String) note[GUID], new Object[]{note[0], note[3], note[MID]});
+                    mNotes.put(guid, new Object[]{nid, mod, mid});
                 } else {
                     // a duplicate or changed schema - safe to update?
                     dupes += 1;
                     if (mAllowUpdate) {
-                        Object[] n = mNotes.get(note[GUID]);
+                        Object[] n = mNotes.get(guid);
                         //todo: oldNid could be Long instead of long.
                         long oldNid = (Long) n[0];
                         long oldMod = (Long) n[1];
                         @NonNull Long oldMid = (Long) n[2];
                         // will update if incoming note more recent
-                        if (oldMod < (Long) note[MOD]) {
+                        if (oldMod < mod) {
                             // safe if note types identical
-                            if (Utils.equals(oldMid, note[MID])) {
-                                // incoming note should use existing id
-                                note[0] = oldNid;
-                                note[4] = usn;
-                                note[6] = _mungeMedia((Long) note[MID], (String) note[6]);
-                                update.add(note);
-                                dirty.add((Long) note[0]);
+                            if (Utils.equals(oldMid, mid)) {
+                                // incoming note should use existing nid
+                                nid = oldNid;
+                                oldUsn = usn;
+                                flds = _mungeMedia(mid, flds);
+                                update.add(new Object[]{nid, guid, mid, mod, oldUsn, tags, flds, sfld, csum, flag, data});
+                                dirty.add(nid);
                             } else {
                                 dupesIgnored.add(String.format("%s: %s",
                                         mCol.getModels().get(oldMid).getString("name"),
-                                        ((String) note[6]).replace('\u001f', ',')));
-                                mIgnoredGuids.put((String) note[GUID], true);
+                                        flds.replace('\u001f', ',')));
+                                mIgnoredGuids.put(guid, true);
                             }
                         }
                     }
@@ -542,12 +547,28 @@ public class Anki2Importer extends Importer {
             int i = 0;
 
             while (cur.moveToNext()) {
-                Object[] card = new Object[] { cur.getString(0), cur.getLong(1), cur.getLong(2),
-                        cur.getLong(3), cur.getLong(4), cur.getInt(5), cur.getLong(6), cur.getInt(7),
-                        cur.getInt(8), cur.getInt(9), cur.getLong(10), cur.getLong(11), cur.getLong(12),
-                        cur.getInt(13), cur.getInt(14), cur.getInt(15), cur.getLong(16),
-                        cur.getLong(17), cur.getInt(18), cur.getString(19) };
-                String guid = (String) card[0];
+                String guid = cur.getString(0);
+                long mid = cur.getLong(1);
+                long cid = cur.getLong(2);
+                long scid = cid;
+                long nid = cur.getLong(3);
+                long did = cur.getLong(4);
+                int ord = cur.getInt(5);
+                long mod = cur.getLong(6);
+                int oldUsn = cur.getInt(7);
+                @Consts.CARD_TYPE int type = cur.getInt(8);
+                @Consts.CARD_QUEUE int queue = cur.getInt(9);
+                long due = cur.getLong(10);
+                long ivl = cur.getLong(11);
+                long factor = cur.getLong(12);
+                int reps = cur.getInt(13);
+                int lapses = cur.getInt(14);
+                int left = cur.getInt(15);
+                long odue = cur.getLong(16);
+                long odid = cur.getLong(17);
+                int flags = cur.getInt(18);
+                String data = cur.getString(19);
+
                 if (mIgnoredGuids.containsKey(guid)) {
                     continue;
                 }
@@ -557,59 +578,53 @@ public class Anki2Importer extends Importer {
                 }
                 Object[] dnid = mNotes.get(guid);
                 // does the card already exist in the dst col?
-                int ord = (Integer) card[5];
                 if (mCards.containsKey(guid) && mCards.get(guid).containsKey(ord)) {
                     // fixme: in future, could update if newer mod time
                     continue;
                 }
-                // doesn't exist. strip off note info, and save src id for later
-                Object[] oc = card;
-                card = new Object[oc.length - 2];
-                System.arraycopy(oc, 2, card, 0, card.length);
-                long scid = (Long) card[0];
                 // ensure the card id is unique
-                while (existing.containsKey(card[0])) {
-                    card[0] = (Long) card[0] + 999;
+                while (existing.containsKey(cid)) {
+                    cid += 999;
                 }
-                existing.put((Long) card[0], true);
+                existing.put(cid, true);
                 // update cid, nid, etc
-                card[1] = mNotes.get(guid)[0];
-                card[2] = _did((Long) card[2]);
-                card[4] = mCol.getTime().intTime();
-                card[5] = usn;
+                nid = (long) mNotes.get(guid)[0];
+                did = _did(did);
+                mod = mCol.getTime().intTime();
+                oldUsn = usn;
                 // review cards have a due date relative to collection
-                if ((Integer) card[7] == QUEUE_TYPE_REV || (Integer) card[7] == QUEUE_TYPE_DAY_LEARN_RELEARN || (Integer) card[6] == CARD_TYPE_REV) {
-                    card[8] = (Long) card[8] - aheadBy;
+                if (queue == QUEUE_TYPE_REV || queue == QUEUE_TYPE_DAY_LEARN_RELEARN || type == CARD_TYPE_REV) {
+                    due -= aheadBy;
                 }
                 // odue needs updating too
-                if ((Long) card[14] != 0) {
-                    card[14] = (Long) card[14] - aheadBy;
+                if (odue != 0) {
+                    odue -= aheadBy;
                 }
                 // if odid true, convert card from filtered to normal
-                if ((Long) card[15] != 0) {
+                if (odid != 0) {
                     // odid
-                    card[15] = 0;
+                    odid = 0;
                     // odue
-                    card[8] = card[14];
-                    card[14] = 0;
+                    due = odue;
+                    odue = 0;
                     // queue
-                    if ((Integer) card[6] == CARD_TYPE_LRN) {
-                        card[7] = QUEUE_TYPE_NEW;
+                    if (type == CARD_TYPE_LRN) { // type
+                        queue = QUEUE_TYPE_NEW;
                     } else {
-                        card[7] = card[6];
+                        queue = type;
                     }
                     // type
-                    if ((Integer) card[6] == CARD_TYPE_LRN) {
-                        card[6] = CARD_TYPE_NEW;
+                    if (type == CARD_TYPE_LRN) {
+                        type = CARD_TYPE_NEW;
                     }
                 }
-                cards.add(card);
+                cards.add(new Object[]{cid, nid, did, ord, mod, usn, type, queue, due, ivl, factor, reps, lapses, left, odue, odid, flags, data});
                 // we need to import revlog, rewriting card ids and bumping usn
                 try (Cursor cur2 = mSrc.getDb().query("select * from revlog where cid = " + scid)) {
                     while (cur2.moveToNext()) {
                         Object[] rev = new Object[] { cur2.getLong(0), cur2.getLong(1), cur2.getInt(2), cur2.getInt(3),
                                 cur2.getLong(4), cur2.getLong(5), cur2.getLong(6), cur2.getLong(7), cur2.getInt(8) };
-                        rev[1] = card[0];
+                        rev[1] = cid;
                         rev[2] = mDst.usn();
                         revlog.add(rev);
                     }


### PR DESCRIPTION
Importing my main deck takes 6'24''. This PR' reduces it to 6'01''. Not exactly game changing, but still some noticeable progress.
It saves time by:
* Avoiding to query from the database some values that are never used
* Avoiding to convert multiple time between int/long and Int/Long (One last conversion is needed, because sql always takes Object[] which is actually a huge loss of time)

As a benefits, it becomes more clear, since instead of an array of Object, each variable has a readable name. 

It was tested by importing back my deck in a fresk ankidroid collection and seeing that everythnig seems to be alright