### PR TITLE
Dependency updates 20201111

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -238,7 +238,7 @@ dependencies {
     // #6419  - API 27 (& maybe others) could not perform new ZipFile() on a 2GB+ apkg
     // noinspection GradleDependency - pinned at 1.12 until API21 minSdkVersion (File.toPath usage)
     implementation 'org.apache.commons:commons-compress:1.12'
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.3'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
 
 
     // May need a resolution strategy for support libs to our versions

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -3,7 +3,7 @@ import com.android.build.OutputFile
 
 plugins {
  // Gradle plugin portal 
- id 'com.github.triplet.play' version '2.8.0'
+ id 'com.github.triplet.play' version '3.0.0'
 }
 
 apply plugin: 'com.android.application'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -179,8 +179,8 @@ android {
 }
 
 play {
-    serviceAccountCredentials = file("${homePath}/src/AnkiDroid-GCP-Publish-Credentials.json")
-    track = 'alpha'
+    serviceAccountCredentials.set(file("${homePath}/src/AnkiDroid-GCP-Publish-Credentials.json"))
+    track.set('alpha')
 }
 amazon {
     securityProfile = file("${homePath}/src/AnkiDroid-Amazon-Publish-Security-Profile.json")

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.2'
+        classpath 'com.android.tools.build:gradle:4.1.1'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
         classpath "app.brant:amazonappstorepublisher:0.1.0"

--- a/build.gradle
+++ b/build.gradle
@@ -9,9 +9,28 @@ buildscript {
         maven {
             url "https://plugins.gradle.org/m2/"
         }
+        // Temporary, needed while investigating https://github.com/ankidroid/Anki-Android/issues/7558
+        maven {
+            url 'https://storage.googleapis.com/r8-releases/raw'
+        }
+        maven {
+            url "https://storage.googleapis.com/r8-releases/raw/master"
+        }
+        // End temporary #7558 work
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.1'
+        // Temporary, for #7558 where AGP4.0.x works, 4.1.x fails, from https://issuetracker.google.com/issues/169584856
+        // Without workarounds we get 'com.android.tools.r8.CompilationFailedException: Compilation failed to complete'
+        // test case is to run `./gradlew assembleRelease` - if it gets to the point where it fails on keystore password, R8 already worked == success
+        //classpath 'com.android.tools:r8:25999632a8450072e0e39f2b28085ccb9766203f'  // This is diagnostic. Should Assertion error. Works?
+        //classpath 'com.android.tools:r8:89ac4c72113fdb73b43159522c932a1665de96c9' // This is diagnostic. Expect Assertion failure. Works?
+        //classpath 'com.android.tools:r8:2.2.28' // Release version, should work. Works.
+        //classpath 'com.android.tools:r8:2.1.74' // Cherry-picked / backport release, should work, fails with NullPointerException.
+        //classpath 'com.android.tools:r8:2.1.80' // Current stable release matched to AGP4.1.1 I think. Should work, fails with NullPointerException.
+        classpath 'com.android.tools:r8:2.2.40' // Current stable release matched to AGP4.2 I think. Should work.
+        // End of Temporary #7558 work
+
+        classpath 'com.android.tools.build:gradle:4.1.1' // This includes R8, and future versions will allow removal of #7558 workarounds.
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
         classpath "app.brant:amazonappstorepublisher:0.1.0"

--- a/lint-rules/build.gradle
+++ b/lint-rules/build.gradle
@@ -16,5 +16,5 @@ dependencies {
 
     testImplementation "junit:junit:4.13.1"
     testImplementation "com.android.tools.lint:lint:27.1.0"
-    testImplementation "com.android.tools.lint:lint-tests:27.1.0"
+    testImplementation "com.android.tools.lint:lint-tests:27.1.1"
 }

--- a/lint-rules/build.gradle
+++ b/lint-rules/build.gradle
@@ -12,7 +12,7 @@ repositories {
 
 dependencies {
     compileOnly "com.android.tools.lint:lint-api:27.1.1"
-    compileOnly "com.android.tools.lint:lint:27.1.0"
+    compileOnly "com.android.tools.lint:lint:27.1.1"
 
     testImplementation "junit:junit:4.13.1"
     testImplementation "com.android.tools.lint:lint:27.1.0"

--- a/lint-rules/build.gradle
+++ b/lint-rules/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly "com.android.tools.lint:lint-api:27.1.0"
+    compileOnly "com.android.tools.lint:lint-api:27.1.1"
     compileOnly "com.android.tools.lint:lint:27.1.0"
 
     testImplementation "junit:junit:4.13.1"

--- a/lint-rules/build.gradle
+++ b/lint-rules/build.gradle
@@ -15,6 +15,6 @@ dependencies {
     compileOnly "com.android.tools.lint:lint:27.1.1"
 
     testImplementation "junit:junit:4.13.1"
-    testImplementation "com.android.tools.lint:lint:27.1.0"
+    testImplementation "com.android.tools.lint:lint:27.1.1"
     testImplementation "com.android.tools.lint:lint-tests:27.1.1"
 }


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Standard dependency update PR with notable item:

- R8 workaround to fix the release minify bug we started seeing with AGP4.1.x (upstream has fixes already)

## Fixes
Fixes #7558 
Related / unblocked #7587 

## Approach

I added a couple new repositories that allow access to pre-release / standalone R8 tool builds, and found a version that works for us when layered on to the android gradle plugin 4.1.x. This is standard in the google issue tracker when troubleshooting / resolving R8 problems.

The version I chose is the one that will go live with AGP4.2.x I believe, you can see the tags here in case the 2.2.x branch moves on and we need to track a new one, prior to AGP4.2.x release https://r8.googlesource.com/r8/

When AGP4.2.x comes out, there's a note in the code that we can remove the temporary blocks

## How Has This Been Tested?

`./gradlew assembleRelease` will fail on signing keys if R8 succeeds. It fails on R8 when this breaks.
I found a version where it passes, then when I had that I used `./tools/parallel-package-release.sh 2.15alpha2` to generate a minified (R8) parallel release and compare it's size to previous ones, plus test it. It worked.

## Learning (optional, can help others)

Entropy sucks? Unintended consequences of code changes are...unintended?
