### PR TITLE
Add Open Collective Backer count to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 <a href="https://github.com/ankidroid/Anki-Android/releases"><img src="https://img.shields.io/github/v/release/ankidroid/Anki-Android" alt="release"/></a>
 <a href="https://travis-ci.org/github/ankidroid/Anki-Android"><img src="https://img.shields.io/travis/ankidroid/Anki-Android" alt="build"/></a>
+<a href="https://opencollective.com/ankidroid"><img src="https://img.shields.io/opencollective/all/ankidroid" alt="Open Collective backers and sponsors"/></a>
 <a href="https://github.com/ankidroid/Anki-Android/issues"><img src="https://img.shields.io/github/commit-activity/m/ankidroid/Anki-Android" alt="commit-activity"/></a>
 <a href="https://github.com/ankidroid/Anki-Android/network/members"><img src="https://img.shields.io/github/forks/ankidroid/Anki-Android" alt="forks"/></a>
 <a href="https://github.com/ankidroid/Anki-Android/stargazers"><img src="https://img.shields.io/github/stars/ankidroid/Anki-Android" alt="stars"/></a>


### PR DESCRIPTION
Preview: https://github.com/david-allison-1/Anki-Android/blob/readme-open-collective/README.md


We have 4 choices (one of which is per-tier):

![Open Collective backers and sponsors](https://img.shields.io/opencollective/all/ankidroid)
![Open Collective backers](https://img.shields.io/opencollective/backers/ankidroid)

![Open Collective members by tier](https://img.shields.io/opencollective/tier/ankidroid/21516) (per tier)
![Open Collective members by tier](https://img.shields.io/opencollective/tier/ankidroid/21517) (sponsors - doesn't seem to work as nobody's on the tier?)

![Open Collective sponsors](https://img.shields.io/opencollective/sponsors/ankidroid)


Sensible options:
![Open Collective backers and sponsors](https://img.shields.io/opencollective/all/ankidroid)
![Open Collective members by tier](https://img.shields.io/opencollective/tier/ankidroid/21516)

Unsure whether we should optimise for transparency with the total number, or for monthly backers:

Backers was picked, after much hesitation.