### PR TITLE
Implement "Follow System Night Mode"

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -264,6 +264,7 @@ dependencies {
     testImplementation "org.robolectric:robolectric:4.4"
     testImplementation 'androidx.test:core:1.3.0'
     testImplementation 'androidx.test.ext:junit:1.1.2'
+    testImplementation 'com.github.IvanShafran:shared-preferences-mock:1.0'
     // debugImplementation required vs testImplementation: https://issuetracker.google.com/issues/128612536
     debugImplementation("androidx.fragment:fragment-testing:1.2.5") {
         // monitor dep constrained to 1.2 by fragment-testing, 1.3+ is needed: https://github.com/android/android-test/issues/481

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -889,7 +889,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
     }
 
     @ Override
-    public void onConfigurationChanged(Configuration config) {
+    public void onConfigurationChanged(@NonNull Configuration config) {
         // called when screen rotated, etc, since recreating the Webview is too expensive
         super.onConfigurationChanged(config);
         refreshActionBar();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.java
@@ -178,6 +178,9 @@ public class AnkiDroidApp extends MultiDexApplication {
      */
     public static final int CHECK_PREFERENCES_AT_VERSION = 20500225;
 
+    @VisibleForTesting
+    private static SharedPreferences sSharedPreferencesMock;
+
     /** Our ACRA configurations, initialized during onCreate() */
     private CoreConfigurationBuilder acraCoreConfigBuilder;
 
@@ -362,6 +365,10 @@ public class AnkiDroidApp extends MultiDexApplication {
      */
     @SuppressWarnings("deprecation") // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5019
     public static SharedPreferences getSharedPrefs(Context context) {
+        if (sSharedPreferencesMock != null) {
+            return sSharedPreferencesMock;
+        }
+
         return android.preference.PreferenceManager.getDefaultSharedPreferences(context);
     }
 
@@ -643,6 +650,18 @@ public class AnkiDroidApp extends MultiDexApplication {
             return null;
         }
         return ExceptionUtil.getExceptionMessage(error);
+    }
+
+
+
+    @VisibleForTesting
+    public static void resetPreferenceMock() {
+        sSharedPreferencesMock = null;
+    }
+
+    @VisibleForTesting
+    public static void setPreferenceMock(SharedPreferences sharedPreferences) {
+        sSharedPreferencesMock = sharedPreferences;
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
@@ -95,12 +95,7 @@ public abstract class NavigationDrawerActivity extends AnkiActivity implements N
             // Decide which action to take when the navigation button is tapped.
             toolbar.setNavigationOnClickListener(v -> onNavigationPressed());
         }
-        // Configure night-mode switch
-        final SharedPreferences preferences = getPreferences();
-        View actionLayout = mNavigationView.getMenu().findItem(R.id.nav_night_mode).getActionView();
-        mNightModeSwitch = actionLayout.findViewById(R.id.switch_compat);
-        mNightModeSwitch.setChecked(preferences.getBoolean(NIGHT_MODE_PREFERENCE, false));
-        mNightModeSwitch.setOnCheckedChangeListener((buttonView, isChecked) -> applyNightMode(isChecked));
+        setupNightModeSwitch();
         // ActionBarDrawerToggle ties together the the proper interactions
         // between the sliding drawer and the action bar app icon
         mDrawerToggle = new ActionBarDrawerToggle(this, mDrawerLayout, 0, 0) {
@@ -134,6 +129,18 @@ public abstract class NavigationDrawerActivity extends AnkiActivity implements N
         }
         mDrawerToggle.setDrawerSlideAnimationEnabled(animationEnabled());
         mDrawerLayout.addDrawerListener(mDrawerToggle);
+    }
+
+
+    private void setupNightModeSwitch() {
+        if (mNightModeSwitch == null) {
+            View actionLayout = mNavigationView.getMenu().findItem(R.id.nav_night_mode).getActionView();
+            mNightModeSwitch = actionLayout.findViewById(R.id.switch_compat);
+        }
+
+        final SharedPreferences preferences = getPreferences();
+        mNightModeSwitch.setChecked(preferences.getBoolean(NIGHT_MODE_PREFERENCE, false));
+        mNightModeSwitch.setOnCheckedChangeListener((buttonView, isChecked) -> applyNightMode(isChecked));
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
@@ -37,6 +37,8 @@ import android.view.MenuItem;
 import android.view.View;
 
 import com.ichi2.anki.dialogs.HelpDialog;
+import com.ichi2.anki.servicelayer.NightModeService;
+import com.ichi2.anki.servicelayer.NightModeService.NightMode;
 import com.ichi2.compat.CompatHelper;
 import com.ichi2.themes.Themes;
 import androidx.drawerlayout.widget.ClosableDrawerLayout;
@@ -66,7 +68,6 @@ public abstract class NavigationDrawerActivity extends AnkiActivity implements N
     public static final int REQUEST_PREFERENCES_UPDATE = 100;
     public static final int REQUEST_BROWSE_CARDS = 101;
     public static final int REQUEST_STATISTICS = 102;
-    private static final String NIGHT_MODE_PREFERENCE = "invertedColors";
 
     /**
      * runnable that will be executed after the drawer has been closed.
@@ -138,8 +139,8 @@ public abstract class NavigationDrawerActivity extends AnkiActivity implements N
             mNightModeSwitch = actionLayout.findViewById(R.id.switch_compat);
         }
 
-        final SharedPreferences preferences = getPreferences();
-        mNightModeSwitch.setChecked(preferences.getBoolean(NIGHT_MODE_PREFERENCE, false));
+        NightMode nightMode = NightModeService.getNightMode();
+        mNightModeSwitch.setChecked(nightMode.isNightModeEnabled());
         mNightModeSwitch.setOnCheckedChangeListener((buttonView, isChecked) -> applyNightMode(isChecked));
     }
 
@@ -196,9 +197,7 @@ public abstract class NavigationDrawerActivity extends AnkiActivity implements N
     }
 
     private void applyNightMode(boolean setToNightMode) {
-        final SharedPreferences preferences = getPreferences();
-        Timber.i("Night mode was %s", setToNightMode ? "enabled" : "disabled");
-        preferences.edit().putBoolean(NIGHT_MODE_PREFERENCE, setToNightMode).apply();
+        NightModeService.setManualNightModeMode(setToNightMode);
         restartActivityInvalidateBackstack(NavigationDrawerActivity.this);
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.java
@@ -1,24 +1,24 @@
-/****************************************************************************************
- * Copyright (c) 2014 Timothy Rae <perceptualchaos2@gmail.com>                          *
- *                                                                                      *
- * This program is free software; you can redistribute it and/or modify it under        *
- * the terms of the GNU General Public License as published by the Free Software        *
- * Foundation; either version 3 of the License, or (at your option) any later           *
- * version.                                                                             *
- *                                                                                      *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
- * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
- *                                                                                      *
- * You should have received a copy of the GNU General Public License along with         *
- * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
- ****************************************************************************************/
+/*
+ Copyright (c) 2014 Timothy Rae <perceptualchaos2@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package com.ichi2.anki;
 
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.res.Configuration;
-import android.net.Uri;
 import android.os.Bundle;
 import android.os.Handler;
 import com.google.android.material.navigation.NavigationView;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NightModeService.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NightModeService.java
@@ -1,0 +1,60 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.servicelayer;
+
+import android.content.SharedPreferences;
+
+import com.ichi2.anki.AnkiDroidApp;
+
+import timber.log.Timber;
+
+public class NightModeService {
+
+    private static final String NIGHT_MODE_PREFERENCE = "invertedColors";
+
+    public static NightMode getNightMode() {
+        final SharedPreferences preferences = getPreferences();
+
+        return new NightMode(getManualNightMode(preferences));
+    }
+
+    public static void setManualNightModeMode(boolean isNightMode) {
+        final SharedPreferences preferences = getPreferences();
+        Timber.i("Night mode was %s", isNightMode ? "enabled" : "disabled");
+        preferences.edit().putBoolean(NIGHT_MODE_PREFERENCE, isNightMode).apply();
+    }
+
+    protected static boolean getManualNightMode(SharedPreferences preferences) {
+        return preferences.getBoolean(NIGHT_MODE_PREFERENCE, false);
+    }
+
+    protected static SharedPreferences getPreferences() {
+        return AnkiDroidApp.getSharedPrefs(AnkiDroidApp.getInstance());
+    }
+
+    public static class NightMode {
+        private final boolean mNightModeEnabled;
+
+        public NightMode(boolean nightModeEnabled) {
+            mNightModeEnabled = nightModeEnabled;
+        }
+
+        public boolean isNightModeEnabled() {
+            return mNightModeEnabled;
+        }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/themes/Themes.java
+++ b/AnkiDroid/src/main/java/com/ichi2/themes/Themes.java
@@ -25,6 +25,8 @@ import androidx.core.content.ContextCompat;
 
 import com.ichi2.anki.AnkiDroidApp;
 import com.ichi2.anki.R;
+import com.ichi2.anki.servicelayer.NightModeService;
+import com.ichi2.anki.servicelayer.NightModeService.NightMode;
 
 public class Themes {
     public final static int ALPHA_ICON_ENABLED_LIGHT = 255; // 100%
@@ -41,7 +43,7 @@ public class Themes {
 
     public static void setTheme(Context context) {
         SharedPreferences prefs = AnkiDroidApp.getSharedPrefs(context.getApplicationContext());
-        if (prefs.getBoolean("invertedColors", false)) {
+        if (isNightModeEnabled()) {
             int theme = Integer.parseInt(prefs.getString("nightTheme", "0"));
             switch (theme) {
                 case THEME_NIGHT_DARK:
@@ -66,7 +68,7 @@ public class Themes {
 
     public static void setThemeLegacy(Context context) {
         SharedPreferences prefs = AnkiDroidApp.getSharedPrefs(context.getApplicationContext());
-        if (prefs.getBoolean("invertedColors", false)) {
+        if (isNightModeEnabled()) {
             int theme = Integer.parseInt(prefs.getString("nightTheme", "0"));
             switch (theme) {
                 case THEME_NIGHT_DARK:
@@ -125,10 +127,16 @@ public class Themes {
      */
     public static int getCurrentTheme(Context context) {
         SharedPreferences prefs = AnkiDroidApp.getSharedPrefs(context);
-        if (prefs.getBoolean("invertedColors", false)) {
+        if (isNightModeEnabled()) {
             return Integer.parseInt(prefs.getString("nightTheme", "0"));
         } else {
             return Integer.parseInt(prefs.getString("dayTheme", "0"));
         }
+    }
+
+
+    protected static boolean isNightModeEnabled() {
+        NightMode nightMode = NightModeService.getNightMode();
+        return nightMode.isNightModeEnabled();
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/themes/Themes.java
+++ b/AnkiDroid/src/main/java/com/ichi2/themes/Themes.java
@@ -43,7 +43,7 @@ public class Themes {
 
     public static void setTheme(Context context) {
         SharedPreferences prefs = AnkiDroidApp.getSharedPrefs(context.getApplicationContext());
-        if (isNightModeEnabled()) {
+        if (isNightModeEnabled(context)) {
             int theme = Integer.parseInt(prefs.getString("nightTheme", "0"));
             switch (theme) {
                 case THEME_NIGHT_DARK:
@@ -68,7 +68,7 @@ public class Themes {
 
     public static void setThemeLegacy(Context context) {
         SharedPreferences prefs = AnkiDroidApp.getSharedPrefs(context.getApplicationContext());
-        if (isNightModeEnabled()) {
+        if (isNightModeEnabled(context)) {
             int theme = Integer.parseInt(prefs.getString("nightTheme", "0"));
             switch (theme) {
                 case THEME_NIGHT_DARK:
@@ -127,7 +127,7 @@ public class Themes {
      */
     public static int getCurrentTheme(Context context) {
         SharedPreferences prefs = AnkiDroidApp.getSharedPrefs(context);
-        if (isNightModeEnabled()) {
+        if (isNightModeEnabled(context)) {
             return Integer.parseInt(prefs.getString("nightTheme", "0"));
         } else {
             return Integer.parseInt(prefs.getString("dayTheme", "0"));
@@ -135,8 +135,8 @@ public class Themes {
     }
 
 
-    protected static boolean isNightModeEnabled() {
-        NightMode nightMode = NightModeService.getNightMode();
+    protected static boolean isNightModeEnabled(Context context) {
+        NightMode nightMode = NightModeService.setupNightMode(context.getResources().getConfiguration());
         return nightMode.isNightModeEnabled();
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/ui/MenuItemUtil.java
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/MenuItemUtil.java
@@ -14,34 +14,27 @@
  *  this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.ichi2.testutils;
+package com.ichi2.ui;
 
-import android.content.SharedPreferences;
+import android.app.Activity;
+import android.os.Handler;
+import android.view.MenuItem;
+import android.view.View;
 
-import com.ichi2.anki.AnkiDroidApp;
+import com.ichi2.anki.NavigationDrawerActivity;
+import com.ichi2.anki.R;
+import com.ichi2.anki.UIUtils;
+import com.ichi2.anki.servicelayer.NightModeService;
 
-import org.junit.After;
-import org.junit.Before;
+public class MenuItemUtil {
 
-/** A test class which does not use Robolectric */
-public class FastTest {
+    public static void setOnLongPressListener(Activity activity, MenuItem item, View.OnLongClickListener listener) {
+        new Handler().post(() -> {
+            View view = activity.findViewById(item.getItemId());
 
-    private SharedPreferences mPreferences;
-
-
-    @Before
-    public void before() {
-        SharedPreferences preferences = PreferencesMock.getInstance();
-        AnkiDroidApp.setPreferenceMock(preferences);
-        this.mPreferences = preferences;
-    }
-
-    @After
-    public void after() {
-        AnkiDroidApp.resetPreferenceMock();
-    }
-
-    protected SharedPreferences getSharedPrefs() {
-        return mPreferences;
+            if (view != null) {
+                view.setOnLongClickListener(listener);
+            }
+        });
     }
 }

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -360,4 +360,9 @@
     <string name="create_shortcut_error_vivo" comment="iManager is an app on Vivo phones">You may need to use iManager to allow AnkiDroid to add shortcuts</string>
     <string name="create_shortcut_failed" comment="home screen == launcher">Your home screen does not allow AnkiDroid to add shortcuts</string>
     <string name="create_shortcut_error">Error adding shortcut: %s</string>
+
+    <string name="night_mode_follow_system">Following system night mode</string>
+    <string name="night_mode_set_manual">Accepting manual night mode input</string>
+    <string name="night_mode_error_disable_follow">Disabled ‘follow system night mode’. Could not load night mode status</string>
+    <string name="night_mode_explain_long_press">Long press or use preferences to disable ‘follow system night mode’</string>
 </resources>

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -276,4 +276,6 @@
 
     <string name="note_editor_replace_newlines">Replace newlines with HTML</string>
     <string name="note_editor_replace_newlines_summ">In the Note Editor, convert any instances of &lt;br&gt; to newlines when editing a card.</string>
+
+    <string name="follow_system_night_mode">Follow System Night Mode</string>
 </resources>

--- a/AnkiDroid/src/main/res/xml/preferences_appearance.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_appearance.xml
@@ -39,6 +39,10 @@
             android:entryValues="@array/night_theme_values"
             android:key="nightTheme"
             android:title="@string/night_theme" />
+        <CheckBoxPreference
+            android:key="followSystemNightMode"
+            android:defaultValue="true"
+            android:title="@string/follow_system_night_mode" />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/background_image_title" >
         <CheckBoxPreference

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/NightModeServiceTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/NightModeServiceTest.java
@@ -1,0 +1,37 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.servicelayer;
+
+import com.ichi2.testutils.FastTest;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class NightModeServiceTest extends FastTest {
+    @Test
+    public void defaultManualNightModeIsOff() {
+        assertThat("default night mode should be off", NightModeService.getNightMode().isNightModeEnabled(), is(false));
+    }
+
+    @Test
+    public void setNightModeIntegrationTest() {
+        NightModeService.setManualNightModeMode(true);
+        assertThat("Night mode should be on if set", NightModeService.getNightMode().isNightModeEnabled(), is(true));
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/FastTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/FastTest.java
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.testutils;
+
+import com.ichi2.anki.AnkiDroidApp;
+
+import org.junit.After;
+import org.junit.Before;
+
+/** A test class which does not use Robolectric */
+public class FastTest {
+
+    @Before
+    public void before() {
+        AnkiDroidApp.setPreferenceMock(PreferencesMock.getInstance());
+    }
+
+    @After
+    public void after() {
+        AnkiDroidApp.resetPreferenceMock();
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/PreferencesMock.java
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/PreferencesMock.java
@@ -1,0 +1,27 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.testutils;
+
+import android.content.SharedPreferences;
+
+import com.github.ivanshafran.sharedpreferencesmock.SPMockBuilder;
+
+public class PreferencesMock {
+    public static SharedPreferences getInstance() {
+        return new SPMockBuilder().createSharedPreferences();
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,12 @@ buildscript {
             url "https://storage.googleapis.com/r8-releases/raw/master"
         }
         // End temporary #7558 work
+
+        allprojects {
+            repositories {
+                maven { url 'https://jitpack.io' }
+            }
+        }
     }
     dependencies {
         // Temporary, for #7558 where AGP4.0.x works, 4.1.x fails, from https://issuetracker.google.com/issues/169584856


### PR DESCRIPTION
## Purpose / Description


## Approach

This is a change: this setting is enabled by default.

We add a long-press action on the "night mode" toggle to toggle manual/auto.

If this setting is set, clicking "night mode" notifies the user of the
long press action

We also add a preference in "Appearance" to disable it

If we can't read the Android System setting, then we disable this.

## Fixes
Fixes #5685


## How Has This Been Tested?

Android 9 phone & unit tests

![image](https://user-images.githubusercontent.com/62114487/101187067-c924a080-364b-11eb-8e42-00b1a88cc19f.png)
![image](https://user-images.githubusercontent.com/62114487/101187075-cc1f9100-364b-11eb-8114-b4a94f5f5bea.png)
![image](https://user-images.githubusercontent.com/62114487/101187082-cde95480-364b-11eb-9782-3ff8f9637386.png)
![image](https://user-images.githubusercontent.com/62114487/101187123-dc377080-364b-11eb-9530-1a114db26613.png)



## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)