### PR TITLE
Fix "star" shortcut for Mark Note

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/PeripheralCommand.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/PeripheralCommand.java
@@ -41,12 +41,12 @@ public class PeripheralCommand {
     private final ModifierKeys modifierKeys;
 
 
-    private PeripheralCommand(int keyCode, @ViewerCommandDef int command, @NonNull CardSide side) {
+    private PeripheralCommand(int keyCode, @ViewerCommandDef int command, @NonNull CardSide side, ModifierKeys modifierKeys) {
         this.mKeyCode = keyCode;
         this.mUnicodeCharacter = null;
         this.mCommand = command;
         this.mCardSide = side;
-        this.modifierKeys = ModifierKeys.none();
+        this.modifierKeys = modifierKeys;
     }
 
     private PeripheralCommand(@Nullable Character unicodeCharacter, @ViewerCommandDef int command, @NonNull CardSide side, ModifierKeys modifierKeys) {
@@ -78,24 +78,34 @@ public class PeripheralCommand {
     }
 
     public static PeripheralCommand unicode(char unicodeChar, @ViewerCommandDef int command, CardSide side) {
-        return unicode(unicodeChar, command, side, ModifierKeys.none());
+        return unicode(unicodeChar, command, side, ModifierKeys.allowShift());
     }
 
     private static PeripheralCommand unicode(char unicodeChar, @ViewerCommandDef int command, CardSide side, ModifierKeys modifierKeys) {
-        return new PeripheralCommand(unicodeChar, command, side, modifierKeys);
+        // Note: cast is needed to select the correct constructor
+        return new PeripheralCommand((Character) unicodeChar, command, side, modifierKeys);
     }
 
     public static PeripheralCommand keyCode(int keyCode, @ViewerCommandDef int command, CardSide side) {
-        return new PeripheralCommand(keyCode, command, side);
+        return keyCode(keyCode, command, side, ModifierKeys.none());
+    }
+
+    private static PeripheralCommand keyCode(int keyCode, @ViewerCommandDef int command, CardSide side, ModifierKeys modifiers) {
+        return new PeripheralCommand(keyCode, command, side, modifiers);
     }
 
     public static List<PeripheralCommand> getDefaultCommands() {
         List<PeripheralCommand> ret = new ArrayList<>(28); // Number of elements below
 
-        ret.add(PeripheralCommand.unicode('1', COMMAND_ANSWER_FIRST_BUTTON, CardSide.ANSWER));
-        ret.add(PeripheralCommand.unicode('2', COMMAND_ANSWER_SECOND_BUTTON, CardSide.ANSWER));
-        ret.add(PeripheralCommand.unicode('3', COMMAND_ANSWER_THIRD_BUTTON, CardSide.ANSWER));
-        ret.add(PeripheralCommand.unicode('4', COMMAND_ANSWER_FOURTH_BUTTON, CardSide.ANSWER));
+        ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_1, COMMAND_ANSWER_FIRST_BUTTON, CardSide.ANSWER));
+        ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_2, COMMAND_ANSWER_SECOND_BUTTON, CardSide.ANSWER));
+        ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_3, COMMAND_ANSWER_THIRD_BUTTON, CardSide.ANSWER));
+        ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_4, COMMAND_ANSWER_FOURTH_BUTTON, CardSide.ANSWER));
+
+        ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_NUMPAD_1, COMMAND_ANSWER_FIRST_BUTTON, CardSide.ANSWER));
+        ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_NUMPAD_2, COMMAND_ANSWER_SECOND_BUTTON, CardSide.ANSWER));
+        ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_NUMPAD_3, COMMAND_ANSWER_THIRD_BUTTON, CardSide.ANSWER));
+        ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_NUMPAD_4, COMMAND_ANSWER_FOURTH_BUTTON, CardSide.ANSWER));
 
         ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_BUTTON_Y, COMMAND_FLIP_OR_ANSWER_EASE1, CardSide.BOTH));
         ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_BUTTON_X, COMMAND_FLIP_OR_ANSWER_EASE2, CardSide.BOTH));
