### PR TITLE
Split AnswerCard

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1419,7 +1419,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         mSoundPlayer.stopSounds();
         mCurrentEase = ease;
 
-        CollectionTask.launchCollectionTask(ANSWER_CARD, mAnswerCardHandler(true),
+        CollectionTask.launchCollectionTask(ANSWER_AND_GET_CARD, mAnswerCardHandler(true),
                 new TaskData(mCurrentCard, mCurrentEase));
     }
 
@@ -3722,8 +3722,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
 
     @VisibleForTesting
     void loadInitialCard() {
-        CollectionTask.launchCollectionTask(ANSWER_CARD, mAnswerCardHandler(false),
-                new TaskData(null, 0));
+        CollectionTask.launchCollectionTask(GET_CARD, mAnswerCardHandler(false));
     }
 
     public ReviewerUi.ControlBlock getControlBlocked() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -286,8 +286,7 @@ public class Reviewer extends AbstractFlashcardViewer {
 
         col.getSched().deferReset();     // Reset schedule in case card was previously loaded
         getCol().startTimebox();
-        CollectionTask.launchCollectionTask(ANSWER_CARD, mAnswerCardHandler(false),
-                new TaskData(null, 0));
+        CollectionTask.launchCollectionTask(GET_CARD, mAnswerCardHandler(false));
 
         disableDrawerSwipeOnConflicts();
         // Add a weak reference to current activity so that scheduler can talk to to Activity
@@ -808,8 +807,7 @@ public class Reviewer extends AbstractFlashcardViewer {
     @Override
     protected void performReload() {
         getCol().getSched().deferReset();
-        CollectionTask.launchCollectionTask(ANSWER_CARD, mAnswerCardHandler(false),
-                new TaskData(null, 0));
+        CollectionTask.launchCollectionTask(GET_CARD, mAnswerCardHandler(false));
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -605,24 +605,16 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
         Card oldCard = param.getCard();
         @Consts.BUTTON_TYPE int ease = param.getInt();
         Timber.i(oldCard != null ? "Answering card" : "Obtaining card");
-        try {
-            col.getDb().executeInTransaction(() -> {
-                if (oldCard != null) {
-                    Timber.i("Answering card %d", oldCard.getId());
-                    sched.answerCard(oldCard, ease);
-                }
-                Card newCard = sched.getCard();
-                if (newCard != null) {
-                    // render cards before locking database
-                    newCard._getQA(true);
-                }
-                publishProgress(new TaskData(newCard));
-            });
-        } catch (RuntimeException e) {
-            Timber.e(e, "doInBackgroundAnswerCard - RuntimeException on answering card");
-            AnkiDroidApp.sendExceptionReport(e, "doInBackgroundAnswerCard");
-            return new TaskData(false);
+        if (oldCard != null) {
+            Timber.i("Answering card %d", oldCard.getId());
+            sched.answerCard(oldCard, ease);
         }
+        Card newCard = sched.getCard();
+        if (newCard != null) {
+            // render cards before locking database
+            newCard._getQA(true);
+        }
+        publishProgress(new TaskData(newCard));
         return new TaskData(true);
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -94,7 +94,8 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
 
     public enum TASK_TYPE {
         SAVE_COLLECTION,
-        ANSWER_CARD,
+        ANSWER_AND_GET_CARD,
+        GET_CARD,
         ADD_NOTE,
         UPDATE_NOTE,
         UNDO,
@@ -381,8 +382,11 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
                 doInBackgroundSaveCollection(param);
                 break;
 
-            case ANSWER_CARD:
-                return doInBackgroundAnswerCard(param);
+            case ANSWER_AND_GET_CARD:
+                return doInBackgroundAnswerAndGetCard(param);
+
+            case GET_CARD:
+                return doInBackgroundGetCard();
 
             case ADD_NOTE:
                 return doInBackgroundAddNote(param);
@@ -599,16 +603,19 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
     }
 
 
-    private TaskData doInBackgroundAnswerCard(TaskData param) {
+    private TaskData doInBackgroundAnswerAndGetCard(TaskData param) {
+        Collection col = getCol();
+        @NonNull Card oldCard = param.getCard();
+        @Consts.BUTTON_TYPE int ease = param.getInt();
+        Timber.i("Answering card %d", oldCard.getId());
+        col.getSched().answerCard(oldCard, ease);
+        return doInBackgroundGetCard();
+    }
+
+    private TaskData doInBackgroundGetCard() {
         Collection col = getCol();
         AbstractSched sched = col.getSched();
-        Card oldCard = param.getCard();
-        @Consts.BUTTON_TYPE int ease = param.getInt();
-        Timber.i(oldCard != null ? "Answering card" : "Obtaining card");
-        if (oldCard != null) {
-            Timber.i("Answering card %d", oldCard.getId());
-            sched.answerCard(oldCard, ease);
-        }
+        Timber.i("Obtaining card");
         Card newCard = sched.getCard();
         if (newCard != null) {
             // render cards before locking database


### PR DESCRIPTION
It's counterIntuitive to use `answerCard` most of the time without card.

In AnswerCard it's valid to assume card is non null, since it's called only from reviewer when it already has got a card.

The try/catch was introduced in c12bac38d4096373dfdcb1b8c9b4e89542979f09, and while it may have been useful in 2011, I don't see any reason to assume a bug here specially with current wok.

I can't figure out how to check for a specific message in acralyzer, but if we find any "doInBackgroundAnswerCard" then I was wrong and this should be rejected.
