### PR TITLE
"Undo" feature: Fix race condition

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -65,11 +65,11 @@ import java.util.Collections;
 import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.LinkedBlockingDeque;
 import java.util.regex.Pattern;
 
 import androidx.annotation.CheckResult;
@@ -121,7 +121,8 @@ public class Collection {
     private JSONObject mConf;
     // END: SQL table columns
 
-    private LinkedList<Undoable> mUndo;
+    // API 21: Use a ConcurrentLinkedDeque
+    private LinkedBlockingDeque<Undoable> mUndo;
 
     private final String mPath;
     private boolean mDebugLog;
@@ -1340,7 +1341,7 @@ public class Collection {
      * wasLeech should have been recorded for each card, not globally
      */
     public void clearUndo() {
-        mUndo = new LinkedList<>();
+        mUndo = new LinkedBlockingDeque<>();
     }
 
 


### PR DESCRIPTION
There appears to be a race condition in `LinkedList.unlinkFirst`

We can't use a `synchronizedList` here, as we want the Linked List
specific methods, so use a lock.

Fixes #7723

Waiting for #7727 