@@ -108,23 +118,30 @@ public class PeripheralCommand {
         // See: 1643 - Unsure if this will work - nothing came through on the emulator.
         ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_DPAD_CENTER, COMMAND_FLIP_OR_ANSWER_RECOMMENDED, CardSide.BOTH));
 
-        ret.add(PeripheralCommand.unicode('e', COMMAND_EDIT, CardSide.BOTH));
+        ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_E, COMMAND_EDIT, CardSide.BOTH));
+
+        // Using a char rather than "Ctrl + 1" is not ideal due to the potential need to handle Shift/Fn + character on
+        // international layouts but is what Anki Desktop does
         ret.add(PeripheralCommand.unicode('*', COMMAND_MARK, CardSide.BOTH));
         ret.add(PeripheralCommand.unicode('-', COMMAND_BURY_CARD, CardSide.BOTH));
         ret.add(PeripheralCommand.unicode('=', COMMAND_BURY_NOTE, CardSide.BOTH));
         ret.add(PeripheralCommand.unicode('@', COMMAND_SUSPEND_CARD, CardSide.BOTH));
         ret.add(PeripheralCommand.unicode('!', COMMAND_SUSPEND_NOTE, CardSide.BOTH));
-        ret.add(PeripheralCommand.unicode('r', COMMAND_PLAY_MEDIA, CardSide.BOTH));
+        ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_R, COMMAND_PLAY_MEDIA, CardSide.BOTH));
         ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_F5, COMMAND_PLAY_MEDIA, CardSide.BOTH));
-        ret.add(PeripheralCommand.unicode('v', COMMAND_REPLAY_VOICE, CardSide.BOTH));
-        // TODO: Rethink this - needed a capital V
-        ret.add(PeripheralCommand.unicode('V', COMMAND_RECORD_VOICE, CardSide.BOTH, ModifierKeys.shift()));
-        ret.add(PeripheralCommand.unicode('z', COMMAND_UNDO, CardSide.BOTH));
+        ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_V, COMMAND_REPLAY_VOICE, CardSide.BOTH));
+        ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_V, COMMAND_RECORD_VOICE, CardSide.BOTH, ModifierKeys.shift()));
+        ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_Z, COMMAND_UNDO, CardSide.BOTH));
 
-        ret.add(PeripheralCommand.unicode('1', COMMAND_TOGGLE_FLAG_RED, CardSide.BOTH, ModifierKeys.ctrl()));
-        ret.add(PeripheralCommand.unicode('2', COMMAND_TOGGLE_FLAG_ORANGE, CardSide.BOTH, ModifierKeys.ctrl()));
-        ret.add(PeripheralCommand.unicode('3', COMMAND_TOGGLE_FLAG_GREEN, CardSide.BOTH, ModifierKeys.ctrl()));
-        ret.add(PeripheralCommand.unicode('4', COMMAND_TOGGLE_FLAG_BLUE, CardSide.BOTH, ModifierKeys.ctrl()));
+        ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_1, COMMAND_TOGGLE_FLAG_RED, CardSide.BOTH, ModifierKeys.ctrl()));
+        ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_2, COMMAND_TOGGLE_FLAG_ORANGE, CardSide.BOTH, ModifierKeys.ctrl()));
+        ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_3, COMMAND_TOGGLE_FLAG_GREEN, CardSide.BOTH, ModifierKeys.ctrl()));
+        ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_4, COMMAND_TOGGLE_FLAG_BLUE, CardSide.BOTH, ModifierKeys.ctrl()));
+
+        ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_NUMPAD_1, COMMAND_TOGGLE_FLAG_RED, CardSide.BOTH, ModifierKeys.ctrl()));
+        ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_NUMPAD_2, COMMAND_TOGGLE_FLAG_ORANGE, CardSide.BOTH, ModifierKeys.ctrl()));
+        ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_NUMPAD_3, COMMAND_TOGGLE_FLAG_GREEN, CardSide.BOTH, ModifierKeys.ctrl()));
+        ret.add(PeripheralCommand.keyCode(KeyEvent.KEYCODE_NUMPAD_4, COMMAND_TOGGLE_FLAG_BLUE, CardSide.BOTH, ModifierKeys.ctrl()));
 
         return ret;
     }
