### PR TITLE
Improve error if test class not annotated

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.java
@@ -217,7 +217,16 @@ public class RobolectricTest {
 
 
     protected Context getTargetContext() {
-        return ApplicationProvider.getApplicationContext();
+        try {
+            return ApplicationProvider.getApplicationContext();
+        } catch (IllegalStateException e) {
+            if (e.getMessage() != null && e.getMessage().startsWith("No instrumentation registered!")) {
+                // Explicitly ignore the inner exception - generates line noise
+                throw new IllegalStateException("Annotate class: '" + getClass().getSimpleName() + "' with '@RunWith(AndroidJUnit4.class)'");
+            }
+            throw e;
+        }
+
     }
 
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTestAnnotationTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTestAnnotationTest.java
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki;
+
+import com.ichi2.testutils.AnkiAssert;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.StringContains.containsString;
+
+// explicitly missing @RunWith(AndroidJUnit4.class)
+public class RobolectricTestAnnotationTest extends RobolectricTest {
+
+    @Test
+    public void readableErrorIfNotAnnotated() {
+        IllegalStateException exception = AnkiAssert.assertThrows(this::getTargetContext, IllegalStateException.class);
+        assertThat(exception.getMessage(), containsString("RobolectricTestAnnotationTest"));
+        assertThat(exception.getMessage(), containsString("@RunWith(AndroidJUnit4.class)"));
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/AnkiAssert.java
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/AnkiAssert.java
@@ -5,15 +5,13 @@ import android.util.Pair;
 import com.ichi2.libanki.Card;
 import com.ichi2.libanki.Collection;
 
-import androidx.annotation.NonNull;
-import timber.log.Timber;
-
-import org.junit.Assert;
-
 import java.util.Arrays;
 import java.util.List;
 
+import androidx.annotation.NonNull;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 /** Assertion methods that aren't currently supported by our dependencies */
 public class AnkiAssert {
@@ -25,6 +23,27 @@ public class AnkiAssert {
         } catch (Exception e) {
             throw new AssertionError("method should not throw", e);
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T extends Throwable> T assertThrows(Runnable r, Class<T> clazz) {
+        try {
+            r.run();
+            fail("Expected exception: " + clazz.getSimpleName() + ". No exception thrown.");
+        } catch (Throwable t) {
+            if (t.getClass().equals(clazz)) {
+                return (T) t;
+            }
+
+            if (t.getMessage() != null && t.getMessage().startsWith("Expected exception: ")) {
+                // We need to add a "throws" if we rethrow t, so fail with the same code.
+                fail("Expected exception: " + clazz.getSimpleName() + ". No exception thrown.");
+            }
+
+            // We don't want to assert here as we want to include the exception.
+            throw new AssertionError("Expected '" + clazz.getSimpleName() + "' got '" + t.getClass().getSimpleName() + "'", t);
+        }
+        throw new IllegalStateException("unreachable");
     }
 
     public static <T> void assertEqualsArrayList(T[] ar, List<T> l) {

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/AnkiAssertTest.java
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/AnkiAssertTest.java
@@ -1,0 +1,63 @@
+/*
+ *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.testutils;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.fail;
+
+public class AnkiAssertTest {
+
+    // We're not going to use the class under test to verify that these are working.
+
+    @Test
+    public void assertThrowsNoException() {
+        try {
+            AnkiAssert.assertThrows(() -> { }, IllegalStateException.class);
+            fail("No exception thrown");
+        } catch (AssertionError e) {
+            assertThat(e.getMessage(), containsString("Expected exception: IllegalStateException"));
+            assertThat(e.getMessage(), containsString("No exception thrown"));
+        }
+    }
+
+    @Test
+    public void assertThrowsWrongException() {
+        IllegalArgumentException toThrow = new IllegalArgumentException();
+        try {
+            AnkiAssert.assertThrows(() -> { throw toThrow; }, IllegalStateException.class);
+            fail("No exception thrown");
+        } catch (AssertionError e) {
+            assertThat(e.getMessage(), containsString("Expected 'IllegalStateException' got 'IllegalArgumentException'"));
+            assertThat(e.getCause(), notNullValue());
+            assertThat(e.getCause(), sameInstance(toThrow));
+        }
+    }
+
+    @Test
+    public void assertThrowsSameException() {
+        IllegalStateException ex = new IllegalStateException();
+
+        IllegalStateException exception = AnkiAssert.assertThrows(() -> { throw ex; }, IllegalStateException.class);
+
+        assertThat(exception, sameInstance(ex));
+    }
+}


### PR DESCRIPTION
Previously:

```
java.lang.IllegalStateException: No instrumentation registered! Must run under a registering instrumentation.

	at androidx.test.platform.app.InstrumentationRegistry.getInstrumentation(InstrumentationRegistry.java:45)
```

Now:

```
java.lang.IllegalStateException: Annotate class: 'PreferencesTest' with '@RunWith(AndroidJUnit4.class)'

	at com.ichi2.anki.RobolectricTest.getTargetContext(RobolectricTest.java:225)
```

## Checklist
- [x] You have not changed whitespace unnecessarily (it makes diffs hard to read)
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] Your code follows the style of the project (e.g. never omit braces in `if` statements) 
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)