### PR TITLE
BugFix: Safe Display - Don't block nav drawer

### DIFF
--- a/AnkiDroid/src/main/java/androidx/drawerlayout/widget/ClosableDrawerLayout.java
+++ b/AnkiDroid/src/main/java/androidx/drawerlayout/widget/ClosableDrawerLayout.java
@@ -25,6 +25,7 @@ import androidx.annotation.Nullable;
 import androidx.core.view.GravityCompat;
 
 public class ClosableDrawerLayout extends DrawerLayout {
+    @SuppressWarnings( {"FieldCanBeLocal", "unused", "RedundantSuppression"})
     private boolean mAnimationEnabled = true;
 
     public ClosableDrawerLayout(@NonNull Context context) {
@@ -48,10 +49,13 @@ public class ClosableDrawerLayout extends DrawerLayout {
     // This is called internally (onTouchEvent outside the control will close it), so we need it here
     @Override
     void closeDrawers(boolean peekingOnly) {
-        if (mAnimationEnabled) {
-            super.closeDrawers(peekingOnly);
-        } else {
+        // TODO: This fails due to #7344 - tapping on the left side partially opens the menu and blocks the UI
+        // permanently. I didn't work too hard on resolving this, but it didn't seem like a simple fix.
+        /*
+        if (!mAnimationEnabled) {
             closeDrawer(GravityCompat.START, false);
         }
+        */
+        super.closeDrawers(peekingOnly);
     }
 }


### PR DESCRIPTION
For now, the handling of blocking the animation was buggy, so keep showing animations even if Safe Display Mode is on.

Tapping on the left side of the navigation drawer caused it to partially pop out, closing it made the entire UI unresponsive.

I had a few tries, but both of these meant that the drawer closed immediately when it was swiped open.

We might need to copy the navigation drawer code and recode it.

## Fixes
Fixes #7344
Related #7119
Related #7114

## Approach
Disable the offending code

## How Has This Been Tested?

API 19 emulator

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)