### PR TITLE
Image Paste: Handle Context Menu & Deduplicate

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.java
@@ -99,7 +99,8 @@ public class FieldEditText extends FixedEditText {
     @Override
     public InputConnection onCreateInputConnection(EditorInfo editorInfo) {
         InputConnection inputConnection = super.onCreateInputConnection(editorInfo);
-        String[] mimeTypes = new String[] {"image/gif", "image/png", "image/jpg"};
+        //image/jpeg often comes from the keyboard
+        String[] mimeTypes = new String[] {"image/gif", "image/png", "image/jpg", "image/jpeg"};
         androidx.core.view.inputmethod.EditorInfoCompat.setContentMimeTypes(editorInfo, mimeTypes);
         return androidx.core.view.inputmethod.InputConnectionCompat.createWrapper(inputConnection, editorInfo, (contentInfo, flags, opts) -> {
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1523,14 +1523,22 @@ public class NoteEditor extends AnkiActivity {
                 editText.getText().append(field.getFormattedValue());
                 return true;
             }
+        } catch (SecurityException ex) {
+            // Tested under FB Messenger and GMail, both apps do nothing if this occurs.
+            // This typically works if the user copies again - don't know the exact cause
+
+            //  java.lang.SecurityException: Permission Denial: opening provider
+            //  org.chromium.chrome.browser.util.ChromeFileProvider from ProcessRecord{80125c 11262:com.ichi2.anki/u0a455}
+            //  (pid=11262, uid=10455) that is not exported from UID 10057
+            Timber.w(ex, "Failed to paste image");
+            return false;
         } catch (Exception e) {
             // NOTE: This is happy path coding which works on Android 9.
             AnkiDroidApp.sendExceptionReport(e, "NoteEditor:onImagePaste");
+            Timber.w(e, "Failed to paste image");
             UIUtils.showThemedToast(this, getString(R.string.multimedia_editor_something_wrong), false);
             return false;
         }
-
-
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -247,6 +247,9 @@ public class NoteEditor extends AnkiActivity {
 
     private Toolbar mToolbar;
 
+    // Use the same HTML if the same image is pasted multiple times.
+    private HashMap<String, String> mPastedImageCache = new HashMap<>();
+
     private SaveNoteHandler saveNoteHandler() {
         return new SaveNoteHandler(this);
     }
@@ -395,6 +398,7 @@ public class NoteEditor extends AnkiActivity {
             mCurrentDid = savedInstanceState.getLong("did");
             mSelectedTags = savedInstanceState.getStringArrayList("tags");
             mReloadRequired = savedInstanceState.getBoolean("reloadRequired");
+            mPastedImageCache = (HashMap<String, String>) savedInstanceState.getSerializable("imageCache");
             mChanged = savedInstanceState.getBoolean("changed");
         } else {
             mCaller = intent.getIntExtra(EXTRA_CALLER, CALLER_NOCALLER);
@@ -424,6 +428,7 @@ public class NoteEditor extends AnkiActivity {
         savedInstanceState.putBoolean("changed", mChanged);
         savedInstanceState.putBoolean("reloadRequired", mReloadRequired);
         savedInstanceState.putIntegerArrayList("customViewIds", mCustomViewIds);
+        savedInstanceState.putSerializable("imageCache", mPastedImageCache);
         if (mSelectedTags == null) {
             mSelectedTags = new ArrayList<>();
         }
@@ -1488,9 +1493,11 @@ public class NoteEditor extends AnkiActivity {
     }
 
     private boolean onImagePaste(EditText editText, Uri uri) {
-        // NOTE: This does not handle duplication
         try {
-            String imageTag = loadImageIntoCollection(uri);
+            if (!mPastedImageCache.containsKey(uri.toString())) {
+                mPastedImageCache.put(uri.toString(), loadImageIntoCollection(uri));
+            }
+            String imageTag = mPastedImageCache.get(uri.toString());
             if (imageTag == null) {
                 return false;
             }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ClipboardUtil.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ClipboardUtil.java
@@ -1,0 +1,77 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.utils;
+
+import android.content.ClipData;
+import android.content.ClipDescription;
+import android.content.ClipboardManager;
+import android.net.Uri;
+
+import androidx.annotation.Nullable;
+
+public class ClipboardUtil {
+
+    // JPEG is sent via pasted content
+    public static final String[] IMAGE_MIME_TYPES = new String[] {"image/gif", "image/png", "image/jpg", "image/jpeg"};
+
+    public static boolean hasImage(@Nullable ClipboardManager clipboard) {
+        if (clipboard == null) {
+            return false;
+        }
+
+        if (!clipboard.hasPrimaryClip()) {
+            return false;
+        }
+
+        ClipData primaryClip = clipboard.getPrimaryClip();
+
+        return hasImage(primaryClip.getDescription());
+    }
+
+    public static boolean hasImage(ClipDescription description) {
+        if (description == null) {
+            return false;
+        }
+
+        for (String mimeType : IMAGE_MIME_TYPES) {
+            if (description.hasMimeType(mimeType)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+
+    public static Uri getImageUri(ClipboardManager clipboard) {
+        if (clipboard == null) {
+            return null;
+        }
+
+        if (!clipboard.hasPrimaryClip()) {
+            return null;
+        }
+
+        ClipData primaryClip = clipboard.getPrimaryClip();
+
+        if (primaryClip.getItemCount() == 0) {
+            return null;
+        }
+
+        return primaryClip.getItemAt(0).getUri();
+    }
+}


### PR DESCRIPTION
## Purpose / Description
* A user wants to be able to paste images via Ctrl+V or the context menu
* image/jpeg wasn't supported
* Images weren't deduplicated when pasted (as the timestamp was added to the image).

## Fixes
Fixes #7566
Fixes #7626

## Approach
* onTextContextMenuItem
* Add jpeg
* Add a cache while the activity is open

## How Has This Been Tested?

Android 9 device - works as expected. Including "Don't Keep Activities"

## Learning (optional, can help others)

This exception can occur, all tested apps ignore this. Works again if image is copied again.
<details><summary>Exception</summary>

```
    java.lang.SecurityException: Permission Denial: opening provider org.chromium.chrome.browser.util.ChromeFileProvider from ProcessRecord{f1583aa 17356:com.ichi2.anki/u0a455} (pid=17356, uid=10455) that is not exported from UID 10057
        at android.os.Parcel.createException(Parcel.java:1953)
        at android.os.Parcel.readException(Parcel.java:1921)
        at android.os.Parcel.readException(Parcel.java:1871)
        at android.app.IActivityManager$Stub$Proxy.getContentProvider(IActivityManager.java:4159)
        at android.app.ActivityThread.acquireProvider(ActivityThread.java:6845)
        at android.app.ContextImpl$ApplicationContentResolver.acquireUnstableProvider(ContextImpl.java:2922)
        at android.content.ContentResolver.acquireUnstableProvider(ContentResolver.java:1879)
        at android.content.ContentResolver.query(ContentResolver.java:800)
        at android.content.ContentResolver.query(ContentResolver.java:766)
        at android.content.ContentResolver.query(ContentResolver.java:717)
        at com.ichi2.anki.NoteEditor.onImagePaste(NoteEditor.java:1495)
        at com.ichi2.anki.NoteEditor.lambda$touY4mnObSLmuk3dQ0lTy9_f8W0(Unknown Source:0)
        at com.ichi2.anki.-$$Lambda$NoteEditor$touY4mnObSLmuk3dQ0lTy9_f8W0.onImagePaste(Unknown Source:2)
        at com.ichi2.anki.FieldEditText.onImagePaste(FieldEditText.java:236)
        at com.ichi2.anki.FieldEditText.onTextContextMenuItem(FieldEditText.java:225)
        at android.widget.Editor$TextActionModeCallback.onActionItemClicked(Editor.java:4318)
        at com.android.internal.policy.DecorView$ActionModeCallback2Wrapper.onActionItemClicked(DecorView.java:2747)
        at com.android.internal.view.FloatingActionMode$3.onMenuItemSelected(FloatingActionMode.java:101)
        at com.android.internal.view.menu.MenuBuilder.dispatchMenuItemSelected(MenuBuilder.java:776)
        at com.android.internal.view.menu.MenuItemImpl.invoke(MenuItemImpl.java:161)
        at com.android.internal.view.menu.MenuBuilder.performItemAction(MenuBuilder.java:923)
        at com.android.internal.view.menu.MenuBuilder.performItemAction(MenuBuilder.java:913)
        at com.android.internal.view.FloatingActionMode.lambda$setFloatingToolbar$0(FloatingActionMode.java:126)
        at com.android.internal.view.-$$Lambda$FloatingActionMode$LU5MpPuKYDtwlFAuYhXYfzgLNLE.onMenuItemClick(Unknown Source:2)
        at com.android.internal.widget.FloatingToolbar$FloatingToolbarPopup$2.onClick(FloatingToolbar.java:514)
        at android.view.View.performClick(View.java:6659)
        at android.view.View.performClickInternal(View.java:6631)
        at android.view.View.access$3100(View.java:790)
        at android.view.View$PerformClick.run(View.java:26187)
        at android.os.Handler.handleCallback(Handler.java:907)
        at android.os.Handler.dispatchMessage(Handler.java:105)
        at android.os.Looper.loop(Looper.java:216)
        at android.app.ActivityThread.main(ActivityThread.java:7625)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:524)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:987)
     Caused by: android.os.RemoteException: Remote stack trace:
        at com.android.server.am.ActivityManagerService.getContentProviderImpl(ActivityManagerService.java:13613)
        at com.android.server.am.ActivityManagerService.getContentProvider(ActivityManagerService.java:14106)
        at android.app.IActivityManager$Stub.onTransact(IActivityManager.java:357)
        at com.android.server.am.ActivityManagerService.onTransact(ActivityManagerService.java:3654)
        at com.android.server.am.HwActivityManagerService.onTransact(HwActivityManagerService.java:609)
```

</details>

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] Strings resources: All strings added as resources are unique or contain a comment for seemingly duplicate strings to explain the difference between both resources
