### PR TITLE
[BugFix] Import shows dialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -796,7 +796,7 @@ public class DeckPicker extends NavigationDrawerActivity implements
             return true;
         } else if (itemId == R.id.action_import) {
             Timber.i("DeckPicker:: Import button pressed");
-            showImportDialog();
+            showImportDialog(ImportDialog.DIALOG_IMPORT_HINT);
             return true;
         } else if (itemId == R.id.action_new_filtered_deck) {
             Timber.i("DeckPicker:: New filtered deck button pressed");
@@ -1503,7 +1503,13 @@ public class DeckPicker extends NavigationDrawerActivity implements
     }
 
     @Override
-    public void showImportDialog() {
+    public void showImportDialog(int id) {
+        showImportDialog(id, "");
+    }
+
+
+    @Override
+    public void showImportDialog(int id, String message) {
         Timber.d("showImportDialog() delegating to file picker intent");
         Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
         intent.addCategory(Intent.CATEGORY_OPENABLE);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.java
@@ -1510,14 +1510,21 @@ public class DeckPicker extends NavigationDrawerActivity implements
 
     @Override
     public void showImportDialog(int id, String message) {
-        Timber.d("showImportDialog() delegating to file picker intent");
-        Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
-        intent.addCategory(Intent.CATEGORY_OPENABLE);
-        intent.setType("*/*");
-        intent.putExtra("android.content.extra.SHOW_ADVANCED", true);
-        intent.putExtra("android.content.extra.FANCY", true);
-        intent.putExtra("android.content.extra.SHOW_FILESIZE", true);
-        startActivityForResultWithoutAnimation(intent, PICK_APKG_FILE);
+        // On API19+ we only use import dialog to confirm, otherwise we use it the whole time
+        if ((id == ImportDialog.DIALOG_IMPORT_ADD_CONFIRM) || (id == ImportDialog.DIALOG_IMPORT_REPLACE_CONFIRM)) {
+            Timber.d("showImportDialog() delegating to ImportDialog");
+            AsyncDialogFragment newFragment = ImportDialog.newInstance(id, message);
+            showAsyncDialogFragment(newFragment);
+        } else {
+            Timber.d("showImportDialog() delegating to file picker intent");
+            Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
+            intent.addCategory(Intent.CATEGORY_OPENABLE);
+            intent.setType("*/*");
+            intent.putExtra("android.content.extra.SHOW_ADVANCED", true);
+            intent.putExtra("android.content.extra.FANCY", true);
+            intent.putExtra("android.content.extra.SHOW_FILESIZE", true);
+            startActivityForResultWithoutAnimation(intent, PICK_APKG_FILE);
+        }
     }
 
     public void onSdCardNotMounted() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DialogHandler.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DialogHandler.java
@@ -78,10 +78,10 @@ public class DialogHandler extends Handler {
             ((DeckPicker) mActivity.get()).showDatabaseErrorDialog(DatabaseErrorDialog.DIALOG_LOAD_FAILED);
         } else if (msg.what == MSG_SHOW_COLLECTION_IMPORT_REPLACE_DIALOG) {
             // Handle import of collection package APKG
-            ((DeckPicker) mActivity.get()).showImportDialog();
+            ((DeckPicker) mActivity.get()).showImportDialog(ImportDialog.DIALOG_IMPORT_REPLACE_CONFIRM, msgData.getString("importPath"));
         } else if (msg.what == MSG_SHOW_COLLECTION_IMPORT_ADD_DIALOG) {
             // Handle import of deck package APKG
-            ((DeckPicker) mActivity.get()).showImportDialog();
+            ((DeckPicker) mActivity.get()).showImportDialog(ImportDialog.DIALOG_IMPORT_ADD_CONFIRM, msgData.getString("importPath"));
         } else if (msg.what == MSG_SHOW_SYNC_ERROR_DIALOG) {
             int id = msgData.getInt("dialogType");
             String message = msgData.getString("dialogMessage");

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportDialog.java
@@ -27,7 +27,8 @@ public class ImportDialog extends AsyncDialogFragment {
     public static final int DIALOG_IMPORT_REPLACE_CONFIRM = 3;
 
     public interface ImportDialogListener {
-        void showImportDialog();
+        void showImportDialog(int id, String message);
+        void showImportDialog(int id);
         void importAdd(String importPath);
         void importReplace(String importPath);
         void dismissAllDialogFragments();
@@ -67,7 +68,7 @@ public class ImportDialog extends AsyncDialogFragment {
                         .content(res.getString(R.string.import_hint, CollectionHelper.getCurrentAnkiDroidDirectory(getActivity())))
                         .positiveText(R.string.dialog_ok)
                         .negativeText(R.string.dialog_cancel)
-                        .onPositive((dialog, which) -> ((ImportDialogListener) getActivity()).showImportDialog())
+                        .onPositive((dialog, which) -> ((ImportDialogListener) getActivity()).showImportDialog(DIALOG_IMPORT_SELECT))
                         .onNegative((dialog, which) -> dismissAllDialogFragments())
                         .show();
             }
@@ -91,10 +92,10 @@ public class ImportDialog extends AsyncDialogFragment {
                                 String importPath = importValues[i];
                                 // If collection package, we assume the collection will be replaced
                                 if (ImportUtils.isCollectionPackage(filenameFromPath(importPath))) {
-                                    ((ImportDialogListener) getActivity()).showImportDialog();
+                                    ((ImportDialogListener) getActivity()).showImportDialog(DIALOG_IMPORT_REPLACE_CONFIRM, importPath);
                                     // Otherwise we add the file since exported decks / shared decks can't be imported via replace anyway
                                 } else {
-                                    ((ImportDialogListener) getActivity()).showImportDialog();
+                                    ((ImportDialogListener) getActivity()).showImportDialog(DIALOG_IMPORT_ADD_CONFIRM, importPath);
                                 }
                             })
                             .show();

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerImportTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerImportTest.java
@@ -1,0 +1,81 @@
+/*
+ *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki;
+
+import android.content.Intent;
+
+import com.ichi2.anki.dialogs.AsyncDialogFragment;
+import com.ichi2.anki.dialogs.ImportDialog;
+
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.fail;
+
+@RunWith(AndroidJUnit4.class)
+public class DeckPickerImportTest extends RobolectricTest {
+
+    @Test
+    public void importAddShowsImportDialog() {
+        DeckPickerImport deckPicker = super.startActivityNormallyOpenCollectionWithIntent(DeckPickerImport.class, new Intent());
+
+        deckPicker.showImportDialog(ImportDialog.DIALOG_IMPORT_ADD_CONFIRM);
+
+        assertThat(deckPicker.getAsyncDialogFragmentClass(), Matchers.typeCompatibleWith(ImportDialog.class));
+    }
+
+    @Test
+    public void replaceShowsImportDialog() {
+        DeckPickerImport deckPicker = super.startActivityNormallyOpenCollectionWithIntent(DeckPickerImport.class, new Intent());
+
+        deckPicker.showImportDialog(ImportDialog.DIALOG_IMPORT_REPLACE_CONFIRM);
+
+        assertThat(deckPicker.getAsyncDialogFragmentClass(), Matchers.typeCompatibleWith(ImportDialog.class));
+    }
+
+    @Test
+    public void hintDoesNotShowDialog() {
+        DeckPickerImport deckPicker = super.startActivityNormallyOpenCollectionWithIntent(DeckPickerImport.class, new Intent());
+
+        deckPicker.showImportDialog(ImportDialog.DIALOG_IMPORT_HINT);
+
+        assertThat(deckPicker.dialogFragment, nullValue());
+    }
+
+    private static class DeckPickerImport extends DeckPicker {
+
+        private AsyncDialogFragment dialogFragment;
+
+        private Class<?> getAsyncDialogFragmentClass() {
+            if (dialogFragment == null) {
+                fail("No async fragment shown");
+            }
+            return dialogFragment.getClass();
+        }
+
+        @Override
+        public void showAsyncDialogFragment(AsyncDialogFragment newFragment) {
+            this.dialogFragment = newFragment;
+            super.showAsyncDialogFragment(newFragment);
+        }
+    }
+}


### PR DESCRIPTION
## Purpose / Description
Import was broken - the "Add" dialog did not display

This was caused by the code path being removed in the API 21 upgrade

## Fixes
Fixes #7898

## Approach
Revert, and add unit tests

## How Has This Been Tested?

Unit test and on my Android 9

## Learning 
* Need more tests
* Review missed this - my fault - possibly DeckPicker.java wasn't expanded and I missed it, possibly just missed the functionality change

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)