### PR TITLE
Gesture Strings: Move Card Info to correct place

### DIFF
--- a/AnkiDroid/src/main/res/values-ar/11-arrays.xml
+++ b/AnkiDroid/src/main/res/values-ar/11-arrays.xml
@@ -50,6 +50,7 @@
         <item>الإجابة بأفضل مما أوصي به</item>
         <item>تراجع</item>
         <item>تحرير الملحوظة</item>
+        <item>Card Info</item>
         <item>إضافة وسم إلى الملحوظة</item>
         <item>تعليم الملحوظة</item>
         <item>بحث عن التعبير</item>
@@ -67,7 +68,6 @@
         <item>إزالة المؤشر</item>
         <item>تمرير صفحة إلى الأعلى</item>
         <item>تمرير صفحة إلى الأسفل</item>
-        <item>Page Down</item>
         <item>Abort Learning and Sync</item>
     </string-array>
     <string-array name="leech_action_labels">

--- a/AnkiDroid/src/main/res/values-be/11-arrays.xml
+++ b/AnkiDroid/src/main/res/values-be/11-arrays.xml
@@ -50,6 +50,7 @@
         <item>Лепш, чым рэкамендаваны</item>
         <item>Адмяніць</item>
         <item>Рэдагаваць нататку</item>
+        <item>Card Info</item>
         <item>Пазначыць</item>
         <item>Пазначыць нататку</item>
         <item>Пошук выразу</item>
@@ -67,7 +68,6 @@
         <item>Прыбраць сцяжок</item>
         <item>Пракруціць уверх</item>
         <item>Пракруціць уніз</item>
-        <item>Page Down</item>
         <item>Abort Learning and Sync</item>
     </string-array>
     <string-array name="leech_action_labels">

--- a/AnkiDroid/src/main/res/values-de/11-arrays.xml
+++ b/AnkiDroid/src/main/res/values-de/11-arrays.xml
@@ -50,6 +50,7 @@
         <item>Antwort besser als empfohlen</item>
         <item>Rückgängig</item>
         <item>Notiz bearbeiten</item>
+        <item>Card Info</item>
         <item>Notiz verschlagworten</item>
         <item>Notiz markieren</item>
         <item>Ausdruck nachschlagen</item>
@@ -67,7 +68,6 @@
         <item>Flagge entfernen</item>
         <item>Seite hoch</item>
         <item>Seite runter</item>
-        <item>Page Down</item>
         <item>Abort Learning and Sync</item>
     </string-array>
     <string-array name="leech_action_labels">

--- a/AnkiDroid/src/main/res/values-eo/11-arrays.xml
+++ b/AnkiDroid/src/main/res/values-eo/11-arrays.xml
@@ -51,6 +51,7 @@
         <item>Malfari</item>
         <item>Redakti noton</item>
         <item>Etikedi noton</item>
+        <item>Card Info</item>
         <item>Marki noton</item>
         <item>Serĉi tekston</item>
         <item>Kaŝi karton por tago</item>
@@ -66,7 +67,6 @@
         <item>Baskuli bluan flagon</item>
         <item>Forigi flagon</item>
         <item>Paĝo supren</item>
-        <item>Paĝo suben</item>
         <item>Paĝo suben</item>
         <item>Pri lernado kaj samtempigo</item>
     </string-array>

--- a/AnkiDroid/src/main/res/values-es-rAR/11-arrays.xml
+++ b/AnkiDroid/src/main/res/values-es-rAR/11-arrays.xml
@@ -50,6 +50,7 @@
         <item>Respuesta mejor que la recomendada</item>
         <item>Deshacer</item>
         <item>Editar nota</item>
+        <item>Card Info</item>
         <item>Etiquetar nota</item>
         <item>Marcar nota</item>
         <item>Buscar expresión</item>
@@ -67,7 +68,6 @@
         <item>Eliminar Bandera</item>
         <item>Página Arriba</item>
         <item>Página Abajo</item>
-        <item>Page Down</item>
         <item>Abort Learning and Sync</item>
     </string-array>
     <string-array name="leech_action_labels">

--- a/AnkiDroid/src/main/res/values-es-rES/11-arrays.xml
+++ b/AnkiDroid/src/main/res/values-es-rES/11-arrays.xml
@@ -50,6 +50,7 @@
         <item>Respuesta mejor que la recomendada</item>
         <item>Deshacer</item>
         <item>Editar nota</item>
