### PR TITLE
Fixes 8043

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/template/ParsedNode.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/template/ParsedNode.java
@@ -102,7 +102,7 @@ public abstract class ParsedNode {
                     break;
                 }
                 case Replacement: {
-                    String[] it = token.getText().split(":");
+                    String[] it = token.getText().split(":", -1);
                     String key = it[it.length - 1];
                     List<String> filters = new ArrayList<>(it.length - 1);
                     for (int i = it.length - 2; i >= 0; i--) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/template/Replacement.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/template/Replacement.java
@@ -66,7 +66,11 @@ public class Replacement extends ParsedNode {
     public void render_into(Map<String, String> fields, Set<String> nonempty_fields, StringBuilder builder) throws TemplateError.FieldNotFound {
         String txt = fields.get(mKey);
         if (txt == null) {
-            throw new TemplateError.FieldNotFound(mFilters, mKey);
+            if (mKey.trim().isEmpty() && !mFilters.isEmpty()) {
+                txt = "";
+            } else {
+                throw new TemplateError.FieldNotFound(mFilters, mKey);
+            }
         }
         for (String filter: mFilters) {
             txt = TemplateFilters.apply_filter(txt, filter, mKey, mTag);

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/template/Tokenizer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/template/Tokenizer.java
@@ -175,7 +175,7 @@ public class Tokenizer implements Iterator<Tokenizer.Token> {
      */
     protected static @NonNull Token classify_handle(@NonNull String handle) {
         int start_pos = 0;
-        while (handle.charAt(start_pos) == '{') {
+        while (start_pos < handle.length() && handle.charAt(start_pos) == '{') {
             start_pos++;
         }
         String start = handle.substring(start_pos).trim();

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/template/ParserTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/template/ParserTest.java
@@ -27,7 +27,6 @@ import static org.junit.Assert.fail;
 @RunWith(AndroidJUnit4.class)
 public class ParserTest extends RobolectricTest {
     @Test
-    @Ignore("Corrected in next commit")
     public void parsing() {
         assertThat(ParsedNode.parse_inner(""), is(new EmptyNode()));
         assertThat(ParsedNode.parse_inner("Test"), is(new Text("Test")));

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/template/ParserTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/template/ParserTest.java
@@ -5,6 +5,7 @@ import com.ichi2.testutils.AnkiAssert;
 import com.ichi2.utils.Assert;
 
 import org.hamcrest.Matcher;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -26,10 +27,14 @@ import static org.junit.Assert.fail;
 @RunWith(AndroidJUnit4.class)
 public class ParserTest extends RobolectricTest {
     @Test
+    @Ignore("Corrected in next commit")
     public void parsing() {
         assertThat(ParsedNode.parse_inner(""), is(new EmptyNode()));
         assertThat(ParsedNode.parse_inner("Test"), is(new Text("Test")));
         assertThat(ParsedNode.parse_inner("{{Test}}"), is(new Replacement("Test")));
+        assertThat(ParsedNode.parse_inner("{{filter:Test}}"), is(new Replacement("Test", "filter")));
+        assertThat(ParsedNode.parse_inner("{{filter:}}"), is(new Replacement("", "filter")));
+        assertThat(ParsedNode.parse_inner("{{}}"), is(new Replacement("")));
         assertThat(ParsedNode.parse_inner("{{!Test}}"), is(new Replacement("!Test")));
         assertThat(ParsedNode.parse_inner("{{Filter2:Filter1:Test}}"), is(new Replacement("Test", "Filter1", "Filter2")));
         assertThat(ParsedNode.parse_inner("Foo{{Test}}"), is(

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/template/TemplateTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/template/TemplateTest.java
@@ -154,7 +154,6 @@ public class TemplateTest extends RobolectricTest {
     }
 
     @Test
-    @Ignore("Corrected in next commit")
     @Config(qualifiers = "en")
     public void empty_field_name() {
         Map m = new HashMap();

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/template/TemplateTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/template/TemplateTest.java
@@ -36,11 +36,11 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
 @RunWith(AndroidJUnit4.class)
 public class TemplateTest extends RobolectricTest {
-
     private String render(String template, Map<String, String> fields) {
         return ParsedNode.parse_inner(template).render(fields, true, getTargetContext());
     }
@@ -154,15 +154,23 @@ public class TemplateTest extends RobolectricTest {
     }
 
     @Test
+    @Ignore("Corrected in next commit")
+    @Config(qualifiers = "en")
     public void empty_field_name() {
         Map m = new HashMap();
         // Empty field is not usually a valid field name and should be corrected.
         // However, if we have an empty field name in the collection, this test ensure
         // that it works as expected.
         // This is especially relevant because filter applied to no field is valid
+        m.put("Test", "Test");
+        m.put("Foo", "Foo");
+        assertThat(render("{{}}", m), containsString("there is no field called ''"));
+        assertThat(render("{{  }}", m), containsString("there is no field called ''"));
+        assertThat(render("{{filterName:}}", m), is(""));
+        assertThat(render("{{filterName:    }}", m), is(""));
+
         m.put("", "Test");
         assertThat(render("{{}}", m), is("Test"));
+        m.clear();
     }
-
-
 }

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/template/TemplateTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/template/TemplateTest.java
@@ -152,4 +152,18 @@ public class TemplateTest extends RobolectricTest {
         assertThat(render("{{^Foo}}{{Test}}{{/Foo}}", m),
                 is("Test"));
     }
+
+    @Test
+    @Ignore("Corrected in next commit")
+    public void empty_field_name() {
+        Map m = new HashMap();
+        // Empty field is not usually a valid field name and should be corrected.
+        // However, if we have an empty field name in the collection, this test ensure
+        // that it works as expected.
+        // This is especially relevant because filter applied to no field is valid
+        m.put("", "Test");
+        assertThat(render("{{}}", m), is("Test"));
+    }
+
+
 }

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/template/TemplateTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/template/TemplateTest.java
@@ -154,7 +154,6 @@ public class TemplateTest extends RobolectricTest {
     }
 
     @Test
-    @Ignore("Corrected in next commit")
     public void empty_field_name() {
         Map m = new HashMap();
         // Empty field is not usually a valid field name and should be corrected.

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/template/TokenizerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/template/TokenizerTest.java
@@ -84,6 +84,7 @@ public class TokenizerTest extends RobolectricTest {
     }
 
     @Test
+    @Ignore
     public void test_handlebar_token() {
         assertThat(handlebar_token("{{#foo}} bar"),
                 Matchers.is(new Tokenizer.IResult(
@@ -124,6 +125,24 @@ public class TokenizerTest extends RobolectricTest {
                 Matchers.is(new Tokenizer.IResult(
                         new Tokenizer.Token(Replacement,
                                 "foo"),
+                        " bar")));
+        assertThat(handlebar_token("{{filter:field}} bar"),
+                Matchers.is(new Tokenizer.IResult(
+                        new Tokenizer.Token(Replacement,
+                                "filter:field"),
+                        " bar")));
+        // The empty field name without filter is not valid in Anki,
+        // However, it's not the lexer job to deal with it, and so it should be lexed correctly.
+        assertThat(handlebar_token("{{}} bar"),
+                Matchers.is(new Tokenizer.IResult(
+                        new Tokenizer.Token(Replacement,
+                                ""),
+                        " bar")));
+        // Empty field name with filter is valid and has special meaning
+        assertThat(handlebar_token("{{filter:}} bar"),
+                Matchers.is(new Tokenizer.IResult(
+                        new Tokenizer.Token(Replacement,
+                                "filter:"),
                         " bar")));
         assertThat(handlebar_token(""),
                 is(nullValue()));

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/template/TokenizerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/template/TokenizerTest.java
@@ -84,7 +84,6 @@ public class TokenizerTest extends RobolectricTest {
     }
 
     @Test
-    @Ignore
     public void test_handlebar_token() {
         assertThat(handlebar_token("{{#foo}} bar"),
                 Matchers.is(new Tokenizer.IResult(


### PR DESCRIPTION
This fixes #8043

When porting template generation rules, I missed a special cases: filter applied to an empty field name. This is now corrected with regression test. Actually there is far more tests because I had to ensure that empty name are accepted, it was raising an uncatched exception in lexing because I assumed that all field names are not empty.

Thanks @thiswillbeyourgithub for the feedback