### PR TITLE
Card Browser: Fix "Undo" not appearing and stale data

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1225,10 +1225,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
         }
 
         long[] selectedCardIds = getSelectedCardIds();
-        FunctionalInterfaces.Consumer<Integer> consumer = newDays ->
-            CollectionTask.launchCollectionTask(DISMISS_MULTI,
-                rescheduleCardHandler(),
-                new TaskData(new Object[]{selectedCardIds, Collection.DismissType.RESCHEDULE_CARDS, newDays}));
+        FunctionalInterfaces.Consumer<Integer> consumer = newDays -> rescheduleWithoutValidation(selectedCardIds, newDays);
 
         RescheduleDialog rescheduleDialog;
         if (selectedCardIds.length == 1) {
@@ -1241,6 +1238,14 @@ public class CardBrowser extends NavigationDrawerActivity implements
                     selectedCardIds.length);
         }
         showDialogFragment(rescheduleDialog);
+    }
+
+
+    @VisibleForTesting
+    void rescheduleWithoutValidation(long[] selectedCardIds, Integer newDays) {
+        CollectionTask.launchCollectionTask(DISMISS_MULTI,
+            rescheduleCardHandler(),
+            new TaskData(new Object[]{selectedCardIds, Collection.DismissType.RESCHEDULE_CARDS, newDays}));
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1129,18 +1129,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
             return true;
         } else if (itemId == R.id.action_reset_cards_progress) {
             Timber.i("NoteEditor:: Reset progress button pressed");
-            // Show confirmation dialog before resetting card progress
-            ConfirmationDialog dialog = new ConfirmationDialog();
-            String title = getString(R.string.reset_card_dialog_title);
-            String message = getString(R.string.reset_card_dialog_message);
-            dialog.setArgs(title, message);
-            Runnable confirm = () -> {
-                Timber.i("CardBrowser:: ResetProgress button pressed");
-                CollectionTask.launchCollectionTask(DISMISS_MULTI, resetProgressCardHandler(),
-                        new TaskData(new Object[] {getSelectedCardIds(), Collection.DismissType.RESET_CARDS}));
-            };
-            dialog.setConfirm(confirm);
-            showDialogFragment(dialog);
+            onResetProgress();
             return true;
         } else if (itemId == R.id.action_reschedule_cards) {
             Timber.i("CardBrowser:: Reschedule button pressed");
@@ -1186,6 +1175,23 @@ public class CardBrowser extends NavigationDrawerActivity implements
         }
         return super.onOptionsItemSelected(item);
     }
+
+
+    protected void onResetProgress() {
+        // Show confirmation dialog before resetting card progress
+        ConfirmationDialog dialog = new ConfirmationDialog();
+        String title = getString(R.string.reset_card_dialog_title);
+        String message = getString(R.string.reset_card_dialog_message);
+        dialog.setArgs(title, message);
+        Runnable confirm = () -> {
+            Timber.i("CardBrowser:: ResetProgress button pressed");
+            CollectionTask.launchCollectionTask(DISMISS_MULTI, resetProgressCardHandler(),
+                    new TaskData(new Object[] {getSelectedCardIds(), Collection.DismissType.RESET_CARDS}));
+        };
+        dialog.setConfirm(confirm);
+        showDialogFragment(dialog);
+    }
+
 
     @VisibleForTesting
     void repositionCardsNoValidation(long[] cardIds, Integer position) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -2715,7 +2715,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    void checkedCardsAtPositions(int[] positions) {
+    void checkCardsAtPositions(int[] positions) {
         for (int position : positions) {
             if (position >= mCards.size()) {
                 throw new IllegalStateException(
@@ -2789,6 +2789,6 @@ public class CardBrowser extends NavigationDrawerActivity implements
     @VisibleForTesting
     void replaceSelectionWith(int[] positions) {
         mCheckedCards.clear();
-        checkedCardsAtPositions(positions);
+        checkCardsAtPositions(positions);
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1185,11 +1185,17 @@ public class CardBrowser extends NavigationDrawerActivity implements
         dialog.setArgs(title, message);
         Runnable confirm = () -> {
             Timber.i("CardBrowser:: ResetProgress button pressed");
-            CollectionTask.launchCollectionTask(DISMISS_MULTI, resetProgressCardHandler(),
-                    new TaskData(new Object[] {getSelectedCardIds(), Collection.DismissType.RESET_CARDS}));
+            resetProgressNoConfirm(getSelectedCardIds());
         };
         dialog.setConfirm(confirm);
         showDialogFragment(dialog);
+    }
+
+
+    @VisibleForTesting
+    void resetProgressNoConfirm(long[] cardIds) {
+        CollectionTask.launchCollectionTask(DISMISS_MULTI, resetProgressCardHandler(),
+                new TaskData(new Object[] {cardIds, Collection.DismissType.RESET_CARDS}));
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1167,10 +1167,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
                     getString(R.string.reposition_card_dialog_title),
                     getString(R.string.reposition_card_dialog_message),
                     5);
-            repositionDialog.setCallbackRunnable(days ->
-                    CollectionTask.launchCollectionTask(DISMISS_MULTI, repositionCardHandler(),
-                            new TaskData(new Object[] {cardIds, Collection.DismissType.REPOSITION_CARDS, days}))
-            );
+            repositionDialog.setCallbackRunnable(position -> repositionCardsNoValidation(cardIds, position));
             showDialogFragment(repositionDialog);
             return true;
         } else if (itemId == R.id.action_edit_note) {
@@ -1188,6 +1185,12 @@ public class CardBrowser extends NavigationDrawerActivity implements
             return true;
         }
         return super.onOptionsItemSelected(item);
+    }
+
+    @VisibleForTesting
+    void repositionCardsNoValidation(long[] cardIds, Integer position) {
+        CollectionTask.launchCollectionTask(DISMISS_MULTI, repositionCardHandler(),
+                new TaskData(new Object[] {cardIds, Collection.DismissType.REPOSITION_CARDS, position}));
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -290,6 +290,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
             int cardCount = result.getObjArray().length;
             UIUtils.showThemedToast(browser,
                     browser.getResources().getQuantityString(R.plurals.reposition_card_dialog_acknowledge, cardCount, cardCount), true);
+            browser.reloadCards((Card[]) result.getObjArray());
         }
     }
 
@@ -314,6 +315,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
             int cardCount = result.getObjArray().length;
             UIUtils.showThemedToast(browser,
                     browser.getResources().getQuantityString(R.plurals.reset_cards_dialog_acknowledge, cardCount, cardCount), true);
+            browser.reloadCards((Card[]) result.getObjArray());
         }
     }
 