+        <item>Card Info</item>
         <item>Etiquetar nota</item>
         <item>Marcar nota</item>
         <item>Buscar expresión</item>
@@ -67,7 +68,6 @@
         <item>Eliminar Bandera</item>
         <item>Página Arriba</item>
         <item>Página Abajo</item>
-        <item>Page Down</item>
         <item>Abort Learning and Sync</item>
     </string-array>
     <string-array name="leech_action_labels">

--- a/AnkiDroid/src/main/res/values-fa/11-arrays.xml
+++ b/AnkiDroid/src/main/res/values-fa/11-arrays.xml
@@ -50,6 +50,7 @@
         <item>پاسخ بهتر از توصيه شده</item>
         <item>بازگردانی</item>
         <item>ويرايش يادداشت</item>
+        <item>Card Info</item>
         <item>برچسب یادداشت</item>
         <item>نشان کردن یادداشت</item>
         <item>جستجوی عبارت</item>
@@ -67,7 +68,6 @@
         <item>حذف پرچم</item>
         <item>بالا بردن صفحه</item>
         <item>پایین بردن صفحه</item>
-        <item>Page Down</item>
         <item>Abort Learning and Sync</item>
     </string-array>
     <string-array name="leech_action_labels">

--- a/AnkiDroid/src/main/res/values-fr/11-arrays.xml
+++ b/AnkiDroid/src/main/res/values-fr/11-arrays.xml
@@ -50,6 +50,7 @@
         <item>Réponse meilleure que celle recommandée</item>
         <item>Annuler</item>
         <item>Modifier la note</item>
+        <item>Card Info</item>
         <item>Note d\'étiquette</item>
         <item>Marquer la note</item>
         <item>Vérifier l\'expression</item>
@@ -66,7 +67,6 @@
         <item>Activer/désactiver le marqueur bleu</item>
         <item>Retirer le marqueur</item>
         <item>Remonter</item>
-        <item>Descendre</item>
         <item>Descendre</item>
         <item>Abandonner l\'apprentissage et la synchronisation</item>
     </string-array>

--- a/AnkiDroid/src/main/res/values-hu/11-arrays.xml
+++ b/AnkiDroid/src/main/res/values-hu/11-arrays.xml
@@ -50,6 +50,7 @@
         <item>Jobb válasz, mint a javasolt</item>
         <item>Visszavonás</item>
         <item>Megjegyzés szerkesztése</item>
+        <item>Card Info</item>
         <item>Jegyzet címkézése</item>
         <item>Jegyzet megjelölése</item>
         <item>Kifejezés keresése</item>
@@ -67,7 +68,6 @@
         <item>Jelölő Törlése</item>
         <item>Felfele</item>
         <item>Lefele</item>
-        <item>Page Down</item>
         <item>Abort Learning and Sync</item>
     </string-array>
     <string-array name="leech_action_labels">

--- a/AnkiDroid/src/main/res/values-ind/11-arrays.xml
+++ b/AnkiDroid/src/main/res/values-ind/11-arrays.xml
@@ -50,6 +50,7 @@
         <item>Jawaban yang lebih baik dari yang disarankan</item>
         <item>Urungkan</item>
         <item>Edit catatan</item>
+        <item>Card Info</item>
         <item>Beri catatan tag</item>
         <item>Tandai catatan</item>
         <item>Ekspresi pencarian</item>
@@ -67,7 +68,6 @@
         <item>Hapus Panji</item>
         <item>Halaman Atas</item>
         <item>Halaman Bawah</item>
-        <item>Page Down</item>
         <item>Abort Learning and Sync</item>
     </string-array>
     <string-array name="leech_action_labels">

--- a/AnkiDroid/src/main/res/values-it/11-arrays.xml
+++ b/AnkiDroid/src/main/res/values-it/11-arrays.xml
@@ -50,6 +50,7 @@
         <item>Risposta migliore di quanto raccomandato</item>
         <item>Annulla</item>
         <item>Modifica nota</item>
+        <item>Card Info</item>
         <item>Nota di etichetta</item>
         <item>Contrassegna la nota</item>
         <item>Verifica l\'espressione</item>
@@ -67,7 +68,6 @@
         <item>Rimuovi il contrassegno</item>
         <item>Vai su</item>
         <item>Vai giù</item>
