### PR TITLE
Warn on Protocol-relative URLs

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/MissingImageHandler.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/MissingImageHandler.java
@@ -32,6 +32,7 @@ public class MissingImageHandler {
     public static final int MAX_DISPLAY_TIMES = 2;
 
     private int mNumberOfMissingImages = 0;
+    private boolean mHasShownInefficientImage = false;
     private boolean mHasExecuted = false;
 
 
@@ -76,5 +77,16 @@ public class MissingImageHandler {
 
     public void onCardSideChange() {
         mHasExecuted = false;
+    }
+
+
+    public void processInefficientImage(Runnable onFailure) {
+        if (mHasShownInefficientImage) {
+            return;
+        }
+
+        mHasShownInefficientImage = true;
+
+        onFailure.run();
     }
 }

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -320,6 +320,7 @@
 
     <!-- Card Viewer -->
     <string name="card_viewer_could_not_find_image">Card Content Error: Failed to load ‘%s’</string>
+    <string name="card_viewer_media_relative_protocol">Card Content Error: Media update required</string>
 
     <!-- Deck Picker -->
     <string name="deck_picker_failed_deck_load">Failed to load deck ‘%s’</string>

--- a/AnkiDroid/src/main/res/values/constants.xml
+++ b/AnkiDroid/src/main/res/values/constants.xml
@@ -153,6 +153,7 @@
     <string name="link_manual_note_format_toolbar">https://docs.ankidroid.org/manual.html#noteFormatToolbar</string>
     <string name="link_faq_tts">https://github.com/ankidroid/Anki-Android/wiki/FAQ#tts--text-to-speech-is-not-speaking</string>
     <string name="link_faq_missing_media" tools:ignore="Typos">https://github.com/ankidroid/Anki-Android/wiki/FAQ#why-doesnt-my-sound-or-image-work-on-ankidroid</string>
+    <string name="link_faq_invalid_protocol_relative">https://github.com/ankidroid/Anki-Android/wiki/FAQ#why-do-my-images-need-a-protocol</string>
     <string name="shared_decks_url">https://ankiweb.net/shared/decks/</string>
     <string name="repair_deck">https://docs.ankiweb.net/#/files?id=corrupt-collections</string>
     <string name="resetpw_url">http://ankiweb.net/account/resetpw</string>


### PR DESCRIPTION
Protocol relative URLs didn't work:

## Fixes
Fixes #6102

## Approach
We add a snackbar to warn the user and explain how to fix this.

In Anki, protocol-relative URLS are converted to https://
In AnkIDroid, they're converted to file://

file:// fails to load the image - we can't redirect from `shouldInterceptRequest`
Loading synchronously is not viable, so all we can do is use a snackbar.

## How Has This Been Tested?

On my phone and API 19 emulator

⚠️ Issue: https://github.com/ankidroid/Anki-Android/issues/7665

![image](https://user-images.githubusercontent.com/62114487/99029930-b0086280-256b-11eb-8677-b0f5370e4d07.png)

## Learning
* HTTP 300s aren't supported by `shouldInterceptRequest`
* Section links seem broken on some phones.
* https://github.com/ankidroid/Anki-Android/wiki/FAQ#why-do-my-images-need-a-protocol

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] Strings resources: All strings added as resources are unique or contain a comment for seemingly duplicate strings to explain the difference between both resources
