### PR TITLE
Don't add timestamp to image name

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
@@ -176,7 +176,7 @@ public class MultimediaEditFieldActivity extends AnkiActivity
             return;
         }
 
-        IControllerFactory controllerFactory = BasicControllerFactory.getInstance(getCol().getTime());
+        IControllerFactory controllerFactory = BasicControllerFactory.getInstance();
 
         IFieldController fieldController = controllerFactory.createControllerForField(newUI.getField());
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicControllerFactory.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicControllerFactory.java
@@ -19,18 +19,14 @@
 
 package com.ichi2.anki.multimediacard.fields;
 
-import com.ichi2.libanki.utils.Time;
-
 public class BasicControllerFactory implements IControllerFactory {
 
-    private final Time mTime;
-    private BasicControllerFactory(Time time) {
-        mTime = time;
+    private BasicControllerFactory() {
     }
 
 
-    public static IControllerFactory getInstance(Time time) {
-        return new BasicControllerFactory(time);
+    public static IControllerFactory getInstance() {
+        return new BasicControllerFactory();
     }
 
 
@@ -43,7 +39,7 @@ public class BasicControllerFactory implements IControllerFactory {
                 return new BasicTextFieldController();
 
             case IMAGE:
-                return new BasicImageFieldController(mTime);
+                return new BasicImageFieldController();
 
             case AUDIO_RECORDING:
                 return new BasicAudioRecordingFieldController();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.java
@@ -97,14 +97,8 @@ public class BasicImageFieldController extends FieldControllerBase implements IF
     private @Nullable String mAnkiCacheDirectory; // system provided 'External Cache Dir' with "temp-photos" on it
                                                   // e.g.  '/self/primary/Android/data/com.ichi2.anki.AnkiDroid/cache/temp-photos'
     private DisplayMetrics mMetrics = null;
-    private final Time mTime;
 
     private Button mCropButton = null;
-
-    public BasicImageFieldController(Time time) {
-        super();
-        mTime = time;
-    }
 
     private int getMaxImageSize() {
         DisplayMetrics metrics = getDisplayMetrics();
@@ -280,9 +274,8 @@ public class BasicImageFieldController extends FieldControllerBase implements IF
     }
 
     private File createNewCacheImageFile(@NonNull String extension) throws IOException {
-        String timeStamp = TimeUtils.getTimestamp(mTime);
         File storageDir = new File(mAnkiCacheDirectory);
-        return File.createTempFile("img_" + timeStamp, "." + extension, storageDir);
+        return File.createTempFile("img", "." + extension, storageDir);
     }
 
 


### PR DESCRIPTION
`File.createTempFile` already adds a unique suffix.

## Fixes
Fixes #7102

## Approach
Remove the timestamp and just use the API

## How Has This Been Tested?
None/Unit tests still pass

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] Strings resources: All strings added as resources are unique or contain a comment for seemingly duplicate strings to explain the difference between both resources
