### PR TITLE
BugFix: Handle openUrl if browser is not exported

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.java
@@ -165,13 +165,7 @@ public class MyAccount extends AnkiActivity {
 
 
     private void resetPassword() {
-        if (AdaptionUtil.hasWebBrowser(this)) {
-            Intent intent = new Intent(Intent.ACTION_VIEW);
-            intent.setData(Uri.parse(getResources().getString(R.string.resetpw_url)));
-            startActivityWithoutAnimation(intent);
-        } else {
-            UIUtils.showThemedToast(this, getResources().getString(R.string.no_browser_notification) + getResources().getString(R.string.resetpw_url), false);
-        }
+        super.openUrl(Uri.parse(getResources().getString(R.string.resetpw_url)));
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/compat/customtabs/CustomTabsFallback.java
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/customtabs/CustomTabsFallback.java
@@ -17,13 +17,26 @@ import android.app.Activity;
 import android.content.Intent;
 import android.net.Uri;
 
+import com.ichi2.anki.AnkiDroidApp;
+import com.ichi2.anki.R;
+import com.ichi2.anki.UIUtils;
+
 /**
  * A Fallback that opens a Webview when Custom Tabs is not available
  */
 public class CustomTabsFallback implements CustomTabActivityHelper.CustomTabFallback {
     @Override
     public void openUri(Activity activity, Uri uri) {
-        Intent intent = new Intent(Intent.ACTION_VIEW, uri);
-        activity.startActivity(intent);
+        try {
+            Intent intent = new Intent(Intent.ACTION_VIEW, uri);
+            activity.startActivity(intent);
+        } catch (Exception e) {
+            // This can occur if the provider is not exported: #7721
+            // this should not happen as we don't reach here if there's no valid browser.
+            // and I assume an exported intent will take priority over a non-exported intent.
+            // Add an exception report to see if I'm wrong
+            AnkiDroidApp.sendExceptionReport(e, "CustomTabsFallback::openUri");
+            UIUtils.showThemedToast(activity, activity.getString(R.string.web_page_error, uri), false);
+        }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/AdaptionUtil.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/AdaptionUtil.java
@@ -86,6 +86,10 @@ public class AdaptionUtil {
         PackageManager pm = context.getPackageManager();
         List<ResolveInfo> list = pm.queryIntentActivities(intent, PackageManager.MATCH_DEFAULT_ONLY);
         for (ResolveInfo ri : list) {
+            if (!isValidBrowser(ri)) {
+                continue;
+            }
+
             // If we aren't a restricted device, any browser will do
             if (!isRestrictedLearningDevice()) {
                 return true;
@@ -97,6 +101,12 @@ public class AdaptionUtil {
         }
         // Either there are no web browsers, or we're a restricted learning device and there's no system browsers.
         return false;
+    }
+
+
+    private static boolean isValidBrowser(ResolveInfo ri) {
+        // https://stackoverflow.com/a/57223246/
+        return ri != null && ri.activityInfo != null && ri.activityInfo.exported;
     }
 
 

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -257,6 +257,7 @@
     <string name="activity_start_failed">The system does not have an app installed that can perform this action.</string>
     <string name="multimedia_editor_image_compression_failed"><![CDATA[Camera images may be large. You may wish to compress & resize images in the media directory]]></string>
     <string name="no_browser_notification">No browser found，please visit web page by pc or mobile: </string>
+    <string name="web_page_error">Error loading page: %s</string>
     <string name="no_outgoing_link_in_cardbrowser">External page link in card is not supported.</string>
     <!-- The name of the deck which corrupt cards will be moved to -->
     <string name="check_integrity_recovered_deck_name">Recovered Cards</string>


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
If an ACTION_VIEW intent for a URI was not exported and used, it would crash.

Someone seems to have MXPlayer installed, and likely no other browser?

## Fixes
Fixes #7721

## Approach
Show a "No Browser Installed" if the browser intent is not exported

## How Has This Been Tested?

API 16 emulator - browser fails regardless as it's too old, but still opens.

![image](https://user-images.githubusercontent.com/62114487/99660833-d55d0b00-2a5a-11eb-9ea2-ae5c75a61d82.png)


## Learning (optional, can help others)
I don't get why the intent was selected at all, but oh well.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] Strings resources: All strings added as resources are unique or contain a comment for seemingly duplicate strings to explain the difference between both resources
