### PR TITLE
Note Editor: Add "Capitalize sentences" checkbox

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.java
@@ -11,6 +11,7 @@ import android.os.Build;
 import android.os.LocaleList;
 import android.os.Parcel;
 import android.os.Parcelable;
+import android.text.InputType;
 import android.util.AttributeSet;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnection;
@@ -250,6 +251,22 @@ public class FieldEditText extends FixedEditText {
 
         mOrd = ss.mOrd;
     }
+
+
+    public void setCapitalize(boolean value) {
+        int inputType = this.getInputType();
+        if (value) {
+            this.setInputType(inputType | InputType.TYPE_TEXT_FLAG_CAP_SENTENCES);
+        } else {
+            this.setInputType(inputType & ~InputType.TYPE_TEXT_FLAG_CAP_SENTENCES);
+        }
+    }
+
+
+    public boolean isCapitalized() {
+        return (this.getInputType() & InputType.TYPE_TEXT_FLAG_CAP_SENTENCES) == InputType.TYPE_TEXT_FLAG_CAP_SENTENCES;
+    }
+
 
     static class SavedState extends BaseSavedState {
         private int mOrd;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1091,6 +1091,7 @@ public class NoteEditor extends AnkiActivity {
         }
 
         menu.findItem(R.id.action_show_toolbar).setChecked(!shouldHideToolbar());
+        menu.findItem(R.id.action_capitalize).setChecked(AnkiDroidApp.getSharedPrefs(this).getBoolean("note_editor_capitalize", true));
 
         return super.onCreateOptionsMenu(menu);
     }
@@ -1138,8 +1139,21 @@ public class NoteEditor extends AnkiActivity {
             item.setChecked(!item.isChecked());
             AnkiDroidApp.getSharedPrefs(this).edit().putBoolean("noteEditorShowToolbar", item.isChecked()).apply();
             updateToolbar();
+        } else if (itemId == R.id.action_capitalize) {
+            Timber.i("NoteEditor:: Capitalize button pressed. New State: %b", !item.isChecked());
+            item.setChecked(!item.isChecked()); // Needed for Android 9
+            toggleCapitalize(item.isChecked());
+            return true;
         }
         return super.onOptionsItemSelected(item);
+    }
+
+
+    private void toggleCapitalize(boolean value) {
+        AnkiDroidApp.getSharedPrefs(this).edit().putBoolean("note_editor_capitalize", value).apply();
+        for (FieldEditText f : mEditFields) {
+            f.setCapitalize(value);
+        }
     }
 
 
@@ -1492,9 +1506,11 @@ public class NoteEditor extends AnkiActivity {
             edit_line_view.setHintLocale(getHintLocaleForField(edit_line_view.getName()));
             initFieldEditText(newTextbox, i, !editModelMode, clipboard);
             mEditFields.add(newTextbox);
-            if (AnkiDroidApp.getSharedPrefs(this).getInt("note_editor_font_size", -1) > 0) {
-                newTextbox.setTextSize(AnkiDroidApp.getSharedPrefs(this).getInt("note_editor_font_size", -1));
+            SharedPreferences prefs = AnkiDroidApp.getSharedPrefs(this);
+            if (prefs.getInt("note_editor_font_size", -1) > 0) {
+                newTextbox.setTextSize(prefs.getInt("note_editor_font_size", -1));
             }
+            newTextbox.setCapitalize(prefs.getBoolean("note_editor_capitalize", true));
 
             ImageButton mediaButton = edit_line_view.getMediaButton();
             // Load icons from attributes

--- a/AnkiDroid/src/main/res/menu/note_editor.xml
+++ b/AnkiDroid/src/main/res/menu/note_editor.xml
@@ -25,6 +25,12 @@
         android:title="@string/menu_font_size"
         ankidroid:showAsAction="never"/>
     <item
+        android:id="@+id/action_capitalize"
+        android:checkable="true"
+        android:checked="true"
+        android:title="@string/note_editor_capitalize"
+        ankidroid:showAsAction="never"/>
+    <item
         android:id="@+id/action_show_toolbar"
         android:title="@string/menu_show_toolbar"
         android:checkable="true"

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -360,4 +360,5 @@
     <string name="create_shortcut_error_vivo" comment="iManager is an app on Vivo phones">You may need to use iManager to allow AnkiDroid to add shortcuts</string>
     <string name="create_shortcut_failed" comment="home screen == launcher">Your home screen does not allow AnkiDroid to add shortcuts</string>
     <string name="create_shortcut_error">Error adding shortcut: %s</string>
+    <string name="note_editor_capitalize" comment="This is for a switch with a checkbox - on: enabled">Capitalize sentences</string>
 </resources>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.java
@@ -336,6 +336,14 @@ public class NoteEditorTest extends RobolectricTest {
         assertThat(editor.getFieldForTest(0).getText().toString(), is("12World45"));
     }
 
+    @Test
+    public void defaultsToCapitalized() {
+        // Requested in #3758, this seems like a sensible default
+        NoteEditor editor = getNoteEditorAddingNote(FromScreen.DECK_LIST, NoteEditor.class);
+
+        assertThat("Fields should have their first word capitalized by default", editor.getFieldForTest(0).isCapitalized(), is(true));
+    }
+
     private Intent getCopyNoteIntent(NoteEditor editor) {
         ShadowActivity editorShadow = Shadows.shadowOf(editor);
         editor.copyNote();


### PR DESCRIPTION
## Pull Request template

## Purpose / Description
"Capitalize" was requested, and "true" felt like a sensible default

Note that this differs from Anki Desktop (physical keyboards don't have a capitalize setting)

## Fixes
Fixes #3758

## Approach
Add a checkbox - Save this value in SharedPreferences to keep consistency

## How Has This Been Tested?
Android 9 device - keyboard switches when checkbox is pressed. Menu is consistent with preference value

![image](https://user-images.githubusercontent.com/62114487/100014068-c618ed00-2dcd-11eb-91b9-cdf831caa5c5.png)


## Learning
* I'm bad at days off
* https://stackoverflow.com/questions/4808705/first-letter-capitalization-for-edittext

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)