### PR TITLE
Speed up Card Template Generation

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -95,6 +95,7 @@ import com.ichi2.anki.multimediacard.AudioView;
 import com.ichi2.anki.cardviewer.CardAppearance;
 import com.ichi2.anki.receiver.SdCardReceiver;
 import com.ichi2.anki.reviewer.CardMarker;
+import com.ichi2.anki.cardviewer.CardTemplate;
 import com.ichi2.anki.reviewer.ReviewerCustomFonts;
 import com.ichi2.anki.reviewer.ReviewerUi;
 import com.ichi2.anki.cardviewer.TypedAnswer;
@@ -264,7 +265,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
     private boolean mInAnswer = false;
     private boolean mAnswerSoundsAdded = false;
 
-    private String mCardTemplate;
+    private CardTemplate mCardTemplate;
 
     /**
      * Variables to hold layout objects that we need to update or handle events for
@@ -919,7 +920,8 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
 
         // Load the template for the card
         try {
-            mCardTemplate = Utils.convertStreamToString(getAssets().open("card_template.html"));
+            String data = Utils.convertStreamToString(getAssets().open("card_template.html"));
+            mCardTemplate = new CardTemplate(data);
         } catch (IOException e) {
             e.printStackTrace();
         }
@@ -2176,8 +2178,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
 
 
         content = CardAppearance.convertSmpToHtmlEntity(content);
-        mCardContent = mCardTemplate.replace("::content::", content)
-                .replace("::style::", style).replace("::class::", cardClass);
+        mCardContent = mCardTemplate.render(content, style, cardClass);
         Timber.d("base url = %s", mBaseUrl);
 
         if (AnkiDroidApp.getSharedPrefs(this).getBoolean("html_javascript_debugging", false)) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardTemplate.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardTemplate.java
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.cardviewer;
+
+import androidx.annotation.CheckResult;
+import androidx.annotation.NonNull;
+
+public class CardTemplate {
+    @NonNull
+    private final String mContent;
+
+    public CardTemplate(@NonNull String content) {
+        this.mContent = content;
+    }
+
+    @CheckResult
+    @NonNull
+    public String render(String content, String style, String cardClass) {
+        return mContent.replace("::content::", content).replace("::style::", style).replace("::class::", cardClass);
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardTemplate.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardTemplate.java
@@ -20,16 +20,35 @@ import androidx.annotation.CheckResult;
 import androidx.annotation.NonNull;
 
 public class CardTemplate {
-    @NonNull
-    private final String mContent;
+    private final String mPreStyle;
+    private final String mPreClass;
+    private final String mPreContent;
+    private final String mPostContent;
 
-    public CardTemplate(@NonNull String content) {
-        this.mContent = content;
+    public CardTemplate(@NonNull String template) {
+        // Note: This refactoring means the template must be in the specific order of style, class, content.
+        // Since this is a const loaded from an asset file, I'm fine with this.
+        String classDelim = "::class::";
+        String styleDelim = "::style::";
+        String contentDelim = "::content::";
+
+        int styleIndex = template.indexOf(styleDelim);
+        int classIndex = template.indexOf(classDelim);
+        int contentIndex = template.indexOf(contentDelim);
+
+        try {
+            this.mPreStyle = template.substring(0, styleIndex);
+            this.mPreClass = template.substring(styleIndex + styleDelim.length(), classIndex);
+            this.mPreContent = template.substring(classIndex + classDelim.length(), contentIndex);
+            this.mPostContent = template.substring(contentIndex + contentDelim.length());
+        } catch (StringIndexOutOfBoundsException ex) {
+            throw new IllegalStateException("The card template had replacement string order, or content changed", ex);
+        }
     }
 
     @CheckResult
     @NonNull
     public String render(String content, String style, String cardClass) {
-        return mContent.replace("::content::", content).replace("::style::", style).replace("::class::", cardClass);
+        return mPreStyle + style + mPreClass + cardClass + mPreContent + content + mPostContent;
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/CardTemplateTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/CardTemplateTest.java
@@ -1,0 +1,71 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.cardviewer;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class CardTemplateTest {
+
+    private static final String data = "<!doctype html>\n" +
+            "<html class=\"mobile android linux js\">\n" +
+            "    <head>\n" +
+            "        <title>AnkiDroid Flashcard</title>\n" +
+            "        <meta charset=\"utf-8\">\n" +
+            "        <link rel=\"stylesheet\" type=\"text/css\" href=\"file:///android_asset/flashcard.css\">\n" +
+            "        <link rel=\"stylesheet\" type=\"text/css\" href=\"file:///android_asset/chess.css\">\n" +
+            "        <link rel=\"stylesheet\" type=\"text/css\" href=\"file:///android_asset/mathjax/mathjax.css\">\n" +
+            "        <style>\n" +
+            "        ::style::\n" +
+            "        </style>\n" +
+            "        <script src=\"file:///android_asset/mathjax/conf.js\"> </script>\n" +
+            "        <script src=\"file:///android_asset/mathjax/MathJax.js\"> </script>\n" +
+            "        <script src=\"file:///android_asset/scripts/card.js\" type=\"text/javascript\"> </script>\n" +
+            "    </head>\n" +
+            "    <body class=\"::class::\">\n" +
+            "        <div id=\"content\">\n" +
+            "        ::content::\n" +
+            "        </div>\n" +
+            "    </body>\n" +
+            "</html>\n";
+
+    @Test
+    public void replaceTest() {
+        // Method is sped up - ensure that it still works.
+        String content = "foo";
+        String style = "bar";
+        String cardClass = "baz";
+        String result = new CardTemplate(data).render(content, style, cardClass);
+
+        assertThat(result, is(data.replace("::content::", content).replace("::style::", style).replace("::class::", cardClass)));
+    }
+
+    @Test
+    public void stressTest() {
+        // At length = 10000000
+        // ~500ms before
+        // < 200 after
+        int stringLength = 1000;
+        String content = new String(new char[stringLength]).replace('\0', 'a');
+
+
+        String ret = new CardTemplate(data).render(content, content, content);
+    }
+
+}


### PR DESCRIPTION
## Purpose / Description

The code's been bugging me for a while due to the multiple `.replace` calls.

This is faster, but enforces an order on `card_template.html`. As this is controlled by us, I felt it was worth the risk.

I have confirmed that unit tests break if `card_template.html` is invalid.

```
java.lang.Exception: Main looper has queued unexecuted runnables. This might be the cause of the test failure. You might need a shadowOf(getMainLooper()).idle() call.

	at org.robolectric.android.internal.AndroidTestEnvironment.checkStateAfterTestFailure(AndroidTestEnvironment.java:502)
	at org.robolectric.RobolectricTestRunner$HelperTestRunner$1.evaluate(RobolectricTestRunner.java:581)
	at org.robolectric.internal.SandboxTestRunner$2.lambda$evaluate$0(SandboxTestRunner.java:263)
	at org.robolectric.internal.bytecode.Sandbox.lambda$runOnMainThread$0(Sandbox.java:89)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.IllegalStateException: The card template had replacement strings order, or content changed
	at com.ichi2.anki.cardviewer.CardTemplate.<init>(CardTemplate.java:45)
	at com.ichi2.anki.AbstractFlashcardViewer.onCollectionLoaded(AbstractFlashcardViewer.java:924)
	at com.ichi2.anki.AbstractFlashcardViewerTest.getViewer(AbstractFlashcardViewerTest.java:385)
	at com.ichi2.anki.AbstractFlashcardViewerTest.validEncodingSetsAnswerCorrectly(AbstractFlashcardViewerTest.java:315)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.robolectric.RobolectricTestRunner$HelperTestRunner$1.evaluate(RobolectricTestRunner.java:575)
	... 6 more
Caused by: java.lang.StringIndexOutOfBoundsException: String index out of range: -87
	at java.lang.String.substring(String.java:1967)
	at com.ichi2.anki.cardviewer.CardTemplate.<init>(CardTemplate.java:41)
	... 21 more
```

## How Has This Been Tested?
Unit tested

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] Strings resources: All strings added as resources are unique or contain a comment for seemingly duplicate strings to explain the difference between both resources
