### PR TITLE
Fix overflow menu background

### DIFF
--- a/AnkiDroid/src/main/res/values/attrs.xml
+++ b/AnkiDroid/src/main/res/values/attrs.xml
@@ -21,7 +21,6 @@
      specifically for action bar text color isn't necessary, but it simplifies the color setting
      while making it accessible everywhere and eases the use of themes -->
     <attr name="actionBarTextColor" format="color"/> <!-- For title and subtitle, and any other text that may appear in action bar-->
-    <attr name="actionBarPopupBackgroundColor" format="color"/>
     <attr name="actionBarPopupTextColor" format="color"/>
 
     <!-- Custom preferences -->

--- a/AnkiDroid/src/main/res/values/styles.xml
+++ b/AnkiDroid/src/main/res/values/styles.xml
@@ -109,7 +109,6 @@
     <!-- For all other action bar popups like overflow menu (except spinner dropdown in Lollipop). -->
     <style name="ActionBar.Popup" parent="Base.ThemeOverlay.AppCompat.ActionBar">
         <item name="android:drawSelectorOnTop">true</item>
-        <item name="android:background">?attr/actionBarPopupBackgroundColor</item>
         <item name="android:textColorPrimary">?attr/actionBarPopupTextColor</item>
         <item name="android:textColorSecondary">?attr/actionBarPopupTextColor</item>
     </style>

--- a/AnkiDroid/src/main/res/values/theme_black.xml
+++ b/AnkiDroid/src/main/res/values/theme_black.xml
@@ -32,7 +32,6 @@
         <item name="windowNoTitle">true</item>
         <item name="windowActionModeOverlay">true</item>
         <item name="actionBarTextColor">@color/white</item>
-        <item name="actionBarPopupBackgroundColor">@color/theme_black_primary_light</item>
         <item name="actionBarPopupTextColor">@color/theme_black_primary_text</item>
         <item name="actionModeBackground">@color/theme_black_primary_dark</item>
         <!-- Deck list colors and divider -->

--- a/AnkiDroid/src/main/res/values/theme_dark.xml
+++ b/AnkiDroid/src/main/res/values/theme_dark.xml
@@ -37,7 +37,6 @@
         <item name="windowNoTitle">true</item>
         <item name="windowActionModeOverlay">true</item>
         <item name="actionBarTextColor">@color/white</item>
-        <item name="actionBarPopupBackgroundColor">@color/theme_dark_primary</item>
         <item name="actionBarPopupTextColor">@color/theme_dark_primary_text</item>
         <item name="actionModeBackground">@color/theme_dark_primary</item>
         <!-- Deck list colors and divider -->

--- a/AnkiDroid/src/main/res/values/theme_light.xml
+++ b/AnkiDroid/src/main/res/values/theme_light.xml
@@ -50,7 +50,6 @@ APIs. It's visible when there aren't enough decks to fill the screen.
         <item name="windowNoTitle">true</item>
         <item name="windowActionModeOverlay">true</item>
         <item name="actionBarTextColor">@color/white</item>
-        <item name="actionBarPopupBackgroundColor">@color/white</item>
         <item name="actionBarPopupTextColor">@color/theme_light_primary_text</item>
         <item name="actionModeBackground">@color/theme_light_primary</item>
         <!-- Deck list colors and divider -->

--- a/AnkiDroid/src/main/res/values/theme_plain.xml
+++ b/AnkiDroid/src/main/res/values/theme_plain.xml
@@ -20,7 +20,6 @@
         <item name="largeButtonBackgroundColorFocused">#587180</item>
         <item name="largeButtonBackgroundColorPressed">#475C66</item>
         <!-- Action bar styles -->
-        <item name="actionBarPopupBackgroundColor">@color/theme_plain_primary_light</item>
         <item name="actionBarPopupTextColor">@color/theme_plain_primary_text</item>
         <item name="actionModeBackground">@color/theme_plain_primary</item>
         <!-- Reviewer colors -->


### PR DESCRIPTION
this is more of an issue report than a pull request, but the attached changes fix the problem for me

i did **NOT** test this on any other devices or android versions

this removes changes introduced by @hssm in 448ea4fb5b04f9e1e83063a69c469ea92c569f16 so perhaps they might want to review this

## Purpose / Description
when the overflow menu is animated in, instead of it simply sliding into place, in that place a static rectangle appears with the same color as the menu, and then the menu slides into that. this looks pretty bad on my device (nearly pure android). also the resulting menu lacks rounded colors.

either everyone else is not annoyed by this (unlikely) or it only happens for me (likely)

## Fixes
removed the background for the menu target area along with the relevant elements

## Approach
the menu has its own background. the target area behind it doesn't need to have a background so i removed it

## How Has This Been Tested?

visually tested on my device (xiaomi mi a2, android one, android 10), all themes work fine

ran `gradlew jacocoUnitTestReport`

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings) — there's way too many screens, so i'm including only one screenshot. note that on my particular device things are not as rounded by default https://i.imgur.com/DHfDa3i.png
- [ ] Strings resources: All strings added as resources are unique or contain a comment for seemingly duplicate strings to explain the difference between both resources
