### PR TITLE
Add Preference to disable monospace font usage

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -246,6 +246,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
     protected int mOptWaitQuestionSecond;
 
     protected boolean mUseInputTag;
+    private boolean mDoNotUseCodeFormatting;
 
     // Default short animation duration, provided by Android framework
     protected int mShortAnimDuration;
@@ -776,7 +777,8 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         Matcher m = sTypeAnsPat.matcher(buf);
         DiffEngine diffEngine = new DiffEngine();
         StringBuilder sb = new StringBuilder();
-        sb.append("<div><code id=\"typeans\">");
+        sb.append(mDoNotUseCodeFormatting ? "<div><span id=\"typeans\">" : "<div><code id=\"typeans\">");
+
 
         // We have to use Matcher.quoteReplacement because the inputs here might have $ or \.
 
@@ -803,7 +805,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
                 sb.append(Matcher.quoteReplacement(correctAnswer));
             }
         }
-        sb.append("</code></div>");
+        sb.append(mDoNotUseCodeFormatting ? "</span></div>" : "</code></div>");
         return m.replaceAll(sb.toString());
     }
 
@@ -1765,6 +1767,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(getBaseContext());
 
         mUseInputTag = preferences.getBoolean("useInputTag", false);
+        mDoNotUseCodeFormatting = preferences.getBoolean("noCodeFormatting", false);
         // On newer Androids, ignore this setting, which should be hidden in the prefs anyway.
         mDisableClipboard = "0".equals(preferences.getString("dictionary", "0"));
         // mDeckFilename = preferences.getString("deckFilename", "");

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -274,4 +274,7 @@
 
     <string name="note_editor_replace_newlines">Replace newlines with HTML</string>
     <string name="note_editor_replace_newlines_summ">In the Note Editor, convert any instances of &lt;br&gt; to newlines when editing a card.</string>
+
+    <string name="no_code_formatting">Simple typed answer formatting</string>
+    <string name="no_code_formatting_summ">Fixes ‘􏿾’ appearing in typed answer results</string>
 </resources>

--- a/AnkiDroid/src/main/res/xml/preferences_advanced.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_advanced.xml
@@ -74,6 +74,13 @@
                 android:summary="@string/note_editor_replace_newlines_summ"
                 android:title="@string/note_editor_replace_newlines"
                 />
+            <!-- #7896 - Workaround for old webviews which could not render some characters in a <code> block
+            due to problems with the default monospace font handling -->
+            <CheckBoxPreference
+                android:defaultValue="false"
+                android:key="noCodeFormatting"
+                android:summary="@string/no_code_formatting_summ"
+                android:title="@string/no_code_formatting" />
         </PreferenceCategory>
         <PreferenceCategory
             android:key="category_plugins"

--- a/AnkiDroid/src/test/java/com/ichi2/utils/DiffEngineTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/DiffEngineTest.java
@@ -56,7 +56,8 @@ public class DiffEngineTest extends RobolectricTest {
 
     @Test
     public void polytonicGreekIsNotEscaped() {
-        // #7896 - this should not be necessary after a WebView upgrade.
+        // Implies too much escaping is being performed, which will degrade performance
+        // Not required for #7896 - this behaviour could be reversed without negative impact.
         String input = "αὐτός";
 
         String output = DiffEngine.wrapMissing(input);


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

In older WebViews, using a monospace font meant that some Polytonic Greek characters did not display

This applied to `<pre>` and `<code>`, a `<span>` worked best to fix this.

Replicated on an API 28 emulator - will take a long time to remove this.

## Fixes
Fixes #7896

## Approach
* Add a preference, use a `<span>` tag if set

## How Has This Been Tested?

![image](https://user-images.githubusercontent.com/62114487/102133142-8ed9b100-3e4c-11eb-8496-36072804a6cf.png)
![image](https://user-images.githubusercontent.com/62114487/102133153-90a37480-3e4c-11eb-838d-75934187f40d.png)
![image](https://user-images.githubusercontent.com/62114487/102133148-8f724780-3e4c-11eb-9171-9e8357e78f67.png)

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)