### PR TITLE
fix: "Media checked" Title

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/MediaCheckDialog.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/MediaCheckDialog.java
@@ -130,23 +130,23 @@ public class MediaCheckDialog extends AsyncDialogFragment {
 
     @Override
     public String getNotificationMessage() {
-        if (getArguments().getInt("dialogType") == DIALOG_CONFIRM_MEDIA_CHECK) {
-            return res().getString(R.string.check_media_warning);
-        }
-        return res().getString(R.string.app_name);
-    }
-
-
-    @Override
-    public String getNotificationTitle() {
-        switch (getArguments().getInt("dialogType")) {
+        switch (getArguments().getInt("dialogType") ) {
             case DIALOG_CONFIRM_MEDIA_CHECK:
-                return res().getString(R.string.check_media_title);
+                return res().getString(R.string.check_media_warning);
             case DIALOG_MEDIA_CHECK_RESULTS:
                 return res().getString(R.string.check_media_acknowledge);
             default:
                 return res().getString(R.string.app_name);
         }
+    }
+
+
+    @Override
+    public String getNotificationTitle() {
+        if (getArguments().getInt("dialogType") == DIALOG_CONFIRM_MEDIA_CHECK) {
+            return res().getString(R.string.check_media_title);
+        }
+        return res().getString(R.string.app_name);
     }
 
 


### PR DESCRIPTION
Previously the message was titled "Media checked" with content "AnkiDroid"

We reverse this to stay consistent with other messages

check_media_acknowledge: "Media checked"

Fixes #8031

## How Has This Been Tested?

Untested

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)