### PR TITLE
Sched: Enable New Timezone Handling Code

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -23,7 +23,6 @@ import android.content.Context;
 import android.content.res.Resources;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabaseLockedException;
-import android.os.Build;
 import android.text.TextUtils;
 import android.util.Pair;
 
@@ -37,6 +36,7 @@ import com.ichi2.async.CollectionTask;
 import com.ichi2.libanki.backend.DroidBackend;
 import com.ichi2.async.ProgressSender;
 import com.ichi2.async.TaskManager;
+import com.ichi2.libanki.backend.exception.BackendNotSupportedException;
 import com.ichi2.libanki.exception.NoSuchDeckException;
 import com.ichi2.libanki.exception.UnknownDatabaseVersionException;
 import com.ichi2.libanki.hooks.ChessFilter;
@@ -246,6 +246,13 @@ public class Collection {
             mSched = new Sched(this);
         } else if (ver == 2) {
             mSched = new SchedV2(this);
+            if (!getServer() && isUsingRustBackend()) {
+                try {
+                    getConf().put("localOffset", getSched()._current_timezone_offset());
+                } catch (BackendNotSupportedException e) {
+                    throw e.alreadyUsingRustBackend();
+                }
+            }
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Consts.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Consts.java
@@ -15,6 +15,8 @@
  ****************************************************************************************/
 
 package com.ichi2.libanki;
+import net.ankiweb.rsdroid.RustCleanup;
+
 import java.lang.annotation.Retention;
 
 import androidx.annotation.IntDef;
@@ -124,7 +126,9 @@ public class Consts {
     public static final int SYNC_ZIP_COUNT = 25;
     public static final String SYNC_BASE = "https://sync%s.ankiweb.net/";
     public static final Integer DEFAULT_HOST_NUM = null;
-    public static final int SYNC_VER = 9;
+    /* Note: 10 if using Rust backend, 9 if using Java. Set in BackendFactory.getInstance */
+    @RustCleanup("Use 10")
+    public static int SYNC_VER = 9;
 
     public static final String HELP_SITE = "http://ankisrs.net/docs/manual.html";
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/backend/DroidBackend.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/backend/DroidBackend.java
@@ -17,6 +17,8 @@
 package com.ichi2.libanki.backend;
 
 import com.ichi2.libanki.DB;
+import com.ichi2.libanki.backend.exception.BackendNotSupportedException;
+import com.ichi2.libanki.backend.model.SchedTimingToday;
 
 import androidx.annotation.VisibleForTesting;
 
@@ -34,4 +36,27 @@ public interface DroidBackend {
 
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     void debugEnsureNoOpenPointers();
+
+    /**
+     * Obtains Timing information for the current day.
+     *
+     * @param createdSecs A UNIX timestamp of the collection creation time
+     * @param createdMinsWest The offset west of UTC at the time of creation (eg UTC+10 hours is -600)
+     * @param nowSecs timestamp of the current time
+     * @param nowMinsWest The current offset west of UTC
+     * @param rolloverHour The hour of the day the rollover happens (eg 4 for 4am)
+     * @return Timing information for the current day. See {@link SchedTimingToday}.
+     */
+    SchedTimingToday sched_timing_today(long createdSecs, int createdMinsWest, long nowSecs, int nowMinsWest, int rolloverHour) throws BackendNotSupportedException;
+
+    /**
+     * For the given timestamp, return minutes west of UTC in the local timezone.<br/><br/>
+     *
+     * eg, Australia at +10 hours is -600.<br/>
+     * Includes the daylight savings offset if applicable.
+     *
+     * @param timestampSeconds The timestamp in seconds
+     * @return minutes west of UTC in the local timezone
+     */
+    int local_minutes_west(long timestampSeconds) throws BackendNotSupportedException;
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/backend/DroidBackendFactory.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/backend/DroidBackendFactory.java
@@ -17,9 +17,11 @@
 package com.ichi2.libanki.backend;
 
 import com.ichi2.anki.AnkiDroidApp;
+import com.ichi2.libanki.Consts;
 
 import net.ankiweb.rsdroid.BackendFactory;
 import net.ankiweb.rsdroid.RustBackendFailedException;
+import net.ankiweb.rsdroid.RustCleanup;
 
 import androidx.annotation.Nullable;
 import timber.log.Timber;
@@ -36,6 +38,7 @@ public class DroidBackendFactory {
      * Obtains an instance of a {@link DroidBackend}.
      * Each call to this method will generate a separate instance which can handle a new Anki collection
      */
+    @RustCleanup("Change back to a constant SYNC_VER")
     public static DroidBackend getInstance(boolean useBackend) {
 
         BackendFactory backendFactory = null;
@@ -47,7 +50,11 @@ public class DroidBackendFactory {
                 AnkiDroidApp.sendExceptionReport(e, "DroidBackendFactory::getInstance");
             }
         }
-        return getInstance(backendFactory);
+
+        DroidBackend instance = getInstance(backendFactory);
+        // Update the Sync version if we can load the Rust
+        Consts.SYNC_VER = backendFactory == null ? 9 : 10;
+        return instance;
     }
 
     private static DroidBackend getInstance(@Nullable BackendFactory backendFactory) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/backend/JavaDroidBackend.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/backend/JavaDroidBackend.java
@@ -17,6 +17,8 @@
 package com.ichi2.libanki.backend;
 
 import com.ichi2.libanki.DB;
+import com.ichi2.libanki.backend.exception.BackendNotSupportedException;
+import com.ichi2.libanki.backend.model.SchedTimingToday;
 
 import net.ankiweb.rsdroid.RustCleanup;
 
@@ -55,5 +57,17 @@ public class JavaDroidBackend implements DroidBackend {
     @Override
     public void debugEnsureNoOpenPointers() {
         // no-op
+    }
+
+
+    @Override
+    public SchedTimingToday sched_timing_today(long createdSecs, int createdMinsWest, long nowSecs, int nowMinsWest, int rolloverHour) throws BackendNotSupportedException {
+        throw new BackendNotSupportedException();
+    }
+
+
+    @Override
+    public int local_minutes_west(long timestampSeconds) throws BackendNotSupportedException {
+        throw new BackendNotSupportedException();
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/backend/RustDroidBackend.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/backend/RustDroidBackend.java
@@ -17,12 +17,12 @@
 package com.ichi2.libanki.backend;
 
 import com.ichi2.libanki.DB;
+import com.ichi2.libanki.backend.model.SchedTimingToday;
+import com.ichi2.libanki.backend.model.SchedTimingTodayProto;
 
 import net.ankiweb.rsdroid.BackendFactory;
-import net.ankiweb.rsdroid.BackendUtils;
 
 import BackendProto.AdBackend;
-import timber.log.Timber;
 
 /** The Backend in Rust */
 public class RustDroidBackend implements DroidBackend {
@@ -68,5 +68,17 @@ public class RustDroidBackend implements DroidBackend {
             String numbers = result.getSequenceNumbersList().toString();
             throw new IllegalStateException("Contained unclosed sequence numbers: " + numbers);
         }
+    }
+
+    @Override
+    public SchedTimingToday sched_timing_today(long createdSecs, int createdMinsWest, long nowSecs, int nowMinsWest, int rolloverHour) {
+        AdBackend.SchedTimingTodayOut2 res = mBackend.getBackend().schedTimingTodayLegacy(createdSecs, createdMinsWest, nowSecs, nowMinsWest, rolloverHour);
+        return new SchedTimingTodayProto(res);
+    }
+
+
+    @Override
+    public int local_minutes_west(long timestampSeconds) {
+        return mBackend.getBackend().localMinutesWest(timestampSeconds).getVal();
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/backend/exception/BackendNotSupportedException.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/backend/exception/BackendNotSupportedException.java
@@ -1,0 +1,26 @@
+/*
+ *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.libanki.backend.exception;
+
+import net.ankiweb.rsdroid.RustCleanup;
+
+@RustCleanup("All of these should be removed when JavaBackend is removed")
+public class BackendNotSupportedException extends Exception {
+    public RuntimeException alreadyUsingRustBackend() {
+        return new RuntimeException("A BackendNotSupportedException should not occur when using Rust backend", this);
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/backend/model/SchedTimingToday.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/backend/model/SchedTimingToday.java
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.libanki.backend.model;
+
+public interface SchedTimingToday {
+    /** The number of days that have passed since the collection was created.<br/>
+     *  uint32 upstream */
+    int days_elapsed();
+    /**
+     * Timestamp of the next day rollover.<br/>
+     * int64 upstream */
+    long next_day_at();
+}
+

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/backend/model/SchedTimingTodayProto.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/backend/model/SchedTimingTodayProto.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.libanki.backend.model;
+
+import BackendProto.AdBackend;
+
+/**
+ * Adapter for SchedTimingTodayOut2 result from Rust
+ */
+public class SchedTimingTodayProto implements SchedTimingToday {
+
+    private final AdBackend.SchedTimingTodayOut2 mData;
+
+    public SchedTimingTodayProto(AdBackend.SchedTimingTodayOut2 data) {
+        mData = data;
+    }
+
+
+    @Override
+    public int days_elapsed() {
+        return mData.getDaysElapsed();
+    }
+
+
+    @Override
+    public long next_day_at() {
+        return mData.getNextDayAt();
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/AbstractSched.java
@@ -14,6 +14,7 @@ import com.ichi2.libanki.Consts;
 import com.ichi2.libanki.Deck;
 import com.ichi2.libanki.DeckConfig;
 import com.ichi2.libanki.Collection;
+import com.ichi2.libanki.backend.exception.BackendNotSupportedException;
 
 import java.lang.ref.WeakReference;
 import java.util.List;
@@ -22,8 +23,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import timber.log.Timber;
-
-import androidx.annotation.NonNull;
 
 /**
  * In this documentation, I will call "normal use" the fact that between two successive calls to `getCard`, either the
@@ -518,4 +517,15 @@ public abstract class AbstractSched {
      * @return The number of revlog in the collection
      */
     public abstract int logCount();
+
+    public abstract int _current_timezone_offset() throws BackendNotSupportedException;
+
+    public abstract boolean _new_timezone_enabled();
+    /**
+     * Save the UTC west offset at the time of creation into the DB.
+     * Once stored, this activates the new timezone handling code.
+     */
+    public abstract void set_creation_offset() throws BackendNotSupportedException;
+
+    public abstract void clear_creation_offset();
 }

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -154,6 +154,7 @@
     <string name="learn_cutoff">Learn ahead limit</string>
     <string name="time_limit">Timebox time limit</string>
     <string name="time_limit_summ">XXX min</string>
+    <string name="new_timezone">New timezone handling</string>
     <string name="day_offset">Start of next day</string>
     <string name="day_offset_summ">XXX hours past midnight</string>
     <string name="sched_ver">Experimental V2 scheduler</string>

--- a/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
@@ -50,6 +50,11 @@
             android:title="@string/time_limit"
             app:max="9999"
             app:min="0" />
+        <CheckBoxPreference
+            android:key="newTimezoneHandling"
+            android:title="@string/new_timezone"
+            android:defaultValue="false" />
+
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/pref_cat_flashcard" >
         <Preference


### PR DESCRIPTION
## Purpose / Description
Anki Desktop has modified their code to better handle timezone changes. See linked issue

## Fixes
Fixes #5805

## Approach


Copied from Anki at commit https://github.com/ankitects/anki/commit/131d37dca52c29033432e0149052093ab1c79461
Except one line in Collection which accepts data if server == true.

https://github.com/ankitects/anki/blob/131d37dca52c29033432e0149052093ab1c79461/pylib/anki/collection.py
https://github.com/ankitects/anki/blob/131d37dca52c29033432e0149052093ab1c79461/pylib/anki/schedv2.py

* Bumps SYNC_VERSION to 10 if using Rust
* Add local_minutes_west and sched_timing_today to Backend
* Add "New timezone handling" preference: sets `creationOffset`
* Set "localOffset" preference if using SchedV2 under Rust
* Fix SchedV2:_updateCutoff to better handle timezones

We will calculate this information in the Rust in V2 of the Rust Conversion

We can't do this yet as we're still on V11 of the database schema


## How Has This Been Tested?

* Compared with Anki Desktop - config variables were the same
* Unit Tested
* Syncing config did not work - investigated with help from @dae - likely cause: https://github.com/ankitects/anki/commit/73679b03e73e4df23ad59fdccb6cfb2a7fb50a8e

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)