### PR TITLE
NF: deck ids are long and not int

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.java
@@ -281,7 +281,7 @@ public class CardTemplatePreviewer extends AbstractFlashcardViewer {
         }
         try {
             JSONObject template = model.getJSONArray("tmpls").getJSONObject(ordinal);
-            PreviewerCard card = (PreviewerCard)getCol().getNewLinkedCard(new PreviewerCard(getCol()), n, template, 1, 0, false);
+            PreviewerCard card = (PreviewerCard)getCol().getNewLinkedCard(new PreviewerCard(getCol()), n, template, 1, 0L, false);
             card.setNote(n);
             return card;
         } catch (Exception e) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -910,7 +910,7 @@ public class Collection {
         return previewCards(note, type, did);
     }
 
-    public List<Card> previewCards(Note note, Previewing type, int did) {
+    public List<Card> previewCards(Note note, Previewing type, long did) {
 	    List<JSONObject> cms;
 	    switch (type) {
             case ADD:
@@ -944,17 +944,17 @@ public class Collection {
         return _newCard(note, template, due, flush);
     }
 
-    private Card _newCard(Note note, JSONObject template, int due, int did) {
+    private Card _newCard(Note note, JSONObject template, int due, long did) {
         boolean flush = true;
         return _newCard(note, template, due, did, flush);
     }
 
     private Card _newCard(Note note, JSONObject template, int due, boolean flush) {
-        int did = 0;
+        long did = 0L;
         return _newCard(note, template, due, did, flush);
     }
 
-    private Card _newCard(Note note, JSONObject template, int due, int parameterDid, boolean flush) {
+    private Card _newCard(Note note, JSONObject template, int due, long parameterDid, boolean flush) {
         Card card = new Card(this);
         return getNewLinkedCard(card, note, template, due, parameterDid, flush);
     }
@@ -963,12 +963,12 @@ public class Collection {
     // you pass the Card object in. This allows you to work on 'Card' subclasses that may not have
     // actual backing store (for instance, if you are previewing unsaved changes on templates)
     // TODO: use an interface that we implement for card viewing, vs subclassing an active model to workaround libAnki
-    public Card getNewLinkedCard(Card card, Note note, JSONObject template, int due, int parameterDid, boolean flush) {
+    public Card getNewLinkedCard(Card card, Note note, JSONObject template, int due, long parameterDid, boolean flush) {
         long nid = note.getId();
         card.setNid(nid);
         int ord = template.getInt("ord");
         card.setOrd(ord);
-        long did = mDb.queryScalar("select did from cards where nid = ? and ord = ?", nid, ord);
+        long did = mDb.queryLongScalar("select did from cards where nid = ? and ord = ?", nid, ord);
         // Use template did (deck override) if valid, otherwise did in argument, otherwise model did
         if (did == 0) {
             did = template.optLong("did", 0);


### PR DESCRIPTION
Decks ids are long and not int. This is corrected. In particular `queryScalar` return an int, so part of the returned value is missing.

That was never a problem because  `parameterDid` is ALWAYS 0. There is not a single time where it's set to anything else. So int or long does not matter.

`getNewLinkedCard` is used in two cases. When creating a new card, the query does not return any result since the card does not exists yet it can't be find in the db. When the card is previewed, the wrong deck can be seen only if the card uses `{{Deck}}`

I just realized by the way that previewing a card does not work currently on my phone. Don't know why. This means that I can't test