@@ -338,6 +340,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
             int cardCount = result.getObjArray().length;
             UIUtils.showThemedToast(browser,
                     browser.getResources().getQuantityString(R.plurals.reschedule_cards_dialog_acknowledge, cardCount, cardCount), true);
+            browser.reloadCards((Card[]) result.getObjArray());
         }
     }
 
@@ -2341,6 +2344,28 @@ public class CardBrowser extends NavigationDrawerActivity implements
         } finally {
             mCardsAdapter.notifyDataSetChanged();
         }
+    }
+
+
+    /**
+     * Reloads the data of the cards, taking on their current values from the database.
+     */
+    protected void reloadCards(Card[] cards) {
+        if (cards == null || cards.length == 0) {
+            return;
+        }
+
+        Set<Long> cardIds = new HashSet<>();
+        for (Card c : cards) {
+            cardIds.add(c.getId());
+        }
+
+        for (CardCache props : mCards) {
+            if (cardIds.contains(props.getId())) {
+                props.reload();
+            }
+        }
+        mCardsAdapter.notifyDataSetChanged();
     }
 
     private CardCollection<CardCache> getCards() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -291,6 +291,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
             UIUtils.showThemedToast(browser,
                     browser.getResources().getQuantityString(R.plurals.reposition_card_dialog_acknowledge, cardCount, cardCount), true);
             browser.reloadCards((Card[]) result.getObjArray());
+            browser.supportInvalidateOptionsMenu();
         }
     }
 
@@ -316,6 +317,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
             UIUtils.showThemedToast(browser,
                     browser.getResources().getQuantityString(R.plurals.reset_cards_dialog_acknowledge, cardCount, cardCount), true);
             browser.reloadCards((Card[]) result.getObjArray());
+            browser.supportInvalidateOptionsMenu();
         }
     }
 
@@ -341,6 +343,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
             UIUtils.showThemedToast(browser,
                     browser.getResources().getQuantityString(R.plurals.reschedule_cards_dialog_acknowledge, cardCount, cardCount), true);
             browser.reloadCards((Card[]) result.getObjArray());
