### PR TITLE
BugFix - Previewer: Display same card after edit

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1136,7 +1136,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
                 // content of note was changed so update the note and current card
                 Timber.i("AbstractFlashcardViewer:: Saving card...");
                 CollectionTask.launchCollectionTask(UPDATE_NOTE, mUpdateCardHandler,
-                        new TaskData(sEditorCard, true));
+                        new TaskData(new Object[] { sEditorCard, true, canAccessScheduler() }));
                 onEditedNoteChanged();
             } else if (resultCode == RESULT_CANCELED && !(data!=null && data.hasExtra("reloadRequired"))) {
                 // nothing was changed by the note editor so just redraw the card
@@ -1148,6 +1148,19 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         if (!mDisableClipboard) {
             clipboardSetText("");
         }
+    }
+
+    /**
+     * Whether the class should use collection.getSched() when performing tasks.
+     * The aim of this method is to completely distinguish FlashcardViewer from Reviewer
+     *
+     * This is partially implemented, the end goal is that the FlashcardViewer will not have any coupling to getSched
+     *
+     * Currently, this is used for note edits - in a reviewing context, this should show the next card.
+     * In a previewing context, the card should not change.
+     */
+    protected boolean canAccessScheduler() {
+        return false;
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -1013,6 +1013,16 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
     }
 
 
