### PR TITLE
Remove legacy Whiteboard settings

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -101,7 +101,6 @@ import static com.ichi2.anim.ActivityTransitionAnimation.Direction.*;
 public class Reviewer extends AbstractFlashcardViewer {
     private boolean mHasDrawerSwipeConflicts = false;
     private boolean mShowWhiteboard = true;
-    private boolean mBlackWhiteboard = true;
     private boolean mPrefFullscreenReview = false;
     private static final int ADD_NOTE = 12;
     private static final int REQUEST_AUDIO_PERMISSION = 0;
@@ -912,7 +911,6 @@ public class Reviewer extends AbstractFlashcardViewer {
         mPrefHideDueCount = preferences.getBoolean("hideDueCount", false);
         mPrefShowETA = preferences.getBoolean("showETA", true);
         this.mProcessor.setup();
-        mBlackWhiteboard = preferences.getBoolean("blackWhiteboard", true);
         mPrefFullscreenReview = Integer.parseInt(preferences.getString("fullscreenMode", "0")) > 0;
         mActionButtons.setup(preferences);
         return preferences;
@@ -1151,7 +1149,7 @@ public class Reviewer extends AbstractFlashcardViewer {
     // Create the whiteboard
     private void createWhiteboard() {
         SharedPreferences sharedPrefs = AnkiDroidApp.getSharedPrefs(this);
-        mWhiteboard = new Whiteboard(this, isInNightMode(), mBlackWhiteboard);
+        mWhiteboard = new Whiteboard(this, isInNightMode());
         FrameLayout.LayoutParams lp2 = new FrameLayout.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT);
         mWhiteboard.setLayoutParams(lp2);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.java
@@ -40,6 +40,7 @@ import android.view.Display;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.WindowManager;
+import android.widget.Button;
 import android.widget.LinearLayout;
 
 import com.ichi2.libanki.utils.Time;
@@ -85,23 +86,15 @@ public class Whiteboard extends View {
     @Nullable
     private OnPaintColorChangeListener mOnPaintColorChangeListener;
 
-    public Whiteboard(AbstractFlashcardViewer cardViewer, boolean inverted, boolean monochrome) {
+    public Whiteboard(AbstractFlashcardViewer cardViewer, boolean inverted) {
         super(cardViewer, null);
         mCardViewer = new WeakReference<>(cardViewer);
 
 
         if (!inverted) {
-            if (monochrome) {
                 foregroundColor = Color.BLACK;
-            } else {
-                foregroundColor = ContextCompat.getColor(cardViewer, R.color.wb_fg_color);
-            }
         } else {
-            if (monochrome) {
                 foregroundColor = Color.WHITE;
-            } else {
-                foregroundColor = ContextCompat.getColor(cardViewer, R.color.wb_fg_color_inv);
-            }
         }
 
         mPaint = new Paint();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.java
@@ -256,7 +256,7 @@ public class Whiteboard extends View {
 
     private void createBitmap() {
         // To fix issue #1336, just make the whiteboard big and square.
-        final Point p = getDisplayDimenions();
+        final Point p = getDisplayDimensions();
         int bitmapSize = Math.max(p.x, p.y);
         createBitmap(bitmapSize, bitmapSize);
     }
@@ -358,7 +358,7 @@ public class Whiteboard extends View {
         return false;
     }
 
-    private static Point getDisplayDimenions() {
+    private static Point getDisplayDimensions() {
         Display display = ((WindowManager) AnkiDroidApp.getInstance().getApplicationContext().
                 getSystemService(Context.WINDOW_SERVICE)).getDefaultDisplay();
         Point point = new Point();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.java
@@ -90,10 +90,16 @@ public class Whiteboard extends View {
         super(cardViewer, null);
         mCardViewer = new WeakReference<>(cardViewer);
 
+        Button whitePenColorButton = cardViewer.findViewById(R.id.pen_color_white);
+        Button blackPenColorButton = cardViewer.findViewById(R.id.pen_color_black);
 
         if (!inverted) {
+                whitePenColorButton.setVisibility(View.GONE);
+                blackPenColorButton.setOnClickListener(this::onClick);
                 foregroundColor = Color.BLACK;
         } else {
+                blackPenColorButton.setVisibility(View.GONE);
+                whitePenColorButton.setOnClickListener(this::onClick);
                 foregroundColor = Color.WHITE;
         }
 
@@ -113,8 +119,6 @@ public class Whiteboard extends View {
         // selecting pen color to draw
         mColorPalette = cardViewer.findViewById(R.id.whiteboard_pen_color);
 
-        cardViewer.findViewById(R.id.pen_color_white).setOnClickListener(this::onClick);
-        cardViewer.findViewById(R.id.pen_color_black).setOnClickListener(this::onClick);
         cardViewer.findViewById(R.id.pen_color_red).setOnClickListener(this::onClick);
         cardViewer.findViewById(R.id.pen_color_green).setOnClickListener(this::onClick);
         cardViewer.findViewById(R.id.pen_color_blue).setOnClickListener(this::onClick);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/FullSyncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/FullSyncer.java
@@ -37,6 +37,8 @@ import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Locale;
 
+import androidx.annotation.NonNull;
+
 import okhttp3.Response;
 import okhttp3.ResponseBody;
 import timber.log.Timber;

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -45,8 +45,6 @@
 
     <!-- preferences.xml entries-->
     <string name="whiteboard_stroke_width">Stroke width</string>
-    <string name="whiteboard_black">Black strokes</string>
-    <string name="whiteboard_black_summ">Uses less memory, unless in night mode</string>
     <string name="use_input_tag">Type answer into the card</string>
     <string name="use_input_tag_summ">Use a text input box inside the card to type in the answer</string>
     <string name="dictionary">Lookup dictionary</string>

--- a/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
@@ -132,11 +132,6 @@
             android:summary="@string/preference_summary_literal"
             android:text=""
             android:title="@string/whiteboard_stroke_width" />
-        <CheckBoxPreference
-            android:defaultValue="true"
-            android:key="blackWhiteboard"
-            android:summary="@string/whiteboard_black_summ"
-            android:title="@string/whiteboard_black" />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/timeout_answer_text" >
         <CheckBoxPreference

--- a/AnkiDroid/src/test/java/com/ichi2/anki/WhiteboardDefaultForegroundColorTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/WhiteboardDefaultForegroundColorTest.java
@@ -35,18 +35,13 @@ public class WhiteboardDefaultForegroundColorTest extends RobolectricTest {
     public boolean mIsInverted;
 
     @ParameterizedRobolectricTestRunner.Parameter(1)
-    public boolean mIsMonochrome;
-
-    @ParameterizedRobolectricTestRunner.Parameter(2)
     public int mExpectedResult;
 
     @ParameterizedRobolectricTestRunner.Parameters
     public static java.util.Collection<Object[]> initParameters() {
         return Arrays.asList(new Object[][] {
-                { true, true, Color.WHITE },
-                { true, false, 0xFF0099FF },       // obtained from colors.xml (FF for the alpha channel)
-                { false, true, Color.BLACK },
-                { false, false, 0xB00000FF } });   // obtained from colors.xml
+                { true, Color.WHITE },
+                { false, Color.BLACK } });
     }
 
     @Test
@@ -57,6 +52,6 @@ public class WhiteboardDefaultForegroundColorTest extends RobolectricTest {
 
     protected int getForegroundColor() {
         AbstractFlashcardViewer mock = super.startActivityNormallyOpenCollectionWithIntent(Reviewer.class, new Intent());
-        return new Whiteboard(mock, mIsInverted, mIsMonochrome).getForegroundColor();
+        return new Whiteboard(mock, mIsInverted).getForegroundColor();
     }
 }


### PR DESCRIPTION
## Purpose / Description
Removes "Black strokes" setting (deprecated in #6550) and slight UI fix for pen colors 

## Fixes
Fixes #7836

## Approach
- Removed "black strokes" refs in xml files, UI, and associated Preference vars in other files
- Removed monochrome check for foregroundColor
- Set visibility for black/white pen colors based on Night mode
- Updated Whiteboard Foreground Test 

## How Has This Been Tested?

Tested on emulator & passed unit tests

## Screenshots
### Removed black strokes
![image](https://user-images.githubusercontent.com/17112814/101837426-0b972300-3b0d-11eb-8681-58dfeb0e3f19.png)

### Hides black/white pen color based on Night mode toggle
![image](https://user-images.githubusercontent.com/17112814/101837533-29fd1e80-3b0d-11eb-9ba1-2834d1a257b1.png)
![image](https://user-images.githubusercontent.com/17112814/101837573-3c775800-3b0d-11eb-935a-3d8f306bfe3c.png)

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)