### PR TITLE
Move "Sync" to right of action bar

### DIFF
--- a/AnkiDroid/src/main/res/menu/deck_picker.xml
+++ b/AnkiDroid/src/main/res/menu/deck_picker.xml
@@ -1,16 +1,20 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:ankidroid="http://schemas.android.com/apk/res-auto" >
     <item
-        android:id="@+id/action_sync"
-        android:icon="@drawable/ic_sync_white_24dp"
-        android:title="@string/button_sync"
-        ankidroid:showAsAction="always"/>
-    <item
         android:id="@+id/deck_picker_action_filter"
         android:icon="@drawable/ic_search_white_24dp"
         android:title="@string/search_decks"
         ankidroid:actionViewClass="androidx.appcompat.widget.SearchView"
         ankidroid:showAsAction="always|collapseActionView"/>
+    <!--
+    We want sync on the right, to be consistent with past version: #7737.
+    We're OK to do this as we're using "always" so it won't be hidden
+    -->
+    <item
+        android:id="@+id/action_sync"
+        android:icon="@drawable/ic_sync_white_24dp"
+        android:title="@string/button_sync"
+        ankidroid:showAsAction="always"/>
     <item
         android:id="@+id/action_undo"
         android:icon="@drawable/ic_undo_white_24dp"


### PR DESCRIPTION
I was originally concerned that menu items may be hidden if there are too many.
Sync is most important, so it should be at the "top" of the priority list,
which makes it on the left.

But, as we're using "always show", this shouldn't be a problem

Fixes #7737 

![image](https://user-images.githubusercontent.com/62114487/99885284-aea1fe80-2c2b-11eb-85c9-2b3a51c7903a.png)

