### PR TITLE
Note Editor: Add Toolbar Toggle

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1090,6 +1090,8 @@ public class NoteEditor extends AnkiActivity {
             }
         }
 
+        menu.findItem(R.id.action_show_toolbar).setChecked(!shouldHideToolbar());
+
         return super.onCreateOptionsMenu(menu);
     }
 
@@ -1098,6 +1100,9 @@ public class NoteEditor extends AnkiActivity {
         return AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance()).getBoolean("noteEditorNewlineReplace", true);
     }
 
+    protected static boolean shouldHideToolbar() {
+        return !AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance()).getBoolean("noteEditorShowToolbar", true);
+    }
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
@@ -1129,6 +1134,10 @@ public class NoteEditor extends AnkiActivity {
             repositionDialog.setCallbackRunnable(this::setFontSize);
             showDialogFragment(repositionDialog);
             return true;
+        } else if (itemId == R.id.action_show_toolbar) {
+            item.setChecked(!item.isChecked());
+            AnkiDroidApp.getSharedPrefs(this).edit().putBoolean("noteEditorShowToolbar", item.isChecked()).apply();
+            updateToolbar();
         }
         return super.onOptionsItemSelected(item);
     }
@@ -1879,6 +1888,13 @@ public class NoteEditor extends AnkiActivity {
     private void updateToolbar() {
         if (mToolbar == null) {
             return;
+        }
+
+        if (shouldHideToolbar()) {
+            mToolbar.setVisibility(View.GONE);
+            return;
+        } else {
+            mToolbar.setVisibility(View.VISIBLE);
         }
 
         mToolbar.clearCustomItems();

--- a/AnkiDroid/src/main/res/menu/note_editor.xml
+++ b/AnkiDroid/src/main/res/menu/note_editor.xml
@@ -24,4 +24,9 @@
         android:id="@+id/action_font_size"
         android:title="@string/menu_font_size"
         ankidroid:showAsAction="never"/>
+    <item
+        android:id="@+id/action_show_toolbar"
+        android:title="@string/menu_show_toolbar"
+        android:checkable="true"
+        ankidroid:showAsAction="never"/>
 </menu>

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -333,6 +333,8 @@
     <!-- A Menu item to change the Font Size (currently in the Note Editor) -->
     <string name="menu_font_size">Font Size</string>
 
+    <string name="menu_show_toolbar" comment="Checkable item stating whether the note editor toolbar should be shown">Show Toolbar</string>
+
     <string name="format_insert_bold">Format as Bold</string>
     <string name="format_insert_italic">Format as Italic</string>
     <string name="format_insert_underline">Format as Underline</string>


### PR DESCRIPTION
## Purpose / Description
Some users were unhappy about the reduction in screen real estate

## Fixes
Fixes #7785

## Approach
This adds a "Show Toolbar" menu item, defaulting to "true"

## How Has This Been Tested?

API 19 emulator 

* Initial state matches the preference
* Changing state changes both the toolbar and the checkbox

![image](https://user-images.githubusercontent.com/62114487/100871043-828e4500-3497-11eb-900d-e63b619c1230.png)

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)