@@ -144,12 +161,16 @@ public class PeripheralCommand {
 
 
     public static class ModifierKeys {
-        private final boolean mShift;
-        private final boolean mCtrl;
-        private final boolean mAlt;
+        // null == true/false works.
+        @Nullable
+        private final Boolean mShift;
+        @Nullable
+        private final Boolean mCtrl;
+        @Nullable
+        private final Boolean mAlt;
 
 
-        public ModifierKeys(boolean shift, boolean ctrl, boolean alt) {
+        private ModifierKeys(@Nullable Boolean shift, @Nullable Boolean ctrl, @Nullable Boolean alt) {
             this.mShift = shift;
             this.mCtrl = ctrl;
             this.mAlt = alt;
@@ -168,9 +189,17 @@ public class PeripheralCommand {
             return new ModifierKeys(true, false, false);
         }
 
+        /** Allows shift, but not Ctrl/Alt */
+        public static ModifierKeys allowShift() {
+            return new ModifierKeys(null, false, false);
+        }
+
+
         public boolean matches(KeyEvent event) {
             // return false if Ctrl+1 is pressed and 1 is expected
-            return mShift == event.isShiftPressed() && mCtrl == event.isCtrlPressed() && mAlt == event.isAltPressed();
+            return (mShift == null || mShift == event.isShiftPressed()) &&
+                    (mCtrl == null || mCtrl == event.isCtrlPressed()) &&
+                    (mAlt == null || mAlt == event.isAltPressed());
         }
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerKeyboardInputTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerKeyboardInputTest.java
@@ -28,6 +28,7 @@ import androidx.annotation.CheckResult;
 import androidx.annotation.NonNull;
 import timber.log.Timber;
 
+import static android.view.KeyEvent.*;
 import static com.ibm.icu.impl.Assert.fail;
 import static com.ichi2.anki.AbstractFlashcardViewer.EASE_1;
 import static com.ichi2.anki.AbstractFlashcardViewer.EASE_2;
@@ -45,7 +46,7 @@ public class ReviewerKeyboardInputTest {
     public void whenDisplayingQuestionTyping1DoesNothing() {
         KeyboardInputTestReviewer underTest = KeyboardInputTestReviewer.displayingQuestion();
 
-        underTest.handleAndroidKeyPress(KeyEvent.KEYCODE_1);
+        underTest.handleAndroidKeyPress(KEYCODE_1);
 
         assertThat("Answer should not be displayed", !underTest.didDisplayAnswer());
         assertThat("Answer should not be performed", !underTest.hasBeenAnswered());
@@ -55,7 +56,7 @@ public class ReviewerKeyboardInputTest {
     public void whenDisplayingAnswerTyping1AnswersFarLeftButton() {
         KeyboardInputTestReviewer underTest = KeyboardInputTestReviewer.displayingAnswer();
 
-        underTest.handleAndroidKeyPress(KeyEvent.KEYCODE_1);
+        underTest.handleAndroidKeyPress(KEYCODE_1);
 
         assertThat(underTest.processedAnswer(), equalTo(EASE_1));
     }
@@ -64,7 +65,7 @@ public class ReviewerKeyboardInputTest {
     public void whenDisplayingAnswerTyping2AnswersSecondButton() {
         KeyboardInputTestReviewer underTest = KeyboardInputTestReviewer.displayingAnswer();
 
-        underTest.handleAndroidKeyPress(KeyEvent.KEYCODE_2);
+        underTest.handleAndroidKeyPress(KEYCODE_2);
 
         assertThat(underTest.processedAnswer(), equalTo(EASE_2));
     }
@@ -73,7 +74,7 @@ public class ReviewerKeyboardInputTest {
     public void whenDisplayingAnswerTyping3AnswersThirdButton() {
         KeyboardInputTestReviewer underTest = KeyboardInputTestReviewer.displayingAnswer();
 
-        underTest.handleAndroidKeyPress(KeyEvent.KEYCODE_3);
+        underTest.handleAndroidKeyPress(KEYCODE_3);
 
         assertThat(underTest.processedAnswer(), equalTo(EASE_3));
     }
@@ -82,7 +83,7 @@ public class ReviewerKeyboardInputTest {
     public void whenDisplayingAnswerTyping4AnswersFarRightButton() {
         KeyboardInputTestReviewer underTest = KeyboardInputTestReviewer.displayingAnswer();
 
-        underTest.handleAndroidKeyPress(KeyEvent.KEYCODE_4);
+        underTest.handleAndroidKeyPress(KEYCODE_4);
 
         assertThat(underTest.processedAnswer(), equalTo(EASE_4));
     }
@@ -120,30 +121,30 @@ public class ReviewerKeyboardInputTest {
 
     @Test
     public void gamepadAAnswerFourthButtonOrShowsAnswer() {
-        assertGamepadButtonAnswers(KeyEvent.KEYCODE_BUTTON_A, EASE_4);
+        assertGamepadButtonAnswers(KEYCODE_BUTTON_A, EASE_4);
     }
 
     @Test
     public void gamepadBAnswersThirdButtonOrShowsAnswer() {
-        assertGamepadButtonAnswers(KeyEvent.KEYCODE_BUTTON_B, EASE_3);
+        assertGamepadButtonAnswers(KEYCODE_BUTTON_B, EASE_3);
     }
 
     @Test
     public void gamepadXAnswersSecondButtonOrShowsAnswer() {
-        assertGamepadButtonAnswers(KeyEvent.KEYCODE_BUTTON_X, EASE_2);
+        assertGamepadButtonAnswers(KEYCODE_BUTTON_X, EASE_2);
     }
 
 
     @Test
     public void gamepadYAnswersFirstButtonOrShowsAnswer() {
-        assertGamepadButtonAnswers(KeyEvent.KEYCODE_BUTTON_Y, EASE_1);
+        assertGamepadButtonAnswers(KEYCODE_BUTTON_Y, EASE_1);
     }
 
     @Test
     public void pressingEWillEditCard() {
         KeyboardInputTestReviewer underTest = KeyboardInputTestReviewer.displayingAnswer();
 
-        underTest.handleAndroidKeyPress(KeyEvent.KEYCODE_E);
+        underTest.handleAndroidKeyPress(KEYCODE_E);
 
         assertThat("Edit Card was called", underTest.getEditCardCalled());
     }
@@ -188,7 +189,7 @@ public class ReviewerKeyboardInputTest {
     public void pressingRShouldReplayAudio() {
         KeyboardInputTestReviewer underTest = KeyboardInputTestReviewer.displayingAnswer();
 
-        underTest.handleAndroidKeyPress(KeyEvent.KEYCODE_R);
+        underTest.handleAndroidKeyPress(KEYCODE_R);
 
         assertThat("Replay Audio should be called", underTest.getReplayAudioCalled());
     }
@@ -197,7 +198,7 @@ public class ReviewerKeyboardInputTest {
     public void pressingF5ShouldReplayAudio() {
         KeyboardInputTestReviewer underTest = KeyboardInputTestReviewer.displayingAnswer();
 
-        underTest.handleKeyPress(KeyEvent.KEYCODE_F5, '\0');
+        underTest.handleKeyPress(KEYCODE_F5, '\0');
 
         assertThat("Replay Audio should be called", underTest.getReplayAudioCalled());
     }
@@ -206,7 +207,7 @@ public class ReviewerKeyboardInputTest {
     public void pressingZShouldUndoIfAvailable() {
         KeyboardInputTestReviewer underTest = KeyboardInputTestReviewer.displayingAnswer().withUndoAvailable(true);
 
-        underTest.handleAndroidKeyPress(KeyEvent.KEYCODE_Z);
+        underTest.handleAndroidKeyPress(KEYCODE_Z);
 
         assertThat("Undo should be called", underTest.getUndoCalled());
     }
@@ -323,13 +324,13 @@ public class ReviewerKeyboardInputTest {
             when(key.getUnicodeChar(anyInt())).thenReturn((int)unicodeChar);
 
             try {
-                when(key.getAction()).thenReturn(KeyEvent.ACTION_DOWN);
+                when(key.getAction()).thenReturn(ACTION_DOWN);
                 this.onKeyDown(0, key);
             } catch (Exception e) {
                 Timber.e(e);
             }
             try {
-                when(key.getAction()).thenReturn(KeyEvent.ACTION_UP);
+                when(key.getAction()).thenReturn(ACTION_UP);
                 this.onKeyUp(0, key);
             } catch (Exception e) {
                 Timber.e(e);
@@ -341,7 +342,7 @@ public class ReviewerKeyboardInputTest {
             KeyEvent e = getMockKeyEvent();
             // COULD_BE_BETTER: We do not handle shift
             when(e.getUnicodeChar(anyInt())).thenReturn((int)unicodeChar);
-            when(e.getAction()).thenReturn(KeyEvent.ACTION_DOWN);
+            when(e.getAction()).thenReturn(ACTION_DOWN);
             when(e.getKeyCode()).thenReturn(keycode);
 
             try {
@@ -349,7 +350,7 @@ public class ReviewerKeyboardInputTest {
             } catch (Exception ex) {
                 Timber.e(ex);
             }
-            when(e.getAction()).thenReturn(KeyEvent.ACTION_UP);
+            when(e.getAction()).thenReturn(ACTION_UP);
             try {
                 this.onKeyUp(keycode, e);
             } catch (Exception ex) {
@@ -370,12 +371,12 @@ public class ReviewerKeyboardInputTest {
         @SuppressWarnings({"unused"}) //useful to obtain unicode for kecode if run under AndroidJUnit4.
         public void handleAndroidKeyPress(int keycode) {
             try {
-                this.onKeyDown(keycode, createKeyEvent(KeyEvent.ACTION_DOWN, keycode));
+                this.onKeyDown(keycode, createKeyEvent(ACTION_DOWN, keycode));
             } catch (Exception ex) {
                 Timber.e(ex);
             }
             try {
-                this.onKeyUp(keycode, createKeyEvent(KeyEvent.ACTION_UP, keycode));
+                this.onKeyUp(keycode, createKeyEvent(ACTION_UP, keycode));
             } catch (Exception ex) {
                 Timber.e(ex);
             }
@@ -432,7 +433,7 @@ public class ReviewerKeyboardInputTest {
 
 
         public void handleSpacebar() {
-            handleKeyPress(KeyEvent.KEYCODE_SPACE, ' ');
+            handleKeyPress(KEYCODE_SPACE, ' ');
         }
 
 


### PR DESCRIPTION
## Purpose / Description
I had added filtering for KeyEvents based on whether shift/alt/ctrl was pressed:

7df5008f660ae6c868d34504ccb5a22979161f01


I had not considered the fact that Shift + 8 is `*`

#7140
#7247

## Fixes
Fixes #7840

## Approach
We no longer filter unicode characters based on whether shift is pressed

We also move many of the commands to use known keys, which makes the
implementation much more robust for when we move to custom key maps.

## How Has This Been Tested?
Android 9 + Keyboard

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)