### PR TITLE
Opt out of WebView metrics collection

### DIFF
--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -461,6 +461,14 @@
             android:resource="@drawable/anki"
             />
 
+        <!--
+        Opt out of WebView Metrics: https://developer.android.com/guide/webapps/managing-webview#metrics
+        https://developer.android.com/guide/webapps/webview-privacy
+         -->
+        <meta-data android:name="android.webkit.WebView.MetricsOptOut" android:value="true" />
+
+
+
         <provider
             android:name=".provider.CardContentProvider"
             android:authorities="com.ichi2.anki.flashcards"


### PR DESCRIPTION
> For users who choose to share usage statistics and diagnostics with Google, WebView sends usage statistics and crash reports to Google.
Usage statistics contain information such as system information, active field trials, feature usage, responsiveness, performance,
and memory usage. They do not include any personally identifying details.

https://developer.android.com/guide/webapps/webview-privacy

Eww... no

Fixes #7993

## How Has This Been Tested?

Quick test on API 25 emulator 

## Learning (optional, can help others)
* https://developer.android.com/guide/webapps/webview-privacy
* https://developer.android.com/guide/webapps/managing-webview#metrics

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)