### PR TITLE
NF: correct automated google test creating deck adapter too soon

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.java
@@ -382,7 +382,7 @@ public class DeckAdapter extends RecyclerView.Adapter<DeckAdapter.ViewHolder> im
 
 
     private class DeckFilter extends Filter {
-        private final ArrayList<AbstractDeckTreeNode> mFilteredDecks = new ArrayList<>(mCol.getDecks().count());
+        private final @NonNull ArrayList<AbstractDeckTreeNode> mFilteredDecks = new ArrayList<>();
         private DeckFilter() {
             super();
         }
@@ -394,6 +394,7 @@ public class DeckAdapter extends RecyclerView.Adapter<DeckAdapter.ViewHolder> im
         @Override
         protected FilterResults performFiltering(CharSequence constraint) {
             mFilteredDecks.clear();
+            mFilteredDecks.ensureCapacity(mCol.getDecks().count());
 
             List<AbstractDeckTreeNode> allDecks = getAllDecks();
             if (TextUtils.isEmpty(constraint)) {


### PR DESCRIPTION
According to Mike:
> lots of devices crashing in the automated robotest from google on the alpha release

> > FATAL EXCEPTION: Thread-6
> > Process: com.ichi2.anki, PID: 9642
> > java.lang.NullPointerException: Attempt to invoke virtual method 'com.ichi2.libanki.Decks com.ichi2.libanki.Collection.getDecks()' on a null object reference
> >     at com.ichi2.anki.widgets.DeckAdapter$DeckFilter.<init>(DeckAdapter.java:4)
> >     at com.ichi2.anki.widgets.DeckAdapter$DeckFilter.<init>(DeckAdapter.java:1)
> >     at com.ichi2.anki.widgets.DeckAdapter.getFilter(DeckAdapter.java:1)
> >     at com.ichi2.anki.DeckPicker.__renderPage(DeckPicker.java:21)
> >     at com.ichi2.anki.DeckPicker$UpdateDeckListListener.actualOnPostExecute(DeckPicker.java:9)
> >     at com.ichi2.anki.DeckPicker$UpdateDeckListListener.actualOnPostExecute(DeckPicker.java:1)
> >     at com.ichi2.async.TaskListenerWithContext.onPostExecute(TaskListenerWithContext.java:2)
> >     at com.ichi2.async.CollectionTask.onPostExecute(CollectionTask.java:4)
> >     at com.ichi2.async.CollectionTask.onPostExecute(CollectionTask.java:1)
> >     at android.os.AsyncTask.finish(AsyncTask.java:695)
> >     at android.os.AsyncTask.-wrap1(Unknown Source:0)
> >     at android.os.AsyncTask$InternalHandler.handleMessage(AsyncTask.java:712)
> >     at android.os.Handler.dispatchMessage(Handler.java:105)

This seems to be caused by access to collection before it's loaded. It seems impossible in real use, even when there is
no permission to read data. Moving capacity after constructor is not ideal, but ensure that no resizing copy data and
that it is only done when collection is loaded
