### PR TITLE
Remove toolbar padding when hiding toolbar

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.java
@@ -52,6 +52,7 @@ import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
+import android.view.ViewGroup.MarginLayoutParams;
 import android.view.WindowManager;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.AdapterView;
@@ -1908,6 +1909,13 @@ public class NoteEditor extends AnkiActivity {
         if (mToolbar == null) {
             return;
         }
+
+        View editorLayout = findViewById(R.id.note_editor_layout);
+        int bottomMargin = shouldHideToolbar() ? 0 : (int) getResources().getDimension(R.dimen.note_editor_toolbar_height);
+        MarginLayoutParams params = (MarginLayoutParams) editorLayout.getLayoutParams();
+        params.bottomMargin = bottomMargin;
+        editorLayout.setLayoutParams(params);
+
 
         if (shouldHideToolbar()) {
             mToolbar.setVisibility(View.GONE);

--- a/AnkiDroid/src/main/res/layout/note_editor.xml
+++ b/AnkiDroid/src/main/res/layout/note_editor.xml
@@ -12,7 +12,7 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:orientation="vertical"
-            android:layout_marginBottom="28dp">
+            android:layout_marginBottom="@dimen/note_editor_toolbar_height">
 
         <include layout="@layout/toolbar" />
 

--- a/AnkiDroid/src/main/res/values/dimens.xml
+++ b/AnkiDroid/src/main/res/values/dimens.xml
@@ -27,4 +27,5 @@
     <dimen name="deck_picker_left_padding_small">0dp</dimen>
     <dimen name="deck_picker_left_padding">24dp</dimen>
     <dimen name="deck_picker_right_padding">4dp</dimen>
+    <dimen name="note_editor_toolbar_height">28dp</dimen>
 </resources>


### PR DESCRIPTION
## Purpose / Description
Padding for the toolbar was added, but wasn't removed when the toolbar was hidden

## Fixes
Fixes #7785

## Approach
Remove the padding

## How Has This Been Tested?

API 21 emulator

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)