### PR TITLE
Add onUpdateHook and onShownHook in card.js

### DIFF
--- a/AnkiDroid/src/main/assets/scripts/card.js
+++ b/AnkiDroid/src/main/assets/scripts/card.js
@@ -227,5 +227,12 @@ var onPageFinished = function() {
                 }
             }
         })
+        .then(() => {
+            /* Developers can use CSS ".anki-before-shown { visibility: hidden }" to hide the content
+               of the card regardless of whether MathJax executes or not.
+               This will mimic the behavior on AnkiDesktop more closely */
+            card.classList.remove("anki-before-shown");
+            card.classList.add("anki-after-shown");
+        })
         .then(_runHook(onShownHook))
 }

--- a/AnkiDroid/src/main/assets/scripts/card.js
+++ b/AnkiDroid/src/main/assets/scripts/card.js
@@ -181,33 +181,51 @@ window.onload = function() {
     window.location.href = "#answer";
 };
 
+function _runHook(arr) {
+    var promises = [];
+
+    for (var i = 0; i < arr.length; i++) {
+        promises.push(arr[i]());
+    }
+
+    return Promise.all(promises);
+}
+
+var onUpdateHook = [];
+var onShownHook = [];
+
 var onPageFinished = function() {
     if (!resizeDone) {
         resizeImages();
         /* Re-anchor to answer after image resize since the point changes */
         window.location.href = "#answer";
     }
-    if (window.MathJax != null) {
-        var card = document.querySelector('.card');
-        /* Anki-Android adds mathjax-needs-to-render" as a class to the card when
-           it detects both \( and \) or \[ and \].
 
-           This does not control *loading* MathJax, but rather controls whether or not MathJax
-           renders content.  We hide all the content until MathJax renders, because otherwise
-           the content loads, and has to reflow after MathJax renders, and it's unsightly.
-           However, if we hide all the content every time, folks don't like the repainting after
-           every question or answer.  This is a middleground, where there is no repainting due to
-           MathJax on non-MathJax cards, and on MathJax cards, there is a small flicker, but there's
-           no reflowing because the content only shows after MathJax has rendered. */
+    _runHook(onUpdateHook)
+        .then(() => {
+            if (window.MathJax != null) {
+                var card = document.querySelector('.card');
+                /* Anki-Android adds mathjax-needs-to-render" as a class to the card when
+                   it detects both \( and \) or \[ and \].
 
-        if (card.classList.contains("mathjax-needs-to-render"))
-        {
-            MathJax.startup.promise
-                .then(() => MathJax.typesetPromise([card]))
-                .then(() => {
-                    card.classList.remove("mathjax-needs-to-render");
-                    card.classList.add("mathjax-rendered");
-                });
-        }
-    }
+                   This does not control *loading* MathJax, but rather controls whether or not MathJax
+                   renders content.  We hide all the content until MathJax renders, because otherwise
+                   the content loads, and has to reflow after MathJax renders, and it's unsightly.
+                   However, if we hide all the content every time, folks don't like the repainting after
+                   every question or answer.  This is a middleground, where there is no repainting due to
+                   MathJax on non-MathJax cards, and on MathJax cards, there is a small flicker, but there's
+                   no reflowing because the content only shows after MathJax has rendered. */
+
+                if (card.classList.contains("mathjax-needs-to-render"))
+                {
+                    return MathJax.startup.promise
+                        .then(() => MathJax.typesetPromise([card]))
+                        .then(() => {
+                            card.classList.remove("mathjax-needs-to-render");
+                            card.classList.add("mathjax-rendered");
+                        });
+                }
+            }
+        })
+        .then(_runHook(onShownHook))
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -2162,6 +2162,8 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
 
         // CSS class for card-specific styling
         String cardClass = mCardAppearance.getCardClass(mCurrentCard.getOrd() + 1, Themes.getCurrentTheme(this));
+        cardClass += " anki-before-shown";
+
         if (Template.textContainsMathjax(content)) {
             cardClass += " mathjax-needs-to-render";
         }


### PR DESCRIPTION
## Purpose / Description
Implement the onUpdateHook and onShownHook in AnkiDroid. These two hooks have existed in [the Anki codebase](https://github.com/ankitects/anki/blob/master/qt/aqt/data/web/js/reviewer.ts#L56) for some time now.

I recently updated them to be able to return promises. This allows users to have async functions synchronize with the rendering of MathJax.

## Fixes
No issue.

## Approach
`onUpdateHook` and `onShownHook` are two arrays, which exist to the user, while the card is being rendered.
The user can utilize them in note fields, or the card template, and can push actions to them. 
This will cause those actions to be synchronized with the rendering of MathJax.

1. `onUpdateHook` is run before MathJax
1. `onShownHook` is run after MathJax finished completely

These functions can optionally return promises, which lets users take advantage of asynchronous JS as well.

## How Has This Been Tested?

Here's how an example, how they can be used:

```html
\( 1 + 5 = <span id="fooBar"></span> \)

<script>
  onUpdateHook.push(() => {
    return new Promise((resolve) => {
      setTimeout(() => {
        const foo = document.getElementById('fooBar')

        if (foo) {
          const six = document.createTextNode('6')
          foo.parentElement.replaceChild(six, foo)
        }

        resolve()
      }, 5000)
    })
  })
</script>
```

The user uses MathJax with a "target", identified by an id. In JavaScript, the user can now replace this span with fitting text. it would now render `1 + 5 = 6` to the user. This would have already been possible before, technically, but with some important restrictions:
1. If the user needs to perform an async operation inside the JS, the function would immediately resolve, and not wait for the async action to take place. The user would have no way to make sure the function executes "in time".
2. I'm not sure whether this is the case in AnkiDroid, but on other Anki platforms `script` tags inside the template, or note fields are always executed async, because they are inserted dynamically into the template. Having both hooks on AnkiDroid unifies these interfaces, and makes all platforms behave the same (well AnkiMobile does not have them yet, either, but I'm working on it ;) )

## Caveats

There is one difference though: Other Anki platforms hide the card content before MathJax executes, just like AnkiDroid. However, on other platforms, `MathJax` is executed regardless of whether the card contains MathJax elements. This means, that `onUpdateHook` would execute while the card is still invisible to the user. This allows developers to schedule text replacements on this hook, without the user noticing it. On AnkiDroid, this would only be hidden, if the user also happened to use MathJax at the same time.

However I also understand the reasoning behind not doing this, and opting for avoiding the "blink" (the delay when rendering the screen) that happens if AnkiDroid decided to hide by default.

I could think of one way to solve it: Similar to how `mathjax-needs-to-render`, we could add another `ankidroid-before-shown` class.
After the function handling the MathJax, we could another promise:

```javascript
.then(() => {
    card.classList.remove("ankidroid-before-shown");
    card.classList.add("ankidroid-shown");
});
``` 

This would let the template creator decide themselves, whether to hide the card content before the `onShownHook` runs, by adding to the template styling section:

```css
.ankidroid-before-shown {
    visibility: hidden;
}
```

Also: This PR really exposes this bug: #7790.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)