### PR TITLE
Handle Backup restoration-related crashes

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -31,6 +31,7 @@ import android.os.Environment;
 import android.os.LocaleList;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import android.util.Log;
@@ -187,6 +188,17 @@ public class AnkiDroidApp extends MultiDexApplication {
     @NonNull
     public static InputStream getResourceAsStream(@NonNull String name) {
         return sInstance.getApplicationContext().getClassLoader().getResourceAsStream(name);
+    }
+
+
+    public static boolean isInitialized() {
+        return sInstance == null;
+    }
+
+
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    public static void simulateRestoreFromBackup() {
+        sInstance = null;
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -502,6 +502,9 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        if (showedActivityFailedScreen(savedInstanceState)) {
+            return;
+        }
         super.onCreate(savedInstanceState);
         Timber.d("onCreate()");
         if (wasLoadedFromExternalTextActionItem() && !Permissions.hasStorageAccessPermission(this)) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardInfo.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardInfo.java
@@ -68,6 +68,9 @@ public class CardInfo extends AnkiActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        if (showedActivityFailedScreen(savedInstanceState)) {
+            return;
+        }
         super.onCreate(savedInstanceState);
 
         setContentView(R.layout.card_info);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateBrowserAppearanceEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateBrowserAppearanceEditor.java
@@ -52,6 +52,9 @@ public class CardTemplateBrowserAppearanceEditor extends AnkiActivity {
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
+        if (showedActivityFailedScreen(savedInstanceState)) {
+            return;
+        }
         super.onCreate(savedInstanceState);
         Bundle bundle = savedInstanceState;
         if (bundle == null) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
@@ -102,6 +102,9 @@ public class CardTemplateEditor extends AnkiActivity implements DeckSelectionDia
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        if (showedActivityFailedScreen(savedInstanceState)) {
+            return;
+        }
         Timber.d("onCreate()");
         super.onCreate(savedInstanceState);
         setContentView(R.layout.card_template_editor_activity);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.java
@@ -55,6 +55,9 @@ public class CardTemplatePreviewer extends AbstractFlashcardViewer {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        if (showedActivityFailedScreen(savedInstanceState)) {
+            return;
+        }
         Timber.d("onCreate()");
         super.onCreate(savedInstanceState);
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -434,6 +434,11 @@ public class DeckPicker extends NavigationDrawerActivity implements
     @Override
     protected void onCreate(Bundle savedInstanceState) throws SQLException {
         Timber.d("onCreate()");
+
+        if (showedActivityFailedScreen(savedInstanceState)) {
+            return;
+        }
+
         SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(getBaseContext());
 
         //we need to restore here, as we need it before super.onCreate() is called.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Info.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Info.java
@@ -53,6 +53,9 @@ public class Info extends AnkiActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        if (showedActivityFailedScreen(savedInstanceState)) {
+            return;
+        }
         Timber.d("onCreate()");
         super.onCreate(savedInstanceState);
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.java
@@ -179,6 +179,9 @@ public class ModelBrowser extends AnkiActivity {
     // ----------------------------------------------------------------------------
     @Override
     public void onCreate(Bundle savedInstanceState) {
+        if (showedActivityFailedScreen(savedInstanceState)) {
+            return;
+        }
         super.onCreate(savedInstanceState);
         setContentView(R.layout.model_browser);
         mModelListView = findViewById(R.id.note_type_browser_list);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.java
@@ -82,6 +82,9 @@ public class ModelFieldEditor extends AnkiActivity implements LocaleSelectionDia
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        if (showedActivityFailedScreen(savedInstanceState)) {
+            return;
+        }
         super.onCreate(savedInstanceState);
         setContentView(R.layout.model_field_editor);
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.java
@@ -89,6 +89,9 @@ public class MyAccount extends AnkiActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        if (showedActivityFailedScreen(savedInstanceState)) {
+            return;
+        }
         super.onCreate(savedInstanceState);
 
         if (AdaptionUtil.isUserATestClient()) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -387,6 +387,9 @@ public class NoteEditor extends AnkiActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        if (showedActivityFailedScreen(savedInstanceState)) {
+            return;
+        }
         Timber.d("onCreate()");
         super.onCreate(savedInstanceState);
         mFieldState.setInstanceState(savedInstanceState);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.java
@@ -52,6 +52,9 @@ public class Previewer extends AbstractFlashcardViewer {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        if (showedActivityFailedScreen(savedInstanceState)) {
+            return;
+        }
         Timber.d("onCreate()");
         super.onCreate(savedInstanceState);
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -158,6 +158,9 @@ public class Reviewer extends AbstractFlashcardViewer {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        if (showedActivityFailedScreen(savedInstanceState)) {
+            return;
+        }
         Timber.d("onCreate()");
         super.onCreate(savedInstanceState);
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.java
@@ -81,6 +81,9 @@ public class Statistics extends NavigationDrawerActivity implements DeckDropDown
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        if (showedActivityFailedScreen(savedInstanceState)) {
+            return;
+        }
         Timber.d("onCreate()");
         sIsSubtitle = true;
         super.onCreate(savedInstanceState);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.java
@@ -36,6 +36,9 @@ public class StudyOptionsActivity extends NavigationDrawerActivity implements St
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        if (showedActivityFailedScreen(savedInstanceState)) {
+            return;
+        }
         super.onCreate(savedInstanceState);
         // The empty frame layout is a workaround for fragments not showing when they are added
         // to android.R.id.content when an action bar is used in Android 2.1 (and potentially

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.java
@@ -83,6 +83,9 @@ public class MultimediaEditFieldActivity extends AnkiActivity
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        if (showedActivityFailedScreen(savedInstanceState)) {
+            return;
+        }
         super.onCreate(savedInstanceState);
 
         Bundle controllerBundle = null;

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -348,4 +348,8 @@
     <string name="remove_toolbar_item">Remove Toolbar Item?</string>
 
     <string name="note_editor_paste_too_large">The image is too large to paste, please insert the image manually</string>
+    <string name="ankidroid_cannot_open_after_backup_try_again"
+        comment="After an Android backup is restored, AnkiDroid opens and shows this message.
+        Opening AnkiDroid again will work correctly">
+        Android backup in progress. Please try again</string>
 </resources>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ActivityStartupMetaTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ActivityStartupMetaTest.java
@@ -23,7 +23,6 @@ import android.content.pm.PackageManager;
 import com.ichi2.testutils.ActivityList;
 import com.ichi2.testutils.ActivityList.ActivityLaunchParam;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -40,7 +39,6 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 public class ActivityStartupMetaTest extends RobolectricTest {
 
     @Test
-    @Ignore("Not implemented - 7630")
     public void ensureAllActivitiesAreTested() throws PackageManager.NameNotFoundException {
         // we can't access this in a static context
         PackageManager pm = getTargetContext().getPackageManager();

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ActivityStartupMetaTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ActivityStartupMetaTest.java
@@ -1,0 +1,63 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki;
+
+import android.content.pm.ActivityInfo;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+
+import com.ichi2.testutils.ActivityList;
+import com.ichi2.testutils.ActivityList.ActivityLaunchParam;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+
+@RunWith(AndroidJUnit4.class)
+public class ActivityStartupMetaTest extends RobolectricTest {
+
+    @Test
+    @Ignore("Not implemented - 7630")
+    public void ensureAllActivitiesAreTested() throws PackageManager.NameNotFoundException {
+        // we can't access this in a static context
+        PackageManager pm = getTargetContext().getPackageManager();
+
+        PackageInfo packageInfo = pm.getPackageInfo(getTargetContext().getPackageName(), PackageManager.GET_ACTIVITIES);
+        ActivityInfo[] manifestActivities = packageInfo.activities;
+
+        Set<String> testedActivityClassNames = ActivityList.allActivitiesAndIntents().stream().map(ActivityLaunchParam::getClassName).collect(Collectors.toSet());
+
+        Object[] manifestActivityNames = Arrays.stream(manifestActivities)
+                .map(x -> x.name)
+                .filter(x -> !x.equals("com.ichi2.anki.TestCardTemplatePreviewer"))
+                .filter(x -> !x.equals("com.ichi2.anki.AnkiCardContextMenuAction"))
+                .filter(x -> !x.equals("com.ichi2.anki.analytics.AnkiDroidCrashReportDialog"))
+                .filter(x -> !x.startsWith("androidx"))
+                .filter(x -> !x.startsWith("org.acra"))
+                .toArray();
+        assertThat(testedActivityClassNames, containsInAnyOrder(manifestActivityNames));
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ActivityStartupUnderBackupTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ActivityStartupUnderBackupTest.java
@@ -20,6 +20,7 @@ import android.app.Activity;
 
 import com.ichi2.testutils.ActivityList;
 import com.ichi2.testutils.ActivityList.ActivityLaunchParam;
+import com.ichi2.testutils.EmptyApplication;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -27,6 +28,7 @@ import org.robolectric.ParameterizedRobolectricTestRunner;
 import org.robolectric.ParameterizedRobolectricTestRunner.Parameter;
 import org.robolectric.ParameterizedRobolectricTestRunner.Parameters;
 import org.robolectric.android.controller.ActivityController;
+import org.robolectric.annotation.Config;
 
 import java.util.stream.Collectors;
 
@@ -36,6 +38,7 @@ import static org.hamcrest.Matchers.is;
 import static org.robolectric.Shadows.shadowOf;
 
 @RunWith(ParameterizedRobolectricTestRunner.class)
+@Config(application = EmptyApplication.class) // no point in Application init if we don't use it
 public class ActivityStartupUnderBackupTest extends RobolectricTest {
     @Parameter
     public ActivityLaunchParam mLauncher;

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ActivityStartupUnderBackupTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ActivityStartupUnderBackupTest.java
@@ -18,10 +18,13 @@ package com.ichi2.anki;
 
 import android.app.Activity;
 
+import com.ichi2.anki.multimediacard.activity.LoadPronounciationActivity;
+import com.ichi2.anki.multimediacard.activity.TranslationActivity;
 import com.ichi2.testutils.ActivityList;
 import com.ichi2.testutils.ActivityList.ActivityLaunchParam;
 import com.ichi2.testutils.EmptyApplication;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.ParameterizedRobolectricTestRunner;
@@ -52,6 +55,18 @@ public class ActivityStartupUnderBackupTest extends RobolectricTest {
         return ActivityList.allActivitiesAndIntents().stream().map(x -> new Object[] {x, x.getSimpleName()}).collect(Collectors.toList());
     }
 
+    @Before
+    public void before() {
+        notYetHandled(IntentHandler.class.getSimpleName(), "Not working (or implemented) - inherits from Activity");
+        notYetHandled(VideoPlayer.class.getSimpleName(), "Not working (or implemented) - inherits from Activity");
+        notYetHandled(LoadPronounciationActivity.class.getSimpleName(), "Not working (or implemented) - inherits from Activity");
+        notYetHandled(Preferences.class.getSimpleName(), "Not working (or implemented) - inherits from AppCompatPreferenceActivity");
+        notYetHandled(TranslationActivity.class.getSimpleName(), "Not working (or implemented) - inherits from FragmentActivity");
+        notYetHandled(DeckOptions.class.getSimpleName(), "Not working (or implemented) - inherits from AppCompatPreferenceActivity");
+        notYetHandled(FilteredDeckOptions.class.getSimpleName(), "Not working (or implemented) - inherits from AppCompatPreferenceActivity");
+    }
+
+
     @Test
     public void activityHandlesRestoreBackup() {
         // See: showActivityFailedScreen
@@ -70,5 +85,12 @@ public class ActivityStartupUnderBackupTest extends RobolectricTest {
         controller.destroy();
 
         assertThat("If a backup was taking place, the activity should be destroyed successfully", controller.get().isDestroyed(), is(true));
+    }
+
+
+    protected void notYetHandled(String activityName, String reason) {
+        if (mLauncher.getSimpleName().equals(activityName)) {
+            assumeThat(activityName + " " + reason, true, is(false));
+        }
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ActivityStartupUnderBackupTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ActivityStartupUnderBackupTest.java
@@ -1,0 +1,71 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki;
+
+import android.app.Activity;
+
+import com.ichi2.testutils.ActivityList;
+import com.ichi2.testutils.ActivityList.ActivityLaunchParam;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.ParameterizedRobolectricTestRunner;
+import org.robolectric.ParameterizedRobolectricTestRunner.Parameter;
+import org.robolectric.ParameterizedRobolectricTestRunner.Parameters;
+import org.robolectric.android.controller.ActivityController;
+
+import java.util.stream.Collectors;
+
+import static android.os.Looper.getMainLooper;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.robolectric.Shadows.shadowOf;
+
+@RunWith(ParameterizedRobolectricTestRunner.class)
+public class ActivityStartupUnderBackupTest extends RobolectricTest {
+    @Parameter
+    public ActivityLaunchParam mLauncher;
+
+    @SuppressWarnings( {"unused", "RedundantSuppression"}) // Only used for display, but needs to be defined
+    @Parameter(1)
+    public String mActivityName;
+
+    @Parameters(name = "{1}")
+    public static java.util.Collection<Object[]> initParameters() {
+        return ActivityList.allActivitiesAndIntents().stream().map(x -> new Object[] {x, x.getSimpleName()}).collect(Collectors.toList());
+    }
+
+    @Test
+    public void activityHandlesRestoreBackup() {
+        // See: showActivityFailedScreen
+
+        AnkiDroidApp.simulateRestoreFromBackup();
+        ActivityController<? extends Activity> controller = mLauncher.build(getTargetContext()).create();
+
+        shadowOf(getMainLooper()).idle();
+
+        // Note: Robolectric differs from actual Android (process is not killed).
+        // But we get the main idea: onCreate() doesn't throw an exception and is handled.
+        // and onDestroy() is also called in the real implementation on my phone.
+
+        assertThat("If a backup was taking place, the activity should be finishing", controller.get().isFinishing(), is(true));
+
+        controller.destroy();
+
+        assertThat("If a backup was taking place, the activity should be destroyed successfully", controller.get().isDestroyed(), is(true));
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/ActivityList.java
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/ActivityList.java
@@ -1,0 +1,77 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.testutils;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+
+import com.ichi2.anki.DeckPicker;
+import com.ichi2.utils.FunctionalInterfaces.Function;
+
+import org.robolectric.Robolectric;
+import org.robolectric.android.controller.ActivityController;
+
+import java.util.Collections;
+import java.util.List;
+
+import androidx.annotation.CheckResult;
+
+import static com.ichi2.testutils.ActivityList.ActivityLaunchParam.get;
+
+public class ActivityList {
+    @CheckResult
+    public static List<ActivityLaunchParam> allActivitiesAndIntents() {
+        return Collections.singletonList(
+                get(DeckPicker.class)
+        );
+    }
+
+    public static class ActivityLaunchParam {
+        public Class<? extends Activity> mActivity;
+        public Function<Context, Intent> mIntentBuilder;
+
+
+        public ActivityLaunchParam(Class<? extends Activity> clazz, Function<Context, Intent> intent) {
+            mActivity = clazz;
+            mIntentBuilder = intent;
+        }
+
+
+        public static ActivityLaunchParam get(Class<? extends Activity> clazz) {
+            return get(clazz, c -> new Intent());
+        }
+
+        public static ActivityLaunchParam get(Class<? extends Activity> clazz, Function<Context, Intent> i) {
+            return new ActivityLaunchParam(clazz, i);
+        }
+
+        public String getSimpleName() {
+            return mActivity.getSimpleName();
+        }
+
+
+        public ActivityController<? extends Activity> build(Context context) {
+            return Robolectric.buildActivity(mActivity, mIntentBuilder.apply(context));
+        }
+
+
+        public String getClassName() {
+            return this.mActivity.getName();
+        }
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/ActivityList.java
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/ActivityList.java
@@ -20,26 +20,96 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 
+import com.ichi2.anki.CardBrowser;
+import com.ichi2.anki.CardInfo;
+import com.ichi2.anki.CardTemplateBrowserAppearanceEditor;
+import com.ichi2.anki.CardTemplateEditor;
+import com.ichi2.anki.CardTemplatePreviewer;
+import com.ichi2.anki.DeckOptions;
 import com.ichi2.anki.DeckPicker;
+import com.ichi2.anki.FilteredDeckOptions;
+import com.ichi2.anki.Info;
+import com.ichi2.anki.IntentHandler;
+import com.ichi2.anki.ModelBrowser;
+import com.ichi2.anki.ModelFieldEditor;
+import com.ichi2.anki.MyAccount;
+import com.ichi2.anki.NoteEditor;
+import com.ichi2.anki.Preferences;
+import com.ichi2.anki.Previewer;
+import com.ichi2.anki.Reviewer;
+import com.ichi2.anki.Statistics;
+import com.ichi2.anki.StudyOptionsActivity;
+import com.ichi2.anki.VideoPlayer;
+import com.ichi2.anki.multimediacard.activity.LoadPronounciationActivity;
+import com.ichi2.anki.multimediacard.activity.MultimediaEditFieldActivity;
+import com.ichi2.anki.multimediacard.activity.TranslationActivity;
+import com.ichi2.anki.services.ReminderService;
 import com.ichi2.utils.FunctionalInterfaces.Function;
 
 import org.robolectric.Robolectric;
 import org.robolectric.android.controller.ActivityController;
 
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.List;
 
 import androidx.annotation.CheckResult;
 
+import static com.ichi2.anki.CardTemplateBrowserAppearanceEditor.INTENT_ANSWER_FORMAT;
+import static com.ichi2.anki.CardTemplateBrowserAppearanceEditor.INTENT_QUESTION_FORMAT;
 import static com.ichi2.testutils.ActivityList.ActivityLaunchParam.get;
 
 public class ActivityList {
+    // TODO: This needs a test to ensure that all activities are valid with the given intents
+    // Otherwise, ActivityStartupUnderBackup and other classes could be flaky
     @CheckResult
     public static List<ActivityLaunchParam> allActivitiesAndIntents() {
-        return Collections.singletonList(
-                get(DeckPicker.class)
+        return Arrays.asList(
+                get(DeckPicker.class),
+                // IntentHandler has unhandled intents
+                get(IntentHandler.class, ctx -> ReminderService.getReviewDeckIntent(ctx, 1L)),
+                get(StudyOptionsActivity.class),
+                get(CardBrowser.class),
+                get(ModelBrowser.class),
+                get(ModelFieldEditor.class),
+                // Likely has unhandled intents
+                get(Reviewer.class),
+                get(VideoPlayer.class),
+                get(MyAccount.class),
+                get(Preferences.class),
+                get(DeckOptions.class),
+                get(FilteredDeckOptions.class),
+                // Info has unhandled intents
+                get(Info.class),
+                // NoteEditor has unhandled intents
+                get(NoteEditor.class),
+                get(Statistics.class),
+                get(Previewer.class),
+                get(CardTemplatePreviewer.class),
+                get(MultimediaEditFieldActivity.class),
+                get(TranslationActivity.class),
+                get(LoadPronounciationActivity.class),
+                get(CardInfo.class),
+                get(CardTemplateEditor.class, ActivityList::intentForCardTemplateEditor),
+                get(CardTemplateBrowserAppearanceEditor.class, ActivityList::intentForCardTemplateBrowserAppearanceEditor)
         );
     }
+
+
+    private static Intent intentForCardTemplateBrowserAppearanceEditor(Context context) {
+        // bundle != null
+        Intent intent = new Intent();
+        intent.putExtra(INTENT_QUESTION_FORMAT, "{{Front}}");
+        intent.putExtra(INTENT_ANSWER_FORMAT, "{{FrontSide}}\n{{Back}}");
+        return intent;
+    }
+
+
+    private static Intent intentForCardTemplateEditor(Context ctx) {
+        Intent intent = new Intent();
+        intent.putExtra("modelId", 1L);
+        return intent;
+    }
+
 
     public static class ActivityLaunchParam {
         public Class<? extends Activity> mActivity;

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/EmptyApplication.java
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/EmptyApplication.java
@@ -1,0 +1,22 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.testutils;
+
+import android.app.Application;
+
+public class EmptyApplication extends Application {
+}


### PR DESCRIPTION
## Purpose

If the app is restored from a backup, then `Application.onCreate` is not called. This lead to a lot of crashes as this was assumed to always happen.


## Fixes
Fixes #7630 

## Approach
* On each activity `onCreate`
* Detect if the failure occurred
* Show a message
* Kill the app so it starts normally.

## How Has This Been Tested?

My Android 9 

Test via: `.\adb shell bmgr restore com.ichi2.anki`


![image](https://user-images.githubusercontent.com/62114487/98509530-46314580-2259-11eb-9bfb-26cb93f39462.png)


## Learning

https://stackoverflow.com/questions/57211036/why-backup-related-process-might-cause-applications-oncreate-is-not-executed

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] Strings resources: All strings added as resources are unique or contain a comment for seemingly duplicate strings to explain the difference between both resources
