### PR TITLE
Correct media sync

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
@@ -453,7 +453,7 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
             if (media) {
                 server = new RemoteMediaServer(col, hkey, this, hostNum);
                 MediaSyncer mediaClient = new MediaSyncer(col, (RemoteMediaServer) server, this);
-                Pair<ConnectionResultType, Object> ret;
+                Pair<ConnectionResultType, String> ret;
                 try {
                     Timber.i("Sync - Performing media sync");
                     ret = mediaClient.sync();

--- a/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/Connection.java
@@ -460,7 +460,7 @@ public class Connection extends BaseAsyncTask<Connection.Payload, Object, Connec
                     if (ret == null || ret.first == null) {
                         mediaError = AnkiDroidApp.getAppResources().getString(R.string.sync_media_error);
                     } else {
-                        if ("corruptMediaDB".equals(ret)) {
+                        if (CORRUPT == ret.first) {
                             mediaError = AnkiDroidApp.getAppResources().getString(R.string.sync_media_db_error);
                             noMediaChanges = true;
                         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/MediaSyncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/MediaSyncer.java
@@ -83,8 +83,8 @@ public class MediaSyncer {
         mCon = con;
     }
 
-
-    public Pair<ConnectionResultType, Object> sync() throws UnknownHttpResponseException, MediaSyncException {
+    // Returned string may be null. ConnectionResultType and Pair are not null
+    public Pair<ConnectionResultType, String> sync() throws UnknownHttpResponseException, MediaSyncException {
             // check if there have been any changes
             // If we haven't built the media db yet, do so on this sync. See note at the top
             // of this class about this difference to the original.


### PR DESCRIPTION
For some reason I don't get, in 38ab1ea7ad9878223313e2aab2fb4c4462568dc5, a string was not replaced by the enum value. And since `.equals(Object)` is valid even when it's obviously false, it was not detected by type system