+            browser.supportInvalidateOptionsMenu();
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -2735,7 +2735,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    void checkCardsAtPositions(int[] positions) {
+    void checkCardsAtPositions(int... positions) {
         for (int position : positions) {
             if (position >= mCards.size()) {
                 throw new IllegalStateException(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1120,9 +1120,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
             showChangeDeckDialog();
             return true;
         } else if (itemId == R.id.action_undo) {
-            if (getCol().undoAvailable()) {
-                CollectionTask.launchCollectionTask(UNDO, mUndoHandler);
-            }
+            Timber.w("CardBrowser:: Undo pressed");
+            onUndo();
             return true;
         } else if (itemId == R.id.action_select_none) {
             onSelectNone();
@@ -1180,6 +1179,13 @@ public class CardBrowser extends NavigationDrawerActivity implements
             return true;
         }
         return super.onOptionsItemSelected(item);
+    }
+
+    @VisibleForTesting
+    void onUndo() {
+        if (getCol().undoAvailable()) {
+            CollectionTask.launchCollectionTask(UNDO, mUndoHandler);
+        }
     }
 
 
@@ -1442,6 +1448,12 @@ public class CardBrowser extends NavigationDrawerActivity implements
         mCards.clear();
         mCheckedCards.clear();
     }
+
+    /** Currently unused - to be used in #7676 */
+    private void forceRefreshSearch() {
+        searchCards();
+    }
+
 
     private void searchCards() {
         // cancel the previous search & render tasks if still running
@@ -1871,7 +1883,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
             Timber.d("Card Browser - mUndoHandler.actualOnPostExecute(CardBrowser browser)");
             browser.hideProgressBar();
             // reload whole view
-            browser.searchCards();
+            browser.forceRefreshSearch();
             browser.endMultiSelectMode();
             browser.mCardsAdapter.notifyDataSetChanged();
             browser.updatePreviewMenuItem();

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
@@ -5,6 +5,7 @@ import android.app.Activity;
 import android.app.Application;
 import android.content.ComponentName;
 import android.content.Intent;
+import android.view.MenuItem;
 import android.widget.AdapterView;
 import android.widget.ListView;
 
@@ -32,11 +33,13 @@ import java.util.Objects;
 
 import javax.annotation.CheckReturnValue;
 
+import androidx.annotation.StringRes;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import timber.log.Timber;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasItem;
@@ -462,6 +465,36 @@ public class CardBrowserTest extends RobolectricTest {
         advanceRobolectricLooperWithSleep();
 
         assertThat("Due of checked card after reschedule", card.getColumnHeaderText(CardBrowser.Column.DUE), is("8/12/20"));
+    }
+
+    @Test
+    @Ignore("FLAKY: Robolectric getOptionsMenu does not require supportInvalidateOptionsMenu - so would not fail")
+    public void rescheduleUndoTest() {
+        CardBrowser b = getBrowserWithNotes(1);
+
+        assertUndoDoesNotContain(b, R.string.undo_action_reschedule_card);
+
+        b.checkCardsAtPositions(0);
+
+        b.rescheduleWithoutValidation(new long[] { getCheckedCard(b).getId() }, 2);
+
+        advanceRobolectricLooperWithSleep();
+
+        assertUndoContains(b, R.string.undo_action_reschedule_card);
+    }
+
+    protected void assertUndoDoesNotContain(CardBrowser browser, @StringRes int resId) {
+        ShadowActivity shadowActivity = shadowOf(browser);
+        MenuItem item = shadowActivity.getOptionsMenu().findItem(R.id.action_undo);
+        String expected = browser.getString(resId);
+        assertThat(item.getTitle().toString(), not(containsString(expected)));
+    }
+
+    protected void assertUndoContains(CardBrowser browser, @StringRes int resId) {
+        ShadowActivity shadowActivity = shadowOf(browser);
+        MenuItem item = shadowActivity.getOptionsMenu().findItem(R.id.action_undo);
+        String expected = browser.getString(resId);
+        assertThat(item.getTitle().toString(), containsString(expected));
     }
 
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
@@ -468,6 +468,31 @@ public class CardBrowserTest extends RobolectricTest {
     }
 
     @Test
+    @Ignore("Doesn't work - but should")
+    public void dataUpdatesAfterUndoReposition() {
+        CardBrowser b = getBrowserWithNotes(1);
+
+        b.checkCardsAtPositions(0);
+
+        CardBrowser.CardCache card = getCheckedCard(b);
+
+        assertThat("Initial position of checked card", card.getColumnHeaderText(CardBrowser.Column.DUE), is("1"));
+
+        b.repositionCardsNoValidation(new long[] { card.getId() }, 2);
+
+        advanceRobolectricLooperWithSleep();
+
+        assertThat("Position of checked card after reposition", card.getColumnHeaderText(CardBrowser.Column.DUE), is("2"));
+
+        b.onUndo();
+
+        advanceRobolectricLooperWithSleep();
+        advanceRobolectricLooperWithSleep();
+
+        assertThat("Position of checked card after undo should be reset", card.getColumnHeaderText(CardBrowser.Column.DUE), is("1"));
+    }
+
+    @Test
     @Ignore("FLAKY: Robolectric getOptionsMenu does not require supportInvalidateOptionsMenu - so would not fail")
     public void rescheduleUndoTest() {
         CardBrowser b = getBrowserWithNotes(1);

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
@@ -141,7 +141,7 @@ public class CardBrowserTest extends RobolectricTest {
     @Ignore("Not yet implemented, feature has performance implications in large collections, instead we remove selections")
     public void selectionsAreCorrectWhenNonExistingCardIsRemoved() {
         CardBrowser browser = getBrowserWithNotes(7);
-        browser.checkedCardsAtPositions(new int[] {1, 3, 5, 6});
+        browser.checkCardsAtPositions(new int[] {1, 3, 5, 6});
         deleteCardAtPosition(browser, 2); //delete non-selected
         deleteCardAtPosition(browser, 3); //delete selected, ensure it's not still selected
 
@@ -212,7 +212,7 @@ public class CardBrowserTest extends RobolectricTest {
         addDeck("ZZ");
         selectDefaultDeck();
         CardBrowser b = getBrowserWithNotes(5);
-        b.checkedCardsAtPositions(new int[] {0, 2});
+        b.checkCardsAtPositions(new int[] {0, 2});
 
         advanceRobolectricLooperWithSleep();
 
@@ -239,7 +239,7 @@ public class CardBrowserTest extends RobolectricTest {
         long dynId = addDynamicDeck("World");
         selectDefaultDeck();
         CardBrowser b = getBrowserWithNotes(5);
-        b.checkedCardsAtPositions(new int[] {0, 2});
+        b.checkCardsAtPositions(new int[] {0, 2});
 
         List<Long> cardIds = b.getCheckedCardIds();
 
@@ -332,7 +332,7 @@ public class CardBrowserTest extends RobolectricTest {
         assertThat(b.getPropertiesForCardId(cid1).getPosition(), is(0));
         assertThat(b.getPropertiesForCardId(cid2).getPosition(), is(1));
 
-        b.checkedCardsAtPositions(new int[] { 0 });
+        b.checkCardsAtPositions(new int[] { 0 });
         Intent previewIntent = b.getPreviewIntent();
         assertThat("before: index", previewIntent.getIntExtra("index", -100), is(0));
         assertThat("before: cards", previewIntent.getLongArrayExtra("cardList"), is(new long[] { cid1, cid2 }));

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.java
@@ -141,7 +141,7 @@ public class CardBrowserTest extends RobolectricTest {
     @Ignore("Not yet implemented, feature has performance implications in large collections, instead we remove selections")
     public void selectionsAreCorrectWhenNonExistingCardIsRemoved() {
         CardBrowser browser = getBrowserWithNotes(7);
-        browser.checkCardsAtPositions(new int[] {1, 3, 5, 6});
+        browser.checkCardsAtPositions(1, 3, 5, 6);
         deleteCardAtPosition(browser, 2); //delete non-selected
         deleteCardAtPosition(browser, 3); //delete selected, ensure it's not still selected
 
@@ -212,7 +212,7 @@ public class CardBrowserTest extends RobolectricTest {
         addDeck("ZZ");
         selectDefaultDeck();
         CardBrowser b = getBrowserWithNotes(5);
-        b.checkCardsAtPositions(new int[] {0, 2});
+        b.checkCardsAtPositions(0, 2);
 
         advanceRobolectricLooperWithSleep();
 
@@ -239,7 +239,7 @@ public class CardBrowserTest extends RobolectricTest {
         long dynId = addDynamicDeck("World");
         selectDefaultDeck();
         CardBrowser b = getBrowserWithNotes(5);
-        b.checkCardsAtPositions(new int[] {0, 2});
+        b.checkCardsAtPositions(0, 2);
 
         List<Long> cardIds = b.getCheckedCardIds();
 
@@ -332,7 +332,7 @@ public class CardBrowserTest extends RobolectricTest {
         assertThat(b.getPropertiesForCardId(cid1).getPosition(), is(0));
         assertThat(b.getPropertiesForCardId(cid2).getPosition(), is(1));
 
-        b.checkCardsAtPositions(new int[] { 0 });
+        b.checkCardsAtPositions(0);
         Intent previewIntent = b.getPreviewIntent();
         assertThat("before: index", previewIntent.getIntExtra("index", -100), is(0));
         assertThat("before: cards", previewIntent.getLongArrayExtra("cardList"), is(new long[] { cid1, cid2 }));


### PR DESCRIPTION
## Purpose / Description

* Pressing "Reschedule/Reposition/Reset Cards" did not bring up the "undo" item
* These items and Undo did not update the data in the grid

## Fixes
Fixes #7674 

## Approach
Obtain the cards, reset them and make the grid refresh

## How Has This Been Tested?

Android 9, and some unit tests - some were flaky

## Learning (optional, can help others)
We need more tests


## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] Strings resources: All strings added as resources are unique or contain a comment for seemingly duplicate strings to explain the difference between both resources