### PR TITLE
Alternative approach to handling hiding regarding onUpdateHook

### DIFF
--- a/AnkiDroid/src/main/assets/scripts/card.js
+++ b/AnkiDroid/src/main/assets/scripts/card.js
@@ -220,19 +220,10 @@ var onPageFinished = function() {
                 {
                     return MathJax.startup.promise
                         .then(() => MathJax.typesetPromise([card]))
-                        .then(() => {
-                            card.classList.remove("mathjax-needs-to-render");
-                            card.classList.add("mathjax-rendered");
-                        });
+                        .then(() => card.classList.remove("mathjax-needs-to-render"));
                 }
             }
         })
-        .then(() => {
-            /* Developers can use CSS ".anki-before-shown { visibility: hidden }" to hide the content
-               of the card regardless of whether MathJax executes or not.
-               This will mimic the behavior on AnkiDesktop more closely */
-            card.classList.remove("anki-before-shown");
-            card.classList.add("anki-after-shown");
-        })
+        .then(() => card.classList.add("mathjax-rendered"))
         .then(_runHook(onShownHook))
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -2164,7 +2164,6 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
 
         // CSS class for card-specific styling
         String cardClass = mCardAppearance.getCardClass(mCurrentCard.getOrd() + 1, Themes.getCurrentTheme(this));
-        cardClass += " anki-before-shown";
 
         if (Template.textContainsMathjax(content)) {
             cardClass += " mathjax-needs-to-render";


### PR DESCRIPTION
## Purpose / Description
This is an alternative approach to handling the lack of hiding before `onUpdateHook` on AnkiDroid, implemented in #7791.
It avoids adding two new symbols, but slightly changes the semantic of another symbol.

## Approach
This would could let you use the following CSS to hide the content:
```javascript
.android .card:not(.mathjax-rendered) {
    visibility: hidden;
}
```

This is a trade-off, rather than an improvement:
1. The previous approach introduced two new symbols
2. This one slightly changes the semantic of one existing symbol

I could not really find any sign of use for the `mathjax-rendered` CSS class anywhere, so it might be better to take the slight change in meaning. What's also nice about this is that the CSS selector is pretty self-explanatory.