### PR TITLE
Editing a card in a filtered deck show both decks

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -577,10 +577,17 @@ public class NoteEditor extends AnkiActivity {
         for (Deck d : decks) {
             // add current deck and all other non-filtered decks to deck list
             long thisDid = d.getLong("id");
-            if (d.getInt("dyn") == 0 || (!mAddNote && mCurrentEditedCard != null && mCurrentEditedCard.getDid() == thisDid)) {
-                deckNames.add(d.getString("name"));
-                mAllDeckIds.add(thisDid);
+            String currentName = d.getString("name");
+            String lineContent = null;
+            if (d.getInt("dyn") == 0) {
+                lineContent = currentName ;
+            } else if (!mAddNote && mCurrentEditedCard != null && mCurrentEditedCard.getDid() == thisDid) {
+                lineContent = getApplicationContext().getString(R.string.current_and_default_deck, currentName, col.getDecks().name(mCurrentEditedCard.getODid()));
+            } else {
+                continue;
             }
+            deckNames.add(lineContent);
+            mAllDeckIds.add(thisDid);
         }
 
         ArrayAdapter<String> noteDeckAdapter = new ArrayAdapter<>(this, android.R.layout.simple_spinner_item, deckNames);

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -179,6 +179,7 @@
 
     <!-- Card Browser Appearance -->
     <string name="card_template_browser_appearance_title">Browser appearance</string>
+    <string name="current_and_default_deck">%1$s (%2$s)</string>
 
     <!-- card Info -->
     <string name="card_info_title">Card info</string>


### PR DESCRIPTION
Currently, when you open a card editor, it shows the card current deck. In case of filtered deck, it shows the filtered
deck.  The trouble in my opinion is that there is no way to know what is the usual deck of the card. That's extremely
useful when I need to move a card to a different deck.

The solution I use is to show the current deck and the original deck in parenthesis. This seems to me to be consistent
with anki's browser's deck column.

![Screenshot_20201220-193801_AnkiDroid.jpg](https://user-images.githubusercontent.com/357361/102721556-e0c28100-42fb-11eb-8b63-943b005a0ec3.jpg)