### PR TITLE
Arrays: Extract gestures_labels strings

### DIFF
--- a/AnkiDroid/src/main/res/values/11-arrays.xml
+++ b/AnkiDroid/src/main/res/values/11-arrays.xml
@@ -99,4 +99,29 @@
         <item>x-large</item>
         <item>xx-large</item>
     </string-array>
+
+    <!--
+    #7794 - it's better to use @string references in non-translated arrays as this handles
+    changes in the array ordering better
+     -->
+    <string name="gesture_no_action">No action</string>
+    <string name="gesture_answer_1">Answer button 1</string>
+    <string name="gesture_answer_2">Answer button 2</string>
+    <string name="gesture_answer_3">Answer button 3</string>
+    <string name="gesture_answer_4">Answer button 4</string>
+    <string name="gesture_answer_green">Answer recommended (green)</string>
+    <string name="gesture_answer_better_recommended">Answer better than recommended</string>
+    <string name="gesture_tag_note">Tag note</string>
+    <string name="gesture_lookup">Lookup expression</string>
+    <string name="gesture_play">Play media</string>
+    <string name="gesture_abort_learning">Abort learning</string>
+    <string name="gesture_flag_red">Toggle Red Flag</string>
+    <string name="gesture_flag_orange">Toggle Orange Flag</string>
+    <string name="gesture_flag_green">Toggle Green Flag</string>
+    <string name="gesture_flag_blue">Toggle Blue Flag</string>
+    <string name="gesture_flag_remove">Remove Flag</string>
+    <string name="gesture_page_up">Page Up</string>
+    <string name="gesture_page_down">Page Down</string>
+    <string name="gesture_abort_sync">Abort Learning and Sync</string>
+
 </resources>


### PR DESCRIPTION
We want to move away from `string-array` as it causes problems when adding items in the middle (the array controls both the strings and the positions).

These strings are the ones which do not already have duplicates defined

This will require some manual follow-up work to copy from the existing language files to the new strings, but I'm happy to take this on.

Follow up steps:
* Language sync
* Copy from `string-array` to `string` for each language file
* Move `gestures_labels` to constants.xml

Related: #7794