### PR TITLE
Vivo Phones: Advise on create shortcut failure

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -2583,12 +2583,14 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
         try {
             boolean success = shortcutManager.requestPinShortcut(info, null);
+
+            // User report: "success" is true even if Vivo does not have permission
+            if (AdaptionUtil.isVivo()) {
+                UIUtils.showThemedToast(this, getString(R.string.create_shortcut_error_vivo), false);
+            }
+
             if (!success) {
-                if (AdaptionUtil.isVivo()) {
-                    UIUtils.showThemedToast(this, getString(R.string.create_shortcut_error_vivo), false);
-                } else {
-                    UIUtils.showThemedToast(this, getString(R.string.create_shortcut_failed), false);
-                }
+                UIUtils.showThemedToast(this, getString(R.string.create_shortcut_failed), false);
             }
         } catch (Exception e) {
             UIUtils.showThemedToast(this, getString(R.string.create_shortcut_error, e.getLocalizedMessage()), false);

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -355,7 +355,7 @@
         Android backup in progress. Please try again</string>
 
 
-    <string name="create_shortcut_error_vivo" comment="iManager is an app on Vivo phones">Please use iManager to allow AnkiDroid to add shortcuts</string>
+    <string name="create_shortcut_error_vivo" comment="iManager is an app on Vivo phones">You may need to use iManager to allow AnkiDroid to add shortcuts</string>
     <string name="create_shortcut_failed" comment="home screen == launcher">Your home screen does not allow AnkiDroid to add shortcuts</string>
     <string name="create_shortcut_error">Error adding shortcut: %s</string>
 </resources>


### PR DESCRIPTION
According to beta feedback (confirmed via video), this does not show a message on Vivo phones

This implies that `success` is true on failure - so show the message unconditionally if it's a vivo phone

This is a little annoying, but it's not a hot path and the user should understand

Fixes #7743

Untested