### PR TITLE
Disallow adding 0 byte files to Media

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.java
@@ -37,9 +37,6 @@ import android.os.Build;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import android.os.CancellationSignal;
-import android.os.Parcel;
-import android.os.ParcelFileDescriptor;
 import android.text.TextUtils;
 import android.webkit.MimeTypeMap;
 
@@ -55,6 +52,7 @@ import com.ichi2.libanki.Consts;
 import com.ichi2.libanki.Decks;
 import com.ichi2.libanki.Model;
 import com.ichi2.libanki.Media;
+import com.ichi2.libanki.exception.EmptyMediaException;
 import com.ichi2.libanki.sched.AbstractSched;
 import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
@@ -71,10 +69,7 @@ import com.ichi2.utils.JSONException;
 import com.ichi2.utils.JSONObject;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -1118,7 +1113,7 @@ public class CardContentProvider extends ContentProvider {
             Timber.d("insert -> MEDIA: uriFromF = %s", uriFromF);
             return Uri.fromFile(new File(fname));
 
-        } catch (IOException e) {
+        } catch (IOException | EmptyMediaException e) {
             Timber.w(e, "insert failed from %s", fileUri);
             return null;
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.java
@@ -19,6 +19,7 @@
 
 package com.ichi2.anki.servicelayer;
 
+import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.multimediacard.IMultimediaEditableNote;
 import com.ichi2.anki.multimediacard.fields.AudioClipField;
 import com.ichi2.anki.multimediacard.fields.AudioRecordingField;
@@ -29,12 +30,15 @@ import com.ichi2.anki.multimediacard.impl.MultimediaEditableNote;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Note;
 
+import com.ichi2.libanki.exception.EmptyMediaException;
 import com.ichi2.utils.JSONArray;
 import com.ichi2.utils.JSONException;
 import com.ichi2.utils.JSONObject;
 
 import java.io.File;
 import java.io.IOException;
+
+import timber.log.Timber;
 
 public class NoteService {
     /**
@@ -178,7 +182,7 @@ public class NoteService {
         if (tmpMediaPath != null) {
             try {
                 File inFile = new File(tmpMediaPath);
-                if (inFile.exists()) {
+                if (inFile.exists() && inFile.length() > 0) {
                     String fname = col.getMedia().addFile(inFile);
                     File outFile = new File(col.getMedia().dir(), fname);
                     if (field.hasTemporaryMedia() && !outFile.getAbsolutePath().equals(tmpMediaPath)) {
@@ -199,6 +203,10 @@ public class NoteService {
                 }
             } catch (IOException e) {
                 throw new RuntimeException(e);
+            } catch (EmptyMediaException mediaException) {
+                // This shouldn't happen, but we're fine to ignore it if it does.
+                Timber.w(mediaException);
+                AnkiDroidApp.sendExceptionReport(mediaException, "noteService::importMediaToDirectory");
             }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Media.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Media.java
@@ -25,6 +25,7 @@ import android.text.TextUtils;
 import android.util.Pair;
 
 import com.ichi2.anki.AnkiDroidApp;
+import com.ichi2.libanki.exception.EmptyMediaException;
 import com.ichi2.libanki.template.Template;
 import com.ichi2.utils.Assert;
 
@@ -236,7 +237,10 @@ public class Media {
      * In AnkiDroid, adding a media file will not only copy it to the media directory, but will also insert an entry
      * into the media database marking it as a new addition.
      */
-    public String addFile(File ofile) throws IOException {
+    public String addFile(File ofile) throws IOException, EmptyMediaException {
+        if (ofile == null || ofile.length() == 0) {
+            throw new EmptyMediaException();
+        }
         String fname = writeData(ofile);
         markFileAdd(fname);
         return fname;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/exception/EmptyMediaException.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/exception/EmptyMediaException.java
@@ -1,0 +1,21 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.libanki.exception;
+
+// Empty media files cannot be added to AnkiWeb
+public class EmptyMediaException extends Exception {
+}

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/AnkiPackageExporterTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/AnkiPackageExporterTest.java
@@ -18,6 +18,7 @@ package com.ichi2.libanki;
 
 import com.ichi2.anki.RobolectricTest;
 import com.ichi2.anki.exception.ImportExportException;
+import com.ichi2.libanki.exception.EmptyMediaException;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -154,7 +155,7 @@ public class AnkiPackageExporterTest extends RobolectricTest {
         writer.println("unit test data");
         writer.close();
 
-        String s = getCol().getMedia().addFile(temp);
+        String s = addFile(temp);
         temp.delete();
 
         File newFile = new File(getCol().getMedia().dir(), s);
@@ -165,6 +166,15 @@ public class AnkiPackageExporterTest extends RobolectricTest {
         addNoteUsingBasicModel(String.format("<img src=\"%s\">", newFile.getName()), "Back");
 
         return newFile;
+    }
+
+
+    private String addFile(File temp) throws IOException {
+        try {
+            return getCol().getMedia().addFile(temp);
+        } catch (EmptyMediaException e) {
+            throw new RuntimeException(e);
+        }
     }
 
 }


### PR DESCRIPTION
A 0 byte file causes sync errors - these are handled and shown to the user: 2e3d1168a89e7d4b6627b379453fa2399c0bead2

But better to stop them at the source to reduce errors in ACRA and improve UX.

Fixes #7662

Added instrumented test, they didn't start on my machine (emulator or Device) - so let CI handle it.