### PR TITLE
fix: Issue returning 1000 results from database

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -242,7 +242,7 @@ dependencies {
     implementation 'androidx.webkit:webkit:1.4.0'
 
     // == Rust conversion (from Anki-Android-Backend on GitHub) ==
-    String backendVersion = "0.1.0" // We want both testing and implementation on the same version
+    String backendVersion = "0.1.1" // We want both testing and implementation on the same version
     // build with ./gradlew rsdroid:assembleRelease
     // In my experience, using `files()` currently requires a reindex operation, which is slow.
     // implementation files("C:\\GitHub\\Rust-Test\\rsdroid\\build\\outputs\\aar\\rsdroid-release.aar")

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -246,6 +246,7 @@ dependencies {
     // build with ./gradlew rsdroid:assembleRelease
     // In my experience, using `files()` currently requires a reindex operation, which is slow.
     // implementation files("C:\\GitHub\\Rust-Test\\rsdroid\\build\\outputs\\aar\\rsdroid-release.aar")
+    implementation 'com.google.protobuf:protobuf-java:3.13.0' // This is required when loading from a file
     implementation "io.github.david-allison-1:anki-android-backend:$backendVersion"
     // build with ./gradlew rsdroid-testing:assembleRelease
     // RobolectricTest.java: replace RustBackendLoader.init(); with RustBackendLoader.loadRsdroid(path);

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -242,7 +242,7 @@ dependencies {
     implementation 'androidx.webkit:webkit:1.4.0'
 
     // == Rust conversion (from Anki-Android-Backend on GitHub) ==
-    String backendVersion = "0.1.1" // We want both testing and implementation on the same version
+    String backendVersion = "0.1.2" // We want both testing and implementation on the same version
     // build with ./gradlew rsdroid:assembleRelease
     // In my experience, using `files()` currently requires a reindex operation, which is slow.
     // implementation files("C:\\GitHub\\Rust-Test\\rsdroid\\build\\outputs\\aar\\rsdroid-release.aar")

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.java
@@ -2170,6 +2170,10 @@ public class Collection {
         return mDroidBackend.isUsingRustBackend();
     }
 
+    public DroidBackend getBackend() {
+        return mDroidBackend;
+    }
+
     /** Allows a mock db to be inserted for testing */
     @VisibleForTesting
     public void setDb(DB database) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/backend/DroidBackend.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/backend/DroidBackend.java
@@ -18,6 +18,8 @@ package com.ichi2.libanki.backend;
 
 import com.ichi2.libanki.DB;
 
+import androidx.annotation.VisibleForTesting;
+
 /**
  * Interface to the rust backend listing all currently supported functionality.
  */
@@ -29,4 +31,7 @@ public interface DroidBackend {
     boolean databaseCreationCreatesSchema();
 
     boolean isUsingRustBackend();
+
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    void debugEnsureNoOpenPointers();
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/backend/JavaDroidBackend.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/backend/JavaDroidBackend.java
@@ -50,4 +50,10 @@ public class JavaDroidBackend implements DroidBackend {
     public boolean isUsingRustBackend() {
         return false;
     }
+
+
+    @Override
+    public void debugEnsureNoOpenPointers() {
+        // no-op
+    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/backend/RustDroidBackend.java
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/backend/RustDroidBackend.java
@@ -21,10 +21,13 @@ import com.ichi2.libanki.DB;
 import net.ankiweb.rsdroid.BackendFactory;
 import net.ankiweb.rsdroid.BackendUtils;
 
+import BackendProto.AdBackend;
 import timber.log.Timber;
 
 /** The Backend in Rust */
 public class RustDroidBackend implements DroidBackend {
+    public static final int UNUSED_VALUE = 0;
+
     // I think we can change this to BackendV1 once new DB() accepts it.
     private final BackendFactory mBackend;
 
@@ -55,5 +58,15 @@ public class RustDroidBackend implements DroidBackend {
     @Override
     public boolean isUsingRustBackend() {
         return true;
+    }
+
+
+    @Override
+    public void debugEnsureNoOpenPointers() {
+        AdBackend.DebugActiveDatabaseSequenceNumbersOut result = mBackend.getBackend().debugActiveDatabaseSequenceNumbers(UNUSED_VALUE);
+        if (result.getSequenceNumbersCount() > 0) {
+            String numbers = result.getSequenceNumbersList().toString();
+            throw new IllegalStateException("Contained unclosed sequence numbers: " + numbers);
+        }
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
@@ -145,6 +145,9 @@ public class RobolectricTest {
         controllersForCleanup.clear();
 
         try {
+            if (CollectionHelper.getInstance().colIsOpen()) {
+                CollectionHelper.getInstance().getCol(getTargetContext()).getBackend().debugEnsureNoOpenPointers();
+            }
             // If you don't tear down the database you'll get unexpected IllegalStateExceptions related to connections
             CollectionHelper.getInstance().closeCollection(false, "RoboelectricTest: End");
         } catch (BackendException ex) {


### PR DESCRIPTION
Caused by an issue paging exactly 1000 items by the new database code

Fixes #8055

See:

https://github.com/david-allison-1/Anki-Android-Backend/issues/28
https://github.com/david-allison-1/Anki-Android-Backend/commit/7c5037079bb31f1c80b55a995bd06b5a2fc0381d

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)