### PR TITLE
Codecov tuning

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,2 @@
+coverage:
+  range: "36...100"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - '**'
     paths:
+      - '.github/workflows/**'
       - 'AnkiDroid/**'
       - 'api/**'
       - 'lint-rules/**'
@@ -18,6 +19,7 @@ on:
       - i18n_sync
       - 'release**'
     paths:
+      - '.github/workflows/**'
       - 'AnkiDroid/**'
       - 'api/**'
       - 'lint-rules/**'

--- a/.github/workflows/tests_emulator.yml
+++ b/.github/workflows/tests_emulator.yml
@@ -40,7 +40,7 @@ jobs:
 
       - uses: actions/checkout@v2
         with:
-          fetch-depth: 1
+          fetch-depth: 50
 
       - name: Gradle Cache
         uses: actions/cache@v2

--- a/.github/workflows/tests_emulator.yml
+++ b/.github/workflows/tests_emulator.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - '**'
     paths:
+      - '.github/workflows/**'
       - 'AnkiDroid/**'
       - 'api/**'
       - 'lint-rules/**'
@@ -18,6 +19,7 @@ on:
       - i18n_sync
       - 'release**'
     paths:
+      - '.github/workflows/**'
       - 'AnkiDroid/**'
       - 'api/**'
       - 'lint-rules/**'

--- a/.github/workflows/tests_unit.yml
+++ b/.github/workflows/tests_unit.yml
@@ -39,7 +39,7 @@ jobs:
 
       - uses: actions/checkout@v2
         with:
-          fetch-depth: 1
+          fetch-depth: 50
 
       - name: Configure JDK 1.8
         uses: actions/setup-java@v1

--- a/.github/workflows/tests_unit.yml
+++ b/.github/workflows/tests_unit.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - '**'
     paths:
+      - '.github/workflows/**'
       - 'AnkiDroid/**'
       - 'api/**'
       - 'lint-rules/**'
@@ -18,6 +19,7 @@ on:
       - i18n_sync
       - 'release**'
     paths:
+      - '.github/workflows/**'
       - 'AnkiDroid/**'
       - 'api/**'
       - 'lint-rules/**'


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

- codecov was not posting expected coverage results
- codecov graphs had useless coloration
- github workflows were not executing on workflow definition changes

## Fixes
Fixes issue noticed by @david-allison-1 that coverage diffs weren't as expected, e.g. https://github.com/ankidroid/Anki-Android/pull/7977#issuecomment-751676625 where root cause appears to be 

>  ->  Issue detecting commit SHA. Please run actions/checkout with fetch-depth > 1 or set to 0

...from https://github.com/ankidroid/Anki-Android/pull/7977/checks?check_run_id=1616994735

## Approach
- set github checkout action to fetch-depth of 20, that's fairly arbitrary but should cover all our PRs
- set coverage range minimum to 36 so that coloration divergence starts from our current baseline
- add workflow files to the path inclusion list for workflow execution

## How Has This Been Tested?

It is literally made of tests. The codecov comment on this PR should show whether it worked.

## Learning (optional, can help others)
The default, we only need to override one part: https://docs.codecov.io/docs/codecov-yaml
The config reference: https://docs.codecov.io/docs/codecovyml-reference


## Checklist

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)