### PR TITLE
NF: varible has a specific server class

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/FullSyncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/FullSyncer.java
@@ -62,7 +62,6 @@ public class FullSyncer extends HttpSyncer {
         mCon = con;
     }
 
-    @Override
     public @NonNull ConnectionResultType download() throws UnknownHttpResponseException {
         InputStream cont;
         ResponseBody body = null;
@@ -139,8 +138,6 @@ public class FullSyncer extends HttpSyncer {
         }
     }
 
-
-    @Override
     public Pair<ConnectionResultType, Object[]> upload() throws UnknownHttpResponseException {
         // make sure it's ok before we try to upload
         mCon.publishProgress(R.string.sync_check_upload_file);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HttpSyncer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/HttpSyncer.java
@@ -341,62 +341,6 @@ public class HttpSyncer {
         }
     }
 
-
-    public Response hostKey(String arg1, String arg2) throws UnknownHttpResponseException {
-        return null;
-    }
-
-
-    public JSONObject applyChanges(JSONObject kw) throws UnknownHttpResponseException {
-        return null;
-    }
-
-
-    public JSONObject start(JSONObject kw) throws UnknownHttpResponseException {
-        return null;
-    }
-
-
-    public JSONObject chunk() throws UnknownHttpResponseException {
-        return null;
-    }
-
-
-    public long finish() throws UnknownHttpResponseException {
-        return 0;
-    }
-
-
-    public void abort() throws UnknownHttpResponseException {
-        // do nothing
-    }
-
-
-    public Response meta() throws UnknownHttpResponseException {
-        return null;
-    }
-
-
-    public @Nullable Syncer.ConnectionResultType download() throws UnknownHttpResponseException {
-        return null;
-    }
-
-
-    public Pair<Syncer.ConnectionResultType, Object[]> upload() throws UnknownHttpResponseException {
-        return null;
-    }
-
-
-    public JSONObject sanityCheck2(JSONObject client) throws UnknownHttpResponseException {
-        return null;
-    }
-
-
-    public void applyChunk(JSONObject sech) throws UnknownHttpResponseException {
-        // do nothing
-    }
-
-
     public class ProgressByteEntity extends AbstractHttpEntity {
 
         private InputStream mInputStream;

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteServer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sync/RemoteServer.java
@@ -41,7 +41,6 @@ public class RemoteServer extends HttpSyncer {
 
 
     /** Returns hkey or null if user/pw incorrect. */
-    @Override
     public Response hostKey(String user, String pw) throws UnknownHttpResponseException {
         try {
             mPostVars = new HashMap<>(0);
@@ -55,7 +54,6 @@ public class RemoteServer extends HttpSyncer {
     }
 
 
-    @Override
     public Response meta() throws UnknownHttpResponseException {
         mPostVars = new HashMap<>(2);
         mPostVars.put("k", mHKey);
@@ -68,42 +66,34 @@ public class RemoteServer extends HttpSyncer {
     }
 
 
-    @Override
     public JSONObject applyChanges(JSONObject kw) throws UnknownHttpResponseException {
         return parseDict(_run("applyChanges", kw));
     }
 
 
-    @Override
     public JSONObject start(JSONObject kw) throws UnknownHttpResponseException {
         return parseDict(_run("start", kw));
     }
 
 
-    @Override
     public JSONObject chunk() throws UnknownHttpResponseException {
         JSONObject co = new JSONObject();
         return parseDict(_run("chunk", co));
     }
 
 
-    @Override
     public void applyChunk(JSONObject sech) throws UnknownHttpResponseException {
         _run("applyChunk", sech);
     }
 
-
-    @Override
     public JSONObject sanityCheck2(JSONObject client) throws UnknownHttpResponseException {
         return parseDict(_run("sanityCheck2", client));
     }
 
-    @Override
     public long finish() throws UnknownHttpResponseException {
         return parseLong(_run("finish", new JSONObject()));
     }
 
-    @Override
     public void abort() throws UnknownHttpResponseException {
         _run("abort", new JSONObject());
     }


### PR DESCRIPTION
For some reason, a lot of variable has type `HttpSyncer` while there type where always the same more specific type. I thus moved them to the specific type.

There were methods in `HttpSyncer` that always returned null, or 0, and were not redefined in all descendant, because this method makes sens for a single descendant. So I removed the method and left here only where it is actually used instead of having a method whose meaning is not even properly defined.

In my opinion, it leads to code which is quite easier to read, since I know as soon as I read a variable what kind of server I'm connected too, what I am expected to be able to do, and I don't have to wonder what could be the sanity check of a media server, e.g.