### PR TITLE
Remove MIUI Keyboard Hack Preference

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -933,14 +933,6 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
                 plugins.removePreference(doubleScrolling);
             }
         }
-
-        if (AdaptionUtil.canUseContextMenu()) {
-            android.preference.PreferenceCategory workarounds = (android.preference.PreferenceCategory) screen.findPreference("category_workarounds");
-            if (workarounds != null) {
-                android.preference.CheckBoxPreference miuiClipboardHack = (android.preference.CheckBoxPreference) screen.findPreference("enableMIUIClipboardHack");
-                workarounds.removePreference(miuiClipboardHack);
-            }
-        }
     }
 
 

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -272,8 +272,4 @@
     <string name="analytics_dialog_title">Help make AnkiDroid better!</string>
     <string name="analytics_title">Share feature usage</string>
     <string name="analytics_summ">You can contribute to AnkiDroid by helping the development team see which features people use</string>
-
-
-    <string name="enable_miui_keyboard_hack">\'Paste\' to insert cloze deletion</string>
-    <string name="enable_miui_keyboard_hack_summ">In the Note Editor, \'Paste\' will turn the selected text into a cloze</string>
 </resources>

--- a/AnkiDroid/src/main/res/xml/preferences_advanced.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_advanced.xml
@@ -68,13 +68,6 @@
                 android:key="disableExtendedTextUi"
                 android:summary="@string/disable_extended_text_ui_summ"
                 android:title="@string/disable_extended_text_ui" />
-
-            <!-- HACK before 7124 MIUI Clipboard Cloze -->
-            <CheckBoxPreference
-                android:defaultValue="true"
-                android:key="enableMIUIClipboardHack"
-                android:summary="@string/enable_miui_keyboard_hack_summ"
-                android:title="@string/enable_miui_keyboard_hack" />
         </PreferenceCategory>
         <PreferenceCategory
             android:key="category_plugins"


### PR DESCRIPTION
No longer necessary now we have the note editor toolbar.

Related: 43151b618758c80b2bd4b7134f498a56f5b27170
Fixed By: #7124