### PR TITLE
Note Editor: Option to replace newline with HTML

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/FieldEditLineTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/FieldEditLineTest.java
@@ -36,7 +36,7 @@ public class FieldEditLineTest extends NoteEditorTest {
     public void testSetters() {
         FieldEditLine line = getFieldEditLine();
 
-        line.setContent("Hello");
+        line.setContent("Hello", true);
         line.setName("Name");
         line.setOrd(5);
         FieldEditText text = line.getEditText();
@@ -50,7 +50,7 @@ public class FieldEditLineTest extends NoteEditorTest {
     public void testSaveRestore() {
         FieldEditLine toSave = getFieldEditLine();
 
-        toSave.setContent("Hello");
+        toSave.setContent("Hello", true);
         toSave.setName("Name");
         toSave.setOrd(5);
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditLine.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditLine.java
@@ -173,8 +173,8 @@ public class FieldEditLine extends FrameLayout {
         }
     }
 
-    public void setContent(String content) {
-        mEditText.setContent(content);
+    public void setContent(String content, boolean replaceNewline) {
+        mEditText.setContent(content, replaceNewline);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.java
@@ -193,10 +193,10 @@ public class FieldEditText extends FixedEditText {
     }
 
 
-    public void setContent(String content) {
+    public void setContent(String content, boolean replaceNewLine) {
         if (content == null) {
             content = "";
-        } else {
+        } else if (replaceNewLine) {
             content = content.replaceAll("<br(\\s*/*)>", NEW_LINE);
         }
         setText(content);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -283,7 +283,7 @@ public class NoteEditor extends AnkiActivity {
             if (count > 0) {
                 noteEditor.mChanged = true;
                 noteEditor.mSourceText = null;
-                noteEditor.refreshNoteData(FieldChangeType.refreshWithStickyFields());
+                noteEditor.refreshNoteData(FieldChangeType.refreshWithStickyFields(shouldReplaceNewlines()));
                 UIUtils.showThemedToast(noteEditor,
                         noteEditor.getResources().getQuantityString(R.plurals.factadder_cards_added, count, count), true);
             } else {
@@ -607,7 +607,7 @@ public class NoteEditor extends AnkiActivity {
 
         setDid(mEditorNote);
 
-        setNote(mEditorNote, FieldChangeType.onActivityCreation());
+        setNote(mEditorNote, FieldChangeType.onActivityCreation(shouldReplaceNewlines()));
 
         if (mAddNote) {
             mNoteTypeSpinner.setOnItemSelectedListener(new SetNoteTypeListener());
@@ -1090,7 +1090,13 @@ public class NoteEditor extends AnkiActivity {
                 }
             }
         }
+
         return super.onCreateOptionsMenu(menu);
+    }
+
+
+    protected static boolean shouldReplaceNewlines() {
+        return AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance()).getBoolean("noteEditorNewlineReplace", true);
     }
 
 
@@ -2057,6 +2063,9 @@ public class NoteEditor extends AnkiActivity {
 
 
     private String convertToHtmlNewline(@NonNull String fieldData) {
+        if (!shouldReplaceNewlines()) {
+            return fieldData;
+        }
         return fieldData.replace(FieldEditText.NEW_LINE, "<br>");
     }
 
@@ -2074,7 +2083,7 @@ public class NoteEditor extends AnkiActivity {
      * Update all the field EditText views based on the currently selected note type and the mModelChangeFieldMap
      */
     private void updateFieldsFromMap(Model newModel) {
-        FieldChangeType type = FieldChangeType.refreshWithMap(newModel, mModelChangeFieldMap);
+        FieldChangeType type = FieldChangeType.refreshWithMap(newModel, mModelChangeFieldMap, shouldReplaceNewlines());
         populateEditFields(type, true);
         updateCards(newModel);
     }
@@ -2122,7 +2131,7 @@ public class NoteEditor extends AnkiActivity {
                     updateDeckPosition();
                 }
 
-                refreshNoteData(FieldChangeType.changeFieldCount());
+                refreshNoteData(FieldChangeType.changeFieldCount(shouldReplaceNewlines()));
                 setDuplicateFieldStyles();
             }
         }
@@ -2175,7 +2184,7 @@ public class NoteEditor extends AnkiActivity {
                     mNoteDeckSpinner.setSelection(position, false);
                 }
             } else {
-                populateEditFields(FieldChangeType.refresh(), false);
+                populateEditFields(FieldChangeType.refresh(shouldReplaceNewlines()), false);
                 updateCards(mCurrentEditedCard.model());
                 findViewById(R.id.CardEditorTagButton).setEnabled(true);
                 //((LinearLayout) findViewById(R.id.CardEditorCardsButton)).setEnabled(false);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/FieldState.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/FieldState.java
@@ -83,7 +83,7 @@ public class FieldState {
             JSONArray flds = mEditor.getCurrentFields();
             for (int fldIdx = 0; fldIdx < flds.length(); fldIdx++) {
                 if (flds.getJSONObject(fldIdx).getBoolean("sticky")) {
-                    fieldEditLines.get(fldIdx).setContent(currentFieldStrings[fldIdx]);
+                    fieldEditLines.get(fldIdx).setContent(currentFieldStrings[fldIdx], type.replaceNewlines);
                 }
             }
         }
@@ -92,7 +92,7 @@ public class FieldState {
             String[] currentFieldStrings = mEditor.getCurrentFieldStrings();
 
             for (int i = 0; i < Math.min(currentFieldStrings.length, fieldEditLines.size()); i++) {
-                fieldEditLines.get(i).setContent(currentFieldStrings[i]);
+                fieldEditLines.get(i).setContent(currentFieldStrings[i], type.replaceNewlines);
             }
         }
 
@@ -124,7 +124,7 @@ public class FieldState {
             FieldEditLine edit_line_view = new FieldEditLine(mEditor);
             editLines.add(edit_line_view);
             edit_line_view.setName(fields[i][0]);
-            edit_line_view.setContent(fields[i][1]);
+            edit_line_view.setContent(fields[i][1], type.replaceNewlines);
             edit_line_view.setOrd(i);
         }
         return editLines;
@@ -215,38 +215,40 @@ public class FieldState {
 
         private Map<Integer, Integer> modelChangeFieldMap;
         private Model newModel;
+        private final boolean replaceNewlines;
 
-        public FieldChangeType(Type type) {
+        public FieldChangeType(Type type, boolean replaceNewlines) {
             this.mType = type;
+            this.replaceNewlines = replaceNewlines;
         }
 
-        public static FieldChangeType refreshWithMap(Model newModel, Map<Integer, Integer> modelChangeFieldMap) {
-            FieldChangeType typeClass = new FieldChangeType(Type.REFRESH_WITH_MAP);
+        public static FieldChangeType refreshWithMap(Model newModel, Map<Integer, Integer> modelChangeFieldMap, boolean replaceNewlines) {
+            FieldChangeType typeClass = new FieldChangeType(Type.REFRESH_WITH_MAP, replaceNewlines);
             typeClass.newModel = newModel;
             typeClass.modelChangeFieldMap = modelChangeFieldMap;
             return typeClass;
         }
 
-        public static FieldChangeType refresh() {
-            return fromType(FieldState.Type.REFRESH);
+        public static FieldChangeType refresh(boolean replaceNewlines) {
+            return fromType(FieldState.Type.REFRESH, replaceNewlines);
         }
 
 
-        public static FieldChangeType refreshWithStickyFields() {
-            return fromType(Type.CLEAR_KEEP_STICKY);
+        public static FieldChangeType refreshWithStickyFields(boolean replaceNewlines) {
+            return fromType(Type.CLEAR_KEEP_STICKY, replaceNewlines);
         }
 
 
-        public static FieldChangeType changeFieldCount() {
-            return fromType(Type.CHANGE_FIELD_COUNT);
+        public static FieldChangeType changeFieldCount(boolean replaceNewlines) {
+            return fromType(Type.CHANGE_FIELD_COUNT, replaceNewlines);
         }
 
-        public static FieldChangeType onActivityCreation() {
-            return fromType(Type.INIT);
+        public static FieldChangeType onActivityCreation(boolean replaceNewlines) {
+            return fromType(Type.INIT, replaceNewlines);
         }
 
-        private static FieldChangeType fromType(Type type) {
-            return new FieldChangeType(type);
+        private static FieldChangeType fromType(Type type, boolean replaceNewlines) {
+            return new FieldChangeType(type, replaceNewlines);
         }
     }
 

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -272,4 +272,8 @@
     <string name="analytics_dialog_title">Help make AnkiDroid better!</string>
     <string name="analytics_title">Share feature usage</string>
     <string name="analytics_summ">You can contribute to AnkiDroid by helping the development team see which features people use</string>
+
+
+    <string name="note_editor_replace_newlines">Replace newlines with HTML</string>
+    <string name="note_editor_replace_newlines_summ">In the Note Editor, convert any instances of &lt;br&gt; to newlines when editing a card.</string>
 </resources>

--- a/AnkiDroid/src/main/res/xml/preferences_advanced.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_advanced.xml
@@ -68,6 +68,12 @@
                 android:key="disableExtendedTextUi"
                 android:summary="@string/disable_extended_text_ui_summ"
                 android:title="@string/disable_extended_text_ui" />
+            <CheckBoxPreference
+                android:defaultValue="true"
+                android:key="noteEditorNewlineReplace"
+                android:summary="@string/note_editor_replace_newlines_summ"
+                android:title="@string/note_editor_replace_newlines"
+                />
         </PreferenceCategory>
         <PreferenceCategory
             android:key="category_plugins"


### PR DESCRIPTION
## Purpose / Description
Many user complaints that some cards are handled incorrectly. If a card from Anki Desktop with a newline (not a `<br>`) is added, this this gets converted to a `BR`, which changes formatting.

## Fixes
Fixes: #3304
Related: #7124 (toolbar)

## Approach

Add a **persistent** (reviewers: note) flag to see if newlines should be converted to HTML and vice-versa.

If this is selected, then fields are reloaded from the database

## How Has This Been Tested?

Android 10 emulator

```
AAA<br/>
AAA
```

now appears as HTML

![image](https://user-images.githubusercontent.com/62114487/99200381-d95c0500-279c-11eb-9773-0703ad30d42b.png)



## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] Strings resources: All strings added as resources are unique or contain a comment for seemingly duplicate strings to explain the difference between both resources
