### PR TITLE
NF: uses linked hash for sets which are iterated

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -134,6 +134,7 @@ import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.concurrent.locks.Lock;
@@ -208,7 +209,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
     private static final int ankiJsErrorCodeFlagCard = 2;
 
     // JS api list enable/disable status
-    private final HashMap<String, Boolean> mJsApiListMap = new HashMap<>();
+    private final HashMap<String, Boolean> mJsApiListMap = new LinkedHashMap<>();
 
     /**
      * Broadcast that informs us when the sd card is about to be unmounted

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
@@ -62,6 +62,7 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
@@ -92,7 +93,7 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
 
     public class DeckPreferenceHack implements SharedPreferences {
 
-        private final Map<String, String> mValues = new HashMap<>();
+        private final Map<String, String> mValues = new LinkedHashMap<>();
         private final Map<String, String> mSummaries = new HashMap<>();
         private MaterialDialog mProgressDialog;
         private final List<OnSharedPreferenceChangeListener> listeners = new LinkedList<>();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FilteredDeckOptions.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FilteredDeckOptions.java
@@ -43,6 +43,7 @@ import com.ichi2.utils.JSONException;
 import com.ichi2.utils.JSONObject;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -77,7 +78,7 @@ public class FilteredDeckOptions extends AppCompatPreferenceActivity implements 
 
     public class DeckPreferenceHack implements SharedPreferences {
 
-        private final Map<String, String> mValues = new HashMap<>();
+        private final Map<String, String> mValues = new LinkedHashMap<>();
         private final Map<String, String> mSummaries = new HashMap<>();
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -123,6 +123,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
@@ -2179,7 +2180,7 @@ public class NoteEditor extends AnkiActivity {
             // Configure the interface according to whether note type is getting changed or not
             if (mAllModelIds.get(pos) != noteModelId) {
                 // Initialize mapping between fields of old model -> new model
-                mModelChangeFieldMap = new HashMap<>();
+                mModelChangeFieldMap = new LinkedHashMap<>();
                 for (int i=0; i < mEditorNote.items().length; i++) {
                     mModelChangeFieldMap.put(i, i);
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Preferences.java
@@ -74,6 +74,7 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -107,7 +108,7 @@ public class Preferences extends AppCompatPreferenceActivity implements Preferen
     public static final int PENDING_NOTIFICATIONS_ONLY = 1000000;
 
     // Other variables
-    private final HashMap<String, String> mOriginalSumarries = new HashMap<>();
+    private final HashMap<String, String> mOriginalSumarries = new LinkedHashMap<>();
     private static final String [] sCollectionPreferences = {"showEstimates", "showProgress",
             "learnCutoff", "timeLimit", "useCurrent", "newSpread", "dayOffset", "schedVer"};
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/language/LanguageListerBase.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/language/LanguageListerBase.java
@@ -22,6 +22,7 @@ package com.ichi2.anki.multimediacard.language;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 
 /**
  * This is some sort of tool, which translates from languages in a user readable form to a code, used to invoke some
@@ -35,7 +36,7 @@ public class LanguageListerBase {
 
 
     public LanguageListerBase() {
-        mLanguageMap = new HashMap<>();
+        mLanguageMap = new LinkedHashMap<>();
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtonStatus.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtonStatus.java
@@ -9,6 +9,7 @@ import com.ichi2.anki.R;
 import com.ichi2.themes.Themes;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import androidx.annotation.IdRes;
@@ -22,7 +23,7 @@ public class ActionButtonStatus {
      * Custom button allocation
      */
     @NonNull
-    protected final Map<Integer, Integer> mCustomButtons = new HashMap<>();
+    protected final Map<Integer, Integer> mCustomButtons = new LinkedHashMap<>();
     private final ReviewerUi mReviewerUi;
 
     public static final int SHOW_AS_ACTION_NEVER = MenuItem.SHOW_AS_ACTION_NEVER;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ReviewerCustomFonts.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ReviewerCustomFonts.java
