### PR TITLE
Fixes #7984

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/LrnCardQueue.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/LrnCardQueue.java
@@ -11,10 +11,6 @@ class LrnCardQueue extends CardQueue<LrnCard> {
         add(new LrnCard(getCol(), due, cid));
     }
 
-    public void add(int pos, LrnCard card) {
-        getQueue().add(pos, card);
-    }
-
     public void sort() {
         Collections.sort(getQueue());
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/LrnCardQueue.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/LrnCardQueue.java
@@ -3,6 +3,12 @@ package com.ichi2.libanki.sched;
 import java.util.Collections;
 
 class LrnCardQueue extends CardQueue<LrnCard> {
+    /**
+     * Whether the queue already contains its current expected value.
+     * If it's not the case, then we won't add cards reviewed immediately and wait for a filling to occur.
+     */
+    private boolean mIsFilled = false;
+
     public LrnCardQueue(AbstractSched sched) {
         super(sched);
     }
@@ -17,5 +23,20 @@ class LrnCardQueue extends CardQueue<LrnCard> {
 
     public long getFirstDue() {
         return getQueue().getFirst().getDue();
+    }
+
+
+    @Override
+    public void clear() {
+        super.clear();
+        mIsFilled = false;
+    }
+
+    public void setFilled() {
+        mIsFilled = true;
+    }
+
+    public boolean isFilled() {
+        return mIsFilled;
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Sched.java
@@ -366,6 +366,7 @@ public class Sched extends SchedV2 {
          * _getLrnCard which did remove the card from the queue. _sortIntoLrn will add the card back to the queue if
          * required when the card is reviewed.
          */
+        mLrnQueue.setFilled();
         try (Cursor cur = mCol.getDb().query(
                            "SELECT due, id FROM cards WHERE did IN " + _deckLimit() + " AND queue = " + Consts.QUEUE_TYPE_LRN + " AND due < ? AND id != ? LIMIT ?",
                            mDayCutoff, currentCardId(), mReportLimit)) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/SchedV2.java
@@ -1084,6 +1084,7 @@ public class SchedV2 extends AbstractSched {
                     .query(
                             "SELECT due, id FROM cards WHERE did IN " + _deckLimit() + " AND queue IN (" + Consts.QUEUE_TYPE_LRN + ", " + Consts.QUEUE_TYPE_PREVIEW + ") AND due < ?"
                             + " AND id != ? LIMIT ?", cutoff, currentCardId(), mReportLimit)) {
+            mLrnQueue.setFilled();
             while (cur.moveToNext()) {
                 mLrnQueue.add(cur.getLong(0), cur.getLong(1));
             }
@@ -3044,6 +3045,11 @@ public class SchedV2 extends AbstractSched {
      * Sorts a card into the lrn queue LIBANKI: not in libanki
      */
     protected void _sortIntoLrn(long due, long id) {
+        if (!mLrnQueue.isFilled()) {
+            // We don't want to add an element to the queue if it's not yet assumed to have its normal content.
+            // Adding anything is useless while the queue awaits beeing filled
+            return;
+        }
         ListIterator<LrnCard> i = mLrnQueue.listIterator();
         while (i.hasNext()) {
             if (i.next().getDue() > due) {

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/AbstractSchedTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/AbstractSchedTest.java
@@ -410,7 +410,6 @@ mw.col.sched.extendLimits(1, 0)
     }
 
     @Test
-    @Ignore("Regression test that will be solved in next commit")
     public void regression_7984() {
         Collection col = getCol();
         AbstractSched sched = col.getSched();

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/sched/AbstractSchedTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/sched/AbstractSchedTest.java
@@ -32,6 +32,7 @@ import com.ichi2.testutils.AnkiAssert;
 import com.ichi2.utils.JSONArray;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.ParameterizedRobolectricTestRunner;
@@ -47,6 +48,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -405,5 +407,28 @@ mw.col.sched.extendLimits(1, 0)
         card = sched.getCard();
         sched.setCurrentCard(card);
         AnkiAssert.assertDoesNotThrow(sched::preloadNextCard);
+    }
+
+    @Test
+    @Ignore("Regression test that will be solved in next commit")
+    public void regression_7984() {
+        Collection col = getCol();
+        AbstractSched sched = col.getSched();
+        Card card1 = addNoteUsingBasicModel("One", "Two").cards().get(0);
+        Card card2 = addNoteUsingBasicModel("Three", "Four").cards().get(0);
+        Card gotten = sched.getCard();
+        assertThat(gotten, is(card1));
+        sched.answerCard(gotten, Consts.BUTTON_ONE);
+        gotten = sched.getCard();
+        assertThat(gotten, is(card2));
+        sched.answerCard(gotten, Consts.BUTTON_ONE);
+        sched.reset();
+        // Regression test success non deterministically without the sleep
+        advanceRobolectricLooperWithSleep();
+        gotten = sched.getCard();
+        assertThat(gotten, is(notNullValue()));
+        sched.answerCard(gotten, Consts.BUTTON_ONE);
+        gotten = sched.getCard();
+        assertThat(gotten, is(notNullValue()));
     }
 }


### PR DESCRIPTION
## Fixes #7984

## Approach

The logic is that either the queue is empty and should be filled, or the queue is non-empty and its head is the next element to review.

When we answer a card and it goes to learn mode, it should be added to the learn queue usually. But this breaks the logic if the queue is not yet filled. So I added a variable checking whether the queue is supposed to be filled or not, and in this case I don't add the element in it.

## How Has This Been Tested?

Regression test, and manual testing on emulator. Get a deck with only card in learning, open it, see multiple time