-        <item>Pagina Giù</item>
         <item>Interrompi Apprendimento e Sincronizzazione</item>
     </string-array>
     <string-array name="leech_action_labels">

--- a/AnkiDroid/src/main/res/values-ja/11-arrays.xml
+++ b/AnkiDroid/src/main/res/values-ja/11-arrays.xml
@@ -51,6 +51,7 @@
         <item>元に戻す</item>
         <item>ノートを編集</item>
         <item>カード情報</item>
+        <item>Card Info</item>
         <item>ノートにタグを付ける</item>
         <item>ノートにマークを付ける/取り外す</item>
         <item>カードを延期</item>
@@ -66,7 +67,6 @@
         <item>青フラグを付ける/取り外す</item>
         <item>フラグを取り外す</item>
         <item>１画面分上へスクロール</item>
-        <item>１画面分下へスクロール</item>
         <item>１画面分下へスクロール</item>
         <item>学習を中断して同期</item>
     </string-array>

--- a/AnkiDroid/src/main/res/values-nl/11-arrays.xml
+++ b/AnkiDroid/src/main/res/values-nl/11-arrays.xml
@@ -50,6 +50,7 @@
         <item>Antwoord beter dan aangeraden</item>
         <item>Ongedaan maken</item>
         <item>Memo bewerken</item>
+        <item>Card Info</item>
         <item>Tagnaam</item>
         <item>Markeermemo</item>
         <item>Uitdrukking opzoeken</item>
@@ -67,7 +68,6 @@
         <item>Vlag verwijderen</item>
         <item>Pagina omhoog</item>
         <item>Pagina omlaag</item>
-        <item>Page Down</item>
         <item>Abort Learning and Sync</item>
     </string-array>
     <string-array name="leech_action_labels">

--- a/AnkiDroid/src/main/res/values-pl/11-arrays.xml
+++ b/AnkiDroid/src/main/res/values-pl/11-arrays.xml
@@ -50,6 +50,7 @@
         <item>Odpowiedź lepsza niż zalecana</item>
         <item>Cofnij</item>
         <item>Edytuj notatkę</item>
+        <item>Card Info</item>
         <item>Ustaw tagi</item>
         <item>Wyróżnij notatkę</item>
         <item>Wyszukaj wyrażenie</item>
@@ -67,7 +68,6 @@
         <item>Usuń flagę</item>
         <item>Przewiń w górę</item>
         <item>Przewiń w dół</item>
-        <item>Page Down</item>
         <item>Abort Learning and Sync</item>
     </string-array>
     <string-array name="leech_action_labels">

--- a/AnkiDroid/src/main/res/values-pt-rBR/11-arrays.xml
+++ b/AnkiDroid/src/main/res/values-pt-rBR/11-arrays.xml
@@ -51,6 +51,7 @@
         <item>Desfazer</item>
         <item>Editar nota</item>
         <item>Colocar tag no cartão</item>
+        <item>Card Info</item>
         <item>Marcar nota</item>
         <item>Procurar expressão</item>
         <item>Enterrar cartão</item>
@@ -67,7 +68,6 @@
         <item>Remover marca</item>
         <item>Subir página</item>
         <item>Descer página</item>
-        <item>Page Down</item>
         <item>Abortar Estudo e Sincronizar</item>
     </string-array>
     <string-array name="leech_action_labels">

--- a/AnkiDroid/src/main/res/values-ru/11-arrays.xml
+++ b/AnkiDroid/src/main/res/values-ru/11-arrays.xml
@@ -50,6 +50,7 @@
         <item>Лучше рекомендованного ответа</item>
         <item>Отменить</item>
         <item>Править запись</item>
+        <item>Card Info</item>
         <item>Добавить метку</item>
         <item>Отметить запись</item>
         <item>Посмотреть в словаре</item>
@@ -67,7 +68,6 @@
         <item>Убрать флажок</item>
         <item>На страницу вверх</item>
         <item>На страницу вниз</item>
-        <item>Page Down</item>
         <item>Abort Learning and Sync</item>
     </string-array>
     <string-array name="leech_action_labels">

