### PR TITLE
"Unknown field" message gets translated

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/template/TemplateFilters.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/template/TemplateFilters.java
@@ -101,7 +101,7 @@ public class TemplateFilters {
                 }
             } catch (Exception e) {
                 Timber.e(e, "Exception while running hook %s", filter);
-                return "Error in filter " + filter;
+                return AnkiDroidApp.getAppResources().getString(R.string.filter_error, filter);
             }
         }
     }

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -200,4 +200,5 @@
     <string name="missing_closing_bracket">Missing \'}}\' in \'%s\'.</string>
     <string name="open_tag_not_closed">Missing \'{{%s}}\'.</string>
     <string name="wrong_tag_closed">Found \'{{/%1$s}}\', but expected \'{{/%2$s}}\'</string>
+    <string name="filter_error">Error in filter %s</string>
 </resources>


### PR DESCRIPTION
When a field is not found in a card template, the error message was always in English. I correct that.