### PR TITLE
prevent OR search from bypassing RestrictOnDeck

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.java
@@ -1486,7 +1486,7 @@ public class CardBrowser extends NavigationDrawerActivity implements
         if (mSearchTerms.contains("deck:")) {
             searchText = mSearchTerms;
         } else {
-            searchText = mRestrictOnDeck + mSearchTerms;
+            searchText = mRestrictOnDeck + "(" + mSearchTerms + ")";
         }
         if (colIsOpen() && mCardsAdapter!= null) {
             // clear the existing card list


### PR DESCRIPTION
## Purpose / Description
When searching in the card browser restricted to a single deck, using the `or` keyword would give results from outside that deck. This happened from the deck restrction (`deck:<name>`) being concatenated with the user's search using a space, so the deck search is only applied in the left half of the `or` logic.

## Fixes
Fixes #8027

## Approach
Wrap the user's search terms in parentheses so the deck restriction applies to all results.

Originally deck-restricted searches were:
`deck:"<name>" <search>`
This changes them to be:
`deck:"<name>" (<search>)`

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code