--- a/AnkiDroid/src/main/res/values-sat/11-arrays.xml
+++ b/AnkiDroid/src/main/res/values-sat/11-arrays.xml
@@ -50,6 +50,7 @@
         <item>ᱢᱚᱱᱡᱩᱨ ᱠᱷᱚᱱ ᱵᱮᱥ ᱛᱮᱞᱟ ᱮᱢᱚᱜ ᱢᱮ</item>
         <item>ᱢᱟᱲᱟᱝᱟᱜ</item>
         <item>ᱠᱷᱟᱴᱚ ᱵᱤᱪᱟᱹᱨ ᱥᱟᱯᱲᱟᱣ</item>
+        <item>Card Info</item>
         <item>ᱠᱷᱟᱴᱚ ᱵᱤᱪᱟᱹᱨ ᱴᱮᱜ ᱢᱮ</item>
         <item>ᱠᱷᱟᱴᱚ ᱵᱤᱪᱟᱹᱨ ᱪᱤᱱᱦᱟᱹᱭ ᱢᱮ</item>
         <item>ᱪᱤᱱᱦᱟ ᱧᱮᱞᱢᱮ</item>
@@ -66,7 +67,6 @@
         <item>ᱞᱤᱞ ᱯᱚᱛᱠᱟ ᱴᱚᱜᱟᱹᱞ</item>
         <item>ᱯᱚᱛᱠᱟ ᱚᱪᱚᱜ ᱢᱮ</item>
         <item>ᱥᱟᱠᱟᱢ ᱪᱮᱛᱟᱱ</item>
-        <item>ᱥᱟᱠᱟᱢ ᱞᱟᱛᱟᱨ</item>
         <item>ᱥᱟᱠᱟᱢ ᱞᱟᱛᱟᱨ</item>
         <item>ᱪᱮᱫᱚᱜ ᱵᱚᱸᱫᱚᱭ ᱢᱮ ᱟᱨ ᱥᱭᱸᱠ ᱢᱮ</item>
     </string-array>

--- a/AnkiDroid/src/main/res/values-uk/11-arrays.xml
+++ b/AnkiDroid/src/main/res/values-uk/11-arrays.xml
@@ -50,6 +50,7 @@
         <item>Краще, ніж рекомендована відповідь</item>
         <item>Скасувати</item>
         <item>Редагувати запис</item>
+        <item>Card Info</item>
         <item>Примітка запису</item>
         <item>Позначити запис</item>
         <item>Пошук виразу</item>
@@ -67,7 +68,6 @@
         <item>Переключити синій прапорець</item>
         <item>Попередня сторінка</item>
         <item>Наступна сторінка</item>
-        <item>Сторінка вниз</item>
         <item>Перервати навчання та синхронізувати</item>
     </string-array>
     <string-array name="leech_action_labels">

--- a/AnkiDroid/src/main/res/values-zh-rCN/11-arrays.xml
+++ b/AnkiDroid/src/main/res/values-zh-rCN/11-arrays.xml
@@ -50,6 +50,7 @@
         <item>好于建议的回答</item>
         <item>撤销</item>
         <item>编辑笔记</item>
+        <item>Card Info</item>
         <item>标签笔记</item>
         <item>标记笔记</item>
         <item>查找表达式</item>
@@ -66,7 +67,6 @@
         <item>切换蓝色标识</item>
         <item>移除标识</item>
         <item>向上翻页</item>
-        <item>向下翻页</item>
         <item>向下翻页</item>
         <item>中止学习和同步</item>
     </string-array>

--- a/AnkiDroid/src/main/res/values-zh-rTW/11-arrays.xml
+++ b/AnkiDroid/src/main/res/values-zh-rTW/11-arrays.xml
@@ -50,6 +50,7 @@
         <item>優於建議的答案</item>
         <item>復原</item>
         <item>編輯筆記</item>
+        <item>Card Info</item>
         <item>標記筆記</item>
         <item>標記筆記</item>
         <item>查找運算式</item>
@@ -67,7 +68,6 @@
         <item>移除標記</item>
         <item>向上翻頁</item>
         <item>向下翻頁</item>
-        <item>Page Down</item>
         <item>Abort Learning and Sync</item>
     </string-array>
     <string-array name="leech_action_labels">


### PR DESCRIPTION
An issue with the CrowdIn translation process meant that "Page Down" was duplicated instead of "Card Info" being inserted in the correct place

This hopefully repairs the damage when uploaded

Screenshots will also need to be regenerated

Fixes #7793 (needs verification on CrowdIn)

Untested