### PR TITLE
Fixes #7585: previewer get the card's ord

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1214,7 +1214,9 @@ public class NoteEditor extends AnkiActivity {
     void performPreview() {
         Intent previewer = new Intent(NoteEditor.this, CardTemplatePreviewer.class);
 
-        previewer.putExtra("ordinal", 0);
+        if (mCurrentEditedCard != null) {
+            previewer.putExtra("ordinal", mCurrentEditedCard.getOrd());
+        }
         previewer.putExtra(TemporaryModel.INTENT_MODEL_FILENAME, TemporaryModel.saveTempModel(this, mEditorNote.model()));
 
         // Send the previewer all our current editing information

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.java
@@ -73,7 +73,7 @@ public class NoteEditorTest extends RobolectricTest {
         assertThat("Bundle has fields", fieldsBundle, notNullValue());
         assertThat("Bundle has fields edited value", fieldsBundle.getString("0"), is("Preview Test"));
         assertThat("Bundle has empty tag list", noteEditorBundle.getStringArrayList("tags"), is(new ArrayList<>()));
-        assertThat("Bundle has ordinal 0 for ephemeral preview", intent.intent.getIntExtra("ordinal", -1), is(0));
+        assertThat("Bundle has no ordinal for ephemeral preview", intent.intent.hasExtra("ordinal"), is(false));
         assertThat("Bundle has a temporary model saved", intent.intent.hasExtra(TemporaryModel.INTENT_MODEL_FILENAME), is(true));
     }
 


### PR DESCRIPTION
First, putting the value 0 in intent is useless. getInt returns 0 if the value is absent.
Second, if we are editing a card, we need to put the card ord.

This make me realize there is no way with "Add card" to preview card that are not the first card. This seems to be a
problem.

I tested previwing from browser and from add card. Both work. Fixes #7585 