### PR TITLE
BugFix: confirmDeckDeletion crash

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -2640,9 +2640,14 @@ public class DeckPicker extends NavigationDrawerActivity implements
             return;
         }
         // Get the number of cards contained in this deck and its subdecks
-        java.util.Collection<Long> children = getCol().getDecks().children(did).values();
-        children.add(did);
-        String ids = Utils.ids2str(children);
+        TreeMap<String, Long> children = getCol().getDecks().children(did);
+        long[] dids = new long[children.size() + 1];
+        dids[0] = did;
+        int i = 1;
+        for (Long l : children.values()) {
+            dids[i++] = l;
+        }
+        String ids = Utils.ids2str(dids);
         int cnt = getCol().getDb().queryScalar(
                 "select count() from cards where did in " + ids + " or odid in " + ids);
         // Delete empty decks without warning

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.java
@@ -4,6 +4,8 @@ import android.content.Context;
 
 import androidx.test.core.app.ActivityScenario;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
 
@@ -19,6 +21,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static com.ichi2.anki.DeckPicker.UPGRADE_VERSION_KEY;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
@@ -176,5 +180,20 @@ public class DeckPickerTest extends RobolectricTest {
                 assertEquals(10, deckPicker.mDueTree.get(0).getNewCount());
             });
         }
+    }
+
+    @Test
+    public void confirmDeckDeletionDeletesEmptyDeck() {
+        long did = addDeck("Hello World");
+
+        assertThat("Deck was added", getCol().getDecks().count(), is(2));
+
+        DeckPicker deckPicker = startActivityNormallyOpenCollectionWithIntent(DeckPicker.class, new Intent());
+
+        deckPicker.confirmDeckDeletion(did);
+
+        advanceRobolectricLooper();
+
+        assertThat("deck was deleted", getCol().getDecks().count(), is(1));
     }
 }


### PR DESCRIPTION
Cause: 2d96e47e9e3f7d72c019d1231aa3df7fe060f9c1 - partially reverted


## Fixes
Fixes #7649

## How Has This Been Tested?

Unit tested

## Learning (optional, can help others)

`TreeMap.values()` does not support `.add()`

https://docs.oracle.com/javase/7/docs/api/java/util/TreeMap.html#values()

> Returns a Collection view of the values contained in this map. The collection's iterator returns the values in ascending order of the corresponding keys. The collection is backed by the map, so changes to the map are reflected in the collection, and vice-versa. If the map is modified while an iteration over the collection is in progress (except through the iterator's own remove operation), the results of the iteration are undefined. The collection supports element removal, which removes the corresponding mapping from the map, via the Iterator.remove, Collection.remove, removeAll, retainAll and clear operations. **It does not support the add or addAll operations.**

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] Strings resources: All strings added as resources are unique or contain a comment for seemingly duplicate strings to explain the difference between both resources