+    @Override
+    @Nullable
+    protected Long getCurrentCardId() {
+        if (mCurrentCard == null) {
+            return null;
+        }
+        return mCurrentCard.getId();
+    }
+
+
     private boolean processHardwareButtonScroll(int keyCode, WebView card) {
         if (keyCode == KeyEvent.KEYCODE_PAGE_UP) {
             card.pageUp(false);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1244,18 +1244,21 @@ public class CardBrowser extends NavigationDrawerActivity implements
     @NonNull
     @VisibleForTesting
     Intent getPreviewIntent() {
-        Intent previewer = new Intent(CardBrowser.this, Previewer.class);
         if (mInMultiSelectMode && checkedCardCount() > 1) {
             // Multiple cards have been explicitly selected, so preview only those cards
-            previewer.putExtra("index", 0);
-            previewer.putExtra("cardList", getSelectedCardIds());
+            int index = 0;
+            return getPreviewIntent(index, getSelectedCardIds());
         } else {
             // Preview all cards, starting from the one that is currently selected
             int startIndex = mCheckedCards.isEmpty() ? 0 : mCheckedCards.iterator().next().getPosition();
-            previewer.putExtra("index", startIndex);
-            previewer.putExtra("cardList", getAllCardIds());
+            return getPreviewIntent(startIndex, getAllCardIds());
         }
-        return previewer;
+    }
+
+
+    @NonNull
+    private Intent getPreviewIntent(int index, long[] selectedCardIds) {
+        return Previewer.getPreviewIntent(CardBrowser.this, index, selectedCardIds);
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1347,7 +1347,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
         if (requestCode == EDIT_CARD && resultCode != RESULT_CANCELED) {
             Timber.i("CardBrowser:: CardBrowser: Saving card...");
             CollectionTask.launchCollectionTask(UPDATE_NOTE, updateCardHandler(),
-                    new TaskData(sCardBrowserCard, false));
+                    new TaskData(new Object[] { sCardBrowserCard, false, false }));
         } else if (requestCode == ADD_NOTE && resultCode == RESULT_OK) {
             if (mSearchView != null) {
                 mSearchTerms = mSearchView.getQuery().toString();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
@@ -24,6 +24,7 @@ import android.os.Handler;
 import com.google.android.material.navigation.NavigationView;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.core.app.TaskStackBuilder;
 import androidx.core.content.ContextCompat;
 import androidx.core.view.GravityCompat;
@@ -338,6 +339,7 @@ public abstract class NavigationDrawerActivity extends AnkiActivity implements N
     }
 
     // Override this to specify a specific card id
+    @Nullable
     protected Long getCurrentCardId() {
         return null;
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.java
@@ -18,6 +18,7 @@
 
 package com.ichi2.anki;
 
+import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
@@ -32,6 +33,7 @@ import com.ichi2.themes.Themes;
 import java.util.HashSet;
 import java.util.List;
 
+import androidx.annotation.CheckResult;
 import androidx.annotation.NonNull;
 import timber.log.Timber;
 
@@ -48,6 +50,16 @@ public class Previewer extends AbstractFlashcardViewer {
     /** Communication with Browser */
     private boolean mReloadRequired;
     private boolean mNoteChanged;
+
+
+    @CheckResult
+    @NonNull
+    public static Intent getPreviewIntent(Context context, int index, long[] cardList) {
+        Intent intent = new Intent(context, Previewer.class);
+        intent.putExtra("index", index);
+        intent.putExtra("cardList", cardList);
+        return intent;
+    }
 
 
     @Override

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -798,6 +798,12 @@ public class Reviewer extends AbstractFlashcardViewer {
 
 
     @Override
+    protected boolean canAccessScheduler() {
+        return true;
+    }
+
+
+    @Override
     protected void performReload() {
         getCol().getSched().deferReset();
         CollectionTask.launchCollectionTask(ANSWER_CARD, mAnswerCardHandler(false),

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -558,9 +558,10 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
         // Save the note
         Collection col = getCol();
         AbstractSched sched = col.getSched();
-        Card editCard = param.getCard();
+        Card editCard = (Card) param.getObjArray()[0];
         Note editNote = editCard.note();
-        boolean fromReviewer = param.getBoolean();
+        boolean fromReviewer = (boolean) param.getObjArray()[1];
+        boolean canAccessScheduler = (boolean) param.getObjArray()[2];
 
         try {
             col.getDb().executeInTransaction(() -> {
@@ -570,7 +571,7 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
                 editCard.flush();
                 if (fromReviewer) {
                     Card newCard;
-                    if (col.getDecks().active().contains(editCard.getDid())) {
+                    if (col.getDecks().active().contains(editCard.getDid()) || !canAccessScheduler) {
                         newCard = editCard;
                         newCard.load();
                         // reload qa-cache

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -577,6 +577,7 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
                         newCard.q(true);
                     } else {
                         newCard = sched.getCard();
+                        Timber.i("Obtained new card from scheduler: %d", newCard == null ? -1 : newCard.getId());
                     }
                     publishProgress(new TaskData(newCard));
                 } else {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/PreviewerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/PreviewerTest.java
@@ -1,0 +1,101 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki;
+
+import android.app.Activity;
+import android.content.Intent;
+
+import com.ichi2.libanki.Card;
+import com.ichi2.libanki.Note;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+
+@RunWith(AndroidJUnit4.class)
+public class PreviewerTest extends RobolectricTest {
+
+    @Test
+    public void editingNoteDoesNotChangePreviewedCardId() {
+        // #7801
+        addNoteUsingBasicModel("Hello", "World");
+
+        Card cardToPreview = addNoteUsingBasicModel("Hello", "World").firstCard();
+        setDeck("Deck", cardToPreview);
+
+        Previewer previewer = getPreviewerPreviewing(cardToPreview);
+
+        assertThat("Initially should be previewing selected card", previewer.getCurrentCardId(), is(cardToPreview.getId()));
+
+        previewer.onActivityResult(AbstractFlashcardViewer.EDIT_CURRENT_CARD, Activity.RESULT_OK, null);
+
+        advanceRobolectricLooperWithSleep();
+
+        assertThat("Should be previewing selected card after edit", previewer.getCurrentCardId(), is(cardToPreview.getId()));
+    }
+
+    @Test
+    public void editingNoteChangesContent() {
+        // #7801
+        addNoteUsingBasicModel("Hello", "World");
+
+        Card cardToPreview = addNoteUsingBasicModel("Hello", "World").firstCard();
+        setDeck("Deck", cardToPreview);
+
+        Previewer previewer = getPreviewerPreviewing(cardToPreview);
+
+        assertThat("Initial content assumption", previewer.getCardContent(), not(containsString("Hi")));
+
+        cardToPreview.note().setField(0, "Hi");
+
+        previewer.onActivityResult(AbstractFlashcardViewer.EDIT_CURRENT_CARD, Activity.RESULT_OK, null);
+
+        advanceRobolectricLooperWithSleep();
+
+        assertThat("Card content should be updated after editing", previewer.getCardContent(), containsString("Hi"));
+    }
+
+    @Test
+    public void previewerShouldNotAccessScheduler() {
+        Card cardToPreview = addNoteUsingBasicModel("Hello", "World").firstCard();
+        Previewer previewer = getPreviewerPreviewing(cardToPreview);
+
+        assertThat("Previewer is not a reviewer", previewer.canAccessScheduler(), is(false));
+    }
+
+
+    @SuppressWarnings("SameParameterValue")
+    protected void setDeck(String name, Card card) {
+        long did = addDeck(name);
+        card.setDid(did);
+        card.flush();
+    }
+
+
+    protected Previewer getPreviewerPreviewing(Card usableCard) {
+        Intent previewIntent = Previewer.getPreviewIntent(getTargetContext(), 0, new long[] { usableCard.getId() });
+        Previewer previewer = super.startActivityNormallyOpenCollectionWithIntent(Previewer.class, previewIntent);
+        AbstractFlashcardViewer.setEditorCard(usableCard);
+        return previewer;
+    }
+}


### PR DESCRIPTION
Editing a note would call UPDATE_NOTE with parameter `isReviewer:true`.

If the card was not in the same deck as the 'currently active' deck, then
the next card was obtained from the scheduler

The UPDATE_NOTE callback gets this card and renders it, even though it's not being previewed, showing the wrong card


## Fixes
Fixes #7801

## Approach
Now, we pass a new boolean, which skips the scheduler when not reviewing

This means we still update the content, but without getting another CardId

## How Has This Been Tested?

Android 9 device, and unit tests

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)