### PR TITLE
Add experimental support for dynamic import in Reviewer JS

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -228,7 +228,7 @@ dependencies {
     // noinspection GradleDependency - pinned at 1.12 until API26 minSdkVersion (File.toPath usage)
     implementation 'org.apache.commons:commons-compress:1.12' // #6419 - handle >2GB apkg files
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
-    implementation 'androidx.webkit:webkit:1.2.0'
+    implementation 'androidx.webkit:webkit:1.4.0'
 
 
     // May need a resolution strategy for support libs to our versions

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -228,6 +228,7 @@ dependencies {
     // noinspection GradleDependency - pinned at 1.12 until API26 minSdkVersion (File.toPath usage)
     implementation 'org.apache.commons:commons-compress:1.12' // #6419 - handle >2GB apkg files
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
+    implementation 'androidx.webkit:webkit:1.2.0'
 
 
     // May need a resolution strategy for support libs to our versions


### PR DESCRIPTION
## Purpose / Description
This PR should be seen with a grain of salt: I never worked with Android before, and my last Java experience is ten years back. So see this as a starting point :)

This PR addresses the issue, where the WebView in the reviewer can not load dynamic JavaScript modules via `import("<nameofmodule>")`. This is a really useful pattern in modern JavaScript, because it allows for asynchronous execution.

This is currently not possible on AnkiDroid, because you cannot request modules via the `file` scheme. 

With this PR, the user can use `import('https://appassets.androidplatform.net/<nameofmodule>.js')` to import modules from collection.media; and in fact even use `fetch('https://appassets.androidplatform.net/<nameoffile>')` to dynamically get files from the collection.media directory.

The prefix "https://appassets.androidplatform.net" comes from the custom implementation of WebViewAssetLoader. It seems like android reserves this URL particularly for this purpose. Having to use it is not really beautiful, but it's an OK compromise as I see it.

## Fixes
#7760

## Approach
This uses the [WebViewAssetLoader](https://developer.android.com/reference/androidx/webkit/WebViewAssetLoader) class to enable special handling of the url "https://appassets.androidplatform.net"

## How Has This Been Tested?
No test yet.

## Learning (optional, can help others)
[Docs for WebViewAssetLoader](https://developer.android.com/reference/androidx/webkit/WebViewAssetLoader)
[This is how I came up with overriding PathLoader](https://github.com/ionic-team/cordova-plugin-ionic-webview/issues/483)

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [~] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)