### PR TITLE
NF: Correcting a bad merge conflict

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/Syncer.java
@@ -823,11 +823,12 @@ public class Syncer {
             ids[i] = data.getJSONArray(i).getLong(0);
         }
         HashMap<Long, Long> lmods = new HashMap<>();
+        Pair<String, Object[]> limAndArg = usnLim();
         try (Cursor cur = mCol
                     .getDb()
                     .query(
                             "SELECT id, mod FROM " + table + " WHERE id IN " + Utils.ids2str(ids) + " AND "
-                                    + usnLim())) {
+                                    +  limAndArg.first, limAndArg.second)) {
             while (cur.moveToNext()) {
                 lmods.put(cur.getLong(0), cur.getLong(1));
             }


### PR DESCRIPTION
It seems that 11e837336359ba50da637e09a8cc7e3933532d70 and 359fe6b6875661a748269d8bc4aaedb7d49ff7d9 were incorrectly merged. It corrects this.