### PR TITLE
BugFix: NoteEditor: stop "C" opening preview

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -756,8 +756,8 @@ public class NoteEditor extends AnkiActivity {
                     if (!isClozeType()) {
                         UIUtils.showSimpleSnackbar(this, R.string.note_editor_insert_cloze_no_cloze_note_type, false);
                     }
-
                 }
+                break;
             }
             case KeyEvent.KEYCODE_P: {
                 if (event.isCtrlPressed()) {


### PR DESCRIPTION
Java has fall-through case statements

Fixes #7771