### PR TITLE
NF: Study option fragment computation can be cancelled

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/async/CancelListener.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CancelListener.java
@@ -16,7 +16,17 @@
 
 package com.ichi2.async;
 
+import androidx.annotation.Nullable;
+
 @FunctionalInterface
 public interface CancelListener {
     boolean isCancelled();
+
+    /**
+     * @param cancelListener Either null or a cancel listener
+     * @return whether the listener exists and is cancelled
+     */
+    static boolean isCancelled(@Nullable CancelListener cancelListener) {
+        return cancelListener != null && cancelListener.isCancelled();
+    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -1364,11 +1364,15 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
             boolean reset = (Boolean) obj[0];
             if (reset) {
                 // reset actually required because of counts, which is used in getCollectionTaskListener
-                sched.resetCounts();
+                sched.resetCounts(this);
             }
-            Counts counts = sched.counts();
+            Counts counts = sched.counts(this);
             int totalNewCount = sched.totalNewForCurrentDeck();
             int totalCount = sched.cardCount();
+            if (isCancelled()) {
+                Timber.d("Update values from deck is cancelled");
+                return null;
+            }
             return new TaskData(new Object[]{counts.getNew(), counts.getLrn(), counts.getRev(), totalNewCount,
                     totalCount, sched.eta(counts)});
         } catch (RuntimeException e) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -82,6 +82,7 @@ import timber.log.Timber;
 
 import com.ichi2.async.TaskData;
 
+import static com.ichi2.async.CancelListener.isCancelled;
 import static com.ichi2.libanki.Collection.DismissType.REVIEW;
 import static com.ichi2.libanki.Collection.Previewing.*;
 
@@ -790,7 +791,7 @@ public class Collection {
         HashMap<Long, Long> dues = new HashMap<>();
         try (Cursor cur = mDb.query("select id, nid, ord, (CASE WHEN odid != 0 THEN odid ELSE did END), (CASE WHEN odid != 0 THEN odue ELSE due END), type from cards where nid in " + snids)) {
             while (cur.moveToNext()) {
-                if (task != null && task.isCancelled()) {
+                if (isCancelled(task)) {
                     Timber.v("Empty card cancelled");
                     return null;
                 }
@@ -829,7 +830,7 @@ public class Collection {
         int usn = usn();
         try (Cursor cur = mDb.query("SELECT id, flds FROM notes WHERE id IN " + snids)) {
             while (cur.moveToNext()) {
-                if (task != null && task.isCancelled()) {
+                if (isCancelled(task)) {
                     Timber.v("Empty card cancelled");
                     return null;
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
@@ -50,6 +50,7 @@ import java.util.regex.Pattern;
 import androidx.annotation.CheckResult;
 import timber.log.Timber;
 
+import static com.ichi2.async.CancelListener.isCancelled;
 import static com.ichi2.libanki.stats.Stats.SECONDS_PER_DAY;
 
 @SuppressWarnings({"PMD.ExcessiveClassLength", "PMD.AvoidThrowingRawExceptionTypes","PMD.AvoidReassigningParameters","PMD.NPathComplexity","PMD.MethodNamingConventions"})
@@ -113,7 +114,7 @@ public class Finder {
         boolean sendProgress = task != null;
         try (Cursor cur = mCol.getDb().getDatabase().query(sql, args)) {
             while (cur.moveToNext()) {
-                if (task != null && task.isCancelled()) {
+                if (isCancelled(task)) {
                     return new ArrayList<>();
                 }
                 res.add(cur.getLong(0));

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
@@ -62,6 +62,7 @@ public abstract class AbstractSched {
 
     /** Recompute the counts of the currently selected deck. */
     public abstract void resetCounts();
+    public abstract void resetCounts(CancelListener cancelListener);
 
     /** Ensure that reset will be called before returning any card or count. */
     public abstract void deferReset();
@@ -127,6 +128,7 @@ public abstract class AbstractSched {
      * @param card A card that should be added to the count result.
      * @return same array as counts(), apart that Card is added*/
     public abstract @NonNull Counts counts(@NonNull Card card);
+    public abstract @NonNull Counts counts(@NonNull CancelListener cancelListener);
 
     /**
      * @param days A number of day

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -325,12 +325,15 @@ public class Sched extends SchedV2 {
 
     @Override
     protected void _resetLrnCount() {
+        _resetLrnCount(null);
+    }
+    protected void _resetLrnCount(@Nullable CancelListener cancelListener) {
         // sub-day
         mLrnCount = mCol.getDb().queryScalar(
                 "SELECT sum(left / 1000) FROM (SELECT left FROM cards WHERE did IN " + _deckLimit()
                 + " AND queue = " + Consts.QUEUE_TYPE_LRN + " AND due < ? and id != ? LIMIT ?)",
                 mDayCutoff, currentCardId(), mReportLimit);
-
+        if (isCancelled(cancelListener)) return;
         // day
         mLrnCount += mCol.getDb().queryScalar(
                 "SELECT count() FROM cards WHERE did IN " + _deckLimit() + " AND queue = " + Consts.QUEUE_TYPE_DAY_LEARN_RELEARN + " AND due <= ? "+
@@ -646,8 +649,11 @@ public class Sched extends SchedV2 {
 
     @Override
     protected void _resetRevCount() {
+        _resetRevCount(null);
+    }
+    protected void _resetRevCount(@Nullable CancelListener cancelListener) {
         mRevCount = _walkingCount(d -> _deckRevLimitSingle(d, true),
-                                  this::_cntFnRev);
+                                  this::_cntFnRev, cancelListener);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -54,6 +54,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase;
 import timber.log.Timber;
 
 
+import static com.ichi2.async.CancelListener.isCancelled;
 import static com.ichi2.libanki.sched.Counts.Queue.*;
 import static com.ichi2.libanki.sched.Counts.Queue;
 import static com.ichi2.libanki.stats.Stats.SECONDS_PER_DAY;
@@ -217,7 +218,7 @@ public class Sched extends SchedV2 {
         HashMap<String, Integer[]> lims = new HashMap<>();
         ArrayList<DeckDueTreeNode> deckNodes = new ArrayList<>();
         for (Deck deck : decks) {
-            if (cancelListener != null && cancelListener.isCancelled()) {
+            if (isCancelled(cancelListener)) {
                 return null;
             }
             String deckName = deck.getString("name");

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -67,6 +67,7 @@ import timber.log.Timber;
 
 import static com.ichi2.libanki.Consts.CARD_TYPE_RELEARNING;
 import static com.ichi2.libanki.Consts.QUEUE_TYPE_DAY_LEARN_RELEARN;
+import static com.ichi2.async.CancelListener.isCancelled;
 import static com.ichi2.libanki.sched.AbstractSched.UnburyType.*;
 import static com.ichi2.libanki.sched.Counts.Queue.*;
 import static com.ichi2.libanki.sched.Counts.Queue;
@@ -476,7 +477,7 @@ public class SchedV2 extends AbstractSched {
         ArrayList<DeckDueTreeNode> deckNodes = new ArrayList<>();
         Decks.Node childMap = mCol.getDecks().childMap();
         for (Deck deck : decks) {
-            if (collectionTask != null && collectionTask.isCancelled()) {
+            if (isCancelled(collectionTask)) {
                 return null;
             }
             String deckName = deck.getString("name");

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -33,6 +33,7 @@ import android.util.Pair;
 
 import com.ichi2.anki.R;
 import com.ichi2.async.CancelListener;
+import com.ichi2.async.CollectionTask;
 import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Consts;
@@ -208,18 +209,42 @@ public class SchedV2 extends AbstractSched {
     }
 
     @Override
-    public void resetCounts() {
+    public void resetCounts(@NonNull CancelListener cancelListener) {
         resetCounts(true);
     }
 
+    public void resetCounts(boolean checkCutoff) {
+        resetCounts(null, checkCutoff);
+    }
+
+    public void resetCounts() {
+        resetCounts(null, true);
+    }
+
     /** @param checkCutoff whether we should check cutoff before resetting*/
-    private void resetCounts(boolean checkCutoff) {
+    private void resetCounts(@Nullable CancelListener cancelListener, boolean checkCutoff) {
         if (checkCutoff) {
             _updateCutoff();
         }
-        _resetLrnCount();
-        _resetRevCount();
-        _resetNewCount();
+
+        // Indicate that the counts can't be assumed to be correct since some are computed again and some not
+        // In theory it is useless, as anything that change counts should have set mHaveCounts to false
+        mHaveCounts = false;
+        _resetLrnCount(cancelListener);
+        if (isCancelled(cancelListener)) {
+            Timber.v("Cancel computing counts of deck %s", mCol.getDecks().current().getString("name"));
+            return;
+        }
+        _resetRevCount(cancelListener);
+        if (isCancelled(cancelListener)) {
+            Timber.v("Cancel computing counts of deck %s", mCol.getDecks().current().getString("name"));
+            return;
+        }
+        _resetNewCount(cancelListener);
+        if (isCancelled(cancelListener)) {
+            Timber.v("Cancel computing counts of deck %s", mCol.getDecks().current().getString("name"));
+            return;
+        }
         mHaveCounts = true;
     }
 
@@ -315,8 +340,11 @@ public class SchedV2 extends AbstractSched {
 
     /** new count, lrn count, rev count.  */
     public @NonNull Counts counts() {
+        return counts((CancelListener) null);
+    }
+    public @NonNull Counts counts(@Nullable CancelListener cancelListener) {
         if (!mHaveCounts) {
-            resetCounts();
+            resetCounts(cancelListener);
         }
         return new Counts (mNewCount, mLrnCount, mRevCount);
     }
@@ -418,10 +446,22 @@ public class SchedV2 extends AbstractSched {
 
 
     protected int _walkingCount(@NonNull LimitMethod limFn, @NonNull CountMethod cntFn) {
+        return _walkingCount(limFn, cntFn, null);
+    }
+
+
+    /**
+     * @param limFn Method sending a deck to the maximal number of card it can have. Normally into account both limits and cards seen today
+     * @param cntFn Method sending a deck to the number of card it has got to see today.
+     * @param cancelListener Whether the task is not useful anymore
+     * @return -1 if it's cancelled. Sum of the results of cntFn, limited by limFn,
+     */
+    protected int _walkingCount(@NonNull LimitMethod limFn, @NonNull CountMethod cntFn, @Nullable CancelListener cancelListener) {
         int tot = 0;
         HashMap<Long, Integer> pcounts = new HashMap<>();
         // for each of the active decks
         for (long did : mCol.getDecks().active()) {
+            if (isCancelled(cancelListener)) return -1;
             // get the individual deck's limit
             int lim = limFn.operation(mCol.getDecks().get(did));
             if (lim == 0) {
@@ -722,8 +762,11 @@ public class SchedV2 extends AbstractSched {
      */
 
     protected void _resetNewCount() {
+        _resetNewCount(null);
+    }
+    protected void _resetNewCount(@Nullable CancelListener cancelListener) {
         mNewCount = _walkingCount((Deck g) -> _deckNewLimitSingle(g, true),
-                                  this::_cntFnNew);
+                                  this::_cntFnNew, cancelListener);
     }
 
 
@@ -969,17 +1012,21 @@ public class SchedV2 extends AbstractSched {
 
     // Overridden: V1 has less queues
     protected void _resetLrnCount() {
+        _resetLrnCount(null);
+    }
+
+    protected void _resetLrnCount(@Nullable CancelListener cancelListener) {
         _updateLrnCutoff(true);
         // sub-day
         mLrnCount = mCol.getDb().queryScalar(
                 "SELECT count() FROM cards WHERE did IN " + _deckLimit()
                 + " AND queue = " + Consts.QUEUE_TYPE_LRN + " AND id != ? AND due < ?", currentCardId(), mLrnCutoff);
-
+        if (isCancelled(cancelListener)) return;
         // day
         mLrnCount += mCol.getDb().queryScalar(
                 "SELECT count() FROM cards WHERE did IN " + _deckLimit() + " AND queue = " + Consts.QUEUE_TYPE_DAY_LEARN_RELEARN + " AND due <= ? AND id != ?",
                 mToday, currentCardId());
-
+        if (isCancelled(cancelListener)) return;
         // previews
         mLrnCount += mCol.getDb().queryScalar(
                 "SELECT count() FROM cards WHERE did IN " + _deckLimit() + " AND queue = " + Consts.QUEUE_TYPE_PREVIEW + " AND id != ? ", currentCardId());
@@ -1501,7 +1548,11 @@ public class SchedV2 extends AbstractSched {
 
     // Overriden: V1 uses _walkingCount
     protected void _resetRevCount() {
+        _resetRevCount(null);
+    }
+    protected void _resetRevCount(@Nullable CancelListener cancelListener) {
         int lim = _currentRevLimit(true);
+        if (isCancelled(cancelListener)) return;
         mRevCount = mCol.getDb().queryScalar("SELECT count() FROM (SELECT id FROM cards WHERE did in " + _deckLimit() + " AND queue = " + Consts.QUEUE_TYPE_REV + " AND due <= ? AND id != ? LIMIT ?)",
                                              mToday, currentCardId(), lim);
     }


### PR DESCRIPTION
On tablet, clicking on the deck open an extra tab. This tab computes counts. This means that if you click on many deck without really thinking about it, you add a lot of computation in background. It also means that when you open the deck picker, there is a deck selected by default, whose counts is being computed uselessly, and this delay the opening of the deck you actually care about.

So I add the possibility to cancel those counts.

I should note that I pay close attention not to cancel the counts when we go to reviewer, because in this case those are the very same counts we need to use, and the computation will be useful. (At least until the PR to get a first card faster is merged)
