### PR TITLE
 Change rename field string

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.java
@@ -271,7 +271,7 @@ public class ModelFieldEditor extends AnkiActivity implements LocaleSelectionDia
         mFieldNameInput.setText(mFieldLabels.get(mCurrentPos));
         mFieldNameInput.setSelection(mFieldNameInput.getText().length());
         new MaterialDialog.Builder(this)
-                .title(R.string.rename_model)
+                .title(R.string.model_field_editor_rename)
                 .positiveText(R.string.rename)
                 .customView(mFieldNameInput, true)
                 .onPositive((dialog, which) -> {


### PR DESCRIPTION
It previously read "Rename note type" while renaming a field

## Pull Request template

## Purpose / Description
_Describe the problem or feature and motivation_

## Fixes
Fixes #7695 
## Approach
_How does this change address the problem?_

## How Has This Been Tested?
Not at all :)
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration (SDK version(s), emulator or physical, etc)

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x ] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x ] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ x] You have commented your code, particularly in hard-to-understand areas
- [x ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] Strings resources: All strings added as resources are unique or contain a comment for seemingly duplicate strings to explain the difference between both resources
