### PR TITLE
Empty cloze are detected

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Models.java
@@ -66,7 +66,7 @@ public class Models {
     private static final Pattern fClozePattern1 = Pattern.compile("\\{\\{[^}]*?cloze:(?:[^}]?:)*(.+?)\\}\\}");
     private static final Pattern fClozePattern2 = Pattern.compile("<%cloze:(.+?)%>");
     @SuppressWarnings("RegExpRedundantEscape")
-    private static final Pattern fClozeOrdPattern = Pattern.compile("(?si)\\{\\{c(\\d+)::.+?\\}\\}");
+    private static final Pattern fClozeOrdPattern = Pattern.compile("(?si)\\{\\{c(\\d+)::.*?\\}\\}");
 
     public static final String defaultModel =
               "{'sortf': 0, "

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/ModelTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/ModelTest.java
@@ -6,6 +6,7 @@ import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.utils.JSONArray;
 import com.ichi2.utils.JSONObject;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
@@ -190,6 +191,16 @@ public class ModelTest extends RobolectricTest {
         // first card should have first ord
         assertEquals(0, c.getOrd());
         assertEquals(1, c2.getOrd());
+    }
+
+    @Test
+    @Ignore("Corrected in next commit")
+    public void test_cloze_empty() {
+        Collection col = getCol();
+        Models mm = col.getModels();
+        Model cloze_model = mm.byName("Cloze");
+        mm.setCurrent(cloze_model);
+        assertEquals(new ArrayList<>(Arrays.asList(0, 1)), Models.availOrds(cloze_model, new String[]{"{{c1::Empty}} and {{c2::}}", ""}));
     }
 
 

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/ModelTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/ModelTest.java
@@ -194,7 +194,6 @@ public class ModelTest extends RobolectricTest {
     }
 
     @Test
-    @Ignore("Corrected in next commit")
     public void test_cloze_empty() {
         Collection col = getCol();
         Models mm = col.getModels();


### PR DESCRIPTION
This fixes #8030. I add a regression test and ensure that even the absence of text is detected as a valid cloze content. I tested upstream and confirm that this was indeed a difference with upstream.

This code was intoduced in 2015 8d7f08e8e1618b6437a81c1f5b004d1a39153046 and the original requirement of non empty cloze was introduced in 2012 in 5040ef1a3e19d1a60359945bd5dfb4bcce8886fe. I won't state it was a bug, I honestly don't know for how long upstream did accept empty cloze content. This may be worth an update in 2.14 in my opinion, because there is a slight risk that it leads to cards deleted by accident. However, only DAE can tell us how often this is used, since he got the only database with a lot of users.

