### PR TITLE
Keyboard Input: Handle Keys which require NumLock 

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/reviewer/PeripheralKeymapTest.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/reviewer/PeripheralKeymapTest.java
@@ -1,0 +1,60 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.reviewer;
+
+import android.view.KeyEvent;
+
+import com.ichi2.anki.cardviewer.ViewerCommand;
+import com.ichi2.anki.testutil.MockReviewerUi;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import androidx.annotation.NonNull;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+@RunWith(AndroidJUnit4.class)
+public class PeripheralKeymapTest {
+
+    @Test
+    public void testNumpadAction() {
+        // #7736 Ensures that a numpad key is passed through (mostly testing num lock)
+        List<Integer> processed = new ArrayList<>();
+
+        PeripheralKeymap peripheralKeymap = new PeripheralKeymap(MockReviewerUi.displayingAnswer(), processed::add);
+        peripheralKeymap.setup();
+
+        peripheralKeymap.onKeyUp(KeyEvent.KEYCODE_NUMPAD_1, getNumpadEvent(KeyEvent.KEYCODE_NUMPAD_1));
+
+
+        assertThat(processed, hasSize(1));
+        assertThat(processed.get(0), is(ViewerCommand.COMMAND_ANSWER_FIRST_BUTTON));
+    }
+
+
+    @NonNull
+    protected KeyEvent getNumpadEvent(@SuppressWarnings("SameParameterValue") int keycode) {
+        return new KeyEvent(0, 0, KeyEvent.ACTION_UP, keycode, 0, KeyEvent.META_NUM_LOCK_ON);
+    }
+}

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/testutil/MockReviewerUi.java
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/testutil/MockReviewerUi.java
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.testutil;
+
+import com.ichi2.anki.reviewer.ReviewerUi;
+
+public class MockReviewerUi implements ReviewerUi {
+    private boolean mDisplayingAnswer;
+
+
+    public static ReviewerUi displayingAnswer() {
+        MockReviewerUi mockReviewerUi = new MockReviewerUi();
+        mockReviewerUi.mDisplayingAnswer = true;
+        return mockReviewerUi;
+    }
+
+
+    @Override
+    public ControlBlock getControlBlocked() {
+        return null;
+    }
+
+
+    @Override
+    public boolean isControlBlocked() {
+        return false;
+    }
+
+
+    @Override
+    public boolean isDisplayingAnswer() {
+        return mDisplayingAnswer;
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/PeripheralKeymap.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/PeripheralKeymap.java
@@ -100,7 +100,7 @@ public class PeripheralKeymap {
             {
                 // passing in metaState: 0 means that Ctrl+1 returns '1' instead of '\0'
                 // NOTE: We do not differentiate on upper/lower case via KeyEvent.META_CAPS_LOCK_ON
-                int unicodeChar = event.getUnicodeChar(event.getMetaState() & KeyEvent.META_SHIFT_ON);
+                int unicodeChar = event.getUnicodeChar(event.getMetaState() & (KeyEvent.META_SHIFT_ON | KeyEvent.META_NUM_LOCK_ON));
                 List<PeripheralCommand> unicodeLookup = mUnicodeToCommand.get(unicodeChar);
                 if (unicodeLookup != null) {
                     for (PeripheralCommand command : unicodeLookup) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/PeripheralKeymap.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/PeripheralKeymap.java
@@ -57,7 +57,7 @@ public class PeripheralKeymap {
     }
 
 
-    @SuppressWarnings("unused")
+    @SuppressWarnings( {"unused", "RedundantSuppression"})
     public boolean onKeyDown(int keyCode, KeyEvent event) {
         return false;
     }


### PR DESCRIPTION
## Purpose / Description
A recent change had meant that NumLock was removed from `getUnicodeChar` - this was incorrect

## Fixes
Fixes #7736 

## Approach
Don't strip numlock when obtaining the unicode character to compare to.

## How Has This Been Tested?

Could not repro (no keyboard with numpad) - used Unit Test - passed on 2.13, failed on 2.14

Tested on API 16 emulator

## Learning (optional, can help others)
* It's a nightmare to test instrumented tests between 2.13 and 2.14 - gradle has changed the metadata format for builds, and this requires a reindex operation and full rebuild if you change branches.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)