### PR TITLE
Remove Duplicate String check from PR Template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,4 +27,3 @@ _Please, go through these checks before submitting the PR._
 - [ ] You have commented your code, particularly in hard-to-understand areas
 - [ ] You have performed a self-review of your own code
 - [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
-- [ ] Strings resources: All strings added as resources are unique or contain a comment for seemingly duplicate strings to explain the difference between both resources

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.java
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.java
@@ -7,6 +7,7 @@ import com.ichi2.anki.lint.rules.DirectSystemTimeInstantiation;
 import com.ichi2.anki.lint.rules.DirectSystemCurrentTimeMillisUsage;
 import com.ichi2.anki.lint.rules.DirectDateInstantiation;
 import com.ichi2.anki.lint.rules.DirectGregorianInstantiation;
+import com.ichi2.anki.lint.rules.DuplicateCrowdInStrings;
 import com.ichi2.anki.lint.rules.DuplicateTextInPreferencesXml;
 import com.ichi2.anki.lint.rules.InconsistentAnnotationUsage;
 
@@ -27,6 +28,7 @@ public class IssueRegistry extends com.android.tools.lint.client.api.IssueRegist
         issues.add(DirectSystemTimeInstantiation.ISSUE);
         issues.add(InconsistentAnnotationUsage.ISSUE);
         issues.add(DuplicateTextInPreferencesXml.ISSUE);
+        issues.add(DuplicateCrowdInStrings.ISSUE);
         return issues;
     }
 

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DuplicateCrowdInStrings.java
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DuplicateCrowdInStrings.java
@@ -197,12 +197,6 @@ public class DuplicateCrowdInStrings extends ResourceXmlDetector {
                 prevLocation = location;
                 prevString = string;
             }
