### PR TITLE
Download Javadoc/Sources for all dependencies

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -8,11 +8,22 @@ plugins {
 
 apply plugin: 'com.android.application'
 apply plugin: 'app.brant.amazonappstorepublisher'
+apply plugin: 'idea'
+
 
 repositories {
     google()
     jcenter()
 }
+
+
+idea {
+    module {
+        downloadJavadoc = System.getenv("CI") != "true"
+        downloadSources = System.getenv("CI") != "true"
+    }
+}
+
 def homePath = System.properties['user.home']
 android {
     compileSdkVersion 29 // change .travis.yml build tools at same time


### PR DESCRIPTION
## Purpose / Description

**This is a non-necessary proposal - happy to see it rejected**

Download Javadoc/Sources for all dependencies

This will help keep a developer in the IDE when coding and looking into the definition of our dependencies.

Swaps an initial one-time download for ease of development

## How Has This Been Tested?

Still builds - one time hit to download docs and sources

## Learning (optional, can help others)
https://docs.gradle.org/current/javadoc/org/gradle/plugins/ide/idea/model/IdeaModule.html#isDownloadJavadoc--

https://docs.gradle.org/current/javadoc/org/gradle/plugins/ide/idea/model/IdeaModule.html#isDownloadSources--

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)