### PR TITLE
Alter robolectric pre-download task for minSdkVersion 21

### DIFF
--- a/AnkiDroid/robolectricDownloader.gradle
+++ b/AnkiDroid/robolectricDownloader.gradle
@@ -14,11 +14,7 @@ import java.nio.file.Files
 // This list will need to be updated for new Android SDK versions that come out.
 // Only the versions currently used in AnkiDroid Robolectric tests are active, the rest are commented out
 def robolectricAndroidSdkVersions = [
-        [androidVersion: "4.1.2_r1", frameworkSdkBuildVersion: "r1"],
-        [androidVersion: "4.2.2_r1.2", frameworkSdkBuildVersion: "r1"],
-//        [androidVersion: "4.3_r2", frameworkSdkBuildVersion: "r1"],
-//        [androidVersion: "4.4_r1", frameworkSdkBuildVersion: "r2"],
-//        [androidVersion: "5.0.2_r3", frameworkSdkBuildVersion: "r0"],
+        [androidVersion: "5.0.2_r3", frameworkSdkBuildVersion: "r0"],
 //        [androidVersion: "5.1.1_r9", frameworkSdkBuildVersion: "r2"],
 //        [androidVersion: "6.0.1_r3", frameworkSdkBuildVersion: "r1"],
         [androidVersion: "7.0.0_r1", frameworkSdkBuildVersion: "r1"],


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

When #7843 went in, I adjusted the robolectric tests that use SDK brackets to use API21 vs API16 but I had not bumped the robolectric cache warmer / SDK download task to download the different set of robolectric android.jar implementations required

## Approach
- Remove all the Android 4.x robolectric android.jar implementation entries from possible download list
- Uncomment the API21 robolectric android.jar implementation so it is downloaded now

## How Has This Been Tested?

It is literally made of tests. But I will visually verify also.

## Learning (optional, can help others)

If you don't occasionally read your test execution output, you will slowly succumb to entropy.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)