### PR TITLE
NF: Uses constant for decks "dyn" value

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -108,6 +108,7 @@ import com.ichi2.async.TaskListener;
 import com.ichi2.async.TaskManager;
 import com.ichi2.compat.CompatHelper;
 import com.ichi2.libanki.Decks;
+import com.ichi2.libanki.Model;
 import com.ichi2.libanki.sched.AbstractSched;
 import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
@@ -2177,7 +2178,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
      * getAnswerFormat returns the answer part of this card's template as entered by user, without any parsing
      */
     public String getAnswerFormat() {
-        JSONObject model = mCurrentCard.model();
+        Model model = mCurrentCard.model();
         JSONObject template;
         if (model.isStd()) {
             template = model.getJSONArray("tmpls").getJSONObject(mCurrentCard.getOrd());

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -2179,7 +2179,7 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
     public String getAnswerFormat() {
         JSONObject model = mCurrentCard.model();
         JSONObject template;
-        if (model.getInt("type") == Consts.MODEL_STD) {
+        if (model.isStd()) {
             template = model.getJSONArray("tmpls").getJSONObject(mCurrentCard.getOrd());
         } else {
             template = model.getJSONArray("tmpls").getJSONObject(0);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardInfo.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardInfo.java
@@ -388,7 +388,7 @@ public class CardInfo extends AnkiActivity {
         protected static String getCardType(Card c, Model model) {
             try {
                 int ord = c.getOrd();
-                if (Models.isCloze(c.model())) {
+                if (c.model().isCloze()) {
                     ord = 0;
                 }
                 return model.getJSONArray("tmpls").getJSONObject(ord).getString("name");

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
@@ -431,7 +431,7 @@ public class CardTemplateEditor extends AnkiActivity implements DeckSelectionDia
             menu.clear();
             inflater.inflate(R.menu.card_template_editor, menu);
 
-            if (mTemplateEditor.getTempModel().getModel().getInt("type") == Consts.MODEL_CLOZE) {
+            if (mTemplateEditor.getTempModel().getModel().isCloze()) {
                 Timber.d("Editing cloze model, disabling add/delete card template and deck override functionality");
                 menu.findItem(R.id.action_add).setVisible(false);
                 menu.findItem(R.id.action_add_deck_override).setVisible(false);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.java
@@ -223,7 +223,7 @@ public class CardTemplateEditor extends AnkiActivity implements DeckSelectionDia
     /** When a deck is selected via Deck Override */
     @Override
     public void onDeckSelected(@Nullable SelectableDeck deck) {
-        if (Models.isCloze(getTempModel().getModel())) {
+        if (getTempModel().getModel().isCloze()) {
             Timber.w("Attempted to set deck for cloze model");
             UIUtils.showThemedToast(this, getString(R.string.multimedia_editor_something_wrong), true);
             return;
@@ -547,7 +547,7 @@ public class CardTemplateEditor extends AnkiActivity implements DeckSelectionDia
 
         private void displayDeckOverrideDialog(Collection col, TemporaryModel tempModel) {
             AnkiActivity activity = (AnkiActivity) requireActivity();
-            if (Models.isCloze(tempModel.getModel())) {
+            if (tempModel.getModel().isCloze()) {
                 UIUtils.showThemedToast(activity, getString(R.string.multimedia_editor_something_wrong), true);
                 return;
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
@@ -852,7 +852,7 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
         int count = 0;
         long conf = mDeck.getLong("conf");
         for (Deck deck : mCol.getDecks().all()) {
-            if (deck.getInt("dyn") == 1) {
+            if (deck.getInt("dyn") == Consts.DECK_DYN) {
                 continue;
             }
             if (deck.getLong("conf") == conf) {
@@ -881,7 +881,7 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
         TreeMap<String, Long> children = mCol.getDecks().children(did);
         for (long childDid : children.values()) {
             Deck child = mCol.getDecks().get(childDid);
-            if (child.getInt("dyn") == 1) {
+            if (child.getInt("dyn") == Consts.DECK_DYN) {
                 continue;
             }
             count++;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckOptions.java
@@ -852,7 +852,7 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
         int count = 0;
         long conf = mDeck.getLong("conf");
         for (Deck deck : mCol.getDecks().all()) {
-            if (deck.getInt("dyn") == Consts.DECK_DYN) {
+            if (deck.isDyn()) {
                 continue;
             }
             if (deck.getLong("conf") == conf) {
@@ -881,7 +881,7 @@ public class DeckOptions extends AppCompatPreferenceActivity implements OnShared
         TreeMap<String, Long> children = mCol.getDecks().children(did);
         for (long childDid : children.values()) {
             Deck child = mCol.getDecks().get(childDid);
-            if (child.getInt("dyn") == Consts.DECK_DYN) {
+            if (child.isDyn()) {
                 continue;
             }
             count++;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FilteredDeckOptions.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FilteredDeckOptions.java
@@ -52,6 +52,7 @@ import java.util.Set;
 import timber.log.Timber;
 
 import static com.ichi2.anim.ActivityTransitionAnimation.Direction.FADE;
+import static com.ichi2.libanki.Consts.DECK_STD;
 
 /**
  * Preferences for the current deck.
@@ -356,7 +357,7 @@ public class FilteredDeckOptions extends AppCompatPreferenceActivity implements 
 
         registerExternalStorageListener();
 
-        if (mCol == null || mDeck.getInt("dyn") != 1) {
+        if (mCol == null || mDeck.getInt("dyn") == DECK_STD) {
             Timber.w("No Collection loaded or deck is not a dyn deck");
             finish();
             return;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -1927,7 +1927,7 @@ public class NoteEditor extends AnkiActivity {
         mToolbar.clearCustomItems();
 
         View clozeIcon = mToolbar.getClozeIcon();
-        if (Models.isCloze(mEditorNote.model())) {
+        if (mEditorNote.model().isCloze()) {
             Toolbar.TextFormatter clozeFormatter = s -> {
                 Toolbar.TextWrapper.StringFormat stringFormat = new Toolbar.TextWrapper.StringFormat();
                 String prefix = "{{c" + getNextClozeIndex() + "::";

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -580,7 +580,7 @@ public class NoteEditor extends AnkiActivity {
             long thisDid = d.getLong("id");
             String currentName = d.getString("name");
             String lineContent = null;
-            if (d.getInt("dyn") == Consts.DECK_STD) {
+            if (d.isStd()) {
                 lineContent = currentName ;
             } else if (!mAddNote && mCurrentEditedCard != null && mCurrentEditedCard.getDid() == thisDid) {
                 lineContent = getApplicationContext().getString(R.string.current_and_default_deck, currentName, col.getDecks().name(mCurrentEditedCard.getODid()));

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -580,7 +580,7 @@ public class NoteEditor extends AnkiActivity {
             long thisDid = d.getLong("id");
             String currentName = d.getString("name");
             String lineContent = null;
-            if (d.getInt("dyn") == 0) {
+            if (d.getInt("dyn") == Consts.DECK_STD) {
                 lineContent = currentName ;
             } else if (!mAddNote && mCurrentEditedCard != null && mCurrentEditedCard.getDid() == thisDid) {
                 lineContent = getApplicationContext().getString(R.string.current_and_default_deck, currentName, col.getDecks().name(mCurrentEditedCard.getODid()));

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -2382,7 +2382,7 @@ public class NoteEditor extends AnkiActivity {
     }
 
     private boolean isClozeType() {
-        return getCurrentlySelectedModel().getInt("type") == Consts.MODEL_CLOZE;
+        return getCurrentlySelectedModel().isCloze();
     }
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.java
@@ -56,6 +56,8 @@ import com.ichi2.utils.HtmlUtils;
 import timber.log.Timber;
 
 import static com.ichi2.anim.ActivityTransitionAnimation.Direction.*;
+import static com.ichi2.libanki.Consts.DECK_DYN;
+import static com.ichi2.libanki.Consts.DECK_STD;
 
 public class StudyOptionsFragment extends Fragment implements Toolbar.OnMenuItemClickListener {
 
@@ -457,7 +459,7 @@ public class StudyOptionsFragment extends Fragment implements Toolbar.OnMenuItem
             if (mLoadWithDeckOptions) {
                 mLoadWithDeckOptions = false;
                 Deck deck = getCol().getDecks().current();
-                if (deck.getInt("dyn") != 0 && deck.has("empty")) {
+                if (deck.getInt("dyn") == DECK_DYN && deck.has("empty")) {
                     deck.remove("empty");
                 }
                     mProgressDialog = StyledProgressDialog.show(getActivity(), "",
@@ -588,7 +590,7 @@ public class StudyOptionsFragment extends Fragment implements Toolbar.OnMenuItem
                     }
 
                     // Switch between the empty view, the ordinary view, and the "congratulations" view
-                    boolean isDynamic = deck.optInt("dyn", 0) != 0;
+                    boolean isDynamic = deck.optInt("dyn", DECK_STD) == DECK_DYN;
                     if (totalCards == 0 && !isDynamic) {
                         mCurrentContentView = CONTENT_EMPTY;
                         mDeckInfoLayout.setVisibility(View.VISIBLE);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
@@ -433,7 +433,7 @@ public class CustomStudyDialog extends AnalyticsDialogFragment {
         Deck cur = col.getDecks().byName(customStudyDeck);
         if (cur != null) {
             Timber.i("Found deck: '%s'", customStudyDeck);
-            if (cur.getInt("dyn") == Consts.DECK_STD) {
+            if (cur.isStd()) {
                 Timber.w("Deck: '%s' was non-dynamic", customStudyDeck);
                 UIUtils.showThemedToast(getActivity(), getString(R.string.custom_study_deck_exists), true);
                 return;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomStudyDialog.java
@@ -433,7 +433,7 @@ public class CustomStudyDialog extends AnalyticsDialogFragment {
         Deck cur = col.getDecks().byName(customStudyDeck);
         if (cur != null) {
             Timber.i("Found deck: '%s'", customStudyDeck);
-            if (cur.getInt("dyn") != 1) {
+            if (cur.getInt("dyn") == Consts.DECK_STD) {
                 Timber.w("Deck: '%s' was non-dynamic", customStudyDeck);
                 UIUtils.showThemedToast(getActivity(), getString(R.string.custom_study_deck_exists), true);
                 return;

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionTask.java
@@ -96,6 +96,7 @@ import static com.ichi2.libanki.Collection.DismissType.REPOSITION_CARDS;
 import static com.ichi2.libanki.Collection.DismissType.RESCHEDULE_CARDS;
 import static com.ichi2.libanki.Collection.DismissType.RESET_CARDS;
 import static com.ichi2.libanki.Collection.DismissType.SUSPEND_NOTE;
+import static com.ichi2.libanki.Consts.DECK_DYN;
 import static com.ichi2.libanki.Undoable.*;
 import static com.ichi2.utils.BooleanGetter.False;
 import static com.ichi2.utils.BooleanGetter.True;
@@ -1625,7 +1626,7 @@ public class CollectionTask<ProgressListener, ProgressBackground extends Progres
                 TreeMap<String, Long> children = col.getDecks().children(deck.getLong("id"));
                 for (long childDid : children.values()) {
                     Deck child = col.getDecks().get(childDid);
-                    if (child.getInt("dyn") == 1) {
+                    if (child.getInt("dyn") == DECK_DYN) {
                         continue;
                     }
                     boolean changed = new ConfChange(child, conf).task(col, collectionTask);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.java
@@ -186,7 +186,7 @@ class AnkiExporter extends Exporter {
             if (dids != null && !dids.contains(d.getLong("id"))) {
                 continue;
             }
-            if (d.getInt("dyn") == Consts.DECK_STD && d.getLong("conf") != 1L) {
+            if (d.isStd() && d.getLong("conf") != 1L) {
                 if (mIncludeSched) {
                     dconfs.put(Long.toString(d.getLong("conf")), true);
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/AnkiPackageExporter.java
@@ -186,7 +186,7 @@ class AnkiExporter extends Exporter {
             if (dids != null && !dids.contains(d.getLong("id"))) {
                 continue;
             }
-            if (d.getInt("dyn") != 1 && d.getLong("conf") != 1L) {
+            if (d.getInt("dyn") == Consts.DECK_STD && d.getLong("conf") != 1L) {
                 if (mIncludeSched) {
                     dconfs.put(Long.toString(d.getLong("conf")), true);
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.java
@@ -323,7 +323,7 @@ public class Card implements Cloneable {
 
 
     public JSONObject template() {
-        JSONObject m = model();
+        Model m = model();
         if (m.isStd()) {
             return m.getJSONArray("tmpls").getJSONObject(mOrd);
         } else {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.java
@@ -324,7 +324,7 @@ public class Card implements Cloneable {
 
     public JSONObject template() {
         JSONObject m = model();
-        if (m.getInt("type") == Consts.MODEL_STD) {
+        if (m.isStd()) {
             return m.getJSONArray("tmpls").getJSONObject(mOrd);
         } else {
             return model().getJSONArray("tmpls").getJSONObject(0);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -1450,7 +1450,7 @@ public class Collection {
 
         executeIntegrityTask.consume(this::deleteNotesWithMissingModel);
         // for each model
-        for (JSONObject m : getModels().all()) {
+        for (Model m : getModels().all()) {
             executeIntegrityTask.consume((callback) -> deleteCardsWithInvalidModelOrdinals(callback, m));
             executeIntegrityTask.consume((callback) -> deleteNotesWithWrongFieldCounts(callback, m));
         }
@@ -1838,7 +1838,7 @@ public class Collection {
     }
 
 
-    private ArrayList<String> deleteCardsWithInvalidModelOrdinals(Runnable notifyProgress, JSONObject m) throws JSONException {
+    private ArrayList<String> deleteCardsWithInvalidModelOrdinals(Runnable notifyProgress, Model m) throws JSONException {
         Timber.d("deleteCardsWithInvalidModelOrdinals()");
         ArrayList<String> problems = new ArrayList<>(1);
         notifyProgress.run();

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -84,6 +84,7 @@ import timber.log.Timber;
 
 import static com.ichi2.async.CancelListener.isCancelled;
 import static com.ichi2.libanki.Collection.DismissType.REVIEW;
+import static com.ichi2.libanki.Consts.DECK_DYN;
 
 // Anki maintains a cache of used tags so it can quickly present a list of tags
 // for autocomplete and in the browser. For efficiency, deletions are not
@@ -940,7 +941,7 @@ public class Collection {
         card.setDid(did);
         // if invalid did, use default instead
         Deck deck = mDecks.get(card.getDid());
-        if (deck.getInt("dyn") == 1) {
+        if (deck.getInt("dyn") == DECK_DYN) {
             // must not be a filtered deck
             card.setDid(1);
         } else {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -718,7 +718,7 @@ public class Collection {
      */
     private ArrayList<JSONObject> _tmplsFromOrds(Model model, ArrayList<Integer> avail) {
         JSONArray tmpls;
-        if (model.getInt("type") == Consts.MODEL_STD) {
+        if (model.isStd()) {
             tmpls = model.getJSONArray("tmpls");
             ArrayList<JSONObject> ok = new ArrayList<>(avail.size());
             for (Integer ord : avail) {
@@ -1122,7 +1122,7 @@ public class Collection {
         fields.put("Subdeck", baseName);
         fields.put("CardFlag", _flagNameFromCardFlags(flags));
         JSONObject template;
-        if (model.getInt("type") == Consts.MODEL_STD) {
+        if (model.isStd()) {
             template = model.getJSONArray("tmpls").getJSONObject(ord);
         } else {
             template = model.getJSONArray("tmpls").getJSONObject(0);
@@ -1154,7 +1154,7 @@ public class Collection {
             }
             d.put(type, html);
             // empty cloze?
-            if ("q".equals(type) && model.getInt("type") == Consts.MODEL_CLOZE) {
+            if ("q".equals(type) && model.isCloze()) {
                 if (Models._availClozeOrds(model, flist, false).size() == 0) {
                     String link = String.format("<a href=%s#cloze>%s</a>", Consts.HELP_SITE, "help");
                     d.put("q", mContext.getString(R.string.empty_cloze_warning, link));
@@ -1842,7 +1842,7 @@ public class Collection {
         Timber.d("deleteCardsWithInvalidModelOrdinals()");
         ArrayList<String> problems = new ArrayList<>(1);
         notifyProgress.run();
-        if (m.getInt("type") == Consts.MODEL_STD) {
+        if (m.isStd()) {
             JSONArray tmpls = m.getJSONArray("tmpls");
             ArrayList<Integer> ords = new ArrayList<>(tmpls.length());
             for (JSONObject tmpl: tmpls.jsonObjectIterable()) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Consts.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Consts.java
@@ -109,6 +109,13 @@ public class Consts {
     @IntDef({MODEL_STD, MODEL_CLOZE})
     public @interface MODEL_TYPE {}
 
+    // deck types
+    public static final int DECK_STD = 0;
+    public static final int DECK_DYN = 1;
+    @Retention(SOURCE)
+    @IntDef({DECK_STD, DECK_DYN})
+    public @interface DECK_TYPE {}
+
     public static final int STARTING_FACTOR = 2500;
 
     // deck schema & syncing vars

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Deck.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Deck.java
@@ -39,4 +39,12 @@ public class Deck extends JSONObject {
         Deck clone = new Deck();
         return deepClonedInto(clone);
     }
+
+    public boolean isDyn() {
+        return getInt("dyn") == Consts.DECK_DYN;
+    }
+
+    public boolean isStd() {
+        return getInt("dyn") == Consts.DECK_STD;
+    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.java
@@ -55,6 +55,8 @@ import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import timber.log.Timber;
 
+import static com.ichi2.libanki.Consts.DECK_DYN;
+import static com.ichi2.libanki.Consts.DECK_STD;
 import static com.ichi2.utils.CollectionUtils.addAll;
 
 // fixmes:
@@ -368,7 +370,7 @@ public class Decks {
         if (deck == null) {
             return;
         }
-        if (deck.getInt("dyn") != 0) {
+        if (deck.getInt("dyn") == DECK_DYN) {
             // deleting a cramming deck returns cards to their previous deck
             // rather than deleting the cards
             mCol.getSched().emptyDyn(did);
@@ -419,7 +421,7 @@ public class Decks {
             }
         } else {
             for (Deck x : mDecks.values()) {
-                if (x.getInt("dyn") == 0) {
+                if (x.getInt("dyn") == DECK_STD) {
                     list.add(x.getString("name"));
                 }
             }
@@ -553,7 +555,7 @@ public class Decks {
         if (newName.contains("::")) {
             List<String> parts = Arrays.asList(path(newName));
             String newParent = TextUtils.join("::", parts.subList(0, parts.size() - 1));
-            if (byName(newParent).getInt("dyn") != 0) {
+            if (byName(newParent).getInt("dyn") == DECK_DYN) {
                 throw new DeckRenameException(DeckRenameException.FILTERED_NOSUBDEKCS);
             }
         }
@@ -703,7 +705,7 @@ public class Decks {
         assert deck != null;
         if (deck.has("conf")) {
             DeckConfig conf = getConf(deck.getLong("conf"));
-            conf.put("dyn", 0);
+            conf.put("dyn", DECK_STD);
             return conf;
         }
         // dynamic decks have embedded conf
@@ -1121,7 +1123,7 @@ public class Decks {
 
 
     public boolean isDyn(long did) {
-        return get(did).getInt("dyn") != 0;
+        return get(did).getInt("dyn") == DECK_DYN;
     }
 
     /*
@@ -1210,7 +1212,7 @@ public class Decks {
     }
 
     public static boolean isDynamic(Deck deck) {
-        return deck.getInt("dyn") != 0;
+        return deck.getInt("dyn") == DECK_DYN;
     }
 
     /** Retruns the fully qualified name of the subdeck, or null if unavailable */

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
@@ -719,7 +719,7 @@ public class Finder {
                 String templateName = t.getString("name");
                 Normalizer.normalize(templateName, Normalizer.Form.NFC);
                 if (templateName.equalsIgnoreCase(val)) {
-                    if (m.getInt("type") == Consts.MODEL_CLOZE) {
+                    if (m.isCloze()) {
                         // if the user has asked for a cloze card, we want
                         // to give all ordinals, so we just limit to the
                         // model instead

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Finder.java
@@ -713,7 +713,7 @@ public class Finder {
         }
         // search for template names
         List<String> lims = new ArrayList<>();
-        for (JSONObject m : mCol.getModels().all()) {
+        for (Model m : mCol.getModels().all()) {
             JSONArray tmpls = m.getJSONArray("tmpls");
             for (JSONObject t: tmpls.jsonObjectIterable()) {
                 String templateName = t.getString("name");

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Media.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Media.java
@@ -311,7 +311,7 @@ public class Media {
         List<String> l = new ArrayList<>();
         Model model = mCol.getModels().get(mid);
         List<String> strings = new ArrayList<>();
-        if (model.getInt("type") == Consts.MODEL_CLOZE && string.contains("{{c")) {
+        if (model.isCloze() && string.contains("{{c")) {
             // if the field has clozes in it, we'll need to expand the
             // possibilities so we can render latex
             strings = _expandClozes(string);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Model.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Model.java
@@ -56,4 +56,12 @@ public class Model extends JSONObject {
     public List<String> getTemplatesNames() {
         return getJSONArray("tmpls").toStringList("name");
     }
+
+    public boolean isStd() {
+        return getInt("type") == Consts.MODEL_STD;
+    }
+
+    public boolean isCloze() {
+        return getInt("type") == Consts.MODEL_CLOZE;
+    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -1270,7 +1270,4 @@ public class Models {
 		return (count == 0);
 	}
 
-	public static boolean isCloze(Model model) {
-	    return model.isCloze();
-    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -1270,7 +1270,7 @@ public class Models {
 		return (count == 0);
 	}
 
-	public static boolean isCloze(JSONObject model) {
+	public static boolean isCloze(Model model) {
 	    return model.isCloze();
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -958,7 +958,7 @@ public class Models {
      */
 
     private void _updateRequired(Model m) {
-        if (m.getInt("type") == Consts.MODEL_CLOZE) {
+        if (m.isCloze()) {
             // nothing to do
             return;
         }
@@ -1025,7 +1025,7 @@ public class Models {
      * @return Whether this card is empty
      */
     public static boolean emptyCard(Model m, int ord, String[] sfld) {
-        if (m.getInt("type") == Consts.MODEL_CLOZE) {
+        if (m.isCloze()) {
             // For cloze, getting the list of cloze numbes is linear in the size of the template
             // So computing the full list is almost as efficient as checking for a particular number
             return !_availClozeOrds(m, sfld, false).contains(ord);
@@ -1085,7 +1085,7 @@ public class Models {
      * @param sfld Fields of a note
      * @return The index of the cards that are generated. For cloze cards, if no card is generated, then {0} */
     public static ArrayList<Integer> availOrds(Model m, String[] sfld) {
-        if (m.getInt("type") == Consts.MODEL_CLOZE) {
+        if (m.isCloze()) {
             return _availClozeOrds(m, sfld);
         }
         return _availStandardOrds(m, sfld);
@@ -1271,6 +1271,6 @@ public class Models {
 	}
 
 	public static boolean isCloze(JSONObject model) {
-	    return model.getInt("type") == Consts.MODEL_CLOZE;
+	    return model.isCloze();
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Storage.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Storage.java
@@ -35,6 +35,8 @@ import java.util.Arrays;
 import androidx.annotation.NonNull;
 import timber.log.Timber;
 
+import static com.ichi2.libanki.Consts.DECK_STD;
+
 @SuppressWarnings({"PMD.AvoidThrowingRawExceptionTypes","PMD.AvoidReassigningParameters",
         "PMD.NPathComplexity","PMD.MethodNamingConventions","PMD.ExcessiveMethodLength","PMD.OneDeclarationPerLine",
         "PMD.SwitchStmtsShouldHaveDefault","PMD.EmptyIfStmt","PMD.SimplifyBooleanReturns","PMD.CollapsibleIfStatements"})
@@ -128,7 +130,7 @@ public class Storage {
             if (ver < 3) {
                 // new deck properties
                 for (Deck d : col.getDecks().all()) {
-                    d.put("dyn", 0);
+                    d.put("dyn", DECK_STD);
                     d.put("collapsed", false);
                     col.getDecks().save(d);
                 }
@@ -196,7 +198,7 @@ public class Storage {
             if (ver < 11) {
                 col.modSchemaNoCheck();
                 for (Deck d : col.getDecks().all()) {
-                    if (d.getInt("dyn") != 0) {
+                    if (d.getInt("dyn") == Consts.DECK_DYN) {
                         int order = d.getInt("order");
                         // failed order was removed
                         if (order >= 5) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Storage.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Storage.java
@@ -198,7 +198,7 @@ public class Storage {
             if (ver < 11) {
                 col.modSchemaNoCheck();
                 for (Deck d : col.getDecks().all()) {
-                    if (d.getInt("dyn") == Consts.DECK_DYN) {
+                    if (d.isDyn()) {
                         int order = d.getInt("order");
                         // failed order was removed
                         if (order >= 5) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/DeckDueTreeNode.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/DeckDueTreeNode.java
@@ -1,6 +1,7 @@
 package com.ichi2.libanki.sched;
 
 import com.ichi2.libanki.Collection;
+import com.ichi2.libanki.Consts;
 import com.ichi2.libanki.Deck;
 import com.ichi2.libanki.Decks;
 import com.ichi2.utils.JSONObject;
@@ -71,7 +72,7 @@ public class DeckDueTreeNode extends AbstractDeckTreeNode<DeckDueTreeNode> {
         }
         // limit the counts to the deck's limits
         JSONObject conf = getCol().getDecks().confForDid(getDid());
-        if (conf.getInt("dyn") == 0) {
+        if (conf.getInt("dyn") == Consts.DECK_STD) {
             Deck deck = getCol().getDecks().get(getDid());
             limitNewCount(conf.getJSONObject("new").getInt("perDay") - deck.getJSONArray("newToday").getInt(1));
             if (addRev) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/DeckDueTreeNode.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/DeckDueTreeNode.java
@@ -3,6 +3,7 @@ package com.ichi2.libanki.sched;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Consts;
 import com.ichi2.libanki.Deck;
+import com.ichi2.libanki.DeckConfig;
 import com.ichi2.libanki.Decks;
 import com.ichi2.utils.JSONObject;
 
@@ -71,7 +72,7 @@ public class DeckDueTreeNode extends AbstractDeckTreeNode<DeckDueTreeNode> {
             }
         }
         // limit the counts to the deck's limits
-        JSONObject conf = getCol().getDecks().confForDid(getDid());
+        DeckConfig conf = getCol().getDecks().confForDid(getDid());
         if (conf.getInt("dyn") == Consts.DECK_STD) {
             Deck deck = getCol().getDecks().get(getDid());
             limitNewCount(conf.getJSONObject("new").getInt("perDay") - deck.getJSONArray("newToday").getInt(1));

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -54,6 +54,8 @@ import timber.log.Timber;
 
 
 import static com.ichi2.async.CancelListener.isCancelled;
+import static com.ichi2.libanki.Consts.DECK_DYN;
+import static com.ichi2.libanki.Consts.DECK_STD;
 import static com.ichi2.libanki.sched.Counts.Queue.*;
 import static com.ichi2.libanki.sched.Counts.Queue;
 import static com.ichi2.libanki.stats.Stats.SECONDS_PER_DAY;
@@ -624,7 +626,7 @@ public class Sched extends SchedV2 {
      * */
     @Override
     protected int _deckRevLimitSingle(@NonNull Deck d, boolean considerCurrentCard) {
-        if (d.getInt("dyn") != 0) {
+        if (d.getInt("dyn") == DECK_DYN) {
             return mReportLimit;
         }
         long did = d.getLong("id");
@@ -706,7 +708,7 @@ public class Sched extends SchedV2 {
                 }
                 if (!mRevQueue.isEmpty()) {
                     // ordering
-                    if (mCol.getDecks().get(did).getInt("dyn") != 0) {
+                    if (mCol.getDecks().get(did).getInt("dyn") == DECK_DYN) {
                         // dynamic decks need due order preserved
                         // Note: libanki reverses mRevQueue and returns the last element in _getRevCard().
                         // AnkiDroid differs by leaving the queue intact and returning the *first* element
@@ -898,7 +900,7 @@ public class Sched extends SchedV2 {
             did = mCol.getDecks().selected();
         }
         Deck deck = mCol.getDecks().get(did);
-        if (deck.getInt("dyn") == 0) {
+        if (deck.getInt("dyn") == DECK_STD) {
             Timber.e("error: deck is not a filtered deck");
             return;
         }
@@ -1078,7 +1080,7 @@ public class Sched extends SchedV2 {
 
     private boolean _resched(@NonNull Card card) {
         DeckConfig conf = _cardConf(card);
-        if (conf.getInt("dyn") == 0) {
+        if (conf.getInt("dyn") == DECK_STD) {
             return true;
         }
         return conf.getBoolean("resched");

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -68,6 +68,8 @@ import androidx.annotation.VisibleForTesting;
 import timber.log.Timber;
 
 import static com.ichi2.libanki.Consts.CARD_TYPE_RELEARNING;
+import static com.ichi2.libanki.Consts.DECK_DYN;
+import static com.ichi2.libanki.Consts.DECK_STD;
 import static com.ichi2.libanki.Consts.QUEUE_TYPE_DAY_LEARN_RELEARN;
 import static com.ichi2.async.CancelListener.isCancelled;
 import static com.ichi2.libanki.sched.AbstractSched.UnburyType.*;
@@ -985,7 +987,7 @@ public class SchedV2 extends AbstractSched {
      * @param considerCurrentCard whether the current card should be taken from the limit (if it belongs to this deck)
      * */
     public int _deckNewLimitSingle(@NonNull Deck g, boolean considerCurrentCard) {
-        if (g.getInt("dyn") != 0) {
+        if (g.getInt("dyn") == DECK_DYN) {
             return mDynReportLimit;
         }
         long did = g.getLong("id");
@@ -1527,7 +1529,7 @@ public class SchedV2 extends AbstractSched {
         if (d == null) {
             return 0;
         }
-        if (d.getInt("dyn") != 0) {
+        if (d.getInt("dyn") == DECK_DYN) {
             return mDynReportLimit;
         }
         long did = d.getLong("id");
@@ -1880,7 +1882,7 @@ public class SchedV2 extends AbstractSched {
             did = mCol.getDecks().selected();
         }
         Deck deck = mCol.getDecks().get(did);
-        if (deck.getInt("dyn") == 0) {
+        if (deck.getInt("dyn") == DECK_STD) {
             Timber.e("error: deck is not a filtered deck");
             return;
         }
@@ -2155,7 +2157,7 @@ public class SchedV2 extends AbstractSched {
     private boolean _previewingCard(@NonNull Card card) {
         DeckConfig conf = _cardConf(card);
 
-        return conf.getInt("dyn") != 0 && !conf.getBoolean("resched");
+        return conf.getInt("dyn") == DECK_DYN && !conf.getBoolean("resched");
     }
 
 
@@ -2275,7 +2277,7 @@ public class SchedV2 extends AbstractSched {
             sb.append("\n\n");
             sb.append("").append(context.getString(R.string.sched_has_buried)).append(now);
         }
-        if (mCol.getDecks().current().getInt("dyn") == 0) {
+        if (mCol.getDecks().current().getInt("dyn") == DECK_STD) {
             sb.append("\n\n");
             sb.append(context.getString(R.string.studyoptions_congrats_custom));
         }
@@ -3082,7 +3084,7 @@ public class SchedV2 extends AbstractSched {
         // write old data
         oldCardData.flush(false);
         DeckConfig conf = _cardConf(oldCardData);
-        boolean previewing = conf.getInt("dyn") != 0 && ! conf.getBoolean("resched");
+        boolean previewing = conf.getInt("dyn") == DECK_DYN && ! conf.getBoolean("resched");
         if (! previewing) {
             // and delete revlog entry
             long last = mCol.getDb().queryLongScalar("SELECT id FROM revlog WHERE cid = ? ORDER BY id DESC LIMIT 1", oldCardData.getId());

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/stats/AdvancedStatistics.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/stats/AdvancedStatistics.java
@@ -497,7 +497,7 @@ public class AdvancedStatistics {
             int revPerDay = Settings.getMaxReviewsPerDay();
             int initialFactor = Settings.getInitialFactor();
 
-            if (conf.getInt("dyn") == 0) {
+            if (conf.getInt("dyn") == Consts.DECK_STD) {
                 revPerDay = conf.getJSONObject("rev").getInt("perDay");
                 newPerDay = conf.getJSONObject("new").getInt("perDay");
                 initialFactor = conf.getJSONObject("new").getInt("initialFactor");

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.java
@@ -35,6 +35,7 @@ import androidx.fragment.app.testing.FragmentScenario;
 import androidx.lifecycle.Lifecycle;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
+import static com.ichi2.libanki.Consts.DECK_DYN;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsNull.notNullValue;
@@ -59,7 +60,7 @@ public class CustomStudyDialogTest extends RobolectricTest {
 
 
         Deck customStudy = getCol().getDecks().current();
-        assertThat("Custom Study should be dynamic", customStudy.getInt("dyn") == 1);
+        assertThat("Custom Study should be dynamic", customStudy.getInt("dyn") == DECK_DYN);
         assertThat("could not find deck: Custom study session", customStudy, notNullValue());
         customStudy.remove("id");
         customStudy.remove("mod");


### PR DESCRIPTION
The goal is only to improve readability. Values are only 0 and 1, so rewritting `!= 0` to `== DECK_DYN` is always correct.