### PR TITLE
Replace menu string “Options” with either “Deck options” or “Study options”

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
@@ -309,8 +309,8 @@ public class StudyOptionsFragment extends Fragment implements Toolbar.OnMenuItem
             Timber.i("StudyOptionsFragment:: Undo button pressed");
             CollectionTask.launchCollectionTask(UNDO, undoListener);
             return true;
-        } else if (itemId == R.id.action_deck_options) {
-            Timber.i("StudyOptionsFragment:: Deck options button pressed");
+        } else if (itemId == R.id.action_deck_or_study_options) {
+            Timber.i("StudyOptionsFragment:: Deck or study options button pressed");
             if (getCol().getDecks().isDyn(getCol().getDecks().selected())) {
                 openFilteredDeckOptions();
             } else {
@@ -369,10 +369,12 @@ public class StudyOptionsFragment extends Fragment implements Toolbar.OnMenuItem
                 menu.findItem(R.id.action_rebuild).setVisible(true);
                 menu.findItem(R.id.action_empty).setVisible(true);
                 menu.findItem(R.id.action_custom_study).setVisible(false);
+                menu.findItem(R.id.action_deck_or_study_options).setTitle(R.string.menu__study_options);
             } else {
                 menu.findItem(R.id.action_rebuild).setVisible(false);
                 menu.findItem(R.id.action_empty).setVisible(false);
                 menu.findItem(R.id.action_custom_study).setVisible(true);
+                menu.findItem(R.id.action_deck_or_study_options).setTitle(R.string.menu__deck_options);
             }
             // Don't show custom study icon if congrats shown
             if (mCurrentContentView == CONTENT_CONGRATS) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
@@ -302,7 +302,7 @@ public class CustomStudyDialog extends AnalyticsDialogFragment {
         keyValueMap.put(CUSTOM_STUDY_RANDOM, res.getString(R.string.custom_study_random_selection));
         keyValueMap.put(CUSTOM_STUDY_PREVIEW, res.getString(R.string.custom_study_preview_new));
         keyValueMap.put(CUSTOM_STUDY_TAGS, res.getString(R.string.custom_study_limit_tags));
-        keyValueMap.put(DECK_OPTIONS, res.getString(R.string.study_options));
+        keyValueMap.put(DECK_OPTIONS, res.getString(R.string.menu__deck_options));
         keyValueMap.put(MORE_OPTIONS, res.getString(R.string.more_options));
         return keyValueMap;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.java
@@ -98,7 +98,7 @@ public class DeckPickerContextMenu extends AnalyticsDialogFragment {
         Resources res = getResources();
         HashMap<Integer, String> keyValueMap = new HashMap<>();
         keyValueMap.put(CONTEXT_MENU_RENAME_DECK, res.getString(R.string.rename_deck));
-        keyValueMap.put(CONTEXT_MENU_DECK_OPTIONS, res.getString(R.string.study_options));
+        keyValueMap.put(CONTEXT_MENU_DECK_OPTIONS, res.getString(R.string.menu__deck_options));
         keyValueMap.put(CONTEXT_MENU_CUSTOM_STUDY, res.getString(R.string.custom_study));
         keyValueMap.put(CONTEXT_MENU_DELETE_DECK, res.getString(R.string.contextmenu_deckpicker_delete_deck));
         keyValueMap.put(CONTEXT_MENU_EXPORT_DECK, res.getString(R.string.export_deck));

--- a/AnkiDroid/src/main/res/menu-television/reviewer.xml
+++ b/AnkiDroid/src/main/res/menu-television/reviewer.xml
@@ -129,7 +129,7 @@
         android:visible="false"/>
     <item
         android:id="@+id/action_open_deck_options"
-        android:title="@string/study_options" />
+        android:title="@string/menu__deck_options" />
     <item
         android:id="@+id/action_select_tts"
         android:title="@string/select_tts"

--- a/AnkiDroid/src/main/res/menu/reviewer.xml
+++ b/AnkiDroid/src/main/res/menu/reviewer.xml
@@ -121,7 +121,7 @@
         android:visible="false"/>
     <item
         android:id="@+id/action_open_deck_options"
-        android:title="@string/study_options" />
+        android:title="@string/menu__deck_options" />
     <item
         android:id="@+id/action_select_tts"
         android:title="@string/select_tts"

--- a/AnkiDroid/src/main/res/menu/study_options_fragment.xml
+++ b/AnkiDroid/src/main/res/menu/study_options_fragment.xml
@@ -27,9 +27,10 @@
         android:id="@+id/action_rename"
         android:title="@string/rename_deck"
         android:visibility = "gone"/>
+    <!-- the title for the following option will be set dynamically -->
     <item
-        android:id="@+id/action_deck_options"
-        android:title="@string/study_options"/>
+        android:id="@+id/action_deck_or_study_options"
+        android:title="@string/menu__deck_options"/>
     <item
         android:id="@+id/action_delete"
         android:title="@string/contextmenu_deckpicker_delete_deck"

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -191,7 +191,9 @@
     <string name="export_unsuccessful">Error exporting apkg file</string>
     <string name="import_hint">Place the apkg file in directory “%s” and touch “OK” to import cards</string>
     <string name="upgrade_import_no_file_found">No importable %1$s file found</string>
-    <string name="study_options" comment="Menu entry to open an options menu">Options</string>
+    <string name="study_options" comment="Name for a preference category in Filtered deck (aka Cram deck, aka Custom study) options">Options</string>
+    <string name="menu__deck_options">Deck options</string>
+    <string name="menu__study_options" comment="Menu item that opens options for a Filtered deck (aka Cram deck, aka Custom study)">Study options</string>
     <string name="select_tts">Set TTS language</string>
     <string name="custom_study">Custom study</string>
     <string name="more_options">More</string>

--- a/AnkiDroid/src/main/res/xml/preferences_custom_buttons.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_custom_buttons.xml
@@ -89,7 +89,7 @@ TODO: Add a unit test
             android:entries="@array/custom_button_labels_menu_and_disabled"
             android:entryValues="@array/custom_button_values_menu_and_disabled"
             android:key="customButtonDeckOptions"
-            android:title="@string/study_options" />
+            android:title="@string/menu__deck_options" />
         <ListPreference
             android:defaultValue="1"
             android:entries="@array/custom_button_labels"


### PR DESCRIPTION
***WARNING**: although i tested this to the best of my understanding of the app, it has many menus and functionality that i personally don't use so i might have missed something. particularly, i don't have a tablet*

the new strings "Deck options" and "Study options" replace the string "Options" that is ambiguous andd can be confused with "Settings".

## Purpose / Description
the word "options" ("preferences", "settings") when used by itself usually means global settings. i think it helps to clarify the intent behind it otherwise

## Approach
created new strings for "Deck options" and "Study options". the string "Options" (`study_options`) remains as a preference category. as per the wiki i did not rename its key, but i changed the comment. (i think it'd be nice to rename the key also.) in StudyOptionsFragment, the string for menu item `action_deck_or_study_options` is set dynamically.

## How Has This Been Tested?

visually on my device, also ran `gradlew jacocoUnitTestReport`

i did **NOT** test this on a tablet as i don't have one

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings): hopefully didn't miss any https://x0.at/ckl.zip
- [x] Strings resources: All strings added as resources are unique or contain a comment for seemingly duplicate strings to explain the difference between both resources
