### PR TITLE
Queue as array

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -59,16 +59,19 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.lang.reflect.Field;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
+import java.util.Deque;
 import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Queue;
 import java.util.Random;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.Set;
@@ -1314,7 +1317,7 @@ public class Collection {
     @VisibleForTesting
     public @Nullable DismissType undoType() {
         if (mUndo.size() > 0) {
-            return mUndo.getLast().getDismissType();
+            return mUndo.peekLast().getDismissType();
         }
         return null;
     }
@@ -1339,7 +1342,7 @@ public class Collection {
 
     public void markUndo(@NonNull Undoable undo) {
         Timber.d("markUndo() of type %s", undo.getDismissType());
-        mUndo.add(undo);
+        mUndo.addLast(undo);
         while (mUndo.size() > UNDO_SIZE_MAX) {
             mUndo.removeFirst();
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -41,7 +41,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -36,6 +36,7 @@ import com.ichi2.utils.JSONObject;
 import com.ichi2.utils.SyncStatus;
 
 import java.text.Normalizer;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -45,6 +46,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Queue;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.regex.Pattern;
@@ -954,9 +956,9 @@ public class Decks {
     /**
      * The currently active dids. Make sure to copy before modifying.
      */
-    public LinkedList<Long> active() {
+    public Queue<Long> active() {
         JSONArray activeDecks = mCol.getConf().getJSONArray("activeDecks");
-        LinkedList<Long> result = new LinkedList<>();
+        Queue<Long> result = new ArrayDeque<>(activeDecks.length());
         addAll(result, activeDecks.longIterable());
         return result;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
@@ -632,7 +632,7 @@ public class Finder {
 
 
     private String _findModel(String val) {
-        LinkedList<Long> ids = new LinkedList<>();
+        List<Long> ids = new ArrayList<>();
         for (JSONObject m : mCol.getModels().all()) {
             String modelName = m.getString("name");
             modelName = Normalizer.normalize(modelName, Normalizer.Form.NFC);
@@ -773,7 +773,7 @@ public class Finder {
             // nothing has that field
             return null;
         }
-        LinkedList<Long> nids = new LinkedList<>();
+        List<Long> nids = new ArrayList<>();
         try (Cursor cur = mCol.getDb().query(
                 "select id, mid, flds from notes where mid in " +
                         Utils.ids2str(mods.keySet()) +

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
@@ -776,7 +776,7 @@ public class Finder {
         LinkedList<Long> nids = new LinkedList<>();
         try (Cursor cur = mCol.getDb().query(
                 "select id, mid, flds from notes where mid in " +
-                        Utils.ids2str(new LinkedList<>(mods.keySet())) +
+                        Utils.ids2str(mods.keySet()) +
                         " and flds like ? escape '\\'",  "%" + sqlVal + "%")) {
             /*
              * Here we use the sqlVal expression, that is required for LIKE syntax in sqllite.

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Note.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Note.java
@@ -26,7 +26,6 @@ import com.ichi2.utils.JSONObject;
 import java.util.AbstractSet;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/CardQueue.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/CardQueue.java
@@ -3,28 +3,42 @@ package com.ichi2.libanki.sched;
 import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
 
+import java.util.ArrayDeque;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.ListIterator;
 import java.util.NoSuchElementException;
+import java.util.Queue;
 import java.util.Random;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+/**
+ * @param <T>
+ */
 abstract class CardQueue<T extends Card.Cache> {
     // We need to store mSched and not queue, because during initialization of sched, when CardQueues are initialized
     // sched.getCol is null.
-    private final AbstractSched mSched;
-    private final LinkedList<T> mQueue = new LinkedList<>();
+    private final @NonNull AbstractSched mSched;
+    private final @Nullable Queue<T> mQueue;
 
-
+    /** Constructor for an empty queue. Nothing should be added to it.*/
     public CardQueue(AbstractSched sched) {
         mSched = sched;
+        mQueue = new ArrayDeque<>(0);
+    }
+
+    public CardQueue(AbstractSched sched, Queue queue) {
+        mSched = sched;
+        mQueue = queue;
     }
 
 
     public void loadFirstCard() {
         if (!mQueue.isEmpty()) {
             // No nead to reload. If the card was changed, reset would have been called and emptied the queue
-            mQueue.get(0).loadQA(false, false);
+            mQueue.peek().loadQA(false, false);
         }
     }
 
@@ -35,10 +49,6 @@ abstract class CardQueue<T extends Card.Cache> {
     public boolean remove(long cid) {
         // CardCache and LrnCache with the same id will be considered as equal so it's a valid implementation.
         return mQueue.remove(new Card.Cache(getCol(), cid));
-    }
-
-    public void add(T elt) {
-        mQueue.add(elt);
     }
 
     public void clear() {
@@ -54,16 +64,8 @@ abstract class CardQueue<T extends Card.Cache> {
         return mQueue.size();
     }
 
-    protected LinkedList<T> getQueue() {
+    protected java.util.Queue<T> getQueue() {
         return mQueue;
-    }
-
-    public void shuffle(Random r) {
-        Collections.shuffle(mQueue, r);
-    }
-
-    public ListIterator<T> listIterator() {
-        return mQueue.listIterator();
     }
 
     protected Collection getCol() {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/LrnCardQueue.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/LrnCardQueue.java
@@ -1,25 +1,22 @@
 package com.ichi2.libanki.sched;
 
 import java.util.Collections;
+import java.util.PriorityQueue;
 
 class LrnCardQueue extends CardQueue<LrnCard> {
     public LrnCardQueue(AbstractSched sched) {
-        super(sched);
+        super(sched, new PriorityQueue<LrnCard>());
     }
 
     public void add(long due, long cid) {
-        add(new LrnCard(getCol(), due, cid));
+        getQueue().add(new LrnCard(getCol(), due, cid));
     }
 
-    public void add(int pos, LrnCard card) {
-        getQueue().add(pos, card);
-    }
-
-    public void sort() {
-        Collections.sort(getQueue());
+    public void add(LrnCard card) {
+        getQueue().add(card);
     }
 
     public long getFirstDue() {
-        return getQueue().getFirst().getDue();
+        return getQueue().peek().getDue();
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -40,9 +40,9 @@ import com.ichi2.utils.JSONObject;
 import com.ichi2.utils.SyncStatus;
 
 
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Random;
@@ -69,7 +69,7 @@ public class Sched extends SchedV2 {
     private static final int[] FACTOR_ADDITION_VALUES = { -150, 0, 150 };
 
     // Queues
-    private @NonNull LinkedList<Long> mRevDids = new LinkedList<>();
+    private @NonNull java.util.Queue<Long> mRevDids = new ArrayDeque<>();
 
     /**
      * queue types: 0=new/cram, 1=lrn, 2=rev, 3=day lrn, -1=suspended, -2=buried
@@ -193,7 +193,7 @@ public class Sched extends SchedV2 {
         unburyCardsForDeck(mCol.getDecks().active());
     }
 
-    private void unburyCardsForDeck(@NonNull List<Long> allDecks) {
+    private void unburyCardsForDeck(@NonNull java.util.Collection<Long> allDecks) {
         // Refactored to allow unburying an arbitrary deck
         String sids = Utils.ids2str(allDecks);
         mCol.log(mCol.getDb().queryLongList("select id from cards where " + queueIsBuriedSnippet() + " and did in " + sids));
@@ -682,7 +682,7 @@ public class Sched extends SchedV2 {
             return false;
         }
         while (!mRevDids.isEmpty()) {
-            long did = mRevDids.getFirst();
+            long did = mRevDids.peek();
             int lim = Math.min(mQueueLimit, _deckRevLimit(did, false));
             if (lim != 0) {
                 mRevQueue.clear();
@@ -1124,7 +1124,7 @@ public class Sched extends SchedV2 {
         return haveBuried(mCol.getDecks().active());
     }
 
-    private boolean haveBuried(@NonNull List<Long> allDecks) {
+    private boolean haveBuried(@NonNull java.util.Collection<Long> allDecks) {
         // Refactored to allow querying an arbitrary deck
         String sdids = Utils.ids2str(allDecks);
         int cnt = mCol.getDb().queryScalar(

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -52,6 +52,7 @@ import com.ichi2.utils.JSONObject;
 import com.ichi2.utils.SyncStatus;
 
 import java.lang.ref.WeakReference;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
@@ -113,8 +114,8 @@ public class SchedV2 extends AbstractSched {
     protected final @NonNull SimpleCardQueue mLrnDayQueue = new SimpleCardQueue(this);
     protected final @NonNull SimpleCardQueue mRevQueue = new SimpleCardQueue(this);
 
-    private @NonNull LinkedList<Long> mNewDids = new LinkedList<>();
-    protected @NonNull LinkedList<Long> mLrnDids = new LinkedList<>();
+    private @NonNull java.util.Queue<Long> mNewDids = new ArrayDeque<>();
+    protected @NonNull java.util.Queue<Long> mLrnDids = new ArrayDeque<>();
 
     // Not in libanki
     protected @Nullable WeakReference<Activity> mContextReference;
@@ -794,7 +795,7 @@ public class SchedV2 extends AbstractSched {
     }
 
     private void _resetNewQueue() {
-        mNewDids = new LinkedList<>(mCol.getDecks().active());
+        mNewDids = mCol.getDecks().active();
         mNewQueue.clear();
         _updateNewCardRatio();
     }
@@ -842,7 +843,7 @@ public class SchedV2 extends AbstractSched {
             return false;
         }
         while (!mNewDids.isEmpty()) {
-            long did = mNewDids.getFirst();
+            long did = mNewDids.peek();
             int lim = Math.min(mQueueLimit, _deckNewLimit(did, true));
             if (lim != 0) {
                 mNewQueue.clear();
@@ -1133,7 +1134,7 @@ public class SchedV2 extends AbstractSched {
             return true;
         }
         while (!mLrnDids.isEmpty()) {
-            long did = mLrnDids.getFirst();
+            long did = mLrnDids.peek();
             // fill the queue with the current did
             mLrnDayQueue.clear();
                 /* Difference with upstream:
@@ -2317,7 +2318,7 @@ public class SchedV2 extends AbstractSched {
     }
 
 
-    private boolean haveBuriedSiblings(@NonNull List<Long> allDecks) {
+    private boolean haveBuriedSiblings(@NonNull java.util.Collection<Long> allDecks) {
         // Refactored to allow querying an arbitrary deck
         String sdids = Utils.ids2str(allDecks);
         int cnt = mCol.getDb().queryScalar(
@@ -2331,7 +2332,7 @@ public class SchedV2 extends AbstractSched {
     }
 
 
-    private boolean haveManuallyBuried(@NonNull List<Long> allDecks) {
+    private boolean haveManuallyBuried(@NonNull java.util.Collection<Long> allDecks) {
         // Refactored to allow querying an arbitrary deck
         String sdids = Utils.ids2str(allDecks);
         int cnt = mCol.getDb().queryScalar(

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SimpleCardQueue.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SimpleCardQueue.java
@@ -2,15 +2,37 @@ package com.ichi2.libanki.sched;
 
 import com.ichi2.libanki.Card;
 
+import java.util.ArrayDeque;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+
 import androidx.annotation.VisibleForTesting;
 
 @VisibleForTesting
 class SimpleCardQueue extends CardQueue<Card.Cache> {
+
+    /**
+     * @param sched Constructor for empty queue. Nothing should be added to it
+     */
     public SimpleCardQueue(AbstractSched sched) {
         super(sched);
     }
 
-    public void add(long id) {
-        add(new Card.Cache(getCol(), id));
+    public SimpleCardQueue(AbstractSched sched, List<Long> cards, boolean shuffle) {
+        super(sched, toQueue(sched, cards, shuffle));
+    }
+
+    public static java.util.Queue<Card.Cache> toQueue(AbstractSched sched, List<Long> cids, boolean shuffle) {
+        if (shuffle) {
+            Random r = new Random();
+            r.setSeed(sched.getToday());
+            Collections.shuffle(cids, r);
+        }
+        java.util.Queue<Card.Cache> deque = new ArrayDeque<>(cids.size());
+        for (long cid: cids) {
+            deque.add(new Card.Cache(sched.mCol, cid));
+        }
+        return deque;
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.java
@@ -42,13 +42,14 @@ import com.ichi2.utils.JSONException;
 import com.ichi2.utils.JSONObject;
 
 import java.io.IOException;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Queue;
 
 import androidx.annotation.NonNull;
 import okhttp3.Response;
@@ -83,7 +84,7 @@ public class Syncer {
     private boolean mLNewer;
     private String mSyncMsg;
 
-    private LinkedList<String> mTablesLeft;
+    private Queue<String> mTablesLeft;
     private Cursor mCursor;
 
 
@@ -528,7 +529,7 @@ public class Syncer {
      */
 
     private void prepareToChunk() {
-        mTablesLeft = new LinkedList<>();
+        mTablesLeft = new ArrayDeque<>();
         mTablesLeft.add("revlog");
         mTablesLeft.add("cards");
         mTablesLeft.add("notes");
@@ -575,7 +576,7 @@ public class Syncer {
         int lim = 250;
         List<Integer> colTypes = null;
         while (!mTablesLeft.isEmpty() && lim > 0) {
-            String curTable = mTablesLeft.getFirst();
+            String curTable = mTablesLeft.peek();
             if (mCursor == null) {
                 mCursor = cursorForTable(curTable);
             }
@@ -605,7 +606,7 @@ public class Syncer {
             }
             if (fetched != lim) {
                 // table is empty
-                mTablesLeft.removeFirst();
+                mTablesLeft.remove();
                 mCursor.close();
                 mCursor = null;
                 // if we're the client, mark the objects as having been sent

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/AbstractSchedTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/AbstractSchedTest.java
@@ -38,7 +38,9 @@ import org.robolectric.ParameterizedRobolectricTestRunner;
 import org.robolectric.ParameterizedRobolectricTestRunner.Parameter;
 import org.robolectric.ParameterizedRobolectricTestRunner.Parameters;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 import static com.ichi2.anki.AbstractFlashcardViewer.EASE_3;
 import static com.ichi2.async.CollectionTask.nonTaskUndo;
@@ -132,9 +134,10 @@ public class AbstractSchedTest extends RobolectricTest {
     public void testCardQueue() {
         Collection col = getCol();
         SchedV2 sched = (SchedV2) col.getSched();
-        SimpleCardQueue queue = new SimpleCardQueue(sched);
-        assertThat(queue.size(), is(0));
+        SimpleCardQueue cardQueue = new SimpleCardQueue(sched);
+        assertThat(cardQueue.size(), is(0));
         final int nbCard = 6;
+        List<Long> queue = new ArrayList<>(nbCard);
         long[] cids = new long[nbCard];
         for (int i = 0; i < nbCard; i++) {
             Note note = addNoteUsingBasicModel("foo", "bar");
@@ -143,17 +146,18 @@ public class AbstractSchedTest extends RobolectricTest {
             cids[i] = cid;
             queue.add(cid);
         }
-        assertThat(queue.size(), is(nbCard));
-        assertEquals(cids[0], queue.removeFirstCard().getId());
-        assertThat(queue.size(), is(nbCard - 1));
-        queue.remove(cids[1]);
-        assertThat(queue.size(), is(nbCard - 2));
-        queue.remove(cids[3]);
-        assertThat(queue.size(), is(nbCard - 3));
-        assertEquals(cids[2], queue.removeFirstCard().getId());
-        assertThat(queue.size(), is(nbCard - 4));
-        assertEquals(cids[4], queue.removeFirstCard().getId());
-        assertThat(queue.size(), is(nbCard - 5));
+        cardQueue = new SimpleCardQueue(sched, queue, false);
+        assertThat(cardQueue.size(), is(nbCard));
+        assertEquals(cids[0], cardQueue.removeFirstCard().getId());
+        assertThat(cardQueue.size(), is(nbCard - 1));
+        cardQueue.remove(cids[1]);
+        assertThat(cardQueue.size(), is(nbCard - 2));
+        cardQueue.remove(cids[3]);
+        assertThat(cardQueue.size(), is(nbCard - 3));
+        assertEquals(cids[2], cardQueue.removeFirstCard().getId());
+        assertThat(cardQueue.size(), is(nbCard - 4));
+        assertEquals(cids[4], cardQueue.removeFirstCard().getId());
+        assertThat(cardQueue.size(), is(nbCard - 5));
     }
 
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/AnkiAssert.java
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/AnkiAssert.java
@@ -13,6 +13,7 @@ import org.junit.Assert;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
 /** Assertion methods that aren't currently supported by our dependencies */
@@ -27,8 +28,8 @@ public class AnkiAssert {
         }
     }
 
-    public static <T> void assertEqualsArrayList(T[] ar, List<T> l) {
-        assertEquals(Arrays.asList(ar), l);
+    public static <T> void assertEqualsArrayList(T[] ar, java.util.Collection<T> l) {
+        assertArrayEquals(ar, l.toArray());
     }
 
 


### PR DESCRIPTION
There is rarely a good reason to uses LinkedList, except when you want to add or remove elements at specific position often. Otherwise, Queues and Dequeues are more efficient. Actually https://docs.oracle.com/javase/7/docs/api/java/util/ArrayDeque.html suggest using ArrayDeque. This means using an array of Long instead of two object by Long (e.g. the node object and the Long object).

The only case where ArrayDeque is not optimal is for cards in learning mode. Since we want the card with least due date, that's actually the job of priority queue normally