### PR TITLE
Login: Improve error message on no connection

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.java
@@ -23,7 +23,6 @@ import android.os.Build;
 import android.os.Bundle;
 import androidx.appcompat.widget.Toolbar;
 
-import android.util.Pair;
 import android.view.KeyEvent;
 import android.view.View;
 import android.view.inputmethod.InputMethodManager;
@@ -33,7 +32,6 @@ import android.widget.TextView;
 
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.google.android.material.textfield.TextInputLayout;
-import com.ichi2.anim.ActivityTransitionAnimation;
 import com.ichi2.anki.web.HostNumFactory;
 import com.ichi2.async.Connection;
 import com.ichi2.async.Connection.Payload;
@@ -41,10 +39,11 @@ import com.ichi2.themes.StyledProgressDialog;
 import com.ichi2.ui.TextInputEditField;
 import com.ichi2.utils.AdaptionUtil;
 
+import java.net.UnknownHostException;
+
 import timber.log.Timber;
 
 import static com.ichi2.anim.ActivityTransitionAnimation.Direction.FADE;
-import static com.ichi2.libanki.sync.Syncer.ConnectionResultType.*;
 
 public class MyAccount extends AnkiActivity {
     private final static int STATE_LOG_IN  = 1;
@@ -267,7 +266,7 @@ public class MyAccount extends AnkiActivity {
                     String message = getResources().getString(R.string.connection_error_message);
                     Object[] result = data.result;
                     if (result != null && result.length > 0 && result[0] instanceof Exception) {
-                        showSimpleMessageDialog(message, ((Exception)result[0]).getLocalizedMessage(), false);
+                        showSimpleMessageDialog(message, getHumanReadableLoginErrorMessage((Exception) result[0]), false);
                     } else {
                         UIUtils.showSimpleSnackbar(MyAccount.this, message, false);
                     }
@@ -281,6 +280,22 @@ public class MyAccount extends AnkiActivity {
             UIUtils.showSimpleSnackbar(MyAccount.this, R.string.youre_offline, true);
         }
     };
+
+
+    protected String getHumanReadableLoginErrorMessage(Exception exception) {
+        if (exception == null) {
+            return "";
+        }
+
+        if (exception.getCause() != null) {
+            Throwable cause = exception.getCause();
+            if (cause instanceof UnknownHostException) {
+                return getString(R.string.sync_error_unknown_host_readable, exception.getLocalizedMessage());
+            }
+        }
+
+        return exception.getLocalizedMessage();
+    }
 
 
     @Override

--- a/AnkiDroid/src/main/res/values/04-network.xml
+++ b/AnkiDroid/src/main/res/values/04-network.xml
@@ -112,4 +112,5 @@
     <!-- Deck Picker Sync Icon -->
     <string name="sync_menu_title_full_sync">Sync (full)</string>
     <string name="sync_menu_title_no_account">Sync (log in)</string>
+    <string name="sync_error_unknown_host_readable">Could not connect to AnkiWeb. Is your internet working?\n\n%s</string>
 </resources>


### PR DESCRIPTION
This occurred on my PC due to internet instability. The error message is
much more human readable now

## How Has This Been Tested?

![image](https://user-images.githubusercontent.com/62114487/105568301-2f669f00-5d30-11eb-9249-0c09da4eeba4.png)

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)