### PR TITLE
Counts picker

### DIFF
--- a/AnkiDroid/src/main/res/layout/deck_item.xml
+++ b/AnkiDroid/src/main/res/layout/deck_item.xml
@@ -63,6 +63,7 @@
 
     <LinearLayout
         android:id="@+id/counts_layout"
+        android:contentDescription="@string/deck_picker_counts"
         android:background="?attr/selectableItemBackground"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/AnkiDroid/src/main/res/layout/deck_item.xml
+++ b/AnkiDroid/src/main/res/layout/deck_item.xml
@@ -73,6 +73,7 @@
         android:layout_centerVertical="true" >
         <com.ichi2.ui.FixedTextView
             android:id="@+id/deckpicker_new"
+            android:contentDescription="@string/deck_picker_new"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
@@ -84,6 +85,7 @@
 
         <com.ichi2.ui.FixedTextView
             android:id="@+id/deckpicker_lrn"
+            android:contentDescription="@string/deck_picker_lrn"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
@@ -95,6 +97,7 @@
 
         <com.ichi2.ui.FixedTextView
             android:id="@+id/deckpicker_rev"
+            android:contentDescription="@string/deck_picker_rev"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -202,5 +202,4 @@
     <string name="open_tag_not_closed">Missing \'{{%s}}\'.</string>
     <string name="wrong_tag_closed">Found \'{{/%1$s}}\', but expected \'{{/%2$s}}\'</string>
     <string name="filter_error">Error in filter %s</string>
-
 </resources>

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -202,4 +202,5 @@
     <string name="open_tag_not_closed">Missing \'{{%s}}\'.</string>
     <string name="wrong_tag_closed">Found \'{{/%1$s}}\', but expected \'{{/%2$s}}\'</string>
     <string name="filter_error">Error in filter %s</string>
+
 </resources>

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -249,5 +249,10 @@
         <item quantity="one">An automatic sync may be triggered in %d second</item>
         <item quantity="other">An automatic sync may be triggered in %d seconds</item>
     </plurals>
+    <string name="deck_picker_new">Number of new cards to see today in this deck.</string>
+    <string name="deck_picker_rev">Number of cards due today in this deck.</string>
+    <string name="deck_picker_lrn">Number of cards in learning in this deck.</string> <!-- This description is valid fos
+    sched V2. For V1, it was counting the number of repetitions of cards in learning. This approximation is acceptable
+    for the sake of simplicity and because V1 will leave.-->
 
 </resources>

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -254,5 +254,5 @@
     <string name="deck_picker_lrn">Number of cards in learning in this deck.</string> <!-- This description is valid fos
     sched V2. For V1, it was counting the number of repetitions of cards in learning. This approximation is acceptable
     for the sake of simplicity and because V1 will leave.-->
-
+    <string name="deck_picker_counts">Open the deck overview page containing the number of cards to see today.</string>
 </resources>


### PR DESCRIPTION
There is an accessibility problem, which I believe to be a problem related to unexpected behaviour, so this is a bad fix.

Clicking on the counts in the deck picker has an action, which I find surprising. There is no way to know what clicking will do, and it should be described for accessibility. I believe to be honest that it should actually be removed and if options are actually that useful, a more natural way to get to them should be used.

Is there a way to know the number of deck option page opened in ankidroid on small screen ? I.e. the number of cases where it's opened in it's own page, and not only because it's a mandatory step up to the reviewer?