### PR TITLE
UX: Hide full screen after user input

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.java
@@ -894,7 +894,8 @@ public abstract class AbstractFlashcardViewer extends NavigationDrawerActivity i
         return R.layout.reviewer;
     }
 
-    protected boolean isFullscreen() {
+    @VisibleForTesting(otherwise = VisibleForTesting.PROTECTED)
+    boolean isFullscreen() {
         return !getSupportActionBar().isShowing();
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.java
@@ -302,6 +302,8 @@ public class Reviewer extends AbstractFlashcardViewer {
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
+        // 100ms was not enough on my device (Honor 9 Lite -  Android Pie)
+        delayedHide(1000);
         if (getDrawerToggle().onOptionsItemSelected(item)) {
             return true;
         }
@@ -974,7 +976,14 @@ public class Reviewer extends AbstractFlashcardViewer {
     public void displayCardQuestion() {
         // show timer, if activated in the deck's preferences
         initTimer();
+        delayedHide(100);
         super.displayCardQuestion();
+    }
+
+    @Override
+    protected void displayCardAnswer() {
+        delayedHide(100);
+        super.displayCardAnswer();
     }
 
     @Override
@@ -1057,6 +1066,7 @@ public class Reviewer extends AbstractFlashcardViewer {
         }
     };
 
+    /** Hide the navigation if in full-screen mode after a given period of time */
     protected void delayedHide(int delayMillis) {
         Timber.d("Fullscreen delayed hide in %dms", delayMillis);
         mFullScreenHandler.removeMessages(0);

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.java
@@ -13,7 +13,6 @@ import com.ichi2.anki.exception.ConfirmModSchemaException;
 import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
 import com.ichi2.libanki.Consts;
-import com.ichi2.libanki.Deck;
 import com.ichi2.libanki.Decks;
 import com.ichi2.libanki.Model;
 import com.ichi2.libanki.Models;
@@ -48,7 +47,6 @@ import static org.hamcrest.Matchers.isEmptyString;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assume.assumeTrue;
 
 @RunWith(ParameterizedRobolectricTestRunner.class)
 public class ReviewerTest extends RobolectricTest {
@@ -247,7 +245,6 @@ public class ReviewerTest extends RobolectricTest {
         waitForAsyncTasksToComplete();
         assertThat(reviewer.getSupportActionBar().getTitle(), is("B"));
     }
-    
 
     private void toggleWhiteboard(ReviewerForMenuItems reviewer) {
         reviewer.toggleWhiteboard();
@@ -368,7 +365,7 @@ public class ReviewerTest extends RobolectricTest {
         return startReviewer(this, clazz);
     }
 
-    private static <T extends Reviewer> T startReviewer(RobolectricTest testClass, Class<T> clazz) {
+    public static <T extends Reviewer> T startReviewer(RobolectricTest testClass, Class<T> clazz) {
         T reviewer = startActivityNormallyOpenCollectionWithIntent(testClass, clazz, new Intent());
         waitForAsyncTasksToComplete();
         return reviewer;

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.java
@@ -158,28 +158,6 @@ public class ReviewerTest extends RobolectricTest {
         assertThat("No menu items should be visible if all are disabled in Settings - Reviewer - App Bar Buttons", visibleButtons, empty());
     }
 
-
-    private void toggleWhiteboard(ReviewerForMenuItems reviewer) {
-        reviewer.toggleWhiteboard();
-
-        assumeTrue("Whiteboard should now be enabled", reviewer.mPrefWhiteboard);
-
-        advanceRobolectricLooperWithSleep();
-    }
-
-
-    private void disableAllReviewerAppBarButtons() {
-        Set<String> keys = PreferenceUtils.getAllCustomButtonKeys(getTargetContext());
-
-        SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(getTargetContext());
-
-        SharedPreferences.Editor e =  preferences.edit();
-        for (String k : keys) {
-            e.putString(k, Integer.toString(ActionButtonStatus.MENU_DISABLED));
-        }
-        e.apply();
-    }
-
     @Test
     public synchronized void testMultipleCards() throws ConfirmModSchemaException {
         addNoteWithThreeCards();
@@ -253,6 +231,44 @@ public class ReviewerTest extends RobolectricTest {
         equalFirstField(cards[0], reviewer.mCurrentCard); // This failed in #6898 because this card was not in the queue
     }
 
+    @Test
+    public void baseDeckName() {
+        Collection col = getCol();
+        Models models = col.getModels();
+
+        Decks decks = col.getDecks();
+        Long didAb = decks.id("A::B");
+        Model basic = models.byName(AnkiDroidApp.getAppResources().getString(R.string.basic_model_name));
+        basic.put("did", didAb);
+        addNoteUsingBasicModel("foo", "bar");
+        Long didA = decks.id("A");
+        decks.select(didA);
+        Reviewer reviewer = startReviewer();
+        waitForAsyncTasksToComplete();
+        assertThat(reviewer.getSupportActionBar().getTitle(), is("B"));
+    }
+    
+
+    private void toggleWhiteboard(ReviewerForMenuItems reviewer) {
+        reviewer.toggleWhiteboard();
+
+        assumeTrue("Whiteboard should now be enabled", reviewer.mPrefWhiteboard);
+
+        advanceRobolectricLooperWithSleep();
+    }
+
+
+    private void disableAllReviewerAppBarButtons() {
+        Set<String> keys = PreferenceUtils.getAllCustomButtonKeys(getTargetContext());
+
+        SharedPreferences preferences = AnkiDroidApp.getSharedPrefs(getTargetContext());
+
+        SharedPreferences.Editor e =  preferences.edit();
+        for (String k : keys) {
+            e.putString(k, Integer.toString(ActionButtonStatus.MENU_DISABLED));
+        }
+        e.apply();
+    }
 
     private void assertCurrentOrdIsNot(Reviewer r, int i) {
         waitForAsyncTasksToComplete();
@@ -405,22 +421,4 @@ public class ReviewerTest extends RobolectricTest {
             return visibleButtons;
         }
     }
-
-    @Test
-    public void baseDeckName() {
-        Collection col = getCol();
-        Models models = col.getModels();
-
-        Decks decks = col.getDecks();
-        Long didAb = decks.id("A::B");
-        Model basic = models.byName(AnkiDroidApp.getAppResources().getString(R.string.basic_model_name));
-        basic.put("did", didAb);
-        addNoteUsingBasicModel("foo", "bar");
-        Long didA = decks.id("A");
-        decks.select(didA);
-        Reviewer reviewer = startReviewer();
-        waitForAsyncTasksToComplete();
-        assertThat(reviewer.getSupportActionBar().getTitle(), is("B"));
-    }
-
 }


### PR DESCRIPTION
## Purpose / Description
It was frustrating to undo a card while in full screen, and the menu bars did not auto-hide.

This was the same for answering or flipping cards

## Fixes
Fixes #7643 

## Approach
Add a delayed hide call

## How Has This Been Tested?

My device & unit tests

## Learning (optional, can help others)
DelayedHide did not work with a 100ms delay when an options item was selected

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)