### PR TITLE
NF: Remove Specific Error String

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardInfo.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardInfo.java
@@ -78,7 +78,7 @@ public class CardInfo extends AnkiActivity {
         mCardId = getCardId(savedInstanceState);
 
         if (!hasValidCardId()) {
-            UIUtils.showThemedToast(this, getString(R.string.card_info_cannot_load), false);
+            UIUtils.showThemedToast(this, getString(R.string.multimedia_editor_something_wrong), false);
             finishWithoutAnimation();
             return;
         }
@@ -96,7 +96,7 @@ public class CardInfo extends AnkiActivity {
         Card c = getCard(col);
 
         if (c == null) {
-            UIUtils.showThemedToast(this, getString(R.string.card_info_cannot_load), false);
+            UIUtils.showThemedToast(this, getString(R.string.multimedia_editor_something_wrong), false);
             finishWithoutAnimation();
             return;
         }

--- a/AnkiDroid/src/main/res/values/07-cardbrowser.xml
+++ b/AnkiDroid/src/main/res/values/07-cardbrowser.xml
@@ -106,5 +106,4 @@
     <string name="card_info_revlog_filtered">Filtered</string>
 
     <string name="card_info_ease_not_applicable">N/A</string>
-    <string name="card_info_cannot_load">An unexpected error occurred</string>
 </resources>


### PR DESCRIPTION
Removed: `card_info_cannot_load`

The user knows they're opening the info screen - so we can show a generic error