### PR TITLE
Expender

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.java
@@ -51,6 +51,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
+import static android.view.View.IMPORTANT_FOR_ACCESSIBILITY_NO;
+import static android.view.View.IMPORTANT_FOR_ACCESSIBILITY_YES;
+
 public class DeckAdapter<T extends AbstractDeckTreeNode<T>> extends RecyclerView.Adapter<DeckAdapter.ViewHolder> implements Filterable {
 
     /* Make the selected deck roughly half transparent if there is a background */
@@ -284,6 +287,7 @@ public class DeckAdapter<T extends AbstractDeckTreeNode<T>> extends RecyclerView
         boolean collapsed = mCol.getDecks().get(node.getDid()).optBoolean("collapsed", false);
         // Apply the correct expand/collapse drawable
         if (node.hasChildren()) {
+            expander.setImportantForAccessibility(IMPORTANT_FOR_ACCESSIBILITY_YES);
             if (collapsed) {
                 expander.setImageDrawable(mExpandImage);
                 expander.setContentDescription(expander.getContext().getString(R.string.expand));
@@ -293,6 +297,7 @@ public class DeckAdapter<T extends AbstractDeckTreeNode<T>> extends RecyclerView
             }
         } else {
             expander.setImageDrawable(mNoExpander);
+            expander.setImportantForAccessibility(IMPORTANT_FOR_ACCESSIBILITY_NO);
         }
         // Add some indenting for each nested level
         int width = (int) indent.getResources().getDimension(R.dimen.keyline_1) * node.getDepth();

--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.java
@@ -217,7 +217,7 @@ public class DeckAdapter<T extends AbstractDeckTreeNode<T>> extends RecyclerView
             holder.deckExpander.setTag(node.getDid());
             holder.deckExpander.setOnClickListener(mDeckExpanderClickListener);
         } else {
-            holder.deckExpander.setOnClickListener(null);
+            holder.deckExpander.setClickable(false);
         }
         holder.deckLayout.setBackgroundResource(mRowCurrentDrawable);
         // Set background colour. The current deck has its own color


### PR DESCRIPTION
Removing warning related to accessibility issues. In this case, removing a button which was hidden but actually still present. It could be detected previously because you can still click on the hidden button and see a small click visual effect even if nothing occurred.

I tested on my collection and checked that the remaining buttons still worked and alignment was not changed. 