@@ -25,6 +25,7 @@ import com.ichi2.anki.AnkiFont;
 import com.ichi2.libanki.Utils;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -152,7 +153,7 @@ public class ReviewerCustomFonts {
      */
     private static Map<String, AnkiFont> getCustomFontsMap(Context context) {
         List<AnkiFont> fonts = Utils.getCustomFonts(context);
-        Map<String, AnkiFont> customFontsMap = new HashMap<>();
+        Map<String, AnkiFont> customFontsMap = new LinkedHashMap<>();
         for (AnkiFont f : fonts) {
             customFontsMap.put(f.getName(), f);
         }

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -67,6 +67,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -1502,7 +1503,7 @@ public class CollectionTask extends BaseAsyncTask<TaskData, TaskData, TaskData> 
             // data and rely on them running a media db check to get rid of any
             // unwanted media. in the future we might also want to duplicate this step
             // import media
-            HashMap<String, String> nameToNum = new HashMap<>();
+            HashMap<String, String> nameToNum = new LinkedHashMap<>();
             HashMap<String, String> numToName = new HashMap<>();
             File mediaMapFile = new File(dir.getAbsolutePath(), "media");
             if (mediaMapFile.exists()) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -65,6 +65,7 @@ import java.util.Collections;
 import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -804,7 +805,7 @@ public class Collection {
 
                 // existing cards
                 if (!have.containsKey(nid)) {
-                    have.put(nid, new HashMap<>());
+                    have.put(nid, new LinkedHashMap<>());
                 }
                 have.get(nid).put(ord, id);
                 // and their dids

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -40,6 +40,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
@@ -147,8 +148,8 @@ public class Decks {
 
 
     private final Collection mCol;
-    private HashMap<Long, Deck> mDecks;
-    private HashMap<Long, DeckConfig> mDconf;
+    private LinkedHashMap<Long, Deck> mDecks;
+    private LinkedHashMap<Long, DeckConfig> mDconf;
     // Never access mNameMap directly. Uses byName
     private NameMap mNameMap;
     private boolean mChanged;
@@ -227,8 +228,8 @@ public class Decks {
 
 
     public void load(String decks, String dconf) {
-        mDecks = new HashMap<>();
-        mDconf = new HashMap<>();
+        mDecks = new LinkedHashMap<>();
+        mDconf = new LinkedHashMap<>();
         JSONObject decksarray = new JSONObject(decks);
         JSONArray ids = decksarray.names();
         for (String id: ids.stringIterable()) {
@@ -1011,7 +1012,7 @@ public class Decks {
         return actv;
     }
 
-    public static class Node extends HashMap<Long, Node> {}
+    public static class Node extends LinkedHashMap<Long, Node> {}
 
     private void gather(Node node, List<Long> arr) {
         for (Map.Entry<Long, Node> entry : node.entrySet()) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
@@ -38,6 +38,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
@@ -758,7 +759,7 @@ public class Finder {
         Pattern pattern = Pattern.compile("\\Q" + javaVal + "\\E", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
 
         // find models that have that field
-        Map<Long, Object[]> mods = new HashMap<>();
+        Map<Long, Object[]> mods = new LinkedHashMap<>();
         for (JSONObject m : mCol.getModels().all()) {
             JSONArray flds = m.getJSONArray("flds");
             for (JSONObject f: flds.jsonObjectIterable()) {
@@ -908,7 +909,7 @@ public class Finder {
 
         ArrayList<Object[]> d = new ArrayList<>();
         String snids = Utils.ids2str(nids);
-        Map<Long, java.util.Collection<Long>> midToNid = new HashMap<>();
+        Map<Long, java.util.Collection<Long>> midToNid = new LinkedHashMap<>();
         try (Cursor cur = col.getDb().query(
                 "select id, mid, flds from notes where id in " + snids)) {
             while (cur.moveToNext()) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Media.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Media.java
@@ -48,6 +48,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -437,7 +439,7 @@ public class Media {
     private List<List<String>> check(File[] local) {
         File mdir = new File(dir());
         // gather all media references in NFC form
-        Set<String> allRefs = new HashSet<>();
+        Set<String> allRefs = new LinkedHashSet<>();
         try (Cursor cur = mCol.getDb().query("select id, mid, flds from notes")) {
             while (cur.moveToNext()) {
                 long nid = cur.getLong(0);
@@ -697,7 +699,7 @@ public class Media {
 
 
     private Pair<List<String>, List<String>> _changes() {
-        Map<String, Object[]> cache = new HashMap<>();
+        Map<String, Object[]> cache = new LinkedHashMap<>();
         try (Cursor cur = mDb.query("select fname, csum, mtime from media where csum is not null")) {
             while (cur.moveToNext()) {
                 String name = cur.getString(0);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -37,6 +37,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -111,7 +112,7 @@ public class Models {
 
     private final Collection mCol;
     private boolean mChanged;
-    private HashMap<Long, Model> mModels;
+    private LinkedHashMap<Long, Model> mModels;
 
     // BEGIN SQL table entries
     private int mId;
@@ -163,7 +164,7 @@ public class Models {
      */
     public void load(String json) {
         mChanged = false;
-        mModels = new HashMap<>();
+        mModels = new LinkedHashMap<>();
         JSONObject modelarray = new JSONObject(json);
         JSONArray ids = modelarray.names();
         if (ids != null) {
@@ -436,7 +437,7 @@ public class Models {
     public static Map<String, Pair<Integer, JSONObject>> fieldMap(@NonNull Model m) {
         JSONArray flds = m.getJSONArray("flds");
         // TreeMap<Integer, String> map = new TreeMap<Integer, String>();
-        Map<String, Pair<Integer, JSONObject>> result = new HashMap<>();
+        Map<String, Pair<Integer, JSONObject>> result = new LinkedHashMap<>();
         for (JSONObject f: flds.jsonObjectIterable()) {
             result.put(f.getString("name"), new Pair<>(f.getInt("ord"), f));
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Tags.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Tags.java
@@ -27,6 +27,7 @@ import com.ichi2.utils.JSONObject;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -180,7 +181,7 @@ public class Tags {
         }
         // Cast to set to remove duplicates
         // Use methods used to get all tags to parse tags here as well.
-        return new ArrayList<>(new HashSet<>(split(TextUtils.join(" ", tags))));
+        return new ArrayList<>(new LinkedHashSet<>(split(TextUtils.join(" ", tags))));
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/AnkiPackageImporter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/AnkiPackageImporter.java
@@ -33,6 +33,7 @@ import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import org.apache.commons.compress.archivers.zip.ZipFile;
 
@@ -118,7 +119,7 @@ public class AnkiPackageImporter extends Anki2Importer {
             // we need the media dict in advance, and we'll need a map of fname ->
             // number to use during the import
             File mediaMapFile = new File(tempDir, "media");
-            mNameToNum = new HashMap<>();
+            mNameToNum = new LinkedHashMap<>();
             String dirPath = tmpCol.getMedia().dir();
             File dir = new File(dirPath);
             // We need the opposite mapping in AnkiDroid since our extraction method requires it.

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/importer/python/CsvSniffer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/importer/python/CsvSniffer.java
@@ -29,6 +29,7 @@ import com.ichi2.libanki.importer.CsvException;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -133,8 +134,8 @@ public class CsvSniffer {
         }
 
 
-        Map<Character, Integer> quotes = new HashMap<>();
-        Map<Character, Integer> delims = new HashMap<>();
+        Map<Character, Integer> quotes = new LinkedHashMap<>();
+        Map<Character, Integer> delims = new LinkedHashMap<>();
         int spaces = 0;
         for (Group m : matches) {
             char key = m.quote;
@@ -228,9 +229,9 @@ public class CsvSniffer {
         // build frequency tables
         int chunkLength = Math.min(10, data.size());
         int iteration = 0;
-        Map<Character, Map<Integer, Integer>> charFrequency = new HashMap<>();
-        Map<Character, Tuple> modes = new HashMap<>();
-        Map<Character, Tuple> delims = new HashMap<>();
+        Map<Character, Map<Integer, Integer>> charFrequency = new LinkedHashMap<>();
+        Map<Character, Tuple> modes = new LinkedHashMap<>();
+        Map<Character, Tuple> delims = new LinkedHashMap<>();
         int start = 0;
         int end = chunkLength;
 
@@ -238,7 +239,7 @@ public class CsvSniffer {
             iteration++;
             for (String line : data.subList(start, end)) {
                 for (char c : ascii) {
-                    Map<Integer, Integer> metaFrequency = charFrequency.getOrDefault(c, new HashMap<>());
+                    Map<Integer, Integer> metaFrequency = charFrequency.getOrDefault(c, new LinkedHashMap<>());
                     // must count even if frequency is 0
                     int freq = countInString(line, c);
                     // value is the mode

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/FullSyncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/FullSyncer.java
@@ -34,6 +34,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Locale;
 
 import okhttp3.Response;
@@ -49,7 +50,7 @@ public class FullSyncer extends HttpSyncer {
 
     public FullSyncer(Collection col, String hkey, Connection con, HostNum hostNum) {
         super(hkey, con, hostNum);
-        mPostVars = new HashMap<>();
+        mPostVars = new LinkedHashMap<>();
         mPostVars.put("k", hkey);
         mPostVars.put("v",
                 String.format(Locale.US, "ankidroid,%s,%s", VersionUtils.getPkgVersionName(), Utils.platDesc()));

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HttpSyncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HttpSyncer.java
@@ -49,6 +49,7 @@ import java.io.OutputStream;
 import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
@@ -101,7 +102,7 @@ public class HttpSyncer {
         mHKey = hkey;
         mSKey = Utils.checksum(Float.toString(new Random().nextFloat())).substring(0, 8);
         mCon = con;
-        mPostVars = new HashMap<>();
+        mPostVars = new LinkedHashMap<>();
         mHostNum = hostNum;
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteMediaServer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteMediaServer.java
@@ -36,6 +36,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.zip.ZipFile;
@@ -75,7 +76,7 @@ public class RemoteMediaServer extends HttpSyncer {
 
     public JSONObject begin() throws UnknownHttpResponseException, MediaSyncException {
         try {
-            mPostVars = new HashMap<>();
+            mPostVars = new LinkedHashMap<>();
             mPostVars.put("k", mHKey);
             mPostVars.put("v",
                     String.format(Locale.US, "ankidroid,%s,%s", VersionUtils.getPkgVersionName(), Utils.platDesc()));
@@ -94,7 +95,7 @@ public class RemoteMediaServer extends HttpSyncer {
     // args: lastUsn
     public JSONArray mediaChanges(int lastUsn) throws UnknownHttpResponseException, MediaSyncException {
         try {
-            mPostVars = new HashMap<>();
+            mPostVars = new LinkedHashMap<>();
             mPostVars.put("sk", mSKey);
 
             Response resp = super.req("mediaChanges",

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteServer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteServer.java
@@ -28,6 +28,7 @@ import com.ichi2.utils.JSONObject;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Locale;
 
 import okhttp3.Response;
@@ -44,7 +45,7 @@ public class RemoteServer extends HttpSyncer {
     @Override
     public Response hostKey(String user, String pw) throws UnknownHttpResponseException {
         try {
-            mPostVars = new HashMap<>();
+            mPostVars = new LinkedHashMap<>();
             JSONObject credentials = new JSONObject();
             credentials.put("u", user);
             credentials.put("p", pw);
@@ -57,7 +58,7 @@ public class RemoteServer extends HttpSyncer {
 
     @Override
     public Response meta() throws UnknownHttpResponseException {
-        mPostVars = new HashMap<>();
+        mPostVars = new LinkedHashMap<>();
         mPostVars.put("k", mHKey);
         mPostVars.put("s", mSKey);
         JSONObject meta = new JSONObject();

--- a/api/src/main/java/com/ichi2/anki/api/AddContentApi.java
+++ b/api/src/main/java/com/ichi2/anki/api/AddContentApi.java
@@ -51,6 +51,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -766,7 +767,7 @@ public final class AddContentApi {
         @Override
         public SparseArray<List<NoteInfo>> findDuplicateNotes(long modelId, List<String> keys) {
             // Build set of checksums and a HashMap from the key (first field) back to the original index in fieldsArray
-            Set<Long> csums = new HashSet<>(keys.size());
+            Set<Long> csums = new LinkedHashSet<>(keys.size());
             Map<String, List<Integer>> keyToIndexesMap = new HashMap<>(keys.size());
             for (int i = 0; i < keys.size(); i++) {
                 String key = keys.get(i);


### PR DESCRIPTION
According to https://docs.oracle.com/javase/8/docs/api/java/util/HashMap.html iterating over a hashed map (or set)
depends both on the size of the set but also on its capacity. If we want to efficiently iterate over map and sets we
should use LinkedHashMap, where iteration is done in linear time over the size of the map.

To do this modification, I:
* checked all entrySet, keySet and values call on map, and looked where there maps where defined. I changed those maps
* Looks at all HashSet construction and checked whether they were used in an iteration