### PR TITLE
Put card outside of scope of MathJax callback

### DIFF
--- a/AnkiDroid/src/main/assets/scripts/card.js
+++ b/AnkiDroid/src/main/assets/scripts/card.js
@@ -201,10 +201,11 @@ var onPageFinished = function() {
         window.location.href = "#answer";
     }
 
+    var card = document.querySelector('.card');
+
     _runHook(onUpdateHook)
         .then(() => {
             if (window.MathJax != null) {
-                var card = document.querySelector('.card');
                 /* Anki-Android adds mathjax-needs-to-render" as a class to the card when
                    it detects both \( and \) or \[ and \].
 


### PR DESCRIPTION
## Purpose / Description
Fix a bug caused by using `card` outside of the MathJax callback. Was introduced in #7807 .

## Approach
Put it outside of scope of MathJax callback.

## How Has This Been Tested?
Error message is no longer raised in WebView Inspector