### PR TITLE
Note Editor: Paste image at cursor

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1351,20 +1351,13 @@ public class NoteEditor extends AnkiActivity {
                     mNote.setField(index, field);
                     FieldEditText fieldEditText = mEditFields.get(index);
                     // Completely replace text for text fields (because current text was passed in)
+                    String formattedValue = field.getFormattedValue();
                     if (field.getType() == EFieldType.TEXT) {
-                        fieldEditText.setText(field.getFormattedValue());
+                        fieldEditText.setText(formattedValue);
                     }
                     // Insert text at cursor position if the field has focus
                     else if (fieldEditText.getText() != null) {
-                        if (fieldEditText.hasFocus()) {
-                            fieldEditText.getText().replace(fieldEditText.getSelectionStart(),
-                                    fieldEditText.getSelectionEnd(),
-                                    field.getFormattedValue());
-                        }
-                        // Append text if the field doesn't have focus
-                        else {
-                            fieldEditText.getText().append(field.getFormattedValue());
-                        }
+                        insertStringInField(fieldEditText, formattedValue);
                     }
                     //DA - I think we only want to save the field here, not the note.
                     NoteService.saveMedia(col, mNote);
@@ -1398,6 +1391,21 @@ public class NoteEditor extends AnkiActivity {
             }
         }
     }
+
+    /** Appends a string at the selection point, or appends to the end if not in focus */
+    @VisibleForTesting
+    void insertStringInField(EditText fieldEditText, String formattedValue) {
+        if (fieldEditText.hasFocus()) {
+            fieldEditText.getText().replace(fieldEditText.getSelectionStart(),
+                    fieldEditText.getSelectionEnd(),
+                    formattedValue);
+        }
+        // Append text if the field doesn't have focus
+        else {
+            fieldEditText.getText().append(formattedValue);
+        }
+    }
+
 
     /** @param col Readonly variable to get cache dir */
     private MultimediaEditableNote getCurrentMultimediaEditableNote(Collection col) {
@@ -1510,7 +1518,7 @@ public class NoteEditor extends AnkiActivity {
             if (imageTag == null) {
                 return false;
             }
-            editText.getText().append(imageTag);
+            insertStringInField(editText, imageTag);
             return true;
         } catch (SecurityException ex) {
             // Tested under FB Messenger and GMail, both apps do nothing if this occurs.
@@ -2356,6 +2364,13 @@ public class NoteEditor extends AnkiActivity {
     @VisibleForTesting
     long getDeckId() {
         return mCurrentDid;
+    }
+
+
+    @SuppressWarnings("SameParameterValue")
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    FieldEditText getFieldForTest(int index) {
+        return mEditFields.get(index);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1396,9 +1396,11 @@ public class NoteEditor extends AnkiActivity {
     @VisibleForTesting
     void insertStringInField(EditText fieldEditText, String formattedValue) {
         if (fieldEditText.hasFocus()) {
-            fieldEditText.getText().replace(fieldEditText.getSelectionStart(),
-                    fieldEditText.getSelectionEnd(),
-                    formattedValue);
+            // Crashes if start > end, although this is fine for a selection via keyboard.
+            int start = fieldEditText.getSelectionStart();
+            int end = fieldEditText.getSelectionEnd();
+
+            fieldEditText.getText().replace(Math.min(start, end), Math.max(start, end), formattedValue);
         }
         // Append text if the field doesn't have focus
         else {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.java
@@ -20,6 +20,7 @@ import android.app.Activity;
 import android.app.Instrumentation;
 import android.content.Intent;
 import android.os.Bundle;
+import android.widget.EditText;
 import android.widget.TextView;
 
 import com.ichi2.anki.multimediacard.activity.MultimediaEditFieldActivity;
@@ -287,6 +288,21 @@ public class NoteEditorTest extends RobolectricTest {
         editor.clearField(1);
         assertThat(editor.getCurrentFieldStrings()[1], is(""));
 
+    }
+
+    @Test
+    public void insertIntoFocusedFieldStartsAtSelection() {
+        NoteEditor editor = getNoteEditorAddingNote(FromScreen.DECK_LIST, NoteEditor.class);
+
+        EditText field = editor.getFieldForTest(0);
+
+        editor.insertStringInField(field, "Hello");
+
+        field.setSelection(3);
+
+        editor.insertStringInField(field, "World");
+
+        assertThat(editor.getFieldForTest(0).getText().toString(), is("HelWorldlo"));
     }
 
     private Intent getCopyNoteIntent(NoteEditor editor) {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.java
@@ -305,6 +305,37 @@ public class NoteEditorTest extends RobolectricTest {
         assertThat(editor.getFieldForTest(0).getText().toString(), is("HelWorldlo"));
     }
 
+    @Test
+    public void insertIntoFocusedFieldReplacesSelection() {
+        NoteEditor editor = getNoteEditorAddingNote(FromScreen.DECK_LIST, NoteEditor.class);
+
+        EditText field = editor.getFieldForTest(0);
+
+        editor.insertStringInField(field, "12345");
+
+        field.setSelection(2, 3); //select "3"
+
+        editor.insertStringInField(field, "World");
+
+        assertThat(editor.getFieldForTest(0).getText().toString(), is("12World45"));
+    }
+
+    @Test
+    public void insertIntoFocusedFieldReplacesSelectionIfBackwards() {
+        // selections can be backwards if the user uses keyboards
+        NoteEditor editor = getNoteEditorAddingNote(FromScreen.DECK_LIST, NoteEditor.class);
+
+        EditText field = editor.getFieldForTest(0);
+
+        editor.insertStringInField(field, "12345");
+
+        field.setSelection(3, 2); //select "3" (right to left)
+
+        editor.insertStringInField(field, "World");
+
+        assertThat(editor.getFieldForTest(0).getText().toString(), is("12World45"));
+    }
+
     private Intent getCopyNoteIntent(NoteEditor editor) {
         ShadowActivity editorShadow = Shadows.shadowOf(editor);
         editor.copyNote();


### PR DESCRIPTION
Note: this will conflict due to double addition of getFieldForTest

## Purpose / Description
It's better if paste pastes at the cursor
This also raised a bug in the Multimedia edit implementation if a selection was made where start > end

## Fixes
Fixes #7770

## Approach
* Insert at cursor, or replace if selection
* Insert at end if field is not selected

## How Has This Been Tested?

Unit tested

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)