### PR TITLE
Remove useless conversions

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -83,6 +83,7 @@ import com.ichi2.utils.Permissions;
 import com.ichi2.widget.WidgetStatus;
 
 import java.lang.ref.WeakReference;
+import java.util.Collections;
 
 import timber.log.Timber;
 
@@ -514,7 +515,7 @@ public class Reviewer extends AbstractFlashcardViewer {
     private void showRescheduleCardDialog() {
         Consumer<Integer> runnable = days ->
             CollectionTask.launchCollectionTask(DISMISS_MULTI, mRescheduleCardHandler,
-                    new TaskData(new Object[]{new long[]{mCurrentCard.getId()},
+                    new TaskData(new Object[]{Collections.singleton(mCurrentCard.getId()),
                     Collection.DismissType.RESCHEDULE_CARDS, days})
             );
         RescheduleDialog dialog = RescheduleDialog.rescheduleSingleCard(getResources(), mCurrentCard, runnable);
@@ -534,7 +535,7 @@ public class Reviewer extends AbstractFlashcardViewer {
         Runnable confirm = () -> {
             Timber.i("NoteEditor:: ResetProgress button pressed");
             CollectionTask.launchCollectionTask(DISMISS_MULTI, mResetProgressCardHandler,
-                    new TaskData(new Object[]{new long[]{mCurrentCard.getId()}, Collection.DismissType.RESET_CARDS}));
+                    new TaskData(new Object[]{Collections.singleton(mCurrentCard.getId()), Collection.DismissType.RESET_CARDS}));
         };
         dialog.setConfirm(confirm);
         showDialogFragment(dialog);

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -944,11 +944,11 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
         Collection col = getCol();
         AbstractSched sched = col.getSched();
         Object[] data = param.getObjArray();
-        long[] cardIds = Utils.toPrimitive((List<Long>) data[0]);
+        List<Long> cardIds = (List<Long>) data[0];
         // query cards
-        Card[] cards = new Card[cardIds.length];
-        for (int i = 0; i < cardIds.length; i++) {
-            cards[i] = col.getCard(cardIds[i]);
+        Card[] cards = new Card[cardIds.size()];
+        for (int i = 0; i < cardIds.size(); i++) {
+            cards[i] = col.getCard(cardIds.get(i));
         }
 
         Collection.DismissType type = (Collection.DismissType) data[1];

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -944,7 +944,7 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
         Collection col = getCol();
         AbstractSched sched = col.getSched();
         Object[] data = param.getObjArray();
-        long[] cardIds = (long[]) data[0];
+        long[] cardIds = Utils.toPrimitive((List<Long>) data[0]);
         // query cards
         Card[] cards = new Card[cardIds.length];
         for (int i = 0; i < cardIds.length; i++) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -2029,7 +2029,7 @@ public class Collection {
     /**
      * Card Flags *****************************************************************************************************
      */
-    public void setUserFlag(int flag, long[] cids)  {
+    public void setUserFlag(int flag, List<Long> cids)  {
         assert (0<= flag && flag <= 7);
         mDb.execute("update cards set flags = (flags & ~?) | ?, usn=?, mod=? where id in " + Utils.ids2str(cids),
                     0b111, flag, usn(), getTime().intTime());

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
@@ -221,6 +221,7 @@ public abstract class AbstractSched {
      *i @param cids Cards to remove from their dynamic deck (it is assumed they are in one)
      */
     // In this abstract class for testing purpose only
+    public abstract void remFromDyn(List<Long> cids);
     public abstract void remFromDyn(long[] cids);
 
     /**
@@ -308,7 +309,7 @@ public abstract class AbstractSched {
 
     /**
      * @param ids Ids of cards to put at the end of the new queue. */
-    public abstract void forgetCards(@NonNull long[] ids);
+    public abstract void forgetCards(@NonNull List<Long> ids);
 
     /**
      * Put cards in review queue with a new interval in days (min, max).
@@ -317,7 +318,7 @@ public abstract class AbstractSched {
      * @param imin the minimum interval (inclusive)
      * @param imax The maximum interval (inclusive)
      */
-    public abstract void reschedCards(@NonNull long[] ids, int imin, int imax);
+    public abstract void reschedCards(@NonNull List<Long> ids, int imin, int imax);
 
     /**
      * @param ids Ids of cards to reset for export
@@ -331,7 +332,7 @@ public abstract class AbstractSched {
      * @param shuffle Whether the list should be shuffled.
      * @param shift Whether the cards already new should be shifted to make room for cards of cids
      */
-    public abstract void sortCards(@NonNull long[] cids, int start, int step, boolean shuffle, boolean shift);
+    public abstract void sortCards(@NonNull List<Long> cids, int start, int step, boolean shuffle, boolean shift);
 
     /**
      * Randomize the cards of did

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -580,7 +580,7 @@ public class Sched extends SchedV2 {
                 ", usn = ?, odue = 0 where queue IN (" + Consts.QUEUE_TYPE_LRN + "," + Consts.QUEUE_TYPE_DAY_LEARN_RELEARN + ") and type = " + Consts.CARD_TYPE_REV + " " + extra,
                 getTime().intTime(), mCol.usn());
         // new cards in learning
-        forgetCards(Utils.collection2Array(mCol.getDb().queryLongList( "SELECT id FROM cards WHERE queue IN (" + Consts.QUEUE_TYPE_LRN + "," + Consts.QUEUE_TYPE_DAY_LEARN_RELEARN + ") " + extra)));
+        forgetCards(mCol.getDb().queryLongList( "SELECT id FROM cards WHERE queue IN (" + Consts.QUEUE_TYPE_LRN + "," + Consts.QUEUE_TYPE_DAY_LEARN_RELEARN + ") " + extra));
     }
 
     private int _lrnForDeck(long did) {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
@@ -419,7 +419,7 @@ public class CardBrowserTest extends RobolectricTest {
 
         assertThat("Initial position of checked card", card.getColumnHeaderText(CardBrowser.Column.DUE), is("1"));
 
-        b.repositionCardsNoValidation(new long[] { card.getId() }, 2);
+        b.repositionCardsNoValidation(Collections.singletonList(card.getId()), 2);
 
         advanceRobolectricLooperWithSleep();
 
@@ -443,7 +443,7 @@ public class CardBrowserTest extends RobolectricTest {
 
         assertThat("Initial due of checked card", card.getColumnHeaderText(CardBrowser.Column.DUE), is("8/12/20"));
 
-        b.resetProgressNoConfirm(new long[] { card.getId() });
+        b.resetProgressNoConfirm(Collections.singletonList(card.getId()));
 
         advanceRobolectricLooperWithSleep();
 
@@ -461,7 +461,7 @@ public class CardBrowserTest extends RobolectricTest {
 
         assertThat("Initial position of checked card", card.getColumnHeaderText(CardBrowser.Column.DUE), is("1"));
 
-        b.rescheduleWithoutValidation(new long[] { card.getId() }, 5);
+        b.rescheduleWithoutValidation(Collections.singletonList(card.getId()), 5);
 
         advanceRobolectricLooperWithSleep();
 
@@ -479,7 +479,7 @@ public class CardBrowserTest extends RobolectricTest {
 
         assertThat("Initial position of checked card", card.getColumnHeaderText(CardBrowser.Column.DUE), is("1"));
 
-        b.repositionCardsNoValidation(new long[] { card.getId() }, 2);
+        b.repositionCardsNoValidation(Collections.singletonList(card.getId()), 2);
 
         advanceRobolectricLooperWithSleep();
 
@@ -502,7 +502,7 @@ public class CardBrowserTest extends RobolectricTest {
 
         b.checkCardsAtPositions(0);
 
-        b.rescheduleWithoutValidation(new long[] { getCheckedCard(b).getId() }, 2);
+        b.rescheduleWithoutValidation(Collections.singletonList(getCheckedCard(b).getId()), 2);
 
         advanceRobolectricLooperWithSleep();
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
@@ -250,7 +250,7 @@ public class CardBrowserTest extends RobolectricTest {
 
         List<Long> cardIds = b.getCheckedCardIds();
 
-        b.executeChangeCollectionTask(toLongArray(cardIds), dynId);
+        b.executeChangeCollectionTask(cardIds, dynId);
 
         for (Long cardId: cardIds) {
             assertThat("Deck should not be changed", getCol().getCard(cardId).getDid(), not(dynId));

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/FlagTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/FlagTest.java
@@ -5,6 +5,8 @@ import com.ichi2.anki.RobolectricTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.util.Collections;
+
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import static org.junit.Assert.assertEquals;
@@ -33,7 +35,7 @@ public class FlagTest extends RobolectricTest {
         assertEquals(1, col.findCards("flag:0").size());
         assertEquals(0, col.findCards("flag:1").size());
         // set flag 2
-        col.setUserFlag(2, new long[] {c.getId()});
+        col.setUserFlag(2, Collections.singletonList(c.getId()));
         c.load();
         assertEquals(2, c.userFlag());
         // assertEquals(origBits, c.flags & origBits);TODO: create direct access to real flag value
@@ -41,11 +43,11 @@ public class FlagTest extends RobolectricTest {
         assertEquals(1, col.findCards("flag:2").size());
         assertEquals(0, col.findCards("flag:3").size());
         // change to 3
-        col.setUserFlag(3, new long[] {c.getId()});
+        col.setUserFlag(3, Collections.singletonList(c.getId()));
         c.load();
         assertEquals(3, c.userFlag());
         // unset
-        col.setUserFlag(0, new long[] {c.getId()});
+        col.setUserFlag(0, Collections.singletonList(c.getId()));
         c.load();
         assertEquals(0, c.userFlag());
 

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedTest.java
@@ -40,6 +40,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.util.Collections;
 import java.util.List;
 
 import androidx.annotation.NonNull;
@@ -1353,7 +1354,7 @@ public class SchedTest extends RobolectricTest {
         c.flush();
         col.reset();
         assertEquals(new Counts(0, 0, 1), col.getSched().counts());
-        col.getSched().forgetCards(new long[] {c.getId()});
+        col.getSched().forgetCards(Collections.singletonList(c.getId()));
         col.reset();
         assertEquals(new Counts(1, 0, 0), col.getSched().counts());
     }
@@ -1366,13 +1367,13 @@ public class SchedTest extends RobolectricTest {
         note.setItem("Front", "one");
         col.addNote(note);
         Card c = note.cards().get(0);
-        col.getSched().reschedCards(new long[] {c.getId()}, 0, 0);
+        col.getSched().reschedCards(Collections.singletonList(c.getId()), 0, 0);
         c.load();
         assertEquals(col.getSched().getToday(), c.getDue());
         assertEquals(1, c.getIvl());
         assertEquals(CARD_TYPE_REV, c.getType());
         assertEquals(QUEUE_TYPE_REV, c.getQueue());
-        col.getSched().reschedCards(new long[] {c.getId()}, 1, 1);
+        col.getSched().reschedCards(Collections.singletonList(c.getId()), 1, 1);
         c.load();
         assertEquals(col.getSched().getToday() + 1, c.getDue());
         assertEquals(+1, c.getIvl());

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/SchedV2Test.java
@@ -1481,7 +1481,7 @@ public class SchedV2Test extends RobolectricTest {
         c.flush();
         col.reset();
         assertEquals(new Counts(0, 0, 1), col.getSched().counts());
-        col.getSched().forgetCards(new long[] {c.getId()});
+        col.getSched().forgetCards(Collections.singletonList(c.getId()));
         col.reset();
         assertEquals(new Counts(1, 0, 0), col.getSched().counts());
     }
@@ -1494,13 +1494,13 @@ public class SchedV2Test extends RobolectricTest {
         note.setItem("Front", "one");
         col.addNote(note);
         Card c = note.cards().get(0);
-        col.getSched().reschedCards(new long[] {c.getId()}, 0, 0);
+        col.getSched().reschedCards(Collections.singletonList(c.getId()), 0, 0);
         c.load();
         assertEquals(col.getSched().getToday(), c.getDue());
         assertEquals(1, c.getIvl());
         assertEquals(QUEUE_TYPE_REV, c.getType());
         assertEquals(CARD_TYPE_REV, c.getQueue());
-        col.getSched().reschedCards(new long[] {c.getId()}, 1, 1);
+        col.getSched().reschedCards(Collections.singletonList(c.getId()), 1, 1);
         c.load();
         assertEquals(col.getSched().getToday() + 1, c.getDue());
         assertEquals(+1, c.getIvl());
@@ -1605,7 +1605,7 @@ public class SchedV2Test extends RobolectricTest {
         // make sure relearning cards transition correctly to v1
         col.changeSchedulerVer(2);
         // card with 100 day interval, answering again
-        col.getSched().reschedCards(new long[] {c.getId()}, 100, 100);
+        col.getSched().reschedCards(Collections.singletonList(c.getId()), 100, 100);
         c.load();
         c.setDue(0);
         c.flush();


### PR DESCRIPTION
There are multiple conversion between types that are useless. I remove those `collection2Array` and `toPrimitive`. This require to create directly a List of Long. 

This require to add one conversion, but since it's used only in test, it's still save time