### PR TITLE
correct typing of tasks

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -516,7 +516,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
     protected final NextCardHandler<BooleanGetter> mDismissCardHandler = new NextCardHandler() { /* superclass is sufficient */ };
 
 
-    private final TaskListener<CardGetter, Boolean> mUpdateCardHandler = new TaskListener<CardGetter, Boolean>() {
+    private final TaskListener<CardGetter, BooleanGetter> mUpdateCardHandler = new TaskListener<CardGetter, BooleanGetter>() {
         private boolean mNoMoreCards;
 
 
@@ -566,8 +566,8 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
 
 
         @Override
-        public void onPostExecute(Boolean result) {
-            if (!result) {
+        public void onPostExecute(BooleanGetter result) {
+            if (!result.getBoolean()) {
                 // RuntimeException occurred on update cards
                 closeReviewer(DeckPicker.RESULT_DB_ERROR, false);
                 return;
@@ -1151,7 +1151,9 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
             if (resultCode == RESULT_OK) {
                 // content of note was changed so update the note and current card
                 Timber.i("AbstractFlashcardViewer:: Saving card...");
-                TaskManager.launchCollectionTask(new CollectionTask.UpdateNote(sEditorCard, true, canAccessScheduler()), mUpdateCardHandler);
+                TaskManager.launchCollectionTask(
+                        new CollectionTask.UpdateNote(sEditorCard, true, canAccessScheduler()),
+                        mUpdateCardHandler);
                 onEditedNoteChanged();
             } else if (resultCode == RESULT_CANCELED && !(data!=null && data.hasExtra("reloadRequired"))) {
                 // nothing was changed by the note editor so just redraw the card

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -84,6 +84,7 @@ import com.ichi2.utils.BooleanGetter;
 import com.ichi2.utils.FunctionalInterfaces;
 import com.ichi2.utils.LanguageUtil;
 import com.ichi2.utils.PairWithBoolean;
+import com.ichi2.utils.PairWithCard;
 import com.ichi2.utils.Permissions;
 import com.ichi2.widget.WidgetStatus;
 
@@ -1342,7 +1343,8 @@ public class CardBrowser extends NavigationDrawerActivity implements
 
         if (requestCode == EDIT_CARD && resultCode != RESULT_CANCELED) {
             Timber.i("CardBrowser:: CardBrowser: Saving card...");
-            TaskManager.launchCollectionTask(new CollectionTask.UpdateNote(sCardBrowserCard, false, false), updateCardHandler());
+            TaskManager.launchCollectionTask(new CollectionTask.UpdateNote(sCardBrowserCard, false, false),
+                    updateCardHandler());
         } else if (requestCode == ADD_NOTE && resultCode == RESULT_OK) {
             if (mSearchView != null) {
                 mSearchTerms = mSearchView.getQuery().toString();
@@ -1674,18 +1676,18 @@ public class CardBrowser extends NavigationDrawerActivity implements
         return new UpdateCardHandler(this);
     }
 
-    private static class UpdateCardHandler<Result extends BooleanGetter> extends ListenerWithProgressBarCloseOnFalse<Pair<Card, String>, Result> {
+    private static class UpdateCardHandler extends ListenerWithProgressBarCloseOnFalse<PairWithCard<String>, BooleanGetter> {
         public UpdateCardHandler(CardBrowser browser) {
             super("Card Browser - UpdateCardHandler.actualOnPostExecute(CardBrowser browser)", browser);
         }
 
         @Override
-        public void actualOnProgressUpdate(@NonNull CardBrowser browser, Pair<Card, String> value) {
-            browser.updateCardInList(value.first);
+        public void actualOnProgressUpdate(@NonNull CardBrowser browser, PairWithCard<String> value) {
+            browser.updateCardInList(value.getCard());
         }
 
         @Override
-        protected void actualOnValidPostExecute(CardBrowser browser, Result result) {
+        protected void actualOnValidPostExecute(CardBrowser browser, BooleanGetter result) {
             browser.hideProgressBar();
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -97,6 +97,8 @@ import static com.ichi2.libanki.Collection.DismissType.RESCHEDULE_CARDS;
 import static com.ichi2.libanki.Collection.DismissType.RESET_CARDS;
 import static com.ichi2.libanki.Collection.DismissType.SUSPEND_NOTE;
 import static com.ichi2.libanki.Undoable.*;
+import static com.ichi2.utils.BooleanGetter.False;
+import static com.ichi2.utils.BooleanGetter.True;
 import static com.ichi2.utils.BooleanGetter.fromBoolean;
 
 /**
@@ -286,7 +288,7 @@ public class CollectionTask<ProgressListener, ProgressBackground extends Progres
     }
 
 
-    public static class UpdateNote extends Task<PairWithCard<String>, Boolean> {
+    public static class UpdateNote extends Task<PairWithCard<String>, BooleanGetter> {
         private final Card editCard;
         private final boolean fromReviewer;
         private final boolean canAccessScheduler;
@@ -298,7 +300,7 @@ public class CollectionTask<ProgressListener, ProgressBackground extends Progres
             this.canAccessScheduler = canAccessScheduler;
         }
 
-        protected Boolean task(Collection col, ProgressSenderAndCancelListener<PairWithCard<String>> collectionTask) {
+        protected BooleanGetter task(Collection col, ProgressSenderAndCancelListener<PairWithCard<String>> collectionTask) {
             Timber.d("doInBackgroundUpdateNote");
             // Save the note
             AbstractSched sched = col.getSched();
@@ -328,9 +330,9 @@ public class CollectionTask<ProgressListener, ProgressBackground extends Progres
             } catch (RuntimeException e) {
                 Timber.e(e, "doInBackgroundUpdateNote - RuntimeException on updating note");
                 AnkiDroidApp.sendExceptionReport(e, "doInBackgroundUpdateNote");
-                return false;
+                return False;
             }
-            return true;
+            return True;
         }
 
         public boolean isFromReviewer() {
@@ -348,7 +350,7 @@ public class CollectionTask<ProgressListener, ProgressBackground extends Progres
                 newCard._getQA(true);
             }
             collectionTask.doProgress(newCard);
-            return fromBoolean(true);
+            return True;
         }
     }
 
@@ -539,9 +541,9 @@ public class CollectionTask<ProgressListener, ProgressBackground extends Progres
             } catch (RuntimeException e) {
                 Timber.e(e, "doInBackgroundDismissNote - RuntimeException on dismissing note, dismiss type %s", type);
                 AnkiDroidApp.sendExceptionReport(e, "doInBackgroundDismissNote");
-                return fromBoolean(false);
+                return False;
             }
-            return fromBoolean(true);
+            return True;
         }
     }
 
@@ -1018,9 +1020,9 @@ public class CollectionTask<ProgressListener, ProgressBackground extends Progres
             } catch (RuntimeException e) {
                 Timber.e(e, "doInBackgroundUndo - RuntimeException on undoing");
                 AnkiDroidApp.sendExceptionReport(e, "doInBackgroundUndo");
-                return fromBoolean(false);
+                return False;
             }
-            return fromBoolean(true);
+            return True;
         }
     }
 
@@ -1346,7 +1348,7 @@ public class CollectionTask<ProgressListener, ProgressBackground extends Progres
             } catch (IOException e) {
                 Timber.e(e, "doInBackgroundImportReplace - Error while unzipping");
                 AnkiDroidApp.sendExceptionReport(e, "doInBackgroundImportReplace0");
-                return fromBoolean(false);
+                return False;
             }
             try {
                 // v2 scheduler?
@@ -1356,11 +1358,11 @@ public class CollectionTask<ProgressListener, ProgressBackground extends Progres
                 Utils.unzipFiles(zip, dir.getAbsolutePath(), new String[] {colname, "media"}, null);
             } catch (IOException e) {
                 AnkiDroidApp.sendExceptionReport(e, "doInBackgroundImportReplace - unzip");
-                return fromBoolean(false);
+                return False;
             }
             String colFile = new File(dir, colname).getAbsolutePath();
             if (!(new File(colFile)).exists()) {
-                return fromBoolean(false);
+                return False;
             }
 
             Collection tmpCol = null;
@@ -1368,7 +1370,7 @@ public class CollectionTask<ProgressListener, ProgressBackground extends Progres
                 tmpCol = Storage.Collection(context, colFile);
                 if (!tmpCol.validCollection()) {
                     tmpCol.close();
-                    return fromBoolean(false);
+                    return False;
                 }
             } catch (Exception e) {
                 Timber.e("Error opening new collection file... probably it's invalid");
@@ -1378,7 +1380,7 @@ public class CollectionTask<ProgressListener, ProgressBackground extends Progres
                     // do nothing
                 }
                 AnkiDroidApp.sendExceptionReport(e, "doInBackgroundImportReplace - open col");
-                return fromBoolean(false);
+                return False;
             } finally {
                 if (tmpCol != null) {
                     tmpCol.close();
@@ -1400,7 +1402,7 @@ public class CollectionTask<ProgressListener, ProgressBackground extends Progres
             File f = new File(colFile);
             if (!f.renameTo(new File(colPath))) {
                 // Exit early if this didn't work
-                return fromBoolean(false);
+                return False;
             }
             int addedCount = -1;
             try {
@@ -1443,19 +1445,19 @@ public class CollectionTask<ProgressListener, ProgressBackground extends Progres
                 zip.close();
                 // delete tmp dir
                 BackupManager.removeDir(dir);
-                return fromBoolean(true);
+                return True;
             } catch (RuntimeException e) {
                 Timber.e(e, "doInBackgroundImportReplace - RuntimeException");
                 AnkiDroidApp.sendExceptionReport(e, "doInBackgroundImportReplace1");
-                return fromBoolean(false);
+                return False;
             } catch (FileNotFoundException e) {
                 Timber.e(e, "doInBackgroundImportReplace - FileNotFoundException");
                 AnkiDroidApp.sendExceptionReport(e, "doInBackgroundImportReplace2");
-                return fromBoolean(false);
+                return False;
             } catch (IOException e) {
                 Timber.e(e, "doInBackgroundImportReplace - IOException");
                 AnkiDroidApp.sendExceptionReport(e, "doInBackgroundImportReplace3");
-                return fromBoolean(false);
+                return False;
             }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/async/TaskManager.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/TaskManager.java
@@ -67,8 +67,9 @@ public class TaskManager {
      * @param listener to the status and result of the task, may be null
      * @return the newly created task
      */
-    public static <ProgressListener, ProgressBackground extends ProgressListener, ResultListener, ResultBackground extends ResultListener> CollectionTask<ProgressListener, ProgressBackground, ResultListener, ResultBackground> launchCollectionTask(@NonNull CollectionTask.Task<ProgressBackground, ResultBackground> task,
-                                                                                                                                                                                                                                                       @Nullable TaskListener<ProgressListener, ResultListener> listener) {
+    public static <ProgressListener, ProgressBackground extends ProgressListener, ResultListener, ResultBackground extends ResultListener> CollectionTask<ProgressListener, ProgressBackground, ResultListener, ResultBackground>
+        launchCollectionTask(@NonNull CollectionTask.Task<ProgressBackground, ResultBackground> task,
+        @Nullable TaskListener<ProgressListener, ResultListener> listener) {
         // Start new task
         CollectionTask<ProgressListener, ProgressBackground, ResultListener, ResultBackground> newTask = new CollectionTask<>(task, listener, sLatestInstance);
         newTask.execute();

--- a/AnkiDroid/src/main/java/com/ichi2/utils/BooleanGetter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/BooleanGetter.java
@@ -6,7 +6,9 @@ package com.ichi2.utils;
 public interface BooleanGetter {
     boolean getBoolean();
 
-    public static BooleanGetter fromBoolean(boolean b) {
+    BooleanGetter True = () -> true;
+    BooleanGetter False = () -> false;
+    static BooleanGetter fromBoolean(boolean b) {
         return (() -> b);
     }
 }


### PR DESCRIPTION
The very wrong line was
```java
private static class UpdateCardHandler<Result extends BooleanGetter> extends
ListenerWithProgressBarCloseOnFalse<Pair<Card, String>, Result> {
```

`UpdateCardHandler` should not have taken a parameter, and especially, no variable of this type should have been
declared without parameters. This stopped typechecking to work, and lead to #7862.

The remaining changes are the one detected by the correction of this first line.

The irony is that the whole point of using Task was to ensure type safety

Fixes #7860
Fixes #7864