### PR TITLE
Delete a method never used

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -903,30 +903,6 @@ public class Collection {
         MODELS
     }
 
-    public List<Card> previewCards(Note note, Previewing type, long did) {
-	    List<JSONObject> cms;
-	    switch (type) {
-            case ADD:
-    	        cms = findTemplates(note);
-    	        break;
-            case EDIT:
-                ArrayList<Card> cards = note.cards();
-    	        cms = new ArrayList<>(cards.size());
-	            for (Card c : cards) {
-	                cms.add(c.template());
-	            }
-	            break;
-            default: // MODELS
-                JSONArray tmpls = note.model().getJSONArray("tmpls");
-                cms = tmpls.toJSONObjectList();
-	    }
-	    List<Card> cards = new ArrayList<>(cms.size());
-	    for (JSONObject template : cms) {
-	        cards.add(_newCard(note, template, 1, did, false));
-	    }
-	    return cards;
-	}
-
     /**
      * Create a new card.
      */

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -903,19 +903,6 @@ public class Collection {
         MODELS
     }
 
-	/**
-	 * Return cards of a note, without saving them
-	 * @param note The note whose cards are going to be previewed
-     * @param type 0 - when previewing in add dialog, only non-empty
-     *             1 - when previewing edit, only existing
-     *             2 - when previewing in models dialog, all templates
-     * @return list of cards
-	 */
-	public List<Card> previewCards(Note note, Previewing type) {
-        int did = 0;
-        return previewCards(note, type, did);
-    }
-
     public List<Card> previewCards(Note note, Previewing type, long did) {
 	    List<JSONObject> cms;
 	    switch (type) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -939,9 +939,6 @@ public class Collection {
 	    }
 	    return cards;
 	}
-    public List<Card> previewCards(Note note) {
-        return previewCards(note, ADD);
-    }
 
     /**
      * Create a new card.

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -86,7 +86,6 @@ import com.ichi2.async.TaskData;
 
 import static com.ichi2.async.CancelListener.isCancelled;
 import static com.ichi2.libanki.Collection.DismissType.REVIEW;
-import static com.ichi2.libanki.Collection.Previewing.*;
 
 // Anki maintains a cache of used tags so it can quickly present a list of tags
 // for autocomplete and in the browser. For efficiency, deletions are not
@@ -895,12 +894,6 @@ public class Collection {
         // bulk update
         mDb.executeMany("INSERT INTO cards VALUES (?,?,?,?,?,?,0,0,?,0,0,0,0,0,0,0,0,\"\")", data);
         return rem;
-    }
-
-    public enum Previewing {
-        ADD,
-        EDIT,
-        MODELS
     }
 
     /**


### PR DESCRIPTION
A quick search in git history shows that the method `previewCards` was introduced in 2012 in 2f3ea8868ce37534b1d3b7fee1c7f0c9fb1edbfa and has never been used since. I can't find a single time where `previewCards(` appears in the code base, appart when I did some changes such as replacing ints by constant.

As far as I understand, this is unrelated to previewing as we consider it today (it would be hard, in 2012). It returns instead the card that should be shown to the user if they asked to preview cards. If the user was creating a card, then it would show all cards generated. If the user was asking to edit the cards it would show already existing cards. If the user was trying to edit a note type, it would show all card types.

David called my attention on the fact that it's not used in https://github.com/ankidroid/Anki-Android/pull/7271#pullrequestreview-546721128 and I suggest to delete it instead of trying to figure out the correct way to edit a function which is never called