### PR TITLE
[BugFix] Android 8: Fix Missing menu items

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -678,15 +678,6 @@ public class DeckPicker extends NavigationDrawerActivity implements
         if (CollectionHelper.getInstance().getColSafe(this) == null) {
             return false;
         }
-        // Show / hide undo
-        if (mFragmented || !getCol().undoAvailable()) {
-            menu.findItem(R.id.action_undo).setVisible(false);
-        } else {
-            Resources res = getResources();
-            menu.findItem(R.id.action_undo).setVisible(true);
-            String undo = res.getString(R.string.studyoptions_congrats_undo, getCol().undoName(res));
-            menu.findItem(R.id.action_undo).setTitle(undo);
-        }
         return super.onPrepareOptionsMenu(menu);
     }
 
@@ -726,6 +717,18 @@ public class DeckPicker extends NavigationDrawerActivity implements
                 return true;
             }
         });
+
+        if (colIsOpen()) {
+            // Show / hide undo
+            if (mFragmented || !getCol().undoAvailable()) {
+                menu.findItem(R.id.action_undo).setVisible(false);
+            } else {
+                Resources res = getResources();
+                menu.findItem(R.id.action_undo).setVisible(true);
+                String undo = res.getString(R.string.studyoptions_congrats_undo, getCol().undoName(res));
+                menu.findItem(R.id.action_undo).setTitle(undo);
+            }
+        }
 
         return super.onCreateOptionsMenu(menu);
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Statistics.java
@@ -155,31 +155,25 @@ public class Statistics extends NavigationDrawerActivity implements DeckDropDown
         //System.err.println("in onCreateOptionsMenu");
         MenuInflater inflater = getMenuInflater();
         inflater.inflate(R.menu.anki_stats, menu);
-        return true;
-    }
 
-
-    @Override
-    public boolean onPrepareOptionsMenu(Menu menu) {
         // exit if mTaskHandler not initialized yet
-        if (mTaskHandler == null) {
-            return true;
+        if (mTaskHandler != null) {
+            switch (mTaskHandler.getStatType()) {
+                case TYPE_MONTH:
+                    MenuItem monthItem = menu.findItem(R.id.item_time_month);
+                    monthItem.setChecked(true);
+                    break;
+                case TYPE_YEAR:
+                    MenuItem yearItem = menu.findItem(R.id.item_time_year);
+                    yearItem.setChecked(true);
+                    break;
+                case TYPE_LIFE:
+                    MenuItem lifeItem = menu.findItem(R.id.item_time_all);
+                    lifeItem.setChecked(true);
+                    break;
+            }
         }
-        switch (mTaskHandler.getStatType()) {
-            case TYPE_MONTH:
-                MenuItem monthItem = menu.findItem(R.id.item_time_month);
-                monthItem.setChecked(true);
-                break;
-            case TYPE_YEAR:
-                MenuItem yearItem = menu.findItem(R.id.item_time_year);
-                yearItem.setChecked(true);
-                break;
-            case TYPE_LIFE:
-                MenuItem lifeItem = menu.findItem(R.id.item_time_all);
-                lifeItem.setChecked(true);
-                break;
-        }
-        return super.onPrepareOptionsMenu(menu);
+        return super.onCreateOptionsMenu(menu);
     }
 
     @Override


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
onPrepareOptionsMenu bug

`menu.findItem(R.id.action_undo)` would return null on Android 8

Cause unknown. This should work around the issue.

## Fixes
Fixes #7755

## Approach
Stop using `onPrepareOptionsMenu`

## How Has This Been Tested?

Android 9  - couldn't repro on Android 8 emulators

## Learning (optional, can help others)
https://github.com/wordpress-mobile/WordPress-Android/issues/9748

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)