### PR TITLE
Typed Answer: Fix Polytonic Greek Characters

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/utils/DiffEngine.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/DiffEngine.java
@@ -16,7 +16,7 @@
 
 package com.ichi2.utils;
 
-import android.text.Html;
+import android.text.TextUtils;
 
 import org.bitbucket.cowwoc.diffmatchpatch.DiffMatchPatch;
 
@@ -81,6 +81,6 @@ public class DiffEngine {
     /** Escapes dangerous HTML tags (for XSS-like issues/rendering problems) */
     @NonNull
     protected static String escapeHtml(String in) {
-        return Html.escapeHtml(in).replace("\\", "&#x5c;");
+        return TextUtils.htmlEncode(in).replace("\\", "&#x5c;");
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/DiffEngine.java
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/DiffEngine.java
@@ -20,6 +20,9 @@ import android.text.Html;
 
 import org.bitbucket.cowwoc.diffmatchpatch.DiffMatchPatch;
 
+import androidx.annotation.CheckResult;
+import androidx.annotation.NonNull;
+
 /**
  * Functions for diff, match and patch. Computes the difference between two texts to create a patch. Applies the patch
  * onto another text, allowing for errors.
@@ -61,16 +64,23 @@ public class DiffEngine {
         // We do the comparison with “<”s &c. in the strings, but should of course not just put those in the HTML
         // output. Also, it looks like the Android WebView swallows single “\”s, so replace those with the entity by
         // hand.
-        return "<span class=\"typeBad\">" + Html.escapeHtml(in).replace("\\", "&#x5c;") + "</span>";
+        return "<span class=\"typeBad\">" + escapeHtml(in) + "</span>";
     }
 
-
+    @CheckResult
     public static String wrapGood(String in) {
-        return "<span class=\"typeGood\">" + Html.escapeHtml(in).replace("\\", "&#x5c;") + "</span>";
+        return "<span class=\"typeGood\">" + escapeHtml(in) + "</span>";
+    }
+
+    @CheckResult
+    public static String wrapMissing(String in) {
+        return "<span class=\"typeMissed\">" + escapeHtml(in) + "</span>";
     }
 
 
-    public static String wrapMissing(String in) {
-        return "<span class=\"typeMissed\">" + Html.escapeHtml(in).replace("\\", "&#x5c;") + "</span>";
+    /** Escapes dangerous HTML tags (for XSS-like issues/rendering problems) */
+    @NonNull
+    protected static String escapeHtml(String in) {
+        return Html.escapeHtml(in).replace("\\", "&#x5c;");
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/utils/DiffEngineTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/DiffEngineTest.java
@@ -1,0 +1,57 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.utils;
+
+import com.ichi2.anki.RobolectricTest;
+import com.ichi2.testutils.EmptyApplication;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.annotation.Config;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@RunWith(AndroidJUnit4.class)
+@Config(application = EmptyApplication.class)
+public class DiffEngineTest extends RobolectricTest {
+
+    @Test
+    public void checkEscapedHtmlCharacters() {
+        // The HTML escaping that used to occur in 13c27a6a1fa8465cc6656c67bd9db25afc7a51fa (CompatV15.detagged)
+        // This was the original intention of the escaping.
+        String input = "<>\"&' \\ aa";
+
+        String output = DiffEngine.wrapMissing(input);
+
+        assertThat(output, containsString("&lt;&gt;\"&amp;' &#x5c; aa"));
+    }
+
+    @Test
+    @Ignore("#7896")
+    public void polytonicGreekIsNotEscaped() {
+        // #7896 - this should not be necessary after a WebView upgrade.
+        String input = "αὐτός";
+
+        String output = DiffEngine.wrapMissing(input);
+
+        assertThat("There were problems displaying 'ὐ' when output as &#8016;", output, containsString(input));
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/utils/DiffEngineTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/DiffEngineTest.java
@@ -19,7 +19,6 @@ package com.ichi2.utils;
 import com.ichi2.anki.RobolectricTest;
 import com.ichi2.testutils.EmptyApplication;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
@@ -37,15 +36,25 @@ public class DiffEngineTest extends RobolectricTest {
     public void checkEscapedHtmlCharacters() {
         // The HTML escaping that used to occur in 13c27a6a1fa8465cc6656c67bd9db25afc7a51fa (CompatV15.detagged)
         // This was the original intention of the escaping.
-        String input = "<>\"&' \\ aa";
+        String input = "<>& \\ aa";
 
         String output = DiffEngine.wrapMissing(input);
 
-        assertThat(output, containsString("&lt;&gt;\"&amp;' &#x5c; aa"));
+        assertThat(output, containsString("&lt;&gt;&amp; &#x5c; aa"));
     }
 
     @Test
-    @Ignore("#7896")
+    public void quoteEscaping() {
+        // This is an interesting one - escaping a bare quote is not necessary but escaping a quote in an attribute is
+        // A breakage here may be acceptable, but should flag the issue for investigation.
+        String input = "\"'";
+
+        String output = DiffEngine.wrapMissing(input);
+
+        assertThat(output, containsString("&quot;&#39;"));
+    }
+
+    @Test
     public void polytonicGreekIsNotEscaped() {
         // #7896 - this should not be necessary after a WebView upgrade.
         String input = "αὐτός";


### PR DESCRIPTION
## Purpose / Description
Some Polytonic Greek characters did not display within the WebView when shown as HTML entities rather than unicode characters

## Fixes
Fixes #7896 

## Approach
* Only escape dangerous HTML characters (as we did before API 16)
* This leads to a non-context free escaping (quote characters are now escaped)

## How Has This Been Tested?

Unit tested

## Learning 
* Please see unit tests and commit messages
* Explanation in #7896 
* https://stackoverflow.com/questions/35104032/whats-the-difference-between-androids-html-escapehtml-and-textutils-htmlencode


## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)