### PR TITLE
Check Media: Recreate database on schema error

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -1640,6 +1640,12 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
     private TaskData doInBackgroundCheckMedia() {
         Timber.d("doInBackgroundCheckMedia");
         Collection col = getCol();
+        // Ensure that the DB is valid - unknown why, but some users were missing the meta table.
+        try {
+            col.getMedia().rebuildIfInvalid();
+        } catch (IOException e) {
+            return new TaskData(false);
+        }
         // A media check on AnkiDroid will also update the media db
         col.getMedia().findChanges(true);
         // Then do the actual check

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Media.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Media.java
@@ -24,9 +24,11 @@ import android.text.TextUtils;
 
 import android.util.Pair;
 
+import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.libanki.template.Template;
 import com.ichi2.utils.Assert;
 
+import com.ichi2.utils.ExceptionUtil;
 import com.ichi2.utils.JSONArray;
 import com.ichi2.utils.JSONObject;
 
@@ -1018,4 +1020,35 @@ public class Media {
         long mod = mDb.queryLongScalar("select dirMod from meta");
         return mod == 0;
     }
+
+
+    public void rebuildIfInvalid() throws IOException {
+        try {
+            _changed();
+            return;
+        } catch (Exception e) {
+            if (!ExceptionUtil.containsMessage(e, "no such table: meta")) {
+                throw e;
+            }
+            AnkiDroidApp.sendExceptionReport(e, "media::rebuildIfInvalid");
+
+            // TODO: We don't know the root cause of the missing meta table
+            Timber.w(e, "Error accessing media database. Rebuilding");
+            // continue below
+        }
+
+
+        // Delete and recreate the file
+        mDb.getDatabase().close();
+
+        String path = mDb.getPath();
+        Timber.i("Deleted %s", path);
+
+        new File(path).delete();
+
+        mDb = new DB(path);
+        _initDB();
+    }
+
+
 }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ExceptionUtil.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ExceptionUtil.java
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.utils;
+
+public class ExceptionUtil {
+    public static boolean containsMessage(Throwable e, String needle) {
+        if (e == null) {
+            return false;
+        }
+
+        if (containsMessage(e.getCause(), needle)) {
+            return true;
+        }
+
+        String message = e.getMessage();
+        return message != null && message.contains(needle);
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/CheckMediaTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/CheckMediaTest.java
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.libanki;
+
+import com.ichi2.anki.RobolectricTest;
+import com.ichi2.async.CollectionTask;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.ExecutionException;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@RunWith(AndroidJUnit4.class)
+public class CheckMediaTest extends RobolectricTest {
+
+    @Override
+    protected boolean useInMemoryDatabase() {
+        return false;
+    }
+
+
+    @Test
+    public void checkMediaWorksAfterMissingMetaTable() throws ExecutionException, InterruptedException {
+        // 7421
+        getCol().getMedia().getDb().getDatabase().execSQL("drop table meta");
+
+        assertThat(getCol().getMedia().getDb().queryScalar("SELECT count(*) FROM sqlite_master WHERE type='table' AND name='meta';"), is(0));
+
+        CollectionTask task = CollectionTask.launchCollectionTask(CollectionTask.TASK_TYPE.CHECK_MEDIA);
+
+        task.get();
+
+        assertThat(getCol().getMedia().getDb().queryScalar("SELECT count(*) FROM sqlite_master WHERE type='table' AND name='meta';"), is(1));
+    }
+}


### PR DESCRIPTION
## Purpose / Description
For some reason, some users were missing the meta table.

This meant that both syncing and Check Media failed.

Now, only syncing fails, and the error is recoverable.

## Fixes
Fixes #7421

## Approach
If the meta table does not exist, delete the media database and recreate it

## How Has This Been Tested?

Unit tested

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] Strings resources: All strings added as resources are unique or contain a comment for seemingly duplicate strings to explain the difference between both resources