### PR TITLE
Add check that onPageFinished runs on the viewer url

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -338,6 +338,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
 
     private String mCardContent;
     private String mBaseUrl;
+    private String mViewerUrl;
 
     private final int mFadeDuration = 300;
 
@@ -904,6 +905,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         super.onCollectionLoaded(col);
         mSched = col.getSched();
         mBaseUrl = Utils.getBaseUrl(col.getMedia().dir());
+        mViewerUrl = mBaseUrl + "__viewer__.html";
 
         registerExternalStorageListener();
 
@@ -2348,7 +2350,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
     private void loadContentIntoCard(WebView card, String content) {
         if (card != null) {
             CompatHelper.getCompat().setHTML5MediaAutoPlay(card.getSettings(), getConfigForCurrentCard().optBoolean("autoplay"));
-            card.loadDataWithBaseURL(mBaseUrl + "__viewer__.html", content, "text/html", "utf-8", null);
+            card.loadDataWithBaseURL(mViewerUrl, content, "text/html", "utf-8", null);
         }
     }
 
@@ -3478,10 +3480,14 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         // Run any post-load events in javascript that rely on the window being completely loaded.
         @Override
         public void onPageFinished(WebView view, String url) {
-            Timber.d("onPageFinished triggered");
-            drawFlag();
-            drawMark();
-            view.loadUrl("javascript:onPageFinished();");
+            Timber.d("onPageFinished triggered: %s", url);
+
+            // onPageFinished will be called multiple times if the WebView redirects by setting window.location.href
+            if (url.equals(mViewerUrl)) {
+                drawFlag();
+                drawMark();
+                view.loadUrl("javascript:onPageFinished();");
+            }
         }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -3480,10 +3480,11 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         // Run any post-load events in javascript that rely on the window being completely loaded.
         @Override
         public void onPageFinished(WebView view, String url) {
-            Timber.d("onPageFinished triggered: %s", url);
+            Timber.d("Java onPageFinished triggered: %s", url);
 
             // onPageFinished will be called multiple times if the WebView redirects by setting window.location.href
             if (url.equals(mViewerUrl)) {
+                Timber.d("New URL, drawing flags, marks, and triggering JS onPageFinished: %s", url);
                 drawFlag();
                 drawMark();
                 view.loadUrl("javascript:onPageFinished();");


### PR DESCRIPTION
## Purpose / Description
Fixes `onPageFinished` in JavaScript being run multiple times unneccessarily.

## Fixes
https://github.com/ankidroid/Anki-Android/issues/7790

## Approach
It checks that `onPageFinished` runs agains the viewers main url, without any anchors.

## How Has This Been Tested?
I made sure, that `onPageFinished` within JavaScript is only ever executed once.

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code