### PR TITLE
Don't add "uncollapse" arrow if there is no subdeck

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.java
@@ -283,12 +283,14 @@ public class DeckAdapter<T extends AbstractDeckTreeNode<T>> extends RecyclerView
     private void setDeckExpander(ImageButton expander, ImageButton indent, AbstractDeckTreeNode<?> node){
         boolean collapsed = mCol.getDecks().get(node.getDid()).optBoolean("collapsed", false);
         // Apply the correct expand/collapse drawable
-        if (collapsed) {
-            expander.setImageDrawable(mExpandImage);
-            expander.setContentDescription(expander.getContext().getString(R.string.expand));
-        } else if (node.hasChildren()) {
-            expander.setImageDrawable(mCollapseImage);
-            expander.setContentDescription(expander.getContext().getString(R.string.collapse));
+        if (node.hasChildren()) {
+            if (collapsed) {
+                expander.setImageDrawable(mExpandImage);
+                expander.setContentDescription(expander.getContext().getString(R.string.expand));
+            } else  {
+                expander.setImageDrawable(mCollapseImage);
+                expander.setContentDescription(expander.getContext().getString(R.string.collapse));
+            }
         } else {
             expander.setImageDrawable(mNoExpander);
         }


### PR DESCRIPTION
This made a change only if a deck is collapsed but has no children. This can occurs if you do the following steps:
* On device A, create a deck A::B and sync
* on device B, sync, delete A::B and sync
* On device A, collapse A and sync

The deck A has property collapsed and no subdeck.
This is especially a problem because if you try to click on the arrow to uncolapse, you'll get a message stating there
is no subdeck, and so the "collapsed" sign will remain and can't be removed anymore.

Another solution should be to ensure that each deck without subdeck is uncollapsed.

To be perfectly honest, I only found this bug because I looked at the code and figure out how to reproduce it. I do not
know whether it's a bug for any real user.