-            // Was in the Kotlin - but marked as unreachable - maybe a bug?
-                /*
-                if (firstLocation == null) {
-                    continue;
-                }
-                */
 
             List<String> nameValues = new ArrayList<>();
             for (String name : names) {
@@ -211,7 +205,8 @@ public class DuplicateCrowdInStrings extends ResourceXmlDetector {
 
 
             String nameList = LintUtils.formatList(nameValues, nameValues.size(),true);
-            String message = String.format("Duplicate string value `%s`, used in %s", prevString, nameList);
+            // we use both quotes and code styling here so it appears in the console quoted
+            String message = String.format("Duplicate string value \"`%s`\", used in %s", prevString, nameList);
             if (caseVaries) {
                 message += ". Use `android:inputType` or `android:capitalize` " +
                         "to treat these as the same and avoid string duplication.";

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DuplicateCrowdInStrings.java
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DuplicateCrowdInStrings.java
@@ -112,6 +112,11 @@ public class DuplicateCrowdInStrings extends ResourceXmlDetector {
 
     @Override
     public void visitElement(@NotNull XmlContext context, @NotNull Element element) {
+        // Only check the golden copy - not the translated sources.
+        if (!"values".equals(context.file.getParentFile().getName())) {
+            return;
+        }
+
         NodeList childNodes = element.getChildNodes();
         if (childNodes.getLength() > 0) {
             if (childNodes.getLength() == 1) {

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DuplicateCrowdInStrings.java
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DuplicateCrowdInStrings.java
@@ -168,6 +168,15 @@ public class DuplicateCrowdInStrings extends ResourceXmlDetector {
             String prevString = "";
             boolean caseVaries = false;
             List<String> names = new ArrayList<>();
+
+            if (duplicates.stream().allMatch(x -> {
+                Element el = (Element) x.getLocation().getClientData();
+                return el.hasAttribute("comment");
+            })) {
+                // skipping as all instances have a comment
+                continue;
+            }
+
             for (StringDeclaration duplicate : duplicates) {
                 names.add(duplicate.getName());
                 String string = duplicate.getText();

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DuplicateCrowdInStrings.java
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DuplicateCrowdInStrings.java
@@ -1,0 +1,207 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  This file incorporates work covered by the following copyright and
+ *  permission notice:
+ *
+ *     Copyright (C) 2018 The Android Open Source Project
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ *  https://android.googlesource.com/platform/tools/base/+/studio-master-dev/lint/libs/lint-checks/src/main/java/com/android/tools/lint/checks/StringCasingDetector.kt?autodive=0%2F
+ */
+
+package com.ichi2.anki.lint.rules;
+
+
+import com.android.ide.common.resources.configuration.LocaleQualifier;
+import com.android.resources.ResourceFolderType;
+import com.android.tools.lint.checks.StringCasingDetector.StringDeclaration;
+import com.android.tools.lint.detector.api.Context;
+import com.android.tools.lint.detector.api.Implementation;
+import com.android.tools.lint.detector.api.Issue;
+import com.android.tools.lint.detector.api.LintUtils;
+import com.android.tools.lint.detector.api.Location;
+import com.android.tools.lint.detector.api.ResourceXmlDetector;
+import com.android.tools.lint.detector.api.Scope;
+import com.android.tools.lint.detector.api.XmlContext;
+import com.android.utils.Pair;
+import com.ichi2.anki.lint.utils.Constants;
+import com.ichi2.anki.lint.utils.StringFormatDetector;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+
+import static com.android.SdkConstants.ATTR_NAME;
+import static com.android.SdkConstants.ATTR_TRANSLATABLE;
+import static com.android.SdkConstants.TAG_STRING;
+import static com.android.SdkConstants.VALUE_FALSE;
+
+public class DuplicateCrowdInStrings extends ResourceXmlDetector {
+
+    private static Implementation IMPLEMENTATION_XML =
+            new Implementation(DuplicateCrowdInStrings.class, Scope.ALL_RESOURCES_SCOPE);
+
+    /**
+     * Whether there are any duplicate strings, including capitalization adjustments.
+     */
+    public static Issue ISSUE = Issue.create(
+            "DuplicateCrowdInStrings",
+            "Duplicate Strings (CrowdIn)",
+            "Duplicate strings are ambiguous for translators." +
+                    "This lint check looks for duplicate strings, including differences for strings" +
+                    "where the only difference is in capitalization. Title casing and all uppercase can" +
+                    "all be adjusted in the layout or in code. Any duplicate strings should have a comment" +
+                    "attribute added if they are intentional and required for translations.",
+            Constants.ANKI_CROWDIN_CATEGORY,
+            Constants.ANKI_CROWDIN_PRIORITY,
+            Constants.ANKI_CROWDIN_SEVERITY,
+            IMPLEMENTATION_XML);
+
+    /*
+     * Map of all locale,strings in lower case, to their raw elements to ensure that there are no
+     * duplicate strings.
+     */
+    private final HashMap<Pair<String, String>, List<StringDeclaration>> allStrings = new HashMap<>();
+
+
+    @Override
+    public boolean appliesTo(ResourceFolderType folderType) {
+        return folderType == ResourceFolderType.VALUES;
+    }
+
+
+    @Nullable
+    @Override
+    public Collection<String> getApplicableElements() {
+        return Collections.singletonList(TAG_STRING);
+    }
+
+
+    @Override
+    public void visitElement(@NotNull XmlContext context, @NotNull Element element) {
+        NodeList childNodes = element.getChildNodes();
+        if (childNodes.getLength() > 0) {
+            if (childNodes.getLength() == 1) {
+                Node child = childNodes.item(0);
+                if (child.getNodeType() == Node.TEXT_NODE) {
+                    checkTextNode(
+                            context,
+                            element,
+                            StringFormatDetector.stripQuotes(child.getNodeValue())
+                    );
+                }
+            } else {
+                StringBuilder sb = new StringBuilder();
+                StringFormatDetector.addText(sb, element);
+                if (sb.length() != 0) {
+                    checkTextNode(context, element, sb.toString());
+                }
+            }
+        }
+    }
+
+
+    private void checkTextNode(XmlContext context, Element element, String text) {
+        if (VALUE_FALSE.equals(element.getAttribute(ATTR_TRANSLATABLE))) {
+            return;
+        }
+
+        LocaleQualifier locale = LintUtils.getLocale(context);
+        Pair<String, String> key = locale != null ?
+                Pair.of(locale.getFull(), text.toLowerCase(Locale.forLanguageTag(locale.getTag()))) :
+                Pair.of("default", text.toLowerCase(Locale.US));
+
+        Location.Handle handle = context.createLocationHandle(element);
+        handle.setClientData(element);
+        List<StringDeclaration> handleList = allStrings.getOrDefault(key, new ArrayList<>());
+        handleList.add(new StringDeclaration(element.getAttribute(ATTR_NAME), text, handle));
+        allStrings.put(key, handleList);
+    }
+
+
+    @Override
+    public void afterCheckRootProject(@NotNull Context context) {
+        for (List<StringDeclaration> duplicates : allStrings.values()) {
+            if (duplicates.size() > 1) {
+                Location firstLocation = null;
+                Location prevLocation = null;
+                String prevString = "";
+                boolean caseVaries = false;
+                List<String> names = new ArrayList<>();
+                for (StringDeclaration duplicate : duplicates) {
+                    names.add(duplicate.getName());
+                    String string = duplicate.getText();
+                    Location location = duplicate.getLocation().resolve();
+                    if (prevLocation == null) {
+                        firstLocation = location;
+                    } else {
+                        prevLocation.setSecondary(location);
+                        location.setMessage(String.format("Duplicates value in `%s`", names.get(0)));
+                        location.setSelfExplanatory(false);
+                        if (!string.equals(prevString)) {
+                            caseVaries = true;
+                            location.setMessage(location.getMessage() + " (case varies, but you can use " +
+                                    "`android:inputType` or `android:capitalize` in the " +
+                                    "presentation)");
+                        }
+                    }
+                    prevLocation = location;
+                    prevString = string;
+                }
+                // Was in the Kotlin - but marked as unreachable - maybe a bug?
+                /*
+                if (firstLocation == null) {
+                    continue;
+                }
+                */
+
+                List<String> nameValues = new ArrayList<>();
+                for (String name : names) {
+                    nameValues.add(String.format("`%s`", name));
+                }
+
+
+                String nameList = LintUtils.formatList(nameValues, nameValues.size(),true);
+                String message = String.format("Duplicate string value `%s`, used in %s", prevString, nameList);
+                if (caseVaries) {
+                    message += ". Use `android:inputType` or `android:capitalize` " +
+                            "to treat these as the same and avoid string duplication.";
+                }
+                context.report(ISSUE, firstLocation, message);
+            }
+        }
+    }
+}

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DuplicateCrowdInStrings.java
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DuplicateCrowdInStrings.java
@@ -185,7 +185,7 @@ public class DuplicateCrowdInStrings extends ResourceXmlDetector {
                     firstLocation = location;
                 } else {
                     prevLocation.setSecondary(location);
-                    location.setMessage(String.format("Duplicates value in `%s`", names.get(0)));
+                    location.setMessage(String.format("Duplicates value in `%s`. Add a `comment` attribute to explain this duplication", names.get(0)));
                     location.setSelfExplanatory(false);
                     if (!string.equals(prevString)) {
                         caseVaries = true;

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DuplicateCrowdInStrings.java
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/DuplicateCrowdInStrings.java
@@ -160,53 +160,54 @@ public class DuplicateCrowdInStrings extends ResourceXmlDetector {
     @Override
     public void afterCheckRootProject(@NotNull Context context) {
         for (List<StringDeclaration> duplicates : allStrings.values()) {
-            if (duplicates.size() > 1) {
-                Location firstLocation = null;
-                Location prevLocation = null;
-                String prevString = "";
-                boolean caseVaries = false;
-                List<String> names = new ArrayList<>();
-                for (StringDeclaration duplicate : duplicates) {
-                    names.add(duplicate.getName());
-                    String string = duplicate.getText();
-                    Location location = duplicate.getLocation().resolve();
-                    if (prevLocation == null) {
-                        firstLocation = location;
-                    } else {
-                        prevLocation.setSecondary(location);
-                        location.setMessage(String.format("Duplicates value in `%s`", names.get(0)));
-                        location.setSelfExplanatory(false);
-                        if (!string.equals(prevString)) {
-                            caseVaries = true;
-                            location.setMessage(location.getMessage() + " (case varies, but you can use " +
-                                    "`android:inputType` or `android:capitalize` in the " +
-                                    "presentation)");
-                        }
+            if (duplicates.size() <= 1) {
+                continue;
+            }
+            Location firstLocation = null;
+            Location prevLocation = null;
+            String prevString = "";
+            boolean caseVaries = false;
+            List<String> names = new ArrayList<>();
+            for (StringDeclaration duplicate : duplicates) {
+                names.add(duplicate.getName());
+                String string = duplicate.getText();
+                Location location = duplicate.getLocation().resolve();
+                if (prevLocation == null) {
+                    firstLocation = location;
+                } else {
+                    prevLocation.setSecondary(location);
+                    location.setMessage(String.format("Duplicates value in `%s`", names.get(0)));
+                    location.setSelfExplanatory(false);
+                    if (!string.equals(prevString)) {
+                        caseVaries = true;
+                        location.setMessage(location.getMessage() + " (case varies, but you can use " +
+                                "`android:inputType` or `android:capitalize` in the " +
+                                "presentation)");
                     }
-                    prevLocation = location;
-                    prevString = string;
                 }
-                // Was in the Kotlin - but marked as unreachable - maybe a bug?
+                prevLocation = location;
+                prevString = string;
+            }
+            // Was in the Kotlin - but marked as unreachable - maybe a bug?
                 /*
                 if (firstLocation == null) {
                     continue;
                 }
                 */
 
-                List<String> nameValues = new ArrayList<>();
-                for (String name : names) {
-                    nameValues.add(String.format("`%s`", name));
-                }
-
-
-                String nameList = LintUtils.formatList(nameValues, nameValues.size(),true);
-                String message = String.format("Duplicate string value `%s`, used in %s", prevString, nameList);
-                if (caseVaries) {
-                    message += ". Use `android:inputType` or `android:capitalize` " +
-                            "to treat these as the same and avoid string duplication.";
-                }
-                context.report(ISSUE, firstLocation, message);
+            List<String> nameValues = new ArrayList<>();
+            for (String name : names) {
+                nameValues.add(String.format("`%s`", name));
             }
+
+
+            String nameList = LintUtils.formatList(nameValues, nameValues.size(),true);
+            String message = String.format("Duplicate string value `%s`, used in %s", prevString, nameList);
+            if (caseVaries) {
+                message += ". Use `android:inputType` or `android:capitalize` " +
+                        "to treat these as the same and avoid string duplication.";
+            }
+            context.report(ISSUE, firstLocation, message);
         }
     }
 }

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/utils/Constants.java
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/utils/Constants.java
@@ -25,4 +25,22 @@ public class Constants {
      * The severity for the Lint issues used by all rules related to the restrictions introduced by SystemTime.
      */
     public static final Severity ANKI_TIME_SEVERITY = Severity.FATAL;
+
+    /**
+     * The priority for the Lint issues used by all rules related to the restrictions introduced by SystemTime.
+     */
+    public static final int ANKI_CROWDIN_PRIORITY = 10;
+
+    /**
+     * A special {@link Category} which groups the Lint issues related to the usage of CrowdIn as a
+     * sub category for {@link Category#CORRECTNESS}.
+     */
+    public static final Category ANKI_CROWDIN_CATEGORY = create(Category.CORRECTNESS, "AnkiCrowdIn", ANKI_CROWDIN_PRIORITY);
+
+
+    /**
+     * The severity for the Lint issues used by all rules related to CrowdIn restrictions.
+     */
+    public static final Severity ANKI_CROWDIN_SEVERITY = Severity.FATAL;
+
 }

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/utils/StringFormatDetector.java
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/utils/StringFormatDetector.java
@@ -1,0 +1,86 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  This file incorporates work covered by the following copyright and
+ *  permission notice:
+ *
+ *     Copyright (C) 2011 The Android Open Source Project
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ *  https://android.googlesource.com/platform/tools/base/+/2856eb45fc34aff6c86ab8729d545c147dfd9c19/lint/libs/lint_checks/src/main/java/com/android/tools/lint/checks/StringFormatDetector.java
+ */
+
+package com.ichi2.anki.lint.utils;
+
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+public class StringFormatDetector {
+
+    public static void addText(StringBuilder sb, Node node) {
+        short nodeType = node.getNodeType();
+        if (nodeType == Node.TEXT_NODE || nodeType == Node.CDATA_SECTION_NODE) {
+            sb.append(stripQuotes(node.getNodeValue().trim()));
+        } else {
+            NodeList childNodes = node.getChildNodes();
+            for (int i = 0, n = childNodes.getLength(); i < n; i++) {
+                addText(sb, childNodes.item(i));
+            }
+        }
+    }
+
+    /**
+     * Removes all the unescaped quotes. See <a
+     * href="http://developer.android.com/guide/topics/resources/string-resource.html#FormattingAndStyling">Escaping
+     * apostrophes and quotes</a>
+     */
+    public static String stripQuotes(String s) {
+        StringBuilder sb = new StringBuilder();
+        boolean isEscaped = false;
+        boolean isQuotedBlock = false;
+        for (int i = 0, len = s.length(); i < len; i++) {
+            char current = s.charAt(i);
+            if (isEscaped) {
+                sb.append(current);
+                isEscaped = false;
+            } else {
+                isEscaped = current == '\\'; // Next char will be escaped so we will just copy it
+                if (current == '"') {
+                    isQuotedBlock = !isQuotedBlock;
+                } else if (current == '\'') {
+                    if (isQuotedBlock) {
+                        // We only add single quotes when they are within a quoted block
+                        sb.append(current);
+                    }
+                } else {
+                    sb.append(current);
+                }
+            }
+        }
+
+        return sb.toString();
+    }
+}

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/DuplicateCrowdInStringsTest.java
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/DuplicateCrowdInStringsTest.java
@@ -26,7 +26,7 @@ public class DuplicateCrowdInStringsTest {
 
     /** Easiest test case: Two exact duplicates in the same file */
     @Language("XML")
-    private final String selfInvalid = "<resources>\n" +
+    private final String mSelfInvalid = "<resources>\n" +
             "   <string name=\"hello\">a</string>\n" +
             "   <string name=\"hello2\">a</string>\n" +
             "</resources>";
@@ -38,9 +38,22 @@ public class DuplicateCrowdInStringsTest {
         lint()
         .allowMissingSdk()
         .allowCompilationErrors()
-        .files(xml("res/values/string.xml", selfInvalid))
+        .files(xml("res/values/string.xml", mSelfInvalid))
         .issues(DuplicateCrowdInStrings.ISSUE)
         .run()
         .expectErrorCount(1);
+    }
+
+    @Test
+    public void invalidStringInNonEnglishPasses() {
+        // We only want to check the base resource files, not the translated ones -
+        // translators know if values are equivalent and do not require a comment explaining why.
+        lint()
+        .allowMissingSdk()
+        .allowCompilationErrors()
+        .files(xml("res/values-af/string.xml", mSelfInvalid))
+        .issues(DuplicateCrowdInStrings.ISSUE)
+        .run()
+        .expectErrorCount(0);
     }
 }

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/DuplicateCrowdInStringsTest.java
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/DuplicateCrowdInStringsTest.java
@@ -1,0 +1,46 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.lint.rules;
+
+import org.intellij.lang.annotations.Language;
+import org.junit.Test;
+
+import static com.android.tools.lint.checks.infrastructure.TestLintTask.lint;
+import static com.android.tools.lint.checks.infrastructure.TestFiles.xml;
+
+public class DuplicateCrowdInStringsTest {
+
+    /** Easiest test case: Two exact duplicates in the same file */
+    @Language("XML")
+    private final String selfInvalid = "<resources>\n" +
+            "   <string name=\"hello\">a</string>\n" +
+            "   <string name=\"hello2\">a</string>\n" +
+            "</resources>";
+
+
+    @Test
+    public void duplicateStringsInSameFileDetected() {
+        // This appears to be a bug in StringCasingDetector - string is self-referential.
+        lint()
+        .allowMissingSdk()
+        .allowCompilationErrors()
+        .files(xml("res/values/string.xml", selfInvalid))
+        .issues(DuplicateCrowdInStrings.ISSUE)
+        .run()
+        .expectErrorCount(1);
+    }
+}

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/DuplicateCrowdInStringsTest.java
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/DuplicateCrowdInStringsTest.java
@@ -31,6 +31,23 @@ public class DuplicateCrowdInStringsTest {
             "   <string name=\"hello2\">a</string>\n" +
             "</resources>";
 
+    @Language("XML")
+    private final String mFirstCommentButInvalid = "<resources>\n" +
+            "   <string name=\"hello\" comment=\"hello\">a</string>\n" +
+            "   <string name=\"hello2\">a</string>\n" +
+            "</resources>";
+
+    @Language("XML")
+    private final String mSecondCommentButInvalid = "<resources>\n" +
+            "   <string name=\"hello\">a</string>\n" +
+            "   <string name=\"hello2\" comment=\"hello\">a</string>\n" +
+            "</resources>";
+
+    @Language("XML")
+    private final String mDuplicateBothValid = "<resources>\n" +
+            "   <string name=\"hello\" comment=\"hello\">a</string>\n" +
+            "   <string name=\"hello2\" comment=\"hello\">a</string>\n" +
+            "</resources>";
 
     @Test
     public void duplicateStringsInSameFileDetected() {
@@ -52,6 +69,39 @@ public class DuplicateCrowdInStringsTest {
         .allowMissingSdk()
         .allowCompilationErrors()
         .files(xml("res/values-af/string.xml", mSelfInvalid))
+        .issues(DuplicateCrowdInStrings.ISSUE)
+        .run()
+        .expectErrorCount(0);
+    }
+
+    @Test
+    public void duplicateStringWithFirstCommentFails() {
+        lint()
+        .allowMissingSdk()
+        .allowCompilationErrors()
+        .files(xml("res/values/string.xml", mFirstCommentButInvalid))
+        .issues(DuplicateCrowdInStrings.ISSUE)
+        .run()
+        .expectErrorCount(1);
+    }
+
+    @Test
+    public void duplicateStringWithSecondCommentFails() {
+        lint()
+        .allowMissingSdk()
+        .allowCompilationErrors()
+        .files(xml("res/values/string.xml", mSecondCommentButInvalid))
+        .issues(DuplicateCrowdInStrings.ISSUE)
+        .run()
+        .expectErrorCount(1);
+    }
+
+    @Test
+    public void duplicateStringWithBothCommentsPasses() {
+        lint()
+        .allowMissingSdk()
+        .allowCompilationErrors()
+        .files(xml("res/values/string.xml", mDuplicateBothValid))
         .issues(DuplicateCrowdInStrings.ISSUE)
         .run()
         .expectErrorCount(0);


### PR DESCRIPTION
## Purpose / Description
We had a step in our "Pull Request" template to check for duplicate strings.

Automation > Process, so we get rid of this and convert it to a lint check

## Fixes
Fixes #7582

## Approach
We copy some AOSP classes:
* `StringCasingDetector.kt`
* `StringFormatDetector.java`

Then convert `StringCasingDetector` to only handle:
* /values/ - ignore any language-specific 
* Ignore strings if all have a "comment=" attribute

Finally, turn it on and remove it from the PR template

## How Has This Been Tested?

Test only - CI should tell us

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] Strings resources: All strings added as resources are unique or contain a comment for seemingly duplicate strings to explain the difference between both resources