### PR TITLE
Solve #7918

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.java
@@ -24,6 +24,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.ActionBar;
 
+import android.util.Pair;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -98,7 +99,7 @@ public class ModelBrowser extends AnkiActivity {
     private LoadingModelsHandler loadingModelsHandler() {
         return new LoadingModelsHandler(this);
     }
-    private static class LoadingModelsHandler extends TaskListenerWithContext<ModelBrowser, Void, Triple<Boolean, ArrayList<Model>, ArrayList<Integer>>> {
+    private static class LoadingModelsHandler extends TaskListenerWithContext<ModelBrowser, Void, Pair<ArrayList<Model>, ArrayList<Integer>>> {
         public LoadingModelsHandler(ModelBrowser browser) {
             super(browser);
         }
@@ -114,13 +115,13 @@ public class ModelBrowser extends AnkiActivity {
         }
 
         @Override
-        public void actualOnPostExecute(@NonNull ModelBrowser browser, Triple<Boolean, ArrayList<Model>, ArrayList<Integer>> result) {
-            if (!result.first) {
+        public void actualOnPostExecute(@NonNull ModelBrowser browser, Pair<ArrayList<Model>, ArrayList<Integer>> result) {
+            if (result == null) {
                 throw new RuntimeException();
             }
             browser.hideProgressBar();
-            browser.mModels = result.second;
-            browser.mCardCounts = result.third;
+            browser.mModels = result.first;
+            browser.mCardCounts = result.second;
 
             browser.fillModelList();
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelBrowser.java
@@ -258,7 +258,7 @@ public class ModelBrowser extends AnkiActivity {
      */
     private void fillModelList() {
         //Anonymous class for handling list item clicks
-        mModelDisplayList = new ArrayList<>(mModelIds.size());
+        mModelDisplayList = new ArrayList<>(mModels.size());
         mModelIds = new ArrayList<>(mModels.size());
 
         for (int i = 0; i < mModels.size(); i++) {

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -1758,8 +1758,8 @@ public class CollectionTask<ProgressListener, ProgressBackground extends Progres
      *
      * @return {ArrayList<JSONObject> models, ArrayList<Integer> cardCount}
      */
-    public static class CountModels extends Task<Void, Triple<Boolean, ArrayList<Model>, ArrayList<Integer>>> {
-        protected Triple<Boolean, ArrayList<Model>, ArrayList<Integer>> task(Collection col, ProgressSenderAndCancelListener<Void> collectionTask) {
+    public static class CountModels extends Task<Void, Pair<ArrayList<Model>, ArrayList<Integer>>> {
+        protected Pair<ArrayList<Model>, ArrayList<Integer>> task(Collection col, ProgressSenderAndCancelListener<Void> collectionTask) {
             Timber.d("doInBackgroundLoadModels");
 
             ArrayList<Model> models = col.getModels().all();
@@ -1775,7 +1775,7 @@ public class CollectionTask<ProgressListener, ProgressBackground extends Progres
                 cardCount.add(col.getModels().useCount(n));
             }
 
-            return new Triple<>(false, models, cardCount);
+            return new Pair<>(models, cardCount);
         }
     }
 


### PR DESCRIPTION
For some reason, in 3e7983670370141b6dc2e1ab3d7a4036c0585def a true was changed to false. Given that the boolean is
never used, it can just be deleted. Instead, if there is a problem, the returned value is null, and that is what should
be checked.

Fixes #7918 