### PR TITLE
Move gestures_labels to constants.xml

### DIFF
--- a/AnkiDroid/src/main/res/values/11-arrays.xml
+++ b/AnkiDroid/src/main/res/values/11-arrays.xml
@@ -19,37 +19,6 @@
         <item>Never report</item>
         <item>Ask me</item>
     </string-array>
-    <string-array name="gestures_labels">
-        <item>No action</item>
-        <item>Show answer</item>
-        <item>Answer button 1</item>
-        <item>Answer button 2</item>
-        <item>Answer button 3</item>
-        <item>Answer button 4</item>
-        <item>Answer recommended (green)</item>
-        <item>Answer better than recommended</item>
-        <item>Undo</item>
-        <item>Edit note</item>
-        <item>Card Info</item>
-        <item>Tag note</item>
-        <item>Mark note</item>
-        <item>Lookup expression</item>
-        <item>Bury card</item>
-        <item>Suspend card</item>
-        <item>Delete note</item>
-        <item>Play media</item>
-        <item>Abort learning</item>
-        <item>Bury note</item>
-        <item>Suspend note</item>
-        <item>Toggle Red Flag</item>
-        <item>Toggle Orange Flag</item>
-        <item>Toggle Green Flag</item>
-        <item>Toggle Blue Flag</item>
-        <item>Remove Flag</item>
-        <item>Page Up</item>
-        <item>Page Down</item>
-        <item>Abort Learning and Sync</item>
-    </string-array>
     <string-array name="leech_action_labels">
         <item>Suspend card</item>
         <item>Tag only</item>

--- a/AnkiDroid/src/main/res/values/constants.xml
+++ b/AnkiDroid/src/main/res/values/constants.xml
@@ -85,6 +85,37 @@
         <item>200</item>
         <item>500</item>
     </string-array>
+    <string-array name="gestures_labels">
+        <item>@string/gesture_no_action</item>
+        <item>@string/show_answer</item>
+        <item>@string/gesture_answer_1</item>
+        <item>@string/gesture_answer_2</item>
+        <item>@string/gesture_answer_3</item>
+        <item>@string/gesture_answer_4</item>
+        <item>@string/gesture_answer_green</item>
+        <item>@string/gesture_answer_better_recommended</item>
+        <item>@string/undo</item>
+        <item>@string/cardeditor_title_edit_card</item>
+        <item>@string/card_info_title</item>
+        <item>@string/gesture_tag_note</item>
+        <item>@string/menu_mark_note</item>
+        <item>@string/gesture_lookup</item>
+        <item>@string/menu_bury_card</item>
+        <item>@string/menu_suspend_card</item>
+        <item>@string/menu_delete_note</item>
+        <item>@string/gesture_play</item>
+        <item>@string/gesture_abort_learning</item>
+        <item>@string/menu_bury_note</item>
+        <item>@string/menu_suspend_note</item>
+        <item>@string/gesture_flag_red</item>
+        <item>@string/gesture_flag_orange</item>
+        <item>@string/gesture_flag_green</item>
+        <item>@string/gesture_flag_blue</item>
+        <item>@string/gesture_flag_remove</item>
+        <item>@string/gesture_page_up</item>
+        <item>@string/gesture_page_down</item>
+        <item>@string/gesture_abort_sync</item>
+    </string-array>
     <string-array name="gestures_values">
         <item>0</item>
         <item>1</item>


### PR DESCRIPTION
We convert it to string references, then move it from a translatable file

This lets us change the order of, and add items without affecting CrowdIn

## Testing 

* English (default) - works
* esperanto - deleted strings from 11-arrays - works
* French - Translated Strings remain in 11-arrays - works

Related: #7794 (fixes `gestures_labels`)

This is where strings are deleted and we diverge from 2.14.2