### PR TITLE
Ignore revlog.ease == 0 in stats, Fixes #8008

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Consts.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Consts.java
@@ -140,8 +140,9 @@ public class Consts {
     public static final int REVLOG_REV = 1;
     public static final int REVLOG_RELRN = 2;
     public static final int REVLOG_CRAM = 3;
+    public static final int REVLOG_MANUAL = 4;
     @Retention(SOURCE)
-    @IntDef({REVLOG_LRN, REVLOG_REV, REVLOG_RELRN, REVLOG_CRAM})
+    @IntDef({REVLOG_LRN, REVLOG_REV, REVLOG_RELRN, REVLOG_CRAM, REVLOG_MANUAL})
     public @interface REVLOG_TYPE {}
 
     // The labels defined in consts.py are in AnkiDroid's resources files.


### PR DESCRIPTION
## Pull Request template

## Purpose / Description

Upstream has started logging revlog.ease = 0 on manual reschedules from the deck browser

We are not doing that (and still not doing that after this PR) but we do need to ignore them in stats or we get unsightly extra 0 columns and skewed today/overview stats

This adds an 'ease > 0' to all the where clauses, should fix it?

## Fixes
Fixes #8008

## Approach

Simple SQL where clause addition

## How Has This Been Tested?

Relatively untested but if we generate an alpha it appears that @dummifiedme has a collection that reproduces the issue.

## Learning (optional, can help others)

Pays to watch the ankitects/anki repo, which I have not been doing...

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)