### PR TITLE
Field name

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.java
@@ -177,7 +177,7 @@ public class ModelFieldEditor extends AnkiActivity implements LocaleSelectionDia
      */
     private @Nullable String _uniqueName(@NonNull EditText mFieldNameInput) {
         String input = mFieldNameInput.getText().toString()
-                .replaceAll("[\\n\\r]", "");
+                .replaceAll("[\\n\\r{}:\"]", "");
         if (input.length() == 0) {
             UIUtils.showThemedToast(this, getResources().getString(R.string.toast_empty_name), true);
             return null;
@@ -186,7 +186,7 @@ public class ModelFieldEditor extends AnkiActivity implements LocaleSelectionDia
             UIUtils.showThemedToast(this, getResources().getString(R.string.toast_duplicate_field), true);
             return null;
         }
-        return input.trim();
+        return input;
     }
 
     /*

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.java
@@ -45,7 +45,7 @@ import com.ichi2.utils.JSONException;
 import com.ichi2.utils.JSONObject;
 
 
-
+import java.util.Arrays;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Locale;
@@ -178,6 +178,14 @@ public class ModelFieldEditor extends AnkiActivity implements LocaleSelectionDia
     private @Nullable String _uniqueName(@NonNull EditText mFieldNameInput) {
         String input = mFieldNameInput.getText().toString()
                 .replaceAll("[\\n\\r{}:\"]", "");
+        // The number of #, ^, /, space, tab, starting the input
+        int offset;
+        for (offset = 0; offset < input.length(); offset++) {
+            if (!Arrays.asList('#', '^', '/',' ', '\t').contains(input.charAt(offset))) {
+                break;
+            }
+        }
+        input = input.substring(offset).trim();
         if (input.length() == 0) {
             UIUtils.showThemedToast(this, getResources().getString(R.string.toast_empty_name), true);
             return null;


### PR DESCRIPTION
This port https://github.com/ankitects/anki/pull/869
It ensures that #, /  and ^ can't start a field name. It also ensures that :, {, }, " can't be in field name

Currently, the backend also removes them when it meets them. We'll have this when rust is ported. At least, this change ensure that the error can't be entered in the collection, even if we don't correct it.

I should note that I'm not fan of silent correction, so I'm not really pleased by the way anki strip part of field name without warning users. The good point with this PR and the related anki PR is that the change is directly reflected in the field list, so they should see quickly what's going on