### PR TITLE
Indicate we incorporate AGPLv3 code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,3 +88,4 @@ Join Us On
 License
 -------
 [GPL-3.0 License](https://github.com/ankidroid/Anki-Android/blob/master/COPYING)
+[AGPL-3.0 Licence](https://github.com/ankitects/anki/blob/master/LICENSE) for some part of the back-end


### PR DESCRIPTION
Indicate we incorporate AGPLv3 code.

While we don't have to list all licences used from any library, this seems especially relevant because:
* AGPLv3 is seens as a risk by some (e.g. https://opensource.google/docs/using/agpl-policy/ ) and there should be a clear warning I believe
* It can easily be argued that anki backend is very related to ankidroid, and is not just a third-party library. Especially since it seems quite probable that one day we'll need to make some PR to anki backend for our need.