### PR TITLE
Sched: Handle suspended cards in filtered decks

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -146,8 +146,6 @@ import java.util.TreeMap;
 
 import timber.log.Timber;
 
-import static com.ichi2.anki.services.ReminderService.EXTRA_DECK_OPTION_ID;
-import static com.ichi2.anki.services.ReminderService.getReviewDeckIntent;
 import static com.ichi2.async.CollectionTask.TASK_TYPE.*;
 import static com.ichi2.async.Connection.ConflictResolution.FULL_DOWNLOAD;
 
@@ -2317,7 +2315,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
         } else if (getCol().getDecks().isDyn(did)) {
             // Go to the study options screen if filtered deck with no cards to study
             openStudyOptions(false);
-        } else if (!deckDueTreeNode.hasChildren() && getCol().cardCount(new Long[]{did}) == 0) {
+        } else if (!deckDueTreeNode.hasChildren() && getCol().isEmptyDeck(did)) {
             // If the deck is empty and has no children then show a message saying it's empty
             final Uri helpUrl = Uri.parse(getResources().getString(R.string.link_manual_getting_started));
             mayOpenUrl(helpUrl);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1024,8 +1024,12 @@ public class Collection {
 
 
     // NOT IN LIBANKI //
-    public int cardCount(Long[] ls) {
-        return mDb.queryScalar("SELECT count() FROM cards WHERE did IN " + Utils.ids2str(ls));
+    public int cardCount(Long... dids) {
+        return mDb.queryScalar("SELECT count() FROM cards WHERE did IN " + Utils.ids2str(dids));
+    }
+
+    public boolean isEmptyDeck(Long... dids) {
+        return cardCount(dids) == 0;
     }
 
 

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/libanki/CollectionAssert.java
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/libanki/CollectionAssert.java
@@ -1,0 +1,30 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.testutils.libanki;
+
+import com.ichi2.libanki.Collection;
+import com.ichi2.libanki.Consts;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNot.not;
+
+public class CollectionAssert {
+    public static void assertSuspended(Collection collection, long cardId) {
+        assertThat("Card should be suspended", collection.getCard(cardId).getQueue(), is(Consts.QUEUE_TYPE_SUSPENDED));
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/libanki/FilteredDeckUtil.java
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/libanki/FilteredDeckUtil.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.testutils.libanki;
+
+import com.ichi2.libanki.Collection;
+import com.ichi2.libanki.DeckConfig;
+
+public class FilteredDeckUtil {
+    public static long createFilteredDeck(Collection col, String name, String search) {
+        long filteredDid = col.getDecks().newDyn(name);
+
+        DeckConfig conf = col.getDecks().confForDid(filteredDid);
+
+        conf.getJSONArray("terms").getJSONArray(0).put(0, search);
+
+        col.getDecks().updateConf(conf);
+
+        return filteredDid;
+    }
+}


### PR DESCRIPTION
## Purpose / Description
Suspended cards were unsuspended when in a filtered deck and the deck was emptied/rebuilt. Now they're not.

## Fixes
Fixes #7730 

## Approach
Suspended cards are now removed from the filtered decks when emptied/rebuilt and stay suspended

Applies ankitects/anki@fe493e3


## How Has This Been Tested?
Unit tested only

## Learning (optional, can help others)
https://anki.tenderapp.com/discussions/ankidesktop/38247-bug-suspended-cards-automatically-included-in-the-filtered-decks

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] Strings resources: All strings added as resources are unique or contain a comment for seemingly duplicate strings to explain the difference between both resources