### PR TITLE
Note Editor Image Paste: Handle invalid filename

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -27,7 +27,6 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.content.res.Resources;
-import android.database.Cursor;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
@@ -42,7 +41,6 @@ import androidx.annotation.StringRes;
 import androidx.annotation.VisibleForTesting;
 import androidx.appcompat.widget.PopupMenu;
 
-import android.provider.MediaStore;
 import android.text.Editable;
 import android.text.TextUtils;
 import android.text.TextWatcher;
@@ -103,6 +101,7 @@ import com.ichi2.themes.StyledProgressDialog;
 import com.ichi2.themes.Themes;
 import com.ichi2.anki.widgets.PopupMenuWithIcons;
 import com.ichi2.utils.AdaptionUtil;
+import com.ichi2.utils.ContentResolverUtil;
 import com.ichi2.utils.DeckComparator;
 import com.ichi2.utils.FileUtil;
 import com.ichi2.utils.FunctionalInterfaces.Consumer;
@@ -1541,11 +1540,7 @@ public class NoteEditor extends AnkiActivity {
     private String loadImageIntoCollection(Uri uri) throws IOException {
         //noinspection PointlessArithmeticExpression
         final int oneMegabyte = 1 * 1000 * 1000;
-        String filename;
-        try (Cursor c = getContentResolver().query(uri, new String[] { MediaStore.MediaColumns.DISPLAY_NAME }, null, null, null)) {
-            c.moveToNext();
-            filename = c.getString(0);
-        }
+        String filename = ContentResolverUtil.getFileName(getContentResolver(), uri);
         InputStream fd = getContentResolver().openInputStream(uri);
 
         Map.Entry<String, String> fileNameAndExtension = FileUtil.getFileNameAndExtension(filename);

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ContentResolverUtil.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ContentResolverUtil.java
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.utils;
+
+import android.content.ContentResolver;
+import android.database.Cursor;
+import android.net.Uri;
+import android.provider.MediaStore;
+
+import androidx.annotation.CheckResult;
+
+public class ContentResolverUtil {
+    @CheckResult
+    public static String getFileName(ContentResolver contentResolver, Uri uri) {
+        String filename;
+        try (Cursor c = contentResolver.query(uri, new String[] { MediaStore.MediaColumns.DISPLAY_NAME }, null, null, null)) {
+            c.moveToNext();
+            filename = c.getString(0);
+        }
+        return filename;
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/utils/ContentResolverUtilTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/ContentResolverUtilTest.java
@@ -1,0 +1,92 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.utils;
+
+import android.content.ContentResolver;
+import android.database.Cursor;
+import android.database.sqlite.SQLiteException;
+import android.net.Uri;
+import android.webkit.MimeTypeMap;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Shadows;
+
+import androidx.annotation.NonNull;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static android.content.ContentResolver.SCHEME_CONTENT;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(AndroidJUnit4.class) // needs a URI instance
+public class ContentResolverUtilTest {
+
+    @Test
+    public void testViaQueryWorking() {
+        Uri uri = Uri.parse("http://example.com/test.jpeg");
+        ContentResolver mock = mock(ContentResolver.class);
+
+        setQueryReturning(mock, cursorReturning("filename_from_cursor.jpg"));
+
+        String filename = ContentResolverUtil.getFileName(mock, uri);
+
+        assertThat(filename, is("filename_from_cursor.jpg"));
+    }
+
+    @Test
+    public void testViaMimeType() {
+        // #7748: Query can fail on some phones, so fall back to MIME
+        // values obtained via: content://com.google.android.inputmethod.latin.fileprovider/content/tenor_gif/tenor_gif187746302992141903.gif
+        Uri uri = mock(Uri.class);
+        when(uri.getScheme()).thenReturn(SCHEME_CONTENT);
+
+        ContentResolver mock = mock(ContentResolver.class);
+        setQueryThrowing(mock, new SQLiteException("no such column: _display_name (code 1 SQLITE_ERROR[1]): , " +
+                "while compiling: SELECT _display_name FROM ClipboardImageTable WHERE (id=855) ORDER BY _data"));
+
+        when(mock.getType(any())).thenReturn("image/gif");
+        // required for Robolectric
+        Shadows.shadowOf(MimeTypeMap.getSingleton()).addExtensionMimeTypMapping("gif", "image/gif");
+
+        String filename = ContentResolverUtil.getFileName(mock, uri);
+
+
+        // maybe we could do better here, but general guidance is to not parse the uri string
+        assertThat(filename, is("image.gif"));
+    }
+
+
+    @NonNull
+    protected Cursor cursorReturning(@SuppressWarnings("SameParameterValue") String value) {
+        Cursor cursor = mock(Cursor.class);
+        when(cursor.getString(0)).thenReturn(value);
+        return cursor;
+    }
+
+
+    protected void setQueryReturning(ContentResolver mock, Cursor cursorToReturn) {
+        when(mock.query(any(), any(), any(), any(), any())).thenReturn(cursorToReturn);
+    }
+
+    protected void setQueryThrowing(ContentResolver mock, Throwable ex) {
+        when(mock.query(any(), any(), any(), any(), any())).thenThrow(ex);
+    }
+}


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
Obtaining the filename for a pasted image could throw a `SQLiteException`.

## Fixes
Fixes #7748 

## Approach
* Obtain the MIME type
* If this throws, the throw - it's caught, and we get the logcat of both the old and new exception

## How Has This Been Tested?

Unit tested - new code works on my Android 9

## Learning (optional, can help others)

https://stackoverflow.com/questions/8589645/how-to-determine-mime-type-of-file-in-android

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)