### PR TITLE
WebView Exception: show nested exceptions

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -47,6 +47,7 @@ import com.ichi2.anki.services.BootService;
 import com.ichi2.anki.services.NotificationService;
 import com.ichi2.compat.CompatHelper;
 import com.ichi2.utils.AdaptionUtil;
+import com.ichi2.utils.ExceptionUtil;
 import com.ichi2.utils.LanguageUtil;
 import com.ichi2.anki.analytics.UsageAnalytics;
 import com.ichi2.utils.Permissions;
@@ -632,7 +633,7 @@ public class AnkiDroidApp extends MultiDexApplication {
             Timber.w("getWebViewExceptionMessage called without webViewFailedToLoad check");
             return null;
         }
-        return error.getLocalizedMessage();
+        return ExceptionUtil.getExceptionMessage(error);
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ExceptionUtil.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ExceptionUtil.java
@@ -16,6 +16,9 @@
 
 package com.ichi2.utils;
 
+import androidx.annotation.CheckResult;
+import androidx.annotation.NonNull;
+
 public class ExceptionUtil {
     public static boolean containsMessage(Throwable e, String needle) {
         if (e == null) {
@@ -28,5 +31,21 @@ public class ExceptionUtil {
 
         String message = e.getMessage();
         return message != null && message.contains(needle);
+    }
+
+    @NonNull
+    @CheckResult
+    public static String getExceptionMessage(Throwable e) {
+        StringBuilder ret = new StringBuilder();
+        Throwable cause = e;
+        while (cause != null) {
+            if (cause != e) {
+                ret.append("\n");
+            }
+            ret.append(cause.getLocalizedMessage());
+            cause = cause.getCause();
+        }
+
+        return ret.toString();
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/utils/ExceptionUtilTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/ExceptionUtilTest.java
@@ -1,0 +1,51 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.utils;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+public class ExceptionUtilTest {
+
+    @Test
+    public void exceptionMessageSingle() {
+        Exception e = new Exception("Hello");
+
+        String message = ExceptionUtil.getExceptionMessage(e);
+
+        assertThat(message, is("Hello"));
+    }
+
+    @Test
+    public void exceptionMessageNested() {
+        Exception inner = new Exception("Inner");
+        Exception e = new Exception("Hello", inner);
+
+        String message = ExceptionUtil.getExceptionMessage(e);
+
+        assertThat(message, is("Hello\nInner"));
+    }
+
+    @Test
+    public void exceptionMessageNull() {
+        String message = ExceptionUtil.getExceptionMessage(null);
+
+        assertThat(message, is(""));
+    }
+}


### PR DESCRIPTION
## Purpose / Description
An InvocationTargetException had no message, but the nested exception did

## Fixes
Fixes #7739

## Approach
Walk the tree to get all the messages

## How Has This Been Tested?

Unit tests

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)